### PR TITLE
Fix for Master of Metal using 0 impale stacks if the configured number of stacks was blank

### DIFF
--- a/Classes/ConfigTab.lua
+++ b/Classes/ConfigTab.lua
@@ -60,7 +60,7 @@ local ConfigTabClass = newClass("ConfigTab", "UndoHandler", "ControlHost", "Cont
 					self:BuildModList()
 					self.build.buildFlag = true
 				end) 
-			elseif varData.type == "count" or varData.type == "integer" then
+			elseif varData.type == "count" or varData.type == "integer" or varData.type == "countAllowZero" then
 				control = new("EditControl", {"TOPLEFT",lastSection,"TOPLEFT"}, 234, 0, 90, 18, "", nil, varData.type == "integer" and "^%-%d" or "%D", 6, function(buf)
 					self.input[varData.var] = tonumber(buf)
 					self:AddUndoState()
@@ -373,8 +373,8 @@ function ConfigTabClass:BuildModList()
 				if input[varData.var] then
 					varData.apply(true, modList, enemyModList, self.build)
 				end
-			elseif varData.type == "count" or varData.type == "integer" then
-				if input[varData.var] and input[varData.var] ~= 0 then
+			elseif varData.type == "count" or varData.type == "integer" or varData.type == "countAllowZero" then
+				if input[varData.var] and (input[varData.var] ~= 0 or varData.type == "countAllowZero") then
 					varData.apply(input[varData.var], modList, enemyModList, self.build)
 				end
 			elseif varData.type == "list" then

--- a/Classes/ModDB.lua
+++ b/Classes/ModDB.lua
@@ -29,6 +29,35 @@ function ModDBClass:AddMod(mod)
 	t_insert(self.mods[name], mod)
 end
 
+---ReplaceModInternal
+---  Replaces an existing matching mod with a new mod.
+---  If no matching mod exists, the mod is added instead.
+---@param mod table
+function ModDBClass:ReplaceModInternal(mod)
+	local name = mod.name
+	if not self.mods[name] then
+		self.mods[name] = { }
+	end
+
+	-- Find the index of the existing mod, if it is in the table
+	local modList = self.mods[name]
+	local modIndex = -1
+	for i = 1, #modList do
+		local curMod = modList[i]
+		if mod.name == curMod.name and mod.type == curMod.type and mod.flags == curMod.flags and mod.keywordFlags == curMod.keywordFlags and mod.source == curMod.source then
+			modIndex = i
+			break;
+		end
+	end
+
+	-- Add or replace the mod
+	if modIndex == -1 then
+		t_insert(self.mods[name], mod)
+	else
+		modList[modIndex] = mod
+	end
+end
+
 function ModDBClass:AddList(modList)
 	local mods = self.mods
 	for i, mod in ipairs(modList) do
@@ -195,6 +224,34 @@ function ModDBClass:TabulateInternal(context, result, modType, cfg, flags, keywo
 	if self.parent then
 		self.parent:TabulateInternal(context, result, modType, cfg, flags, keywordFlags, source, ...)
 	end
+end
+
+---HasModInternal
+---  Checks if a mod exists with the given properties
+---@param modType string @The type of the mod, e.g. "BASE"
+---@param flags number @The mod flags to match
+---@param keywordFlags number @The mod keyword flags to match
+---@param source string @The mod source to match
+---@return boolean @true if the mod is found, false otherwise.
+function ModDBClass:HasModInternal(modType, flags, keywordFlags, source, ...)
+	for i = 1, select('#', ...) do
+		local modList = self.mods[select(i, ...)]
+		if modList then
+			for i = 1, #modList do
+				local mod = modList[i]
+				if mod.type == modType and band(flags, mod.flags) == mod.flags and (mod.keywordFlags == 0 or band(keywordFlags, mod.keywordFlags) ~= 0) and (not source or mod.source:match("[^:]+") == source) then
+					return true
+				end
+			end
+		end
+	end
+	if self.parent then
+		local parentResult = self.parent:HasModInternal(modType, flags, keywordFlags, source, ...)
+		if parentResult == true then
+			return true
+		end
+	end
+	return false
 end
 
 function ModDBClass:Print()

--- a/Classes/ModStore.lua
+++ b/Classes/ModStore.lua
@@ -75,6 +75,22 @@ function ModStoreClass:NewMod(...)
 	self:AddMod(mod_createMod(...))
 end
 
+---ReplaceMod
+---  Replaces an existing matching mod with a new mod.
+---  A mod is considered the same if the name, type, flags, keywordFlags, and source exactly match.
+---  If no matching mod exists, the mod is added instead.
+---Notes:
+---    See calls to ModStoreClass:NewMod for additional parameter examples.
+---    1 (string): name
+---    2 (string): type
+---    3 (number): value
+---    4 (string): source
+---    5+ (optional, varies): additional options
+---@param ... any @Parameters to be passed along to the modLib.createMod function
+function ModStoreClass:ReplaceMod(...)
+	self:ReplaceModInternal(mod_createMod(...))
+end
+
 function ModStoreClass:Combine(modType, cfg, ...)
 	if modType == "MORE" then
 		return self:More(cfg, ...)
@@ -157,6 +173,25 @@ function ModStoreClass:Tabulate(modType, cfg, ...)
 	local result = { }
 	self:TabulateInternal(self, result, modType, cfg, flags, keywordFlags, source, ...)
 	return result
+end
+
+---HasMod
+---  Checks if a mod exists with the given properties.
+---  Useful for determining if the other aggregate functions will find
+---  anything to aggregate.
+---@param modType string @Mod type to match
+---@param cfg table @Optional configuration to use - contains flags, keywordFlags, and source to match
+---@param ... string @Mod name(s) to check for.
+---@return boolean @true if the mod is found, false otherwise.
+function ModStoreClass:HasMod(modType, cfg, ...)
+	local flags, keywordFlags = 0, 0
+	local source
+	if cfg then
+		flags = cfg.flags or 0
+		keywordFlags = cfg.keywordFlags or 0
+		source = cfg.source
+	end
+	return self:HasModInternal(modType, flags, keywordFlags, source, ...)
 end
 
 function ModStoreClass:GetCondition(var, cfg, noMod)

--- a/Modules/CalcOffence-3_0.lua
+++ b/Modules/CalcOffence-3_0.lua
@@ -2277,8 +2277,8 @@ function calcs.offence(env, actor, activeSkill)
             skillFlags.impale = true
             local impaleChance = m_min(output.ImpaleChance/100, 1)
             local maxStacks = skillModList:Sum("BASE", cfg, "ImpaleStacksMax") -- magic number: base stacks duration
-            local configStacks = enemyDB:Override(nil, "ImpaleStacks") or 0
-            local impaleStacks = configStacks > 0 and m_min(configStacks, maxStacks) or  maxStacks
+			local configStacks = enemyDB:Sum("BASE", cfg, "Multiplier:ImpaleStacks")
+			local impaleStacks = m_min(maxStacks, configStacks)
 
             local baseStoredDamage = 0.1 -- magic number: base impale stored damage
             local storedDamageInc = skillModList:Sum("INC", cfg, "ImpaleEffect")/100

--- a/Modules/CalcPerform.lua
+++ b/Modules/CalcPerform.lua
@@ -1120,6 +1120,16 @@ function calcs.perform(env)
 			env.minion.modDB:AddList(slot.minionBuffModList)
 		end
 	end
+	
+	-- Fix the configured impale stacks on the enemy
+	-- 		If the config is missing (blank), then use the maximum number of stacks
+	--		If the config is larger than the maximum number of stacks, replace it with the correct maximum
+	local maxImpaleStacks = modDB:Sum("BASE", nil, "ImpaleStacksMax")
+	if not enemyDB:HasMod("BASE", nil, "Multiplier:ImpaleStacks") then
+		enemyDB:NewMod("Multiplier:ImpaleStacks", "BASE", maxImpaleStacks, "Config", { type = "Condition", var = "Combat" })
+	elseif enemyDB:Sum("BASE", nil, "Multiplier:ImpaleStacks") > maxImpaleStacks then
+		enemyDB:ReplaceMod("Multiplier:ImpaleStacks", "BASE", maxImpaleStacks, "Config", { type = "Condition", var = "Combat" })
+	end
 
 	-- Check for extra auras
 	for _, value in ipairs(modDB:List(nil, "ExtraAura")) do

--- a/Modules/ConfigOptions.lua
+++ b/Modules/ConfigOptions.lua
@@ -786,8 +786,8 @@ return {
 	{ var = "conditionImpaledRecently", type = "check", ifVer="3_0", ifCond = "ImpaledRecently", label = "Impaled an Enemy recently?", apply = function(val, modList, enemyModLIst)
 		modList:NewMod("Condition:ImpaledRecently", "FLAG", true, "Config", { type = "Condition", var = "Combat" })
 	end },
-	{ var = "multiplierImpalesOnEnemy", type = "count", label = "# of Impales on Enemy (if not maximum):", ifFlag = "impale", tooltip = "Set number of Impales if using Champions Master of Metal node", apply = function(val, modList, enemyModList)
-		enemyModList:NewMod("Multiplier:ImpaleStacks", "BASE", m_min(val, 9), "Config", { type = "Condition", var = "Combat" })
+	{ var = "multiplierImpalesOnEnemy", type = "countAllowZero", label = "# of Impales on Enemy (if not maximum):", ifFlag = "impale", apply = function(val, modList, enemyModList)
+		enemyModList:NewMod("Multiplier:ImpaleStacks", "BASE", val, "Config", { type = "Condition", var = "Combat" })
 	end },
 	{ var = "multiplierBleedsOnEnemy", type = "count", label = "# of Bleeds on Enemy (if not maximum):", ifFlag = "bleed", tooltip = "Set number of Bleeds if using Crimson Dance node", apply = function(val, modList, enemyModList)
 		enemyModList:NewMod("Multiplier:BleedStacks", "BASE", val, "Config", { type = "Condition", var = "Combat" })


### PR DESCRIPTION
This means that the Master of Metal, Watcher's Eye with impale stacks, and the Deep Cuts notable now display the real DPS change when hovered as long as the "# of Impales on Enemy" stacks config is blank or large enough.

Changes to impale:
 - Removed the clamp to 9 stacks from the config
 - If the config value isn't set, the calculated maximum number of impales is used
 - If the config value is 0, then 0 impales are used
 - If the config value is too large, then it is clamped down to the maximum number of impales
 - The "Stacks on Enemy" value in the Impale section is now properly displayed

Added some useful utility functions:
 - modStore:ReplaceMod will find an exact match to the mod and update the value
 - modStore:HasMod will check to see if modStore:Sum would find any matching mods to sum up, so it can be distinguished from a result of 0.
 - Added the "countAllowZero" config type, which works like "count" but will add the mod if its value is 0. This way 0 can be distinguished from blank.