### PR TITLE
Support Infernal Blow

### DIFF
--- a/Data/3_0/Skills/act_str.lua
+++ b/Data/3_0/Skills/act_str.lua
@@ -3557,6 +3557,9 @@ skills["InfernalBlow"] = {
 		if activeSkill.skillPart == 2 or activeSkill.skillPart == 3 then
 			activeSkill.skillModList:NewMod("Damage", "MORE", effect, "Skill:InfernalBlow", 0, { type = "Multiplier", var = "DebuffStack", base = -100 + effect })
 		end
+		if activeSkill.skillPart == 3 then
+			activeSkill.skillData.dpsMultiplier = 1 / 6
+		end
 	end,
 	baseFlags = {
 		attack = true,

--- a/Data/3_0/Skills/act_str.lua
+++ b/Data/3_0/Skills/act_str.lua
@@ -3533,12 +3533,40 @@ skills["InfernalBlow"] = {
 	},
 	statDescriptionScope = "debuff_skill_stat_descriptions",
 	castTime = 1,
+	statMap = {
+		["infernal_blow_explosion_damage_%_of_total_per_stack"] = {
+			mod("DebuffEffect", "BASE", nil)
+		}
+	},
+	parts = {
+		{
+			name = "Melee Hit",
+			area = false
+		},
+		{
+			name = "Debuff Explosion - 1 Stack",
+			area = true
+		},
+		{
+			name = "Debuff Explosion - 6 Stacks",
+			area = true
+		},
+	},
+	preDamageFunc = function(activeSkill, output)
+		local effect = activeSkill.skillModList:Sum("BASE", activeSkill.skillCfg, "DebuffEffect")
+		if activeSkill.skillPart == 2 or activeSkill.skillPart == 3 then
+			activeSkill.skillModList:NewMod("Damage", "MORE", effect, "Skill:InfernalBlow", 0, { type = "Multiplier", var = "DebuffStack", base = -100 + effect })
+		end
+	end,
 	baseFlags = {
 		attack = true,
 		melee = true,
+		duration = true,
 	},
 	baseMods = {
 		skill("radius", 15),
+		skill("showAverage", true, { type = "SkillPart", skillPart = 2 }),
+		mod("Multiplier:DebuffStack", "BASE", 5, 0, 0, { type = "SkillPart", skillPart = 3 }),
 	},
 	qualityStats = {
 		Default = {

--- a/Export/Skills/act_str.txt
+++ b/Export/Skills/act_str.txt
@@ -586,8 +586,35 @@ local skills, mod, flag, skill = ...
 #mods
 
 #skill InfernalBlow
-#flags attack melee
+#flags attack melee duration
+	statMap = {
+		["infernal_blow_explosion_damage_%_of_total_per_stack"] = {
+			mod("DebuffEffect", "BASE", nil)
+		}
+	},
+	parts = {
+		{
+			name = "Melee Hit",
+			area = false
+		},
+		{
+			name = "Debuff Explosion - 1 Stack",
+			area = true
+		},
+		{
+			name = "Debuff Explosion - 6 Stacks",
+			area = true
+		},
+	},
+	preDamageFunc = function(activeSkill, output)
+		local effect = activeSkill.skillModList:Sum("BASE", activeSkill.skillCfg, "DebuffEffect")
+		if activeSkill.skillPart == 2 or activeSkill.skillPart == 3 then
+			activeSkill.skillModList:NewMod("Damage", "MORE", effect, "Skill:InfernalBlow", 0, { type = "Multiplier", var = "DebuffStack", base = -100 + effect })
+		end
+	end,
 #baseMod skill("radius", 15)
+#baseMod skill("showAverage", true, { type = "SkillPart", skillPart = 2 })
+#baseMod mod("Multiplier:DebuffStack", "BASE", 5, 0, 0, { type = "SkillPart", skillPart = 3 })
 #mods
 
 #skill IntimidatingCry

--- a/Export/Skills/act_str.txt
+++ b/Export/Skills/act_str.txt
@@ -611,6 +611,9 @@ local skills, mod, flag, skill = ...
 		if activeSkill.skillPart == 2 or activeSkill.skillPart == 3 then
 			activeSkill.skillModList:NewMod("Damage", "MORE", effect, "Skill:InfernalBlow", 0, { type = "Multiplier", var = "DebuffStack", base = -100 + effect })
 		end
+		if activeSkill.skillPart == 3 then
+			activeSkill.skillData.dpsMultiplier = 1 / 6
+		end
 	end,
 #baseMod skill("radius", 15)
 #baseMod skill("showAverage", true, { type = "SkillPart", skillPart = 2 })

--- a/Modules/ModParser-3_0.lua
+++ b/Modules/ModParser-3_0.lua
@@ -2540,6 +2540,7 @@ local specialModList = {
 	["grants %+(%d+)%% to fire resistance per (%d+)%% quality"] = function(num, _, div) return { mod("FireResist", "BASE", num, { type = "Multiplier", var = "QualityOn{SlotName}", div = tonumber(div) }) } end,
 	["grants %+(%d+)%% to cold resistance per (%d+)%% quality"] = function(num, _, div) return { mod("ColdResist", "BASE", num, { type = "Multiplier", var = "QualityOn{SlotName}", div = tonumber(div) }) } end,
 	["grants %+(%d+)%% to lightning resistance per (%d+)%% quality"] = function(num, _, div) return { mod("LightningResist", "BASE", num, { type = "Multiplier", var = "QualityOn{SlotName}", div = tonumber(div) }) } end,
+	["infernal blow debuff deals an additional (%d+)%% of damage per charge"] = function(num) return { mod("DebuffEffect", "BASE", num, { type = "SkillName", skillName = "Infernal Blow"}) } end,
 	-- Display-only modifiers
 	["extra gore"] = { },
 	["prefixes:"] = { },


### PR DESCRIPTION
- Supports the debuff stacks of Infernal Blow, using SkillParts
- Supports the helmet enchantment that makes the debuff deal a higher % of damage

-----------

Currently I have it set up that the stack SkillParts are only calculating the damage of stack explosions. My question is, should that be the case? Which of these options sounds best for the 6 stacks explosion:

1. Show the DPS of 6 stacks explosion and does not count the melee DPS (this is the current implementation)
2. Show the average damage of the 6 stacks explosion
3. Shows the combined DPS of 6 Stacks explosion + Melee

Also, should there even be a part for the 1 stack explosion? I figure it would be useful to know how much damage it's dealing so it's easy to optimize this explosion for the largest hits possible for clear speed. But it also might not be super useful. I'm curious to hear opinions on these things!

Closes #1115 