### PR TITLE
Fix for crash as described in issue #753

### DIFF
--- a/Modules/CalcPerform.lua
+++ b/Modules/CalcPerform.lua
@@ -888,7 +888,7 @@ function calcs.perform(env)
 					if buff.type == "Buff" then
 						if env.mode_buffs and activeSkill.skillData.enable then
 							local skillCfg = buff.activeSkillBuff and skillCfg
-							local modStore = buff.activeSkillBuff and skillModList or env.minion.modDB
+							local modStore = buff.activeSkillBuff and skillModList or castingMinion.modDB
 							if buff.applyAllies then
 								modDB.conditions["AffectedBy"..buff.name:gsub(" ","")] = true
 								local srcList = new("ModList")


### PR DESCRIPTION
env.minion was nil and wasn't being checked
 - The fix is to use the castingMinion which is guaranteed not nil, and will be equal to env.minion when it is intended to be used.

Reproduction steps:
 - Create new build
 - Add new socket group
 - Add "Summon Lightning Golem"
 - Select Configuration tab
 - Check "Enable Wrath Aura"
 - Select Skills tab
 - Delete "Summon Lightning Golem" socket group
 - Add new socket group
 - Add "Storm Brand" to group
 - Add "Arcane Surge" to group
 - Click to try to add another gem to group
 - Observe crash