### PR TITLE
Fix sorting getting stuck

### DIFF
--- a/Modules/ModParser-3_0.lua
+++ b/Modules/ModParser-3_0.lua
@@ -2327,8 +2327,8 @@ local jewelSelfFuncs = {
 		if node then
 			data.Dex = (data.Dex or 0) + node.modList:Sum("BASE", nil, "Dex")
 			data.Int = (data.Int or 0) + node.modList:Sum("BASE", nil, "Int")
-		else
-			out:NewMod("DexIntToMeleeBonus", "BASE", data.Dex + data.Int, data.modSource)
+		elseif data.Dex or data.Int then
+			out:NewMod("DexIntToMeleeBonus", "BASE", (data.Dex or 0) + (data.Int or 0), data.modSource)
 		end
 	end,
 	["-1 Strength per 1 Strength on Allocated Passives in Radius"] = getPerStat("Str", "BASE", 0, "Str", -1),


### PR DESCRIPTION
When running jewel functions they get called for each node and `nil`. Sockets coming from cluster jewels are not in range of any nodes (which is correct) and the unique effect from Might in All Forms didn't have checks for that case. This would also cause a crash when trying to use the jewel.

Fixes #612 