### PR TITLE
Support Burning Arrow Debuff

### DIFF
--- a/Data/3_0/Skills/act_dex.lua
+++ b/Data/3_0/Skills/act_dex.lua
@@ -1157,7 +1157,7 @@ skills["BurningArrow"] = {
 		}
 	},
 	preDotFunc = function(activeSkill, output)
-		local effect = activeSkill.skillModList:Sum("BASE", activeSkill,skillCfg, "DebuffEffect") * (1 + activeSkill.skillModList:Sum("INC", activeSkill.skillCfg, "DebuffEffect") / 100)
+		local effect = activeSkill.skillModList:Sum("BASE", activeSkill.skillCfg, "DebuffEffect") * (1 + activeSkill.skillModList:Sum("INC", activeSkill.skillCfg, "DebuffEffect") / 100)
 		local debuff = (output.IgniteDPS or 0) * effect
 		if activeSkill.skillPart == 1 then
 			output.FireDot = debuff

--- a/Data/3_0/Skills/act_dex.lua
+++ b/Data/3_0/Skills/act_dex.lua
@@ -1142,11 +1142,36 @@ skills["BurningArrow"] = {
 	},
 	statDescriptionScope = "debuff_skill_stat_descriptions",
 	castTime = 1,
+	parts = {
+		{
+			name = "1 Stack",
+		},
+		{
+			name = "5 Stacks",
+		},
+	},
+	statMap = {
+		["base_additional_burning_debuff_%_of_ignite_damage"] = {
+			mod("DebuffEffect", "BASE", nil),
+			div = 100
+		}
+	},
+	preDotFunc = function(activeSkill, output)
+		local effect = activeSkill.skillModList:Sum("BASE", activeSkill,skillCfg, "DebuffEffect") * (1 + activeSkill.skillModList:Sum("INC", activeSkill.skillCfg, "DebuffEffect") / 100)
+		local debuff = (output.IgniteDPS or 0) * effect
+		if activeSkill.skillPart == 1 then
+			output.FireDot = debuff
+		end
+		if activeSkill.skillPart == 2 then
+			output.FireDot = 5 * debuff
+		end
+	end,
 	baseFlags = {
 		attack = true,
 		projectile = true,
 	},
 	baseMods = {
+		skill("skillIsDot", true),
 	},
 	qualityStats = {
 		{ "fire_dot_multiplier_+", 0.5 },

--- a/Data/3_0/Skills/act_dex.lua
+++ b/Data/3_0/Skills/act_dex.lua
@@ -1171,7 +1171,6 @@ skills["BurningArrow"] = {
 		projectile = true,
 	},
 	baseMods = {
-		skill("skillIsDot", true),
 	},
 	qualityStats = {
 		{ "fire_dot_multiplier_+", 0.5 },

--- a/Export/Skills/act_dex.txt
+++ b/Export/Skills/act_dex.txt
@@ -229,6 +229,31 @@ local skills, mod, flag, skill = ...
 
 #skill BurningArrow
 #flags attack projectile
+	parts = {
+		{
+			name = "1 Stack",
+		},
+		{
+			name = "5 Stacks",
+		},
+	},
+	statMap = {
+		["base_additional_burning_debuff_%_of_ignite_damage"] = {
+			mod("DebuffEffect", "BASE", nil),
+			div = 100
+		}
+	},
+	preDotFunc = function(activeSkill, output)
+		local effect = activeSkill.skillModList:Sum("BASE", activeSkill,skillCfg, "DebuffEffect") * (1 + activeSkill.skillModList:Sum("INC", activeSkill.skillCfg, "DebuffEffect") / 100)
+		local debuff = (output.IgniteDPS or 0) * effect
+		if activeSkill.skillPart == 1 then
+			output.FireDot = debuff
+		end
+		if activeSkill.skillPart == 2 then
+			output.FireDot = 5 * debuff
+		end
+	end,
+#baseMod skill("skillIsDot", true)
 #mods
 
 #skill VaalBurningArrow

--- a/Export/Skills/act_dex.txt
+++ b/Export/Skills/act_dex.txt
@@ -253,7 +253,6 @@ local skills, mod, flag, skill = ...
 			output.FireDot = 5 * debuff
 		end
 	end,
-#baseMod skill("skillIsDot", true)
 #mods
 
 #skill VaalBurningArrow

--- a/Export/Skills/act_dex.txt
+++ b/Export/Skills/act_dex.txt
@@ -244,7 +244,7 @@ local skills, mod, flag, skill = ...
 		}
 	},
 	preDotFunc = function(activeSkill, output)
-		local effect = activeSkill.skillModList:Sum("BASE", activeSkill,skillCfg, "DebuffEffect") * (1 + activeSkill.skillModList:Sum("INC", activeSkill.skillCfg, "DebuffEffect") / 100)
+		local effect = activeSkill.skillModList:Sum("BASE", activeSkill.skillCfg, "DebuffEffect") * (1 + activeSkill.skillModList:Sum("INC", activeSkill.skillCfg, "DebuffEffect") / 100)
 		local debuff = (output.IgniteDPS or 0) * effect
 		if activeSkill.skillPart == 1 then
 			output.FireDot = debuff

