### PR TITLE
Implement Eye of Malice unique helmet

### DIFF
--- a/Modules/CalcOffence-3_0.lua
+++ b/Modules/CalcOffence-3_0.lua
@@ -1290,7 +1290,8 @@ function calcs.offence(env, actor, activeSkill)
 						else
 							resist = enemyDB:Sum("BASE", nil, damageType.."Resist")
 							if isElemental[damageType] then
-								resist = resist + enemyDB:Sum("BASE", nil, "ElementalResist")
+								local base = resist + enemyDB:Sum("BASE", nil, "ElementalResist")
+								resist = base * calcLib.mod(enemyDB, nil, damageType.."Resist")
 								pen = skillModList:Sum("BASE", cfg, damageType.."Penetration", "ElementalPenetration")
 								takenInc = takenInc + enemyDB:Sum("INC", nil, "ElementalDamageTaken")
 							elseif damageType == "Chaos" then
@@ -1624,7 +1625,8 @@ function calcs.offence(env, actor, activeSkill)
 				else
 					resist = enemyDB:Sum("BASE", nil, damageType.."Resist")
 					if isElemental[damageType] then
-						resist = resist + enemyDB:Sum("BASE", dotTypeCfg, "ElementalResist")
+						local base = resist + enemyDB:Sum("BASE", dotTypeCfg, "ElementalResist")
+						resist = base * calcLib.mod(enemyDB, nil, damageType.."Resist")
 						takenInc = takenInc + enemyDB:Sum("INC", dotTypeCfg, "ElementalDamageTaken")
 					end
 					resist = m_min(resist, data.misc.EnemyMaxResist)

--- a/Modules/ModParser-3_0.lua
+++ b/Modules/ModParser-3_0.lua
@@ -1951,6 +1951,10 @@ local specialModList = {
 	["cold resistance is (%d+)%%"] = function(num) return { mod("ColdResist", "OVERRIDE", num) } end,
 	["lightning resistance is (%d+)%%"] = function(num) return { mod("LightningResist", "OVERRIDE", num) } end,
 	["chaos resistance is doubled"] = { mod("ChaosResist", "MORE", 100) },
+	["nearby enemies have (%d+)%% increased fire and cold resistances"] = function(num) return { 
+		mod("EnemyModifier", "LIST", { mod = mod("FireResist", "INC", num) }),
+		mod("EnemyModifier", "LIST", { mod = mod("ColdResist", "INC", num) }),
+	} end,
 	["armour is increased by uncapped fire resistance"] = { mod("Armour", "INC", 1, { type = "PerStat", stat = "FireResistTotal", div = 1 }) },
 	["evasion rating is increased by uncapped cold resistance"] = { mod("Evasion", "INC", 1, { type = "PerStat", stat = "ColdResistTotal", div = 1 }) },
 	["reflects (%d+) physical damage to melee attackers"] = { },


### PR DESCRIPTION
- Adds parsing and support for Eye of Malice unique helmet
![image](https://user-images.githubusercontent.com/39030429/86946112-864bb480-c10f-11ea-915c-1f46f7d3953e.png)


This required changing CalcOffence to support modifiers to enemy resistances other than simply adding or subtracting. Tested on a few builds and couldn't find any other effects of this change (comparing DPS numbers and the effective DPS multiplier).