### PR TITLE
Add Perfidy and support for its mods

### DIFF
--- a/Data/New.lua
+++ b/Data/New.lua
@@ -4,7 +4,17 @@
 
 data.uniques.new = {
 -- New
-
+[[
+Perfidy
+Glorious Plate
+Requires Level 68, 191 Str
+25% increased Melee Damage
++74 to maximum Life
+You can have two different Banners at the same time
+Banners you are carrying gain 1 Stage on Melee Hit, up to 5 per second
+War Banner has 147% increased Adrenaline duration
+Dread Banner has 141% increased Fortify duration
+]],
 
 
 -- Reworked

--- a/Modules/ModParser-3_0.lua
+++ b/Modules/ModParser-3_0.lua
@@ -357,6 +357,7 @@ local modNameList = {
 	-- Buffs
 	["onslaught effect"] = "OnslaughtEffect",
 	["fortify duration"] = "FortifyDuration",
+	["adrenaline duration"] = "AdrenalineDuration",
 	["effect of fortify on you"] = "FortifyEffectOnSelf",
 	["effect of tailwind on you"] = "TailwindEffectOnSelf",
 	["elusive effect"] = "ElusiveEffect",
@@ -1797,6 +1798,7 @@ local specialModList = {
 	["socketed lightning spells [hd][ae][va][el] (%d+)%% increased spell damage if triggered"] = { },
 	["manifeste?d? dancing dervish disables both weapon slots"] = { },
 	["manifeste?d? dancing dervish dies when rampage ends"] = { },
+	["you can have two different banners at the same time"] = { },
 }
 local keystoneList = {
 	-- List of keystones that can be found on uniques


### PR DESCRIPTION
Adds support for "increased Adrenaline duration". "increased Fortify duration" is already supported, but both are not shown anywhere as they are not that interesting for build planning. Also adds a display-only modifier for "You can have two different Banners at the same time". Currently, there are no checks in place to limit banners to one without this item. So I think that superficial support of this mod is less confusing to players than it being unsupported but them still able to have two banners active at the same time.
Related issue to resolve this: #280 
Close #273 
