### PR TITLE
Update Soul Tether to 3.11

### DIFF
--- a/Data/Uniques/belt.lua
+++ b/Data/Uniques/belt.lua
@@ -487,17 +487,20 @@ Your Minions spread Caustic Ground on Death, dealing 20% of their maximum Life a
 ]],[[
 Soul Tether
 Cloth Belt
+Variant: Pre 3.11.0
+Variant: Current
 Requires Level 48
 Implicits: 1
 (15-25)% increased Stun and Block Recovery
 {tags:jewellery_attribute}+(20-40) to Intelligence
-Your Energy Shield starts at zero
-You cannot Recharge Energy Shield
-You cannot Regenerate Energy Shield
-{tags:jewellery_defense}You lose 5% of Energy Shield per second
-{tags:life}Life Leech effects are not removed at Full Life
-{tags:life}Life Leech is applied to Energy Shield instead while on Full Life
 {tags:jewellery_defense,life}Gain (4-6)% of Maximum Life as Extra Maximum Energy Shield
+{variant:1}Your Energy Shield starts at zero
+{variant:1}You cannot Recharge Energy Shield
+{variant:1}You cannot Regenerate Energy Shield
+{variant:1}{tags:jewellery_defense}You lose 5% of Energy Shield per second
+{variant:1}{tags:life}Life Leech effects are not removed at Full Life
+{variant:1}{tags:life}Life Leech is applied to Energy Shield instead while on Full Life
+{variant:2}Immortal Ambition
 ]],[[
 Soulthirst
 Cloth Belt

--- a/Modules/ModParser-3_0.lua
+++ b/Modules/ModParser-3_0.lua
@@ -2060,6 +2060,7 @@ local specialModList = {
 	["immortal ambition"] = {
 		flag("NoEnergyShieldRecharge"),
 		flag("NoEnergyShieldRegen"),
+		flag("CanLeechLifeOnFullLife"),
 		mod("EnergyShieldDegen", "BASE", 1, { type = "PercentStat", stat = "EnergyShield", percent = 5 }) 
 	},
 	["deal no physical damage"] = { flag("DealNoPhysical") },

--- a/Modules/ModParser-3_0.lua
+++ b/Modules/ModParser-3_0.lua
@@ -1913,6 +1913,7 @@ local specialModList = {
 	["right ring slot: you cannot regenerate mana" ] = { flag("NoManaRegen", { type = "SlotNumber", num = 2 }) },
 	["you cannot recharge energy shield"] = { flag("NoEnergyShieldRecharge") },
 	["you cannot regenerate energy shield" ] = { flag("NoEnergyShieldRegen") },
+	["cannot recharge or regenerate energy shield"] = { flag("NoEnergyShieldRecharge"), flag("NoEnergyShieldRegen") },
 	["left ring slot: you cannot recharge or regenerate energy shield"] = { flag("NoEnergyShieldRecharge", { type = "SlotNumber", num = 1 }), flag("NoEnergyShieldRegen", { type = "SlotNumber", num = 1 }) },
 	["cannot gain energy shield"] = { flag("NoEnergyShieldRegen"), flag("NoEnergyShieldRecharge"), flag("CannotLeechEnergyShield") },
 	["you lose (%d+)%% of energy shield per second"] = function(num) return { mod("EnergyShieldDegen", "BASE", 1, { type = "PercentStat", stat = "EnergyShield", percent = num }) } end,
@@ -2056,6 +2057,11 @@ local specialModList = {
 	["iron will"] = { flag("IronWill") },
 	["iron reflexes while stationary"] = { mod("Keystone", "LIST", "Iron Reflexes", { type = "Condition", var = "Stationary" }) },
 	["you have zealot's oath if you haven't been hit recently"] = { mod("Keystone", "LIST", "Zealot's Oath", { type = "Condition", var = "BeenHitRecently", neg = true }) },
+	["immortal ambition"] = {
+		flag("NoEnergyShieldRecharge"),
+		flag("NoEnergyShieldRegen"),
+		mod("EnergyShieldDegen", "BASE", 1, { type = "PercentStat", stat = "EnergyShield", percent = 5 }) 
+	},
 	["deal no physical damage"] = { flag("DealNoPhysical") },
 	["deal no elemental damage"] = { flag("DealNoLightning"), flag("DealNoCold"), flag("DealNoFire") },
 	["deal no chaos damage"] = { flag("DealNoChaos") },


### PR DESCRIPTION
- Adds parsing for the new keystone "Immortal Ambition"
- Also adds actual mod parsing for the one line on Immortal Ambition that would not be parsed if Timeless Jewels ever got more in-depth implementation
- Updates Soul Tether in the unique DB and adds a variant for pre-3.11

I parse Immortal Ambition as a list of mods since it seems that keystone mods on items are generated based on the actual keystone on the tree, and Immortal Ambition is not on the tree.