### PR TITLE
Arcane Surge buff effect now works properly, such as from the Arcane Heroism cluster jewel notable

### DIFF
--- a/Classes/ModStore.lua
+++ b/Classes/ModStore.lua
@@ -516,6 +516,17 @@ function ModStoreClass:EvalMod(mod, cfg)
 			if band(cfg.keywordFlags, tag.keywordFlags) ~= tag.keywordFlags then
 				return
 			end
+		elseif tag.type == "SkillProperties" then
+			if not cfg or not tag.properties or type(tag.properties) ~= "table" then
+				return
+			end
+
+			-- Check that the skill has all the desired properties
+			for k, v in pairs(tag.properties) do
+				if cfg[k] ~= v then
+					return
+				end
+			end
 		end
 	end	
 	return value

--- a/Modules/CalcActiveSkill.lua
+++ b/Modules/CalcActiveSkill.lua
@@ -62,7 +62,9 @@ function calcs.mergeSkillInstanceMods(env, modList, skillEffect, extraStats)
 		local map = grantedEffect.statMap[stat]
 		if map then
 			for _, mod in ipairs(map) do
-				mergeLevelMod(modList, mod, map.value or statValue * (map.mult or 1) / (map.div or 1))
+				local value = map.value or statValue * (map.mult or 1) / (map.div or 1)
+				local buffEffect = 1 + env.modDB:Sum("INC", mod[1], "SkillEffect" ) / 100
+				mergeLevelMod(modList, mod, value * buffEffect)
 			end
 		end
 	end

--- a/Modules/ModParser-3_0.lua
+++ b/Modules/ModParser-3_0.lua
@@ -264,7 +264,7 @@ local modNameList = {
 	["effect of buffs granted by your active ancestor totems"] = { "BuffEffect", tag = { type = "SkillName", skillNameList = { "Ancestral Warchief", "Ancestral Protector" } } },
 	["warcry effect"] = { "BuffEffect", keywordFlags = KeywordFlag.Warcry },
 	["aspect of the avian buff effect"] = { "BuffEffect", tag = { type = "SkillName", skillName = "Aspect of the Avian" } },
-	["effect of arcane surge on you"] = { "BuffEffect", tag = { type = "SkillName", skillName = "Arcane Surge" } },
+	["effect of arcane surge on you"] = { "SkillEffect", tag = { type = "SkillProperties", properties = { type="GlobalEffect", effectType="Buff", effectName="Arcane Surge" } } },
 	-- Charges
 	["maximum power charge"] = "PowerChargesMax",
 	["maximum power charges"] = "PowerChargesMax",


### PR DESCRIPTION
Added "SkillEffect" mod type which can specify "SkillProperties" to look for
 - This is applied in CalcActiveSkill.lua directly as a multiplier to mods added by the skill, as long as they match the desired properties

The node calculator, which is used by the "node power" feature, no longer caches the original environment
 - It is regenerated for the new tree, similar to how the item power calculator works.
 - This is because the new "SkillEffect" will modify the mods added by initEnv
 - There were likely other nodes which were also not calculated properly due to the caching
 - Performance of the node calculator is about 50% worse based on my tests, but this doesn't appear to avoidable for correctness

Requires regenerating the mod cache (ctrl-F5)