### PR TITLE
Handle Arcane Blessing ailment immunity

### DIFF
--- a/Modules/ModParser-3_0.lua
+++ b/Modules/ModParser-3_0.lua
@@ -1359,6 +1359,12 @@ local specialModList = {
 		mod("LifeRegenPercent", "BASE", num, { type = "PerStat", stat = "ActiveTotemLimit" }, 0, KeywordFlag.Totem),
 	} end,
 	["enemies take (%d+)%% increased damage for each of your brands attached to them"] = function(num) return { mod("EnemyModifier", "LIST", { mod = mod("DamageTaken", "INC", num, { type = "Multiplier", var = "BrandsAttached" }) }) } end,
+	["immune to elemental ailments while you have arcane surge"] = {
+		mod("AvoidChill", "BASE", 100, { type = "Condition", var = "AffectedByArcaneSurge" }),
+		mod("AvoidFreeze", "BASE", 100, { type = "Condition", var = "AffectedByArcaneSurge" }),
+		mod("AvoidIgnite", "BASE", 100, { type = "Condition", var = "AffectedByArcaneSurge" }),
+		mod("AvoidShock", "BASE", 100, { type = "Condition", var = "AffectedByArcaneSurge" }),
+	},
 	-- Inquisitor
 	["critical strikes ignore enemy monster elemental resistances"] = { flag("IgnoreElementalResistances", { type = "Condition", var = "CriticalStrike" }) },
 	["non%-critical strikes penetrate (%d+)%% of enemy elemental resistances"] = function(num) return { mod("ElementalPenetration", "BASE", num, { type = "Condition", var = "CriticalStrike", neg = true }) } end,


### PR DESCRIPTION
**Previously**, the mod "Immune to Elemental Ailments while you have Arcane Surge" in the Hierophant's "Arcane Blessing" notable was an unhandled red-text mod.

**Now**, if the user has Arcane Blessing allocated and Arcane Surge active, the appropriate ailment avoidances will be set to 100%.

**Note**, if/when Scorch, Brittle, and Sap are implemented (see e.g. #891), we could consider including avoidance chance readouts for those as well.