### PR TITLE
Fix Avian Tornado showing DPS numbers

### DIFF
--- a/Data/3_0/Skills/other.lua
+++ b/Data/3_0/Skills/other.lua
@@ -2320,6 +2320,7 @@ skills["AvianTornado"] = {
 		duration = true,
 	},
 	baseMods = {
+		skill("showAverage", true),
 	},
 	qualityStats = {
 	},

--- a/Export/Skills/other.txt
+++ b/Export/Skills/other.txt
@@ -548,6 +548,7 @@ local skills, mod, flag, skill = ...
 #skill AvianTornado
 #flags spell projectile duration
 	fromItem = true,
+#baseMod skill("showAverage", true)
 #mods
 
 #skill VoidGaze


### PR DESCRIPTION
The skill is triggered and should only show average damage