### PR TITLE
Fix application of "effect of arcane surge on you"

### DIFF
--- a/Modules/ModParser-3_0.lua
+++ b/Modules/ModParser-3_0.lua
@@ -265,7 +265,7 @@ local modNameList = {
 	["effect of buffs granted by your active ancestor totems"] = { "BuffEffect", tag = { type = "SkillName", skillNameList = { "Ancestral Warchief", "Ancestral Protector" } } },
 	["warcry effect"] = { "BuffEffect", keywordFlags = KeywordFlag.Warcry },
 	["aspect of the avian buff effect"] = { "BuffEffect", tag = { type = "SkillName", skillName = "Aspect of the Avian" } },
-	["effect of arcane surge on you"] = { "BuffEffect", tag = { type = "SkillName", skillName = "Arcane Surge" } },
+	["effect of arcane surge on you"] = { "BuffEffect", tagList = { { type = "GlobalEffect", effectType = "Buff", effectName = "Arcane Surge"}, { type = "Condition", var = "AffectedByArcaneSurge" } } },
 	-- Charges
 	["maximum power charge"] = "PowerChargesMax",
 	["maximum power charges"] = "PowerChargesMax",


### PR DESCRIPTION
Fixes the application "effect of arcane surge on you" which previously passives like 

Passives such as **Mana and Arcane Surge Effect** and **Arcane Capacitor** does not currently affect the Arcane Surge buff - i.e. increasing the effect did not affect spell damage, cast speed, or mana regen.