### PR TITLE
Slight generalization of Brand mods

### DIFF
--- a/Data/3_0/SkillStatMap.lua
+++ b/Data/3_0/SkillStatMap.lua
@@ -1192,6 +1192,13 @@ return {
 ["sigil_attached_target_damage_+%_final"] = {
 	mod("Damage", "MORE", nil, 0, 0, { type = "MultiplierThreshold", var = "BrandsAttachedToEnemy", threshold = 1 }),
 },
+["base_number_of_sigils_allowed_per_target"] = {
+	mod("BrandsAttachedLimit", "BASE", nil)
+},
+["base_sigil_repeat_frequency_ms"] = {
+	skill("repeatFrequency", nil),
+	div = 1000,
+},
 -- Banner
 ["banner_buff_effect_+%_per_stage"] = {
 	mod("AuraEffect", "INC", nil, 0, 0, { type = "Multiplier", var = "BannerStage" }, { type = "Condition", var = "BannerPlanted" }),

--- a/Export/Skills/act_int.txt
+++ b/Export/Skills/act_int.txt
@@ -54,10 +54,6 @@ local skills, mod, flag, skill = ...
 	statMap = {
 		["base_skill_show_average_damage_instead_of_dps"] = {
 		},
-		["base_sigil_repeat_frequency_ms"] = {
-			skill("repeatFrequency", nil),
-			div = 1000,
-		},
 	},
 #baseMod skill("radius", 18)
 #baseMod skill("radiusSecondary", 8)
@@ -1084,10 +1080,6 @@ local skills, mod, flag, skill = ...
 	end,
 	statMap = {
 		["base_skill_show_average_damage_instead_of_dps"] = {
-		},
-		["base_sigil_repeat_frequency_ms"] = {
-			skill("repeatFrequency", nil),
-			div = 1000,
 		},
 	},
 #mods

--- a/Modules/CalcPerform.lua
+++ b/Modules/CalcPerform.lua
@@ -597,6 +597,12 @@ function calcs.perform(env)
 			output.ActiveTotemLimit = m_max(limit, output.ActiveTotemLimit or 0)
 			output.TotemsSummoned = modDB:Override(nil, "TotemsSummoned") or output.ActiveTotemLimit
 		end
+		if activeSkill.skillFlags.brand then
+			local attachLimit = env.player.mainSkill.skillModList:Sum("BASE", env.player.mainSkill.skillCfg, "BrandsAttachedLimit")
+			local attached = modDB:Sum("BASE", nil, "Multiplier:ConfigBrandsAttachedToEnemy")
+			modDB:NewMod("Multiplier:BrandsAttachedToEnemy", "BASE", m_min(attached, attachLimit), "Config")
+			enemyDB:NewMod("Multiplier:BrandsAttached", "BASE", m_min(attached, attachLimit), "Config")
+		end
 	end
 
 	local breakdown

--- a/Modules/ConfigOptions.lua
+++ b/Modules/ConfigOptions.lua
@@ -99,8 +99,7 @@ return {
 	end },
 	{ label = "Brand Skills:", ifSkillList = { "Armageddon Brand", "Storm Brand" } }, -- I barely resisted the temptation to label this "Generic Brand:"
 	{ var = "BrandsAttachedToEnemy", type = "count", label = "# of Brands attached to the enemy", ifSkillList = { "Armageddon Brand", "Storm Brand" }, apply = function(val, modList, enemyModList)
-		modList:NewMod("Multiplier:BrandsAttachedToEnemy", "BASE", m_min(val, 2), "Config")
-		enemyModList:NewMod("Multiplier:BrandsAttached", "BASE", m_min(val, 2), "Config")
+		modList:NewMod("Multiplier:ConfigBrandsAttachedToEnemy", "BASE", val, "Config")
 	end },
 	{ label = "Dark Pact:", ifSkill = "Dark Pact" },
 	{ var = "darkPactSkeletonLife", type = "count", label = "Skeleton Life:", ifSkill = "Dark Pact", tooltip = "Sets the maximum life of the skeleton that is being targeted.", apply = function(val, modList, enemyModList)

--- a/Modules/ModParser-3_0.lua
+++ b/Modules/ModParser-3_0.lua
@@ -1229,6 +1229,7 @@ local specialModList = {
 	["modifiers to critical strike multiplier also apply to damage over time multiplier for ailments from critical strikes at (%d+)%% of their value"] = function(num) return { mod("CritMultiplierAppliesToDegen", "BASE", num) } end,
 	["your bleeding does not deal extra damage while the enemy is moving"] = { flag("Condition:NoExtraBleedDamageToMovingEnemy") },
 	["you can inflict bleeding on an enemy up to (%d+) times?"] = function(num) return { mod("BleedStacksMax", "OVERRIDE", num) } end,
+	["you can have an additional brand attached to an enemy"] = { mod("BrandsAttachedLimit", "BASE", 1) },
 	["gain (%d+) grasping vines each second while stationary"] = function(num) return {
 		flag("Condition:Stationary"),
 		mod("Dummy", "DUMMY", 1, { type = "Condition", var = "Stationary" }), -- Make the Configuration option appear


### PR DESCRIPTION
- Adds a couple of stats, found on Brand skill gems, to SkillStatMap
- Makes it so the # of Brands Attached config option instead calculates its limit in CalcPerform, where it can look at your BrandsAttachedLimit
- Adds parsing for Runebinder's addition brand attached mod

----------------

I realized that Wintertide Brand will have a base limit of 2 Brands attached to the enemy instead of the standard limit of 1 Brand attached, which meant that with the Runebinder keystone you could get to 3 Brands attached. The config option had a hard limit of 2 Brands attached to the enemy due to using m_max(val, 2) to determine the value of BrandsAttachedToEnemy. This PR changes it so that the config option instead gives a useless stat which is then used in CalcPerform, along with a new BrandsAttachedLimit stat, so that the limit is based on your actual Brands attached limit. Necessarily, I also added mod parsing for Runebinder.

The other thing I did was move a couple of stats on the Brand skill gems to be in SkillStatMap instead of on each individual Brand skill, since the new Brand skills in 3.11 are sure to use these exact same stats and it doesn't make sense to have the same statMap on each Brand skill.