### PR TITLE
Fix calculations of crab barriers

### DIFF
--- a/Modules/CalcPerform.lua
+++ b/Modules/CalcPerform.lua
@@ -347,7 +347,7 @@ local function doActorMisc(env, actor)
 	else
 		output.GhostShrouds = 0
 	end
-	output.CrabBarriers = m_max(modDB:Override(nil, "CrabBarriers") or output.CrabBarriersMax, output.CrabBarriersMax)
+	output.CrabBarriers = m_min(modDB:Override(nil, "CrabBarriers") or output.CrabBarriersMax, output.CrabBarriersMax)
 	modDB.multipliers["PowerCharge"] = output.PowerCharges
 	modDB.multipliers["RemovablePowerCharge"] = output.RemovablePowerCharges
 	modDB.multipliers["FrenzyCharge"] = output.FrenzyCharges


### PR DESCRIPTION
Crab barriers would always use the maximum amount for calculations, leading to ignoring user input in configuration.

Fixes #1025

(As a value of '0' is interpreted by the mod database as nil, this means you technically never calculate your damage reduction with zero crabs)