### PR TITLE
Exposure should only be applied once

### DIFF
--- a/Export/Skills/act_int.txt
+++ b/Export/Skills/act_int.txt
@@ -556,7 +556,7 @@ local skills, mod, flag, skill = ...
 #flags spell area duration
 	statMap = {
 		["base_cold_damage_resistance_%"] = {
-			mod("ColdResist", "BASE", nil, 0, 0, { type = "GlobalEffect", effectType = "Debuff" }),
+			mod("ColdResist", "BASE", nil, 0, 0, { type = "GlobalEffect", effectType = "Debuff", effectName = "Cold Exposure" }),
 		},
 		["energy_shield_recharge_rate_+%"] = {
 			mod("EnergyShieldRecharge", "INC", nil, 0, 0, { type = "GlobalEffect", effectType = "Debuff" }),

--- a/Modules/ModTools.lua
+++ b/Modules/ModTools.lua
@@ -59,9 +59,6 @@ function modLib.compareModParams(modA, modB)
 		if tag.type ~= modB[i].type then
 			return false
 		end
-		if modLib.formatTag(tag) ~= modLib.formatTag(modB[i]) then
-			return false
-		end
 	end
 	return true
 end


### PR DESCRIPTION
**This is not meant to be merged in yet**, it's just to allow other people to help test.

By removing the comparison of formatTag, and making sure exposures share the same name we can fix the issue where exposures were being applied multiple times.

This only fixes Cold Exposure for Frost Bomb + Wave of Conviction combo just to prove the point, I will update with other exposure sources in near future

## Testing

For testing I've personally used Frost Bomb + Wave of Conviction. Remember to set Wave of Conviction's exposure type to Cold in config. Also export of act_int is required, or manual adjustement.