### PR TITLE
Fix medium cluster jewel rendering

### DIFF
--- a/Classes/PassiveSpec.lua
+++ b/Classes/PassiveSpec.lua
@@ -762,24 +762,24 @@ function PassiveSpecClass:BuildSubgraph(jewel, parentSocket, id, upSize)
 		if #notableIndexList == notableCount then
 			break
 		end
-		if not indicies[nodeIndex] then
-			if clusterJewel.size == "Medium" then
-				if socketCount == 0 and notableCount == 2 then
-					-- Special rule for two notables in a Medium cluster
-					if nodeIndex == 6 then
-						nodeIndex = 4
-					elseif nodeIndex == 10 then
-						nodeIndex = 8
-					end
-				elseif nodeCount == 4 then
-					-- Special rule for notables in a 4-node Medium cluster
-					if nodeIndex == 10 then
-						nodeIndex = 9
-					elseif nodeIndex == 2 then
-						nodeIndex = 3
-					end
+		if clusterJewel.size == "Medium" then
+			if socketCount == 0 and notableCount == 2 then
+				-- Special rule for two notables in a Medium cluster
+				if nodeIndex == 6 then
+					nodeIndex = 4
+				elseif nodeIndex == 10 then
+					nodeIndex = 8
+				end
+			elseif nodeCount == 4 then
+				-- Special rule for notables in a 4-node Medium cluster
+				if nodeIndex == 10 then
+					nodeIndex = 9
+				elseif nodeIndex == 2 then
+					nodeIndex = 3
 				end
 			end
+		end
+		if not indicies[nodeIndex] then
 			t_insert(notableIndexList, nodeIndex)
 		end
 	end
@@ -818,19 +818,19 @@ function PassiveSpecClass:BuildSubgraph(jewel, parentSocket, id, upSize)
 		if #smallIndexList == smallCount then
 			break
 		end
-		if not indicies[nodeIndex] then
-			if clusterJewel.size == "Medium" then
-				-- Special rules for small nodes in Medium clusters
-				if nodeCount == 5 and nodeIndex == 4 then
+		if clusterJewel.size == "Medium" then
+			-- Special rules for small nodes in Medium clusters
+			if nodeCount == 5 and nodeIndex == 4 then
+				nodeIndex = 3
+			elseif nodeCount == 4 then
+				if nodeIndex == 8 then
+					nodeIndex = 9
+				elseif nodeIndex == 4 then
 					nodeIndex = 3
-				elseif nodeCount == 4 then
-					if nodeIndex == 8 then
-						nodeIndex = 9
-					elseif nodeIndex == 4 then
-						nodeIndex = 3
-					end
 				end
 			end
+		end
+		if not indicies[nodeIndex] then
 			t_insert(smallIndexList, nodeIndex)
 		end
 	end

--- a/Export/spec.lua
+++ b/Export/spec.lua
@@ -4339,7 +4339,7 @@ return {
 			name="Stats",
 			refTo="Stats",
 			type="Key",
-			width=420
+			width=640
 		},
 		[4]={
 			list=false,


### PR DESCRIPTION
Fixes an issue where medium cluster jewels with 4 passive skills would render incorrectly if there was 2 notables and no jewel sockets.
Close 655