### PR TITLE
Add tables to Ailment Threshold calculations

### DIFF
--- a/Classes/CalcBreakdownControl.lua
+++ b/Classes/CalcBreakdownControl.lua
@@ -86,12 +86,14 @@ function CalcBreakdownClass:SetBreakdownData(displayData, pinned)
 					section.width = section.width + col.width
 				end
 			end
-			if section.label then
-				section.width = m_max(section.width, 6 + DrawStringWidth(16, "VAR", section.label..":"))
-			end
 			section.height = #section.rowList * 14 + 20
 			if section.label then
+				self.contentWidth = m_max(self.contentWidth, 6 + DrawStringWidth(16, "VAR", section.label..":"))
 				section.height = section.height + 16
+			end
+			if section.footer then
+				self.contentWidth = m_max(self.contentWidth, 6 + DrawStringWidth(12, "VAR", section.footer))
+				section.height = section.height + 12
 			end
 		end
 		self.contentWidth = m_max(self.contentWidth, section.width)
@@ -139,6 +141,7 @@ function CalcBreakdownClass:AddBreakdownSection(sectionData)
 		local section = {
 			type = "TABLE",
 			label = breakdown.label,
+			footer = breakdown.footer,
 			rowList = breakdown.rowList,
 			colList = breakdown.colList,
 		}
@@ -506,7 +509,7 @@ function CalcBreakdownClass:DrawBreakdownTable(viewPort, x, y, section)
 			if index > 1 then
 				-- Skip the separator for the first column
 				SetDrawColor(0.5, 0.5, 0.5)
-				DrawImage(nil, colX - 2, y, 1, section.label and section.height - 16 or section.height)
+				DrawImage(nil, colX - 2, y, 1, section.height - (section.label and 16 or 0) - (section.footer and 12 or 0))
 			end
 			SetDrawColor(1, 1, 1)
 			DrawString(colX, y + 2, "LEFT", 16, "VAR", col.label)
@@ -563,6 +566,10 @@ function CalcBreakdownClass:DrawBreakdownTable(viewPort, x, y, section)
 			end
 		end
 		rowY = rowY + 14
+	end
+	if section.footer then
+		-- Draw table footer if able
+		DrawString(x + 2, rowY, "LEFT", 12, "VAR", "^7"..section.footer)
 	end
 end
 

--- a/Modules/CalcOffence-3_0.lua
+++ b/Modules/CalcOffence-3_0.lua
@@ -2381,6 +2381,7 @@ function calcs.offence(env, actor, activeSkill)
 					else
 						breakdown.ShockDPS.label = s_format("To Shock for %.1f seconds", 2 * output.ShockDurationMod)
 					end
+					breakdown.ShockDPS.footer = s_format("^8(ailment threshold is about equal to life, except on bosses where it is about half their life)")
 					breakdown.ShockDPS.rowList = { }
 					breakdown.ShockDPS.colList = {
 						{ label = "Shock Effect", key = "effect" },
@@ -2458,6 +2459,7 @@ function calcs.offence(env, actor, activeSkill)
 						{ label = "Chill Effect", key = "effect" },
 						{ label = "Ailment Threshold", key = "thresh" },
 					}
+					breakdown.ChillDPS.footer = s_format("^8(ailment threshold is about equal to life, except on bosses where it is about half their life)")
 					for _, value in ipairs(effList) do
 						local thresh = (((100 + output.ChillEffectMod)^(2.5)) * baseVal) / ((2 * value) ^ (2.5))
 						if value == output.BonechillEffect then

--- a/Modules/CalcOffence-3_0.lua
+++ b/Modules/CalcOffence-3_0.lua
@@ -2365,7 +2365,7 @@ function calcs.offence(env, actor, activeSkill)
 				skillFlags.shock = true
 				output.ShockDurationMod = 1 + skillModList:Sum("INC", cfg, "EnemyShockDuration") / 100 + enemyDB:Sum("INC", nil, "SelfShockDuration") / 100
 				output.ShockEffectMod = skillModList:Sum("INC", cfg, "EnemyShockEffect")
-				local maximum = enemyDB:Override(nil, "ShockMax") or 50
+				local maximum = skillModList:Override(nil, "ShockMax") or 50
 				local current = m_min(enemyDB:Sum("BASE", nil, "ShockVal"), maximum)
 				local effList = { 5, 15, 50 }
 				if maximum ~= 50 then

--- a/Modules/CalcOffence-3_0.lua
+++ b/Modules/CalcOffence-3_0.lua
@@ -2445,16 +2445,31 @@ function calcs.offence(env, actor, activeSkill)
 				output.ChillDurationMod = 1 + skillModList:Sum("INC", cfg, "EnemyChillDuration") / 100
 				if breakdown then
 					breakdown.ChillDPS.label = s_format("To Chill for %.1f seconds", 2 * output.ChillDurationMod)
