### PR TITLE
Catalyst support for crafted rare items

### DIFF
--- a/Data/Uniques/amulet.lua
+++ b/Data/Uniques/amulet.lua
@@ -10,14 +10,14 @@ Variant: Pre 2.6.0
 Variant: Current
 Requires Level 45
 Implicits: 1
-+(20-30) to Strength
-10% reduced Attack Speed
-10% reduced Cast Speed
-+(400-500) to Armour
-{variant:1}+(30-40) Life gained when you Block
-{variant:2,3}+(34-48) Life gained when you Block
-{variant:1}+(10-20) Mana gained when you Block
-{variant:2,3}+(10-24) Mana gained when you Block
+{tags:jewellery_attribute}+(20-30) to Strength
+{tags:attack}10% reduced Attack Speed
+{tags:caster}10% reduced Cast Speed
+{tags:jewellery_defense}+(400-500) to Armour
+{variant:1}{tags:life}+(30-40) Life gained when you Block
+{variant:2,3}{tags:life}+(34-48) Life gained when you Block
+{variant:1}{tags:mana}+(10-20) Mana gained when you Block
+{variant:2,3}{tags:mana}+(10-24) Mana gained when you Block
 {variant:1}20% reduced Movement Speed
 {variant:2}10% reduced Movement Speed
 +3% to maximum Block Chance
@@ -30,23 +30,23 @@ Araku Tiki
 Coral Amulet
 Upgrade: Upgrades to unique{Ngamahu Tiki} via prophecy{A Forest of False Idols}
 Implicits: 1
