### PR TITLE
Allow searching for multiple terms

### DIFF
--- a/Classes/PassiveTreeView.lua
+++ b/Classes/PassiveTreeView.lua
@@ -388,9 +388,7 @@ function PassiveTreeViewClass:Draw(build, viewPort, inputEvents)
 
 	-- Update cached node search data
 	if self.searchStrCached ~= self.searchStr then
-		for nodeId, node in pairs(spec.nodes) do
-			self.searchStrResults[nodeId] = #self.searchStr > 0 and self:DoesNodeMatchSearchStr(node)
-		end
+		self:UpdateSearchCache(spec.nodes)
 		self.searchStrCached = self.searchStr
 	end
 
@@ -661,6 +659,13 @@ function PassiveTreeViewClass:Zoom(level, viewPort)
 	local relY = cursorY - viewPort.y - viewPort.height/2
 	self.zoomX = relX + (self.zoomX - relX) * factor
 	self.zoomY = relY + (self.zoomY - relY) * factor
+end
+
+-- Parse searchStr and update searchStrResults cache
+function PassiveTreeViewClass:UpdateSearchCache(nodes)
+	for nodeId, node in pairs(nodes) do
+		self.searchStrResults[nodeId] = #self.searchStr > 0 and self:DoesNodeMatchSearchStr(node)
+	end
 end
 
 function PassiveTreeViewClass:DoesNodeMatchSearchStr(node)

--- a/Classes/PassiveTreeView.lua
+++ b/Classes/PassiveTreeView.lua
@@ -668,13 +668,13 @@ function PassiveTreeViewClass:UpdateSearchCache(nodes)
 	end
 end
 
-function PassiveTreeViewClass:DoesNodeMatchSearchStr(node)
+function PassiveTreeViewClass:DoesNodeMatchSearchStr(searchTerm, node)
 	if node.type == "ClassStart" or node.type == "Mastery" then
 		return
 	end
 
 	-- Check node name
-	local errMsg, match = PCall(string.match, node.dn:lower(), self.searchStr:lower())
+	local errMsg, match = PCall(string.match, node.dn:lower(), searchTerm:lower())
 	if match then
 		return true
 	end
@@ -682,14 +682,14 @@ function PassiveTreeViewClass:DoesNodeMatchSearchStr(node)
 	-- Check node description
 	for index, line in ipairs(node.sd) do
 		-- Check display text first
-		errMsg, match = PCall(string.match, line:lower(), self.searchStr:lower())
+		errMsg, match = PCall(string.match, line:lower(), searchTerm:lower())
 		if match then
 			return true
 		end
 		if not match and node.mods[index].list then
 			-- Then check modifiers
 			for _, mod in ipairs(node.mods[index].list) do
-				errMsg, match = PCall(string.match, mod.name:lower(), self.searchStr:lower())
+				errMsg, match = PCall(string.match, mod.name:lower(), searchTerm:lower())
 				if match then
 					return true
 				end
@@ -698,7 +698,7 @@ function PassiveTreeViewClass:DoesNodeMatchSearchStr(node)
 	end
 
 	-- Check node type
-	local errMsg, match = PCall(string.match, node.type:lower(), self.searchStr:lower())
+	local errMsg, match = PCall(string.match, node.type:lower(), searchTerm:lower())
 	if match then
 		return true
 	end

--- a/Classes/PassiveTreeView.lua
+++ b/Classes/PassiveTreeView.lua
@@ -689,7 +689,7 @@ function PassiveTreeViewClass:DoesNodeMatchSearchStr(node)
 		if not match and node.mods[index].list then
 			-- Then check modifiers
 			for _, mod in ipairs(node.mods[index].list) do
-				errMsg, match = PCall(string.match, mod.name, self.searchStr)
+				errMsg, match = PCall(string.match, mod.name:lower(), self.searchStr:lower())
 				if match then
 					return true
 				end

--- a/Classes/PassiveTreeView.lua
+++ b/Classes/PassiveTreeView.lua
@@ -548,13 +548,13 @@ function PassiveTreeViewClass:Draw(build, viewPort, inputEvents)
 			for searchIndex=1,self.searchTermsLimit do
 				-- minus one to convert from one-based counting to zero-based
 				if bit.band(self.searchStrResults[nodeId], (2 ^ (searchIndex - 1))) ~= 0 then
-					SetDrawLayer(nil, 30 + searchIndex)
+					SetDrawLayer(nil, 35 - searchIndex)
 					SetDrawColor(
 						self.searchResultColormap[searchIndex].r,
 						self.searchResultColormap[searchIndex].g,
 						self.searchResultColormap[searchIndex].b
 					)
-					local size = (175 + 5 * (searchIndex - 1)) * scale / self.zoom ^ 0.4
+					local size = (175 + 25 * (searchIndex - 1)) * scale / self.zoom ^ 0.4
 					DrawImage(self.highlightRing, scrX - size, scrY - size, size * 2, size * 2)
 				end
 			end

