### PR TITLE
Show build name in title bar

### DIFF
--- a/Classes/ImportTab.lua
+++ b/Classes/ImportTab.lua
@@ -483,6 +483,7 @@ function ImportTabClass:ImportPassiveTreeAndJewels(json, charData)
 	self.build.characterLevel = charData.level
 	self.build.controls.characterLevel:SetText(charData.level)
 	self.build.buildFlag = true
+	main:SetWindowTitleSubtext(string.format("%s (%s, %s, %s)", self.build.buildName, charData.name, charData.class, charData.league))
 end
 
 function ImportTabClass:ImportItemsAndSkills(json)

--- a/Classes/PassiveSpec.lua
+++ b/Classes/PassiveSpec.lua
@@ -239,6 +239,9 @@ function PassiveSpecClass:SelectAscendClass(ascendClassId)
 		startNode.alloc = true
 		self.allocNodes[startNode.id] = startNode
 	end
+	
+	-- This will react to changing either class or ascendancy because self:SelectClass() calls this method
+	self:SetWindowTitleWithBuildClass()
 
 	-- Rebuild all the node paths and dependencies
 	self:BuildAllDependsAndPaths()
@@ -929,4 +932,8 @@ end
 
 function PassiveSpecClass:RestoreUndoState(state)
 	self:ImportFromNodeList(state.classId, state.ascendClassId, state.hashList)
+end
+
+function PassiveSpecClass:SetWindowTitleWithBuildClass()
+	main:SetWindowTitleSubtext(string.format("%s (%s)", self.build.buildName, self.curAscendClassId == 0 and self.curClassName or self.curAscendClassName))
 end

--- a/Classes/PassiveSpec.lua
+++ b/Classes/PassiveSpec.lua
@@ -239,9 +239,6 @@ function PassiveSpecClass:SelectAscendClass(ascendClassId)
 		startNode.alloc = true
 		self.allocNodes[startNode.id] = startNode
 	end
-	
-	-- This will react to changing either class or ascendancy because self:SelectClass() calls this method
-	self:SetWindowTitleWithBuildClass()
 
 	-- Rebuild all the node paths and dependencies
 	self:BuildAllDependsAndPaths()
@@ -932,6 +929,7 @@ end
 
 function PassiveSpecClass:RestoreUndoState(state)
 	self:ImportFromNodeList(state.classId, state.ascendClassId, state.hashList)
+	self:SetWindowTitleWithBuildClass()
 end
 
 function PassiveSpecClass:SetWindowTitleWithBuildClass()

--- a/Modules/Build.lua
+++ b/Modules/Build.lua
@@ -627,8 +627,6 @@ function buildMode:Init(dbFileName, buildName, buildXML, targetVersion)
 	self:RefreshStatList()
 	self.buildFlag = false
 
-	main:SetWindowTitleSubtext(string.format("%s (%s)", self.buildName, self.spec.curAscendClassId == 0 and self.spec.curClassName or self.spec.curAscendClassName))
-
 	--[[
 	local testTooltip = new("Tooltip")
 	for _, item in pairs(main.uniqueDB.list) do

--- a/Modules/Build.lua
+++ b/Modules/Build.lua
@@ -210,11 +210,13 @@ function buildMode:Init(dbFileName, buildName, buildXML, targetVersion)
 			if self.spec:CountAllocNodes() == 0 or self.spec:IsClassConnected(value.classId) then
 				self.spec:SelectClass(value.classId)
 				self.spec:AddUndoState()
+				self.spec:SetWindowTitleWithBuildClass()
 				self.buildFlag = true
 			else
 				main:OpenConfirmPopup("Class Change", "Changing class to "..value.label.." will reset your passive tree.\nThis can be avoided by connecting one of the "..value.label.." starting nodes to your tree.", "Continue", function()
 					self.spec:SelectClass(value.classId)
 					self.spec:AddUndoState()
+					self.spec:SetWindowTitleWithBuildClass()
 					self.buildFlag = true					
 				end)
 			end
@@ -223,6 +225,7 @@ function buildMode:Init(dbFileName, buildName, buildXML, targetVersion)
 	self.controls.ascendDrop = new("DropDownControl", {"LEFT",self.controls.classDrop,"RIGHT"}, 8, 0, 120, 20, nil, function(index, value)
 		self.spec:SelectAscendClass(value.ascendClassId)
 		self.spec:AddUndoState()
+		self.spec:SetWindowTitleWithBuildClass()
 		self.buildFlag = true
 	end)
 
@@ -626,6 +629,8 @@ function buildMode:Init(dbFileName, buildName, buildXML, targetVersion)
 	self.calcsTab:BuildOutput()
 	self:RefreshStatList()
 	self.buildFlag = false
+
+	self.spec:SetWindowTitleWithBuildClass()
 
 	--[[
 	local testTooltip = new("Tooltip")

--- a/Modules/Build.lua
+++ b/Modules/Build.lua
@@ -627,6 +627,8 @@ function buildMode:Init(dbFileName, buildName, buildXML, targetVersion)
 	self:RefreshStatList()
 	self.buildFlag = false
 
+	main:SetWindowTitleSubtext(string.format("%s (%s)", self.buildName, self.spec.curAscendClassId == 0 and self.spec.curClassName or self.spec.curAscendClassName))
+
 	--[[
 	local testTooltip = new("Tooltip")
 	for _, item in pairs(main.uniqueDB.list) do
@@ -683,6 +685,7 @@ function buildMode:GetArgs()
 end
 
 function buildMode:CloseBuild()
+	main:SetWindowTitleSubtext()
 	main:SetMode("LIST", self.dbFileName and self.buildName, self.dbFileSubPath)
 end
 

--- a/Modules/Main.lua
+++ b/Modules/Main.lua
@@ -885,6 +885,14 @@ function main:OpenNewFolderPopup(path, onClose)
 	main:OpenPopup(370, 100, "New Folder", controls, "create", "edit", "cancel")	
 end
 
+function main:SetWindowTitleSubtext(subtext)
+	if not subtext then
+		SetWindowTitle("Path of Building")
+	else
+		SetWindowTitle("Path of Building - "..subtext)
+	end
+end
+
 do
 	local wrapTable = { }
 	function main:WrapString(str, height, width)


### PR DESCRIPTION
Display basic information about the current build in the title of the
window. Three flavors exist, depending on the state of the app:

## Empty
### Example
Path of Building
### When
Application is starting or in the build management view (e.g. if you hit
"<< Back" in the UI)

## Character Name and League
### Example
Path of Building - Unnamed build (CleverName, Gladiator, SSF Delirium)
### When
Build is imported from GGG. The title takes effect when the passive tree
is imported. Importing just the items from a build will have no effect.

## Class Only
### Example
Path of Building - Imported Build (Gladiator)
### When
Build is imported from a Path of Building code, PasteBin, or from a
local XML file. Note that "Imported Build" is literal; Path of Building
does not store the original character name or league in its data.

This can also occur if you import a character from GGG, back out to the
build selection list, and load the build you were just editing. Same
cause as above, this is actually a load that does not have the richer
data.

Lastly, the title will downgrade from the character name and league to
just the class if you change the class or ascendancy of your current
build. This should be uncommon and, from a certain view, makes sense.
Is it really the GGG character if you change its fundamental class?