### PR TITLE
Fix Earthshatter AoE mod

### DIFF
--- a/Data/3_0/Skills/act_str.lua
+++ b/Data/3_0/Skills/act_str.lua
@@ -1836,7 +1836,7 @@ skills["SpikeSlam"] = {
 			mod("Damage", "MORE", nil, 0, 0, { type = "SkillPart", skillPart = 2 }),
 		},
 		["active_skill_area_of_effect_+%_final"] = {
-			skill("AreaOfEffect", "MORE", nil, 0, 0, { type = "SkillPart", skillPart = 1 }),
+			mod("AreaOfEffect", "MORE", nil),
 		},
 	},
 	baseFlags = {

--- a/Export/Skills/act_str.txt
+++ b/Export/Skills/act_str.txt
@@ -317,7 +317,7 @@ local skills, mod, flag, skill = ...
 			mod("Damage", "MORE", nil, 0, 0, { type = "SkillPart", skillPart = 2 }),
 		},
 		["active_skill_area_of_effect_+%_final"] = {
-			skill("AreaOfEffect", "MORE", nil, 0, 0, { type = "SkillPart", skillPart = 1 }),
+			mod("AreaOfEffect", "MORE", nil),
 		},
 	},
 #mods


### PR DESCRIPTION
Whoever did the StatMap on Earthshatter mistakenly put "skill(" at the start of its AoE mod instead of "mod(". There's also no indication that the AoE mod only applies to the main slam, so I removed the type = skillPart on it.