### PR TITLE
Fix Rallying Cry damage cap and config

### DIFF
--- a/Data/3_0/Skills/act_str.lua
+++ b/Data/3_0/Skills/act_str.lua
@@ -4110,6 +4110,7 @@ skills["RallyingCry"] = {
 		},
 		["rallying_cry_weapon_damage_%_for_allies_per_5_monster_power"] = {
 			mod("RallyingCryAllyDamageBonusPer5Power", "BASE", nil),
+			mod("Dummy", "DUMMY", 1, 0, 0, { type = "Multiplier", var = "NearbyAlly"}),
 		},
 		["rallying_cry_buff_effect_on_minions_+%_final"] = {
 			mod("RallyingCryMinionDamageBonusMultiplier", "BASE", nil),

--- a/Export/Skills/act_str.txt
+++ b/Export/Skills/act_str.txt
@@ -705,6 +705,7 @@ local skills, mod, flag, skill = ...
 		},
 		["rallying_cry_weapon_damage_%_for_allies_per_5_monster_power"] = {
 			mod("RallyingCryAllyDamageBonusPer5Power", "BASE", nil),
+			mod("Dummy", "DUMMY", 1, 0, 0, { type = "Multiplier", var = "NearbyAlly"}),
 		},
 		["rallying_cry_buff_effect_on_minions_+%_final"] = {
 			mod("RallyingCryMinionDamageBonusMultiplier", "BASE", nil),

--- a/Modules/CalcOffence-3_0.lua
+++ b/Modules/CalcOffence-3_0.lua
@@ -1204,7 +1204,7 @@ function calcs.offence(env, actor, activeSkill, skillLookupOnly)
 					output.RallyingUpTimeRatio = m_min((numRallyingExerts / output.Speed) / (output.RallyingCryCooldown + output.RallyingCryCastTime), 1)
 					exertedUptime = m_max(exertedUptime, output.RallyingUpTimeRatio)
 					-- Add the average 'More' multiplier on damage accounting for uptime
-					output.RallyingHitEffect = 1 + env.modDB:Sum("BASE", cfg, "Multiplier:NearbyAlly") * (env.modDB:Sum("BASE", nil, "RallyingExertMoreDamagePerAlly") / 100) * output.RallyingUpTimeRatio
+					output.RallyingHitEffect = 1 + m_min(env.modDB:Sum("BASE", cfg, "Multiplier:NearbyAlly"), 5) * (env.modDB:Sum("BASE", nil, "RallyingExertMoreDamagePerAlly") / 100) * output.RallyingUpTimeRatio
 				end
 			end
 		end


### PR DESCRIPTION
The damage per minion was not capped to 5 nearby allies and the config was also not showing up properly