### PR TITLE
Fix incorrect number of Brands attached to enemy with multiple Brand skills enabled

### DIFF
--- a/Modules/CalcPerform.lua
+++ b/Modules/CalcPerform.lua
@@ -611,9 +611,13 @@ function calcs.perform(env)
 		end
 		if activeSkill.skillFlags.brand then
 			local attachLimit = env.player.mainSkill.skillModList:Sum("BASE", env.player.mainSkill.skillCfg, "BrandsAttachedLimit")
+			if activeSkill.activeEffect.grantedEffect.name == "Wintertide Brand" then
+				attachLimit = attachLimit + 1
+			end
 			local attached = modDB:Sum("BASE", nil, "Multiplier:ConfigBrandsAttachedToEnemy")
-			modDB:NewMod("Multiplier:BrandsAttachedToEnemy", "BASE", m_min(attached, attachLimit), "Config")
-			enemyDB:NewMod("Multiplier:BrandsAttached", "BASE", m_min(attached, attachLimit), "Config")
+			local actual = m_min(attachLimit, attached)
+			modDB.multipliers["BrandsAttachedToEnemy"] = m_max(actual, modDB.multipliers["BrandsAttachedToEnemy"] or 0)
+			enemyDB.multipliers["BrandsAttached"] = m_max(actual, enemyDB.multipliers["BrandsAttached"] or 0)
 		end
 		if activeSkill.activeEffect.grantedEffect.name == "Summon Skeletons" then
 			local limit = env.player.mainSkill.skillModList:Sum("BASE", env.player.mainSkill.skillCfg, "ActiveSkeletonLimit")


### PR DESCRIPTION
One of my previous Brand PRs #1021 created an issue where if you had multiple Brand skills enabled, the BrandsAttached multipliers would be added onto for every Brand skill. If you had two Brand skills and config set for 2 Brands attached, it would instead track that you had 4 Brands attached because both skills added 2 to the multipliers.

This PR changes it so the multiplier count is instead set to whatever the highest BrandAttachLimit you have is. It also adds a special case for Wintertide Brand because, despite that skill being the original point of doing my previous PR, the limit of 3 wasn't actually supported anywhere.