### PR TITLE
Fix for crash when viewing a breakdown which includes a cluster node source

### DIFF
--- a/Classes/CalcBreakdownControl.lua
+++ b/Classes/CalcBreakdownControl.lua
@@ -371,7 +371,8 @@ function CalcBreakdownClass:AddModSection(sectionData, modList)
 			-- Modifier is from a passive node, add node name, and add node ID (used to show node location)
 			local nodeId = row.mod.source:match("Tree:(%d+)")
 			if nodeId then
-				local node = build.spec.nodes[tonumber(nodeId)]
+				local nodeIdNumber = tonumber(nodeId)
+				local node = build.spec.nodes[nodeIdNumber] or build.spec.tree.nodes[nodeIdNumber]
 				row.sourceName = node.dn
 				row.sourceNameNode = node
 			end


### PR DESCRIPTION
Cluster node ids are a bit strange
 - The cluster jewel uses a modified id that's used on the actual tree
 - The source uses the original id in the tree.lua file
 - The fix is if the source id isn't found on the current spec, then the original tree data is referenced instead.

![image](https://user-images.githubusercontent.com/10701249/79080937-d1e7f100-7ccd-11ea-84a9-d8c77c642501.png)
