### PR TITLE
Implemented 'if you've been channelling for at least 1 second'

### DIFF
--- a/Modules/ModParser-3_0.lua
+++ b/Modules/ModParser-3_0.lua
@@ -853,6 +853,7 @@ local modTagList = {
 	["while stationary"] = { tag = { type = "Condition", var = "Stationary" } },
 	["while moving"] = { tag = { type = "Condition", var = "Moving" } },
 	["while channelling"] = { tag = { type = "Condition", var = "Channelling" } },
+	["if you've been channelling for at least 1 second"] = { tag = { type = "Condition", var = "Channelling" } },
 	["while you have no power charges"] = { tag = { type = "StatThreshold", stat = "PowerCharges", threshold = 0, upper = true } },
 	["while you have no frenzy charges"] = { tag = { type = "StatThreshold", stat = "FrenzyCharges", threshold = 0, upper = true } },
 	["while you have no endurance charges"] = { tag = { type = "StatThreshold", stat = "EnduranceCharges", threshold = 0, upper = true } },


### PR DESCRIPTION
Fixes #382 

It was implemented as the same as Condition:Channelling because we don't want to clutter the ConfigOptions window with even more count boxes and 1 second is not long.

Test using Incinerate with below Jewel
```
New Item
Ghastly Eye Jewel
Quality: 0
LevelReq: 0
Implicits: 0
50% increased Critical Strike Chance while Channelling
+30% to Critical Strike Multiplier if you've been Channelling for at least 1 second
```