### PR TITLE
Make Ignite Duration breakdown show more consistently

### DIFF
--- a/Modules/CalcOffence-3_0.lua
+++ b/Modules/CalcOffence-3_0.lua
@@ -2102,7 +2102,7 @@ function calcs.offence(env, actor, activeSkill)
 							})
 						end
 					end
-					if globalOutput.IgniteDuration ~= 4 then
+					if incDur ~= 0 or moreDur ~= 1 or rateMod ~= 1 then
 						globalBreakdown.IgniteDuration = {
 							s_format("4.00s ^8(base duration)", durationBase)
 						}


### PR DESCRIPTION
I noticed a few days ago that, when I had 50% increased ignite duration and 50% increased burn rate, the ignite duration breakdown wouldn't show everything it should:
![image](https://user-images.githubusercontent.com/39030429/77982998-61a39d80-72d3-11ea-99a0-382315996917.png)

This PR makes it so this breakdown checks for a modifier to ignite duration instead of checking to see if ignite duration is something other than 4 seconds.
![image](https://user-images.githubusercontent.com/39030429/77983044-8b5cc480-72d3-11ea-8822-98ff321055aa.png)
