### PR TITLE
Added KeywordFlag.MatchAll option to force all KeywordFlags to match rather than just any.

### DIFF
--- a/Classes/ModDB.lua
+++ b/Classes/ModDB.lua
@@ -95,7 +95,7 @@ function ModDBClass:SumInternal(context, modType, cfg, flags, keywordFlags, sour
 		if modList then
 			for i = 1, #modList do
 				local mod = modList[i]
-				if mod.type == modType and band(flags, mod.flags) == mod.flags and (mod.keywordFlags == 0 or band(keywordFlags, mod.keywordFlags) ~= 0) and (not source or mod.source:match("[^:]+") == source) then
+				if mod.type == modType and band(flags, mod.flags) == mod.flags and MatchKeywordFlags(keywordFlags, mod.keywordFlags) and (not source or mod.source:match("[^:]+") == source) then
 					if mod[1] then
 						result = result + (context:EvalMod(mod, cfg) or 0)
 					else
@@ -118,7 +118,7 @@ function ModDBClass:MoreInternal(context, cfg, flags, keywordFlags, source, ...)
 		if modList then
 			for i = 1, #modList do
 				local mod = modList[i]
-				if mod.type == "MORE" and band(flags, mod.flags) == mod.flags and (mod.keywordFlags == 0 or band(keywordFlags, mod.keywordFlags) ~= 0) and (not source or mod.source:match("[^:]+") == source) then
+				if mod.type == "MORE" and band(flags, mod.flags) == mod.flags and MatchKeywordFlags(keywordFlags, mod.keywordFlags) and (not source or mod.source:match("[^:]+") == source) then
 					if mod[1] then
 						result = result * (1 + (context:EvalMod(mod, cfg) or 0) / 100)
 					else
@@ -140,7 +140,7 @@ function ModDBClass:FlagInternal(context, cfg, flags, keywordFlags, source, ...)
 		if modList then
 			for i = 1, #modList do
 				local mod = modList[i]
-				if mod.type == "FLAG" and band(flags, mod.flags) == mod.flags and (mod.keywordFlags == 0 or band(keywordFlags, mod.keywordFlags) ~= 0) and (not source or mod.source:match("[^:]+") == source) then
+				if mod.type == "FLAG" and band(flags, mod.flags) == mod.flags and MatchKeywordFlags(keywordFlags, mod.keywordFlags) and (not source or mod.source:match("[^:]+") == source) then
 					if mod[1] then
 						if context:EvalMod(mod, cfg) then
 							return true
@@ -163,7 +163,7 @@ function ModDBClass:OverrideInternal(context, cfg, flags, keywordFlags, source, 
 		if modList then
 			for i = 1, #modList do
 				local mod = modList[i]
-				if mod.type == "OVERRIDE" and band(flags, mod.flags) == mod.flags and (mod.keywordFlags == 0 or band(keywordFlags, mod.keywordFlags) ~= 0) and (not source or mod.source:match("[^:]+") == source) then
+				if mod.type == "OVERRIDE" and band(flags, mod.flags) == mod.flags and MatchKeywordFlags(keywordFlags, mod.keywordFlags) and (not source or mod.source:match("[^:]+") == source) then
 					if mod[1] then
 						local value = context:EvalMod(mod, cfg)
 						if value then
@@ -187,7 +187,7 @@ function ModDBClass:ListInternal(context, result, cfg, flags, keywordFlags, sour
 		if modList then
 			for i = 1, #modList do
 				local mod = modList[i]
-				if mod.type == "LIST" and band(flags, mod.flags) == mod.flags and (mod.keywordFlags == 0 or band(keywordFlags, mod.keywordFlags) ~= 0) and (not source or mod.source:match("[^:]+") == source) then
+				if mod.type == "LIST" and band(flags, mod.flags) == mod.flags and MatchKeywordFlags(keywordFlags, mod.keywordFlags) and (not source or mod.source:match("[^:]+") == source) then
 					local value
 					if mod[1] then
 						local value = context:EvalMod(mod, cfg) or nullValue
@@ -213,7 +213,7 @@ function ModDBClass:TabulateInternal(context, result, modType, cfg, flags, keywo
 		if modList then
 			for i = 1, #modList do
 				local mod = modList[i]
-				if (mod.type == modType or not modType) and band(flags, mod.flags) == mod.flags and (mod.keywordFlags == 0 or band(keywordFlags, mod.keywordFlags) ~= 0) and (not source or mod.source:match("[^:]+") == source) then
+				if (mod.type == modType or not modType) and band(flags, mod.flags) == mod.flags and MatchKeywordFlags(keywordFlags, mod.keywordFlags) and (not source or mod.source:match("[^:]+") == source) then
 					local value
 					if mod[1] then
 						value = context:EvalMod(mod, cfg)
@@ -245,7 +245,7 @@ function ModDBClass:HasModInternal(modType, flags, keywordFlags, source, ...)
 		if modList then
 			for i = 1, #modList do
 				local mod = modList[i]
-				if mod.type == modType and band(flags, mod.flags) == mod.flags and (mod.keywordFlags == 0 or band(keywordFlags, mod.keywordFlags) ~= 0) and (not source or mod.source:match("[^:]+") == source) then
+				if mod.type == modType and band(flags, mod.flags) == mod.flags and MatchKeywordFlags(keywordFlags, mod.keywordFlags) and (not source or mod.source:match("[^:]+") == source) then
 					return true
 				end
 			end

--- a/Classes/ModList.lua
+++ b/Classes/ModList.lua
@@ -54,7 +54,7 @@ function ModListClass:SumInternal(context, modType, cfg, flags, keywordFlags, so
 		local modName = select(i, ...)
 		for i = 1, #self do
 			local mod = self[i]
-			if mod.name == modName and mod.type == modType and band(flags, mod.flags) == mod.flags and (mod.keywordFlags == 0 or band(keywordFlags, mod.keywordFlags) ~= 0) and (not source or mod.source:match("[^:]+") == source) then
+			if mod.name == modName and mod.type == modType and band(flags, mod.flags) == mod.flags and MatchKeywordFlags(keywordFlags, mod.keywordFlags) and (not source or mod.source:match("[^:]+") == source) then
 				if mod[1] then
 					result = result + (context:EvalMod(mod, cfg) or 0)
 				else
@@ -75,7 +75,7 @@ function ModListClass:MoreInternal(context, cfg, flags, keywordFlags, source, ..
 		local modName = select(i, ...)
 		for i = 1, #self do
 			local mod = self[i]
-			if mod.name == modName and mod.type == "MORE" and band(flags, mod.flags) == mod.flags and (mod.keywordFlags == 0 or band(keywordFlags, mod.keywordFlags) ~= 0) and (not source or mod.source:match("[^:]+") == source) then
+			if mod.name == modName and mod.type == "MORE" and band(flags, mod.flags) == mod.flags and MatchKeywordFlags(keywordFlags, mod.keywordFlags) and (not source or mod.source:match("[^:]+") == source) then
 				if mod[1] then
 					result = result * (1 + (context:EvalMod(mod, cfg) or 0) / 100)
 				else
@@ -95,7 +95,7 @@ function ModListClass:FlagInternal(context, cfg, flags, keywordFlags, source, ..
 		local modName = select(i, ...)
 		for i = 1, #self do
 			local mod = self[i]
-			if mod.name == modName and mod.type == "FLAG" and band(flags, mod.flags) == mod.flags and (mod.keywordFlags == 0 or band(keywordFlags, mod.keywordFlags) ~= 0) and (not source or mod.source:match("[^:]+") == source) then
+			if mod.name == modName and mod.type == "FLAG" and band(flags, mod.flags) == mod.flags and MatchKeywordFlags(keywordFlags, mod.keywordFlags) and (not source or mod.source:match("[^:]+") == source) then
 				if mod[1] then
 					if context:EvalMod(mod, cfg) then
 						return true
@@ -116,7 +116,7 @@ function ModListClass:OverrideInternal(context, cfg, flags, keywordFlags, source
 		local modName = select(i, ...)
 		for i = 1, #self do
 			local mod = self[i]
-			if mod.name == modName and mod.type == "OVERRIDE" and band(flags, mod.flags) == mod.flags and (mod.keywordFlags == 0 or band(keywordFlags, mod.keywordFlags) ~= 0) and (not source or mod.source:match("[^:]+") == source) then
+			if mod.name == modName and mod.type == "OVERRIDE" and band(flags, mod.flags) == mod.flags and MatchKeywordFlags(keywordFlags, mod.keywordFlags) and (not source or mod.source:match("[^:]+") == source) then
 				if mod[1] then
 					local value = context:EvalMod(mod, cfg)
 					if value then
@@ -138,7 +138,7 @@ function ModListClass:ListInternal(context, result, cfg, flags, keywordFlags, so
 		local modName = select(i, ...)
 		for i = 1, #self do
 			local mod = self[i]
-			if mod.name == modName and mod.type == "LIST" and band(flags, mod.flags) == mod.flags and (mod.keywordFlags == 0 or band(keywordFlags, mod.keywordFlags) ~= 0) and (not source or mod.source:match("[^:]+") == source) then
+			if mod.name == modName and mod.type == "LIST" and band(flags, mod.flags) == mod.flags and MatchKeywordFlags(keywordFlags, mod.keywordFlags) and (not source or mod.source:match("[^:]+") == source) then
 				local value
 				if mod[1] then
 					local value = context:EvalMod(mod, cfg) or nullValue
@@ -161,7 +161,7 @@ function ModListClass:TabulateInternal(context, result, modType, cfg, flags, key
 		local modName = select(i, ...)
 		for i = 1, #self do
 			local mod = self[i]
-			if mod.name == modName and (mod.type == modType or not modType) and band(flags, mod.flags) == mod.flags and (mod.keywordFlags == 0 or band(keywordFlags, mod.keywordFlags) ~= 0) and (not source or mod.source:match("[^:]+") == source) then
+			if mod.name == modName and (mod.type == modType or not modType) and band(flags, mod.flags) == mod.flags and MatchKeywordFlags(keywordFlags, mod.keywordFlags) and (not source or mod.source:match("[^:]+") == source) then
 				local value
 				if mod[1] then
 					value = context:EvalMod(mod, cfg)

--- a/Data/Global.lua
+++ b/Data/Global.lua
@@ -113,6 +113,25 @@ KeywordFlag.LightningDot=0x02000000
 KeywordFlag.ColdDot =	0x04000000
 KeywordFlag.FireDot =	0x08000000
 KeywordFlag.ChaosDot =	0x10000000
+---The default behavior for KeywordFlags is to match *any* of the specified flags.
+---Including the "MatchAll" flag when creating a mod will cause *all* flags to be matched rather than any.
+KeywordFlag.MatchAll =	0x40000000
+
+-- Helper function to compare KeywordFlags
+local band = bit.band
+local MatchAllMask = bit.bnot(KeywordFlag.MatchAll)
+---@param keywordFlags number The KeywordFlags to be compared to.
+---@param modKeywordFlags number The KeywordFlags stored in the mod.
+---@return boolean Whether the KeywordFlags in the mod are satified.
+function MatchKeywordFlags(keywordFlags, modKeywordFlags)
+	local matchAll = band(modKeywordFlags, KeywordFlag.MatchAll) ~= 0
+	modKeywordFlags = band(modKeywordFlags, MatchAllMask)
+	keywordFlags = band(keywordFlags, MatchAllMask)
+	if matchAll then
+		return band(keywordFlags, modKeywordFlags) == modKeywordFlags
+	end
+	return modKeywordFlags == 0 or band(keywordFlags, modKeywordFlags) ~= 0
+end
 
 -- Active skill types, used in ActiveSkills.dat and GrantedEffects.dat
 -- Had to reverse engineer this, not sure what all of the values mean

--- a/Modules/ModParser-3_0.lua
+++ b/Modules/ModParser-3_0.lua
@@ -571,7 +571,7 @@ local modFlagList = {
 	["with poison"] = { keywordFlags = KeywordFlag.Poison },
 	["with bleeding"] = { keywordFlags = KeywordFlag.Bleed },
 	["for ailments"] = { flags = ModFlag.Ailment },
-	["for poison"] = { keywordFlags = KeywordFlag.Poison },
+	["for poison"] = { keywordFlags = bor(KeywordFlag.Poison, KeywordFlag.MatchAll) },
 	["for bleeding"] = { keywordFlags = KeywordFlag.Bleed },
 	["for ignite"] = { keywordFlags = KeywordFlag.Ignite },
 	["area"] = { flags = ModFlag.Area },


### PR DESCRIPTION
"for poison" now uses the MatchAll flag so that the following type of text will work:
  - "Spell Skills have +5% to Damage over Time Multiplier for Poison"
