### PR TITLE
Fix buffs from skills used by minions

### DIFF
--- a/Classes/ConfigTab.lua
+++ b/Classes/ConfigTab.lua
@@ -177,6 +177,15 @@ local ConfigTabClass = newClass("ConfigTab", "UndoHandler", "ControlHost", "Cont
 					return self.build.calcsTab.mainEnv.player.mainSkill.skillFlags[varData.ifFlag] -- O_O
 				end
 				control.tooltipText = varData.tooltip
+			elseif varData.ifSkillFlag then
+				control.shown = function()
+					for _, skill in ipairs(self.build.calcsTab.mainEnv.player.activeSkillList) do
+						if skill.skillFlags[varData.ifSkillFlag] then
+							return true
+						end
+					end
+				end
+				control.tooltipText = varData.tooltip
 			elseif varData.ifSkill or varData.ifSkillList then
 				control.shown = function()
 					if varData.ifSkillList then

--- a/Modules/ConfigOptions.lua
+++ b/Modules/ConfigOptions.lua
@@ -133,6 +133,9 @@ return {
 	{ var = "innervateInnervation", type = "check", label = "Is Innervation active?", ifSkill = "Innervate", apply = function(val, modList, enemyModList)
 		modList:NewMod("Condition:InnervationActive", "FLAG", true, "Config")
 	end },
+	{ var = "innervateMinionInnervation", type = "check", label = "Is Minion Innervation active?", ifSkill = "Innervate", apply = function(val, modList, enemyModList)
+		modList:NewMod("MinionModifier", "LIST", { mod = modLib.createMod("Condition:InnervationActive", "FLAG", true) }, "Config")
+	end },
 	{ label = "Intensify:", ifSkill = "Intensify" },
 	{ var = "intensifyIntensity", type = "count", label = "# of Intensity:", ifSkill = "Intensify", apply = function(val, modList, enemyModList)
 		modList:NewMod("Multiplier:Intensity", "BASE", val, "Config")
@@ -188,6 +191,10 @@ return {
 	{ label = "Summon Lightning Golem:", ifSkill = "Summon Lightning Golem" },
 	{ var = "summonLightningGolemEnableWrath", type = "check", label = "Enable Wrath Aura:", ifSkill = "Summon Lightning Golem", apply = function(val, modList, enemyModList)
 		modList:NewMod("SkillData", "LIST", { key = "enable", value = true }, "Config", { type = "SkillId", skillId = "LightningGolemWrath" })
+	end },
+	{ label = "Minion Skills:", ifSkillFlag = "minion" },
+	{ var = "minionEnableBuffs", type = "check", label = "Enable Buffs:", ifSkillFlag = "minion", tooltip = "Enables Buffs from Skills of your Minions.", apply = function(val, modList, enemyModList)
+		modList:NewMod("SkillData", "LIST", { key = "enable", value = true }, "Config", { type = "SkillType", skillType = SkillType.Minion })
 	end },
 	{ label = "Vortex:", ifSkill = "Vortex" },
 	{ var = "vortexCastOnFrostbolt", type = "check", label = "Cast on Frostbolt?", ifSkill = "Vortex", apply = function(val, modList, enemyModList)


### PR DESCRIPTION
This mostly fixes the calculation of buffs and auras minions can grant by using their skills. I've tried to refactor the code to make it less hacky but it turns out the `skillData.enable` property was there for a reason. Currently (whether that's intended or not) minion's skills don't inherit mods (or at least conditions) from the global scope and possibly other scopes as well. They do however work with supports.
I'm not sure how the configuration options should look like. I've decided that the option to enable all buffs doesn't work with buffs inherently granted by a skill as there are options for that already. This setting also enables some weird interactions like the possibility for zombies to gain Arcane Surge.
The whole functionality is a bit weird because the are many more possible cases than actually exist in the game.

Fixes #298, fixes #254, fixes #636, fixes #673, fixes #674 