### PR TITLE
Added support for Strike Leader Notable

### DIFF
--- a/Modules/ModParser-3_0.lua
+++ b/Modules/ModParser-3_0.lua
@@ -353,6 +353,7 @@ local modNameList = {
 	["melee weapon range"] = "MeleeWeaponRange",
 	["melee weapon and unarmed range"] = { "MeleeWeaponRange", "UnarmedRange" },
 	["melee weapon and unarmed attack range"] = { "MeleeWeaponRange", "UnarmedRange" },
+	["melee strike range"] = { "MeleeWeaponRange", "UnarmedRange" },
 	["to deal double damage"] = "DoubleDamageChance",
 	-- Buffs
 	["onslaught effect"] = "OnslaughtEffect",


### PR DESCRIPTION
SkillType.MeleeSingleTarget = Strike tag on gems. Looked up all gems and its the same list as whats on the wiki

Tested on various melee skills and looks to be working. Even works with default attack

Closes #359 

![image](https://user-images.githubusercontent.com/61110094/76403408-9c02d480-63d0-11ea-8b40-0ce7501af4ab.png)
