### PR TITLE
Total up "reduced Extra Damage from Critical Strikes"

### DIFF
--- a/Modules/CalcDefence-3_0.lua
+++ b/Modules/CalcDefence-3_0.lua
@@ -680,6 +680,7 @@ function calcs.defence(env, actor)
 		output.IgniteAvoidChance = m_min(modDB:Sum("BASE", nil, "AvoidIgnite"), 100)
 		output.BleedAvoidChance = m_min(modDB:Sum("BASE", nil, "AvoidBleed"), 100)
 		output.PoisonAvoidChance = m_min(modDB:Sum("BASE", nil, "AvoidPoison"), 100)
+		output.CritExtraDamageReduction = m_min(modDB:Sum("BASE", nil, "ReduceCritExtraDamage"), 100)
 		output.LightRadiusMod = calcLib.mod(modDB, nil, "LightRadius")
 		if breakdown then
 			breakdown.LightRadiusMod = breakdown.mod(nil, "LightRadius")

--- a/Modules/CalcSections-3_0.lua
+++ b/Modules/CalcSections-3_0.lua
@@ -1114,6 +1114,7 @@ return {
 	{ label = "Ignite Avoid Ch.", { format = "{0:output:IgniteAvoidChance}%", { modName = "AvoidIgnite" }, }, },
 	{ label = "Bleed Avoid Ch.", { format = "{0:output:BleedAvoidChance}%", { modName = "AvoidBleed" }, }, },
 	{ label = "Poison Avoid Ch.", { format = "{0:output:PoisonAvoidChance}%", { modName = "AvoidPoison" }, }, },
+	{ label = "Crit Reduction", { format = "{0:output:CritExtraDamageReduction}%", { modName = "ReduceCritExtraDamage" }, }, },
 } }, { defaultCollapsed = false, label = "Dodge", data = {
 	extra = "{0:output:AttackDodgeChance}%/{0:output:SpellDodgeChance}%",
 	{ label = "Dodge Chance", { format = "{0:output:AttackDodgeChance}%", { modName = "AttackDodgeChance" }, }, },

--- a/Modules/CalcSections-3_0.lua
+++ b/Modules/CalcSections-3_0.lua
@@ -1114,7 +1114,7 @@ return {
 	{ label = "Ignite Avoid Ch.", { format = "{0:output:IgniteAvoidChance}%", { modName = "AvoidIgnite" }, }, },
 	{ label = "Bleed Avoid Ch.", { format = "{0:output:BleedAvoidChance}%", { modName = "AvoidBleed" }, }, },
 	{ label = "Poison Avoid Ch.", { format = "{0:output:PoisonAvoidChance}%", { modName = "AvoidPoison" }, }, },
-	{ label = "Crit Reduction", { format = "{0:output:CritExtraDamageReduction}%", { modName = "ReduceCritExtraDamage" }, }, },
+	{ label = "Crit Reduction", haveOutput = "CritExtraDamageReduction", { format = "{0:output:CritExtraDamageReduction}%", { modName = "ReduceCritExtraDamage" }, }, },
 } }, { defaultCollapsed = false, label = "Dodge", data = {
 	extra = "{0:output:AttackDodgeChance}%/{0:output:SpellDodgeChance}%",
 	{ label = "Dodge Chance", { format = "{0:output:AttackDodgeChance}%", { modName = "AttackDodgeChance" }, }, },

--- a/Modules/ModParser-3_0.lua
+++ b/Modules/ModParser-3_0.lua
@@ -2087,6 +2087,8 @@ local specialModList = {
 		mod("LifeRegenPercent", "BASE", tonumber(percent), { type = "Condition", var = "LifeRegenBurstFull" }),
 		mod("LifeRegenPercent", "BASE", tonumber(percent) / num, { type = "Condition", var = "LifeRegenBurstAvg" }),
 	} end,
+	["you take (%d+)%% reduced extra damage from critical strikes"] = function(num) return { mod("ReduceCritExtraDamage", "BASE", num) } end,
+	["you take (%d+)%% reduced extra damage from critical strikes while you have no power charges"] = function(num) return { mod("ReduceCritExtraDamage", "BASE", num, { type = "StatThreshold", stat = "PowerCharges", threshold = 0, upper = true }) } end,
 }
 local keystoneList = {
 	-- List of keystones that can be found on uniques


### PR DESCRIPTION
**Previously**, "you take x% reduced Extra Damage from Critical Strikes", found on the Sanctum of Thought notable, body armor corruptions, the Belt of the Deceiver, etc. was an unhandled red-text mod.

**Now**, these mods are handled, totaled up in a "Crit Reduction" field under Other Avoidance in the Calcs tab.

**Note**: I would have liked to handle the "while you have no Power Charges" condition on Ahn's Contempt modularly rather than as a special case, but the parser kept getting hung up on "critical strikes" and trying (unsuccessfully) to interpret the mod as something else. If this functionality is desired overall, and that refactor would be valuable, advice on how to better structure it would be appreciated!