### PR TITLE
Fix for Dying Sun not changing "increased" to "reduced" properly for the first mod.

### DIFF
--- a/Modules/ItemTools.lua
+++ b/Modules/ItemTools.lua
@@ -55,7 +55,7 @@ function itemLib.applyRange(line, range, valueScalar)
 			local numVal = m_floor((tonumber(min) + range * (tonumber(max) - tonumber(min))) * 10 + 0.5) / 10
 			return tostring(numVal) 
 		end)
-		:gsub("%-(%d+%%) increased", function(num) return num.."%% reduced" end)
+		:gsub("%-(%d+%%) increased", function(num) return num.." reduced" end)
 	return itemLib.applyValueScalar(line, valueScalar)
 end
 


### PR DESCRIPTION
Issue before the fix:
1) Too many percent signs added to the first mod.
2) The slider would start editing the second mod instead of the first.
![image](https://user-images.githubusercontent.com/10701249/80934351-a9a75b80-8d7c-11ea-961d-9ef68b06573a.png)

After the fix, the slider works as expected:
![image](https://user-images.githubusercontent.com/10701249/80934318-82508e80-8d7c-11ea-93ba-289332c33870.png)