+					if output.BonechillEffect then
+						breakdown.ChillDPS.label = s_format("To Chill for %.1f seconds ^8(with a ^7%s%% ^8Bonechill effect on the enemy)^7", 2 * output.ChillDurationMod, output.BonechillEffect)
+					else
+						breakdown.ChillDPS.label = s_format("To Chill for %.1f seconds", 2 * output.ChillDurationMod)
+					end
 					breakdown.ChillDPS.rowList = { }
 					breakdown.ChillDPS.colList = {
 						{ label = "Chill Effect", key = "effect" },
 						{ label = "Ailment Threshold", key = "thresh" },
 					}
 				end
-				for _, value in ipairs({ 5, 10, 30 }) do
+				effList = { 5, 10, 30 }
+				if output.BonechillEffect then
+					t_insert(effList, output.BonechillEffect)
+					table.sort(effList)
+				end
+				for _, value in ipairs(effList) do
 					if breakdown then
 						local thresh = (((100 + output.ChillEffectMod)^(2.5)) * baseVal) / ((2 * value) ^ (2.5))
-						if value == 30 then
+						if value == output.BonechillEffect then
+							t_insert(breakdown.ChillDPS.rowList, {
+								effect = s_format("%s%% ^8(current)", value),
+								thresh = s_format("%.0f", thresh),
+							})
+						elseif value == 30 then
 							t_insert(breakdown.ChillDPS.rowList, {
 								effect = s_format("%s%% ^8(maximum)", value),
 								thresh = s_format("%.0f", thresh),

--- a/Modules/CalcOffence-3_0.lua
+++ b/Modules/CalcOffence-3_0.lua
@@ -2386,9 +2386,7 @@ function calcs.offence(env, actor, activeSkill)
 						{ label = "Shock Effect", key = "effect" },
 						{ label = "Ailment Threshold", key = "thresh" },
 					}
-				end
-				for _, value in ipairs(effList) do
-					if breakdown then
+					for _, value in ipairs(effList) do
 						local thresh = (((100 + output.ShockEffectMod)^(2.5)) * baseVal) / ((2 * value) ^ (2.5))
 						if value == current then
 							t_insert(breakdown.ShockDPS.rowList, {
@@ -2443,6 +2441,11 @@ function calcs.offence(env, actor, activeSkill)
 				skillFlags.chill = true
 				output.ChillEffectMod = skillModList:Sum("INC", cfg, "EnemyChillEffect")
 				output.ChillDurationMod = 1 + skillModList:Sum("INC", cfg, "EnemyChillDuration") / 100
+				effList = { 5, 10, 30 }
+				if output.BonechillEffect then
+					t_insert(effList, output.BonechillEffect)
+					table.sort(effList)
+				end
 				if breakdown then
 					breakdown.ChillDPS.label = s_format("To Chill for %.1f seconds", 2 * output.ChillDurationMod)
 					if output.BonechillEffect then
@@ -2455,14 +2458,7 @@ function calcs.offence(env, actor, activeSkill)
 						{ label = "Chill Effect", key = "effect" },
 						{ label = "Ailment Threshold", key = "thresh" },
 					}
-				end
-				effList = { 5, 10, 30 }
-				if output.BonechillEffect then
-					t_insert(effList, output.BonechillEffect)
-					table.sort(effList)
-				end
-				for _, value in ipairs(effList) do
-					if breakdown then
+					for _, value in ipairs(effList) do
 						local thresh = (((100 + output.ChillEffectMod)^(2.5)) * baseVal) / ((2 * value) ^ (2.5))
 						if value == output.BonechillEffect then
 							t_insert(breakdown.ChillDPS.rowList, {

--- a/Modules/CalcOffence-3_0.lua
+++ b/Modules/CalcOffence-3_0.lua
@@ -2365,9 +2365,53 @@ function calcs.offence(env, actor, activeSkill)
 				skillFlags.shock = true
 				output.ShockDurationMod = 1 + skillModList:Sum("INC", cfg, "EnemyShockDuration") / 100 + enemyDB:Sum("INC", nil, "SelfShockDuration") / 100
 				output.ShockEffectMod = skillModList:Sum("INC", cfg, "EnemyShockEffect")
+				local maximum = enemyDB:Override(nil, "ShockMax") or 50
+				local current = m_min(enemyDB:Sum("BASE", nil, "ShockVal"), maximum)
+				local effList = { 5, 15, 50 }
+				if maximum ~= 50 then
+					t_insert(effList, maximum)
+				end
+				if current > 5 and current ~= (15 or 50 or maximum) and current < maximum then
+					t_insert(effList, current)
+				end
+				table.sort(effList)
 				if breakdown then
-					t_insert(breakdown.ShockDPS, s_format("For the minimum 5%% Shock to apply for %.1f seconds, target must have no more than %.0f Ailment Threshold.", 2 * output.ShockDurationMod, (((100 + output.ShockEffectMod)^(2.5)) * baseVal) / (100 * m_sqrt(10))))
-					t_insert(breakdown.ShockDPS, s_format("^8(Ailment Threshold is about equal to Life except on bosses where it is about half of their life)"))
+					if current > 0 then
+						breakdown.ShockDPS.label = s_format("To Shock for %.1f seconds ^8(with a ^7%s%% ^8shock on the enemy)^7", 2 * output.ShockDurationMod, current)
+					else
+						breakdown.ShockDPS.label = s_format("To Shock for %.1f seconds", 2 * output.ShockDurationMod)
+					end
+					breakdown.ShockDPS.rowList = { }
+					breakdown.ShockDPS.colList = {
+						{ label = "Shock Effect", key = "effect" },
+						{ label = "Ailment Threshold", key = "thresh" },
+					}
+				end
+				for _, value in ipairs(effList) do
+					if breakdown then
+						local thresh = (((100 + output.ShockEffectMod)^(2.5)) * baseVal) / ((2 * value) ^ (2.5))
+						if value == current then
+							t_insert(breakdown.ShockDPS.rowList, {
+								effect = s_format("%s%% ^8(current)", value),
+								thresh = s_format("%.0f", thresh),
+							})
+						elseif value == maximum then
+							t_insert(breakdown.ShockDPS.rowList, {
+								effect = s_format("%s%% ^8(maximum)", value),
+								thresh = s_format("%.0f", thresh),
+							})
+						elseif value == 5 then
+							t_insert(breakdown.ShockDPS.rowList, {
+								effect = s_format("%s%% ^8(minimum)", value),
+								thresh = s_format("%.0f", thresh),
+							})
+						else
+							t_insert(breakdown.ShockDPS.rowList, {
+								effect = s_format("%s%%", value),
+								thresh = s_format("%.0f", thresh),
+							})
+						end
+					end
 				end
  			end
 		end
@@ -2400,8 +2444,33 @@ function calcs.offence(env, actor, activeSkill)
 				output.ChillEffectMod = skillModList:Sum("INC", cfg, "EnemyChillEffect")
 				output.ChillDurationMod = 1 + skillModList:Sum("INC", cfg, "EnemyChillDuration") / 100
 				if breakdown then
-					t_insert(breakdown.ChillDPS, s_format("For the minimum 5%% Chill to apply for %.1f seconds, target must have no more than %.0f Ailment Threshold.", 2 * output.ChillDurationMod, (((100 + output.ChillEffectMod)^(2.5)) * baseVal) / (100 * m_sqrt(10))))
-					t_insert(breakdown.ChillDPS, s_format("^8(Ailment Threshold is about equal to Life except on bosses where it is about half of their life)"))
+					breakdown.ChillDPS.label = s_format("To Chill for %.1f seconds", 2 * output.ChillDurationMod)
+					breakdown.ChillDPS.rowList = { }
+					breakdown.ChillDPS.colList = {
+						{ label = "Chill Effect", key = "effect" },
+						{ label = "Ailment Threshold", key = "thresh" },
+					}
+				end
+				for _, value in ipairs({ 5, 10, 30 }) do
+					if breakdown then
+						local thresh = (((100 + output.ChillEffectMod)^(2.5)) * baseVal) / ((2 * value) ^ (2.5))
+						if value == 30 then
+							t_insert(breakdown.ChillDPS.rowList, {
+								effect = s_format("%s%% ^8(maximum)", value),
+								thresh = s_format("%.0f", thresh),
+							})
+						elseif value == 5 then
+							t_insert(breakdown.ChillDPS.rowList, {
+								effect = s_format("%s%% ^8(minimum)", value),
+								thresh = s_format("%.0f", thresh),
+							})
+						else
+							t_insert(breakdown.ChillDPS.rowList, {
+								effect = s_format("%s%%", value),
+								thresh = s_format("%.0f", thresh),
+							})
+						end
+					end
 				end
 			end
 		end


### PR DESCRIPTION
- Adds tables to the Ailment Threshold calculations for Shock and Chill
- By default Shock shows 5%(the minimum), 15%(the global "standard"), and 50%(default maximum)
![image](https://user-images.githubusercontent.com/39030429/86503882-ffe24c00-bd77-11ea-98e0-0566cd117d42.png)

- If you have a Shock applied to the enemy there will be a note that the enemy is already Shocked and for how much. If you have a mod that increases Maximum Shock, it will also be reflected in the table
![image](https://user-images.githubusercontent.com/39030429/86503873-f35df380-bd77-11ea-99c0-f6030bbc13dc.png)

- By default Chill shows 5%(the minimum), 10%(the global "standard"), and 30%(hard maximum). In a separate commit I also added support for my Bonechill PR #1127, which can be reverted if my Bonechill PR is not committed at the same time as this PR(though the stuff I added just does nothing if the output.BonechillEffect doesn't exist)
![image](https://user-images.githubusercontent.com/39030429/86503615-76ca1580-bd75-11ea-95b0-504a19825189.png)

- Also one final commit to update ShockMax to use my new position, on the player instead of the enemy, from #1126. Would need reverted if that PR is not committed as well, as the maximum Shock override will not get added to the table otherwise