### PR TITLE
Changes needed to detect new-style installation

### DIFF
--- a/Launch.lua
+++ b/Launch.lua
@@ -14,6 +14,7 @@ SetMainObject(launch)
 
 function launch:OnInit()
 	self.devMode = false
+	self.installedMode = false
 	self.versionNumber = "?"
 	self.versionBranch = "?"
 	self.versionPlatform = "?"
@@ -52,6 +53,11 @@ function launch:OnInit()
 		-- Looks like a remote manifest, so we're probably running from a repository
 		-- Enable dev mode to disable updates and set user path to be the script path
 		self.devMode = true
+	end
+	local installedFile = io.open("installed.cfg", "r")
+	if installedFile then
+		self.installedMode = true
+		installedFile:close()
 	end
 	RenderInit()
 	ConPrintf("Loading main script...")

--- a/Modules/Main.lua
+++ b/Modules/Main.lua
@@ -43,7 +43,7 @@ function main:Init()
 	self.modes["LIST"] = LoadModule("Modules/BuildList")
 	self.modes["BUILD"] = LoadModule("Modules/Build")
 
-	if launch.devMode or GetScriptPath() == GetRuntimePath() then
+	if launch.devMode or (GetScriptPath() == GetRuntimePath() and not launch.installedMode) then
 		-- If running in dev mode or standalone mode, put user data in the script path
 		self.userPath = GetScriptPath().."/"
 	else


### PR DESCRIPTION
Current behaviour is to detect standalone version if the directory the launch script is located in is the same as the one the runtime is in. In an effort to assimilate standalone and installed versions, a new less accidental detection method is needed to set the default build save path as expected, using a sentinel file only present in future installed versions. The current detection method has to be kept for backwards compatibility.