### PR TITLE
Correctly save and load choice for build name in titlebar

### DIFF
--- a/Modules/Main.lua
+++ b/Modules/Main.lua
@@ -469,7 +469,7 @@ function main:LoadSettings()
 					self.showThousandsCalcs = node.attrib.showThousandsCalcs == "true"
 				end -- else leave at default
 				if node.attrib.showTitlebarName then
-					self.showTitlebarName = node.attrib.showTitlebarName
+					self.showTitlebarName = node.attrib.showTitlebarName == "true"
 				end
 			end
 		end


### PR DESCRIPTION
I noticed that for some reason, when I restarted PoB, the build name was showing in the title bar even though I had it turned off. Turns out that in my original PR I neglected a simple thing that would make it actually use the value that was in the Settings.xml file when the program started. I saw that it this "== "true"" was there for the thousands separator toggles, but thought it was unneeded for some reason.

In all the testing I did, the toggle always worked just fine! Just forgot to check that the setting actually saved when I restarted the program.