### PR TITLE
Unencumbered Implementation

### DIFF
--- a/Modules/CalcPerform.lua
+++ b/Modules/CalcPerform.lua
@@ -70,6 +70,9 @@ local function doActorAttribsPoolsConditions(env, actor)
 	end
 	if actor.weaponData1.type == "None" then
 		condList["Unarmed"] = true
+		if not actor.itemList["Weapon 2"] and not actor.itemList["Gloves"] then
+			condList["Unencumbered"] = true
+		end
 	else
 		local info = env.data.weaponTypeInfo[actor.weaponData1.type]
 		condList["Using"..info.flag] = true
@@ -1071,6 +1074,9 @@ function calcs.perform(env)
 	if modDB:Flag(nil, "DisableWeapons") then
 		env.player.weaponData1 = copyTable(env.data.unarmedWeaponData[env.classId])
 		modDB.conditions["Unarmed"] = true
+		if not env.player.Gloves or env.player.Gloves == None then
+			modDB.conditions["Unencumbered"] = true
+		end
 	elseif env.weaponModList1 then
 		modDB:AddList(env.weaponModList1)
 	end

--- a/Modules/ModParser-3_0.lua
+++ b/Modules/ModParser-3_0.lua
@@ -1778,6 +1778,7 @@ local specialModList = {
 	["nearby enemies have (%-%d+)%% to fire resistance"] = function(num) return { mod("EnemyModifier", "LIST", { mod = mod("FireResist", "BASE", num) }) } end,
 	["nearby enemies have (%-%d+)%% to lightning resistance"] = function(num) return { mod("EnemyModifier", "LIST", { mod = mod("LightningResist", "BASE", num) }) } end,
 	["nearby enemies take (%d+)%% increased physical damage"] = function(num) return { mod("EnemyModifier", "LIST", { mod = mod("PhysicalDamageTaken", "INC", num) }) } end,
+	["you count as dual wielding while you are unencumbered"] = { flag("Condition:DualWielding", { type = "Condition", var = "Unencumbered" }) },
 	-- Skill-specific enchantment modifiers
 	["(%d+)%% increased decoy totem life"] = function(num) return { mod("TotemLife", "INC", num, { type = "SkillName", skillName = "Decoy Totem" }) } end,
 	["(%d+)%% increased ice spear critical strike chance in second form"] = function(num) return { mod("CritChance", "INC", num, { type = "SkillName", skillName = "Ice Spear" }, { type = "SkillPart", skillPart = 2 }) } end,

--- a/Modules/ModParser-3_0.lua
+++ b/Modules/ModParser-3_0.lua
@@ -823,6 +823,7 @@ local modTagList = {
 	["while wielding a two handed weapon"] = { tag = { type = "Condition", var = "UsingTwoHandedWeapon" } },
 	["while wielding a wand"] = { tag = { type = "Condition", var = "UsingWand" } },
 	["while unarmed"] = { tag = { type = "Condition", var = "Unarmed" } },
+	["while you are unencumbered"] = { tag = { type = "Condition", var = "Unencumbered" } },
 	["with a normal item equipped"] = { tag = { type = "MultiplierThreshold", var = "NormalItem", threshold = 1 } },
 	["with a magic item equipped"] = { tag = { type = "MultiplierThreshold", var = "MagicItem", threshold = 1 } },
 	["with a rare item equipped"] = { tag = { type = "MultiplierThreshold", var = "RareItem", threshold = 1 } },


### PR DESCRIPTION
Added 'Unencumbered' condition and auto-setting it based on weapons/gloves; implemented parsing of 'while you are Unencumbered' for items.

To test you can create a Unique Jewel with:
```
Hollow Palm Simulator
Cobalt Jewel
LevelReq: 1
Implicits: 0
You count as Dual Wielding while you are Unencumbered
Adds 14 to 20 Physical Damage per 10 Dexterity while you are Unencumbered
60% more attack speed while you are Unencumbered
```

Add put it in a Jewel Socket and compare DPS when random gloves or weapons are included and removed. Also, in Dev Console you can see the Condition being present or not.

GGG stated that while weapons are Disabled per Dancing Dervish Unique Item special condition as long as you don't have gloves equipped you will also be considered Unencumbered.

UPDATE: Commit 2 - you can also test any tree nodes that give attack speed while Dual Wielding to test first affix of the above jewel as working.