### PR TITLE
feature(item-tab): add influence abbreviations to item names

### DIFF
--- a/Classes/Helpers/ItemsTabHelpers.lua
+++ b/Classes/Helpers/ItemsTabHelpers.lua
@@ -1,0 +1,46 @@
+local itemTabHelpers = {}
+
+local function createItemNameWithInfluences(item)
+	local stringText = ""
+	stringText = colorCodes[item.rarity]..item.name
+
+	local influences = {}
+
+	if item.corrupted then
+		table.insert(influences, "^1Co")
+	end
+
+	if item.shaper then
+		table.insert(influences, colorCodes.SHAPER.."S")
+	end
+
+	if item.elder then
+		table.insert(influences, colorCodes.ELDER.."E")
+	end
+
+	if item.adjudicator then
+		table.insert(influences, colorCodes.ADJUDICATOR.."W")
+	end
+
+	if item.basilisk then
+		table.insert(influences, colorCodes.BASILISK.."H")
+	end
+
+	if item.crusader then
+		table.insert(influences, colorCodes.CRUSADER.."Cr")
+	end
+
+	if item.eyrie then
+		table.insert(influences, colorCodes.EYRIE.."R")
+	end
+
+	if (#influences > 0) then
+		return stringText.." ("..table.concat(influences, colorCodes[item.rarity]..", ")..colorCodes[item.rarity]..")"
+	end
+
+    return stringText
+end
+
+itemTabHelpers.createItemNameWithInfluences = createItemNameWithInfluences
+
+return itemTabHelpers

--- a/Classes/ItemListControl.lua
+++ b/Classes/ItemListControl.lua
@@ -5,6 +5,7 @@
 --
 local pairs = pairs
 local t_insert = table.insert
+local itemTabHelpers = require("Classes.Helpers.ItemsTabHelpers")
 
 local ItemListClass = newClass("ItemListControl", "ListControl", function(self, anchor, x, y, width, height, itemsTab)
 	self.ListControl(anchor, x, y, width, height, 16, false, true, itemsTab.itemOrderList)
@@ -55,7 +56,7 @@ function ItemListClass:GetRowValue(column, index, itemId)
 		elseif itemSet then
 			used = "  ^9(Used in '" .. (itemSet.title or "Default") .. "')"
 		end
-		return colorCodes[item.rarity] .. item.name .. used
+		return colorCodes[item.rarity] .. itemTabHelpers.createItemNameWithInfluences(item).. used
 	end
 end
 

--- a/Classes/ItemSlotControl.lua
+++ b/Classes/ItemSlotControl.lua
@@ -6,6 +6,7 @@
 local pairs = pairs
 local t_insert = table.insert
 local m_min = math.min
+local itemTabHelpers = require("Classes.Helpers.ItemsTabHelpers")
 
 local ItemSlotClass = newClass("ItemSlotControl", "DropDownControl", function(self, anchor, x, y, itemsTab, slotName, slotLabel, nodeId)
 	self.DropDownControl(anchor, x, y, 310, 20, { }, function(index, value)
@@ -80,7 +81,7 @@ function ItemSlotClass:Populate()
 	for _, item in pairs(self.itemsTab.items) do
 		if self.itemsTab:IsItemValidForSlot(item, self.slotName) then
 			t_insert(self.items, item.id)
-			t_insert(self.list, colorCodes[item.rarity]..item.name)
+			t_insert(self.list, itemTabHelpers.createItemNameWithInfluences(item))
 			if item.id == self.selItemId then
 				self.selIndex = #self.list
 			end


### PR DESCRIPTION
Add influence types in parentheses next to item name

Example:
![image](https://user-images.githubusercontent.com/595925/76696965-717e7900-6667-11ea-9d7f-2f9f1489b130.png)
