### PR TITLE
Stormbind damage per improvement fix

### DIFF
--- a/Data/3_0/Skills/act_int.lua
+++ b/Data/3_0/Skills/act_int.lua
@@ -6840,7 +6840,7 @@ skills["Stormbind"] = {
 	},
 	statMap = {
 		["rune_paint_damage_+%_final_per_rune_level"] = {
-			mod("Damage", "MORE", nil, 0, 0, { type = "Multiplier", var = "RuneLevel" }),
+			mod("Damage", "MORE", nil, 0, bit.bor(KeywordFlag.Hit, KeywordFlag.Ailment), { type = "Multiplier", var = "RuneLevel" }),
 		},
 		["rune_paint_area_of_effect_+%_final_per_rune_level"] = {
 			mod("AreaOfEffect", "MORE", nil, 0, 0, { type = "Multiplier", var = "RuneLevel" }),

--- a/Export/Skills/act_int.txt
+++ b/Export/Skills/act_int.txt
@@ -1120,7 +1120,7 @@ local skills, mod, flag, skill = ...
 	},
 	statMap = {
 		["rune_paint_damage_+%_final_per_rune_level"] = {
-			mod("Damage", "MORE", nil, 0, 0, { type = "Multiplier", var = "RuneLevel" }),
+			mod("Damage", "MORE", nil, 0, bit.bor(KeywordFlag.Hit, KeywordFlag.Ailment), { type = "Multiplier", var = "RuneLevel" }),
 		},
 		["rune_paint_area_of_effect_+%_final_per_rune_level"] = {
 			mod("AreaOfEffect", "MORE", nil, 0, 0, { type = "Multiplier", var = "RuneLevel" }),


### PR DESCRIPTION
Stormbind's more damage per improvement only applies to hits and ailments. Fixes #932

I'm not familiar with the export scripts (and they're going to be used again soon anyway for 3.11) so I haven't updated the incorrect skill gem description in skill_stat_descriptions.lua.