### PR TITLE
Implemented Vicious Skewering Notable

### DIFF
--- a/Modules/CalcOffence-3_0.lua
+++ b/Modules/CalcOffence-3_0.lua
@@ -2221,7 +2221,8 @@ function calcs.offence(env, actor, activeSkill)
             local impaleStacks = configStacks > 0 and m_min(configStacks, maxStacks) or  maxStacks
 
             local baseStoredDamage = 0.1 -- magic number: base impale stored damage
-            local storedDamageInc = skillModList:Sum("INC", cfg, "ImpaleEffect")/100
+            local storedDamageIncOnBleed = skillModList:Sum("INC", cfg, "ImpaleEffectOnBleed")*skillModList:Sum("BASE", cfg, "BleedChance")/100
+            local storedDamageInc = (skillModList:Sum("INC", cfg, "ImpaleEffect") + storedDamageIncOnBleed)/100
             local storedDamageMore = round(skillModList:More(cfg, "ImpaleEffect"), 2)
             local storedDamageModifier = (1 + storedDamageInc) * storedDamageMore
             local impaleStoredDamage = baseStoredDamage * storedDamageModifier

--- a/Modules/ModParser-3_0.lua
+++ b/Modules/ModParser-3_0.lua
@@ -1474,6 +1474,10 @@ local specialModList = {
 		mod("Damage", "MORE", tonumber(more) * num / 200, nil, 0, bor(KeywordFlag.Poison, ModFlag.Attack), { type = "Condition", var = "DualWielding"}),
 		mod("Damage", "MORE", tonumber(more) * num / 100, nil, 0, bor(KeywordFlag.Poison, ModFlag.Attack), { type = "Condition", var = "DualWielding", neg = true })
 	} end,
+	-- Impale
+	["(%d+)%% increased effect of impales inflicted by hits that also inflict bleeding"] = function(num) return {
+		mod("ImpaleEffectOnBleed", "INC", num, nil, 0, KeywordFlag.Hit)
+	} end,
 	-- Buffs/debuffs
 	["phasing"] = { flag("Condition:Phasing") },
 	["onslaught"] = { flag("Condition:Onslaught") },


### PR DESCRIPTION
Fixes Issue #296 

Used for Testing:
```
Viscious Skewering Simulator
Cobalt Jewel
LevelReq: 1
Implicits: 0
Attacks have 10% chance to cause Bleeding
10% chance to Impale enemies on hit with Attacks
15% increased Effect of Impales inflicted by Hits that also inflict Bleeding
```