### PR TITLE
Fix for the "Show power" calculation thinking all nodes have more power when the impale stacks are configured to be higher than the max.

### DIFF
--- a/Classes/ModDB.lua
+++ b/Classes/ModDB.lua
@@ -31,8 +31,9 @@ end
 
 ---ReplaceModInternal
 ---  Replaces an existing matching mod with a new mod.
----  If no matching mod exists, the mod is added instead.
+---  If no matching mod exists, then the function returns false
 ---@param mod table
+---@return boolean @Whether any mod was replaced
 function ModDBClass:ReplaceModInternal(mod)
 	local name = mod.name
 	if not self.mods[name] then
@@ -51,11 +52,16 @@ function ModDBClass:ReplaceModInternal(mod)
 	end
 
 	-- Add or replace the mod
-	if modIndex == -1 then
-		t_insert(self.mods[name], mod)
-	else
+	if modIndex > 0 then
 		modList[modIndex] = mod
+		return true
 	end
+
+	if self.parent then
+		return self.parent:ReplaceModInternal(mod)
+	end
+	
+	return false
 end
 
 function ModDBClass:AddList(modList)

--- a/Classes/ModStore.lua
+++ b/Classes/ModStore.lua
@@ -88,7 +88,10 @@ end
 ---    5+ (optional, varies): additional options
 ---@param ... any @Parameters to be passed along to the modLib.createMod function
 function ModStoreClass:ReplaceMod(...)
-	self:ReplaceModInternal(mod_createMod(...))
+	local mod = mod_createMod(...)
+	if not self:ReplaceModInternal(mod) then
+		self:AddMod(mod)
+	end
 end
 
 function ModStoreClass:Combine(modType, cfg, ...)


### PR DESCRIPTION
The fix is to have ReplaceModInternal recurse into the parent mod list when looking for a mod to replace.
 - The logic to add the mod if it doesn't exist has been moved to ReplaceMod if the function returns false.