### PR TITLE
Update runtime files

### DIFF
--- a/manifest.xml
+++ b/manifest.xml
@@ -15,7 +15,7 @@
 	<File name="UpdateApply.lua" part="program" sha1="4f17937f2b37784e169a3792b235f2a0a3961e61" />
 	<File name="GameVersions.lua" part="program" sha1="4cf43ef67fe750c22e15c7a63d7f77cce7768dba" />
 	<File name="changelog.txt" part="program" sha1="1e9720a8d11162a5573386b376782f5392278e73" />
-	<File name="Path of Building.exe" part="runtime" platform="win32" sha1="7e5a3242c9a4296dc8377feb4c9d824f3f0a3cc1" />
+	<File name="Path of Building Community.exe" part="runtime" platform="win32" sha1="abedf9c43a64c4a9270de5aacc3f02a105fecd1d" />
 	<File name="lua51.dll" part="runtime" platform="win32" sha1="7a973d3c0b5121e6aad0dcb9323be5b432fc63e7" />
 	<File name="SimpleGraphic.dll" part="runtime" platform="win32" sha1="d852ae6eafc9be62aa41d3cb74fb986d0e5b40e5" />
 	<File name="libcurl.dll" part="runtime" platform="win32" sha1="5f68674e22a389dddeb72078b7d9d69d29881bdd" />


### PR DESCRIPTION
Changes:
* Change icon of `Path of Building.exe`  to Path of Building Community icon
* Re-add `vcredist_x86.exe`
* Remove `UpdateUAC.exe`, as it is no longer needed
* Recompute file hash for replaced executable