### PR TITLE
Secrets of Suffering Partial Implementation

### DIFF
--- a/Modules/ModParser-3_0.lua
+++ b/Modules/ModParser-3_0.lua
@@ -1478,6 +1478,7 @@ local specialModList = {
 	["cannot inflict ignite"] = { flag("CannotIgnite") },
 	["cannot inflict freeze or chill"] = { flag("CannotFreeze"), flag("CannotChill") },
 	["cannot inflict shock"] = { flag("CannotShock") },
+	["cannot ignite, chill, freeze or shock"] = { flag("CannotIgnite"),flag("CannotFreeze"), flag("CannotChill"),flag("CannotShock") },
 	-- Bleed
 	["melee attacks cause bleeding"] = { mod("BleedChance", "BASE", 100, nil, ModFlag.Melee) },
 	["attacks cause bleeding when hitting cursed enemies"] = { mod("BleedChance", "BASE", 100, nil, ModFlag.Attack, { type = "ActorCondition", actor = "enemy", var = "Cursed" }) },

--- a/Modules/ModParser-3_0.lua
+++ b/Modules/ModParser-3_0.lua
@@ -1478,7 +1478,7 @@ local specialModList = {
 	["cannot inflict ignite"] = { flag("CannotIgnite") },
 	["cannot inflict freeze or chill"] = { flag("CannotFreeze"), flag("CannotChill") },
 	["cannot inflict shock"] = { flag("CannotShock") },
-	["cannot ignite, chill, freeze or shock"] = { flag("CannotIgnite"),flag("CannotFreeze"), flag("CannotChill"),flag("CannotShock") },
+	["cannot ignite, chill, freeze or shock"] = { flag("CannotIgnite"), flag("CannotChill"), flag("CannotFreeze"), flag("CannotShock") },
 	-- Bleed
 	["melee attacks cause bleeding"] = { mod("BleedChance", "BASE", 100, nil, ModFlag.Melee) },
 	["attacks cause bleeding when hitting cursed enemies"] = { mod("BleedChance", "BASE", 100, nil, ModFlag.Attack, { type = "ActorCondition", actor = "enemy", var = "Cursed" }) },


### PR DESCRIPTION
Partial implementation of #272 that aims to support the new Secrets of Suffering Keystone's `Cannot Ignite, Chill, Freeze or Shock` mod.
Ideally would be modular so that mods like `Cannot Chill or Shock` or `Cannot Ignite,Freeze or Shock` can be supported but this is enough to temporarily support the keystone.
![image](https://user-images.githubusercontent.com/61525290/76484689-2b38d800-6423-11ea-98a8-3f0c66837c3a.png)
