### PR TITLE
Split mod on Abhorrent Interrogation gloves

### DIFF
--- a/Data/Uniques/gloves.lua
+++ b/Data/Uniques/gloves.lua
@@ -609,7 +609,8 @@ Requires Level 45, 35 Dex, 35 Int
 (100-150)% increased Evasion and Energy Shield
 (5-7)% increased Attack and Cast Speed
 (20-25)% chance to inflict Withered for 2 seconds on Hit
-Enemies take 4% increased Elemental Damage from your Hits for each Withered you have inflicted on them
+Enemies take 4% increased Elemental Damage from your Hits for
+each Withered you have inflicted on them
 Your Hits cannot Penetrate or ignore Elemental Resistances
 ]],[[
 Algor Mortis


### PR DESCRIPTION
- Splits withered mod into two lines, like how it is when you copy/paste the item from trade website or from in-game
- When I originally added the item I never bothered to look at how it was entered in the unique DB, only looked at the one I copied from the trade website. My bad!