### PR TITLE
Add parsing for Tailwind mod on Hunter influenced boots

### DIFF
--- a/Modules/ModParser-3_0.lua
+++ b/Modules/ModParser-3_0.lua
@@ -1635,6 +1635,7 @@ local specialModList = {
 	["you have phasing while you have cat's stealth"] = { flag("Condition:Phasing", { type = "Condition", var = "AffectedByCat'sStealth" }) },
 	["you have onslaught while on low life"] = { flag("Condition:Onslaught", { type = "Condition", var = "LowLife" }) },
 	["you have onslaught while not on low mana"] = { flag("Condition:Onslaught", { type = "Condition", var = "LowMana", neg = true }) },
+	["you have tailwind if you have dealt a critical strike recently"] = { flag("Condition:Tailwind", { type = "Condition", var = "CritRecently" }) },
 	["your aura buffs do not affect allies"] = { flag("SelfAurasCannotAffectAllies") },
 	["aura buffs from skills have (%d+)%% increased effect on you for each herald affecting you"] = function(num) return { mod("AuraBuffEffect", "INC", num, { type = "Multiplier", var = "Herald"}) } end,
 	["nearby allies' damage with hits is lucky"] = { mod("ExtraAura", "LIST", { onlyAllies = true, mod = mod("LuckyHits", "FLAG", true) }) },


### PR DESCRIPTION
- Adds parsing for the Tailwind mod on Hunter influenced boots

-----

Of course, there's a Tailwind toggle that's always available on the Config screen, but adding it as a proper mod like this lets you more easily compare boots with and without Tailwind. It also makes it so the mod shows up as blue, which isn't ugly.
![image](https://user-images.githubusercontent.com/39030429/81749302-0091ec80-9471-11ea-8523-1a0d86f54c09.png)
