### PR TITLE
Add hit rate to Orb of Storms

### DIFF
--- a/Data/3_0/Skills/act_int.lua
+++ b/Data/3_0/Skills/act_int.lua
@@ -4997,6 +4997,15 @@ skills["OrbOfStorms"] = {
 	skillTypes = { [SkillType.Spell] = true, [SkillType.Hit] = true, [SkillType.LightningSkill] = true, [SkillType.Duration] = true, [SkillType.Area] = true, [SkillType.Chaining] = true, [SkillType.Triggerable] = true, [SkillType.SkillCanTrap] = true, [SkillType.SkillCanMine] = true, [SkillType.SkillCanTotem] = true, [SkillType.AreaSpell] = true, [SkillType.Type96] = true, },
 	statDescriptionScope = "beam_skill_stat_descriptions",
 	castTime = 0.5,
+	preDamageFunc = function(activeSkill, output)
+		activeSkill.skillData.hitTimeOverride = activeSkill.skillData.hitFrequency / (1 + activeSkill.skillModList:Sum("INC", activeSkill.skillCfg, "Speed") / 100)
+	end,
+	statMap = {
+		["orb_of_storms_base_bolt_frequency_ms"] = {
+			skill("hitFrequency", nil),
+			div = 1000,
+		},
+	},
 	baseFlags = {
 		spell = true,
 		chaining = true,

--- a/Export/Skills/act_int.txt
+++ b/Export/Skills/act_int.txt
@@ -803,6 +803,15 @@ local skills, mod, flag, skill = ...
 
 #skill OrbOfStorms
 #flags spell chaining duration
+	preDamageFunc = function(activeSkill, output)
+		activeSkill.skillData.hitTimeOverride = activeSkill.skillData.hitFrequency / (1 + activeSkill.skillModList:Sum("INC", activeSkill.skillCfg, "Speed") / 100)
+	end,
+	statMap = {
+		["orb_of_storms_base_bolt_frequency_ms"] = {
+			skill("hitFrequency", nil),
+			div = 1000,
+		},
+	},
 #mods
 
 #skill MagmaSigil


### PR DESCRIPTION
- Implements hit rate modifier, affected by increases and reductions to cast speed, for Orb of Storms

Since 3.3, Orb of Storms has had a hit time given on the gem and has been affected by increases to cast speed, but that entire time PoB has always used the time to cast the Orb as its hit rate (which is nearly twice as fast as a level 20 skill actually hits).

The description of the skill says "Modifiers to cast speed will increase how frequently it does this", but despite using the word "modifiers" here, only increases and reductions apply to its hit rate in-game based on my testing.