### PR TITLE
Fix Snipe Stages

### DIFF
--- a/Data/3_0/Skills/other.lua
+++ b/Data/3_0/Skills/other.lua
@@ -430,6 +430,9 @@ skills["ChannelledSnipe"] = {
 	statDescriptionScope = "skill_stat_descriptions",
 	castTime = 1,
 	fromItem = true,
+	initialFunc = function(activeSkill, output)
+		activeSkill.skillData.dpsMultiplier = 1 / math.max(activeSkill.skillModList:Sum("BASE", cfg, "Multiplier:SnipeStage"), 1)
+	end,
 	baseFlags = {
 		attack = true,
 		projectile = true,

--- a/Export/Skills/other.txt
+++ b/Export/Skills/other.txt
@@ -113,6 +113,9 @@ local skills, mod, flag, skill = ...
 #skill ChannelledSnipe
 #flags attack projectile bow
 	fromItem = true,
+	initialFunc = function(activeSkill, output)
+		activeSkill.skillData.dpsMultiplier = 1 / math.max(activeSkill.skillModList:Sum("BASE", cfg, "Multiplier:SnipeStage"), 1)
+	end,
 #mods
 
 #skill ChannelledSnipeSupport


### PR DESCRIPTION
When setting the number of stages, the DPS for the skill was not reduced by the time taken to channel the skill