### PR TITLE
Support for Surging Vitality notable (burst life regen)

### DIFF
--- a/Modules/ConfigOptions.lua
+++ b/Modules/ConfigOptions.lua
@@ -38,6 +38,13 @@ return {
 		modList:NewMod("MinionModifier", "LIST", { mod = modLib.createMod("Condition:FullLife", "FLAG", true, "Config") }, "Config")
 	end },
 	{ var = "igniteMode", type = "list", label = "Ignite calculation mode:", tooltip = "Controls how the base damage for ignite is calculated:\nAverage Damage: Ignite is based on the average damage dealt, factoring in crits and non-crits.\nCrit Damage: Ignite is based on crit damage only.", list = {{val="AVERAGE",label="Average Damage"},{val="CRIT",label="Crit Damage"}} },
+	{ var = "lifeRegenMode", type = "list", label = "Life regen calculation mode:", tooltip = "Controls how life regeneration is calculated:\nMinimum: Does not include burst regen.\nAverage: Averages out burst regen over time.\nBurst: Includes full burst regen in the calculation.", list = {{val="MIN",label="Minimum"},{val="AVERAGE",label="Average"},{val="FULL",label="Burst"}}, apply = function(val, modList, enemyModList)
+		if val == "AVERAGE" then
+			modList:NewMod("Condition:LifeRegenBurstAvg", "FLAG", true, "Config")
+		elseif val == "FULL" then
+			modList:NewMod("Condition:LifeRegenBurstFull", "FLAG", true, "Config")
+		end
+	end },
 
 	-- Section: Skill-specific options
 	{ section = "Skill Options", col = 2 },

--- a/Modules/ModParser-3_0.lua
+++ b/Modules/ModParser-3_0.lua
@@ -1892,6 +1892,10 @@ local specialModList = {
 	["manifeste?d? dancing dervish disables both weapon slots"] = { },
 	["manifeste?d? dancing dervish dies when rampage ends"] = { },
 	["you can have two different banners at the same time"] = { },
+	["every (%d+) seconds, regenerate (%d+)%% of life over one second"] = function (num, _, percent) return {
+		mod("LifeRegenPercent", "BASE", tonumber(percent), { type = "Condition", var = "LifeRegenBurstFull" }),
+		mod("LifeRegenPercent", "BASE", tonumber(percent) / num, { type = "Condition", var = "LifeRegenBurstAvg" }),
+	} end,
 }
 local keystoneList = {
 	-- List of keystones that can be found on uniques


### PR DESCRIPTION
Support burst life regen found in Time of Need, the new Surging Vitality notable, and the Hunter prefix on Body Armour.

Specifically adds support for: "every 5 seconds, regenerate (%d+)%% of life over one second"

Adds a configuration option to choose how life regen is calculated
 - Minimum: Does not include burst regen.
 - Average: Averages out burst regen over time.
 - Burst: Includes full burst regen in the calculation.

Fixes #436

Configuration:
![image](https://user-images.githubusercontent.com/10701249/76518981-56202d80-641d-11ea-9c9d-169f6814f61e.png)

Minimum:
![image](https://user-images.githubusercontent.com/10701249/76518948-46a0e480-641d-11ea-8507-f018dd70b990.png)

Average:
![image](https://user-images.githubusercontent.com/10701249/76519029-6df7b180-641d-11ea-8485-fe484686bc4a.png)

Burst:
![image](https://user-images.githubusercontent.com/10701249/76519047-7819b000-641d-11ea-870c-5538e2adc32d.png)
