### PR TITLE
Fix hybrid flasks not counting as life/mana flasks

### DIFF
--- a/Modules/CalcPerform.lua
+++ b/Modules/CalcPerform.lua
@@ -612,6 +612,10 @@ function calcs.perform(env)
 			if item.baseName:match("Mana Flask") then
 				usingManaFlask = true
 			end
+			if item.baseName:match("Hybrid Flask") then
+				usingLifeFlask = true
+				usingManaFlask = true
+			end
 
 			-- Avert thine eyes, lest they be forever scarred
 			-- I have no idea how to determine which buff is applied by a given flask, 


### PR DESCRIPTION
Hybrid flasks count as both life and mana flasks. This is relevant for certain passive skills. Fixes #858 