### PR TITLE
Fix league character filter on subsequent imports

### DIFF
--- a/Classes/ImportTab.lua
+++ b/Classes/ImportTab.lua
@@ -381,8 +381,11 @@ function ImportTabClass:DownloadCharacterList()
 					league = league,
 				})
 			end				
+			if self.controls.charSelectLeague.selIndex > #self.controls.charSelectLeague.list then
+				self.controls.charSelectLeague.selIndex = 1
+			end
 			self.lastCharList = charList
-			self:BuildCharacterList()
+			self:BuildCharacterList(self.controls.charSelectLeague:GetSelValue("league"))
 		end, sessionID and "POESESSID="..sessionID)
 	end, sessionID and "POESESSID="..sessionID)
 end


### PR DESCRIPTION
The import dialog saves the selected index of the league dropdown, but
only applies it as a filter when the dropdown value changes. It breaks
the following flow:

1. Import -> Start
1. Change league filter to something other than "All" (e.g. SSF).
Character list is filtered as expected.
1. Finish character import of jewels and items and hit "Done"
1. Start another import via Import -> Start
1. League dropdown still has your selection from step 2 (SSF), but the
character list has all characters.

The bug is that the import dialog remembers the league selected index so
it appears the filter is applied, but the logic does not pass the league
when creating the character list. It only does this when the league
dropdown value changes.

Fix is to pass the league in both scenarios.