### PR TITLE
Fix femur mods

### DIFF
--- a/Modules/CalcPerform.lua
+++ b/Modules/CalcPerform.lua
@@ -597,6 +597,24 @@ function calcs.perform(env)
 			output.ActiveTotemLimit = m_max(limit, output.ActiveTotemLimit or 0)
 			output.TotemsSummoned = modDB:Override(nil, "TotemsSummoned") or output.ActiveTotemLimit
 		end
+		if activeSkill.activeEffect.grantedEffect.name == "Summon Skeletons" then
+			ConPrintf("'%s':", env.player.mainSkill)
+			ConPrintf("'%s':", env.player.mainSkill.skillModList)
+			local limit = env.player.mainSkill.skillModList:Sum("BASE", env.player.mainSkill.skillCfg, "ActiveSkeletonLimit")
+			output.ActiveSkeletonLimit = m_max(limit, output.ActiveSkeletonLimit or 0)
+		end
+		if activeSkill.activeEffect.grantedEffect.name == "Raise Zombie" then
+			local limit = env.player.mainSkill.skillModList:Sum("BASE", env.player.mainSkill.skillCfg, "ActiveZombieLimit")
+			output.ActiveZombieLimit = m_max(limit, output.ActiveZombieLimit or 0)
+		end
+		if activeSkill.activeEffect.grantedEffect.name == "Summon Raging Spirit" then
+			local limit = env.player.mainSkill.skillModList:Sum("BASE", env.player.mainSkill.skillCfg, "ActiveRagingSpiritLimit")
+			output.ActiveRagingSpiritLimit = m_max(limit, output.ActiveRagingSpiritLimit or 0)
+		end
+		if activeSkill.activeEffect.grantedEffect.name == "Raise Spectre" then
+			local limit = env.player.mainSkill.skillModList:Sum("BASE", env.player.mainSkill.skillCfg, "ActiveSpectreLimit")
+			output.ActiveSpectreLimit = m_max(limit, output.ActiveSpectreLimit or 0)
+		end
 	end
 
 	local breakdown

--- a/Modules/CalcPerform.lua
+++ b/Modules/CalcPerform.lua
@@ -598,8 +598,6 @@ function calcs.perform(env)
 			output.TotemsSummoned = modDB:Override(nil, "TotemsSummoned") or output.ActiveTotemLimit
 		end
 		if activeSkill.activeEffect.grantedEffect.name == "Summon Skeletons" then
-			ConPrintf("'%s':", env.player.mainSkill)
-			ConPrintf("'%s':", env.player.mainSkill.skillModList)
 			local limit = env.player.mainSkill.skillModList:Sum("BASE", env.player.mainSkill.skillCfg, "ActiveSkeletonLimit")
 			output.ActiveSkeletonLimit = m_max(limit, output.ActiveSkeletonLimit or 0)
 		end

--- a/Modules/ModParser-3_0.lua
+++ b/Modules/ModParser-3_0.lua
@@ -868,6 +868,10 @@ local modTagList = {
 	["for each golem you have summoned"] = { tag = { type = "PerStat", stat = "ActiveGolemLimit" } },
 	["per summoned golem"] = { tag = { type = "PerStat", stat = "ActiveGolemLimit" } },
 	["per summoned sentinel of purity"] = { tag = { type = "PerStat", stat = "ActiveSentinelOfPurityLimit" } },
+	["per summoned skeleton"] = { tag = { type = "PerStat", stat = "ActiveSkeletonLimit" } },
+	["per summoned raging spirit"] = { tag = { type = "PerStat", stat = "ActiveRagingSpiritLimit" } },
+	["for each raised zombie"] = { tag = { type = "PerStat", stat = "ActiveZombieLimit" } },
+	["per raised spectre"] = { tag = { type = "PerStat", stat = "ActiveSpectreLimit" } },
 	-- Stat conditions
 	["with (%d+) or more strength"] = function(num) return { tag = { type = "StatThreshold", stat = "Str", threshold = num } } end,
 	["with at least (%d+) strength"] = function(num) return { tag = { type = "StatThreshold", stat = "Str", threshold = num } } end,


### PR DESCRIPTION
Enable calculations of Femurs of the Saints Unique staff (https://pathofexile.gamepedia.com/Femurs_of_the_Saints)

Calculation uses the ActiveZombieLimit, ActiveSkeletonLimit, ...

Unfortunately the minion count is dependent on active minion skill.
Maybe this can work as a small fix in the mean time.