### PR TITLE
Added second influence dropdown in item crafting for creating dual-influenced items.

### DIFF
--- a/Classes/DropDownControl.lua
+++ b/Classes/DropDownControl.lua
@@ -130,12 +130,12 @@ function DropDownClass:GetSelValue(key)
 	return self.list[self.selIndex][key]
 end
 
-function DropDownClass:SetSel(newSel)
+function DropDownClass:SetSel(newSel, dontCallSelFunc)
 	newSel = m_max(1, m_min(self:GetDropCount(), newSel))
 	newSel = self:DropIndexToListIndex(newSel)
 	if newSel and newSel ~= self.selIndex then
 		self.selIndex = newSel
-		if self.selFunc then
+		if not dontCallSelFunc and self.selFunc then
 			self.selFunc(newSel, self.list[newSel])
 		end
 	end

--- a/Classes/ImportTab.lua
+++ b/Classes/ImportTab.lua
@@ -12,6 +12,8 @@ local realmList = {
 	{ label = "PS4", id = "SONY", realmCode = "sony", profileURL = "https://www.pathofexile.com/account/sony/view-profile/" },
 }
 
+local influenceInfo = itemLib.influenceInfo
+
 local ImportTabClass = newClass("ImportTab", "ControlHost", "Control", function(self, build)
 	self.ControlHost()
 	self.Control()
@@ -638,12 +640,9 @@ function ImportTabClass:ImportItem(itemData, slotName)
 
 	-- Import item data
 	item.uniqueID = itemData.id
-	item.shaper = itemData.shaper
-	item.elder = itemData.elder
-	item.adjudicator = itemData.adjudicator
-	item.basilisk = itemData.basilisk
-	item.crusader = itemData.crusader
-	item.eyrie = itemData.eyrie
+	for _, curInfluenceInfo in ipairs(influenceInfo) do
+		item[curInfluenceInfo.key] = itemData[curInfluenceInfo.key]
+	end
 	if itemData.ilvl > 0 then
 		item.itemLevel = itemData.ilvl
 	end

--- a/Modules/ItemTools.lua
+++ b/Modules/ItemTools.lua
@@ -11,6 +11,16 @@ local m_floor = math.floor
 
 itemLib = { }
 
+-- Info table for all types of item influence
+itemLib.influenceInfo = {
+	{ key="shaper", display="Shaper", color=colorCodes.SHAPER },
+	{ key="elder", display="Elder", color=colorCodes.ELDER },
+	{ key="adjudicator", display="Warlord", color=colorCodes.ADJUDICATOR },
+	{ key="basilisk", display="Hunter", color=colorCodes.BASILISK },
+	{ key="crusader", display="Crusader", color=colorCodes.CRUSADER },
+	{ key="eyrie", display="Redeemer", color=colorCodes.EYRIE },
+}
+
 -- Apply range value (0 to 1) to a modifier that has a range: (x to x) or (x-x to x-x)
 function itemLib.applyRange(line, range)
 	return line:gsub("%((%d+)%-(%d+) to (%d+)%-(%d+)%)", "(%1-%2) to (%3-%4)")


### PR DESCRIPTION
Changes are relatively straightforward, since multiple influence was already supported for items, just not the crafting UI.

Here's what it looks like:
![image](https://user-images.githubusercontent.com/10701249/79040438-51c26e00-7b9d-11ea-8cc4-5492e41d004a.png)