### PR TITLE
Affected by guard skill

### DIFF
--- a/Modules/ConfigOptions.lua
+++ b/Modules/ConfigOptions.lua
@@ -524,6 +524,9 @@ return {
 	{ var = "conditionCritWithHeraldSkillRecently", type = "check", label = "Have your Herald Skills Crit Recently?", ifCond = "CritWithHeraldSkillRecently", implyCond = "SkillCritRecently", tooltip = "This also implies that your Skills have Crit Recently.", apply = function(val, modList, enemyModList)
 		modList:NewMod("Condition:CritWithHeraldSkillRecently", "FLAG", true, "Config", { type = "Condition", var = "Combat" })
 	end },
+	{ var = "AffectedByAGuardSkill", type = "check", label = "Are you Affected by a guard skill?", ifCond = "AffectedByAGuardSkill", apply = function(val, modList, enemyModList)
+		modList:NewMod("Condition:AffectedByAGuardSkill", "FLAG", true, "Config", { type = "Condition", var = "Combat" })
+	end },
 	{ var = "conditionNonCritRecently", type = "check", label = "Have you dealt a Non-Crit Recently?", ifCond = "NonCritRecently", apply = function(val, modList, enemyModList)
 		modList:NewMod("Condition:NonCritRecently", "FLAG", true, "Config", { type = "Condition", var = "Combat" })
 	end },

--- a/Modules/ModParser-3_0.lua
+++ b/Modules/ModParser-3_0.lua
@@ -874,6 +874,7 @@ local modTagList = {
 	["while you have avian's flight"] = { tag = { type = "Condition", var = "AffectedByAvian'sFlight" } },
 	["while affected by aspect of the cat"] = { tag = { type = "Condition", varList = { "AffectedByCat'sStealth", "AffectedByCat'sAgility" } } },
 	["while affected by a herald"] = { tag = { type = "Condition", varList = { "AffectedByHeraldofAgony", "AffectedByHeraldofAsh", "AffectedByHeraldofIce", "AffectedByHeraldofPurity", "AffectedByHeraldofThunder" } } },
+	["while affected by a guard skill buff"] = { tag = { type = "Condition", var = "AffectedByAGuardSkill" } },
 	["while you have a bestial minion"] = { tag = { type = "Condition", var = "HaveBestialMinion" } },
 	["while focussed"] = { tag = { type = "Condition", var = "Focused" } },
 	["while leeching"] = { tag = { type = "Condition", var = "Leeching" } },


### PR DESCRIPTION
Added base support for missing conditional for nodes on tree, 
![image](https://user-images.githubusercontent.com/49933620/76134289-03d1bc00-606d-11ea-8db8-24479ec04f41.png)

if someone knows how to make it automatically work when steel skin/moltenshell/vaal moltenshell/immortal call are active feel free to fix