### PR TITLE
Fix for exception when parsing "Dexterity and Intelligence from passives in Radius count towards Strength Melee Damage bonus" without a node

### DIFF
--- a/Modules/ModParser-3_0.lua
+++ b/Modules/ModParser-3_0.lua
@@ -2328,7 +2328,7 @@ local jewelSelfFuncs = {
 			data.Dex = (data.Dex or 0) + node.modList:Sum("BASE", nil, "Dex")
 			data.Int = (data.Int or 0) + node.modList:Sum("BASE", nil, "Int")
 		else
-			out:NewMod("DexIntToMeleeBonus", "BASE", data.Dex + data.Int, data.modSource)
+			out:NewMod("DexIntToMeleeBonus", "BASE", (data.Dex or 0) + (data.Int or 0), data.modSource)
 		end
 	end,
 	["-1 Strength per 1 Strength on Allocated Passives in Radius"] = getPerStat("Str", "BASE", 0, "Str", -1),


### PR DESCRIPTION
This happens when sorting the unique item list by DPS when a jewel socket on a cluster jewel is allocated

To reproduce the issue:
 - Create a new build
 - Go to the tree
 - Allocate an outer jewel socket
 - Go to items and craft a large cluster jewel with a jewel socket
 - Add the item and assign it to Socket #1
 - Go back to the tree and allocate the jewel socket in the new cluster jewel
 - Go back to items and sort the unique list by Combined DPS

Previous Result: The progress would stop around 62% complete and the list would not fill. In dev builds an exception is displayed.
New Result: The progress properly finishes and the list fills as expected.