### PR TITLE
Fix Intuitive Leap and Thread of Hope losing remote passives on loading

### DIFF
--- a/Classes/PassiveSpec.lua
+++ b/Classes/PassiveSpec.lua
@@ -545,6 +545,10 @@ function PassiveSpecClass:BuildAllDependsAndPaths()
 			-- Therefore this node and all nodes depending on it are orphans and should be pruned
 			for _, depNode in ipairs(node.depends) do
 				local prune = true
+				-- This method may be called by PassiveSpecClass:SelectAscendClass() when jewels are not populated yet
+				if #self.jewels == 0 then
+					prune = false
+				end
 				for nodeId, itemId in pairs(self.jewels) do
 					if self.allocNodes[nodeId] then
 						if itemId ~= 0 and (


### PR DESCRIPTION
Fixes a regression introduced with the support of cluster jewels where Intuitive Leap-like jewels would lose their remotely connected passives on loading a build.

After changes to the passive skill tree spec. the method that prunes orphaned nodes is called before jewel slots are populated, resulting in all remotely connected nodes being pruned. To fix this, an extra check is introduced to hold off pruning in case that no jewel slots are populated yet.