### PR TITLE
Correctly parse the new purposeful harbinger line

### DIFF
--- a/Modules/CalcPerform.lua
+++ b/Modules/CalcPerform.lua
@@ -17,6 +17,8 @@ local s_format = string.format
 
 local tempTable1 = { }
 
+local PURPOSEFUL_HARBINGER_MAX_BUFF_PERCENT = 40
+
 -- Merge an instance of a buff, taking the highest value of each modifier
 local function mergeBuff(src, destTable, destKey)
 	if not destTable[destKey] then
@@ -887,6 +889,14 @@ function calcs.perform(env)
 						modDB.conditions["AffectedBy"..buff.name:gsub(" ","")] = true
 						local srcList = new("ModList")
 						local inc = skillModList:Sum("INC", skillCfg, "AuraEffect", "BuffEffect", "BuffEffectOnSelf", "AuraEffectOnSelf", "AuraBuffEffect")
+
+						-- Take the Purposeful Harbinger buffs into account.
+						-- These are capped to 40% increased buff effect, no matter the amount allocated
+						local incFromPurposefulHarbinger = math.min(
+							skillModList:Sum("INC", skillCfg, "PurpHarbAuraBuffEffect"),
+							PURPOSEFUL_HARBINGER_MAX_BUFF_PERCENT)
+						inc = inc + incFromPurposefulHarbinger
+
 						local more = skillModList:More(skillCfg, "AuraEffect", "BuffEffect", "BuffEffectOnSelf", "AuraEffectOnSelf", "AuraBuffEffect")
 						srcList:ScaleAddList(buff.modList, (1 + inc / 100) * more)
 						srcList:ScaleAddList(extraAuraModList, (1 + inc / 100) * more)

--- a/Modules/CalcPerform.lua
+++ b/Modules/CalcPerform.lua
@@ -17,8 +17,6 @@ local s_format = string.format
 
 local tempTable1 = { }
 
-local PURPOSEFUL_HARBINGER_MAX_BUFF_PERCENT = 40
-
 -- Merge an instance of a buff, taking the highest value of each modifier
 local function mergeBuff(src, destTable, destKey)
 	if not destTable[destKey] then
@@ -894,7 +892,7 @@ function calcs.perform(env)
 						-- These are capped to 40% increased buff effect, no matter the amount allocated
 						local incFromPurposefulHarbinger = math.min(
 							skillModList:Sum("INC", skillCfg, "PurpHarbAuraBuffEffect"),
-							PURPOSEFUL_HARBINGER_MAX_BUFF_PERCENT)
+							data.misc.PurposefulHarbingerMaxBuffPercent)
 						inc = inc + incFromPurposefulHarbinger
 
 						local more = skillModList:More(skillCfg, "AuraEffect", "BuffEffect", "BuffEffectOnSelf", "AuraEffectOnSelf", "AuraBuffEffect")

--- a/Modules/Data.lua
+++ b/Modules/Data.lua
@@ -230,6 +230,7 @@ data.misc = { -- magic numbers
 	TrapTriggerRadiusBase = 10,
 	MineDetonationRadiusBase = 60,
 	MineAuraRadiusBase = 35,
+	PurposefulHarbingerMaxBuffPercent = 40,
 }
 
 ---------------------------