--- a/Classes/PassiveTreeView.lua
+++ b/Classes/PassiveTreeView.lua
@@ -374,10 +374,10 @@ function PassiveTreeViewClass:Draw(build, viewPort, inputEvents)
 
 	-- Update cached node data
 	if self.searchStrCached ~= self.searchStr then
-		self.searchStrCached = self.searchStr
 		for nodeId, node in pairs(spec.nodes) do
 			self.searchStrResults[nodeId] = #self.searchStr > 0 and self:DoesNodeMatchSearchStr(node)
 		end
+		self.searchStrCached = self.searchStr
 	end
 
 	-- Draw the nodes

--- a/Classes/PassiveTreeView.lua
+++ b/Classes/PassiveTreeView.lua
@@ -545,17 +545,19 @@ function PassiveTreeViewClass:Draw(build, viewPort, inputEvents)
 			SetDrawColor(1, 1, 1)
 		end
 		if self.searchStrResults[nodeId] and self.searchStrResults[nodeId] ~= 0 then
+			local searchResultsCounter = 0
 			for searchIndex=1,self.searchTermsLimit do
 				-- minus one to convert from one-based counting to zero-based
 				if bit.band(self.searchStrResults[nodeId], (2 ^ (searchIndex - 1))) ~= 0 then
-					SetDrawLayer(nil, 35 - searchIndex)
+					SetDrawLayer(nil, 35 - searchResultsCounter)
 					SetDrawColor(
 						self.searchResultColormap[searchIndex].r,
 						self.searchResultColormap[searchIndex].g,
 						self.searchResultColormap[searchIndex].b
 					)
-					local size = (175 + 25 * (searchIndex - 1)) * scale / self.zoom ^ 0.4
+					local size = (175 + 25 * (searchResultsCounter)) * scale / self.zoom ^ 0.4
 					DrawImage(self.highlightRing, scrX - size, scrY - size, size * 2, size * 2)
+					searchResultsCounter = searchResultsCounter + 1
 				end
 			end
 		end

--- a/Classes/PassiveTreeView.lua
+++ b/Classes/PassiveTreeView.lua
@@ -386,7 +386,7 @@ function PassiveTreeViewClass:Draw(build, viewPort, inputEvents)
 		build.calcsTab:BuildPower()
 	end
 
-	-- Update cached node data
+	-- Update cached node search data
 	if self.searchStrCached ~= self.searchStr then
 		for nodeId, node in pairs(spec.nodes) do
 			self.searchStrResults[nodeId] = #self.searchStr > 0 and self:DoesNodeMatchSearchStr(node)

--- a/Classes/PassiveTreeView.lua
+++ b/Classes/PassiveTreeView.lua
@@ -57,6 +57,20 @@ local PassiveTreeViewClass = newClass("PassiveTreeView", function(self)
 	self.searchStr = ""
 	self.searchStrCached = ""
 	self.searchStrResults = {}
+	self.searchResultColormap = {
+		-- Color list generated from Google's FOSS colormap, 'Turbo':
+		{r = 0.941, g = 0.356, b = 0.070},
+		{r = 0.996, g = 0.643, b = 0.192},
+		{r = 0.883, g = 0.866, b = 0.217},
+		{r = 0.644, g = 0.990, b = 0.234},
+		{r = 0.276, g = 0.971, b = 0.517},
+		{r = 0.098, g = 0.837, b = 0.803},
+		{r = 0.244, g = 0.609, b = 0.997},
+		{r = 0.270, g = 0.349, b = 0.796},
+	}
+	self.searchTermsLimit = #self.searchResultColormap
+	self.searchTermSentinal = "|"
+
 	self.showStatDifferences = true
 end)
 


### PR DESCRIPTION
This pull request mirrors https://github.com/Openarl/PathOfBuilding/pull/1853. There's been no feedback there, so I thought I'd try here.

---

This series of commits allow the search bar to handle multiple search terms. When the user searches with the string, `bleed|frenzy`, nodes that contain text with either `bleed` or `frenzy` will be highlighted. In other words, this change allows searching the [union](https://en.wikipedia.org/wiki/Union_(set_theory)) of each term. This is a change from the previous functionality of **PoB** searching only for the entire search string, including any whitespace. For comparison, the game allows whitespace to separate search terms and performs a search of the [intersection](https://en.wikipedia.org/wiki/Intersection_(set_theory)) of each term.

There are ***two*** big changes that should be considered before accepting this pull request.

---

#### 1. The search cache has been changed from a table of booleans to a table of bitmaps (integers)
I don't know how this will work with the current serialization method. From reading the code, it looks like only `searchStr`, not `searchStrResults`, is serialized and saved, but I may be misunderstanding something. My testing did not show any issues.

---

#### 2. Users can no longer search for `|` (the pipe symbol)
I don't think this will affect anyone.

---

Some other comments:
- https://github.com/LocalIdentity/PathOfBuilding/commit/ebc599699c445860232d4229c60dbc14b3a92a3e This commit may need to be reverted. I wasn't sure why the search term was case-sensitive for this comparison.
- The search is currently limited to just eight terms. Additional terms will be ignored.

Thank you for any feedback.