### PR TITLE
Change Vaal Timeless Jewel to disable stats from nodes in radius

### DIFF
--- a/Modules/ModParser-3_0.lua
+++ b/Modules/ModParser-3_0.lua
@@ -2312,6 +2312,11 @@ local jewelOtherFuncs = {
 			end
 		end
 	end,
+	["Passives in radius are Conquered by the Vaal"] = function(node, out, data)
+		if node and node.type ~= "Keystone" then
+			out:NewMod("PassiveSkillHasNoEffect", "FLAG", true, data.modSource)
+		end
+	end,
 }
 
 -- Radius jewels that modify the jewel itself based on nearby allocated nodes


### PR DESCRIPTION
The Vaal timeless jewel changes all the nodes in its radius anyway so disabling the stats they give makes sense