### PR TITLE
Improved tooltip for cluster jewel notables

### DIFF
--- a/Classes/ItemsTab.lua
+++ b/Classes/ItemsTab.lua
@@ -541,6 +541,56 @@ If there's 2 slots an item can go in, holding Shift will put it in the second.]]
 					if mod.modTags and #mod.modTags > 0 then
 						tooltip:AddLine(16, "Tags: "..table.concat(mod.modTags, ', '))
 					end
+
+					local notableName = mod[1] and mod[1]:match("1 Added Passive Skill is (.*)")
+					local node = notableName and self.build.spec.tree.clusterNodeMap[notableName]
+					if node then
+						tooltip:AddSeparator(14)
+
+						-- Node name
+						self.socketViewer:AddNodeName(tooltip, node, self.build)
+
+						-- Node description
+						if node.sd[1] then
+							tooltip:AddLine(16, "")
+							for i, line in ipairs(node.sd) do
+								tooltip:AddLine(16, ((node.mods[i].extra or not node.mods[i].list) and colorCodes.UNSUPPORTED or colorCodes.MAGIC)..line)
+							end
+						end
+
+						-- Reminder text
+						if node.reminderText then
+							tooltip:AddSeparator(14)
+							for _, line in ipairs(node.reminderText) do
+								tooltip:AddLine(14, "^xA0A080"..line)
+							end
+						end
+
+						-- Comparison
+						tooltip:AddSeparator(14)
+						self:AppendAnointTooltip(tooltip, node, "Allocating")
+
+						-- Information of for this notable appears
+						local clusterInfo = self.build.data.clusterJewelInfoForNotable[notableName]
+						if clusterInfo then
+							tooltip:AddSeparator(14)
+							tooltip:AddLine(20, "^7"..notableName.." can appear on:")
+							local isFirstSize = true
+							for size, v in pairs(clusterInfo.size) do
+								tooltip:AddLine(18, colorCodes.MAGIC..size..":")
+								local sizeSkills = self.build.data.clusterJewels.jewels[size].skills
+								for i, type in ipairs(clusterInfo.jewelTypes) do
+									if sizeSkills[type] then
+										tooltip:AddLine(14, "^7    "..sizeSkills[type].name)
+									end
+								end
+								if not isFirstSize then
+									tooltip:AddLine(10, "")
+								end
+								isFirstSize = false
+							end
+						end
+					end
 				else
 					tooltip:AddLine(16, "^7"..#modList.." Tiers")
 					local minMod = self.displayItem.affixes[modList[1]]
@@ -1803,15 +1853,19 @@ end
 ---Appends tooltip information for anointing a new passive tree node onto the currently editing amulet
 ---@param tooltip table @The tooltip to append into
 ---@param node table @The passive tree node that will be anointed, or nil to remove the current anoint.
-function ItemsTabClass:AppendAnointTooltip(tooltip, node)
+function ItemsTabClass:AppendAnointTooltip(tooltip, node, actionText)
 	if not self.displayItem then
 		return
+	end
+
+	if not actionText then
+		actionText = "Anointing"
 	end
 
 	local header
 	if node then
 		if self.build.spec.allocNodes[node.id] then
-			tooltip:AddLine(14, "^7Anointing "..node.dn.." changes nothing because this node is already allocated on the tree.")
+			tooltip:AddLine(14, "^7"..actionText.." "..node.dn.." changes nothing because this node is already allocated on the tree.")
 			return
 		end
 
@@ -1819,22 +1873,22 @@ function ItemsTabClass:AppendAnointTooltip(tooltip, node)
 		if curAnoints and #curAnoints > 0 then
 			for _, curAnoint in ipairs(curAnoints) do
 				if curAnoint == node.dn then
-					tooltip:AddLine(14, "^7Anointing "..node.dn.." changes nothing because this node is already anointed.")
+					tooltip:AddLine(14, "^7"..actionText.." "..node.dn.." changes nothing because this node is already anointed.")
 					return
 				end
 			end
 		end
 
-		header = "^7Anointing "..node.dn.." will give you: "
+		header = "^7"..actionText.." "..node.dn.." will give you: "
 	else
-		header = "^7Anointing nothing will give you: "
+		header = "^7"..actionText.." nothing will give you: "
 	end
 	local calcFunc = self.build.calcsTab:GetMiscCalculator()
 	local outputBase = calcFunc({ repSlotName = "Amulet", repItem = self.displayItem })
 	local outputNew = calcFunc({ repSlotName = "Amulet", repItem = self:anointItem(node) })
 	local numChanges = self.build:AddStatComparesToTooltip(tooltip, outputBase, outputNew, header)
 	if node and numChanges == 0 then
-		tooltip:AddLine(14, "^7Anointing "..node.dn.." changes nothing.")
+		tooltip:AddLine(14, "^7"..actionText.." "..node.dn.." changes nothing.")
 	end
 end
 

--- a/Modules/Data.lua
+++ b/Modules/Data.lua
@@ -273,6 +273,44 @@ for _, targetVersion in ipairs(targetVersionList) do
 	-- Cluster jewel data
 	if targetVersion ~= "2_6" then	
 		verData.clusterJewels = dataModule("ClusterJewels")
+
+		-- Create a quick lookup cache from cluster jewel skill to the notables which use that skill
+		---@type table<string, table<string>>
+		local clusterSkillToNotables = { }
+		for notableKey, notableInfo in pairs(verData.itemMods.JewelCluster) do
+			-- Translate the notable key to its name
+			local notableName = notableInfo[1] and notableInfo[1]:match("1 Added Passive Skill is (.*)")
+			if notableName then
+				for weightIndex, clusterSkill in pairs(notableInfo.weightKey) do
+					if notableInfo.weightVal[weightIndex] > 0 then
+						if not clusterSkillToNotables[clusterSkill] then
+							clusterSkillToNotables[clusterSkill] = { }
+						end
+						table.insert(clusterSkillToNotables[clusterSkill], notableName)
+					end
+				end
+			end
+		end
+
+		-- Create easy lookup from cluster node name -> cluster jewel size and types
+		verData.clusterJewelInfoForNotable = { }
+		for size, jewel in pairs(verData.clusterJewels.jewels) do
+			for skill, skillInfo in pairs(jewel.skills) do
+				local notables = clusterSkillToNotables[skill]
+				if notables then
+					for _, notableKey in ipairs(notables) do
+						if not verData.clusterJewelInfoForNotable[notableKey] then
+							verData.clusterJewelInfoForNotable[notableKey] = { }
+							verData.clusterJewelInfoForNotable[notableKey].jewelTypes = { }
+							verData.clusterJewelInfoForNotable[notableKey].size = { }
+						end
+						local curJewelInfo = verData.clusterJewelInfoForNotable[notableKey]
+						curJewelInfo.size[size] = true
+						table.insert(curJewelInfo.jewelTypes, skill)
+					end
+				end
+			end
+		end
 	end
 
 	-- Load skills


### PR DESCRIPTION
When hovering a cluster jewel notable in the prefix/suffix dropdowns, the tooltip now shows the following:
 - What the notable does
 - Comparison if the notable is allocated
 - What cluster jewel types this notable appears on

![image](https://user-images.githubusercontent.com/10701249/87182911-ee2e0680-c299-11ea-9c54-d4efad0d2520.png)
