### PR TITLE
Vaal aura implies Soul Gain Prevention

### DIFF
--- a/Modules/CalcPerform.lua
+++ b/Modules/CalcPerform.lua
@@ -163,6 +163,11 @@ local function doActorAttribsPoolsConditions(env, actor)
 		if actor.mainSkill.skillFlags.mine then
 			condList["DetonatedMinesRecently"] = true
 		end
+		for _, activeSkill in ipairs(env.player.activeSkillList) do
+			if activeSkill.skillTypes[SkillType.Vaal] and activeSkill.skillTypes[SkillType.Aura] and not activeSkill.skillFlags.disable then
+				condList["SoulGainPrevention"] = true
+			end
+		end
 	end
 
 	-- Calculate attributes

--- a/Modules/ConfigOptions.lua
+++ b/Modules/ConfigOptions.lua
@@ -739,7 +739,7 @@ return {
 		modList:NewMod("Condition:UsedVaalSkillRecently", "FLAG", true, "Config", { type = "Condition", var = "Combat" })
 		modList:NewMod("Condition:UsedSkillRecently", "FLAG", true, "Config", { type = "Condition", var = "Combat" })
 	end },
-	{ var = "conditionSoulGainPrevention", type = "check", label = "Do you have Soul Gain Prevention?", ifCond = "SoulGainPrevention", apply = function(val, modList, enemyModList)
+	{ var = "conditionSoulGainPrevention", type = "check", label = "Do you have Soul Gain Prevention?", ifCond = "SoulGainPrevention", tooltip = "You will automatically be considered to have Soul Gain Prevention if you have a Vaal aura active.", apply = function(val, modList, enemyModList)
 		modList:NewMod("Condition:SoulGainPrevention", "FLAG", true, "Config", { type = "Condition", var = "Combat" })
 	end },
 	{ var = "conditionUsedWarcryRecently", type = "check", label = "Have you used a Warcry Recently?", ifCond = "UsedWarcryRecently", implyCondList = {"UsedWarcryInPast8Seconds", "UsedSkillRecently"}, tooltip = "This also implies that you have used a Skill Recently.", apply = function(val, modList, enemyModList)


### PR DESCRIPTION
Soul Gain Prevention always lasts for at least the duration of a Vaal aura, so if the user has a Vaal aura active, automatically include any Soul Gain Prevention bonuses without the need for an additional checkbox tick.