### PR TITLE
Fix Vinktar crash and a couple of OVERRIDE -> BASE

### DIFF
--- a/Modules/CalcPerform.lua
+++ b/Modules/CalcPerform.lua
@@ -1264,6 +1264,9 @@ function calcs.perform(env)
 			local mod = value.mod
 			local inc = 1 + modDB:Sum("INC", nil, "EnemyShockEffect") / 100
 			local effect = mod.value
+			if mod.name == "ShockOverride" then
+				enemyDB:NewMod("Condition:Shocked", "FLAG", true, mod.source)
+			end
 			if mod.name == "ShockBase" then
 				effect = effect * inc
 				modDB:NewMod("ShockOverride", "BASE", effect, mod.source, mod.flags, mod.keywordFlags, unpack(mod))

--- a/Modules/ModParser-3_0.lua
+++ b/Modules/ModParser-3_0.lua
@@ -1707,7 +1707,7 @@ local specialModList = {
 		mod("ShockBase", "BASE", 15, { type = "Condition", var = "Focused" }),
 		mod("EnemyModifier", "LIST", { mod = flag("Condition:Shocked") }, { type = "Condition", var = "Focused" } ),
 	},
-	["drops shocked ground while moving, lasting (%d+) seconds"] = { mod("ShockOverride", "OVERRIDE", 10, { type = "ActorCondition", actor = "enemy", var = "OnShockedGround"} ) },
+	["drops shocked ground while moving, lasting (%d+) seconds"] = { mod("ShockOverride", "BASE", 10, { type = "ActorCondition", actor = "enemy", var = "OnShockedGround"} ) },
 	-- Bleed
 	["melee attacks cause bleeding"] = { mod("BleedChance", "BASE", 100, nil, ModFlag.Melee) },
 	["attacks cause bleeding when hitting cursed enemies"] = { mod("BleedChance", "BASE", 100, nil, ModFlag.Attack, { type = "ActorCondition", actor = "enemy", var = "Cursed" }) },
@@ -2040,8 +2040,7 @@ local specialModList = {
 	["zealot's oath during flask effect"] = { mod("ZealotsOath", "FLAG", true, { type = "Condition", var = "UsingFlask" }) },
 	["grants level (%d+) (.+) curse aura during flask effect"] = function(num, _, skill) return { mod("ExtraCurse", "LIST", { skillId = gemIdLookup[skill:gsub(" skill","")] or "Unknown", level = num }, { type = "Condition", var = "UsingFlask" }) } end,
 	["shocks nearby enemies during flask effect, causing (%d+)%% increased damage taken"] = function(num) return { 
-		mod("EnemyModifier", "LIST", { mod = mod("Condition:Shocked", "FLAG", true) } ),
-		mod("ShockOverride", "OVERRIDE", num)
+		mod("ShockOverride", "BASE", num, { type = "Condition", var = "UsingFlask" } )
 	} end,
 	["during flask effect, (%d+)%% reduced damage taken of each element for which your uncapped elemental resistance is lowest"] = function(num) return {
 		mod("LightningDamageTaken", "INC", -num, { type = "StatThreshold", stat = "LightningResistTotal", thresholdStat = "ColdResistTotal", upper = true }, { type = "StatThreshold", stat = "LightningResistTotal", thresholdStat = "FireResistTotal", upper = true }),


### PR DESCRIPTION
- Fixes a crash on Vessel of Vinktar that was caused by setting the Shocked flag on the flask then scaling the flag by flask effect
- Changes Vinktar and Wake of Destruction to give BASE ShockOverride instead of OVERRIDE, which was a change I made to other ShockOverride sources late in the last PR and missed here

The "Shocked" flag on the enemy is now set anytime you have ShockOverride BASE. Every source of ShockOverride has some other condition on it (using flask, on shocked ground, or Summon Skitterbots) so this is only a functional change for Vessel of Vinktar.