### PR TITLE
Update experience multiplier to take new game mechanics into account

### DIFF
--- a/Modules/Common.lua
+++ b/Modules/Common.lua
@@ -463,6 +463,14 @@ function round(val, dec)
 	end
 end
 
+---@param n number
+---@return number
+function triangular(n)
+	--- Returns the n-th triangular number
+	--- See https://en.wikipedia.org/wiki/Triangular_number
+	return n * (n + 1) / 2
+end
+
 -- Formats "1234.56" -> "1,234.5"
 function formatNumSep(str)
 	return str:gsub("(%d*)(%d%.?)", function(s, e)

--- a/Modules/Data.lua
+++ b/Modules/Data.lua
@@ -131,9 +131,25 @@ data.labyrinths = {
 	{ name = "NORMAL", label = "Normal" },
 }
 
-data.monsterExperienceLevelMap = { [71] = 70.94, [72] = 71.82, [73] = 72.64, [74] = 73.40, [75] = 74.10, [76] = 74.74, [77] = 75.32, [78] = 75.84, [79] = 76.30, [80] = 76.70, [81] = 77.04, [82] = 77.32, [83] = 77.54, [84] = 77.70, }
-for i = 1, 70 do
-	data.monsterExperienceLevelMap[i] = i
+local maxPenaltyFreeAreaLevel = 70
+local maxAreaLevel = 88 -- T16 map + side area + four watchstones that grant +1 level
+local penaltyMultiplier = 0.06
+
+---@param areaLevel number
+---@return number
+local function effectiveMonsterLevel(areaLevel)
+	--- Areas with area level above a certain penalty-free level are considered to have
+	--- a scaling lower effective monster level for experience penalty calculations.
+	if areaLevel <= maxPenaltyFreeAreaLevel then
+		return areaLevel
+	end
+	return areaLevel - triangular(areaLevel - maxPenaltyFreeAreaLevel) * penaltyMultiplier
+end
+
+---@type table<number, number>
+data.monsterExperienceLevelMap = {}
+for i = 1, maxAreaLevel do
+	data.monsterExperienceLevelMap[i] = effectiveMonsterLevel(i)
 end
 
 data.weaponTypeInfo = {


### PR DESCRIPTION
Through watchstones, it is possible to reach a higher maximum area level than before.
Also "disenchanted" all magic numbers used in the calculations.