### PR TITLE
Add support for Septic Spells

### DIFF
--- a/Modules/ModParser-3_0.lua
+++ b/Modules/ModParser-3_0.lua
@@ -515,6 +515,7 @@ local modFlagList = {
 	-- Skill types
 	["spell"] = { flags = ModFlag.Spell },
 	["with spells"] = { flags = ModFlag.Spell },
+	["with spell damage"] = { flags = ModFlag.Spell },
 	["for spells"] = { flags = ModFlag.Spell },
 	["with attacks"] = { keywordFlags = KeywordFlag.Attack },
 	["with attack skills"] = { keywordFlags = KeywordFlag.Attack },


### PR DESCRIPTION
```
Septic Spells
Cobalt Jewel
Quality: 0
Implicits: 0
8% increased Cast Speed
Spell Skills have +10% to Damage over Time Multiplier for Poison
20% chance to Poison on Hit with Spell Damage
===
8% chance to Knock Enemies Back on Hit with Spell Damage
```
With #511 closes #439 and also adds support for Burden Projection