### PR TITLE
Fix gem/cluster jewel importer

### DIFF
--- a/Classes/ImportTab.lua
+++ b/Classes/ImportTab.lua
@@ -699,16 +699,18 @@ function ImportTabClass:ImportItem(itemData, slotName)
 	item.explicitModLines = { }
 	if itemData.enchantMods then
 		for _, line in ipairs(itemData.enchantMods) do
-			line = line:gsub("\n"," ")
-			local modList, extra = modLib.parseMod[self.build.targetVersion](line)
-			t_insert(item.enchantModLines, { line = line, extra = extra, mods = modList or { }, crafted = true })
+			for line in line:gmatch("[^\n]+") do
+				local modList, extra = modLib.parseMod[self.build.targetVersion](line)
+				t_insert(item.enchantModLines, { line = line, extra = extra, mods = modList or { }, crafted = true })
+			end
 		end
 	end
 	if itemData.implicitMods then
 		for _, line in ipairs(itemData.implicitMods) do
-			line = line:gsub("\n"," ")
-			local modList, extra = modLib.parseMod[self.build.targetVersion](line)
-			t_insert(item.implicitModLines, { line = line, extra = extra, mods = modList or { } })
+			for line in line:gmatch("[^\n]+") do
+				local modList, extra = modLib.parseMod[self.build.targetVersion](line)
+				t_insert(item.implicitModLines, { line = line, extra = extra, mods = modList or { } })
+			end
 		end
 	end
 	if itemData.fracturedMods then
@@ -769,26 +771,34 @@ function ImportTabClass:ImportSocketedItems(item, socketedItems, slotName)
 			self:ImportItem(socketedItem, slotName .. " Abyssal Socket "..abyssalSocketId)
 			abyssalSocketId = abyssalSocketId + 1
 		else
-			local gemInstance = { level = 20, quality = 0, enabled = true, enableGlobal1 = true }
-			gemInstance.nameSpec = socketedItem.typeLine:gsub(" Support","")
-			gemInstance.support = socketedItem.support
-			for _, property in pairs(socketedItem.properties) do
-				if property.name == "Level" then
-					gemInstance.level = tonumber(property.values[1][1]:match("%d+"))
-				elseif property.name == "Quality" then
-					gemInstance.quality = tonumber(property.values[1][1]:match("%d+"))
+			local gemId = self.build.data.gemForBaseName[socketedItem.typeLine] 
+			if not gemId and socketedItem.hybrid then
+				-- Dual skill gems (currently just Stormbind) show the second skill as the typeLine, which won't match the actual gem
+				-- Luckily the primary skill name is also there, so we can find the gem using that
+				gemId = self.build.data.gemForBaseName[socketedItem.hybrid.baseTypeName]
+			end
+			if gemId then
+				local gemInstance = { level = 20, quality = 0, enabled = true, enableGlobal1 = true, gemId = gemId }
+				gemInstance.nameSpec = self.build.data.gems[gemId].name
+				gemInstance.support = socketedItem.support
+				for _, property in pairs(socketedItem.properties) do
+					if property.name == "Level" then
+						gemInstance.level = tonumber(property.values[1][1]:match("%d+"))
+					elseif property.name == "Quality" then
+						gemInstance.quality = tonumber(property.values[1][1]:match("%d+"))
+					end
 				end
-			end
-			local groupID = item.sockets[socketedItem.socket + 1].group
-			if not itemSocketGroupList[groupID] then
-				itemSocketGroupList[groupID] = { label = "", enabled = true, gemList = { }, slot = slotName }
-			end
-			local socketGroup = itemSocketGroupList[groupID]
-			if not socketedItem.support and socketGroup.gemList[1] and socketGroup.gemList[1].support then
-				-- If the first gemInstance is a support gemInstance, put the first active gemInstance before it
-				t_insert(socketGroup.gemList, 1, gemInstance)
-			else
-				t_insert(socketGroup.gemList, gemInstance)
+				local groupID = item.sockets[socketedItem.socket + 1].group
+				if not itemSocketGroupList[groupID] then
+					itemSocketGroupList[groupID] = { label = "", enabled = true, gemList = { }, slot = slotName }
+				end
+				local socketGroup = itemSocketGroupList[groupID]
+				if not socketedItem.support and socketGroup.gemList[1] and socketGroup.gemList[1].support then
+					-- If the first gemInstance is a support gemInstance, put the first active gemInstance before it
+					t_insert(socketGroup.gemList, 1, gemInstance)
+				else
+					t_insert(socketGroup.gemList, gemInstance)
+				end
 			end
 		end
 	end

