### PR TITLE
Allow ifOption config options to have tooltips

### DIFF
--- a/Classes/ConfigTab.lua
+++ b/Classes/ConfigTab.lua
@@ -94,6 +94,7 @@ local ConfigTabClass = newClass("ConfigTab", "UndoHandler", "ControlHost", "Cont
 				control.shown = function()
 					return self.input[varData.ifOption]
 				end
+				control.tooltipText = varData.tooltip
 			elseif varData.ifCond or varData.ifMinionCond or varData.ifEnemyCond then
 				control.shown = function()
 					local mainEnv = self.build.calcsTab.mainEnv

--- a/Modules/ConfigOptions.lua
+++ b/Modules/ConfigOptions.lua
@@ -894,10 +894,10 @@ return {
 	{ var = "conditionEnemyFrozen", type = "check", label = "Is the enemy Frozen?", implyCond = "Chilled", tooltip = "This also implies that the enemy is Chilled.", apply = function(val, modList, enemyModList)
 		enemyModList:NewMod("Condition:Frozen", "FLAG", true, "Config", { type = "Condition", var = "Effective" })
 	end },
-	{ var = "conditionEnemyShocked", type = "check", label = "Is the enemy Shocked?", tooltip = "In addition to allowing any 'against Shocked Enemies' modifiers to apply,\nthis will allow you to input the effect of the Shock applied to the enemy.\n\nShock increases Damage Taken by the enemy by the Effect of Shock specified, up to 50%.\nGuaranteed sources of Shock with an unspecified effect apply a base Shock of 15%.", apply = function(val, modList, enemyModList)
+	{ var = "conditionEnemyShocked", type = "check", label = "Is the enemy Shocked?", tooltip = "In addition to allowing any 'against Shocked Enemies' modifiers to apply,\nthis will allow you to input the effect of the Shock applied to the enemy.", apply = function(val, modList, enemyModList)
 		enemyModList:NewMod("Condition:Shocked", "FLAG", true, "Config", { type = "Condition", var = "Effective" })
 	end },
-	{ var = "conditionShockEffect", type = "count", label = "Effect of Shock:", ifOption = "conditionEnemyShocked", apply = function(val,modList,enemyModList)
+	{ var = "conditionShockEffect", type = "count", label = "Effect of Shock:", ifOption = "conditionEnemyShocked", tooltip = "Shock causes the enemy to take increased Damage, up to 50%.\nGuaranteed sources of Shock with an unspecified effect apply a base Shock of 15%.", apply = function(val,modList,enemyModList)
 		enemyModList:NewMod("DamageTaken", "INC", m_min(val, 50), "Shock", { type = "Condition", var = "Shocked" })
 	end },
 	{ var = "multiplierFreezeShockIgniteOnEnemy", type = "count", label = "# of Freeze/Shock/Ignite on Enemy:", ifMult = "FreezeShockIgniteOnEnemy", apply = function(val, modList, enemyModList)


### PR DESCRIPTION
- Adds tooltip functionality to config options that use ifOption

---------

For some reason, there is just no code that allows an ifOption config option to have a tooltip. It seems to be the only thing that has this problem on the config page.

I ran into this limitation when initially implementing Shock, and worked around it by just making the tooltip for the Shock checkbox really long to make it clear exactly how it works. But when I ran into the same issue for my PR to implement alternate ailments(#891), I figured out how to fix it very easily. Here is that fix. As an example, this finally lets me split the Shock tooltip up and make it less wordy since it's much clearer now:
![image](https://user-images.githubusercontent.com/39030429/81521293-539e5f00-930c-11ea-82b7-053ef558f056.png)

![image](https://user-images.githubusercontent.com/39030429/81521298-5731e600-930c-11ea-9bf1-1bb7245f4462.png)