### PR TITLE
Fix item slot not being displayed for belt skills

### DIFF
--- a/Classes/SkillsTab.lua
+++ b/Classes/SkillsTab.lua
@@ -23,6 +23,7 @@ local groupSlotDropList = {
 	{ label = "Amulet", slotName = "Amulet" },
 	{ label = "Ring 1", slotName = "Ring 1" },
 	{ label = "Ring 2", slotName = "Ring 2" },
+	{ label = "Belt", slotName = "Belt" },
 }
 
 local showSupportGemTypeList = {


### PR DESCRIPTION
![1](https://user-images.githubusercontent.com/18018499/82889500-1dd3ba00-9f4b-11ea-8c26-9e8b24b3ccab.png)
Previously it said "Socketed in: None" for belts. The side effect is that skills can now be socketed in belts which is incorrect most of the time but it's not checked anyway (you can socket gems in Kaom's Heart for example)