### PR TITLE
Adds support for Eye to Eye

### DIFF
--- a/Modules/ConfigOptions.lua
+++ b/Modules/ConfigOptions.lua
@@ -775,6 +775,9 @@ return {
 		modList:NewMod("ChainCount", "BASE", val, "Config", { type = "Condition", var = "Effective" })
 	end },
 	{ var = "meleeDistance", type = "count", label = "Melee distance to enemy:", ifFlag = "melee" },
+	{ var = "enemyDistance", type = "count", label = "Distance to enemy",  apply = function(val, modList, enemyModList)
+		enemyModList:NewMod("Multiplier:EnemyDistance", "BASE", val, "Config")
+	end },
 	{ var = "projectileDistance", type = "count", label = "Projectile travel distance:", ifFlag = "projectile" },
 	{ var = "conditionAtCloseRange", type = "check", label = "Is the enemy at Close Range?", ifCond = "AtCloseRange", apply = function(val, modList, enemyModList)
 		modList:NewMod("Condition:AtCloseRange", "FLAG", true, "Config", { type = "Condition", var = "Effective" })

--- a/Modules/ModParser-3_0.lua
+++ b/Modules/ModParser-3_0.lua
@@ -993,6 +993,7 @@ local modTagList = {
 	["if you have a summoned golem"] = { tag = { type = "Condition", varList = { "HavePhysicalGolem", "HaveLightningGolem", "HaveColdGolem", "HaveFireGolem", "HaveChaosGolem", "HaveCarrionGolem" } } },
 	-- Enemy status conditions
 	["at close range"] = { tag = { type = "Condition", var = "AtCloseRange" }, flags = ModFlag.Hit },
+	["against nearby enemies"] = { tag = { type = "MultiplierThreshold", actor = "enemy", var = "EnemyDistance", threshold = 60, upper = true } },
 	["against rare and unique enemies"] = { tag = { type = "ActorCondition", actor = "enemy", var = "RareOrUnique" }, keywordFlags = KeywordFlag.Hit },
 	["against unique enemies"] = { tag = { type = "ActorCondition", actor = "enemy", var = "RareOrUnique" }, keywordFlags = KeywordFlag.Hit },
 	["against enemies on full life"] = { tag = { type = "ActorCondition", actor = "enemy", var = "FullLife" }, keywordFlags = KeywordFlag.Hit },


### PR DESCRIPTION
closes #462 

Jewel:

`35% increased Projectile Damage with Hits against Nearby Enemies`

I added a generic `EnemyDistance` multiplier, which can be reused. For the `against Nearby Enemies`, I set the threshold to 60, which is the distance defined on the wiki as `The definition of "nearby" on Ascendancy notables, and Fossil-crafted Delve League helmet suffixes.`