### PR TITLE
Top node and per-point heatmap changes

### DIFF
--- a/Classes/CalcsTab.lua
+++ b/Classes/CalcsTab.lua
@@ -453,8 +453,11 @@ function CalcsTabClass:PowerBuilder()
 	local cache = { }
 	local newPowerMax = {
 		singleStat = 0,
+		singleStatPerPoint = 0,
 		offence = 0,
-		defence = 0
+		offencePerPoint = 0,
+		defence = 0,
+		defencePerPoint = 0
 	}
 	if not self.powerMax then
 		self.powerMax = newPowerMax
@@ -474,6 +477,7 @@ function CalcsTabClass:PowerBuilder()
 				node.power.singleStat = self:CalculatePowerStat(self.powerStat, output, calcBase)
 				if node.path then
 					newPowerMax.singleStat = m_max(newPowerMax.singleStat, node.power.singleStat)
+					newPowerMax.singleStatPerPoint = m_max(node.power.singleStat / #node.path, newPowerMax.singleStatPerPoint)
 				end
 			else
 				if calcBase.Minion then
@@ -490,6 +494,9 @@ function CalcsTabClass:PowerBuilder()
 				if node.path then
 					newPowerMax.offence = m_max(newPowerMax.offence, node.power.offence)
 					newPowerMax.defence = m_max(newPowerMax.defence, node.power.defence)
+					newPowerMax.offencePerPoint = m_max(newPowerMax.offencePerPoint, node.power.offence / #node.path)
+					newPowerMax.defencePerPoint = m_max(newPowerMax.defencePerPoint, node.power.defence / #node.path)
+
 				end
 			end
 		end

--- a/Classes/CalcsTab.lua
+++ b/Classes/CalcsTab.lua
@@ -475,9 +475,10 @@ function CalcsTabClass:PowerBuilder()
 			local output = cache[node.modKey]
 			if self.powerStat and self.powerStat.stat and not self.powerStat.ignoreForNodes then
 				node.power.singleStat = self:CalculatePowerStat(self.powerStat, output, calcBase)
-				if node.path then
+				if node.path or node.recipe and not node.ascendancyName then
 					newPowerMax.singleStat = m_max(newPowerMax.singleStat, node.power.singleStat)
-					newPowerMax.singleStatPerPoint = m_max(node.power.singleStat / #node.path, newPowerMax.singleStatPerPoint)
+					local pathCost = node.path and #node.path or 1
+					newPowerMax.singleStatPerPoint = m_max(node.power.singleStat / pathCost, newPowerMax.singleStatPerPoint)
 				end
 			else
 				if calcBase.Minion then
@@ -491,11 +492,12 @@ function CalcsTabClass:PowerBuilder()
 								(output.Evasion - calcBase.Evasion) / m_max(10000, calcBase.Evasion) +
 								(output.LifeRegen - calcBase.LifeRegen) / 500 +
 								(output.EnergyShieldRegen - calcBase.EnergyShieldRegen) / 1000
-				if node.path then
+				if node.path or node.recipe and not node.ascendancyName then
 					newPowerMax.offence = m_max(newPowerMax.offence, node.power.offence)
 					newPowerMax.defence = m_max(newPowerMax.defence, node.power.defence)
-					newPowerMax.offencePerPoint = m_max(newPowerMax.offencePerPoint, node.power.offence / #node.path)
-					newPowerMax.defencePerPoint = m_max(newPowerMax.defencePerPoint, node.power.defence / #node.path)
+					local pathCost = node.path and #node.path or 1
+					newPowerMax.offencePerPoint = m_max(newPowerMax.offencePerPoint, node.power.offence / pathCost)
+					newPowerMax.defencePerPoint = m_max(newPowerMax.defencePerPoint, node.power.defence / pathCost)
 
 				end
 			end

--- a/Classes/PassiveTreeView.lua
+++ b/Classes/PassiveTreeView.lua
@@ -470,6 +470,14 @@ function PassiveTreeViewClass:Draw(build, viewPort, inputEvents)
 					-- Calculate color based on a single stat
 					local stat = m_max(node.power.singleStat or 0, 0)
 					local statCol = (stat / build.calcsTab.powerMax.singleStat * 1.5) ^ 0.5
+					local path = (node.alloc and node.depends) or self.tracePath or node.path or { }
+					if(self.heatMapStatPerPoint and self.heatMapTopPick) then
+						statCol = stat / #path == build.calcsTab.powerMax.singleStatPerPoint and 1.5 ^ 0.5 or 0
+					elseif self.heatMapStatPerPoint then
+						statCol = statCol / #path * 4
+					elseif self.heatMapTopPick then
+						statCol = stat == build.calcsTab.powerMax.singleStat and 1.5 ^ 0.5 or 0
+					end
 					if main.nodePowerTheme == "RED/BLUE" then
 						SetDrawColor(statCol, 0, 0)
 					elseif main.nodePowerTheme == "RED/GREEN" then

--- a/Classes/PassiveTreeView.lua
+++ b/Classes/PassiveTreeView.lua
@@ -491,6 +491,17 @@ function PassiveTreeViewClass:Draw(build, viewPort, inputEvents)
 					local defence = m_max(node.power.defence or 0, 0)
 					local dpsCol = (offence / build.calcsTab.powerMax.offence * 1.5) ^ 0.5
 					local defCol = (defence / build.calcsTab.powerMax.defence * 1.5) ^ 0.5
+					local path = (node.alloc and node.depends) or self.tracePath or node.path or { }
+					if(self.heatMapStatPerPoint and self.heatMapTopPick) then
+						dpsCol = offence / #path == build.calcsTab.powerMax.offencePerPoint and 1.5 ^ 0.5 or 0
+						defCol = defence / #path == build.calcsTab.powerMax.defencePerPoint and 1.5 ^ 0.5 or 0
+					elseif self.heatMapStatPerPoint then
+						dpsCol = dpsCol / #path * 4
+						defCol = defCol / #path * 4
+					elseif self.heatMapTopPick then
+						dpsCol = offence == build.calcsTab.powerMax.offence and 1.5 ^ 0.5 or 0
+						defCol = defence == build.calcsTab.powerMax.defence and 1.5 ^ 0.5 or 0
+					end
 					local mixCol = (m_max(dpsCol - 0.5, 0) + m_max(defCol - 0.5, 0)) / 2
 					if main.nodePowerTheme == "RED/BLUE" then
 						SetDrawColor(dpsCol, mixCol, defCol)

--- a/Classes/PassiveTreeView.lua
+++ b/Classes/PassiveTreeView.lua
@@ -471,11 +471,12 @@ function PassiveTreeViewClass:Draw(build, viewPort, inputEvents)
 					local stat = m_max(node.power.singleStat or 0, 0)
 					local statCol = (stat / build.calcsTab.powerMax.singleStat * 1.5) ^ 0.5
 					local path = (node.alloc and node.depends) or self.tracePath or node.path or { }
+					local pathCost = #path == 0 and 1 or #path
 					if(stat ~= 0) then
 						if(self.heatMapStatPerPoint and self.heatMapTopPick) then
-							statCol = stat / #path == build.calcsTab.powerMax.singleStatPerPoint and 1.5 ^ 0.5 or 0
+							statCol = stat / pathCost == build.calcsTab.powerMax.singleStatPerPoint and 1.5 ^ 0.5 or 0
 						elseif self.heatMapStatPerPoint then
-							statCol = statCol / #path * 4
+							statCol = statCol / pathCost * 4
 						elseif self.heatMapTopPick then
 							statCol = stat == build.calcsTab.powerMax.singleStat and 1.5 ^ 0.5 or 0
 						end
@@ -494,12 +495,13 @@ function PassiveTreeViewClass:Draw(build, viewPort, inputEvents)
 					local dpsCol = (offence / build.calcsTab.powerMax.offence * 1.5) ^ 0.5
 					local defCol = (defence / build.calcsTab.powerMax.defence * 1.5) ^ 0.5
 					local path = (node.alloc and node.depends) or self.tracePath or node.path or { }
+					local pathCost = #path == 0 and 1 or #path
 					if(self.heatMapStatPerPoint and self.heatMapTopPick) then
-						dpsCol = offence / #path == build.calcsTab.powerMax.offencePerPoint and 1.5 ^ 0.5 or 0
-						defCol = defence / #path == build.calcsTab.powerMax.defencePerPoint and 1.5 ^ 0.5 or 0
+						dpsCol = offence / pathCost == build.calcsTab.powerMax.offencePerPoint and 1.5 ^ 0.5 or 0
+						defCol = defence / pathCost == build.calcsTab.powerMax.defencePerPoint and 1.5 ^ 0.5 or 0
 					elseif self.heatMapStatPerPoint then
-						dpsCol = dpsCol / #path * 4
-						defCol = defCol / #path * 4
+						dpsCol = dpsCol / pathCost * 4
+						defCol = defCol / pathCost * 4
 					elseif self.heatMapTopPick then
 						dpsCol = offence == build.calcsTab.powerMax.offence and 1.5 ^ 0.5 or 0
 						defCol = defence == build.calcsTab.powerMax.defence and 1.5 ^ 0.5 or 0

--- a/Classes/PassiveTreeView.lua
+++ b/Classes/PassiveTreeView.lua
@@ -471,12 +471,14 @@ function PassiveTreeViewClass:Draw(build, viewPort, inputEvents)
 					local stat = m_max(node.power.singleStat or 0, 0)
 					local statCol = (stat / build.calcsTab.powerMax.singleStat * 1.5) ^ 0.5
 					local path = (node.alloc and node.depends) or self.tracePath or node.path or { }
-					if(self.heatMapStatPerPoint and self.heatMapTopPick) then
-						statCol = stat / #path == build.calcsTab.powerMax.singleStatPerPoint and 1.5 ^ 0.5 or 0
-					elseif self.heatMapStatPerPoint then
-						statCol = statCol / #path * 4
-					elseif self.heatMapTopPick then
-						statCol = stat == build.calcsTab.powerMax.singleStat and 1.5 ^ 0.5 or 0
+					if(stat ~= 0) then
+						if(self.heatMapStatPerPoint and self.heatMapTopPick) then
+							statCol = stat / #path == build.calcsTab.powerMax.singleStatPerPoint and 1.5 ^ 0.5 or 0
+						elseif self.heatMapStatPerPoint then
+							statCol = statCol / #path * 4
+						elseif self.heatMapTopPick then
+							statCol = stat == build.calcsTab.powerMax.singleStat and 1.5 ^ 0.5 or 0
+						end
 					end
 					if main.nodePowerTheme == "RED/BLUE" then
 						SetDrawColor(statCol, 0, 0)

--- a/Classes/TreeTab.lua
+++ b/Classes/TreeTab.lua
@@ -105,7 +105,7 @@ local TreeTabClass = newClass("TreeTab", "ControlHost", function(self, build)
 	end )
 
 	self.controls.treeHeatMapTopStat.tooltipText = function()
-		return "When enabled, only the best node for the selected stats will be highlighted.\nIf 'Power per point:' is also enabled, only the node that gives you the best stat\nper point will be highlighted"
+		return "When enabled, only the strongest node for the selected stat will be highlighted."
 	end
 
 	self.controls.treeHeatMapStatPerPoint = new("CheckBoxControl", {"LEFT", self.controls.treeHeatMapTopStat,"RIGHT"}, 115, 0, 20, "Power per point:", function(state)
@@ -113,7 +113,7 @@ local TreeTabClass = newClass("TreeTab", "ControlHost", function(self, build)
 	end )
 
 	self.controls.treeHeatMapStatPerPoint.tooltipText = function()
-		return "When enabled, node power is divided by the point cost it would take to get there,\nso closer points are highlighted brighter"
+		return "When enabled, node power is divided by the point cost it would take to get there,\nso closer points are considered stronger"
 	end
 
 	self.controls.specConvertText = new("LabelControl", {"BOTTOMLEFT",self.controls.specSelect,"TOPLEFT"}, 0, -14, 0, 16, "^7This is an older tree version, which may not be fully compatible with the current game version.")
@@ -163,7 +163,7 @@ function TreeTabClass:Draw(viewPort, inputEvents)
 		self.controls.treeHeatMap.x = 125
 
 		self.controls.specSelect.y = -24
-		self.controls.specConvertText.y = self.controls.specConvertText.y - 2
+		self.controls.specConvertText.y = -16
 	elseif viewPort.x + viewPort.width - (select(1, self.controls.treeSearch:GetPos()) + select(1, self.controls.treeSearch:GetSize())) > (select(1, self.controls.treeHeatMapStatPerPoint:GetPos()) + select(1, self.controls.treeHeatMapStatPerPoint:GetSize())) - viewPort.x  then
 		twoLineHeight = 0
 		self.controls.treeHeatMap:SetAnchor("LEFT",self.controls.treeSearch,"RIGHT",nil,nil,nil)
@@ -171,7 +171,7 @@ function TreeTabClass:Draw(viewPort, inputEvents)
 		self.controls.treeHeatMap.x = 130
 
 		self.controls.specSelect.y = 0
-		self.controls.specConvertText.y = self.controls.specConvertText.y + 2
+		self.controls.specConvertText.y = -14
 	end
 	--
 

--- a/Classes/TreeTab.lua
+++ b/Classes/TreeTab.lua
@@ -19,7 +19,7 @@ local TreeTabClass = newClass("TreeTab", "ControlHost", function(self, build)
 	self:SetActiveSpec(1)
 
 	self.anchorControls = new("Control", nil, 0, 0, 0, 20)
-	self.controls.specSelect = new("DropDownControl", {"LEFT",self.anchorControls,"RIGHT"}, 0, -22, 190, 20, nil, function(index, value)
+	self.controls.specSelect = new("DropDownControl", {"LEFT",self.anchorControls,"RIGHT"}, 0, -24, 190, 20, nil, function(index, value)
 		if self.specList[index] then
 			self.build.modFlag = true
 			self:SetActiveSpec(index)
@@ -146,7 +146,7 @@ function TreeTabClass:Draw(viewPort, inputEvents)
 	end
 	self:ProcessControlsInput(inputEvents, viewPort)
 
-	local treeViewPort = { x = viewPort.x, y = viewPort.y, width = viewPort.width, height = viewPort.height - (self.showConvert and 86 or 54) }
+	local treeViewPort = { x = viewPort.x, y = viewPort.y, width = viewPort.width, height = viewPort.height - (self.showConvert and 90 or 58) }
 	self.viewer:Draw(self.build, treeViewPort, inputEvents)
 
 	self.controls.specSelect.selIndex = self.activeSpec
@@ -171,15 +171,15 @@ function TreeTabClass:Draw(viewPort, inputEvents)
 	SetDrawLayer(1)
 
 	SetDrawColor(0.05, 0.05, 0.05)
-	DrawImage(nil, viewPort.x, viewPort.y + viewPort.height - 50, viewPort.width, 50)
+	DrawImage(nil, viewPort.x, viewPort.y + viewPort.height - 54, viewPort.width, 54)
 	SetDrawColor(0.85, 0.85, 0.85)
-	DrawImage(nil, viewPort.x, viewPort.y + viewPort.height - 54, viewPort.width, 4)
+	DrawImage(nil, viewPort.x, viewPort.y + viewPort.height - 58, viewPort.width, 4)
 
 	if self.showConvert then
 		SetDrawColor(0.05, 0.05, 0.05)
-		DrawImage(nil, viewPort.x, viewPort.y + viewPort.height - 82, viewPort.width, 28)
+		DrawImage(nil, viewPort.x, viewPort.y + viewPort.height - 86, viewPort.width, 28)
 		SetDrawColor(0.85, 0.85, 0.85)
-		DrawImage(nil, viewPort.x, viewPort.y + viewPort.height - 86, viewPort.width, 4)
+		DrawImage(nil, viewPort.x, viewPort.y + viewPort.height - 90, viewPort.width, 4)
 	end
 
 	self:DrawControls(viewPort)

--- a/Classes/TreeTab.lua
+++ b/Classes/TreeTab.lua
@@ -19,7 +19,7 @@ local TreeTabClass = newClass("TreeTab", "ControlHost", function(self, build)
 	self:SetActiveSpec(1)
 
 	self.anchorControls = new("Control", nil, 0, 0, 0, 20)
-	self.controls.specSelect = new("DropDownControl", {"LEFT",self.anchorControls,"RIGHT"}, 0, 0, 190, 20, nil, function(index, value)
+	self.controls.specSelect = new("DropDownControl", {"LEFT",self.anchorControls,"RIGHT"}, 0, -22, 190, 20, nil, function(index, value)
 		if self.specList[index] then
 			self.build.modFlag = true
 			self:SetActiveSpec(index)
@@ -81,7 +81,7 @@ local TreeTabClass = newClass("TreeTab", "ControlHost", function(self, build)
 	self.controls.treeSearch = new("EditControl", {"LEFT",self.controls.export,"RIGHT"}, 8, 0, 300, 20, "", "Search", "%c%(%)", 100, function(buf)
 		self.viewer.searchStr = buf
 	end)
-	self.controls.treeHeatMap = new("CheckBoxControl", {"LEFT",self.controls.treeSearch,"RIGHT"}, 130, 0, 20, "Show Node Power:", function(state)	
+	self.controls.treeHeatMap = new("CheckBoxControl", {"BOTTOMLEFT",self.controls.specSelect,"BOTTOMLEFT"}, 125, 24, 20, "Show Node Power:", function(state)
 		self.viewer.showHeatMap = state
 		self.controls.treeHeatMapStatSelect.shown = state
 	end)
@@ -100,11 +100,11 @@ local TreeTabClass = newClass("TreeTab", "ControlHost", function(self, build)
 		end
 	end
 
-	self.controls.treeHeatMapTopStat = new("CheckBoxControl", {"LEFT", self.controls.treeHeatMapStatSelect,"RIGHT"}, 130, 0, 20, "Show only top stat:", function(state)
+	self.controls.treeHeatMapTopStat = new("CheckBoxControl", {"LEFT", self.controls.treeHeatMapStatSelect,"RIGHT"}, 110, 0, 20, "Show top node:", function(state)
 		self.viewer.heatMapTopPick = state
 	end )
 
-	self.controls.treeHeatMapStatPerPoint = new("CheckBoxControl", {"LEFT", self.controls.treeHeatMapTopStat,"RIGHT"}, 75, 0, 20, "Per point?", function(state)
+	self.controls.treeHeatMapStatPerPoint = new("CheckBoxControl", {"LEFT", self.controls.treeHeatMapTopStat,"RIGHT"}, 115, 0, 20, "Power per point:", function(state)
 		self.viewer.heatMapStatPerPoint = state
 	end )
 
@@ -146,7 +146,7 @@ function TreeTabClass:Draw(viewPort, inputEvents)
 	end
 	self:ProcessControlsInput(inputEvents, viewPort)
 
-	local treeViewPort = { x = viewPort.x, y = viewPort.y, width = viewPort.width, height = viewPort.height - (self.showConvert and 64 or 32) }
+	local treeViewPort = { x = viewPort.x, y = viewPort.y, width = viewPort.width, height = viewPort.height - (self.showConvert and 86 or 54) }
 	self.viewer:Draw(self.build, treeViewPort, inputEvents)
 
 	self.controls.specSelect.selIndex = self.activeSpec
@@ -171,15 +171,15 @@ function TreeTabClass:Draw(viewPort, inputEvents)
 	SetDrawLayer(1)
 
 	SetDrawColor(0.05, 0.05, 0.05)
-	DrawImage(nil, viewPort.x, viewPort.y + viewPort.height - 28, viewPort.width, 28)
+	DrawImage(nil, viewPort.x, viewPort.y + viewPort.height - 50, viewPort.width, 50)
 	SetDrawColor(0.85, 0.85, 0.85)
-	DrawImage(nil, viewPort.x, viewPort.y + viewPort.height - 32, viewPort.width, 4)
+	DrawImage(nil, viewPort.x, viewPort.y + viewPort.height - 54, viewPort.width, 4)
 
 	if self.showConvert then
 		SetDrawColor(0.05, 0.05, 0.05)
-		DrawImage(nil, viewPort.x, viewPort.y + viewPort.height - 60, viewPort.width, 28)
+		DrawImage(nil, viewPort.x, viewPort.y + viewPort.height - 82, viewPort.width, 28)
 		SetDrawColor(0.85, 0.85, 0.85)
-		DrawImage(nil, viewPort.x, viewPort.y + viewPort.height - 64, viewPort.width, 4)
+		DrawImage(nil, viewPort.x, viewPort.y + viewPort.height - 86, viewPort.width, 4)
 	end
 
 	self:DrawControls(viewPort)

--- a/Classes/TreeTab.lua
+++ b/Classes/TreeTab.lua
@@ -83,6 +83,7 @@ local TreeTabClass = newClass("TreeTab", "ControlHost", function(self, build)
 	end)
 	self.controls.treeHeatMap = new("CheckBoxControl", {"LEFT",self.controls.treeSearch,"RIGHT"}, 130, 0, 20, "Show Node Power:", function(state)	
 		self.viewer.showHeatMap = state
+		self.controls.treeHeatMapStatSelect.shown = state
 	end)
 	self.controls.treeHeatMapStatSelect = new("DropDownControl", {"LEFT",self.controls.treeHeatMap,"RIGHT"}, 8, 0, 150, 20, nil, function(index, value)
 		self:SetPowerCalc(value)
@@ -98,6 +99,15 @@ local TreeTabClass = newClass("TreeTab", "ControlHost", function(self, build)
 			t_insert(self.powerStatList, stat)
 		end
 	end
+
+	self.controls.treeHeatMapTopStat = new("CheckBoxControl", {"LEFT", self.controls.treeHeatMapStatSelect,"RIGHT"}, 130, 0, 20, "Show only top stat:", function(state)
+		self.viewer.heatMapTopPick = state
+	end )
+
+	self.controls.treeHeatMapStatPerPoint = new("CheckBoxControl", {"LEFT", self.controls.treeHeatMapTopStat,"RIGHT"}, 75, 0, 20, "Per point?", function(state)
+		self.viewer.heatMapStatPerPoint = state
+	end )
+
 	self.controls.specConvertText = new("LabelControl", {"BOTTOMLEFT",self.controls.specSelect,"TOPLEFT"}, 0, -14, 0, 16, "^7This is an older tree version, which may not be fully compatible with the current game version.")
 	self.controls.specConvertText.shown = function()
 		return self.showConvert


### PR DESCRIPTION
Did some hacking on the heatmap to show the top node and the best nodes per-point.  This is a first step towards providing a list of the best nodes to take to improve your various stats.  Easy changes from here would be to show more than the topmost choice, and show a few more; allow the user to input a limit on how far away to search; color scaling tweaks; and changes in the UI.

Choice UI:
![image](https://user-images.githubusercontent.com/1209372/86730429-244a5c80-bff4-11ea-9dca-8f87edaddf4e.png)

Random tree with life power selected, production build:
![image](https://user-images.githubusercontent.com/1209372/86660944-d2ccae00-bfb0-11ea-9c9f-6604bb8b4b4f.png)

Top stat checked (Showing Discipline and Training, in this case):
![image](https://user-images.githubusercontent.com/1209372/86660997-e11aca00-bfb0-11ea-8d50-6289da3e5fd3.png)

Per point checked:
![image](https://user-images.githubusercontent.com/1209372/86661083-fa237b00-bfb0-11ea-9b83-18c7daa960ae.png)

Both checked (Now showing Herbalism):
![image](https://user-images.githubusercontent.com/1209372/86661125-0576a680-bfb1-11ea-986f-1c00254c4d5e.png)

