### PR TITLE
Fix Wintertide Brand gem quality

### DIFF
--- a/Data/3_0/SkillStatMap.lua
+++ b/Data/3_0/SkillStatMap.lua
@@ -688,6 +688,9 @@ return {
 ["fire_dot_multiplier_+"] = {
 	mod("FireDotMultiplier", "BASE", nil),
 },
+["cold_dot_multiplier_+"] = {
+	mod("ColdDotMultiplier", "BASE", nil),
+},
 ["active_skill_ignite_damage_+%_final"] = {
 	mod("Damage", "MORE", nil, 0, KeywordFlag.Ignite),
 },


### PR DESCRIPTION
The quality for Wintertide Brand was not working as the mod was not mapped