-(2-4) Life Regenerated per second
-You gain 100 Evasion Rating when on Low Life
-+(30-50) to maximum Life
-+(20-30)% to Fire Resistance
-1% of Life Regenerated per Second while on Low Life
+{tags:life}(2-4) Life Regenerated per second
+{tags:jewellery_defense,life}You gain 100 Evasion Rating when on Low Life
+{tags:life}+(30-50) to maximum Life
+{tags:jewellery_resistance}+(20-30)% to Fire Resistance
+{tags:life}1% of Life Regenerated per Second while on Low Life
 ]],[[
 Ngamahu Tiki
 Coral Amulet
 Source: Upgraded from unique{Araku Tiki} via prophecy{A Forest of False Idols}
 Requires Level 36
 Implicits: 1
-(2-4) Life Regenerated per second
-(50-70)% increased Fire Damage
-You gain 100 Evasion Rating when on Low Life
-+(30-50) to maximum Life
-+(20-30)% to Fire Resistance
-1% of Life Regenerated per Second while on Low Life
+{tags:life}(2-4) Life Regenerated per second
+{tags:jewellery_elemental}(50-70)% increased Fire Damage
+{tags:jewellery_defense,life}You gain 100 Evasion Rating when on Low Life
+{tags:life}+(30-50) to maximum Life
+{tags:jewellery_resistance}+(20-30)% to Fire Resistance
+{tags:life}1% of Life Regenerated per Second while on Low Life
 ]],[[
 The Ascetic
 Gold Amulet
@@ -61,8 +61,8 @@ Astramentis
 Onyx Amulet
 Requires Level 20
 Implicits: 1
-+(10-16) to all Attributes
-+(80-100) to all Attributes
+{tags:jewellery_attribute}+(10-16) to all Attributes
+{tags:jewellery_attribute}+(80-100) to all Attributes
 -4 Physical Damage taken from Attacks
 ]],[[
 Atziri's Foible
@@ -71,14 +71,14 @@ Variant: Pre 2.6.0
 Variant: Current
 Requires Level 16
 Implicits: 1
-(20-30)% increased Mana Regeneration Rate
-{variant:1}+50 to maximum Mana
-{variant:2}+100 to maximum Mana
-{variant:1}(8-12)% increased maximum Mana
-{variant:2}(16-24)% increased maximum Mana
-{variant:1}(40-60)% increased Mana Regeneration Rate
-{variant:2}(80-100)% increased Mana Regeneration Rate
-Items and Gems have 25% reduced Attribute Requirements
+{tags:mana}(20-30)% increased Mana Regeneration Rate
+{variant:1}{tags:mana}+50 to maximum Mana
+{variant:2}{tags:mana}+100 to maximum Mana
+{variant:1}{tags:mana}(8-12)% increased maximum Mana
+{variant:2}{tags:mana}(16-24)% increased maximum Mana
+{variant:1}{tags:mana}(40-60)% increased Mana Regeneration Rate
+{variant:2}{tags:mana}(80-100)% increased Mana Regeneration Rate
+{tags:jewellery_attribute}Items and Gems have 25% reduced Attribute Requirements
 ]],[[
 Aul's Uprising
 Onyx Amulet
@@ -103,22 +103,22 @@ Variant: Intelligence: Zealotry
 Variant: Envy
 Requires Level 55
 Implicits: 1
-+(10-16) to all Attributes
-{variant:1,2,3,4,5}+(20-30) to Strength
-{variant:6,7,8,9}+(20-30) to Dexterity
-{variant:10,11,12,13,14,15,16}+(20-30) to Intelligence
+{tags:jewellery_attribute}+(10-16) to all Attributes
+{variant:1,2,3,4,5}{tags:jewellery_attribute}+(20-30) to Strength
+{variant:6,7,8,9}{tags:jewellery_attribute}+(20-30) to Dexterity
+{variant:10,11,12,13,14,15,16}{tags:jewellery_attribute}+(20-30) to Intelligence
 {variant:17}Grants Level 15 Envy Skill
-{variant:1,2,3,4,5}(15-20)% increased Armour
-{variant:6,7,8,9}(15-20)% increased Evasion Rating
-{variant:10,11,12,13,14,15,16}(15-20)% increased maximum Energy Shield
-{variant:17}+(15-20) to all Attributes
-+(50-70) to maximum Life
+{variant:1,2,3,4,5}{tags:jewellery_defense}(15-20)% increased Armour
+{variant:6,7,8,9}{tags:jewellery_defense}(15-20)% increased Evasion Rating
+{variant:10,11,12,13,14,15,16}{tags:jewellery_defense}(15-20)% increased maximum Energy Shield
+{variant:17}{tags:jewellery_attribute}+(15-20) to all Attributes
+{tags:life}+(50-70) to maximum Life
 {variant:1,2,3,4,5}10% reduced Stun and Block Recovery
 {variant:6,7,8,9}Nearby Enemies grant 25% increased Flask Charges
 {variant:10,11,12,13,14,15,16}2% additional Chance to receive a Critical Strike
 {variant:1,2,3,4,5}Nearby Enemies have 10% reduced Stun and Block Recovery
 {variant:10,11,12,13,14,15,16}Hits against Nearby Enemies have 50% increased Critical Strike Chance
-{variant:17}(15-20)% increased Global Defences
+{variant:17}{tags:jewellery_defense}(15-20)% increased Global Defences
 {variant:1}Anger Reserves no Mana
 {variant:2}Determination Reserves no Mana
 {variant:3}Pride Reserves no Mana
@@ -143,13 +143,13 @@ Variant: Pre 2.5.0
 Variant: Current
 Requires Level 32
 Implicits: 1
-+(16-24) to Strength and Intelligence
-+(30-50) to maximum Life
-+(50-70) to maximum Mana
+{tags:jewellery_attribute}+(16-24) to Strength and Intelligence
+{tags:life}+(30-50) to maximum Life
+{tags:mana}+(50-70) to maximum Mana
 +1 to Maximum Power Charges
-10% increased Mana Regeneration Rate Per Power Charge
+{tags:mana}10% increased Mana Regeneration Rate Per Power Charge
 {variant:2}(80-100)% increased Power Charge Duration
-1% of Damage is taken from Mana before Life per Power Charge
+{tags:mana}1% of Damage is taken from Mana before Life per Power Charge
 40% reduced Critical Strike Chance per Power Charge
 ]],[[
 Badge of the Brotherhood
@@ -157,7 +157,7 @@ Turquoise Amulet
 Requires Level: 20
 Implicits: 1
 League: Blight
-+(16-24) to Dexterity and Intelligence
+{tags:jewellery_attribute}+(16-24) to Dexterity and Intelligence
 (7-10)% increased Cooldown Recovery of Travel Skills per Frenzy Charge
 (7-10)% increased Effect of Elusive on you per Power Charge
 (20-25)% chance to lose a Frenzy Charge when you use a Travel Skill
@@ -184,7 +184,7 @@ League: Talisman Hardcore
 Requires Level 28
 Talisman Tier: 2
 Implicits: 1
-(15-25)% increased Defences
+(15-25)% increased Global Defences
 +(20-30) to maximum Energy Shield
 +(15-30)% to Fire Resistance
 +(15-30)% to Lightning Resistance
@@ -197,11 +197,11 @@ Amber Amulet
 Source: Use currency{Vaal Orb} on unique{Tear of Purity}
 Requires Level 20
 Implicits: 1
-+(20-30) to Strength
+{tags:jewellery_attribute}+(20-30) to Strength
 Grants level 10 Gluttony of Elements Skill
-Adds 19-43 Chaos Damage to Attacks
-−(10-5)% to all Elemental Resistances
-+(17-29)% to Chaos Resistance
+{tags:attack}Adds 19-43 Chaos Damage to Attacks
+{tags:jewellery_resistance}−(10-5)% to all Elemental Resistances
+{tags:jewellery_resistance}+(17-29)% to Chaos Resistance
 Corrupted
 ]],[[
 Bloodgrip
@@ -209,11 +209,11 @@ Coral Amulet
 Variant: Pre 3.0.0
 Requires Level 55
 Implicits: 1
-(2-4) Life Regenerated per second
-Adds 10 to 20 Physical Damage to Attacks
-+(60-70) to maximum Life
-(8-12) Life Regenerated per second
-100% increased Life Recovery from Flasks
+{tags:life}(2-4) Life Regenerated per second
+{tags:attack}Adds 10 to 20 Physical Damage to Attacks
+{tags:life}+(60-70) to maximum Life
+{tags:life}(8-12) Life Regenerated per second
+{tags:life}100% increased Life Recovery from Flasks
 Moving while Bleeding doesn't cause you to take extra Damage
 ]],[[
 Bloodgrip
@@ -221,11 +221,11 @@ Marble Amulet
 Variant: Current
 Requires Level 74
 Implicits: 1
-(1.2-1.6)% of Life Regenerated per second
-Adds 10 to 20 Physical Damage to Attacks
-+(60-70) to maximum Life
-(8-12) Life Regenerated per second
-100% increased Life Recovery from Flasks
+{tags:life}(1.2-1.6)% of Life Regenerated per second
+{tags:attack}Adds 10 to 20 Physical Damage to Attacks
+{tags:life}+(60-70) to maximum Life
+{tags:life}(8-12) Life Regenerated per second
+{tags:life}100% increased Life Recovery from Flasks
 Moving while Bleeding doesn't cause you to take extra Damage
 ]],[[
 Carnage Heart
@@ -234,14 +234,14 @@ Variant: Pre 2.6.0
 Variant: Current
 Requires Level 20
 Implicits: 1
-+(10-16) to all Attributes
-+(20-40) to all Attributes
-{variant:1}25% reduced maximum Life
-{variant:1}25% reduced maximum Energy Shield
-+(10-20)% to all Elemental Resistances
-(1.2-2)% of Physical Attack Damage Leeched as Life
-{variant:2}(30-40)% increased Damage while Leeching
-{variant:2}50% increased Life Leeched per second
+{tags:jewellery_attribute}+(10-16) to all Attributes
+{tags:jewellery_attribute}+(20-40) to all Attributes
+{tags:life}{variant:1}25% reduced maximum Life
+{tags:jewellery_defense}{variant:1}25% reduced maximum Energy Shield
+{tags:jewellery_resistance}+(10-20)% to all Elemental Resistances
+{tags:attack,life}(1.2-2)% of Physical Attack Damage Leeched as Life
+{tags:life}{variant:2}(30-40)% increased Damage while Leeching
+{tags:life}{variant:2}50% increased Life Leeched per second
 Extra Gore
 ]],[[
 Daresso's Salute
@@ -249,13 +249,13 @@ Citrine Amulet
 League: Anarchy
 Requires Level 16
 Implicits: 1
-+(16-24) to Strength and Dexterity
-50% reduced maximum Energy Shield
-+(30-40)% to Fire Resistance
-+(30-40)% to Cold Resistance
-10% increased Movement Speed when on Full Life
-+2 to Melee Weapon and Unarmed range
-60% increased Melee Damage when on Full Life
+{tags:jewellery_attribute}+(16-24) to Strength and Dexterity
+{tags:jewellery_defense}50% reduced maximum Energy Shield
+{tags:jewellery_resistance}+(30-40)% to Fire Resistance
+{tags:jewellery_resistance}+(30-40)% to Cold Resistance
+{tags:life}10% increased Movement Speed when on Full Life
+{tags:attack}+2 to Melee Weapon and Unarmed range
+{tags:attack,life}60% increased Melee Damage when on Full Life
 ]],[[
 Extractor Mentis
 Agate Amulet
@@ -263,23 +263,23 @@ Variant: {2_6}Pre 3.5.0
 Variant: Current
 Requires Level 16
 Implicits: 1
-+(16-24) to Strength and Intelligence
-+(30-50) to Strength
+{tags:jewellery_attribute}+(16-24) to Strength and Intelligence
+{tags:jewellery_attribute}+(30-50) to Strength
 5% chance to grant Unholy Might to nearby Enemies on Kill
 5% chance to grant Onslaught to nearby Enemies on Kill
 {variant:1}5% chance to gain Unholy Might for 3 seconds on Kill
 {variant:2}10% chance to gain Unholy Might for 10 seconds on Kill
-{variant:1}5% chance to gain Onslaught for 3 seconds on Kill
-{variant:2}10% chance to gain Onslaught for 10 seconds on Kill
-Recover 1% of Maximum Life on Kill
+{variant:1}{tags:caster,attack}5% chance to gain Onslaught for 3 seconds on Kill
+{variant:2}{tags:caster,attack}10% chance to gain Onslaught for 10 seconds on Kill
+{tags:life}Recover 1% of Maximum Life on Kill
 ]],[[
 Eye of Chayula
 Onyx Amulet
 Upgrade: Upgrades to unique{Presence of Chayula} using currency{Blessing of Chayula}
 Requires Level 20
 Implicits: 1
-+(10-16) to all Attributes
-20% reduced maximum Life
+{tags:jewellery_attribute}+(10-16) to all Attributes
+{tags:life}20% reduced maximum Life
 30% increased Rarity of Items found
 Cannot be Stunned
 ]],[[
@@ -289,22 +289,22 @@ League: Breach
 Source: Upgraded from unique{Eye of Chayula} using currency{Blessing of Chayula}
 Requires Level 60
 Implicits: 1
-+(10-16) to all Attributes
+{tags:jewellery_attribute}+(10-16) to all Attributes
 30% increased Rarity of Items found
-+60% to Chaos Resistance
+{tags:jewellery_resistance}+60% to Chaos Resistance
 Cannot be Stunned
-20% of Maximum Life Converted to Energy Shield
+{tags:jewellery_defense,life}20% of Maximum Life Converted to Energy Shield
 ]],[[
 Eye of Innocence
 Citrine Amulet
 Source: Drops from unique{Guardian of the Phoenix}
 Requires Level 68
 Implicits: 1
-+(16-24) to Strength and Dexterity
-10% chance to Ignite
+{tags:jewellery_attribute}+(16-24) to Strength and Dexterity
+{tags:jewellery_elemental}10% chance to Ignite
 (50-70)% increased Damage while Ignited
-Take 100 Fire Damage when you Ignite an Enemy
-2% of Fire Damage Leeched as Life while Ignited
+{tags:jewellery_elemental}Take 100 Fire Damage when you Ignite an Enemy
+{tags:life}2% of Fire Damage Leeched as Life while Ignited
 ]],[[
 Eyes of the Greatwolf
 Greatwolf Talisman
@@ -382,9 +382,9 @@ Turquoise Amulet
 League: Metamorph
 Requires Level 40
 Implicits: 1
-+(16-24) to Dexterity and Intelligence
-(15-25)% increased Evasion Rating
-+(15-20)% to all Elemental Resistances
+{tags:jewellery_attribute}+(16-24) to Dexterity and Intelligence
+{tags:jewellery_defense}(15-25)% increased Evasion Rating
+{tags:jewellery_resistance}+(15-20)% to all Elemental Resistances
 Skills fire 2 additional Projectiles
 (20-30)% increased Projectile Speed
 Modifiers to number of Projectiles instead apply to the number of targets Projectiles Split towards
@@ -394,10 +394,10 @@ Blue Pearl Amulet
 Source: Drops from unique{The Purifier}
 Requires Level 77
 Implicits: 1
-(48-56)% increased Mana Regeneration Rate
-0.5% of Chaos Damage Leeched as Life
-Lose (10-15) Life for each Enemy hit by your Spells
-Lose (20-25) Life for each Enemy hit by your Attacks
+{tags:mana}(48-56)% increased Mana Regeneration Rate
+{tags:life}0.5% of Chaos Damage Leeched as Life
+{tags:caster,life}Lose (10-15) Life for each Enemy hit by your Spells
+{tags:attack,life}Lose (20-25) Life for each Enemy hit by your Attacks
 Skills Chain +1 times
 Projectiles gain (15-20)% of Non-Chaos Damage as extra Chaos Damage per Chain
 ]],[[
@@ -408,11 +408,11 @@ Source: Drops in Tul Breach or from unique{Tul, Creeping Avalanche}
 Upgrade: Upgrades to unique{The Pandemonius} using currency{Blessing of Tul}
 Requires Level 35
 Implicits: 1
-+(20-30) to Dexterity
-(10-20)% increased Cold Damage
-+(35-40)% to Cold Resistance
+{tags:jewellery_attribute}+(20-30) to Dexterity
+{tags:jewellery_elemental}(10-20)% increased Cold Damage
+{tags:jewellery_resistance}+(35-40)% to Cold Resistance
 30% increased Freeze Duration on Enemies
-10% chance to Freeze
+{tags:jewellery_elemental}10% chance to Freeze
 60% increased Damage if you've Frozen an Enemy Recently
 ]],[[
 The Pandemonius
@@ -421,20 +421,20 @@ League: Breach
 Source: Upgraded from unique{The Halcyon} using currency{Blessing of Tul}
 Requires Level 64
 Implicits: 1
-+(20-30) to Dexterity
-(20-30)% increased Cold Damage
-+(35-40)% to Cold Resistance
+{tags:jewellery_attribute}+(20-30) to Dexterity
+{tags:jewellery_elemental}(20-30)% increased Cold Damage
+{tags:jewellery_resistance}+(35-40)% to Cold Resistance
 Chill Enemy for 1 second when Hit
 Blind Chilled Enemies on Hit
-Damage Penetrates 20% Cold Resistance against Chilled Enemies
+{tags:jewellery_elemental}Damage Penetrates 20% Cold Resistance against Chilled Enemies
 ]],[[
 Hinekora's Sight
 Onyx Amulet
 Source: Any prophecy{Prophecy} enemy
 Requires Level 20
 Implicits: 1
-+(10-16) to all Attributes
-+1000 to Accuracy Rating
+{tags:jewellery_attribute}+(10-16) to all Attributes
+{tags:attack}+1000 to Accuracy Rating
 (6-10)% chance to Dodge Attacks
 (6-10)% chance to Dodge Spell Damage
 Cannot be Blinded
@@ -444,13 +444,13 @@ Jade Amulet
 League: Synthesis
 Requires Level 64
 Implicits: 1
-+(20-30) to Dexterity
+{tags:jewellery_attribute}+(20-30) to Dexterity
 Grants Level 22 Precision Skill
-+(25-35) to Dexterity
-Adds (12-15) to (24-28) Physical Damage to Attacks
-Adds (11-15) to (23-28) Cold Damage to Attacks
+{tags:jewellery_attribute}+(25-35) to Dexterity
+{tags:attack}Adds (12-15) to (24-28) Physical Damage to Attacks
+{tags:jewellery_elemental,attack}Adds (11-15) to (23-28) Cold Damage to Attacks
 +(23-28)% to Global Critical Strike Multiplier
-(0.8-1)% of Physical Attack Damage Leeched as Life
+{tags:attack,life}(0.8-1)% of Physical Attack Damage Leeched as Life
 ]],[[
 The Ignomon
 Gold Amulet
@@ -458,11 +458,11 @@ Upgrade: Upgrades to unique{The Effigon} via prophecy{Blind Faith}
 Requires Level 8
 Implicits: 1
 (12-20)% increased Rarity of Items found
-+10 to Dexterity
-Adds 12 to 24 Fire Damage to Attacks
-+(100-150) to Accuracy Rating
-+(100-150) to Evasion Rating
-+20% to Fire Resistance
+{tags:jewellery_attribute}+10 to Dexterity
+{tags:jewellery_elemental,attack}Adds 12 to 24 Fire Damage to Attacks
+{tags:attack}+(100-150) to Accuracy Rating
+{tags:jewellery_defense}+(100-150) to Evasion Rating
+{tags:jewellery_resistance}+20% to Fire Resistance
 ]],[[
 The Effigon
 Gold Amulet
@@ -470,11 +470,11 @@ Source: Upgraded from unique{The Ignomon} via prophecy{Blind Faith}
 Requires Level 57
 Implicits: 1
 (12-20)% increased Rarity of Items found
-+10 to Dexterity
-Adds 12 to 24 Fire Damage to Attacks
-+(100-150) to Accuracy Rating
-+(100-150) to Evasion Rating
-+20% to Fire Resistance
+{tags:jewellery_attribute}+10 to Dexterity
+{tags:jewellery_elemental,attack}Adds 12 to 24 Fire Damage to Attacks
+{tags:attack}+(100-150) to Accuracy Rating
+{tags:jewellery_defense}+(100-150) to Evasion Rating
+{tags:jewellery_resistance}+20% to Fire Resistance
 Your Hits can't be Evaded by Blinded Enemies
 Damage Penetrates 10% Fire Resistance against Blinded Enemies
 ]],[[
@@ -488,23 +488,23 @@ Variant: Lightning
 Variant: Chaos
 Requires Level 64
 Implicits: 1
-+(10-16) to all Attributes
-{variant:1}Adds (12-16) to (20-25) Physical Damage
-{variant:2}Adds (20-24) to (33-36) Fire Damage
-{variant:3}Adds (20-24) to (33-36) Cold Damage
-{variant:4}Adds (10-13) to (43-47) Lightning Damage
+{tags:jewellery_attribute}+(10-16) to all Attributes
+{variant:1}{tags:attack}Adds (12-16) to (20-25) Physical Damage
+{variant:2}{tags:jewellery_elemental}Adds (20-24) to (33-36) Fire Damage
+{variant:3}{tags:jewellery_elemental}Adds (20-24) to (33-36) Cold Damage
+{variant:4}{tags:jewellery_elemental}Adds (10-13) to (43-47) Lightning Damage
 {variant:5}Adds (17-19) to (23-29) Chaos Damage
-{variant:1}+(400-500) to Armour
-{variant:2}1% of Life Regenerated per second
-{variant:3}(45-50)% increased Mana Regeneration Rate
-{variant:4}1% of Energy Shield Regenerated per second
+{variant:1}{tags:jewellery_defense}+(400-500) to Armour
+{variant:2}{tags:life}1% of Life Regenerated per second
+{variant:3}{tags:mana}(45-50)% increased Mana Regeneration Rate
+{variant:4}{tags:jewellery_defense}1% of Energy Shield Regenerated per second
 {variant:5}(30-40)% increased Damage over Time
-+(50-70) to maximum Life
+{tags:life}+(50-70) to maximum Life
 {variant:1}(30-40)% increased Stun and Block Recovery
-{variant:2}+(20-25)% to Fire Resistance
-{variant:3}+(20-25)% to Cold Resistance
-{variant:4}+(20-25)% to Lightning Resistance
-{variant:5}+(17-23)% to Chaos Resistance
+{variant:2}{tags:jewellery_resistance}+(20-25)% to Fire Resistance
+{variant:3}{tags:jewellery_resistance}+(20-25)% to Cold Resistance
+{variant:4}{tags:jewellery_resistance}+(20-25)% to Lightning Resistance
+{variant:5}{tags:jewellery_resistance}+(17-23)% to Chaos Resistance
 {variant:1}100% reduced Vulnerability Mana Reservation
 {variant:2}100% reduced Flammability Mana Reservation
 {variant:3}100% reduced Frostbite Mana Reservation
@@ -520,9 +520,9 @@ Variant: Pre 2.6.0
 Variant: Current
 Requires Level 5
 Implicits: 1
-+(20-30) to Dexterity
-+(20-30) to Strength
-+100 to Accuracy Rating
+{tags:jewellery_attribute}+(20-30) to Dexterity
+{tags:jewellery_attribute}+(20-30) to Strength
+{tags:attack}+100 to Accuracy Rating
 {variant:2}30% increased Projectile Damage
 30% increased Projectile Speed
 10% increased Movement Speed
@@ -534,11 +534,11 @@ Variant: Pre 2.6.0
 Variant: Current
 Requires Level 24
 Implicits: 1
-+(20-30) to Dexterity
-+(20-30) to Strength
-{variant:1}(15-20)% increased Attack Speed
-{variant:2}(5-10)% increased Attack Speed
-+100 to Accuracy Rating
+{tags:jewellery_attribute}+(20-30) to Dexterity
+{tags:jewellery_attribute}+(20-30) to Strength
+{tags:attack}{variant:1}(15-20)% increased Attack Speed
+{tags:attack}{variant:2}(5-10)% increased Attack Speed
+{tags:attack}+100 to Accuracy Rating
 {variant:2}30% increased Projectile Damage
 30% increased Projectile Speed
 10% increased Movement Speed
@@ -547,8 +547,8 @@ Maligaro's Cruelty
 Turquoise Amulet
 Requires Level 20
 Implicits: 1
-+(16-24) to Dexterity and Intelligence
-(4-8)% increased maximum Life
+{tags:jewellery_attribute}+(16-24) to Dexterity and Intelligence
+{tags:life}(4-8)% increased maximum Life
 (25-30)% chance to gain a Frenzy Charge on Killing an Enemy affected by 5 or more Poisons
 (12-15)% chance to gain a Power Charge on Killing an Enemy affected by fewer than 5 Poisons
 10% increased Damage with Poison per Frenzy Charge
@@ -558,9 +558,9 @@ The Jinxed Juju
 Citrine Amulet
 Requires Level 48
 Implicits: 1
-+(16-24) to Strength and Dexterity
-+(30-40) to Intelligence
-+(23-31)% to Chaos Resistance
+{tags:jewellery_attribute}+(16-24) to Strength and Dexterity
+{tags:jewellery_attribute}+(30-40) to Intelligence
+{tags:jewellery_resistance}+(23-31)% to Chaos Resistance
 (10-15)% increased Effect of your Curses
 (10-15)% increased effect of Non-Curse Auras from your Skills
 10% of Damage from Hits is taken from your Spectres' Life before you
@@ -575,11 +575,11 @@ Variant: Pre 2.6.0
 Variant: Current
 Requires Level 40
 Implicits: 1
-+(20-30) to Intelligence
-+(80-120) to Accuracy Rating
+{tags:jewellery_attribute}+(20-30) to Intelligence
+{tags:attack}+(80-120) to Accuracy Rating
 {variant:1,2,3}+(140-160)% to Global Critical Strike Multiplier
 {variant:4,5}+(210-240)% to Global Critical Strike Multiplier
-+(80-100) to Evasion Rating
+{tags:jewellery_defense}+(80-100) to Evasion Rating
 (10-15)% increased Light Radius
 {variant:1,2}Non-critical strikes deal 25% Damage
 {variant:3,4}Non-critical strikes deal 40% Damage
@@ -620,7 +620,7 @@ Gold Amulet
 Requires Level 29
 Implicits: 1
 (12-20)% increased Rarity of Items found
-+(40-50) to Dexterity
+{tags:jewellery_attribute}+(40-50) to Dexterity
 (5-8)% increased Movement Speed
 Lightning Damage from Enemies Hitting you is Lucky
 Nearby Allies' Damage with Hits is Lucky
@@ -630,7 +630,7 @@ Coral Amulet
 League: Delve
 Requires Level 34
 Implicits: 1
-(2-4) Life Regenerated per second
+{tags:life}(2-4) Life Regenerated per second
 Can Summon up to 3 additional Golems at a time
 You cannot have non-Golem Minions
 25% reduced Golem Size
@@ -645,13 +645,13 @@ Variant: {2_6}Pre 3.0.0
 Variant: Current
 Requires Level 61
 Implicits: 1
-+(20-30) to Dexterity
-+(40-80) to maximum Life
-+(20-40) to maximum Mana
-{variant:1}20% increased Duration of Elemental Status Ailments on Enemies
-{variant:2}20% increased Duration of Elemental Ailments on Enemies
-Items and Gems have 10% reduced Attribute Requirements
-5% chance to Freeze, Shock and Ignite
+{tags:jewellery_attribute}+(20-30) to Dexterity
+{tags:life}+(40-80) to maximum Life
+{tags:mana}+(20-40) to maximum Mana
+{variant:1}{tags:jewellery_elemental}20% increased Duration of Elemental Status Ailments on Enemies
+{variant:2}{tags:jewellery_elemental}20% increased Duration of Elemental Ailments on Enemies
+{tags:jewellery_attribute}Items and Gems have 10% reduced Attribute Requirements
+{tags:jewellery_elemental}5% chance to Freeze, Shock and Ignite
 Cannot gain Power Charges
 ]],[[
 Rigwald's Curse
@@ -677,12 +677,12 @@ Source: Drops from unique{The Vaal Omnitect}
 Upgrade: Upgrades to unique{Zerphi's Heart} via currency{Vial of Sacrifice}
 Requires Level 32
 Implicits: 1
-(20-30)% increased Mana Regeneration Rate
-Adds (22-27) to (34-38) Fire Damage
-Adds (20-23) to (31-35) Cold Damage
-Adds (1-3) to (47-52) Lightning Damage
+{tags:mana}(20-30)% increased Mana Regeneration Rate
+{tags:jewellery_elemental}Adds (22-27) to (34-38) Fire Damage
+{tags:jewellery_elemental}Adds (20-23) to (31-35) Cold Damage
+{tags:jewellery_elemental}Adds (1-3) to (47-52) Lightning Damage
 Gain a Power Charge when you use a Vaal Skill
-10 Life gained for each Enemy Hit if you have used a Vaal Skill Recently
+{tags:life}10 Life gained for each Enemy Hit if you have used a Vaal Skill Recently
 10% increased Movement Speed if you have used a Vaal Skill Recently
 ]],[[
 Zerphi's Heart
@@ -693,9 +693,9 @@ Variant: Pre 3.10.0
 Variant: Current
 Requires Level 70
 Implicits: 1
-(20-30)% increased Mana Regeneration Rate
+{tags:mana}(20-30)% increased Mana Regeneration Rate
 Adds (48-53) to (58-60) Chaos Damage
-Items and Gems have 50% increased Attribute Requirements
+{tags:jewellery_attribute}Items and Gems have 50% increased Attribute Requirements
 Chaos Damage can Ignite, Chill and Shock
 {variant:1}Gain Soul Eater for 10 seconds when you use a Vaal Skill
 {variant:2}Gain Soul Eater for 20 seconds when you use a Vaal Skill
@@ -706,12 +706,12 @@ Variant: Pre 2.6.0
 Variant: Current
 Requires Level 16
 Implicits: 1
-+(16-24) to Strength and Intelligence
-(30-50)% increased Mana Regeneration Rate
-2% of Life Regenerated per Second
-{variant:1}Nearby Allies gain 1% of Life Regenerated per Second
-{variant:2}Nearby Allies gain 2% of Life Regenerated per Second
-Nearby Allies gain 40% increased Mana Regeneration Rate
+{tags:jewellery_attribute}+(16-24) to Strength and Intelligence
+{tags:mana}(30-50)% increased Mana Regeneration Rate
+{tags:life}2% of Life Regenerated per Second
+{variant:1}{tags:life}Nearby Allies gain 1% of Life Regenerated per Second
+{variant:2}{tags:life}Nearby Allies gain 2% of Life Regenerated per Second
+{tags:mana}Nearby Allies gain 40% increased Mana Regeneration Rate
 ]],[[
 Sidhebreath
 Paua Amulet
@@ -719,13 +719,13 @@ Variant: {2_6}Pre 3.0.0
 Variant: Pre 3.8.0
 Variant: Current
 (20-30)% increased Mana Regeneration Rate
-+25% to Cold Resistance
+{tags:jewellery_resistance}+25% to Cold Resistance
 {variant:1,2}0.2% of Physical Attack Damage Leeched as Mana
 Minions have (10-15)% increased maximum Life
 Minions have (10-15)% increased Movement Speed
 {variant:3}Minions deal 6 to 13 additional Cold Damage
 {variant:1,2}Minions deal (10-15)% increased Damage
-{variant:2,3}(10-15)% reduced Mana Cost of Minion Skills
+{variant:2,3}{tags:mana}(10-15)% reduced Mana Cost of Minion Skills
 ]],[[
 Solstice Vigil
 Onyx Amulet
@@ -734,13 +734,13 @@ Variant: Pre 3.10.0
 Variant: Current
 Requires Level 64
 Implicits: 1
-+(10-16) to all Attributes
+{tags:jewellery_attribute}+(10-16) to all Attributes
 {variant:1}(20-25)% increased Damage
 {variant:2}(30-40)% increased Damage
-+(50-70) to maximum Life
-{variant:1}(2-3) Mana Regenerated per second
-{variant:2}(8-10) Mana Regenerated per second
-Temporal Chains has 100% reduced Mana Reservation
+{tags:life}+(50-70) to maximum Life
+{variant:1}{tags:mana}(2-3) Mana Regenerated per second
+{variant:2}{tags:mana}(8-10) Mana Regenerated per second
+{tags:mana}Temporal Chains has 100% reduced Mana Reservation
 Gain Shaper's Presence for 10 seconds when you kill a Rare or Unique Enemy
 ]],[[
 Star of Wraeclast
@@ -751,10 +751,10 @@ Variant: Pre 3.8.0
 Variant: Current
 Requires Level 28
 Implicits: 1
-+(20-30)% to Fire Resistance
+{tags:jewellery_resistance}+(20-30)% to Fire Resistance
 {variant:3}Grants Level 10 Frostblink Skill
 (30-50)% increased Cold Damage
-+(10-15)% to all Elemental Resistances
+{tags:jewellery_resistance}+(10-15)% to all Elemental Resistances
 {variant:1}30% increased Radius of Curse Skills
 {variant:2}60% increased Area of Effect of Curse Skills
 You cannot be Cursed with Silence
@@ -768,12 +768,12 @@ Variant: Pre 3.4.0
 Variant: Current
 Requires Level 5
 Implicits: 1
-+(20-30) to Intelligence
+{tags:jewellery_attribute}+(20-30) to Intelligence
 {variant:1}50% of Block Chance applied to Spells
 {variant:2}+15% chance to Block Spell Damage
 {variant:3}+(12-15)% chance to Block Spell Damage
-(10-15)% increased Cast Speed
-+(30-50) to maximum Mana
+{tags:caster}(10-15)% increased Cast Speed
+{tags:mana}+(30-50) to maximum Mana
 ]],[[
 Tavukai
 Coral Amulet
@@ -781,22 +781,22 @@ League: Legion
 Source: Drops from Karui Legion
 Requires Level 54
 Implicits: 1
-(2.0-4.0) Life regenerated per second
-+(30-40) to Intelligence
-Minions have (-17-17)% to Chaos Resistance
+{tags:life}(2.0-4.0) Life regenerated per second
+{tags:jewellery_attribute}+(30-40) to Intelligence
+{tags:jewellery_resistance}Minions have (-17-17)% to Chaos Resistance
 Summon Raging Spirit has (20-30)% increased Duration
 Summoned Raging Spirits deal (60-80)% increased Damage
-Summoned Raging Spirits have (80-100)% increased maximum Life
-Summoned Raging Spirits take 20% of their Maximum Life per second as Chaos Damage
+{tags:life}Summoned Raging Spirits have (80-100)% increased maximum Life
+{tags:life}Summoned Raging Spirits take 20% of their Maximum Life per second as Chaos Damage
 ]],[[
 Tear of Purity
 Lapis Amulet
 Requires Level 20
 Implicits: 1
-+(20-30) to Intelligence
+{tags:jewellery_attribute}+(20-30) to Intelligence
 Grants level 10 Purity of Elements Skill
-+(5-10) to all Attributes
-+(20-40) to maximum Life
+{tags:jewellery_attribute}+(5-10) to all Attributes
+{tags:life}+(20-40) to maximum Life
 5% chance to avoid Elemental Ailments
 ]],[[
 Ungil's Harmony
@@ -806,23 +806,23 @@ Variant: Pre 2.6.0
 Variant: Current
 Requires Level 23
 Implicits: 1
-+(16-24) to Dexterity and Intelligence
+{tags:jewellery_attribute}+(16-24) to Dexterity and Intelligence
 100% increased Global Critical Strike Chance
 {variant:1}−50% to Global Critical Strike Multiplier
 {variant:2}−75% to Global Critical Strike Multiplier
 {variant:3}−25% to Global Critical Strike Multiplier
-+(30-50) to maximum Life
-+(30-50) to maximum Mana
-40% increased Stun Recovery
+{tags:life}+(30-50) to maximum Life
+{tags:mana}+(30-50) to maximum Mana
+40% increased Stun and Block Recovery
 ]],[[
 Victario's Acuity
 Turquoise Amulet
 League: Onslaught
 Requires Level 16
 Implicits: 1
-+(16-24) to Dexterity and Intelligence
-+(30-40)% to Lightning Resistance
-+(8-10)% to Chaos Resistance
+{tags:jewellery_attribute}+(16-24) to Dexterity and Intelligence
+{tags:jewellery_resistance}+(30-40)% to Lightning Resistance
+{tags:jewellery_resistance}+(8-10)% to Chaos Resistance
 10% chance to gain a Frenzy Charge on Kill
 10% chance to gain a Power Charge on Kill
 5% increased Projectile Speed per Frenzy Charge
@@ -835,10 +835,10 @@ Source: Drops in Esh Breach or from unique{Esh, Forked Thought}
 Upgrade: Upgrades to unique{Choir of the Storm} using currency{Blessing of Esh}
 Requires Level 40
 Implicits: 1
-+(20-30) to Intelligence
+{tags:jewellery_attribute}+(20-30) to Intelligence
 Trigger Level 12 Lightning Bolt when you deal a Critical Strike
-+(10-15) to all Attributes
-(10-20)% increased maximum Mana
+{tags:jewellery_attribute}+(10-15) to all Attributes
+{tags:mana}(10-20)% increased maximum Mana
 Critical Strike Chance is increased by Lightning Resistance
 ]],[[
 Choir of the Storm
@@ -849,11 +849,11 @@ Variant: {2_6}Pre 3.0.0
 Variant: Current
 Requires Level 69
 Implicits: 1
-+(20-30) to Intelligence
+{tags:jewellery_attribute}+(20-30) to Intelligence
 Trigger Level 20 Lightning Bolt when you deal a Critical Strike
-50% increased Lightning Damage
-(10-20)% increased maximum Mana
-{variant:1}-30% to Lightning Resistance
+{tags:jewellery_elemental}50% increased Lightning Damage
+{tags:mana}(10-20)% increased maximum Mana
+{variant:1}{tags:jewellery_resistance}-30% to Lightning Resistance
 Critical Strike Chance is increased by Lightning Resistance
 ]],[[
 Voll's Devotion
@@ -861,10 +861,10 @@ Agate Amulet
 League: Anarchy, Onslaught
 Requires Level 32
 Implicits: 1
-+(16-24) to Strength and Intelligence
-+(30-40) to maximum Life
-+(20-30) to maximum Energy Shield
-+(15-20)% to all Elemental Resistances
+{tags:jewellery_attribute}+(16-24) to Strength and Intelligence
+{tags:life}+(30-40) to maximum Life
+{tags:jewellery_defense}+(20-30) to maximum Energy Shield
+{tags:jewellery_resistance}+(15-20)% to all Elemental Resistances
 30% reduced Endurance Charge Duration
 30% reduced Power Charge Duration
 Gain an Endurance Charge when a Power Charge expires or is consumed
@@ -873,36 +873,36 @@ Warped Timepiece
 Turquoise Amulet
 Requires Level 50
 Implicits: 1
-+(16-24) to Dexterity and Intelligence
-(8-12)% increased Attack Speed
-(8-12)% increased Cast Speed
+{tags:jewellery_attribute}+(16-24) to Dexterity and Intelligence
+{tags:attack}(8-12)% increased Attack Speed
+{tags:caster}(8-12)% increased Cast Speed
 12% increased Movement Speed
 (8-12)% reduced Skill Effect Duration
-30% increased Life Leeched per second
-30% increased Mana Leeched per second
+{tags:life}30% increased Life Leeched per second
+{tags:mana}30% increased Mana Leeched per second
 ]],[[
 Willowgift
 Jade Amulet
 Requires Level 52
 Implicits: 1
-+(20-30) to Dexterity
-10% reduced Strength
-15% increased Dexterity
--(30-20)% to Fire Resistance
-+(30-40)% to Cold Resistance
+{tags:jewellery_attribute}+(20-30) to Dexterity
+{tags:jewellery_attribute}10% reduced Strength
+{tags:jewellery_attribute}15% increased Dexterity
+{tags:jewellery_resistance}-(30-20)% to Fire Resistance
+{tags:jewellery_resistance}+(30-40)% to Cold Resistance
 Fortify Buffs you create instead grant 30% more Evasion Rating
-(15-25)% increased Attack and Cast Speed while you have Fortify
+{tags:caster,attack}15-25)% increased Attack and Cast Speed while you have Fortify
 ]],[[
 Winterheart
 Gold Amulet
 Requires Level 42
 Implicits: 1
 (12-20)% increased Rarity of Items found
-+(20-30) to Dexterity
-+(50-70) to maximum Life
-+75% to Cold Resistance
+{tags:jewellery_attribute}+(20-30) to Dexterity
+{tags:life}+(50-70) to maximum Life
+{tags:jewellery_resistance}+75% to Cold Resistance
 Cannot be Chilled
-20% of Life Regenerated per Second while Frozen
+{tags:life}20% of Life Regenerated per Second while Frozen
 ]],[[
 Xoph's Heart
 Amber Amulet
@@ -911,11 +911,11 @@ Source: Drops in Xoph Breach or from unique{Xoph, Dark Embers}
 Upgrade: Upgrades to unique{Xoph's Blood} using currency{Blessing of Xoph}
 Requires Level 35
 Implicits: 1
-+(20-30) to Strength
-+(20-30) to Strength
-25% increased Fire Damage
-+(25-35) to maximum Life
-+(20-40)% to Fire Resistance
+{tags:jewellery_attribute}+(20-30) to Strength
+{tags:jewellery_attribute}+(20-30) to Strength
+{tags:jewellery_elemental}25% increased Fire Damage
+{tags:life}+(25-35) to maximum Life
+{tags:jewellery_resistance}+(20-40)% to Fire Resistance
 Cover Enemies in Ash when they Hit you
 ]],[[
 Xoph's Blood
@@ -924,11 +924,11 @@ League: Breach
 Source: Upgraded from unique{Xoph's Heart} using currency{Blessing of Xoph}
 Requires Level 64
 Implicits: 1
-+(20-30) to Strength
-10% increased maximum Life
-+(20-40)% to Fire Resistance
-10% increased Strength
-Damage Penetrates 10% Fire Resistance
+{tags:jewellery_attribute}+(20-30) to Strength
+{tags:life}10% increased maximum Life
+{tags:jewellery_resistance}+(20-40)% to Fire Resistance
+{tags:jewellery_attribute}10% increased Strength
+{tags:jewellery_elemental}Damage Penetrates 10% Fire Resistance
 Cover Enemies in Ash when they Hit you
 Avatar of Fire
 ]],[[
@@ -937,12 +937,12 @@ Onyx Amulet
 Source: Drops from unique{The Eradicator} (Tier 11+)
 Requires Level 25
 Implicits: 1
-+(10-16) to all Attributes
-+(10-20)% to Fire Resistance
-+(10-20)% to Cold Resistance
-+(20-40)% to Lightning Resistance
+{tags:jewellery_attribute}+(10-16) to all Attributes
+{tags:jewellery_resistance}+(10-20)% to Fire Resistance
+{tags:jewellery_resistance}+(10-20)% to Cold Resistance
+{tags:jewellery_resistance}+(20-40)% to Lightning Resistance
 30% reduced Duration of Ailments on Enemies
-(5-10)% chance to Shock
+{tags:jewellery_elemental}(5-10)% chance to Shock
 Enemies take 5% increased Damage for each type of Ailment you have inflicted on them
 Your Elemental Damage can Shock
 ]],

--- a/Data/Uniques/belt.lua
+++ b/Data/Uniques/belt.lua
@@ -10,11 +10,11 @@ Variant: Pre 2.6.0
 Variant: Current
 Requires Level 44
 Implicits: 1
-+(9-20) to maximum Energy Shield
-+300 to Evasion Rating
-{variant:1}+(35-45) to maximum Energy Shield
-{variant:2}+(75-80) to maximum Energy Shield
-+(10-15)% to Elemental Resistances
+{tags:jewellery_defense}+(9-20) to maximum Energy Shield
+{tags:jewellery_defense}+300 to Evasion Rating
+{variant:1}{tags:jewellery_defense}+(35-45) to maximum Energy Shield
+{variant:2}{tags:jewellery_defense}+(75-80) to maximum Energy Shield
+{tags:jewellery_resistance}+(10-15)% to all Elemental Resistances
 You have Phasing if Energy Shield Recharge has started Recently
 6% chance to Dodge Attacks while Phasing
 10% increased Movement Speed while Phasing
@@ -24,11 +24,11 @@ Chain Belt
 Variant: Pre 2.6.0
 Requires Level 70
 Implicits: 1
-+(9-20) to maximum Energy Shield
-(10-20)% increased Elemental Damage with Attack Skills
-+(45-55) to maximum Mana
-+(60-70) to maximum Energy Shield
-0.2% of Physical Attack Damage Leeched as Mana per Power Charge
+{tags:jewellery_defense}+(9-20) to maximum Energy Shield
+{tags:attack,jewellery_elemental}(10-20)% increased Elemental Damage with Attack Skills
+{tags:mana}+(45-55) to maximum Mana
+{tags:jewellery_defense}+(60-70) to maximum Energy Shield
+{tags:attack,life}0.2% of Physical Attack Damage Leeched as Mana per Power Charge
 Chill and Freeze duration on you is based on 65% of Energy Shield
 ]],[[
 Auxium
@@ -37,14 +37,14 @@ Variant: Pre 3.5.0
 Variant: Current
 Requires Level 70
 Implicits: 1
-+(60-80) to maximum Energy Shield
-{variant:1}(10-20)% increased Elemental Damage with Attack Skills
-{variant:2}(20-25)% increased Elemental Damage with Attack Skills per Power Charge
-+(45-55) to maximum Mana
-+(60-70) to maximum Energy Shield
-0.2% of Attack Damage Leeched as Mana per Power Charge
-{variant:1}Chill Effect and Freeze duration on you is based on 65% of Energy Shield
-{variant:2}Chill Effect and Freeze duration on you is based on 100% of Energy Shield
+{tags:jewellery_defense}+(60-80) to maximum Energy Shield
+{variant:1}{tags:attack,jewellery_elemental}(10-20)% increased Elemental Damage with Attack Skills
+{variant:2}{tags:attack,jewellery_elemental}(20-25)% increased Elemental Damage with Attack Skills per Power Charge
+{tags:mana}+(45-55) to maximum Mana
+{tags:jewellery_defense}+(60-70) to maximum Energy Shield
+{tags:attack,life}0.2% of Attack Damage Leeched as Mana per Power Charge
+{variant:1}{tags:jewellery_defense}Chill Effect and Freeze duration on you is based on 65% of Energy Shield
+{variant:2}{tags:jewellery_defense}Chill Effect and Freeze duration on you is based on 100% of Energy Shield
 ]],[[
 Bated Breath
 Chain Belt
@@ -52,12 +52,12 @@ Variant: Pre 2.6.0
 Variant: Current
 Requires Level 22
 Implicits: 1
-+(9-20) to maximum Energy Shield
+{tags:jewellery_defense}+(9-20) to maximum Energy Shield
 10% increased Damage
-+(15-25) to Intelligence
-+(20-30) to maximum Energy Shield
-{variant:2}20% increased maximum Energy Shield
-50% increased Energy Shield Recharge Rate
+{tags:jewellery_attribute}+(15-25) to Intelligence
+{tags:jewellery_defense}+(20-30) to maximum Energy Shield
+{variant:2}{tags:jewellery_defense}20% increased maximum Energy Shield
+{tags:jewellery_defense}50% increased Energy Shield Recharge Rate
 ]],[[
 Belt of the Deceiver
 Heavy Belt
@@ -65,22 +65,22 @@ Variant: Pre 2.6.0
 Variant: Current
 Requires Level 20
 Implicits: 1
-+(25-35) to Strength
+{tags:jewellery_attribute}+(25-35) to Strength
 {variant:1}10% reduced Chance to Block Attacks and Spells
 (15-25)% increased Physical Damage
 You take 30% reduced Extra Damage from Critical Strikes
-+(30-40) to maximum Life
-{variant:1}+(6-10)% to all Elemental Resistances
-{variant:2}+(10-15)% to all Elemental Resistances
+{tags:life}+(30-40) to maximum Life
+{variant:1}{tags:jewellery_resistance}+(6-10)% to all Elemental Resistances
+{variant:2}{tags:jewellery_resistance}+(10-15)% to all Elemental Resistances
 {variant:2}Nearby Enemies are Intimidated
 ]],[[
 Bisco's Leash
 Heavy Belt
 Requires Level 30
 Implicits: 1
-+(25-35) to Strength
+{tags:jewellery_attribute}+(25-35) to Strength
 5% increased Quantity of Items found
-+(20-40)% to Cold Resistance
+{tags:jewellery_resistance}+(20-40)% to Cold Resistance
 Rampage
 1% increased Rarity of Items found per 15 Rampage Kills
 ]],[[
@@ -90,9 +90,9 @@ League: Incursion
 Upgrade: Upgrades to unique{Coward's Legacy} via currency{Vial of Consequence}
 Requires Level 22
 Implicits: 1
-+(9-20) to maximum Energy Shield
+{tags:jewellery_defense}+(9-20) to maximum Energy Shield
 (20-25)% increased Damage
-+(10-15) to all Attributes
+{tags:jewellery_attribute}+(10-15) to all Attributes
 (5-10)% increased Movement Speed
 Damage from Enemies Hitting you is Unlucky while you are Cursed with Vulnerability
 You are cursed with Level 10 Vulnerability
@@ -103,11 +103,11 @@ League: Incursion
 Source: Upgraded from unique{Coward's Chains} via currency{Vial of Consequence}
 Requires Level 52
 Implicits: 1
-+(9-20) to maximum Energy Shield
-+(15-20) to all Attributes
+{tags:jewellery_defense}+(9-20) to maximum Energy Shield
+{tags:jewellery_attribute}+(15-20) to all Attributes
 (5-10)% increased Movement Speed
 50% increased Effect of Curses on you
-You count as on Low Life while you are Cursed with Vulnerability
+{tags:life}You count as on Low Life while you are Cursed with Vulnerability
 You are Cursed with Level 20 Vulnerability
 ]],[[
 Cyclopean Coil
@@ -115,13 +115,13 @@ Leather Belt
 Source: Drops from unique{The Elder}
 Requires Level 68
 Implicits: 1
-+(25-40) to maximum Life
-+(60-80) to maximum Life
-(5-15)% increased Attributes
+{tags:life}+(25-40) to maximum Life
+{tags:life}+(60-80) to maximum Life
+{tags:jewellery_attribute}(5-15)% increased Attributes
 Cannot be Frozen if Dexterity is higher than Intelligence
 Cannot be Ignited if Strength is higher than Dexterity
 Cannot be Shocked if Intelligence is higher than Strength
-1% increased Damage per 5 of your lowest Attribute
+{tags:life}1% increased Damage per 5 of your lowest Attribute
 Elder Item
 ]],[[
 Darkness Enthroned
@@ -142,19 +142,19 @@ Variant: Cold
 Variant: Lightning
 Requires Level 68
 Implicits: 1
-+(25-35) to Strength
+{tags:jewellery_attribute}+(25-35) to Strength
 {variant:1}(20-30)% increased Physical Damage
-{variant:2}(20-30)% increased Fire Damage
-{variant:3}(20-30)% increased Cold Damage
-{variant:4}(20-30)% increased Lightning Damage
-{variant:2,3,4}+(300-350) to Armour
-{variant:1,3,4}+(30-35)% to Fire Resistance
-{variant:1,2,4}+(30-35)% to Cold Resistance
-{variant:1,2,3}+(30-35)% to Lightning Resistance
-{variant:1}0.2% of Physical Damage Leeched as Life
-{variant:2}0.2% of Fire Damage Leeched as Life
-{variant:3}0.2% of Cold Damage Leeched as Life
-{variant:4}0.2% of Lightning Damage Leeched as Life
+{variant:2}{tags:jewellery_elemental}(20-30)% increased Fire Damage
+{variant:3}{tags:jewellery_elemental}(20-30)% increased Cold Damage
+{variant:4}{tags:jewellery_elemental}(20-30)% increased Lightning Damage
+{variant:2,3,4}{tags:jewellery_defense}+(300-350) to Armour
+{variant:1,3,4}{tags:jewellery_resistance}+(30-35)% to Fire Resistance
+{variant:1,2,4}{tags:jewellery_resistance}+(30-35)% to Cold Resistance
+{variant:1,2,3}{tags:jewellery_resistance}+(30-35)% to Lightning Resistance
+{variant:1}{tags:life}0.2% of Physical Damage Leeched as Life
+{variant:2}{tags:lifejewellery_elemental}0.2% of Fire Damage Leeched as Life
+{variant:3}{tags:lifejewellery_elemental}0.2% of Cold Damage Leeched as Life
+{variant:4}{tags:lifejewellery_elemental}0.2% of Lightning Damage Leeched as Life
 {variant:1}Your Flasks grant 25% reduced Enemy Stun Threshold during flask effect
 {variant:2}Your Flasks grant 10% chance to Ignite during flask effect
 {variant:3}Your Flasks grant 10% chance to Freeze during flask effect
@@ -166,14 +166,14 @@ Variant: Pre 2.6.0
 Variant: Current
 Requires Level 52
 Implicits: 1
-+(25-35) to Strength
-+(70-85) to maximum Life
-+(20-40)% to Fire Resistance
-+(20-40)% to Cold Resistance
-{variant:1}0.6% of Attack Damage Leeched as Life against Chilled enemies
-{variant:2}1% of Attack Damage Leeched as Life against Chilled enemies
-{variant:1}Ignites you inflict with Attacks deal Damage 20% faster
-{variant:2}Ignites you inflict with Attacks deal Damage 35% faster
+{tags:jewellery_attribute}+(25-35) to Strength
+{tags:life}+(70-85) to maximum Life
+{tags:jewellery_resistance}+(20-40)% to Fire Resistance
+{tags:jewellery_resistance}+(20-40)% to Cold Resistance
+{variant:1}{tags:attack,life}0.6% of Attack Damage Leeched as Life against Chilled enemies
+{variant:2}{tags:attack,life}1% of Attack Damage Leeched as Life against Chilled enemies
+{variant:1}{tags:jewellery_elemental,attack}Ignites you inflict with Attacks deal Damage 20% faster
+{variant:2}{tags:jewellery_elemental,attack}Ignites you inflict with Attacks deal Damage 35% faster
 Deal no Physical Damage
 ]],[[
 Faminebind
@@ -182,7 +182,7 @@ League: Talisman Standard, Talisman Hardcore
 Requires Level 18
 Implicits: 1
 (12-24)% increased Physical Damage
-+(20-30)% to Cold Resistance
+{tags:jewellery_resistance}+(20-30)% to Cold Resistance
 60% increased Flask effect duration
 Deals 50 Chaos Damage per second to nearby Enemies
 20% increased Projectile Damage
@@ -194,11 +194,11 @@ League: Talisman Standard, Talisman Hardcore
 Requires Level 11
 Implicits: 1
 (12-24)% increased Physical Damage
-Adds 5 to 10 Physical Damage to Attacks
-+(20-40) to maximum Life
-0.2% of Physical Attack Damage Leeched as Life
+{tags:attack}Adds 5 to 10 Physical Damage to Attacks
+{tags:life}+(20-40) to maximum Life
+{tags:attack,life}0.2% of Physical Attack Damage Leeched as Life
 50% increased Flask Charges gained while using a Flask
-50% increased Mana Regeneration while using a Flask
+{tags:mana}50% increased Mana Regeneration while using a Flask
 ]],[[
 The Flow Untethered
 Cloth Belt
@@ -207,9 +207,9 @@ Requires Level 60
 Implicits: 1
 (15-25)% increased Stun and Block Recovery
 Grants Summon Harbinger of Time Skill
-(10-15)% increased Attack and Cast Speed
-(15-20)% increased Life Recovery rate
-(15-20)% increased Energy Shield Recovery rate
+{tags:caster,attack}(10-15)% increased Attack and Cast Speed
+{tags:life}(15-20)% increased Life Recovery rate
+{tags:jewellery_defense}(15-20)% increased Energy Shield Recovery rate
 (15-20)% increased Cooldown Recovery Speed
 Debuffs on you expire (15-20)% faster
 ]],[[
@@ -217,8 +217,8 @@ Gluttony
 Leather Belt
 Requires Level 48
 Implicits: 1
-+(25-40) to maximum Life
-+(60-80) to maximum Life
+{tags:life}+(25-40) to maximum Life
+{tags:life}+(60-80) to maximum Life
 Culling Strike against Enemies Cursed with Poacher's Mark
 Curse Enemies with Level 30 Poacher's Mark on Hit, which can apply to Hexproof Enemies
 Take (100-200) Physical Damage when you use a Movement Skill
@@ -231,10 +231,10 @@ Variant: {2_6}Pre 3.0.0
 Variant: Current
 Requires Level 40
 Implicits: 1
-+(25-40) to maximum Life
-+(40-55) to Strength
-+(40-55) to Dexterity
-+(50-60) to maximum Life
+{tags:life}+(25-40) to maximum Life
+{tags:jewellery_attribute}+(40-55) to Strength
+{tags:jewellery_attribute}+(40-55) to Dexterity
+{tags:life}+(50-60) to maximum Life
 {variant:1}(20-30)% increased Damage against Rare monsters
 {variant:2}(20-30)% increased Damage with Hits against Rare monsters
 When you Kill a Rare monster, you gain its mods for 20 seconds
@@ -254,20 +254,20 @@ Variant: Energy Shield Regen
 Variant: Lucky Crit Chance while Focussed
 Requires Level 60
 Implicits: 1
-+(25-40) to maximum Life
-+(30-40)% to Cold Resistance
+{tags:life}+(25-40) to maximum Life
+{tags:jewellery_resistance}+(30-40)% to Cold Resistance
 Chill nearby Enemies when you Focus, causing 30% reduced Action Speed
 Focus has (15-25)% increased Cooldown Recovery Speed
 (50-70)% increased Damage with Hits and Ailments against Chilled Enemies
-{variant:1}{crafted}(1.0-2.0)% of Life Regenerated per second during any Flask Effect
-{variant:2}{crafted}+(8-15)% to Fire and Chaos Resistances
-{variant:3}{crafted}+(8-15)% to Cold and Chaos Resistances
-{variant:4}{crafted}+(8-15)% to Lightning and Chaos Resistances
-{variant:5}{crafted}+(6-17) to Strength and Dexterity
-{variant:6}{crafted}+(6-17) to Dexterity and Intelligence
-{variant:7}{crafted}+(6-17) to Strength and Intelligence
+{variant:1}{crafted}{tags:life}(1.0-2.0)% of Life Regenerated per second during any Flask Effect
+{variant:2}{crafted}{tags:jewellery_resistance}+(8-15)% to Fire and Chaos Resistances
+{variant:3}{crafted}{tags:jewellery_resistance}+(8-15)% to Cold and Chaos Resistances
+{variant:4}{crafted}{tags:jewellery_resistance}+(8-15)% to Lightning and Chaos Resistances
+{variant:5}{crafted}{tags:jewellery_attribute}+(6-17) to Strength and Dexterity
+{variant:6}{crafted}{tags:jewellery_attribute}+(6-17) to Dexterity and Intelligence
+{variant:7}{crafted}{tags:jewellery_attribute}+(6-17) to Strength and Intelligence
 {variant:8}{crafted}(7-12)% increased Trap Throwing Speed
-{variant:9}{crafted}(15-120) Energy Shield Regenerated per second while a Rare or Unique Enemy is Nearby
+{variant:9}{crafted}{tags:jewellery_defense}(15-120) Energy Shield Regenerated per second while a Rare or Unique Enemy is Nearby
 {variant:10}{crafted}Your Critical Strike Chance is Lucky while Focussed
 ]],[[
 Immortal Flesh
@@ -277,24 +277,24 @@ Variant: Pre 2.6.0
 Variant: Current
 Requires Level 50
 Implicits: 1
-+(25-40) to maximum Life
-+(75-100) to maximum Life
-(67-75) Life Regenerated per second
-(8-10) Mana Regenerated per second
+{tags:life}+(25-40) to maximum Life
+{tags:life}+(75-100) to maximum Life
+{tags:life}(67-75) Life Regenerated per second
+{tags:mana}(8-10) Mana Regenerated per second
 {variant:1}−40% to all Elemental Resistances
 {variant:3}−(15-25)% to all Elemental Resistances
 {variant:1}−10% to all maximum Resistances
 {variant:2}−5% to all maximum Resistances
 −(50-40) Physical Damage taken from Attacks
-40% increased Armour while not Ignited, Frozen or Shocked
+{tags:jewellery_defense}40% increased Armour while not Ignited, Frozen or Shocked
 ]],[[
 Leash of Oblation
 Leather Belt
 Requires Level 49
 Implicits: 1
-+(25-40) to maximum Life
-+(15-20) to all Attributes
-+(50-70) to maximum Life
+{tags:life}+(25-40) to maximum Life
+{tags:jewellery_attribute}+(15-20) to all Attributes
+{tags:life}+(50-70) to maximum Life
 25% reduced effect of Offerings
 You can have an Offering of each type
 Offering Skills have 50% reduced Duration
@@ -309,9 +309,9 @@ Requires Level 16
 Implicits: 1
 (20-30)% increased Stun Duration on Enemies
 (25-40)% increased Physical Damage
-+(40-50) to Strength
+{tags:jewellery_attribute}+(40-50) to Strength
 50% increased Flask Charges gained
-{variant:2}+(20-25)% to all Elemental Resistances while you have at least 200 Strength
+{variant:2}{tags:jewellery_resistance}+(20-25)% to all Elemental Resistances while you have at least 200 Strength
 ]],[[
 The Nomad
 Studded Belt
@@ -320,10 +320,10 @@ Requires Level 48
 Implicits: 1
 (20-30)% increased Stun Duration on Enemies
 (25-40)% increased Global Physical Damage
-+(40-50) to Strength
-+(40-50) to Dexterity
+{tags:jewellery_attribute}+(40-50) to Strength
+{tags:jewellery_attribute}+(40-50) to Dexterity
 50% increased Flask Charges gained
-+(20-25)% to all Elemental Resistances while you have at least 200 Strength
+{tags:jewellery_resistance}+(20-25)% to all Elemental Resistances while you have at least 200 Strength
 (40-50)% increased Projectile Attack Damage while you have at least 200 Dexterity
 ]],[[
 The Tactician
@@ -333,18 +333,18 @@ Requires Level 48
 Implicits: 1
 (20-30)% increased Stun Duration on Enemies
 (25-40)% increased Global Physical Damage
-+(40-50) to Strength
-+(40-50) to Intelligence
+{tags:jewellery_attribute}+(40-50) to Strength
+{tags:jewellery_attribute}+(40-50) to Intelligence
 50% increased Flask Charges gained
-+(20-25)% to all Elemental Resistances while you have at least 200 Strength
+{tags:jewellery_resistance}+(20-25)% to all Elemental Resistances while you have at least 200 Strength
 (50-60)% increased Critical Strike Chance while you have at least 200 Intelligence
 ]],[[
 Maligaro's Restraint
 Chain Belt
 Requires Level 44
 Implicits: 1
-+(9-20) to maximum Energy Shield
-Adds 1 to (30-50) Lightning Damage to Attacks
+{tags:jewellery_defense}+(9-20) to maximum Energy Shield
+{tags:jewellery_elemental,attack}Adds 1 to (30-50) Lightning Damage to Attacks
 100% increased Shock Duration on You
 Shocks you cause are reflected back to you
 60% increased Damage while Shocked
@@ -356,22 +356,22 @@ Variant: Pre 2.0.0
 Variant: Current
 Requires Level 8
 Implicits: 1
-+(25-35) to Strength
-{variant:1}Adds 10 to 20 Physical Damage to Attacks
-{variant:2}Adds 5 to 15 Physical Damage to Attacks
-+25 to Strength
-10% increased maximum Life
-+(10-20)% to Cold Resistance
-25% increased Flask Life Recovery rate
+{tags:jewellery_attribute}+(25-35) to Strength
+{variant:1}{tags:attack}Adds 10 to 20 Physical Damage to Attacks
+{variant:2}{tags:attack}Adds 5 to 15 Physical Damage to Attacks
+{tags:jewellery_attribute}+25 to Strength
+{tags:life}10% increased maximum Life
+{tags:jewellery_resistance}+(10-20)% to Cold Resistance
+{tags:life}25% increased Flask Life Recovery rate
 ]],[[
 Mother's Embrace
 Heavy Belt
 League: Metamorph
 Requires Level 40
 Implicits: 1
-+(25-35) to Strength
-+(50-70) to maximum Life
-+(20-30)% to Cold Resistance
+{tags:jewellery_attribute}+(25-35) to Strength
+{tags:life}+(50-70) to maximum Life
+{tags:jewellery_resistance}+(20-30)% to Cold Resistance
 Your Minions use your Flasks when summoned
 Minions have (40-25)% reduced Flask Charges used
 Minions have (50-80)% increased Flask Effect Duration
@@ -383,10 +383,10 @@ Variant: Current
 Requires Level 16
 Implicits: 1
 (15-25)% increased Stun Recovery
-+(20-30) to all Attributes
+{tags:jewellery_attribute}+(20-30) to all Attributes
 {variant:1}(8-12)% increased Quantity of Items found
 {variant:2}(6-8)% increased Quantity of Items found
-+20% to Fire Resistance
+{tags:jewellery_resistance}+20% to Fire Resistance
 20% increased Flask effect duration
 −2 Physical Damage taken from Attacks
 ]],[[
@@ -394,11 +394,11 @@ Perseverance
 Vanguard Belt
 Requires Level 78
 Implicits: 1
-+(260-320) to Armour and Evasion Rating
-(4-8)% increased maximum Life
-+(20-40)% to Cold Resistance
-1% increased Attack Damage per 300 of the lowest of Armour and Evasion Rating
-(14-20)% chance to gain Fortify on Melee Stun
+{tags:jewellery_defense}+(260-320) to Armour and Evasion Rating
+{tags:life}(4-8)% increased maximum Life
+{tags:jewellery_resistance}+(20-40)% to Cold Resistance
+{tags:attack}1% increased Attack Damage per 300 of the lowest of Armour and Evasion Rating
+{tags:attack}(14-20)% chance to gain Fortify on Melee Stun
 You have Onslaught while you have Fortify
 ]],[[
 Prismweave
@@ -409,14 +409,14 @@ Requires Level 25
 Implicits: 1
 (12-24)% increased Physical Damage
 10% increased Elemental Damage with Attack Skills
-{variant:1}Adds (3-4) to (7-8) Fire Damage to Attacks
-{variant:2}Adds (7-8) to (15-16) Fire Damage to Attacks
-{variant:1}Adds (2-3) to (5-7) Cold Damage to Attacks
-{variant:2}Adds (5-6) to (12-14) Cold Damage to Attacks
-{variant:1}Adds 1 to (13-17) Lightning Damage to Attacks
-{variant:2}Adds 1 to (30-34) Lightning Damage to Attacks
-+(6-8)% to all Elemental Resistances
-30% increased Elemental Damage with Attack Skills during any Flask Effect
+{variant:1}{tags:jewellery_elemental,attack}Adds (3-4) to (7-8) Fire Damage to Attacks
+{variant:2}{tags:jewellery_elemental,attack}Adds (7-8) to (15-16) Fire Damage to Attacks
+{variant:1}{tags:jewellery_elemental,attack}Adds (2-3) to (5-7) Cold Damage to Attacks
+{variant:2}{tags:jewellery_elemental,attack}Adds (5-6) to (12-14) Cold Damage to Attacks
+{variant:1}{tags:jewellery_elemental,attack}Adds 1 to (13-17) Lightning Damage to Attacks
+{variant:2}{tags:jewellery_elemental,attack}Adds 1 to (30-34) Lightning Damage to Attacks
+{tags:jewellery_resistance}+(6-8)% to all Elemental Resistances
+{tags:jewellery_elemental,attack}30% increased Elemental Damage with Attack Skills during any Flask Effect
 ]],[[
 The Retch
 Rustic Sash
@@ -425,12 +425,12 @@ Source: Vendor recipe
 Requires Level 44
 Implicits: 1
 (12-24)% increased Physical Damage
-+(60-80) to maximum Life
-+(25-40)% to Cold Resistance
-0.4% of Physical Attack Damage Leeched as Life
+{tags:life}+(60-80) to maximum Life
+{tags:jewellery_resistance}+(25-40)% to Cold Resistance
+{tags:attack,life}0.4% of Physical Attack Damage Leeched as Life
 60% increased Flask Effect Duration
 30% reduced Flask Charges gained while using a Flask
-200% of Life Leech applies to enemies as Chaos Damage
+{tags:life}200% of Life Leech applies to enemies as Chaos Damage
 15% increased Movement Speed while using a Flask
 ]],[[
 Ryslatha's Coil
@@ -440,23 +440,23 @@ Variant: Current
 Requires Level 20
 Implicits: 1
 (20-30)% increased Stun Duration on Enemies
-{variant:2}+(80-100) to maximum Life
-+(20-40) to Strength
-Adds 1 to (15-20) Physical Damage to Attacks
-Gain 50 Life when you Stun an Enemy
-{variant:1}20% less Minimum Physical Attack Damage
-{variant:2}(30-40)% less Minimum Physical Attack Damage
-{variant:1}20% more Maximum Physical Attack Damage
-{variant:2}(30-40)% more Maximum Physical Attack Damage
+{variant:2}{tags:life}+(80-100) to maximum Life
+{tags:jewellery_attribute}+(20-40) to Strength
+{tags:attack}Adds 1 to (15-20) Physical Damage to Attacks
+{tags:life}Gain 50 Life when you Stun an Enemy
+{variant:1}{tags:attack}20% less Minimum Physical Attack Damage
+{variant:2}{tags:attack}(30-40)% less Minimum Physical Attack Damage
+{variant:1}{tags:attack}20% more Maximum Physical Attack Damage
+{variant:2}{tags:attack}(30-40)% more Maximum Physical Attack Damage
 ]],[[
 Siegebreaker
 Heavy Belt
 Requires Level: 44
 Implicits: 1
-+(25-35) to Strength
-(6-10)% increased maximum Energy Shield
-(6-10)% increased maximum Life
-+(17-23)% to Chaos Resistance
+{tags:jewellery_attribute}+(25-35) to Strength
+{tags:jewellery_defense}(6-10)% increased maximum Energy Shield
+{tags:life}(6-10)% increased maximum Life
+{tags:jewellery_resistance}+(17-23)% to Chaos Resistance
 Minions have 5% chance to Taunt on Hit with Attacks
 Your Minions spread Caustic Ground on Death, dealing 20% of their maximum Life as Chaos Damage per second
 ]],[[
@@ -465,22 +465,22 @@ Cloth Belt
 Requires Level 48
 Implicits: 1
 (15-25)% increased Stun and Block Recovery
-+(20-40) to Intelligence
+{tags:jewellery_attribute}+(20-40) to Intelligence
 Your Energy Shield starts at zero
 You cannot Recharge Energy Shield
 You cannot Regenerate Energy Shield
-You lose 5% of Energy Shield per second
-Life Leech is applied to Energy Shield instead while on Full Life
-Gain (4-6)% of Maximum Life as Extra Maximum Energy Shield
+{tags:jewellery_defense}You lose 5% of Energy Shield per second
+{tags:life}Life Leech is applied to Energy Shield instead while on Full Life
+{tags:jewellery_defense,life}Gain (4-6)% of Maximum Life as Extra Maximum Energy Shield
 ]],[[
 Soulthirst
 Cloth Belt
 Requires Level 45
 Implicits: 1
 (15-25)% increased Stun Recovery
-+(60-80) to maximum Life
-+15% to all Elemental Resistances
-(20-30)% increased Mana Recovery from Flasks
+{tags:life}+(60-80) to maximum Life
+{tags:jewellery_resistance}+15% to all Elemental Resistances
+{tags:mana}(20-30)% increased Mana Recovery from Flasks
 (20-30)% reduced Flask effect duration
 Gain Soul Eater during Flask Effect
 Lose Souls gained from Soul Eater on Flask Use
@@ -534,7 +534,7 @@ Implicits: 24
 {variant:19}(12-18)% increased Strength
 {variant:20}(12-18)% increased Strength
 {variant:20}(12-18)% increased Intelligence
-{variant:21}+(42-48)% to all Elemental Resistances
+{variant:21}{tags:jewellery_resistance}+(42-48)% to all Elemental Resistances
 Implicit Modifier magnitudes are tripled
 Corrupted
 ]],[[
@@ -544,8 +544,8 @@ Requires Level 37
 Implicits: 1
 (15-25)% increased Stun Recovery
 (30-40)% increased Trap Damage
-20% increased Mana Regeneration Rate
-+(20-30)% to Fire Resistance
+{tags:mana}20% increased Mana Regeneration Rate
+{tags:jewellery_resistance}+(20-30)% to Fire Resistance
 80% reduced Trap Duration
 25% increased Light Radius
 Traps trigger at the end of their Duration
@@ -555,9 +555,9 @@ Leather Belt
 League: Perandus
 Requires Level 30
 Implicits: 1
-+(25-40) to maximum Life
-(8-12)% increased maximum Life
-2% of Life Regenerated per second
+{tags:life}+(25-40) to maximum Life
+{tags:life}(8-12)% increased maximum Life
+{tags:life}2% of Life Regenerated per second
 Flasks do not apply to You
 Flasks apply to your Raised Zombies and Spectres
 ]],[[
@@ -565,11 +565,11 @@ Wurm's Molt
 Leather Belt
 Requires Level 8
 Implicits: 1
-+(25-40) to Maximum Life
-+(20-30) to Strength
-+(20-30) to Intelligence
-+(10-20)% to Cold Resistance
-0.4% of Physical Attack Damage Leeched as Life
-0.4% of Physical Attack Damage Leeched as Mana
+{tags:life}+(25-40) to Maximum Life
+{tags:jewellery_attribute}+(20-30) to Strength
+{tags:jewellery_attribute}+(20-30) to Intelligence
+{tags:jewellery_resistance}+(10-20)% to Cold Resistance
+{tags:attack,life}0.4% of Physical Attack Damage Leeched as Life
+{tags:attack,mana}0.4% of Physical Attack Damage Leeched as Mana
 ]],
 }

--- a/Data/Uniques/ring.lua
+++ b/Data/Uniques/ring.lua
@@ -9,10 +9,10 @@ League: Delve
 Source: Drops from unique{Aul, the Crystal King}
 Requires Level 49
 Implicits: 1
-+(20-30)% to Fire Resistance
-+20 to Strength
-5% increased maximum Energy Shield
-5% increased maximum Life
+{tags:jewellery_resistance}+(20-30)% to Fire Resistance
+{tags:jewellery_attribute}+20 to Strength
+{tags:jewellery_defense}5% increased maximum Energy Shield
+{tags:life}5% increased maximum Life
 ]],[[
 Ahkeli's Mountain
 Ruby Ring
@@ -20,10 +20,10 @@ League: Delve
 Source: Drops from unique{Ahuatotli, the Blind}
 Requires Level 49
 Implicits: 1
-+(20-30)% to Fire Resistance
-+20 to Strength
-5% increased maximum Energy Shield
-5% increased maximum Life
+{tags:jewellery_resistance}+(20-30)% to Fire Resistance
+{tags:jewellery_attribute}+20 to Strength
+{tags:jewellery_defense}5% increased maximum Energy Shield
+{tags:life}5% increased maximum Life
 ]],[[
 Ahkeli's Valley
 Ruby Ring
@@ -31,28 +31,28 @@ League: Delve
 Source: Drops from unique{Kurgal, the Blackblooded}
 Requires Level 49
 Implicits: 1
-+(20-30)% to Fire Resistance
-+20 to Strength
-5% increased maximum Energy Shield
-5% increased maximum Life
+{tags:jewellery_resistance}+(20-30)% to Fire Resistance
+{tags:jewellery_attribute}+20 to Strength
+{tags:jewellery_defense}5% increased maximum Energy Shield
+{tags:life}5% increased maximum Life
 ]],[[
 Andvarius
 Gold Ring
 Requires Level 20
 Implicits: 1
 (6-15)% increased Rarity of Items found
-+10 to Dexterity
+{tags:jewellery_attribute}+10 to Dexterity
 (50-70)% increased Rarity of Items found
-−20% to all Elemental Resistances
+{tags:jewellery_resistance}−20% to all Elemental Resistances
 ]],[[
 Astral Projector
 Topaz Ring
 League: Metamorph
 Requires Level 40
 Implicits: 1
-+(20-30)% to Lightning Resistance
-+(30-50) to Intelligence
-(20-25)% increased Spell Damage
+{tags:jewellery_resistance}+(20-30)% to Lightning Resistance
+{tags:jewellery_attribute}+(30-50) to Intelligence
+{tags:caster}(20-25)% increased Spell Damage
 30% chance to Avoid Elemental Ailments
 Nova Spells have 20% less Area of Effect
 Nova Spells Cast at the targeted location instead of around you
@@ -65,16 +65,16 @@ Variant: Pre 3.8.0
 Variant: Current
 Requires Level 20
 Implicits: 1
-+(12-16)% to Cold and Lightning Resistances
-{variant:1}(10-15)% increased Cold Damage
-{variant:2,3}(25-30)% increased Cold Damage
-{variant:1}Adds 1 to (1-50) Lightning Damage to Attacks
-{variant:2,3}Adds 1 to (50-70) Lightning Damage to Spells and Attacks
-+(30-40) to maximum Life
-{variant:1}1% of Damage Leeched as Life against Frozen Enemies
-{variant:2,3}1% of Damage Leeched as Life against Shocked Enemies
-{variant:1}1% of Damage Leeched as Mana against Shocked Enemies
-{variant:2}1% of Damage Leeched as Mana against Frozen Enemies
+{tags:jewellery_resistance}+(12-16)% to Cold and Lightning Resistances
+{variant:1}{tags:jewellery_elemental}(10-15)% increased Cold Damage
+{variant:2,3}{tags:jewellery_elemental}(25-30)% increased Cold Damage
+{variant:1}{tags:jewellery_elemental,attack}Adds 1 to (1-50) Lightning Damage to Attacks
+{variant:2,3}{tags:jewellery_elemental,attack,caster}Adds 1 to (50-70) Lightning Damage to Spells and Attacks
+{tags:life}+(30-40) to maximum Life
+{variant:1}{tags:life}1% of Damage Leeched as Life against Frozen Enemies
+{variant:2,3}{tags:life}1% of Damage Leeched as Life against Shocked Enemies
+{variant:1}{tags:mana}1% of Damage Leeched as Mana against Shocked Enemies
+{variant:2}{tags:mana}1% of Damage Leeched as Mana against Frozen Enemies
 {variant:3}1% of Damage Leeched as Energy Shield against Frozen Enemies
 ]],[[
 Berek's Pass
@@ -84,14 +84,14 @@ Variant: Pre 2.6.0
 Variant: Current
 Requires Level 20
 Implicits: 1
-+(12-16)% to Fire and Cold Resistances
-{variant:1}(10-15)% increased Fire Damage
-{variant:2}(25-30)% increased Fire Damage
-{variant:1}Adds 1 to (10-30) Cold Damage to Attacks
-{variant:2}Adds (20-25) to (30-50) Cold Damage to Spells and Attacks
-+(30-40) to maximum Energy Shield
+{tags:jewellery_resistance}+(12-16)% to Fire and Cold Resistances
+{variant:1}{tags:jewellery_elemental}(10-15)% increased Fire Damage
+{variant:2}{tags:jewellery_elemental}(25-30)% increased Fire Damage
+{variant:1}{tags:jewellery_elemental,attack}Adds 1 to (10-30) Cold Damage to Attacks
+{variant:2}{tags:jewellery_elemental,attack,caster}Adds (20-25) to (30-50) Cold Damage to Spells and Attacks
+{tags:jewellery_defense}+(30-40) to maximum Energy Shield
 30% increased Damage while Ignited
-+5000 to Armour while Frozen
+{tags:jewellery_defense}+5000 to Armour while Frozen
 ]],[[
 Berek's Respite
 Two-Stone Ring
@@ -100,12 +100,12 @@ Variant: Pre 2.6.0
 Variant: Current
 Requires Level 20
 Implicits: 1
-+(12-16)% to Fire and Lightning Resistances
-{variant:1}Adds 1 to (10-30) Fire Damage to Attacks
-{variant:2}Adds (20-25) to (30-50) Fire Damage to Spells and Attacks
-{variant:1}(10-15)% increased Lightning Damage
-{variant:2}(25-30)% increased Lightning Damage
-+(30-40) to maximum Mana
+{tags:jewellery_resistance}+(12-16)% to Fire and Lightning Resistances
+{variant:1}{tags:jewellery_elemental,attack}Adds 1 to (10-30) Fire Damage to Attacks
+{variant:2}{tags:jewellery_elemental,attack,caster}Adds (20-25) to (30-50) Fire Damage to Spells and Attacks
+{variant:1}{tags:jewellery_elemental}(10-15)% increased Lightning Damage
+{variant:2}{tags:jewellery_elemental}(25-30)% increased Lightning Damage
+{tags:mana}+(30-40) to maximum Mana
 {variant:1}Shock a nearby Enemy for 2 seconds on Killing a Shocked Enemy
 {variant:2}Shocks all nearby Enemies on Killing a Shocked Enemy
 {variant:1}Ignite a nearby Enemy on Killing an Ignited Enemy
@@ -115,11 +115,11 @@ Blackheart
 Iron Ring
 Upgrade: Upgrades to unique{Voidheart} via prophecy{From The Void}
 Implicits: 1
-Adds 1 to 4 Physical Damage to Attacks
+{tags:attack}Adds 1 to 4 Physical Damage to Attacks
 5% increased Physical Damage
-Adds 1 to 3 Chaos Damage to Attacks
-+(20-30) to maximum Life
-(2-4) Life Regenerated per second
+{tags:attack}Adds 1 to 3 Chaos Damage to Attacks
+{tags:life}+(20-30) to maximum Life
+{tags:life}(2-4) Life Regenerated per second
 10% chance to Cause Monsters to Flee
 ]],[[
 Voidheart
@@ -129,16 +129,16 @@ Variant: Pre 2.4.0
 Variant: Current
 Requires Level 48
 Implicits: 1
-Adds 1 to 4 Physical Damage to Attacks
+{tags:attack}Adds 1 to 4 Physical Damage to Attacks
 5% increased Physical Damage
-Adds 1 to 3 Chaos Damage to Attacks
-+(20-30) to maximum Life
-(2-4) Life Regenerated per second
+{tags:attack}Adds 1 to 3 Chaos Damage to Attacks
+{tags:life}+(20-30) to maximum Life
+{tags:life}(2-4) Life Regenerated per second
 10% chance to Cause Monsters to Flee
 {variant:1}Melee Attacks cause Bleeding
-{variant:2}(30-50)% chance to cause Bleeding on Melee Hit
+{variant:2}{tags:attack}(30-50)% chance to cause Bleeding on Melee Hit
 {variant:1}Melee Attacks Poison on Hit
-{variant:2}(20-40)% chance to Poison on Melee Hit
+{variant:2}{tags:attack}(20-40)% chance to Poison on Melee Hit
 ]],[[
 Bloodboil
 Coral Ring
@@ -147,13 +147,13 @@ Variant: Pre 2.6.0
 Variant: Current
 Requires Level 24
 Implicits: 1
-+(20-30) to maximum Life
-{variant:1}Adds (7-10) to (15-20) Fire Damage to Attacks
-{variant:2}Adds (12-15) to (25-30) Fire Damage to Attacks
-+(20-40) to maximum Life
-+(10-15)% to Cold Resistance
-{variant:1}45% reduced Effect of Chill on You
-{variant:2}75% reduced Effect of Chill on You
+{tags:life}+(20-30) to maximum Life
+{variant:1}{tags:jewellery_elemental,attack}Adds (7-10) to (15-20) Fire Damage to Attacks
+{variant:2}{tags:jewellery_elemental,attack}Adds (12-15) to (25-30) Fire Damage to Attacks
+{tags:life}+(20-40) to maximum Life
+{tags:jewellery_resistance}+(10-15)% to Cold Resistance
+{variant:1}{tags:jewellery_elemental}45% reduced Effect of Chill on You
+{variant:2}{tags:jewellery_elemental}75% reduced Effect of Chill on You
 {variant:1}100% increased Ignite Duration on You
 {variant:2}10% increased Movement Speed while Ignited
 ]],[[
@@ -162,11 +162,11 @@ Coral Ring
 Source: Upgraded from unique{Bloodboil} via prophecy{Cold Blooded Fury}
 Requires Level 53
 Implicits: 1
-+(20-30) to maximum Life
-Adds (12-15) to (25-30) Fire Damage to Attacks
-Adds (12-15) to (25-30) Cold Damage to Attacks
-+(20-40) to maximum Life
-+(25-30)% to Cold Resistance
+{tags:life}+(20-30) to maximum Life
+{tags:jewellery_elemental,attack}Adds (12-15) to (25-30) Fire Damage to Attacks
+{tags:jewellery_elemental,attack}Adds (12-15) to (25-30) Cold Damage to Attacks
+{tags:life}+(20-40) to maximum Life
+{tags:jewellery_resistance}+(25-30)% to Cold Resistance
 10% increased Movement Speed while Ignited
 The Effect of Chill on you is reversed
 ]],[[
@@ -182,11 +182,11 @@ Has 1 Socket
 {variant:2}+3 to Level of Socketed Golem Gems
 {variant:1}Socketed Gems are Supported by level 15 Concentrated Effect
 {variant:2}25% increased Effect of Buffs granted by Socketed Golem Skills
-{variant:2}Socketed Golem Skills gain 20% of Maximum Life as Extra Maximum Energy Shield
-{variant:1}(10-25)% increased Spell Damage
-{variant:2}(20-25)% increased Spell Damage
-+(15-25) to maximum Energy Shield
-+(20-40)% to Lightning Resistance
+{variant:2}{tags:jewellery_defense}Socketed Golem Skills gain 20% of Maximum Life as Extra Maximum Energy Shield
+{variant:1}{tags:caster}(10-25)% increased Spell Damage
+{variant:2}{tags:caster}(20-25)% increased Spell Damage
+{tags:jewellery_defense}+(15-25) to maximum Energy Shield
+{tags:jewellery_resistance}+(20-40)% to Lightning Resistance
 {variant:1}Socketed Gems are Supported by level 15 Increased Minion Life
 ]],[[
 Call of the Brotherhood
@@ -195,12 +195,12 @@ Variant: Pre 2.6.0
 Variant: Current
 Requires Level 20
 Implicits: 1
-+(12-16)% to Cold and Lightning Resistances
-+(15-25) to Intelligence
-(15-25)% increased Lightning Damage
-(30-40)% increased Mana Regeneration Rate
-{variant:1}50% of Lightning Damage Converted to Cold Damage
-{variant:2}40% of Lightning Damage Converted to Cold Damage
+{tags:jewellery_resistance}+(12-16)% to Cold and Lightning Resistances
+{tags:jewellery_attribute}+(15-25) to Intelligence
+{tags:jewellery_elemental}(15-25)% increased Lightning Damage
+{tags:mana}(30-40)% increased Mana Regeneration Rate
+{variant:1}{tags:jewellery_elemental}50% of Lightning Damage Converted to Cold Damage
+{variant:2}{tags:jewellery_elemental}40% of Lightning Damage Converted to Cold Damage
 Your spells have 100% chance to Shock against Frozen enemies
 ]],[[
 Circle of Anguish
@@ -215,15 +215,15 @@ Variant: Herald of Ash: Fire Damage
 Variant: Herald of Ash: Buff Effect
 Variant: Herald of Ash: Max Resistance
 Variant: Herald of Ash: Fire Resistance
-+(20-30)% to Fire Resistance
-{fractured}+(20-30) to Strength
-Adds (20-25) to (26-35) Fire Damage
-+(20-30)% to Fire Resistance
-{variant:1}Herald of Ash has (40-30)% reduced Mana Reservation
-{variant:2}(40-60)% increased Fire Damage while affected by Herald of Ash
+{tags:jewellery_resistance}+(20-30)% to Fire Resistance
+{fractured}{tags:jewellery_attribute}+(20-30) to Strength
+{tags:jewellery_elemental}Adds (20-25) to (26-35) Fire Damage
+{tags:jewellery_resistance}+(20-30)% to Fire Resistance
+{variant:1}{tags:mana}Herald of Ash has (40-30)% reduced Mana Reservation
+{variant:2}{tags:jewellery_elemental}(40-60)% increased Fire Damage while affected by Herald of Ash
 {variant:3}Herald of Ash has (70-100)% increased Buff Effect
-{variant:4}+1% to maximum Fire Resistance while affected by Herald of Ash
-{variant:5}+(50-60)% to Fire Resistance while affected by Herald of Ash
+{variant:4}{tags:jewellery_resistance}+1% to maximum Fire Resistance while affected by Herald of Ash
+{variant:5}{tags:jewellery_resistance}+(50-60)% to Fire Resistance while affected by Herald of Ash
 ]],[[
 Circle of Fear
 Sapphire Ring
@@ -237,15 +237,15 @@ Variant: Herald of Ice: Cold Damage
 Variant: Herald of Ice: Buff Effect
 Variant: Herald of Ice: Max Resistance
 Variant: Herald of Ice: Cold Resistance
-+(20-30)% to Cold Resistance
-{fractured}+(20-30) to Dexterity
-Adds (20-25) to (26-35) Cold Damage
-+(20-30)% to Cold Resistance
-{variant:1}Herald of Ice has (40-30)% reduced Mana Reservation
-{variant:2}(40-60)% increased Cold Damage while affected by Herald of Ice
+{tags:jewellery_resistance}+(20-30)% to Cold Resistance
+{fractured}{tags:jewellery_attribute}+(20-30) to Dexterity
+{tags:jewellery_elemental}Adds (20-25) to (26-35) Cold Damage
+{tags:jewellery_resistance}+(20-30)% to Cold Resistance
+{variant:1}{tags:mana}Herald of Ice has (40-30)% reduced Mana Reservation
+{variant:2}{tags:jewellery_elemental}(40-60)% increased Cold Damage while affected by Herald of Ice
 {variant:3}Herald of Ice has (70-100)% increased Buff Effect
-{variant:4}+1% to maximum Cold Resistance while affected by Herald of Ice
-{variant:5}+(50-60)% to Cold Resistance while affected by Herald of Ice
+{variant:4}{tags:jewellery_resistance}+1% to maximum Cold Resistance while affected by Herald of Ice
+{variant:5}{tags:jewellery_resistance}+(50-60)% to Cold Resistance while affected by Herald of Ice
 ]],[[
 Circle of Guilt
 Iron Ring
@@ -259,11 +259,11 @@ Variant: Herald of Purity: Physical Damage
 Variant: Herald of Purity: Buff Effect
 Variant: Herald of Purity: Sentinel Damage
 Variant: Herald of Purity: Damage Reduction
-Adds 1 to 4 Physical Damage to Attacks
-{fractured}+(10-20) to all Attributes
+{tags:attack}Adds 1 to 4 Physical Damage to Attacks
+{fractured}{tags:jewellery_attribute}+(10-20) to all Attributes
 Adds (8-10) to (13-15) Physical Damage
-+(350-400) to Armour
-{variant:1}Herald of Purity has (40-30)% reduced Mana Reservation
+{tags:jewellery_defense}+(350-400) to Armour
+{variant:1}{tags:mana}Herald of Purity has (40-30)% reduced Mana Reservation
 {variant:2}(40-60)% increased Physical Damage while affected by Herald of Purity
 {variant:3}Herald of Purity has (70-100)% increased Buff Effect
 {variant:4}Sentinels of Purity deal (70-100)% increased Damage
@@ -281,15 +281,15 @@ Variant: Herald of Agony: Chaos Damage
 Variant: Herald of Agony: Buff Effect
 Variant: Herald of Agony: Agony Damage
 Variant: Herald of Agony: Chaos Resistance
-+(9-13)% to Chaos Resistance
-{fractured}+(10-20) to all Attributes
-Adds (15-20) to (21-30) Physical Damage
-+(17-23)% to Chaos Resistance
-{variant:1}Herald of Agony has (40-30)% reduced Mana Reservation
+{tags:jewellery_resistance}+(9-13)% to Chaos Resistance
+{fractured}{tags:jewellery_attribute}+(10-20) to all Attributes
+Adds (15-20) to (21-30) Chaos Damage
+{tags:jewellery_resistance}+(17-23)% to Chaos Resistance
+{variant:1}{tags:mana}Herald of Agony has (40-30)% reduced Mana Reservation
 {variant:2}(40-60)% increased Chaos Damage while affected by Herald of Agony
 {variant:3}Herald of Agony has (70-100)% increased Buff Effect
 {variant:4}Agony Crawler deals (70-100)% increased Damage
-{variant:5}+(31-43)% to Chaos Resistance while affected by Herald of Agony
+{variant:5}{tags:jewellery_resistance}+(31-43)% to Chaos Resistance while affected by Herald of Agony
 ]],[[
 Circle of Regret
 Topaz Ring
@@ -303,15 +303,15 @@ Variant: Herald of Thunder: Lightning Damage
 Variant: Herald of Thunder: Buff Effect
 Variant: Herald of Thunder: Max Resistance
 Variant: Herald of Thunder: Lightning Resistance
-+(20-30)% to Lightning Resistance
-{fractured}+(20-30) to Intelligence
-Adds 1 to (48-60) Lightning Damage
-+(20-30)% to Lightning Resistance
-{variant:1}Herald of Thunder has (40-30)% reduced Mana Reservation
-{variant:2}(40-60)% increased Lightning Damage while affected by Herald of Thunder
+{tags:jewellery_resistance}+(20-30)% to Lightning Resistance
+{fractured}{tags:jewellery_attribute}+(20-30) to Intelligence
+{tags:jewellery_elemental}Adds 1 to (48-60) Lightning Damage
+{tags:jewellery_resistance}+(20-30)% to Lightning Resistance
+{variant:1}{tags:mana}Herald of Thunder has (40-30)% reduced Mana Reservation
+{variant:2}{tags:jewellery_elemental}(40-60)% increased Lightning Damage while affected by Herald of Thunder
 {variant:3}Herald of Thunder has (70-100)% increased Buff Effect
-{variant:4}+1% to maximum Lightning Resistance while affected by Herald of Thunder
-{variant:5}+(50-60)% to Lightning Resistance while affected by Herald of Thunder
+{variant:4}{tags:jewellery_resistance}+1% to maximum Lightning Resistance while affected by Herald of Thunder
+{variant:5}{tags:jewellery_resistance}+(50-60)% to Lightning Resistance while affected by Herald of Thunder
 ]],[[
 Death Rush
 Amethyst Ring
@@ -320,23 +320,23 @@ Variant: Pre 2.6.0
 Variant: Current
 Requires Level 46
 Implicits: 1
-+(9-13)% to Chaos Resistance
-+(300-350) to Accuracy Rating
-{variant:1}+(60-80) to Armour
-{variant:2}+(260-300) to Armour
-{variant:2}+(40-50) to maximum Life
-+(15-20)% to Chaos Resistance
-(0.6-0.8)% of Physical Attack Damage Leeched as Life
+{tags:jewellery_resistance}+(9-13)% to Chaos Resistance
+{tags:attack}+(300-350) to Accuracy Rating
+{tags:jewellery_defense}{variant:1}+(60-80) to Armour
+{tags:jewellery_defense}{variant:2}+(260-300) to Armour
+{variant:2}{tags:life}+(40-50) to maximum Life
+{tags:jewellery_resistance}+(15-20)% to Chaos Resistance
+{tags:attack,life}(0.6-0.8)% of Physical Attack Damage Leeched as Life
 {variant:1}You gain Onslaught for 2 seconds on Kill
 {variant:2}You gain Onslaught for 4 seconds on Kill
 ]],[[
 Doedre's Damning
 Paua Ring
 Implicits: 1
-+(20-30) to maximum Mana
-+(5-10) to Intelligence
-+5% to all Elemental Resistances
-+5 Mana Gained on Kill
+{tags:mana}+(20-30) to maximum Mana
+{tags:jewellery_attribute}+(5-10) to Intelligence
+{tags:jewellery_resistance}+5% to all Elemental Resistances
+{tags:mana}+5 Mana Gained on Kill
 Enemies can have 1 additional Curse
 ]],[[
 Dream Fragments
@@ -345,10 +345,10 @@ Variant: Pre 2.6.0
 Variant: Current
 Requires Level 24
 Implicits: 1
-+(20-30)% to Cold Resistance
-20% increased maximum Mana
-50% increased Mana Regeneration Rate
-{variant:2}+(30-40)% to Cold Resistance
+{tags:jewellery_resistance}+(20-30)% to Cold Resistance
+{tags:mana}20% increased maximum Mana
+{tags:mana}50% increased Mana Regeneration Rate
+{variant:2}{tags:jewellery_resistance}+(30-40)% to Cold Resistance
 Cannot be Frozen
 {variant:2}Cannot be Chilled
 ]],[[
@@ -359,12 +359,12 @@ Variant: Pre 3.9.0
 Variant: Current
 Requires Level 16
 Implicits: 1
-+(20-30)% to Fire Resistance
-{variant:1}(15-25)% increased Fire Damage
-{variant:2,3}(30-40)% increased Fire Damage
-(5-10)% increased Cast Speed
-{variant:1}5% chance to Ignite
-{variant:2,3}10% chance to Ignite
+{tags:jewellery_resistance}+(20-30)% to Fire Resistance
+{variant:1}{tags:jewellery_elemental}(15-25)% increased Fire Damage
+{variant:2,3}{tags:jewellery_elemental}(30-40)% increased Fire Damage
+{tags:caster}(5-10)% increased Cast Speed
+{variant:1}{tags:jewellery_elemental}5% chance to Ignite
+{variant:2,3}{tags:jewellery_elemental}10% chance to Ignite
 {variant:1}You can inflict up to 300 Ignites on an Enemy
 {variant:2,3}You can inflict an additional Ignite on an Enemy
 {variant:1}Your Critical Strikes do not deal extra Damage
@@ -379,7 +379,7 @@ Implicits: 1
 Has 1 Socket
 +2 to Level of Socketed Aura Gems
 Socketed Gems Reserve No Mana
-40% increased Mana Reserved
+{tags:mana}40% increased Mana Reserved
 ]],[[
 Gifts from Above
 Diamond Ring
@@ -401,9 +401,9 @@ Heartbound Loop
 Moonstone Ring
 Requires Level 20
 Implicits: 1
-+(15-25) to maximum Energy Shield
-(10-15) Life Regenerated per second
-(20-40)% increased Mana Regeneration Rate
+{tags:jewellery_defense}+(15-25) to maximum Energy Shield
+{tags:life}(10-15) Life Regenerated per second
+{tags:mana}(20-40)% increased Mana Regeneration Rate
 Minions have 15% increased maximum Life
 Minions have 10% increased Area of Effect of Area Skills
 350 Physical Damage taken on Minion Death
@@ -422,8 +422,8 @@ Iron Ring
 Requires Level: 49
 Implicits: 1
 League: Blight
-Adds 1 to 4 Physical Damage to Attacks
-+(20-30) to Dexterity
+{tags:attack}Adds 1 to 4 Physical Damage to Attacks
+{tags:jewellery_attribute}+(20-30) to Dexterity
 25% chance to Poison on Hit
 (40-60)% increased Damage with Poison
 You are Chilled while you are Poisoned
@@ -436,10 +436,10 @@ Upgrade: Upgrades to unique{Kaom's Way} via prophecy{The King's Path}
 Variant: Pre 2.0.0
 Variant: Current
 Implicits: 1
-+(20-30) to maximum Life
-+(10-20) to Strength
-{variant:1}0.4% of Physical Attack Damage Leeched as Life
-{variant:2}+(2-4) Life gained for each Enemy hit by your Attacks
+{tags:life}+(20-30) to maximum Life
+{tags:jewellery_attribute}+(10-20) to Strength
+{variant:1}{tags:attack,life}0.4% of Physical Attack Damage Leeched as Life
+{variant:2}{tags:attack,life}+(2-4) Life gained for each Enemy hit by your Attacks
 +1 Maximum Endurance Charge
 ]],[[
 Kaom's Way
@@ -447,10 +447,10 @@ Coral Ring
 Source: Upgraded from unique{Kaom's Sign} using prophecy{The King's Path}
 Requires Level 32
 Implicits: 1
-+(20-30) to maximum Life
-+(10-20) to Strength
-0.4% of maximum Life Regenerated per second per Endurance Charge
-+(2-4) Life gained for each Enemy hit by your Attacks
+{tags:life}+(20-30) to maximum Life
+{tags:jewellery_attribute}+(10-20) to Strength
+{tags:life}0.4% of maximum Life Regenerated per second per Endurance Charge
+{tags:attack,life}+(2-4) Life gained for each Enemy hit by your Attacks
 +1 Maximum Endurance Charge
 ]],[[
 Kikazaru
@@ -459,11 +459,11 @@ Variant: Pre 2.6.0
 Variant: Current
 Requires Level 20
 Implicits: 1
-+(20-30)% to Lightning Resistance
-+(10-15) to all Attributes
-{variant:1}(13-17) Life Regenerated per second
-{variant:2}1 Life Regenerated per second per Level
-(20-40)% increased Mana Regeneration Rate
+{tags:jewellery_resistance}+(20-30)% to Lightning Resistance
+{tags:jewellery_attribute}+(10-15) to all Attributes
+{variant:1}{tags:life}(13-17) Life Regenerated per second
+{variant:2}{tags:life}1 Life Regenerated per second per Level
+{tags:mana}(20-40)% increased Mana Regeneration Rate
 {variant:1}20% reduced Effect of Curses on You
 {variant:2}40% reduced Effect of Curses on You
 ]],[[
@@ -473,15 +473,15 @@ Variant: Pre 2.6.0
 Variant: Current
 Requires Level 24
 Implicits: 1
-Adds 1 to 4 Physical Damage to Attacks
+{tags:attack}Adds 1 to 4 Physical Damage to Attacks
 {variant:1}(10-20)% increased Damage
 {variant:2}(10-30)% increased Damage
-{variant:1}+(10-20) to all Attributes
-{variant:2}+(10-30) to all Attributes
+{variant:1}{tags:jewellery_attribute}+(10-20) to all Attributes
+{variant:2}{tags:jewellery_attribute}+(10-30) to all Attributes
 {variant:1}(10-20)% increased Rarity of Items found
 {variant:2}(10-30)% increased Rarity of Items found
-{variant:1}+(10-20)% to all Elemental Resistances
-{variant:2}+(10-30)% to all Elemental Resistances
+{variant:1}{tags:jewellery_resistance}+(10-20)% to all Elemental Resistances
+{variant:2}{tags:jewellery_resistance}+(10-30)% to all Elemental Resistances
 ]],[[
 Lori's Lantern
 Prismatic Ring
@@ -489,12 +489,12 @@ Variant: Pre 1.0.0
 Variant: Current
 Requires Level 30
 Implicits: 2
-{variant:1}+(8-12)% to all Elemental Resistances
-{variant:2}+(8-10)% to all Elemental Resistances
-+10% to all Elemental Resistances
+{variant:1}{tags:jewellery_resistance}+(8-12)% to all Elemental Resistances
+{variant:2}{tags:jewellery_resistance}+(8-10)% to all Elemental Resistances
+{tags:jewellery_resistance}+10% to all Elemental Resistances
 (6-8)% increased Movement Speed when on Low Life
 31% increased Light Radius
-+(20-25)% Chaos Resistance when on Low Life
+{tags:jewellery_defense,life}+(20-25)% Chaos Resistance when on Low Life
 While on Low Life, Enemies are Unlucky when Damaging you
 ]],[[
 Malachai's Artifice
@@ -505,11 +505,11 @@ Sockets: W
 Requires Level 5
 Implicits: 1
 Has 1 Socket
-{variant:1}−25% to all Elemental Resistances
-{variant:2}−20% to all Elemental Resistances
-+(75-100)% to Fire Resistance when Socketed with a Red Gem
-+(75-100)% to Cold Resistance when Socketed with a Green Gem
-+(75-100)% to Lightning Resistance when Socketed with a Blue Gem
+{variant:1}{tags:jewellery_resistance}−25% to all Elemental Resistances
+{variant:2}{tags:jewellery_resistance}−20% to all Elemental Resistances
+{tags:jewellery_resistance}+(75-100)% to Fire Resistance when Socketed with a Red Gem
+{tags:jewellery_resistance}+(75-100)% to Cold Resistance when Socketed with a Green Gem
+{tags:jewellery_resistance}+(75-100)% to Lightning Resistance when Socketed with a Blue Gem
 All Sockets are White
 Socketed Gems have Elemental Equilibrium
 ]],[[
@@ -525,10 +525,10 @@ Steel Ring
 Source: Drops from unique{The Elder} (Uber)
 Requires Level 80
 Implicits: 1
-Adds (3-4) to (10-14) Physical Damage to Attacks
-Adds (26-32) to (42-48) Cold Damage to Attacks
-(6-10)% increased maximum Energy Shield
-(6-10)% increased maximum Life
+{tags:attack}Adds (3-4) to (10-14) Physical Damage to Attacks
+{tags:jewellery_elemental,attack}Adds (26-32) to (42-48) Cold Damage to Attacks
+{tags:jewellery_defense}(6-10)% increased maximum Energy Shield
+{tags:life}(6-10)% increased maximum Life
 (60-80)% increased Attack Damage if your other Ring is a Shaper Item
 Cannot be Stunned by Attacks if your other Ring is an Elder Item
 20% chance to Trigger Level 20 Tentacle Whip on Kill
@@ -539,11 +539,11 @@ Opal Ring
 Source: Drops from unique{The Elder} (Uber)
 Requires Level 80
 Implicits: 1
-(15-25)% increased Elemental Damage
-Adds (13-18) to (50-56) Lightning Damage to Spells
-(6-10)% increased maximum Energy Shield
-(6-10)% increased maximum Life
-(60-80)% increased Spell Damage if your other Ring is an Elder Item
+{tags:jewellery_elemental}(15-25)% increased Elemental Damage
+{tags:jewellery_elemental,caster}Adds (13-18) to (50-56) Lightning Damage to Spells
+{tags:jewellery_defense}(6-10)% increased maximum Energy Shield
+{tags:life}(6-10)% increased maximum Life
+{tags:caster}(60-80)% increased Spell Damage if your other Ring is an Elder Item
 Cannot be Stunned by Spells if your other Ring is a Shaper Item
 20% chance to Trigger Level 20 Summon Volatile Anomaly on Kill
 Shaper Item
@@ -555,27 +555,27 @@ Variant: {2_6}Pre 3.0.0
 Variant: Current
 Requires Level 69
 Implicits: 1
-+(9-13)% to Chaos Resistance
-{variant:1}15% reduced maximum Life
-{variant:2}10% reduced maximum Life
-{variant:3}(5-10)% reduced maximum Life
-{variant:1}15% reduced maximum Energy Shield
-{variant:2}10% reduced maximum Energy Shield
-{variant:3}(5-10)% reduced maximum Energy Shield
-+(40-50)% to Chaos Resistance
+{tags:jewellery_resistance}+(9-13)% to Chaos Resistance
+{variant:1}{tags:life}15% reduced maximum Life
+{variant:2}{tags:life}10% reduced maximum Life
+{variant:3}{tags:life}(5-10)% reduced maximum Life
+{variant:1{tags:jewellery_defense}}15% reduced maximum Energy Shield
+{variant:2}{tags:jewellery_defense}10% reduced maximum Energy Shield
+{variant:3}{tags:jewellery_defense}(5-10)% reduced maximum Energy Shield
+{tags:jewellery_resistance}+(40-50)% to Chaos Resistance
 Gain 20% of Physical Damage as Extra Chaos Damage
 ]],[[
 Mokou's Embrace
 Ruby Ring
 Requires Level 16
 Implicits: 1
-+(20-30)% to Fire Resistance
-(15-25)% increased Fire Damage
-+(25-40)% to Cold Resistance
-(5-10)% chance to Ignite
-20% increased Attack Speed while Ignited
-20% increased Cast Speed while Ignited
-+25% chance to be Ignited
+{tags:jewellery_resistance}+(20-30)% to Fire Resistance
+{tags:jewellery_elemental}(15-25)% increased Fire Damage
+{tags:jewellery_resistance}+(25-40)% to Cold Resistance
+{tags:jewellery_elemental}(5-10)% chance to Ignite
+{tags:attack}20% increased Attack Speed while Ignited
+{tags:caster}20% increased Cast Speed while Ignited
+{tags:jewellery_elemental}+25% chance to be Ignited
 ]],[[
 Mutewind Seal
 Unset Ring
@@ -588,9 +588,9 @@ Has 1 Socket
 {variant:1}+2 to Level of Socketed Golem Gems
 {variant:2}+3 to Level of Socketed Golem Gems
 {variant:1}Socketed Gems are Supported by level 13 Faster Attacks
-{variant:2}Socketed Golem Skills have 20% increased Attack and Cast Speed
-Adds (5-10) to (11-15) Physical Damage to Attacks
-(5-10)% increased Attack Speed
+{variant:2{tags:attack,caster}}Socketed Golem Skills have 20% increased Attack and Cast Speed
+{tags:attack}Adds (5-10) to (11-15) Physical Damage to Attacks
+{tags:attack}(5-10)% increased Attack Speed
 {variant:1}(1-2)% chance to Dodge Attacks
 {variant:2}(3-5)% chance to Dodge Attacks
 {variant:1}Socketed Gems are Supported by level 16 Increased Minion Speed
@@ -603,15 +603,15 @@ Variant: Pre 2.6.0
 Variant: Current
 Requires Level 29
 Implicits: 1
-+(20-30)% to Fire Resistance
-+(15-25) to Strength
-{variant:1}Adds (8-10) to (12-14) Fire Damage to Attacks
-{variant:2}Adds (8-10) to (12-14) Fire Damage
-{variant:1}+(4-5) Life gained for each Ignited Enemy hit by your Attacks
-{variant:2}(20-30) Life Gained on Igniting an Enemy
+{tags:jewellery_resistance}+(20-30)% to Fire Resistance
+{tags:jewellery_attribute}+(15-25) to Strength
+{variant:1}{tags:jewellery_elemental,attack}Adds (8-10) to (12-14) Fire Damage to Attacks
+{variant:2}{tags:jewellery_elemental,attack,caster}Adds (8-10) to (12-14) Fire Damage to Spells and Attacks
+{variant:1}{tags:life}+(4-5) Life gained for each Ignited Enemy hit by your Attacks
+{variant:2}{tags:life}Recover (20-30) Life Gained on Igniting an Enemy
 15% increased Ignite Duration on Enemies
-{variant:1}5% chance to Ignite
-{variant:2}10% chance to Ignite
+{variant:1}{tags:jewellery_elemental}5% chance to Ignite
+{variant:2}{tags:jewellery_elemental}10% chance to Ignite
 ]],[[
 The Pariah
 Unset Ring
@@ -620,10 +620,10 @@ Requires Level 60
 Implicits: 1
 Has 1 Socket
 +2 to Level of Socketed Gems
-(5-10)% increased Attack and Cast Speed
-+100 to Maximum Life per Red Socket
-+100 to Maximum Energy Shield per Blue Socket
-+100 to Maximum Mana per Green Socket
+{tags:attack,caster}(5-10)% increased Attack and Cast Speed
+{tags:life}+100 to Maximum Life per Red Socket
+{tags:jewellery_defense}+100 to Maximum Energy Shield per Blue Socket
+{tags:mana}+100 to Maximum Mana per Green Socket
 15% increased Item Quantity per White Socket
 ]],[[
 Perandus Signet
@@ -631,24 +631,24 @@ Paua Ring
 Variant: Pre 2.0.0
 Variant: Current
 Implicits: 1
-+(20-30) to maximum Mana
-+(25-30) to maximum Mana
-(45-65)% increased Mana Regeneration Rate
+{tags:mana}+(20-30) to maximum Mana
+{tags:mana}+(25-30) to maximum Mana
+{tags:mana}(45-65)% increased Mana Regeneration Rate
 {variant:1}3% increased Experience gain
 {variant:2}2% increased Experience gain
-{variant:1}3% increased Intelligence for each Unique Item Equipped
-{variant:2}2% increased Intelligence for each Unique Item Equipped
+{variant:1}{tags:jewellery_attribute}3% increased Intelligence for each Unique Item Equipped
+{variant:2}{tags:jewellery_attribute}2% increased Intelligence for each Unique Item Equipped
 3% additional chance for Slain monsters to drop Scrolls of Wisdom
 ]],[[
 Praxis
 Paua Ring
 Requires Level 22
 Implicits: 1
-+(20-30) to maximum Mana
-+(30-60) to maximum Mana
-(3-6) Mana Regenerated per second
-−(4-8) to Mana Cost of Skills
-8% of Damage taken gained as Mana over 4 seconds when Hit
+{tags:mana}+(20-30) to maximum Mana
+{tags:mana}+(30-60) to maximum Mana
+{tags:mana}(3-6) Mana Regenerated per second
+{tags:mana}−(4-8) to Mana Cost of Skills
+{tags:mana}8% of Damage taken gained as Mana over 4 seconds when Hit
 ]],[[
 Profane Proxy
 Unset Ring
@@ -657,8 +657,8 @@ LevelReq: 52
 Implicits: 1
 Has 1 Socket
 +3 to Level of Socketed Curse Gems
-+(20-30)% to Cold Resistance
-+(20-30)% to Lightning Resistance
+{tags:jewellery_resistance}+(20-30)% to Cold Resistance
+{tags:jewellery_resistance}+(20-30)% to Lightning Resistance
 Left Ring Slot: Your Chilling Skitterbot's Aura applies Socketed Curse instead
 Right Ring Slot: Your Shocking Skitterbot's Aura applies Socketed Curse instead
 ]],[[
@@ -668,10 +668,10 @@ League: Delve
 Source: Drops from unique{Kurgal, the Blackblooded}
 Requires Level 49
 Implicits: 1
-+(20-30)% to Lightning Resistance
-+20 to Intelligence
-5% increased maximum Energy Shield
-5% increased maximum Life
+{tags:jewellery_resistance}+(20-30)% to Lightning Resistance
+{tags:jewellery_attribute}+20 to Intelligence
+{tags:jewellery_defense}5% increased maximum Energy Shield
+{tags:life}5% increased maximum Life
 ]],[[
 Putembo's Mountain
 Topaz Ring
@@ -679,10 +679,10 @@ League: Delve
 Source: Drops from unique{Aul, the Crystal King}
 Requires Level 49
 Implicits: 1
-+(20-30)% to Lightning Resistance
-+20 to Intelligence
-5% increased maximum Energy Shield
-5% increased maximum Life
+{tags:jewellery_resistance}+(20-30)% to Lightning Resistance
+{tags:jewellery_attribute}+20 to Intelligence
+{tags:jewellery_defense}5% increased maximum Energy Shield
+{tags:life}5% increased maximum Life
 ]],[[
 Putembo's Valley
 Topaz Ring
@@ -690,10 +690,10 @@ League: Delve
 Source: Drops from unique{Ahuatotli, the Blind}
 Requires Level 49
 Implicits: 1
-+(20-30)% to Lightning Resistance
-+20 to Intelligence
-5% increased maximum Energy Shield
-5% increased maximum Life
+{tags:jewellery_resistance}+(20-30)% to Lightning Resistance
+{tags:jewellery_attribute}+20 to Intelligence
+{tags:jewellery_defense}5% increased maximum Energy Shield
+{tags:life}5% increased maximum Life
 ]],[[
 Pyre
 Sapphire Ring
@@ -702,12 +702,12 @@ Variant: {2_6}Pre 3.0.0
 Variant: Current
 Requires Level 11
 Implicits: 1
-+(20-30)% to Cold Resistance
-+(25-35)% to Fire Resistance
-{variant:1,2}(25-35)% increased Burning Damage
-{variant:3}(60-80)% increased Burning Damage
-{variant:1}100% of Cold Damage Converted to Fire Damage
-{variant:2,3}40% of Cold Damage Converted to Fire Damage
+{tags:jewellery_resistance}+(20-30)% to Cold Resistance
+{tags:jewellery_resistance}+(25-35)% to Fire Resistance
+{variant:1,2}{tags:jewellery_elemental}(25-35)% increased Burning Damage
+{variant:3}{tags:jewellery_elemental}(60-80)% increased Burning Damage
+{variant:1}{tags:jewellery_elemental}100% of Cold Damage Converted to Fire Damage
+{variant:2,3}{tags:jewellery_elemental}40% of Cold Damage Converted to Fire Damage
 10% increased Light Radius
 Ignited Enemies you hit are destroyed on Kill
 ]],[[
@@ -721,14 +721,14 @@ Implicits: 1
 Has 1 Socket
 {variant:1}+2 to Level of Socketed Golem Gems
 {variant:2}+3 to Level of Socketed Golem Gems
-+(30-40) to Strength
-{variant:2}+(30-40) to maximum Life
-{variant:1}Adds (8-12) to (20-30) Fire Damage to Attacks
-(20-30)% increased Fire Damage
+{tags:jewellery_attribute}+(30-40) to Strength
+{variant:2}{tags:life}+(30-40) to maximum Life
+{variant:1}{tags:jewellery_elemental,attack}Adds (8-12) to (20-30) Fire Damage to Attacks
+{tags:jewellery_elemental}(20-30)% increased Fire Damage
 {variant:1}Socketed Gems are Supported by level 12 Lesser Multiple Projectiles
 {variant:2}Socketed Golem Skills have 25% chance to Taunt on Hit
 {variant:1}Socketed Gems are Supported by level 17 Increased Minion Damage
-{variant:2}Socketed Golem Skills have 5% Life Regenerated per second
+{variant:2}{tags:life}Socketed Golem Skills have 5% Life Regenerated per second
 ]],[[
 Rigwald's Crest
 Two-Stone Ring
@@ -736,10 +736,10 @@ League: Talisman
 Source: Drops from unique{Rigwald, the Wolven King} (Level 60+)
 Requires Level 49
 Implicits: 1
-+(12-16)% to Fire and Cold Resistances
-(20-30)% increased Fire Damage
-(20-30)% increased Cold Damage
-(20-30)% increased Mana Regeneration Rate
+{tags:jewellery_resistance}+(12-16)% to Fire and Cold Resistances
+{tags:jewellery_elemental}(20-30)% increased Fire Damage
+{tags:jewellery_elemental}(20-30)% increased Cold Damage
+{tags:mana}(20-30)% increased Mana Regeneration Rate
 10% Chance to summon a Spectral Wolf on Kill
 ]],[[
 Romira's Banquet
@@ -750,12 +750,12 @@ Variant: Current
 Requires Level 60
 Implicits: 1
 (20-30)% increased Global Critical Strike Chance
-+333 to Accuracy Rating
+{tags:attack}+333 to Accuracy Rating
 {variant:1}+(10-20)% to Global Critical Strike Multiplier
 {variant:2}+(10-15)% to Global Critical Strike Multiplier
 {variant:3}+(15-25)% to Global Critical Strike Multiplier
-+(40-60) to maximum Mana
-0.4% of Physical Attack Damage Leeched as Mana
+{tags:mana}+(40-60) to maximum Mana
+{tags:attack,mana}0.4% of Physical Attack Damage Leeched as Mana
 Gain a Power Charge on non-Critical Strike
 Lose all Power Charges on Critical Strike
 ]],[[
@@ -767,15 +767,15 @@ Variant: Pre 2.6.0
 Variant: Current
 Requires Level 30
 Implicits: 1
-+(15-25) to maximum Energy Shield
-+(60-75) to Intelligence
+{tags:jewellery_defense}+(15-25) to maximum Energy Shield
+{tags:jewellery_attribute}+(60-75) to Intelligence
 Right ring slot: You cannot Regenerate Mana
-{variant:1}Right ring slot: 4% of Energy Shield Regenerated per second
-{variant:2,3}Right ring slot: 3% of Energy Shield Regenerated per second
-{variant:3}Right ring slot: +100 to maximum Mana
-{variant:3}Left ring slot: +100 to maximum Energy Shield
-{variant:1,2}Left ring slot: 100% increased Mana Regeneration Rate
-{variant:3}Left ring slot: 40 Mana Regenerated per second
+{variant:1}{tags:jewellery_defense}Right ring slot: 4% of Energy Shield Regenerated per second
+{variant:2,3}{tags:jewellery_defense}Right ring slot: 3% of Energy Shield Regenerated per second
+{variant:3}{tags:mana}Right ring slot: +100 to maximum Mana
+{variant:3}{tags:jewellery_defense}Left ring slot: +100 to maximum Energy Shield
+{variant:1,2}{tags:mana}Left ring slot: 100% increased Mana Regeneration Rate
+{variant:3}{tags:mana}Left ring slot: 40 Mana Regenerated per second
 Left ring slot: You cannot Recharge or Regenerate Energy Shield
 ]],[[
 Sibyl's Lament
@@ -786,9 +786,9 @@ Variant: Pre 3.9.0
 Variant: Current
 Requires Level 45
 Implicits: 1
-+(20-30) to maximum Life
-(20-30)% increased Elemental Damage with Attack Skills
-Adds (8-15) to (20-28) Fire Damage to Attacks
+{tags:life}+(20-30) to maximum Life
+{tags:jewellery_elemental,attack}(20-30)% increased Elemental Damage with Attack Skills
+{tags:jewellery_elemental,attack}Adds (8-15) to (20-28) Fire Damage to Attacks
 {variant:1}(20-40)% reduced Rarity of Items found
 {variant:2,3,4}(10-20)% reduced Rarity of Items found
 {variant:1,2}Left ring slot: 30% reduced Reflected Elemental Damage taken
@@ -805,10 +805,10 @@ Variant: Current
 Source: Drops from unique{Guardian of the Hydra}
 Requires Level 68
 Implicits: 1
-+(20-30)% to Cold Resistance
-{variant:1}(20-40)% increased Cold Damage
-{variant:2}(20-40)% increased Spell Damage
-(5-10)% increased Cast Speed
+{tags:jewellery_resistance}+(20-30)% to Cold Resistance
+{variant:1}{tags:jewellery_elemental}(20-40)% increased Cold Damage
+{variant:2}{tags:caster}(20-40)% increased Spell Damage
+{tags:caster}(5-10)% increased Cast Speed
 {variant:1}Spells have an additional Projectile
 {variant:2}Left ring slot: Projectiles from Spells cannot Chain
 {variant:2}Left ring slot: Projectiles from Spells Fork
@@ -820,11 +820,11 @@ Stormfire
 Opal Ring
 Requires Level 80
 Implicits: 1
-(15-25)% increased Elemental Damage
-(40-45)% increased Mana Regeneration Rate
-+(20-30)% to Fire and Lightning Resistances
-(4-6)% increased Burning Damage for each Enemy you have Shocked Recently
-Adds (1-3) to (62-70) Lightning Damage to Hits against Ignited Enemies
+{tags:jewellery_elemental}(15-25)% increased Elemental Damage
+{tags:mana}(40-45)% increased Mana Regeneration Rate
+{tags:jewellery_resistance}+(20-30)% to Fire and Lightning Resistances
+{tags:jewellery_elemental}(4-6)% increased Burning Damage for each Enemy you have Shocked Recently
+{tags:jewellery_elemental}Adds (1-3) to (62-70) Lightning Damage to Hits against Ignited Enemies
 Your Lightning Damage can Ignite
 ]],[[
 The Taming
@@ -835,17 +835,17 @@ Variant: {2_6}Pre 3.0.0
 Variant: Current
 Requires Level 30
 Implicits: 1
-+(8-10)% to all Elemental Resistances
-{variant:1}15% increased Elemental Damage with Attack Skills
-{variant:2}30% increased Elemental Damage with Attack Skills
-{variant:1}+(10-15)% to all Elemental Resistances
-{variant:2}+(20-30)% to all Elemental Resistances
-{variant:1}15% increased Elemental Damage
-{variant:2}30% increased Elemental Damage
-{variant:1}5% chance to Freeze, Shock and Ignite
-{variant:2}10% chance to Freeze, Shock and Ignite
-{variant:1}10% increased Damage per Freeze, Shock and Ignite on Enemy
-{variant:2}20% increased Damage with Hits and Ailments per Freeze, Shock and Ignite on Enemy
+{tags:jewellery_resistance}+(8-10)% to all Elemental Resistances
+{variant:1}{tags:jewellery_elemental,attack}15% increased Elemental Damage with Attack Skills
+{variant:2}{tags:jewellery_elemental,attack}30% increased Elemental Damage with Attack Skills
+{variant:1}{tags:jewellery_resistance}+(10-15)% to all Elemental Resistances
+{variant:2}{tags:jewellery_resistance}+(20-30)% to all Elemental Resistances
+{variant:1}{tags:jewellery_elemental}15% increased Elemental Damage
+{variant:2}{tags:jewellery_elemental}30% increased Elemental Damage
+{variant:1}{tags:jewellery_elemental}5% chance to Freeze, Shock and Ignite
+{variant:2}{tags:jewellery_elemental}10% chance to Freeze, Shock and Ignite
+{variant:1}{tags:jewellery_elemental}10% increased Damage per Freeze, Shock and Ignite on Enemy
+{variant:2}{tags:jewellery_elemental}20% increased Damage with Hits and Ailments per Freeze, Shock and Ignite on Enemy
 ]],[[
 Tasalio's Sign
 Sapphire Ring
@@ -854,16 +854,16 @@ Variant: Pre 2.6.0
 Variant: Current
 Requires Level 20
 Implicits: 1
-+(20-30)% to Cold Resistance
-{variant:1}Adds 10 to 15 Physical Damage to Attacks against Frozen Enemies
-{variant:2}Adds 40 to 60 Cold Damage against Chilled Enemies
-{variant:1}Adds (5-6) to (7-9) Cold Damage to Attacks
-{variant:2}Adds (7-10) to (15-20) Cold Damage to Spells and Attacks
-+(200-300) to Evasion Rating
+{tags:jewellery_resistance}+(20-30)% to Cold Resistance
+{variant:1}{tags:jewellery_elemental,{tags:attack}}Adds 10 to 15 Physical Damage to Attacks against Frozen Enemies
+{variant:2}{tags:jewellery_elemental}Adds 40 to 60 Cold Damage against Chilled Enemies
+{variant:1}{tags:jewellery_elemental,attack}Adds (5-6) to (7-9) Cold Damage to Attacks
+{variant:2}{tags:jewellery_elemental,attack,caster}Adds (7-10) to (15-20) Cold Damage to Spells and Attacks
+{tags:jewellery_defense}+(200-300) to Evasion Rating
 {variant:1}20% reduced Chill Duration on You
 {variant:2}50% chance to Avoid being Chilled
-{variant:1}5% chance to Freeze
-{variant:2}10% chance to Freeze
+{variant:1}{tags:jewellery_elemental}5% chance to Freeze
+{variant:2}{tags:jewellery_elemental}10% chance to Freeze
 ]],[[
 Thief's Torment
 Prismatic Ring
@@ -873,18 +873,18 @@ Variant: Pre 2.6.0
 Variant: Current
 Requires Level 30
 Implicits: 2
-{variant:1}+(8-12) to all Elemental Resistances
-{variant:2,3,4}+(8-10)% to all Elemental Resistances
+{variant:1}{tags:jewellery_resistance}+(8-12) to all Elemental Resistances
+{variant:2,3,4}{tags:jewellery_resistance}+(8-10)% to all Elemental Resistances
 {variant:1,2}(15-25)% increased Quantity of Items found
 {variant:3,4}(10-16)% increased Quantity of Items found
 Can't use other Rings
-{variant:1,2,3}+(8-12)% to all Elemental Resistances
-{variant:4}+(16-24)% to all Elemental Resistances
+{variant:1,2,3}{tags:jewellery_resistance}+(8-12)% to all Elemental Resistances
+{variant:4}{tags:jewellery_resistance}+(16-24)% to all Elemental Resistances
 50% reduced Effect of Curses on You
-{variant:1,2,3}+(20-30) Life gained for each Enemy hit by your Attacks
-{variant:4}+(40-60) Life gained for each Enemy hit by your Attacks
-{variant:1,2,3}+15 Mana gained for each Enemy hit by your Attacks
-{variant:4}+30 Mana gained for each Enemy hit by your Attacks
+{variant:1,2,3}{tags:attack,life}+(20-30) Life gained for each Enemy hit by your Attacks
+{variant:4}{tags:attack,life}+(40-60) Life gained for each Enemy hit by your Attacks
+{variant:1,2,3}{tags:attack,mana}+15 Mana gained for each Enemy hit by your Attacks
+{variant:4}{tags:attack,mana}+30 Mana gained for each Enemy hit by your Attacks
 ]],[[
 Timeclasp
 Moonstone Ring
@@ -893,14 +893,14 @@ Variant: Pre 2.6.0
 Variant: Current
 Requires Level 22
 Implicits: 1
-+(15-25) to maximum Energy Shield
-(10-15)% increased Attack Speed
-{variant:1}(5-8)% increased Cast Speed
-{variant:2}(5-10)% increased Cast Speed
-{variant:1}15% reduced Mana Regeneration Rate
-{variant:2}15% increased Mana Regeneration Rate
-{variant:1}+(10-25) to maximum Energy Shield
-{variant:2}+(15-25) to maximum Energy Shield
+{tags:jewellery_defense}+(15-25) to maximum Energy Shield
+{tags:attack}(10-15)% increased Attack Speed
+{variant:1}{tags:attack}(5-8)% increased Cast Speed
+{variant:2}{tags:caster}(5-10)% increased Cast Speed
+{variant:1}{tags:mana}15% reduced Mana Regeneration Rate
+{variant:2}{tags:mana}15% increased Mana Regeneration Rate
+{variant:1}{tags:jewellery_defense}+(10-25) to maximum Energy Shield
+{variant:2}{tags:jewellery_defense}+(15-25) to maximum Energy Shield
 {variant:1}Temporal Chains has 30% reduced Effect on You
 {variant:2}Temporal Chains has 50% reduced Effect on You
 ]],[[
@@ -909,11 +909,11 @@ Moonstone Ring
 Source: Upgraded from unique{Timeclasp} via prophecy{A Rift in Time}
 Requires Level 64
 Implicits: 1
-+(15-25) to maximum Energy Shield
-(10-15)% increased Attack Speed
-(5-10)% increased Cast Speed
-+(30-50) to maximum Energy Shield
-15% increased Mana Regeneration Rate
+{tags:jewellery_defense}+(15-25) to maximum Energy Shield
+{tags:attack}(10-15)% increased Attack Speed
+{tags:caster}(5-10)% increased Cast Speed
+{tags:jewellery_defense}+(30-50) to maximum Energy Shield
+{tags:mana}15% increased Mana Regeneration Rate
 (-10-10)% increased Skill Effect Duration
 Unaffected by Temporal Chains
 ]],[[
@@ -923,10 +923,10 @@ League: Delve
 Source: Drops from unique{Ahuatotli, the Blind}
 Requires Level 49
 Implicits: 1
-+(20-30)% to Cold Resistance
-+20 to Dexterity
-5% increased maximum Energy Shield
-5% increased maximum Life
+{tags:jewellery_resistance}+(20-30)% to Cold Resistance
+{tags:jewellery_attribute}+20 to Dexterity
+{tags:jewellery_defense}5% increased maximum Energy Shield
+{tags:life}5% increased maximum Life
 ]],[[
 Uzaza's Mountain
 Sapphire Ring
@@ -934,10 +934,10 @@ League: Delve
 Source: Drops from unique{Kurgal, the Blackblooded}
 Requires Level 49
 Implicits: 1
-+(20-30)% to Cold Resistance
-+20 to Dexterity
-5% increased maximum Energy Shield
-5% increased maximum Life
+{tags:jewellery_resistance}+(20-30)% to Cold Resistance
+{tags:jewellery_attribute}+20 to Dexterity
+{tags:jewellery_defense}5% increased maximum Energy Shield
+{tags:life}5% increased maximum Life
 ]],[[
 Uzaza's Valley
 Sapphire Ring
@@ -945,10 +945,10 @@ League: Delve
 Source: Drops from unique{Aul, the Crystal King}
 Requires Level 49
 Implicits: 1
-+(20-30)% to Cold Resistance
-+20 to Dexterity
-5% increased maximum Energy Shield
-5% increased maximum Life
+{tags:jewellery_resistance}+(20-30)% to Cold Resistance
+{tags:jewellery_attribute}+20 to Dexterity
+{tags:jewellery_defense}5% increased maximum Energy Shield
+{tags:life}5% increased maximum Life
 ]],[[
 Valako's Sign
 Topaz Ring
@@ -958,24 +958,24 @@ Variant: {2_6}Pre 3.0.0
 Variant: Current
 Requires Level 38
 Implicits: 1
-+(20-30)% to Lightning Resistance
+{tags:jewellery_resistance}+(20-30)% to Lightning Resistance
 {variant:1}15% increased Damage against Shocked Enemies
 {variant:2}40% increased Damage against Shocked Enemies
 {variant:3}40% increased Damage with Hits against Shocked Enemies
-20% increased Lightning Damage
-+(20-40) to maximum Mana
-0.2% of Damage Leeched as Life against Shocked Enemies
-{variant:1}5% chance to Shock
-{variant:2,3}10% chance to Shock
+{tags:jewellery_elemental}20% increased Lightning Damage
+{tags:mana}+(20-40) to maximum Mana
+{tags:life}0.2% of Damage Leeched as Life against Shocked Enemies
+{variant:1}{tags:jewellery_elemental}5% chance to Shock
+{variant:2,3}{tags:jewellery_elemental}10% chance to Shock
 ]],[[
 Valyrium
 Moonstone Ring
 Requires Level 38
 Implicits: 1
-+(15-25) to maximum Energy Shield
-+(10-20) to maximum Energy Shield
-+(20-30)% to Fire Resistance
-−40% to Cold Resistance
+{tags:jewellery_defense}+(15-25) to maximum Energy Shield
+{tags:jewellery_defense}+(10-20) to maximum Energy Shield
+{tags:jewellery_resistance}+(20-30)% to Fire Resistance
+{tags:jewellery_resistance}−40% to Cold Resistance
 Stun Threshold is based on Energy Shield instead of Life
 ]],[[
 Venopuncture
@@ -983,9 +983,9 @@ Iron Ring
 Requires Level: 49
 Implicits: 1
 League: Blight
-Adds 1 to 4 Physical Damage to Attacks
-+(20-30) to Strength
-25% chance to cause Bleeding on Hit
+{tags:attack}Adds 1 to 4 Physical Damage to Attacks
+{tags:jewellery_attribute}+(20-30) to Strength
+{tags:attack}25% chance to cause Bleeding on Hit
 (40-60)% increased Damage with Bleeding
 You are Chilled while you are Bleeding
 Non-Chilled Enemies you inflict Bleeding on are Chilled
@@ -996,12 +996,12 @@ Gold Ring
 Requires Level 65
 Implicits: 1
 (6-15)% increased Rarity of Items found
-+(0-60) to maximum Life
+{tags:life}+(0-60) to maximum Life
 (−10 to 10)% increased Quantity of Items found
 (−40 to 40)% increased Rarity of Items found
-+(−25 to 50)% to Fire Resistance
-+(−25 to 50)% to Cold Resistance
-+(−25 to 50)% to Lightning Resistance
+{tags:jewellery_resistance}+(−25 to 50)% to Fire Resistance
+{tags:jewellery_resistance}+(−25 to 50)% to Cold Resistance
+{tags:jewellery_resistance}+(−25 to 50)% to Lightning Resistance
 ]],[[
 Vivinsect
 Unset Ring
@@ -1021,16 +1021,16 @@ Requires Level 45
 Implicits: 1
 Has 1 Socket
 +5 to Level of Socketed Aura Gems
-Socketed Gems have 10% increased Mana Reservation
-+(15-25) to all Attributes
-15 Life Regenerated per second for each Uncorrupted Item Equipped
--2 to Total Mana Cost of Skills for each Corrupted Item Equipped
-{variant:1}{crafted}+(8-15)% to Fire and Chaos Resistances
-{variant:2}{crafted}+(8-15)% to Cold and Chaos Resistances
-{variant:3}{crafted}+(8-15)% to Lightning and Chaos Resistances
-{variant:4}{crafted}+(6-17) to Strength and Dexterity
-{variant:5}{crafted}+(6-17) to Dexterity and Intelligence
-{variant:6}{crafted}+(6-17) to Strength and Intelligence
+{tags:mana}Socketed Gems have 10% increased Mana Reservation
+{tags:jewellery_attribute}+(15-25) to all Attributes
+{tags:life}15 Life Regenerated per second for each Uncorrupted Item Equipped
+{tags:mana}-2 to Total Mana Cost of Skills for each Corrupted Item Equipped
+{variant:1}{crafted}{tags:jewellery_resistance}+(8-15)% to Fire and Chaos Resistances
+{variant:2}{crafted}{tags:jewellery_resistance}+(8-15)% to Cold and Chaos Resistances
+{variant:3}{crafted}{tags:jewellery_resistance}+(8-15)% to Lightning and Chaos Resistances
+{variant:4}{crafted}{tags:jewellery_attribute}+(6-17) to Strength and Dexterity
+{variant:5}{crafted}{tags:jewellery_attribute}+(6-17) to Dexterity and Intelligence
+{variant:6}{crafted}{tags:jewellery_attribute}+(6-17) to Strength and Intelligence
 {variant:7}{crafted}(11-30)% increased Effect of non-Damaging Ailments on Enemies
 {variant:8}{crafted}Shock nearby Enemies for (2-4) Seconds when you Focus
 {variant:9}{crafted}+1 to Minimum Frenzy Charges
@@ -1049,9 +1049,9 @@ The Warden's Brand
 Iron Ring
 Requires Level 30
 Implicits: 1
-Adds 1 to 4 Physical Damage to Attacks
-Adds (5-15) to (25-50) Physical Damage to Attacks
-30% reduced Attack Speed
+{tags:attack}Adds 1 to 4 Physical Damage to Attacks
+{tags:attack}Adds (5-15) to (25-50) Physical Damage to Attacks
+{tags:attack}30% reduced Attack Speed
 15% chance to gain a Frenzy Charge when you Stun an Enemy
 ]],[[
 Warrior's Legacy
@@ -1059,9 +1059,9 @@ Ruby Ring
 League: Metamorph
 Requires Level 16
 Implicits: 1
-+(20-30)% to Fire Resistance
-+(30-50) to Strength
-(20-25)% increased Melee Damage
+{tags:jewellery_resistance}+(20-30)% to Fire Resistance
+{tags:jewellery_attribute}+(30-50) to Strength
+{tags:attack}(20-25)% increased Melee Damage
 30% chance to Avoid being Stunned
 20% less Attack Speed
 Strike Skills also target the previous location they were Used

--- a/Modules/ItemTools.lua
+++ b/Modules/ItemTools.lua
@@ -21,12 +21,27 @@ itemLib.influenceInfo = {
 	{ key="eyrie", display="Redeemer", color=colorCodes.EYRIE },
 }
 
+-- Apply a value scalar to any numbers present
+function itemLib.applyValueScalar(line, valueScalar)
+	if valueScalar and type(valueScalar) == "number" and valueScalar ~= 1 then
+		return line:gsub("(%d+%.%d*)", function(num)
+			local numVal = (m_floor(tonumber(num) * valueScalar * 10 + 0.001) / 10)
+			return tostring(numVal)
+		end)
+		:gsub("(%d+)([^%.])", function(num, suffix)
+			local numVal = m_floor(num * valueScalar + 0.001)
+			return tostring(numVal)..suffix
+		end)
+	end
+	return line
+end
+
 -- Apply range value (0 to 1) to a modifier that has a range: (x to x) or (x-x to x-x)
-function itemLib.applyRange(line, range)
-	return line:gsub("%((%d+)%-(%d+) to (%d+)%-(%d+)%)", "(%1-%2) to (%3-%4)")
+function itemLib.applyRange(line, range, valueScalar)
+	line = line:gsub("%((%d+)%-(%d+) to (%d+)%-(%d+)%)", "(%1-%2) to (%3-%4)")
 		:gsub("(%+?)%((%-?%d+) to (%d+)%)", "%1(%2-%3)")
 		:gsub("(%+?)%((%-?%d+)%-(%d+)%)", 
-		function(plus, min, max) 
+		function(plus, min, max)
 			local numVal = m_floor(tonumber(min) + range * (tonumber(max) - tonumber(min)) + 0.5)
 			if numVal < 0 then
 				if plus == "+" then
@@ -40,7 +55,8 @@ function itemLib.applyRange(line, range)
 			local numVal = m_floor((tonumber(min) + range * (tonumber(max) - tonumber(min))) * 10 + 0.5) / 10
 			return tostring(numVal) 
 		end)
-		:gsub("%-(%d+%%) increased", function(num) return num.." reduced" end)
+		:gsub("%-(%d+%%) increased", function(num) return num.."%% reduced" end)
+	return itemLib.applyValueScalar(line, valueScalar)
 end
 
 -- Clean item text by removing or replacing unsupported or redundant characters or sequences
@@ -50,7 +66,7 @@ function itemLib.sanitiseItemText(text)
 end
 
 function itemLib.formatModLine(modLine, dbMode)
-	local line = (not dbMode and modLine.range and itemLib.applyRange(modLine.line, modLine.range)) or modLine.line
+	local line = (not dbMode and modLine.range and itemLib.applyRange(modLine.line, modLine.range, modLine.valueScalar)) or modLine.line
 	if line:match("^%+?0%%? ") or (line:match(" %+?0%%? ") and not line:match("0 to [1-9]")) or line:match(" 0%-0 ") or line:match(" 0 to 0 ") then -- Hack to hide 0-value modifiers
 		return
 	end


### PR DESCRIPTION
When crafting rare jewelry, there is now a catalyst dropdown and quality slider
 - The new mod tags are used to determine if a catalyst affects a mod
 - The base implicit mod is also affected, but only if the item is newly crafted after this commit.
 - Also affects crafting bench and essence mods