### PR TITLE
Fix talisman tier parsing

### DIFF
--- a/Classes/Item.lua
+++ b/Classes/Item.lua
@@ -270,6 +270,8 @@ function ItemClass:ParseRaw(raw)
 					else
 						t_insert(self.variantList, specVal)
 					end
+                elseif specName == "Talisman Tier" then
+                    self.talismanTier = tonumber(specVal)
 				elseif specName == "Requires Level" then
 					self.requirements.level = tonumber(specVal)
 				elseif specName == "Requires" then
@@ -599,6 +601,9 @@ function ItemClass:BuildRaw()
 			t_insert(rawLines, "Cluster Jewel Node Count: "..self.clusterJewelNodeCount)
 		end
 	end
+    if self.talismanTier then
+        t_insert(rawLines, "Talisman Tier: "..self.talismanTier)
+    end
 	if self.itemLevel then
 		t_insert(rawLines, "Item Level: "..self.itemLevel)
 	end

--- a/Classes/Item.lua
+++ b/Classes/Item.lua
@@ -270,8 +270,8 @@ function ItemClass:ParseRaw(raw)
 					else
 						t_insert(self.variantList, specVal)
 					end
-                elseif specName == "Talisman Tier" then
-                    self.talismanTier = tonumber(specVal)
+				elseif specName == "Talisman Tier" then
+					self.talismanTier = tonumber(specVal)
 				elseif specName == "Requires Level" then
 					self.requirements.level = tonumber(specVal)
 				elseif specName == "Requires" then
@@ -601,9 +601,9 @@ function ItemClass:BuildRaw()
 			t_insert(rawLines, "Cluster Jewel Node Count: "..self.clusterJewelNodeCount)
 		end
 	end
-    if self.talismanTier then
-        t_insert(rawLines, "Talisman Tier: "..self.talismanTier)
-    end
+	if self.talismanTier then
+		t_insert(rawLines, "Talisman Tier: "..self.talismanTier)
+	end
 	if self.itemLevel then
 		t_insert(rawLines, "Item Level: "..self.itemLevel)
 	end

--- a/Classes/ItemsTab.lua
+++ b/Classes/ItemsTab.lua
@@ -2145,6 +2145,11 @@ function ItemsTabClass:AddItemTooltip(tooltip, item, slot, dbMode)
 	end
 	tooltip:AddSeparator(10)
 
+    if item.talismanTier then
+        tooltip:AddLine(16, "^x7F7F7FTalisman Tier ^xFFFFFF"..item.talismanTier)
+        tooltip:AddSeparator(10)
+    end
+
 	-- Requirements
 	self.build:AddRequirementsToTooltip(tooltip, item.requirements.level, 
 		item.requirements.strMod, item.requirements.dexMod, item.requirements.intMod, 

--- a/Classes/ItemsTab.lua
+++ b/Classes/ItemsTab.lua
@@ -2145,10 +2145,10 @@ function ItemsTabClass:AddItemTooltip(tooltip, item, slot, dbMode)
 	end
 	tooltip:AddSeparator(10)
 
-    if item.talismanTier then
-        tooltip:AddLine(16, "^x7F7F7FTalisman Tier ^xFFFFFF"..item.talismanTier)
-        tooltip:AddSeparator(10)
-    end
+	if item.talismanTier then
+		tooltip:AddLine(16, "^x7F7F7FTalisman Tier ^xFFFFFF"..item.talismanTier)
+		tooltip:AddSeparator(10)
+	end
 
 	-- Requirements
 	self.build:AddRequirementsToTooltip(tooltip, item.requirements.level, 

--- a/Data/Uniques/amulet.lua
+++ b/Data/Uniques/amulet.lua
@@ -181,8 +181,8 @@ Implicits: 1
 Blightwell
 Clutching Talisman
 League: Talisman Hardcore
-Requires Level 28
 Talisman Tier: 2
+Requires Level 28
 Implicits: 1
 (15-25)% increased Global Defences
 +(20-30) to maximum Energy Shield
@@ -591,8 +591,8 @@ Your Critical Strikes have Culling Strike
 Natural Hierarchy
 Rotfeather Talisman
 League: Talisman Standard, Talisman Hardcore
-Requires Level 44
 Talisman Tier: 3
+Requires Level 44
 Implicits: 1
 (25-35)% increased Damage
 (10-15)% increased Physical Damage
@@ -605,9 +605,9 @@ Corrupted
 Night's Hold
 Black Maw Talisman
 League: Talisman Standard, Talisman Hardcore
+Talisman Tier: 1
 Requires Level 25
 Implicits: 1
-Talisman Tier: 1
 Has 1 Socket
 +2 to Level of Socketed Gems
 Socketed Gems are Supported by level 10 Added Chaos Damage
@@ -659,8 +659,8 @@ Wereclaw Talisman
 League: Talisman Standard
 Variant: Pre 2.2.0
 Variant: Current
-Requires Level 28
 Talisman Tier: 2
+Requires Level 28
 Implicits: 2
 {variant:1}+(16-24)% to Global Critical Strike Multiplier
 {variant:2}+(24-36)% to Global Critical Strike Multiplier


### PR DESCRIPTION
This adds proper support for parsing talisman tiers from item data.

Removing talisman tier data from Data\uniques\amulet.lua is also technically an option, but that leaves parsing for existing items in a broken state.

Current behaviour (1.4.169.2):
![](http://puu.sh/FDtoh/c55a9a50b4.png)

----

Fixed behaviour:
![](http://puu.sh/FDtkY/a053577c1c.png)