### PR TITLE
Fixed Cast On Critical Strike support quality stat not included in damage calculations

### DIFF
--- a/Data/3_0/SkillStatMap.lua
+++ b/Data/3_0/SkillStatMap.lua
@@ -363,6 +363,12 @@ return {
 ["critical_strike_chance_+%"] = {
 	mod("CritChance", "INC", nil),
 },
+["spell_critical_strike_chance_+%"] = {
+	mod("CritChance", "INC", nil, ModFlag.Spell),
+},
+["attack_critical_strike_chance_+%"] = {
+	mod("CritChance", "INC", nil, ModFlag.Attack),
+},
 ["base_critical_strike_multiplier_+"] = {
 	mod("CritMultiplier", "BASE", nil),
 },


### PR DESCRIPTION
Adding missing mods in skillstatmap. Tested in-game with zealotry which shares the same mod, but as an aura effect instead. The interaction is working as expected.

Fixes https://github.com/Openarl/PathOfBuilding/issues/1856