### PR TITLE
Support updated Crown of Eyes and Kinetic Bolt spell damage conversion

### DIFF
--- a/Modules/CalcOffence-3_0.lua
+++ b/Modules/CalcOffence-3_0.lua
@@ -202,11 +202,13 @@ function calcs.offence(env, actor, activeSkill)
 			end
 		end
 	end
-	if skillModList:Flag(nil, "SpellDamageAppliesToAttacks") then
-		-- Spell Damage conversion from Crown of Eyes
+	if skillModList:Flag(nil, "SpellDamageAppliesToAttacks") or skillModList:Flag(nil, "ImprovedSpellDamageAppliesToAttacks") then
+		-- Spell Damage conversion from Crown of Eyes, Kinetic Bolt, and the Wandslinger notable
 		for i, value in ipairs(skillModList:Tabulate("INC", { flags = ModFlag.Spell }, "Damage")) do
 			local mod = value.mod
-			if band(mod.flags, ModFlag.Spell) ~= 0 then
+			if band(mod.flags, ModFlag.Spell) ~= 0 and skillModList:Flag(nil, "ImprovedSpellDamageAppliesToAttacks") then
+				skillModList:NewMod("Damage", "INC", mod.value * 1.5, mod.source, bor(band(mod.flags, bnot(ModFlag.Spell)), ModFlag.Attack), mod.keywordFlags, unpack(mod))
+			elseif band(mod.flags, ModFlag.Spell) ~= 0 then
 				skillModList:NewMod("Damage", "INC", mod.value, mod.source, bor(band(mod.flags, bnot(ModFlag.Spell)), ModFlag.Attack), mod.keywordFlags, unpack(mod))
 			end
 		end

--- a/Modules/CalcOffence-3_0.lua
+++ b/Modules/CalcOffence-3_0.lua
@@ -203,15 +203,17 @@ function calcs.offence(env, actor, activeSkill)
 		end
 	end
 	if skillModList:Flag(nil, "SpellDamageAppliesToAttacks") or skillModList:Flag(nil, "ImprovedSpellDamageAppliesToAttacks") then
-		-- Spell Damage conversion from Crown of Eyes, Kinetic Bolt, and the Wandslinger notable
-		for i, value in ipairs(skillModList:Tabulate("INC", { flags = ModFlag.Spell }, "Damage")) do
-			local mod = value.mod
-			if band(mod.flags, ModFlag.Spell) ~= 0 and skillModList:Flag(nil, "ImprovedSpellDamageAppliesToAttacks") then
-				skillModList:NewMod("Damage", "INC", mod.value * 1.5, mod.source, bor(band(mod.flags, bnot(ModFlag.Spell)), ModFlag.Attack), mod.keywordFlags, unpack(mod))
-			elseif band(mod.flags, ModFlag.Spell) ~= 0 then
-				skillModList:NewMod("Damage", "INC", mod.value, mod.source, bor(band(mod.flags, bnot(ModFlag.Spell)), ModFlag.Attack), mod.keywordFlags, unpack(mod))
-			end
-		end
+    -- Spell Damage conversion from Crown of Eyes, Kinetic Bolt, and the Wandslinger notable
+    local multiplier = 1
+    if skillModList:Flag(nil, "ImprovedSpellDamageAppliesToAttacks") then
+        multiplier = 1.5
+    end
+    for i, value in ipairs(skillModList:Tabulate("INC", { flags = ModFlag.Spell }, "Damage")) do
+        local mod = value.mod
+        if band(mod.flags, ModFlag.Spell) ~= 0 then
+            skillModList:NewMod("Damage", "INC", mod.value * multiplier, mod.source, bor(band(mod.flags, bnot(ModFlag.Spell)), ModFlag.Attack), mod.keywordFlags, unpack(mod))
+        end
+    end
 	end
 	if skillModList:Flag(nil, "ClawDamageAppliesToUnarmed") then
 		-- Claw Damage conversion from Rigwald's Curse

--- a/Modules/ModParser-3_0.lua
+++ b/Modules/ModParser-3_0.lua
@@ -1406,6 +1406,7 @@ local specialModList = {
 	["increases and reductions to minion damage also affects? you"] = { flag("MinionDamageAppliesToPlayer") },
 	["increases and reductions to minion attack speed also affects? you"] = { flag("MinionAttackSpeedAppliesToPlayer") },
 	["increases and reductions to spell damage also apply to attacks"] = { flag("SpellDamageAppliesToAttacks") },
+	["increases and reductions to spell damage also apply to attacks at (%d+)%% of their value"] = { flag("ImprovedSpellDamageAppliesToAttacks") },
 	["modifiers to claw damage also apply to unarmed"] = { flag("ClawDamageAppliesToUnarmed") },
 	["modifiers to claw damage also apply to unarmed attack damage"] = { flag("ClawDamageAppliesToUnarmed") },
 	["modifiers to claw attack speed also apply to unarmed"] = { flag("ClawAttackSpeedAppliesToUnarmed") },


### PR DESCRIPTION
Adds support for a new mod that will be coming to Crown of Eyes in 3.10 which will apply increases and reductions to spell damage to apply to attacks at 150% of their value. It does this with a new flag and piggybacks on the implementation of the existing mod. I based the wording on the wording on the Kinetic Bolt gem, but it could be easily updated when we actually see how the new mod is worded.

Kinetic Bolt will also have this mod, so this will make it easier to support that mod when the skill is added with the update tomorrow. Just make the skill set the new flag and it should just work.

In a perfect world, the effect of the spell damage conversion would be directly affected by the value on the mod itself, in case there's ever other values of it, but with the way PoB currently works I don't think there's a way to only use the highest value of a mod like this(as in only apply a mod that says 200% and ignore any mods that say lower than that). For now the only versions of this mod that exist are for 100% conversion and 150% conversion, so it's not a big deal in my opinion.