### PR TITLE
Fix for Hungry Loop attempting to support the skill with the Barrage skill instead of the Barrage support

### DIFF
--- a/Modules/CalcSetup.lua
+++ b/Modules/CalcSetup.lua
@@ -666,6 +666,12 @@ function calcs.initEnv(build, mode, override)
 				-- Add extra supports from the item this group is socketed in
 				for _, value in ipairs(env.modDB:List(groupCfg, "ExtraSupport")) do
 					local grantedEffect = env.data.skills[value.skillId]
+					-- Some skill gems share the same name as support gems, e.g. Barrage.
+					-- Since a support gem is expected here, if the first lookup returns a skill, then
+					-- prepending "Support" to the skillId will find the support version of the gem.
+					if grantedEffect and not grantedEffect.support then
+						grantedEffect = env.data.skills["Support"..value.skillId]
+					end
 					if grantedEffect then
 						t_insert(supportList, { 
 							grantedEffect = grantedEffect,


### PR DESCRIPTION
If the granted skill is not a support gem, then "Support" is prepended to the skillId and the lookup is attempted again.
 - This changes Barrage to SupportBarrage

Fixes #692 