### PR TITLE
Fix DPS sorting for ShowAverage skills

### DIFF
--- a/Modules/CalcOffence-3_0.lua
+++ b/Modules/CalcOffence-3_0.lua
@@ -2421,6 +2421,7 @@ function calcs.offence(env, actor, activeSkill)
 	output.CombinedDPS = baseDPS
 	output.CombinedAvg = baseDPS
 	if skillData.showAverage then
+		output.CombinedDPS = output.CombinedDPS + (output.TotalPoisonDPS or 0)
 		output.CombinedAvg = output.CombinedAvg + (output.PoisonDamage or 0)
 		output.WithPoisonDPS = baseDPS + (output.TotalPoisonAverageDamage or 0)
 	else
@@ -2430,6 +2431,7 @@ function calcs.offence(env, actor, activeSkill)
 	if skillFlags.ignite then
 		if skillFlags.igniteCanStack then
 			if skillData.showAverage then
+				output.CombinedDPS = output.CombinedDPS + output.TotalIgniteDPS
 				output.CombinedAvg = output.CombinedDPS + output.TotalIgniteAverageDamage
 				output.WithIgniteAverageDamage = baseDPS + output.TotalIgniteAverageDamage
 			else
@@ -2438,6 +2440,7 @@ function calcs.offence(env, actor, activeSkill)
 			end
 		elseif skillData.showAverage then
 			output.WithIgniteDPS = baseDPS + output.IgniteDamage
+			output.CombinedDPS = output.CombinedDPS + output.IgniteDPS
 			output.CombinedAvg = output.CombinedAvg + output.IgniteDamage
 		else
 			output.WithIgniteDPS = baseDPS + output.IgniteDPS
@@ -2447,6 +2450,7 @@ function calcs.offence(env, actor, activeSkill)
 	if skillFlags.bleed then
 		if skillData.showAverage then
 			output.WithBleedDPS = baseDPS + output.BleedDamage
+			output.CombinedDPS = output.CombinedDPS + output.BleedDPS
 			output.CombinedAvg = output.CombinedAvg + output.BleedDamage
 		else
 		output.WithBleedDPS = baseDPS + output.BleedDPS


### PR DESCRIPTION
My PR #158 had a mistake where skills which display average damage(Divine Ire, certain triggered skills, etc.) had wildly incorrect sorting for things that sort by Combined DPS, including adding support gems. That's because it was only ever considering the average hit damage, and not considering any bleeds or ignites or poisons or anything, as the only thing that ever got added to the CombinedDPS value was the base hit damage.

This second PR adds a CombinedDPS total to ShowAverage skills, which isn't shown anywhere, but makes sorting by Combined DPS function like it did before my original PR.