### PR TITLE
Fix imported Conqueror influences

### DIFF
--- a/Classes/ImportTab.lua
+++ b/Classes/ImportTab.lua
@@ -640,8 +640,10 @@ function ImportTabClass:ImportItem(itemData, slotName)
 
 	-- Import item data
 	item.uniqueID = itemData.id
-	for _, curInfluenceInfo in ipairs(influenceInfo) do
-		item[curInfluenceInfo.key] = itemData[curInfluenceInfo.key]
+	if itemData.influences then
+		for _, curInfluenceInfo in ipairs(influenceInfo) do
+			item[curInfluenceInfo.key] = itemData.influences[curInfluenceInfo.display:lower()]
+		end
 	end
 	if itemData.ilvl > 0 then
 		item.itemLevel = itemData.ilvl


### PR DESCRIPTION
![Image](https://user-images.githubusercontent.com/39774255/87616283-b3bbe200-c74f-11ea-80ef-ff8aac2d85b4.PNG)
Fixes item import process still following shaper/elder era format, effectively "ignoring" conqueror influences.
Add modifier > Pre/Suffix now works without hand-editing the imported item.