### PR TITLE
Implement Storm Secret unique ring

### DIFF
--- a/Export/Skills/act_int.txt
+++ b/Export/Skills/act_int.txt
@@ -617,6 +617,9 @@ local skills, mod, flag, skill = ...
 
 #skill HeraldOfThunder
 #flags cast duration
+	preDamageFunc = function(activeSkill, output)
+		activeSkill.skillData.hitTimeOverride = activeSkill.skillData.repeatFrequency / (1 + activeSkill.skillModList:Sum("INC", activeSkill,skillCfg, "HeraldStormFrequency") / 100)
+	end,
 	statMap = {
 		["herald_of_thunder_lightning_damage_+%"] = {
 			mod("LightningDamage", "INC", nil, 0, 0, { type = "GlobalEffect", effectType = "Buff" }),
@@ -633,8 +636,13 @@ local skills, mod, flag, skill = ...
 		["attack_maximum_added_lightning_damage"] = {
 			mod("LightningMax", "BASE", nil, 0, KeywordFlag.Attack, { type = "GlobalEffect", effectType = "Buff" }),
 		},
+		["herald_of_thunder_bolt_base_frequency"] = {
+			skill("repeatFrequency", nil),
+			div = 1000,
+		},
 	},
 #baseMod skill("radius", 32)
+#baseMod skill("showAverage", false)
 #mods
 
 #skill IceNova

--- a/Modules/ModParser-3_0.lua
+++ b/Modules/ModParser-3_0.lua
@@ -2095,6 +2095,7 @@ local specialModList = {
 		mod("LightningMin", "BASE", 1, nil, ModFlag.Attack, { type = "PerStat", stat = "Mana", div = 100 / num }),
 		mod("LightningMax", "BASE", 1, nil, ModFlag.Attack, { type = "PerStat", stat = "Mana", div = 100 / num }),
 	} end,
+	["herald of thunder's storms hit enemies with (%d+)%% increased frequency"] = function(num) return { mod("HeraldStormFrequency", "INC", num), } end,
 	-- Pantheon: Soul of Tukohama support
 	["while stationary, gain ([%d%.]+)%% of life regenerated per second every second, up to a maximum of (%d+)%%"] = function(num, _, limit) return {
 		flag("Condition:Stationary"),


### PR DESCRIPTION
- Adds parsing for the Herald of Thunder hit frequency mod on Storm Secret
- Changes Herald of Thunder to not be an average hit skill since the hit frequency is shown on the gem and known now

![image](https://user-images.githubusercontent.com/39030429/85208086-45703500-b2f3-11ea-8a26-32060ebb7703.png)
![image](https://user-images.githubusercontent.com/39030429/85208095-502aca00-b2f3-11ea-8ff8-0232d94669c9.png)
