### PR TITLE
Fixes Item Parsing For Explicits That Contain ":"

### DIFF
--- a/Classes/Item.lua
+++ b/Classes/Item.lua
@@ -292,6 +292,9 @@ function ItemClass:ParseRaw(raw)
 						self.baseName = "Two-Toned Boots (Evasion/Energy Shield)"
 						self.base = verData.itemBases[self.baseName]
 					end
+				else
+					foundExplicit = true
+					gameModeStage = "EXPLICIT"
 				end
 			end
 			if line == "Prefixes:" then


### PR DESCRIPTION
ParseRaw was failing to flag certain mods as EXPLICIT when they contained a ":" character such as Pure Talent jewel.  Looks like this fix was the last piece for supporting the mods on Pure Talent.

<img width="546" alt="pure_talent" src="https://user-images.githubusercontent.com/61510438/75414823-6dc0c780-58ef-11ea-891b-29a3ba60a8b8.png">
<img width="749" alt="quickening_covenant_jewel_fixed" src="https://user-images.githubusercontent.com/61510438/75414842-75806c00-58ef-11ea-9430-ccd5be4640f8.png">