--- a/Modules/ModParser-3_0.lua
+++ b/Modules/ModParser-3_0.lua
@@ -1669,7 +1669,10 @@ local specialModList = {
 	["you have tailwind if you have dealt a critical strike recently"] = { flag("Condition:Tailwind", { type = "Condition", var = "CritRecently" }) },
 	["your aura buffs do not affect allies"] = { flag("SelfAurasCannotAffectAllies") },
 	["aura buffs from skills have (%d+)%% increased effect on you for each herald affecting you"] = function(num) return { mod("AuraBuffEffect", "INC", num, { type = "Multiplier", var = "Herald"}) } end,
-	["aura buffs from skills have (%d+)%% increased effect on you for each herald affecting you, up to (%d+)%%"] = function(num, _, limit) return { mod("PurpHarbAuraBuffEffect", "INC", num, { type = "Multiplier", var = "Herald", limit = tonumber(limit),}) } end,
+	["aura buffs from skills have (%d+)%% increased effect on you for each herald affecting you, up to (%d+)%%"] = function(num, _, limit) return {
+		mod("PurpHarbAuraBuffEffect", "INC", num, { type = "Multiplier", var = "Herald" })
+		-- Maximum buff effect is handled in CalcPerform, PurpHarbAuraBuffEffect is capped with a constant there.
+	} end,
 	["nearby allies' damage with hits is lucky"] = { mod("ExtraAura", "LIST", { onlyAllies = true, mod = mod("LuckyHits", "FLAG", true) }) },
 	["allies' aura buffs do not affect you"] = { flag("AlliesAurasCannotAffectSelf") },
 	["enemies can have 1 additional curse"] = { mod("EnemyCurseLimit", "BASE", 1) },

--- a/Modules/ModParser-3_0.lua
+++ b/Modules/ModParser-3_0.lua
@@ -1668,7 +1668,7 @@ local specialModList = {
 	["you have onslaught while not on low mana"] = { flag("Condition:Onslaught", { type = "Condition", var = "LowMana", neg = true }) },
 	["you have tailwind if you have dealt a critical strike recently"] = { flag("Condition:Tailwind", { type = "Condition", var = "CritRecently" }) },
 	["your aura buffs do not affect allies"] = { flag("SelfAurasCannotAffectAllies") },
-	["aura buffs from skills have (%d+)%% increased effect on you for each herald affecting you"] = function(num) return { mod("AuraBuffEffect", "INC", num, { type = "Multiplier", var = "Herald"}) } end,
+	["aura buffs from skills have (%d+)%% increased effect on you for each herald affecting you, up to (%d+)%%"] = function(num, _, limit) return { mod("PurpHarbAuraBuffEffect", "INC", num, { type = "Multiplier", var = "Herald", limit = tonumber(limit),}) } end,
 	["nearby allies' damage with hits is lucky"] = { mod("ExtraAura", "LIST", { onlyAllies = true, mod = mod("LuckyHits", "FLAG", true) }) },
 	["allies' aura buffs do not affect you"] = { flag("AlliesAurasCannotAffectSelf") },
 	["enemies can have 1 additional curse"] = { mod("EnemyCurseLimit", "BASE", 1) },

--- a/Modules/ModParser-3_0.lua
+++ b/Modules/ModParser-3_0.lua
@@ -1668,6 +1668,7 @@ local specialModList = {
 	["you have onslaught while not on low mana"] = { flag("Condition:Onslaught", { type = "Condition", var = "LowMana", neg = true }) },
 	["you have tailwind if you have dealt a critical strike recently"] = { flag("Condition:Tailwind", { type = "Condition", var = "CritRecently" }) },
 	["your aura buffs do not affect allies"] = { flag("SelfAurasCannotAffectAllies") },
+	["aura buffs from skills have (%d+)%% increased effect on you for each herald affecting you"] = function(num) return { mod("AuraBuffEffect", "INC", num, { type = "Multiplier", var = "Herald"}) } end,
 	["aura buffs from skills have (%d+)%% increased effect on you for each herald affecting you, up to (%d+)%%"] = function(num, _, limit) return { mod("PurpHarbAuraBuffEffect", "INC", num, { type = "Multiplier", var = "Herald", limit = tonumber(limit),}) } end,
 	["nearby allies' damage with hits is lucky"] = { mod("ExtraAura", "LIST", { onlyAllies = true, mod = mod("LuckyHits", "FLAG", true) }) },
 	["allies' aura buffs do not affect you"] = { flag("AlliesAurasCannotAffectSelf") },


### PR DESCRIPTION
It is correctly limited to 40% in calculations. This value is hardcoded, as parsing it again would not be useful as it stands.

Level 20 Precision: +701 accuracy.
Expected at 40% buff effect: 981.4 accuracy
Expected at 24% buff effect: 869.2 accuracy

3 Purposeful Harbinger allocated, 4 heralds enabled (+40%):
![image](https://user-images.githubusercontent.com/373126/85141079-81998c00-b246-11ea-9ddb-adb8c989c1d2.png)

3 Purposeful Harbinger allocated, 1 herald enabled (+24%):
![image](https://user-images.githubusercontent.com/373126/85141131-96761f80-b246-11ea-9bea-21dfd237f206.png)

3 Purposeful Harbinger allocated, 0 herald enabled (+0%):
![image](https://user-images.githubusercontent.com/373126/85141181-ab52b300-b246-11ea-885a-29070f3ea950.png)

