### PR TITLE
Correct Arcane Surge scaling

### DIFF
--- a/Data/3_0/Skills/sup_int.lua
+++ b/Data/3_0/Skills/sup_int.lua
@@ -243,7 +243,7 @@ skills["SupportArcaneSurge"] = {
 		},
 		["support_arcane_surge_mana_regeneration_rate_per_minute_%"] = {
 			mod("ManaRegenPercent", "BASE", nil, 0, 0, { type = "GlobalEffect", effectType = "Buff", effectName = "Arcane Surge" }),
-			div = 60,
+			div = 60.0001,
 		},
 		["support_arcane_surge_spell_damage_+%_final"] = {
 			mod("Damage", "MORE", nil, ModFlag.Spell, 0, { type = "GlobalEffect", effectType = "Buff", effectName = "Arcane Surge" }),

--- a/Export/Skills/sup_int.txt
+++ b/Export/Skills/sup_int.txt
@@ -34,7 +34,7 @@ local skills, mod, flag, skill = ...
 		},
 		["support_arcane_surge_mana_regeneration_rate_per_minute_%"] = {
 			mod("ManaRegenPercent", "BASE", nil, 0, 0, { type = "GlobalEffect", effectType = "Buff", effectName = "Arcane Surge" }),
-			div = 60,
+			div = 60.0001,
 		},
 		["support_arcane_surge_spell_damage_+%_final"] = {
 			mod("Damage", "MORE", nil, ModFlag.Spell, 0, { type = "GlobalEffect", effectType = "Buff", effectName = "Arcane Surge" }),

--- a/Modules/CalcPerform.lua
+++ b/Modules/CalcPerform.lua
@@ -933,7 +933,7 @@ function calcs.perform(env)
 						activeSkill.buffSkill = true
 						modDB.conditions["AffectedBy"..buff.name:gsub(" ","")] = true
 						local srcList = new("ModList")
-						local inc = modStore:Sum("INC", skillCfg, "BuffEffect", "BuffEffectOnSelf", "BuffEffectOnPlayer")
+						local inc = modStore:Sum("INC", skillCfg, "BuffEffect", "BuffEffectOnSelf", "BuffEffectOnPlayer", buff.name:gsub(" ", "").."Effect")
 						local more = modStore:More(skillCfg, "BuffEffect", "BuffEffectOnSelf")
 						srcList:ScaleAddList(buff.modList, (1 + inc / 100) * more)
 						mergeBuff(srcList, buffs, buff.name)

--- a/Modules/ModParser-3_0.lua
+++ b/Modules/ModParser-3_0.lua
@@ -251,6 +251,7 @@ local modNameList = {
 	["effect of auras from mines"] = { "AuraEffect", keywordFlags = KeywordFlag.Mine },
 	["curse effect"] = "CurseEffect",
 	["effect of curses applied by bane"] = { "CurseEffect", tag = { type = "Condition", var = "AppliedByBane" } },
+	["effect of arcane surge on you"] = "ArcaneSurgeEffect",
 	["curse duration"] = { "Duration", keywordFlags = KeywordFlag.Curse },
 	["radius of auras"] = { "AreaOfEffect", keywordFlags = KeywordFlag.Aura },
 	["radius of curses"] = { "AreaOfEffect", keywordFlags = KeywordFlag.Curse },


### PR DESCRIPTION
- Causes all generic buffs to be scaled by "\<buff name\>Effect", which will not affect anything unintended because any other "\<buff name\>Effect" mods are scaled in unique ways ie Curses and Tailwind, and other buffs use BuffEffect with skillTypes or skillNames ie Heralds and Golems
- Adds "ArcaneSurgeEffect" parsing to use that new scaling
- Changes the div on the Mana Regen from Arcane Surge, because for some reason when the mod was equal to 1%, like at level 20, it wasn't being scaled (but was being scaled at all other values). The .0001 extra makes effectively zero difference after rounding

![image](https://user-images.githubusercontent.com/39030429/87344833-b7aff000-c514-11ea-8327-75a21d2cb42c.png)

There is another open Arcane Surge PR over at #826 , but it's *significantly* more complicated than what I did here, so I'd like to open this one anyway. It's been open for a couple of months and not merged so perhaps a simpler one like this can get merged more easily.