### PR TITLE
Adding support for 'targets they chain from'

### DIFF
--- a/Modules/ConfigOptions.lua
+++ b/Modules/ConfigOptions.lua
@@ -849,6 +849,9 @@ return {
 	{ var = "skillChainCount", type = "count", label = "# of times Skill has Chained:", ifFlag = "chaining", apply = function(val, modList, enemyModList)
 		modList:NewMod("ChainCount", "BASE", val, "Config", { type = "Condition", var = "Effective" })
 	end },
+	{ var = "conditionTargetChainedFrom", type = "check", label = "Skill chains to another target?", ifFlag = "chaining", apply = function(val, modList, enemyModList)
+		enemyModList:NewMod("Condition:TargetChainedFrom", "FLAG", true, "Config", { type = "Condition", var = "Effective" })
+	end },
 	{ var = "meleeDistance", type = "count", label = "Melee distance to enemy:", ifFlag = "melee" },
 	{ var = "projectileDistance", type = "count", label = "Projectile travel distance:", ifFlag = "projectile" },
 	{ var = "conditionAtCloseRange", type = "check", label = "Is the enemy at Close Range?", ifCond = "AtCloseRange", apply = function(val, modList, enemyModList)

--- a/Modules/ModParser-3_0.lua
+++ b/Modules/ModParser-3_0.lua
@@ -1153,6 +1153,7 @@ local modTagList = {
 	["against enemies that are affected by no elemental ailments"] = { tagList = { { type = "ActorCondition", actor = "enemy", varList = { "Frozen","Chilled","Shocked","Ignited","Scorched","Brittle","Sapped" }, neg = true }, { type = "Condition", var = "Effective" } }, keywordFlags = KeywordFlag.Hit },
 	["against enemies affected by (%d+) spider's webs"] = function(num) return { tag = { type = "MultiplierThreshold", actor = "enemy", var = "Spider's WebStack", threshold = num } } end,
 	["against enemies on consecrated ground"] = { tag = { type = "ActorCondition", actor = "enemy", var = "OnConsecratedGround" } },
+	["to targets they chain from"] = { tag = { type = "ActorCondition", actor = "enemy", var = "TargetChainedFrom" } },
 	-- Enemy multipliers
 	["per freeze, shock and ignite on enemy"] = { tag = { type = "Multiplier", var = "FreezeShockIgniteOnEnemy" }, keywordFlags = KeywordFlag.Hit },
 	["per poison affecting enemy"] = { tag = { type = "Multiplier", actor = "enemy", var = "PoisonStack" } },


### PR DESCRIPTION
Noted I couldn't apply a check for whether it was capable of chaining or not. So if you link lightning arrow to chain, check the box, then remove chain, the node still appears to provide benefit.
![image](https://user-images.githubusercontent.com/48185793/85223952-c2072000-b394-11ea-90e6-a44796a307e1.png)
![image](https://user-images.githubusercontent.com/48185793/85223960-cc291e80-b394-11ea-84e9-6c2665e546e8.png)
