### PR TITLE
Sort crafting options by prefix/suffix, add tag

### DIFF
--- a/Classes/ItemsTab.lua
+++ b/Classes/ItemsTab.lua
@@ -1954,35 +1954,29 @@ function ItemsTabClass:AddCustomModifierToDisplayItem()
 	local controls = { }
 	local sourceList = { }
 	local modList = { }
+	---Mutates modList to contain mods from the specified source
+	---@param sourceId string @The crafting source id to build the list of mods for
 	local function buildMods(sourceId)
 		wipeTable(modList)
 		if sourceId == "MASTER" then
-			local prefixModList = { }
-			local suffixModList = { }
-
-			for _, craft in ipairs(self.build.data.masterMods) do
+			for i, craft in ipairs(self.build.data.masterMods) do
 				if craft.types[self.displayItem.type] then
-					local destinationModList = suffixModList
-
-					if craft.type == "Prefix" then
-						destinationModList = prefixModList
-					end
-
-					t_insert(destinationModList, {
+					t_insert(modList, {
 						label = table.concat(craft, "/") .. " ^8(" .. craft.type .. ")",
 						mod = craft,
 						type = "crafted",
+						affixType = craft.type,
+						defaultOrder = i,
 					})
 				end
 			end
-
-			for _, mod in ipairs(prefixModList) do
-				t_insert(modList, mod)
-			end
-
-			for _, mod in ipairs(suffixModList) do
-				t_insert(modList, mod)
-			end
+			table.sort(modList, function(a, b)
+				if a.affixType ~= b.affixType then
+					return a.affixType == "Prefix" and b.affixType == "Suffix"
+				else
+					return a.defaultOrder < b.defaultOrder
+				end
+			end)
 		elseif sourceId == "ESSENCE" then
 			for _, essence in pairs(self.build.data.essences) do
 				local modId = essence.mods[self.displayItem.type]

--- a/Classes/ItemsTab.lua
+++ b/Classes/ItemsTab.lua
@@ -1957,27 +1957,38 @@ function ItemsTabClass:AddCustomModifierToDisplayItem()
 	local function buildMods(sourceId)
 		wipeTable(modList)
 		if sourceId == "MASTER" then
+			local prefixModList = { }
+			local suffixModList = { }
+
 			for _, craft in ipairs(self.build.data.masterMods) do
 				if craft.types[self.displayItem.type] then
-					local label
-					if craft.master then
-						label = craft.master .. " " .. craft.masterLevel .. "   "..craft.type:sub(1,3).."^8[" .. table.concat(craft, "/") .. "]"
-					else
-						label = table.concat(craft, "/")
+					local destinationModList = suffixModList
+
+					if craft.type == "Prefix" then
+						destinationModList = prefixModList
 					end
-					t_insert(modList, {
-						label = label,
+
+					t_insert(destinationModList, {
+						label = table.concat(craft, "/") .. " ^8(" .. craft.type .. ")",
 						mod = craft,
 						type = "crafted",
 					})
 				end
+			end
+
+			for _, mod in ipairs(prefixModList) do
+				t_insert(modList, mod)
+			end
+
+			for _, mod in ipairs(suffixModList) do
+				t_insert(modList, mod)
 			end
 		elseif sourceId == "ESSENCE" then
 			for _, essence in pairs(self.build.data.essences) do
 				local modId = essence.mods[self.displayItem.type]
 				local mod = self.displayItem.affixes[modId]
 				t_insert(modList, {
-					label = essence.name .. "   "..mod.type:sub(1,3).."^8[" .. table.concat(mod, "/") .. "]",
+					label = essence.name .. "   " .. "^8[" .. table.concat(mod, "/") .. "]" .. " (" .. mod.type .. ")",
 					mod = mod,
 					type = "custom",
 					essence = essence,


### PR DESCRIPTION
This change sorts the crafted mods in the "Add Crafted Modifiers" modal by prefixes then suffixes and also adds a (prefix) or (suffix) tag. Essences were also updated to keep formatting a little more consistent

Note: for some of the longer mods, the tag may be truncated or hidden

Crafted - Before:
![old](https://user-images.githubusercontent.com/502894/83337126-c8125100-a26d-11ea-9207-3f4536fe682b.png)

Crafted - After:
![new](https://user-images.githubusercontent.com/502894/83337130-cf395f00-a26d-11ea-8b4f-54abbd4a75e4.png)

Essences - Before:
![essence old](https://user-images.githubusercontent.com/502894/83337218-5edf0d80-a26e-11ea-9315-601a24997f9c.png)

Essences - After:
![essence](https://user-images.githubusercontent.com/502894/83337196-3ce58b00-a26e-11ea-91a8-e75a36704926.png)