--- a/Modules/CalcOffence-3_0.lua
+++ b/Modules/CalcOffence-3_0.lua
@@ -1841,7 +1841,7 @@ function calcs.offence(env, actor, activeSkill, skillLookupOnly)
 		else
 			baseVal = 0
 		end
-		if baseVal > 0 then
+		if baseVal > 0 or (output[damageType.."Dot"] or 0) > 0 then
 			skillFlags.dot = true
 			local effMult = 1
 			if env.mode_effective then

--- a/Modules/CalcOffence-3_0.lua
+++ b/Modules/CalcOffence-3_0.lua
@@ -3075,14 +3075,12 @@ function calcs.offence(env, actor, activeSkill, skillLookupOnly)
 			local inc = skillModList:Sum("INC", dotTypeCfg, "Damage", damageType.."Damage", isElemental[damageType] and "ElementalDamage" or nil)
 			local more = round(skillModList:More(dotTypeCfg, "Damage", damageType.."Damage", isElemental[damageType] and "ElementalDamage" or nil), 2)
 			local mult = skillModList:Sum("BASE", dotTypeCfg, "DotMultiplier", damageType.."DotMultiplier")
-			local total = baseVal * (1 + inc/100) * more * (1 + mult/100) * effMult
-			if activeSkill.skillTypes[SkillType.Aura] then
-				total = total * calcLib.mod(skillModList, dotTypeCfg, "AuraEffect")
-			end
+			local aura = activeSkill.skillTypes[SkillType.Aura] and calcLib.mod(skillModList, dotTypeCfg, "AuraEffect")
+			local total = baseVal * (1 + inc/100) * more * (1 + mult/100) * (aura or 1) * effMult
 			output.TotalDot = output.TotalDot + total + (output[damageType.."Dot"] or 0)
 			if breakdown then
 				breakdown[damageType.."Dot"] = { }
-				breakdown.dot(breakdown[damageType.."Dot"], baseVal, inc, more, mult, nil, effMult, total)
+				breakdown.dot(breakdown[damageType.."Dot"], baseVal, inc, more, mult, nil, aura, effMult, total)
 			end
 		end
 	end

--- a/Modules/ModParser-3_0.lua
+++ b/Modules/ModParser-3_0.lua
@@ -2281,6 +2281,7 @@ local specialModList = {
 	["lightning trap pierces (%d) additional targets?"] = function(num) return { mod("PierceCount", "BASE", num, { type = "SkillName", skillName = "Lightning Trap" }) } end,
 	["enemies affected by bear trap take (%d+)%% increased damage from trap or mine hits"] = function(num) return { mod("ExtraSkillMod", "LIST", { mod = mod("TrapMineDamageTaken", "INC", num, { type = "GlobalEffect", effectType = "Debuff" }) }, { type = "SkillName", skillName = "Bear Trap" }) } end,
 	["blade vortex has %+(%d+)%% to critical strike multiplier for each blade"] = function(num) return { mod("CritMultiplier", "BASE", num, { type = "Multiplier", var = "BladeVortexBlade" }, { type = "SkillName", skillName = "Blade Vortex" }) } end,
+	["burning arrow has (%d+)%% increased debuff effect"] = function(num) return { mod("DebuffEffect", "INC", num, { type = "SkillName", skillName = "Burning Arrow"}) } end,
 	["double strike has a (%d+)%% chance to deal double damage to bleeding enemies"] = function(num) return { mod("DoubleDamageChance", "BASE", num, { type = "ActorCondition", actor = "enemy", var = "Bleeding" }, { type = "SkillName", skillName = "Double Strike" }) } end,
 	["ethereal knives pierces an additional target"] = { mod("PierceCount", "BASE", 1, { type = "SkillName", skillName = "Ethereal Knives" }) },
 	["frost bomb has (%d+)%% increased debuff duration"] = function(num) return { mod("SecondaryDuration", "INC", num, { type = "SkillName", skillName = "Frost Bomb" }) } end,


### PR DESCRIPTION
- Adds support for Burning Arrow's stacking Fire DoT debuff
- Uses SkillParts to switch between 1 and 5 stages
- Supports the helmet enchantment for debuff effect

------------

Note: getting this working also involved moving around and adding some things in CalcOffence. I had to move the DoT calculations to be below the Ignite calculations and add a new "preDotFunc" function, both of which were so it could check Ignite DPS for the debuff damage. I also needed to make it so that if a skill has an existing DoT output before the DoT calculations, it would go through the DoT calculations section and give a Total DoT output, so that the debuff damage will actually be displayed in the sidebar and calcs page. 

According to my testing with other Ignite builds, Chaos DoT builds, a Bleed build, and a Poison build, all of the DoT calculations are unaffected by the changes I made. I didn't encounter any errors while changing calculation modes, adding supports, equipping items, or checking nodes on the passive tree. Inspection of CalcOffence also shows that there shouldn't be any issues with the changes I did. But hopefully if I missed something, any errors will be caught if this is committed to the dev branch and tested there for a bit before being used on the master branch.