### PR TITLE
Implement Pure Agony notable

### DIFF
--- a/Modules/ConfigOptions.lua
+++ b/Modules/ConfigOptions.lua
@@ -99,7 +99,10 @@ return {
 	end },
 	{ label = "Herald of Agony:", ifSkill = "Herald of Agony" },
 	{ var = "heraldOfAgonyVirulenceStack", type = "count", label = "# of Virulence Stacks:", ifSkill = "Herald of Agony", apply = function(val, modList, enemyModList)
-		modList:NewMod("Multiplier:VirulenceStack", "BASE", m_min(val, 40), "Config")
+		-- TODO: Figure out a way to keep the original 40 cap, and have another stat to add to that max cap
+		--       For now, let's at least be reasonable and cap it to 80. That would mean 8 jewels (or other sources
+		--       of increases, which is a bit unlikely)
+		modList:NewMod("Multiplier:VirulenceStack", "BASE", m_min(val, 80), "Config")
 	end },
 	{ label = "Ice Nova:", ifSkill = "Ice Nova" },
 	{ var = "iceNovaCastOnFrostbolt", type = "check", label = "Cast on Frostbolt?", ifSkill = "Ice Nova", apply = function(val, modList, enemyModList)

--- a/Modules/ModParser-3_0.lua
+++ b/Modules/ModParser-3_0.lua
@@ -1577,6 +1577,16 @@ local specialModList = {
 	["minions convert (%d+)%% of physical damage to cold damage per green socket"] = function(num) return { mod("MinionModifier", "LIST", { mod = mod("PhysicalDamageConvertToCold", "BASE", num) }, { type = "Multiplier", var = "GreenSocketIn{SlotName}" }) } end,
 	["minions convert (%d+)%% of physical damage to lightning damage per blue socket"] = function(num) return { mod("MinionModifier", "LIST", { mod = mod("PhysicalDamageConvertToLightning", "BASE", num) }, { type = "Multiplier", var = "BlueSocketIn{SlotName}" }) } end,
 	["minions convert (%d+)%% of physical damage to chaos damage per white socket"] = function(num) return { mod("MinionModifier", "LIST", { mod = mod("PhysicalDamageConvertToChaos", "BASE", num) }, { type = "Multiplier", var = "WhiteSocketIn{SlotName}" }) } end,
+	["minions deal (%d+)%% increased damage while you are affected by a herald"] = function(num) return {
+		mod("MinionModifier", "LIST", { mod = mod("Damage", "INC", num, { type = "ActorCondition", actor = "parent", varList = { "AffectedByHeraldofAgony", "AffectedByHeraldofAsh", "AffectedByHeraldofIce", "AffectedByHeraldofPurity", "AffectedByHeraldofThunder" } })
+	})} end,
+	["+(%d+) to maximum virulence"] = function(num) return {
+		-- TODO: there is no way for us to increase the cap on virulence stacks yet. This is effictively a noop for now.
+	} end,
+	["+(%d+) to maximum number of sentinels of purity"] = function(num) return {
+		-- We do not display the maximum amount of sentinels of purity, nor is it used in DPS
+		-- calculations (since it is per minion)
+	} end,
 	-- Projectiles
 	["skills chain %+(%d) times"] = function(num) return { mod("ChainCountMax", "BASE", num) } end,
 	["skills chain an additional time while at maximum frenzy charges"] = { mod("ChainCountMax", "BASE", 1, { type = "StatThreshold", stat = "FrenzyCharges", thresholdStat = "FrenzyChargesMax" }) },


### PR DESCRIPTION
In practice, the only mod that has an effect on calculations is 'Minions deal x% increased damage while you are affected by a herald. The calculations are properly done for this mod. The maximum amount of virulence stacks required to bump the cap from 40 to 80. We still have no way to selectively increase the cap by whatever mod we have. So people can now set themselves at 60 stacks even without jewels. As for the maximum number or sentinels of purity, this is not listed anywhere, making this mod a noop for us. There is an existing helmet enchant that does not do anything either.

Without the virulence buff, 10 stacks;
![image](https://user-images.githubusercontent.com/373126/76396530-9ded7900-6379-11ea-8dc7-c1eecc1c88e0.png)

With the virulence buff, still counted as 10 stacks (along with the 20% damage buff from having a herald):
![image](https://user-images.githubusercontent.com/373126/76396621-d5f4bc00-6379-11ea-950a-6b3d0ea990f5.png)


Mod parsing:
![image](https://user-images.githubusercontent.com/373126/76396592-c7a6a000-6379-11ea-9edb-513965ef5d8f.png)
