### PR TITLE
Support for 2H weapon impale effect mod                             

### DIFF
--- a/Modules/ModParser-3_0.lua
+++ b/Modules/ModParser-3_0.lua
@@ -318,6 +318,7 @@ local modNameList = {
 	["maximum total recovery per second from mana leech"] = "MaxManaLeechRate",
 	["to impale enemies on hit"] = "ImpaleChance",
     ["impale effect"] = "ImpaleEffect",
+	["effect of impales you inflict"] = "ImpaleEffect",
 	-- Projectile modifiers
 	["projectile"] = "ProjectileCount",
 	["projectiles"] = "ProjectileCount",


### PR DESCRIPTION
A small node on the 3.11 Harpooner impale themed cluster introduces the mod "10% increased Effect of Impales you inflict with Two Handed Weapons".
This PR adds support for the mod,as shown here:
![image](https://user-images.githubusercontent.com/61525290/84921166-ca2d3a00-b0cc-11ea-80ac-5a0b0c448549.png)
