### PR TITLE
Emberwake ignite duration

### DIFF
--- a/Data/Uniques/ring.lua
+++ b/Data/Uniques/ring.lua
@@ -390,7 +390,7 @@ Implicits: 1
 {variant:1}Your Critical Strikes do not deal extra Damage
 {variant:1}80% less Burning Damage
 {variant:2}Ignited Enemies Burn 65% slower
-{variant:3}Ignited Enemies Burn 50% slower
+{variant:3}Ignited Enemies Burn (65-50)% slower
 ]],[[
 Essence Worm
 Unset Ring


### PR DESCRIPTION
The ignite duration mod is meant to be a range not a static value as of 3.9