### PR TITLE
Update Indigon and Maw of Conquest Item Data

### DIFF
--- a/Data/Uniques/helmet.lua
+++ b/Data/Uniques/helmet.lua
@@ -439,7 +439,7 @@ Requires Level 69, 154 Int
 Recover (8-10)% of maximum Life when you use a Mana Flask
 Non-instant Mana recovery from Flasks is also recovered as Life
 (50-60)% increased Mana Cost of Skills for each 200 total Mana you have Spent Recently
-{variant:1}(50-60)% increased Spell Damage for each 200 total Mana you have Spent Recently
+{variant:1}(50-60)% increased Spell Damage for each 200 total Mana you have Spent Recently, up to 2000%
 {variant:2}(20-25)% increased Spell Damage for each 200 total Mana you have Spent Recently, up to 2000%
 Shaper Item
 ]],[[
@@ -462,7 +462,7 @@ Requires Level 48, 101 Int
 (200-250)% increased Energy Shield
 +(50-70) to maximum Life
 Unaffected by Poison
-(10-20)% of Damage taken gained a Life over 4 seconds when Hit
+(10-20)% of Damage taken gained as Life over 4 seconds when Hit
 ]],[[
 Rime Gaze
 Mind Cage


### PR DESCRIPTION
The 2000% increased damage cap added in 3.5.0 applies to all versions of Indigon, legacy versions without the cap do not exist. This also fixes a typo with Maw of Conquest.