### PR TITLE
Adjust "Required Level" based on used skill points

### DIFF
--- a/Modules/Build.lua
+++ b/Modules/Build.lua
@@ -150,7 +150,16 @@ function buildMode:Init(dbFileName, buildName, buildXML, targetVersion)
 	end
 	self.controls.pointDisplay.width = function(control)
 		local used, ascUsed = self.spec:CountAllocNodes()
-		local usedMax = 99 + (self.targetVersion == "2_6" and 21 or 22) + (self.calcsTab.mainOutput.ExtraPoints or 0)
+		local rewardThresholds = {89,88,86,82,79,75,73,72,68,66,65,59,57,55,52,48,41,35,29,20,14,7}
+		local unUsedRewards = 0
+		for skillReward in rewardThresholds do
+			if used < skillReward then
+				unUsedRewards += 1
+			else
+				break
+			end
+		end
+		local usedMax = 99 + (self.targetVersion == "2_6" and 21 or 22) + (self.calcsTab.mainOutput.ExtraPoints or 0) - unUsedRewards
 		local ascMax = 8
 		control.str = string.format("%s%3d / %3d   %s%d / %d", used > usedMax and "^1" or "^7", used, usedMax, ascUsed > ascMax and "^1" or "^7", ascUsed, ascMax)
 		control.req = "Required level: "..m_max(1, (100 + used - usedMax))


### PR DESCRIPTION
Based on the number of skill points used we can determine the characters more approximate level based on thresholds of when skill point rewards are given. 

This make the assumption that all skill books are acquired once the area level that the reward is given in has been reached.
+1 Dweller of Deep                      (lvl 6)
+2 Maroon Mariner                      (lvl 12)
+3 Way Forward                          (lvl 17)
+4 Victario                                   (lvl 25)
+5 Piety's Pets                            (lvl 30)
+6 Indomitable Spirit                  (lvl 35)
+7 In Service to Science             (lvl 41)
+8 Kitava's Torments                  (lvl 44)
+9 Father of War                         (lvl 46)
+10 Cloven One                           (lvl 47)
+11 Puppet Mistress                    (lvl 48)
+12 Mast of Million Faces           (lvl 53)
+13 Queen of Despair                 (lvl 53)
+14 Kishara's Star                       (lvl 54)
+15 Love is Dead                         (lvl 57)
+16 Gemling Legion                    (lvl 57)
+17 Reflection of Terror              (lvl 58)
+18 Queen of Sands                    (lvl 61)
+19 Ruler of Highgate                 (lvl 63)
+20 Vilenta's Vengence              (lvl 66)
+22 Enf to Hunger                       (lvl 67)