--- a/Classes/SkillsTab.lua
+++ b/Classes/SkillsTab.lua
@@ -570,7 +570,7 @@ function SkillsTabClass:ProcessSocketGroup(socketGroup)
 			end
 		elseif gemInstance.nameSpec:match("%S") then
 			-- Specified by gem/skill name, try to match it
-			-- Used during character import, and to migrate pre-1.4.20 builds
+			-- Used to migrate pre-1.4.20 builds
 			gemInstance.errMsg, gemInstance.gemData = self:FindSkillGem(gemInstance.nameSpec)
 			gemInstance.gemId = gemInstance.gemData and gemInstance.gemData.id
 			gemInstance.skillId = gemInstance.gemData and gemInstance.gemData.grantedEffectId

--- a/Data/3_0/ClusterJewels.lua
+++ b/Data/3_0/ClusterJewels.lua
@@ -422,9 +422,10 @@ return {
 					icon = "Art/2DArt/SkillIcons/passives/NodeBowDamage.png",
 					masteryIcon = "Art/2DArt/SkillIcons/passives/AltMasteryGroupBow.png",
 					tag = "affliction_bow_damage",
-					stats = { "12% increased Damage with Bows" },
+					stats = { "12% increased Damage with Bows", "12% increased Damage Over Time with Bow Skills" },
 					enchant = {
 						"Added Small Passive Skills grant: 12% increased Damage with Bows",
+						"Added Small Passive Skills grant: 12% increased Damage Over Time with Bow Skills",
 					},
 				},
 				["affliction_wand_damage"] = {

--- a/Data/3_0/Gems.lua
+++ b/Data/3_0/Gems.lua
@@ -6301,7 +6301,7 @@ return {
 		defaultLevel = 20,
 	},
 	["Metadata/Items/Gems/SupportGemBarrage"] = {
-		name = "Barrage Support",
+		name = "Barrage",
 		grantedEffectId = "SupportBarrage",
 		tags = {
 			bow = true,

--- a/Data/3_0/Skills/sup_dex.lua
+++ b/Data/3_0/Skills/sup_dex.lua
@@ -301,7 +301,7 @@ skills["SupportArrowNovaPlus"] = {
 	},
 }
 skills["SupportBarrage"] = {
-	name = "Barrage Support",
+	name = "Barrage",
 	description = "Supports projectile attack skills that use bows or wands. Cannot support triggered skills, channelled skills, or skills that create Minions.",
 	color = 2,
 	support = true,

--- a/Modules/Data.lua
+++ b/Modules/Data.lua
@@ -297,10 +297,12 @@ for _, targetVersion in ipairs(targetVersionList) do
 	-- Load gems
 	verData.gems = dataModule("Gems")
 	verData.gemForSkill = { }
+	verData.gemForBaseName = { }
 	for gemId, gem in pairs(verData.gems) do
 		gem.id = gemId
 		gem.grantedEffect = verData.skills[gem.grantedEffectId]
 		verData.gemForSkill[gem.grantedEffect] = gemId
+		verData.gemForBaseName[gem.name .. (gem.grantedEffect.support and " Support" or "")] = gemId
 		gem.secondaryGrantedEffect = gem.secondaryGrantedEffectId and verData.skills[gem.secondaryGrantedEffectId]
 		gem.grantedEffectList = {
 			gem.grantedEffect,


### PR DESCRIPTION
Comes from Openarl's 1.4.169 update that included changes to the importer to fix Stormbind and Barrage Support not importing correctly when importing a character's skills. Also fixes the importer for cluster jewels that contain 2 lines for the enchant