### PR TITLE
Warcry Exert Support

### DIFF
--- a/Data/3_0/SkillStatMap.lua
+++ b/Data/3_0/SkillStatMap.lua
@@ -349,7 +349,7 @@ return {
 	div = 1000,
 },
 ["warcry_speed_+%"] = {
-	mod("WarcrySpeed", "INC", nil, KeywordFlag.Warcry),
+	mod("WarcrySpeed", "INC", nil, 0, KeywordFlag.Warcry),
 },
 -- AoE
 ["base_skill_area_of_effect_+%"] = {

--- a/Data/3_0/Skills/act_str.lua
+++ b/Data/3_0/Skills/act_str.lua
@@ -1831,9 +1831,14 @@ skills["EnduringCry"] = {
 	statDescriptionScope = "buff_skill_stat_descriptions",
 	castTime = 0.8,
 	statMap = {
-		["base_life_regeneration_rate_per_minute"] = {
+		["regenerate_X_life_over_1_second_on_cast"] = {
 			mod("LifeRegen", "BASE", nil, 0, 0, { type = "GlobalEffect", effectType = "Buff" }),
-			div = 60,
+		},
+		["resist_all_elements_%_per_endurance_charge"] = {
+			mod("ElementalResist", "BASE", nil, 0, 0, { type = "GlobalEffect", effectType = "Buff" }, { type = "Multiplier", var = "EnduranceCharge" }),
+		},
+		["physical_damage_reduction_%_per_endurance_charge"] = {
+			mod("PhysicalDamageReduction", "BASE", nil, 0, 0, { type = "GlobalEffect", effectType = "Buff" }, { type = "Multiplier", var = "EnduranceCharge" }),
 		},
 	},
 	baseFlags = {

--- a/Data/3_0/Skills/act_str.lua
+++ b/Data/3_0/Skills/act_str.lua
@@ -3111,6 +3111,9 @@ skills["IntimidatingCry"] = {
 	statDescriptionScope = "skill_stat_descriptions",
 	castTime = 0.8,
 	statMap = {
+		["skill_empowers_next_x_melee_attacks"] = {
+			mod("IntimidatingExertedAttacks", "BASE", nil, 0, 0, { type = "GlobalEffect", effectType = "Buff" }),
+		},
 	},
 	baseFlags = {
 		warcry = true,
@@ -4262,6 +4265,12 @@ skills["SeismicCry"] = {
 	statDescriptionScope = "skill_stat_descriptions",
 	castTime = 0.8,
 	statMap = {
+		["skill_empowers_next_x_melee_attacks"] = {
+			mod("SeismicExertedAttacks", "BASE", nil, 0, 0, { type = "GlobalEffect", effectType = "Buff" }),
+		},
+		["seismic_cry_slam_skill_damage_+%_final_increase_per_repeat"] = {
+			mod("SeismicHitMultiplier", "BASE", nil, 0, 0, { type = "GlobalEffect", effectType = "Buff" }),
+		},
 	},
 	baseFlags = {
 		warcry = true,

--- a/Export/Skills/act_str.txt
+++ b/Export/Skills/act_str.txt
@@ -477,6 +477,9 @@ local skills, mod, flag, skill = ...
 #skill IntimidatingCry
 #flags warcry area duration
 	statMap = {
+		["skill_empowers_next_x_melee_attacks"] = {
+			mod("IntimidatingExertedAttacks", "BASE", nil, 0, 0, { type = "GlobalEffect", effectType = "Buff" }),
+		},
 	},
 #baseMod skill("radius", 60)
 #mods
@@ -648,6 +651,12 @@ local skills, mod, flag, skill = ...
 #skill SeismicCry
 #flags warcry area duration
 	statMap = {
+		["skill_empowers_next_x_melee_attacks"] = {
+			mod("SeismicExertedAttacks", "BASE", nil, 0, 0, { type = "GlobalEffect", effectType = "Buff" }),
+		},
+		["seismic_cry_slam_skill_damage_+%_final_increase_per_repeat"] = {
+			mod("SeismicHitMultiplier", "BASE", nil, 0, 0, { type = "GlobalEffect", effectType = "Buff" }),
+		},
 	},
 #baseMod skill("radius", 60)
 #mods

--- a/Export/Skills/act_str.txt
+++ b/Export/Skills/act_str.txt
@@ -320,9 +320,14 @@ local skills, mod, flag, skill = ...
 #skill EnduringCry
 #flags warcry area duration
 	statMap = {
-		["base_life_regeneration_rate_per_minute"] = {
+		["regenerate_X_life_over_1_second_on_cast"] = {
 			mod("LifeRegen", "BASE", nil, 0, 0, { type = "GlobalEffect", effectType = "Buff" }),
-			div = 60,
+		},
+		["resist_all_elements_%_per_endurance_charge"] = {
+			mod("ElementalResist", "BASE", nil, 0, 0, { type = "GlobalEffect", effectType = "Buff" }, { type = "Multiplier", var = "EnduranceCharge" }),
+		},
+		["physical_damage_reduction_%_per_endurance_charge"] = {
+			mod("PhysicalDamageReduction", "BASE", nil, 0, 0, { type = "GlobalEffect", effectType = "Buff" }, { type = "Multiplier", var = "EnduranceCharge" }),
 		},
 	},
 #baseMod skill("radius", 60)

--- a/Modules/CalcActiveSkill.lua
+++ b/Modules/CalcActiveSkill.lua
@@ -319,6 +319,9 @@ function calcs.buildActiveSkillModList(env, activeSkill)
 	if skillTypes[SkillType.Spell] and not skillFlags.cast then
 		skillKeywordFlags = bor(skillKeywordFlags, KeywordFlag.Spell)
 	end
+	if skillTypes[SkillType.SlamSkill] then
+		skillKeywordFlags = bor(skillKeywordFlags, KeywordFlag.Slam)
+	end
 
 	-- Get skill totem ID for totem skills
 	-- This is used to calculate totem life

--- a/Modules/CalcActiveSkill.lua
+++ b/Modules/CalcActiveSkill.lua
@@ -319,9 +319,6 @@ function calcs.buildActiveSkillModList(env, activeSkill)
 	if skillTypes[SkillType.Spell] and not skillFlags.cast then
 		skillKeywordFlags = bor(skillKeywordFlags, KeywordFlag.Spell)
 	end
-	if skillTypes[SkillType.SlamSkill] then
-		skillKeywordFlags = bor(skillKeywordFlags, KeywordFlag.Slam)
-	end
 
 	-- Get skill totem ID for totem skills
 	-- This is used to calculate totem life

--- a/Modules/CalcOffence-3_0.lua
+++ b/Modules/CalcOffence-3_0.lua
@@ -1188,10 +1188,18 @@ function calcs.offence(env, actor, activeSkill)
 			output.numSeismicExerts = output.maxSeismicExerts + output.extraExertions
 			for _, value in ipairs(env.auxSkillList) do
 				if value.skillCfg.skillName == "Seismic Cry" then
+					-- get cooldown
 					local gemDefaultCooldown = value.skillData.cooldown
-					output.SeismicCryCooldown = gemDefaultCooldown * (1 - skillModList:Sum("INC", value.skillCfg, "CooldownRecovery") / 100)
+					output.SeismicCryCooldown = gemDefaultCooldown / (1 + skillModList:Sum("INC", value.skillCfg, "CooldownRecovery") / 100)
 					-- round it to the nearest server tick rate
 					output.SeismicCryCooldown = m_ceil(output.SeismicCryCooldown * data.misc.ServerTickRate) / data.misc.ServerTickRate
+
+					-- get castTime
+					local gemDefaultCastTime = value.effectList[1].grantedEffect.castTime
+					output.SeismicCryCastTime = gemDefaultCastTime / (1 + skillModList:Sum("INC", value.skillCfg, "WarcrySpeed") / 100)
+					-- round it to the nearest server tick rate
+					output.SeismicCryCastTime = m_ceil(output.SeismicCryCastTime * data.misc.ServerTickRate) / data.misc.ServerTickRate
+
 					break
 				end
 			end
@@ -1213,9 +1221,16 @@ function calcs.offence(env, actor, activeSkill)
 			for _, value in ipairs(env.auxSkillList) do
 				if value.skillCfg.skillName == "Intimidating Cry" then
 					local gemDefaultCooldown = value.skillData.cooldown
-					output.IntimidatingCryCooldown = gemDefaultCooldown * (1 - skillModList:Sum("INC", value.skillCfg, "CooldownRecovery") / 100)
+					output.IntimidatingCryCooldown = gemDefaultCooldown / (1 + skillModList:Sum("INC", value.skillCfg, "CooldownRecovery") / 100)
 					-- round it to the nearest server tick rate
 					output.IntimidatingCryCooldown = m_ceil(output.IntimidatingCryCooldown * data.misc.ServerTickRate) / data.misc.ServerTickRate
+
+					-- get castTime
+					local gemDefaultCastTime = value.effectList[1].grantedEffect.castTime
+					output.IntimidatingCryCastTime = gemDefaultCastTime / (1 + skillModList:Sum("INC", value.skillCfg, "WarcrySpeed") / 100)
+					-- round it to the nearest server tick rate
+					output.IntimidatingCryCastTime = m_ceil(output.IntimidatingCryCastTime * data.misc.ServerTickRate) / data.misc.ServerTickRate
+
 					break
 				end
 			end
@@ -1310,7 +1325,6 @@ function calcs.offence(env, actor, activeSkill)
 						end
 						if output.SeismicHitEffect ~= 1 then
 							t_insert(breakdown[damageType], s_format("x %.2f ^8(seismic cry exertions effect modifier)", output.SeismicHitEffect))
-							t_insert(breakdown[damageType], s_format("x %.2f ^8(seismic cry cast speed effect modifier)", output.SeismicCryCastSpeed))
 						end
 						if output.IntimidatingHitEffect ~= 1 then
 							t_insert(breakdown[damageType], s_format("x %.2f ^8(intimidating cry exertions effect modifier)", output.IntimidatingHitEffect))

--- a/Modules/CalcOffence-3_0.lua
+++ b/Modules/CalcOffence-3_0.lua
@@ -1406,7 +1406,7 @@ function calcs.offence(env, actor, activeSkill, skillLookupOnly)
 						t_insert(breakdown[damageType], s_format("= %d to %d", damageTypeHitMin, damageTypeHitMax))
 					end
 					
-					--Beginning of Leech Calculation for this DamageType
+					-- Beginning of Leech Calculation for this DamageType
 					if skillFlags.mine or skillFlags.trap or skillFlags.totem then
 						if not noLifeLeech then
 							local lifeLeech = skillModList:Sum("BASE", cfg, "DamageLifeLeechToPlayer")
@@ -2807,5 +2807,5 @@ function calcs.offence(env, actor, activeSkill, skillLookupOnly)
 			t_insert(breakdown.ImpaleDPS, s_format("= %.1f", output.ImpaleDPS))
 		end
 	end
-	return { Cooldown = output.Cooldown, WarcryCastTime = output.WarcryCastTime }
+	return { Cooldown = output.Cooldown, Duration = output.Duration, WarcryCastTime = output.WarcryCastTime }
 end

--- a/Modules/CalcOffence-3_0.lua
+++ b/Modules/CalcOffence-3_0.lua
@@ -1340,11 +1340,9 @@ function calcs.offence(env, actor, activeSkill)
 							t_insert(breakdown[damageType], s_format("x %.2f ^8(fist of war effect modifier)", output.FistOfWarHitEffect))
 						end
 						if output.SeismicHitEffect ~= 1 then
-							t_insert(breakdown[damageType], s_format("x %.2f ^8(seismic cry uptime ratio)", output.SeismicUpTimeRatio))
 							t_insert(breakdown[damageType], s_format("x %.2f ^8(seismic cry exertions effect modifier)", output.SeismicHitEffect))
 						end
 						if output.IntimidatingHitEffect ~= 1 then
-							t_insert(breakdown[damageType], s_format("x %.2f ^8(intimidating cry uptime ratio)", output.IntimidatingUpTimeRatio))
 							t_insert(breakdown[damageType], s_format("x %.2f ^8(intimidating cry exertions effect modifier)", output.IntimidatingHitEffect))
 						end
 					end

--- a/Modules/CalcOffence-3_0.lua
+++ b/Modules/CalcOffence-3_0.lua
@@ -1190,11 +1190,11 @@ function calcs.offence(env, actor, activeSkill)
 			for index, value in ipairs(actor.activeSkillList) do
 				if value.activeEffect.gemData.name == "Seismic Cry" then
 					-- recursively calculate the values for Seismic Cry
-					-- only actual Cooldown and CastTime are returned
+					-- only actual Cooldown and WarcryCastTime are returned
 					local seismicCryData = calcs.offence(env, actor, actor.activeSkillList[index])
 					
 					output.SeismicCryCooldown = seismicCryData.Cooldown
-					output.SeismicCryCastTime = seismicCryData.CastTime
+					output.SeismicCryCastTime = seismicCryData.WarcryCastTime
 					break
 				end
 			end
@@ -1218,11 +1218,11 @@ function calcs.offence(env, actor, activeSkill)
 			for index, value in ipairs(actor.activeSkillList) do
 				if value.activeEffect.gemData.name == "Intimidating Cry" then
 					-- recursively calculate the values for Intimidating Cry
-					-- only actual Cooldown and CastTime are returned
+					-- only actual Cooldown and WarcryCastTime are returned
 					local intimidatingCryData = calcs.offence(env, actor, actor.activeSkillList[index])
 					
 					output.IntimidatingCryCooldown = intimidatingCryData.Cooldown
-					output.IntimidatingCryCastTime = intimidatingCryData.CastTime
+					output.IntimidatingCryCastTime = intimidatingCryData.WarcryCastTime
 					break
 				end
 			end
@@ -2796,5 +2796,5 @@ function calcs.offence(env, actor, activeSkill)
 			t_insert(breakdown.ImpaleDPS, s_format("= %.1f", output.ImpaleDPS))
 		end
 	end
-	return { Cooldown = output.Cooldown, CastTime = output.WarcryCastTime }
+	return { Cooldown = output.Cooldown, WarcryCastTime = output.WarcryCastTime }
 end

--- a/Modules/ConfigOptions.lua
+++ b/Modules/ConfigOptions.lua
@@ -797,6 +797,12 @@ return {
 		modList:NewMod("Multiplier:CorpseConsumedRecently", "BASE", val, "Config", { type = "Condition", var = "Combat" })
 		modList:NewMod("Condition:ConsumedCorpseRecently", "FLAG", true, "Config", { type = "Condition", var = "Combat" })
 	end },
+	{ var = "multiplierWarcryCastRecently", type = "count", label = "# of Warcies Cast Recently:", ifMult = "WarcryCastRecently", implyCondList = {"UsedWarcryRecently", "UsedWarcryInPast8Seconds", "UsedSkillRecently"}, tooltip = "This also implies you have 'Used a Warcry Recently', 'Used a Warcry in the past 8 seconds', and 'Used a Skill Recently'", apply = function(val, modList, enemyModList)
+		modList:NewMod("Multiplier:WarcryCastRecently", "BASE", val, "Config", { type = "Condition", var = "Combat" })
+		modList:NewMod("Condition:UsedWarcryRecently", "FLAG", true, "Config", { type = "Condition", var = "Combat" })
+		modList:NewMod("Condition:UsedWarcryInPast8Seconds", "FLAG", true, "Config", { type = "Condition", var = "Combat" })
+		modList:NewMod("Condition:UsedSkillRecently", "FLAG", true, "Config", { type = "Condition", var = "Combat" })
+	end },
 	{ var = "multiplierEnduranceChargesLostRecently", type = "count", label = "# of Endurance Charges lost Recently:", ifMult = "EnduranceChargesLostRecently", implyCond = "LostEnduranceChargeInPast8Sec", apply = function(val, modList, enemyModList)
 		modList:NewMod("Multiplier:EnduranceChargesLostRecently", "BASE", val, "Config", { type = "Condition", var = "Combat" })
 		modList:NewMod("Condition:LostEnduranceChargeInPast8Sec", "FLAG", true, "Config", { type = "Condition", var = "Combat" })

--- a/Modules/ModParser-3_0.lua
+++ b/Modules/ModParser-3_0.lua
@@ -750,6 +750,8 @@ local preFlagList = {
 	["^socketed melee gems [hgd][ae][via][enl] "] = { addToSkill = { type = "SocketedIn", slotName = "{SlotName}", keyword = "melee" } },
 	["^socketed golem gems [hgd][ae][via][enl] "] = { addToSkill = { type = "SocketedIn", slotName = "{SlotName}", keyword = "golem" } },
 	["^socketed golem skills [hgd][ae][via][enl] "] = { addToSkill = { type = "SocketedIn", slotName = "{SlotName}", keyword = "golem" } },
+	-- Exerted
+	["^exerted attacks deal "] = { addToExerted = true, flags = ModFlag.Attack,  tag = { type = "SkillType", skillType = SkillType.SlamSkill } },
 	-- Other
 	["^your flasks grant "] = { },
 	["^when hit, "] = { },
@@ -1326,6 +1328,7 @@ local specialModList = {
 		flag("Condition:CanGainRage"),
 		mod("Dummy", "DUMMY", 1, { type = "Condition", var = "CanGainRage" }), -- Make the Configuration option appear
 	},
+	["exerted attacks deal (%d+)%% more damage if a warcry sacrificed rage recently"] = function(num) return { mod("ExertedAttacks", "LIST", { mod = mod("Damage", "MORE", num, nil, ModFlag.Attack) }, { type = "SkillType", skillType = SkillType.SlamSkill }) } end,
 	-- Champion
 	["you have fortify"] = { flag("Condition:Fortify") },
 	["cannot be stunned while you have fortify"] = { mod("AvoidStun", "BASE", 100, { type = "Condition", var = "Fortify" }) },
@@ -2069,6 +2072,7 @@ local specialModList = {
 	["added small passive skills have (%d+)%% increased effect"] = function(num) return { mod("JewelData", "LIST", { key = "clusterJewelIncEffect", value = num }) } end,
 	["this jewel's socket has (%d+)%% increased effect per allocated passive skill between it and your class' starting location"] = function(num) return { mod("JewelData", "LIST", { key = "jewelIncEffectFromClassStart", value = num }) } end,
 	-- Misc
+	["warcries exert (%d+) additional attack"] = function(num) return { mod("ExtraExertedAttacks", "BASE", num) } end,
 	["iron will"] = { flag("IronWill") },
 	["iron reflexes while stationary"] = { mod("Keystone", "LIST", "Iron Reflexes", { type = "Condition", var = "Stationary" }) },
 	["you have zealot's oath if you haven't been hit recently"] = { mod("Keystone", "LIST", "Zealot's Oath", { type = "Condition", var = "BeenHitRecently", neg = true }) },
@@ -2930,6 +2934,11 @@ local function parseMod(line, order)
 		elseif misc.convertFortifyEffect then
 			for i, effectMod in ipairs(modList) do
 				modList[i] = mod("convertFortifyBuff", "LIST", { mod = effectMod })
+			end
+		elseif misc.addToExerted then
+			-- Exerted attack modifiers
+			for i, effectMod in ipairs(modList) do
+				modList[i] = mod("ExertedAttacks", "LIST", { mod = effectMod })
 			end
 		end
 	end

--- a/Modules/ModParser-3_0.lua
+++ b/Modules/ModParser-3_0.lua
@@ -750,8 +750,6 @@ local preFlagList = {
 	["^socketed melee gems [hgd][ae][via][enl] "] = { addToSkill = { type = "SocketedIn", slotName = "{SlotName}", keyword = "melee" } },
 	["^socketed golem gems [hgd][ae][via][enl] "] = { addToSkill = { type = "SocketedIn", slotName = "{SlotName}", keyword = "golem" } },
 	["^socketed golem skills [hgd][ae][via][enl] "] = { addToSkill = { type = "SocketedIn", slotName = "{SlotName}", keyword = "golem" } },
-	-- Exerted
-	["^exerted attacks deal "] = { addToExerted = true, flags = ModFlag.Attack,  tag = { type = "SkillType", skillType = SkillType.SlamSkill } },
 	-- Other
 	["^your flasks grant "] = { },
 	["^when hit, "] = { },
@@ -1282,11 +1280,16 @@ local specialModList = {
 	["auras from your skills do not affect allies"] = { flag("SelfAurasCannotAffectAllies") },
 	["auras from your skills have (%d+)%% more effect on you"] = function(num) return { mod("AuraEffectOnSelf", "MORE", num) } end,
 	["increases and reductions to mana regeneration rate instead apply to rage regeneration rate"] = { flag("ManaRegenToRageRegen") },
+<<<<<<< HEAD
 	["maximum energy shield is (%d+)"] = function(num) return { mod("EnergyShield", "OVERRIDE", num ) } end,
 	["while not on full life, sacrifice ([%d%.]+)%% of mana per second to recover that much life"] = function(num) return { 
 		mod("ManaDegen", "BASE", 1, { type = "PercentStat", stat = "ManaUnreserved", percent = num }, { type = "Condition", var = "FullLife", neg = true }),
 		mod("LifeRecovery", "BASE", 1, { type = "PercentStat", stat = "ManaUnreserved", percent = num }, { type = "Condition", var = "FullLife", neg = true }) 
 	} end,
+=======
+	-- Exerted Slams
+	["exerted attacks deal (%d+)%% increased damage"] = function(num) return { mod("ExertIncrease", "INC", num, nil, ModFlag.Attack, 0, { type = "SkillType", skillType = SkillType.SlamSkill }) } end,
+>>>>>>> 57b956be... added INC and MORE handling for tree nodes specific to Exerted Attacks
 	-- Ascendant
 	["grants (%d+) passive skill points?"] = function(num) return { mod("ExtraPoints", "BASE", num) } end,
 	["can allocate passives from the %a+'s starting point"] = { },
@@ -1324,11 +1327,15 @@ local specialModList = {
 	["cannot be stunned while you have at least (%d+) rage"] = function(num) return { mod("AvoidStun", "BASE", 100, { type = "MultiplierThreshold", var = "Rage", threshold = 25 }) } end,
 	["lose ([%d%.]+)%% of life per second per rage while you are not losing rage"] = function(num) return { mod("LifeDegen", "BASE", 1, { type = "PercentStat", stat = "Life", percent = num }, { type = "Multiplier", var = "Rage"}) } end,
 	["if you've warcried recently, you and nearby allies have (%d+)%% increased attack speed"] = function(num) return { mod("ExtraAura", "LIST", { mod = mod("Speed", "INC", num, nil, ModFlag.Attack) }, { type = "Condition", var = "UsedWarcryRecently" }) } end,
+<<<<<<< HEAD
 	["warcries grant (%d+) rage per (%d+) power if you have less than (%d+) rage"] = {
 		flag("Condition:CanGainRage"),
 		mod("Dummy", "DUMMY", 1, { type = "Condition", var = "CanGainRage" }), -- Make the Configuration option appear
 	},
 	["exerted attacks deal (%d+)%% more damage if a warcry sacrificed rage recently"] = function(num) return { mod("ExertedAttacks", "LIST", { mod = mod("Damage", "MORE", num, nil, ModFlag.Attack) }, { type = "SkillType", skillType = SkillType.SlamSkill }) } end,
+=======
+	["exerted attacks deal (%d+)%% more damage if a warcry sacrificed rage recently"] = function(num) return { mod("ExertIncrease", "MORE", num, nil, ModFlag.Attack, 0, { type = "SkillType", skillType = SkillType.SlamSkill }) } end,
+>>>>>>> 57b956be... added INC and MORE handling for tree nodes specific to Exerted Attacks
 	-- Champion
 	["you have fortify"] = { flag("Condition:Fortify") },
 	["cannot be stunned while you have fortify"] = { mod("AvoidStun", "BASE", 100, { type = "Condition", var = "Fortify" }) },
@@ -2934,11 +2941,6 @@ local function parseMod(line, order)
 		elseif misc.convertFortifyEffect then
 			for i, effectMod in ipairs(modList) do
 				modList[i] = mod("convertFortifyBuff", "LIST", { mod = effectMod })
-			end
-		elseif misc.addToExerted then
-			-- Exerted attack modifiers
-			for i, effectMod in ipairs(modList) do
-				modList[i] = mod("ExertedAttacks", "LIST", { mod = effectMod })
 			end
 		end
 	end

--- a/Modules/ModParser-3_0.lua
+++ b/Modules/ModParser-3_0.lua
@@ -1281,16 +1281,13 @@ local specialModList = {
 	["auras from your skills do not affect allies"] = { flag("SelfAurasCannotAffectAllies") },
 	["auras from your skills have (%d+)%% more effect on you"] = function(num) return { mod("AuraEffectOnSelf", "MORE", num) } end,
 	["increases and reductions to mana regeneration rate instead apply to rage regeneration rate"] = { flag("ManaRegenToRageRegen") },
-<<<<<<< HEAD
 	["maximum energy shield is (%d+)"] = function(num) return { mod("EnergyShield", "OVERRIDE", num ) } end,
 	["while not on full life, sacrifice ([%d%.]+)%% of mana per second to recover that much life"] = function(num) return { 
 		mod("ManaDegen", "BASE", 1, { type = "PercentStat", stat = "ManaUnreserved", percent = num }, { type = "Condition", var = "FullLife", neg = true }),
 		mod("LifeRecovery", "BASE", 1, { type = "PercentStat", stat = "ManaUnreserved", percent = num }, { type = "Condition", var = "FullLife", neg = true }) 
 	} end,
-=======
 	-- Exerted Slams
 	["exerted attacks deal (%d+)%% increased damage"] = function(num) return { mod("ExertIncrease", "INC", num, nil, ModFlag.Attack, 0, { type = "SkillType", skillType = SkillType.SlamSkill }) } end,
->>>>>>> 57b956be... added INC and MORE handling for tree nodes specific to Exerted Attacks
 	-- Ascendant
 	["grants (%d+) passive skill points?"] = function(num) return { mod("ExtraPoints", "BASE", num) } end,
 	["can allocate passives from the %a+'s starting point"] = { },
@@ -1328,15 +1325,11 @@ local specialModList = {
 	["cannot be stunned while you have at least (%d+) rage"] = function(num) return { mod("AvoidStun", "BASE", 100, { type = "MultiplierThreshold", var = "Rage", threshold = 25 }) } end,
 	["lose ([%d%.]+)%% of life per second per rage while you are not losing rage"] = function(num) return { mod("LifeDegen", "BASE", 1, { type = "PercentStat", stat = "Life", percent = num }, { type = "Multiplier", var = "Rage"}) } end,
 	["if you've warcried recently, you and nearby allies have (%d+)%% increased attack speed"] = function(num) return { mod("ExtraAura", "LIST", { mod = mod("Speed", "INC", num, nil, ModFlag.Attack) }, { type = "Condition", var = "UsedWarcryRecently" }) } end,
-<<<<<<< HEAD
 	["warcries grant (%d+) rage per (%d+) power if you have less than (%d+) rage"] = {
 		flag("Condition:CanGainRage"),
 		mod("Dummy", "DUMMY", 1, { type = "Condition", var = "CanGainRage" }), -- Make the Configuration option appear
 	},
-	["exerted attacks deal (%d+)%% more damage if a warcry sacrificed rage recently"] = function(num) return { mod("ExertedAttacks", "LIST", { mod = mod("Damage", "MORE", num, nil, ModFlag.Attack) }, { type = "SkillType", skillType = SkillType.SlamSkill }) } end,
-=======
 	["exerted attacks deal (%d+)%% more damage if a warcry sacrificed rage recently"] = function(num) return { mod("ExertIncrease", "MORE", num, nil, ModFlag.Attack, 0, { type = "SkillType", skillType = SkillType.SlamSkill }) } end,
->>>>>>> 57b956be... added INC and MORE handling for tree nodes specific to Exerted Attacks
 	-- Champion
 	["you have fortify"] = { flag("Condition:Fortify") },
 	["cannot be stunned while you have fortify"] = { mod("AvoidStun", "BASE", 100, { type = "Condition", var = "Fortify" }) },

--- a/Modules/ModParser-3_0.lua
+++ b/Modules/ModParser-3_0.lua
@@ -1079,6 +1079,7 @@ local modTagList = {
 	["for each skill you've used recently, up to (%d+)%%"] = function(num) return { tag = { type = "Multiplier", var = "SkillUsedRecently", limit = num, limitTotal = true } } end,
 	["if you[' ]h?a?ve used a warcry recently"] = { tag = { type = "Condition", var = "UsedWarcryRecently" } },
 	["if you[' ]h?a?ve warcried recently"] = { tag = { type = "Condition", var = "UsedWarcryRecently" } },
+	["for each time you[' ]h?a?ve warcried recently"] = { tag = { type = "Multiplier", var = "WarcryCastRecently" } },
 	["if you[' ]h?a?ve warcried in the past 8 seconds"] = { tag = { type = "Condition", var = "UsedWarcryInPast8Seconds" } },
 	["for each of your mines detonated recently, up to (%d+)%%"] = function(num) return { tag = { type = "Multiplier", var = "MineDetonatedRecently", limit = num, limitTotal = true } } end,
 	["for each mine detonated recently, up to (%d+)%%"] = function(num) return { tag = { type = "Multiplier", var = "MineDetonatedRecently", limit = num, limitTotal = true } } end,


### PR DESCRIPTION
First check-in to parse Seismic Cry Exertions and Intimidating Cry Exertions.

Supports parsing exertion related nodes on tree.

Implemented Seismic Cry and Intimidating Cry (minus TODOs below).
Implemented Support for "Warcries Exerted 1 Additional Attack" Notable named "Measured Fury"
Implemented method for making warcry duration reduction matter.

TODO:
[] Add support for other Warcries
