### PR TITLE
Consolidate resistances into single line in sidebar

### DIFF
--- a/Modules/Build.lua
+++ b/Modules/Build.lua
@@ -312,15 +312,10 @@ function buildMode:Init(dbFileName, buildName, buildXML, targetVersion)
 		{ stat = "AttackDodgeChance", label = "Attack Dodge Chance", fmt = "d%%" },
 		{ stat = "SpellDodgeChance", label = "Spell Dodge Chance", fmt = "d%%" },
 		{ },
-		{ stat = "FireResist", label = "Fire Resistance", fmt = "d%%", color = colorCodes.FIRE, condFunc = function() return true end },
-		{ stat = "ColdResist", label = "Cold Resistance", fmt = "d%%", color = colorCodes.COLD, condFunc = function() return true end },
-		{ stat = "LightningResist", label = "Lightning Resistance", fmt = "d%%", color = colorCodes.LIGHTNING, condFunc = function() return true end },
-		{ stat = "ChaosResist", label = "Chaos Resistance", fmt = "d%%", color = colorCodes.CHAOS, condFunc = function() return true end },
-		{ },
-		{ stat = "FireResistOverCap", label = "Fire Res. Over Max", fmt = "d%%", color = colorCodes.FIRE },
-		{ stat = "ColdResistOverCap", label = "Cold Res. Over Max", fmt = "d%%", color = colorCodes.COLD },
-		{ stat = "LightningResistOverCap", label = "Lightning Res. Over Max", fmt = "d%%", color = colorCodes.LIGHTNING },
-		{ stat = "ChaosResistOverCap", label = "Chaos Res. Over Max", fmt = "d%%", color = colorCodes.CHAOS },
+		{ stat = "FireResist", label = "Fire Resistance", fmt = "d%%", color = colorCodes.FIRE, condFunc = function() return true end, resistOverCapStat = "FireResistOverCap"},
+		{ stat = "ColdResist", label = "Cold Resistance", fmt = "d%%", color = colorCodes.COLD, condFunc = function() return true end, resistOverCapStat = "ColdResistOverCap" },
+		{ stat = "LightningResist", label = "Lightning Resistance", fmt = "d%%", color = colorCodes.LIGHTNING, condFunc = function() return true end, resistOverCapStat = "LightningResistOverCap" },
+		{ stat = "ChaosResist", label = "Chaos Resistance", fmt = "d%%", color = colorCodes.CHAOS, condFunc = function() return true end, resistOverCapStat = "ChaosResistOverCap" },
 	}
 	self.minionDisplayStats = {
 		{ stat = "AverageDamage", label = "Average Damage", fmt = ".1f", compPercent = true },
@@ -1129,17 +1124,24 @@ function buildMode:AddDisplayStatList(statList, actor)
 	local statBoxList = self.controls.statBox.list
 	for index, statData in ipairs(statList) do
 		if statData.stat then
-			if not statData.flag or actor.mainSkill.skillFlags[statData.flag] then 
+			if not statData.flag or actor.mainSkill.skillFlags[statData.flag] then
 				local statVal = actor.output[statData.stat]
 				if statVal and ((statData.condFunc and statData.condFunc(statVal,actor.output)) or (not statData.condFunc and statVal ~= 0)) then
 					local labelColor = "^7"
 					if statData.color then
 						labelColor = statData.color
 					end
+					local resistOverCapStatLabel = ""
+					if (statData.resistOverCapStat) then
+						local resistOverCapStatVal = actor.output[statData.resistOverCapStat]
+						if (resistOverCapStatVal) then
+							resistOverCapStatLabel = " ^7(+"..self:FormatStat(statData, resistOverCapStatVal).."^7)"
+						end
+					end
 					t_insert(statBoxList, {
 						height = 16,
 						labelColor..statData.label..":",
-						self:FormatStat(statData, statVal),
+						self:FormatStat(statData, statVal).. resistOverCapStatLabel,
 					})
 				end
 			end

--- a/Modules/Build.lua
+++ b/Modules/Build.lua
@@ -1141,7 +1141,7 @@ function buildMode:AddDisplayStatList(statList, actor)
 					t_insert(statBoxList, {
 						height = 16,
 						labelColor..statData.label..":",
-						self:FormatStat(statData, statVal).. resistOverCapStatLabel,
+						self:FormatStat(statData, statVal)..resistOverCapStatLabel,
 					})
 				end
 			end


### PR DESCRIPTION
Moves the resistances over max next to their prospective resistances in the left pane.
Removes old labels for resistances over max