### PR TITLE
Add config to toggle build name in titlebar

### DIFF
--- a/Classes/TreeTab.lua
+++ b/Classes/TreeTab.lua
@@ -237,6 +237,7 @@ function TreeTabClass:SetActiveSpec(specId)
 	local curSpec = self.specList[self.activeSpec]
 	self.build.spec = curSpec
 	self.build.buildFlag = true
+	self.build.spec:SetWindowTitleWithBuildClass()
 	for _, slot in pairs(self.build.itemsTab.slots) do
 		if slot.nodeId then
 			if prevSpec then

--- a/Modules/Build.lua
+++ b/Modules/Build.lua
@@ -836,6 +836,9 @@ function buildMode:OnFrame(inputEvents)
 	if main.showThousandsSidebar ~= self.lastShowThousandsSidebar then
 		self:RefreshStatList()
 	end
+	if main.showTitlebarName ~= self.lastShowTitlebarName then
+		self.spec:SetWindowTitleWithBuildClass()
+	end
 
 	-- Update contents of main skill dropdowns
 	self:RefreshSkillSelectControls(self.controls, self.mainSocketGroup, "")
@@ -1122,6 +1125,7 @@ function buildMode:FormatStat(statData, statVal)
 		valStr = color .. valStr
 	end
 	self.lastShowThousandsSidebar = main.showThousandsSidebar
+	self.lastShowTitlebarName = main.showTitlebarName
 	return valStr
 end
 

--- a/Modules/Main.lua
+++ b/Modules/Main.lua
@@ -209,6 +209,7 @@ the "Releases" section of the GitHub page.]])
 	self.nodePowerTheme = "RED/BLUE"
 	self.showThousandsSidebar = true
 	self.showThousandsCalcs = true
+	self.showTitlebarName = true
 
 	self:SetMode("BUILD", false, "Unnamed build")
 
@@ -467,6 +468,9 @@ function main:LoadSettings()
 				if node.attrib.showThousandsCalcs then
 					self.showThousandsCalcs = node.attrib.showThousandsCalcs == "true"
 				end -- else leave at default
+				if node.attrib.showTitlebarName then
+					self.showTitlebarName = node.attrib.showTitlebarName
+				end
 			end
 		end
 	end
@@ -511,6 +515,7 @@ function main:SaveSettings()
 		nodePowerTheme = self.nodePowerTheme,
 		showThousandsSidebar = tostring(self.showThousandsSidebar),
 		showThousandsCalcs = tostring(self.showThousandsCalcs),
+		showTitlebarName = tostring(self.showTitlebarName),
 	} })
 	local res, errMsg = common.xml.SaveXMLFile(setXML, self.userPath.."Settings.xml")
 	if not res then
@@ -557,10 +562,15 @@ function main:OpenOptionsPopup()
 		self.showThousandsCalcs = state
 	end)
 	controls.thousandsCalcs.state = self.showThousandsCalcs
+	controls.titlebarName = new("CheckBoxControl", {"TOPLEFT",nil,"TOPLEFT"}, 230, 116, 20, "Show build name in window title:", function(state)
+		self.showTitlebarName = state
+	end)
+	controls.titlebarName.state = self.showTitlebarName
 	local initialNodePowerTheme = self.nodePowerTheme
 	local initialThousandsSidebar = self.showThousandsSidebar
 	local initialThousandsCalcs = self.showThousandsCalcs
-	controls.save = new("ButtonControl", nil, -45, 120, 80, 20, "Save", function()
+	local initialTitlebarName = self.showTitlebarName
+	controls.save = new("ButtonControl", nil, -45, 144, 80, 20, "Save", function()
 		if controls.proxyURL.buf:match("%w") then
 			launch.proxyURL = controls.proxyType.list[controls.proxyType.selIndex].scheme .. "://" .. controls.proxyURL.buf
 		else
@@ -579,13 +589,14 @@ function main:OpenOptionsPopup()
 		end
 		main:ClosePopup()
 	end)
-	controls.cancel = new("ButtonControl", nil, 45, 120, 80, 20, "Cancel", function()
+	controls.cancel = new("ButtonControl", nil, 45, 144, 80, 20, "Cancel", function()
 		self.nodePowerTheme = initialNodePowerTheme
 		self.showThousandsSidebar = initialThousandsSidebar
 		self.showThousandsCalcs = initialThousandsCalcs
+		self.showTitlebarName = initialTitlebarName
 		main:ClosePopup()
 	end)
-	self:OpenPopup(450, 150, "Options", controls, "save", nil, "cancel")
+	self:OpenPopup(450, 174, "Options", controls, "save", nil, "cancel")
 end
 
 function main:OpenUpdatePopup()
@@ -886,7 +897,7 @@ function main:OpenNewFolderPopup(path, onClose)
 end
 
 function main:SetWindowTitleSubtext(subtext)
-	if not subtext then
+	if not subtext or not self.showTitlebarName then
 		SetWindowTitle("Path of Building")
 	else
 		SetWindowTitle("Path of Building - "..subtext)


### PR DESCRIPTION
- Adds a config option to toggle the functionality of #688 , which shows the build name and ascendancy in the window title
- Also fixes a problem with #688 I noticed, where the window title wouldn't change if you selected a new passive tree with a different ascendancy in the dropdown menu

![image](https://user-images.githubusercontent.com/39030429/79054009-4441ce00-7c07-11ea-8cf9-685c52a892b3.png)

- Is toggled on by default
- Updates the window title automatically when the option is changed
- The spacing of the new option in the box lines up and has the same spacing and everything as the other config options

I tested a few different situations to make sure it doesn't cause any errors or crashes. The following all worked fine:
- Starting PoB when settings.xml does not exist
- Starting PoB when settings.xml exists but doesn't have the new option in it
- Changing Ascendancies with the option both on and off
- Changing builds with the option both on and off

Those should all cover the situations where the settings file needs changed or the title bar functions from #688 are called.