### PR TITLE
Implementation of Split Personality Jewel

### DIFF
--- a/Classes/PassiveTreeView.lua
+++ b/Classes/PassiveTreeView.lua
@@ -739,6 +739,12 @@ function PassiveTreeViewClass:AddNodeName(tooltip, node, build)
 			tooltip:AddLine(16, "^7Can support "..colorCodes.INTELLIGENCE.."Intelligence ^7threshold jewels")
 		end
 	end
+	if node.type == "Socket" and node.alloc then
+		if node.distanceToClassStart and node.distanceToClassStart > 0 then
+			tooltip:AddSeparator(14)
+			tooltip:AddLine(16, string.format("^7Distance to start: %d", node.distanceToClassStart))
+		end
+	end
 end
 
 function PassiveTreeViewClass:AddNodeTooltip(tooltip, node, build)
@@ -747,6 +753,10 @@ function PassiveTreeViewClass:AddNodeTooltip(tooltip, node, build)
 		local socket, jewel = build.itemsTab:GetSocketAndJewelForNodeID(node.id)
 		if jewel then
 			build.itemsTab:AddItemTooltip(tooltip, jewel, { nodeId = node.id })
+			if node.distanceToClassStart and node.distanceToClassStart > 0 then
+				tooltip:AddSeparator(14)
+				tooltip:AddLine(16, string.format("^7Distance to start: %d", node.distanceToClassStart))
+			end
 		else
 			self:AddNodeName(tooltip, node, build)
 		end

--- a/Data/Uniques/jewel.lua
+++ b/Data/Uniques/jewel.lua
@@ -604,6 +604,34 @@ Adds 3 Jewel Socket Passive Skills
 {variant:3}Adds 5 Small Passive Skills which grant nothing
 {variant:4}Adds 7 Small Passive Skills which grant nothing
 ]],[[
+Split Personality
+Crimson Jewel
+League: Delirium
+Source: Drops from the Simulacrum Encounter
+Has Alt Variant: true
+Variant: Strength
+Variant: Dexterity
+Variant: Intelligence
+Variant: Life
+Variant: Mana
+Variant: Energy Shield
+Variant: Armour
+Variant: Evasion Rating
+Variant: Accuracy Rating
+This Jewel's Socket has 25% increased effect per Allocated Passive Skill between
+it and your Class' starting location
+{variant:1}+5 to Strength
+{variant:2}+5 to Dexterity
+{variant:3}+5 to Intelligence
+{variant:4}+5 to maximum Life
+{variant:5}+5 to maximum Mana
+{variant:6}+5 to maximum Energy Shield
+{variant:7}+40 to Armour
+{variant:8}+40 to Evasion Rating
+{variant:9}+40 to Accuracy Rating
+--------
+Corrupted
+]],[[
 Watcher's Eye
 Prismatic Jewel
 Source: Drops from unique{The Elder}

--- a/Modules/CalcSetup.lua
+++ b/Modules/CalcSetup.lua
@@ -440,6 +440,12 @@ function calcs.initEnv(build, mode, override)
 				scale = parentItem.socketedJewelEffectModifier
 			end
 		end
+		if slot.nodeId and item and item.type == "Jewel" and item.jewelData and item.jewelData.jewelIncEffectFromClassStart then
+			local node = env.spec.nodes[slot.nodeId]
+			if node and node.distanceToClassStart then
+				scale = scale + node.distanceToClassStart * (item.jewelData.jewelIncEffectFromClassStart / 100)
+			end
+		end
 		if item then
 			env.player.itemList[slotName] = item
 			-- Merge mods for this item

--- a/Modules/ModParser-3_0.lua
+++ b/Modules/ModParser-3_0.lua
@@ -1894,6 +1894,7 @@ local specialModList = {
 	["adds (%d+) small passive skills? which grants? nothing"] = function(num) return { mod("JewelData", "LIST", { key = "clusterJewelNothingnessCount", value = num }) } end,
 	["added small passive skills grant nothing"] = { mod("JewelData", "LIST", { key = "clusterJewelSmallsAreNothingness", value = true }) },
 	["added small passive skills have (%d+)%% increased effect"] = function(num) return { mod("JewelData", "LIST", { key = "clusterJewelIncEffect", value = num }) } end,
+	["this jewel's socket has (%d+)%% increased effect per allocated passive skill between it and your class' starting location"] = function(num) return { mod("JewelData", "LIST", { key = "jewelIncEffectFromClassStart", value = num }) } end,
 	-- Misc
 	["iron will"] = { flag("IronWill") },
 	["iron reflexes while stationary"] = { mod("Keystone", "LIST", "Iron Reflexes", { type = "Condition", var = "Stationary" }) },


### PR DESCRIPTION
Added `PassiveSpecClass:SetNodeDistanceToClassStart` function to calculate the allocated distance from each allocated jewel socket to the class' node start.
 - Uses as similar algorithm to other pathing functions in the file
 - This is Dijkstra's algorithm

Allocated jewel node tooltips show the distance to start to help the user determine the best socket to use.

Added Split Personality to the uniques list
 - Allows selecting both properties similar to Watcher's Eye

Used the jewel scale modifier which was already implemented for abyss jewels in stygians
 - This modifier can now also come from the jewel itself
 - The cached distance to the class' start is used to calculate the scale