### PR TITLE
Fix for crafted and custom modifiers disappearing from custom items when prefix or suffixes are changed

### DIFF
--- a/Classes/Item.lua
+++ b/Classes/Item.lua
@@ -614,6 +614,14 @@ end
 
 -- Rebuild explicit modifiers using the item's affixes
 function ItemClass:Craft()
+	-- Save off any crafted or custom mods so they can be re-added at the end
+	local savedMods = {}
+	for _, mod in ipairs(self.explicitModLines) do
+		if mod.crafted or mod.custom then
+			t_insert(savedMods, mod)
+		end
+	end
+
 	wipeTable(self.explicitModLines)
 	self.namePrefix = ""
 	self.nameSuffix = ""
@@ -658,6 +666,12 @@ function ItemClass:Craft()
 			end
 		end
 	end
+
+	-- Restore the crafted and custom mods
+	for _, mod in ipairs(savedMods) do
+		t_insert(self.explicitModLines, mod)
+	end
+
 	self:BuildAndParseRaw()
 end
 

--- a/Classes/ItemsTab.lua
+++ b/Classes/ItemsTab.lua
@@ -1161,6 +1161,9 @@ function ItemsTabClass:UpdateAffixControls()
 		self:UpdateAffixControl(self.controls["displayItemAffix"..i], item, "Prefix", "prefixes", i)
 		self:UpdateAffixControl(self.controls["displayItemAffix"..(i+item.affixLimit/2)], item, "Suffix", "suffixes", i)
 	end	
+	-- The custom affixes may have had their indexes changed, so the custom control UI is also rebuilt so that it will
+	-- reference the correct affix index.
+	self:UpdateCustomControls()
 end
 
 function ItemsTabClass:UpdateAffixControl(control, item, type, outputTable, outputIndex)


### PR DESCRIPTION
When an item is re-crafted from the chosen prefixes and suffixes, the entire explicit mod list is cleared.
 - This would also clear out crafted and custom mods, so they would be lost.
 - The fix is to save off the crafted and custom mods before clearing, then re-add them after the explicit mod list is regenerated.

How to reproduce the original issue:
1) Craft a new item using the "Craft Item..." button
2) Use the default options
3) Add a prefix using the first prefix dropdown
4) Click the "Add modifier..." button and choose a crafting bench or custom modifier to add
5) Add another prefix or suffix using the dropdown
Result: The crafted modifier will disappear from the item, even though the "Remove" button is still there.