### PR TITLE
Fix minion skills supported by CwC and Arcanist Brand

### DIFF
--- a/Data/3_0/SkillStatMap.lua
+++ b/Data/3_0/SkillStatMap.lua
@@ -1235,7 +1235,7 @@ return {
 },
 -- Other
 ["triggered_skill_damage_+%"] = {
-	mod("Damage", "INC", nil, 0, 0, { type = "SkillType", skillType = SkillType.Triggered }),
+	mod("TriggeredDamage", "INC", nil, 0, 0, { type = "SkillType", skillType = SkillType.Triggered }),
 },
 ["channelled_skill_damage_+%"] = {
 	mod("Damage", "INC", nil, 0, 0, { type = "SkillType", skillType = SkillType.Channelled }),

--- a/Data/3_0/Skills/act_int.lua
+++ b/Data/3_0/Skills/act_int.lua
@@ -6838,13 +6838,13 @@ skills["SupportBrandSupport"] = {
 	statDescriptionScope = "gem_stat_descriptions",
 	statMap = {
 		["support_brand_damage_+%_final"] = {
-			mod("Damage", "MORE", nil),
+			mod("TriggeredDamage", "MORE", nil),
 		},
 		["support_brand_area_of_effect_+%_final"] = {
 			mod("AreaOfEffect", "MORE", nil),
 		},
 		["trigger_brand_support_hit_ailment_damage_+%_final_vs_branded_enemy"] = {
-			mod("Damage", "MORE", nil, 0, 0, { type = "Condition", var = "TargetingBrandedEnemy"}),
+			mod("TriggeredDamage", "MORE", nil, 0, 0, { type = "Condition", var = "TargetingBrandedEnemy"}),
 		},
 	},
 	addSkillTypes = { SkillType.Brand, },

--- a/Data/3_0/Skills/sup_int.lua
+++ b/Data/3_0/Skills/sup_int.lua
@@ -635,7 +635,7 @@ skills["SupportCastWhileChannelling"] = {
 	statDescriptionScope = "gem_stat_descriptions",
 	statMap = {
 		["cast_while_channelling_time_ms"] = {
-			skill("triggerTime", nil),
+			skill("triggerTime", nil, { type = "SkillType", skillType = SkillType.Channelled } ),
 			div = 1000,
 		},
 	},
@@ -701,7 +701,7 @@ skills["SupportCastWhileChannellingTriggered"] = {
 	statDescriptionScope = "gem_stat_descriptions",
 	statMap = {
 		["support_cast_while_channelling_triggered_skill_damage_+%_final"] = {
-			mod("Damage", "MORE", nil, 0, 0, { type = "SkillType", skillType = SkillType.Triggerable }),
+			mod("TriggeredDamage", "MORE", nil, 0, 0, { type = "SkillType", skillType = SkillType.Triggerable }),
 		},
 	},
 	baseMods = {
@@ -770,7 +770,7 @@ skills["SupportCastWhileChannellingPlus"] = {
 	statDescriptionScope = "gem_stat_descriptions",
 	statMap = {
 		["cast_while_channelling_time_ms"] = {
-			skill("triggerTime", nil),
+			skill("triggerTime", nil, { type = "SkillType", skillType = SkillType.Channelled } ),
 			div = 1000,
 		},
 	},
@@ -817,7 +817,7 @@ skills["SupportCastWhileChannellingTriggeredPlus"] = {
 	statDescriptionScope = "gem_stat_descriptions",
 	statMap = {
 		["support_cast_while_channelling_triggered_skill_damage_+%_final"] = {
-			mod("Damage", "MORE", nil, 0, 0, { type = "SkillType", skillType = SkillType.Triggerable }),
+			mod("TriggeredDamage", "MORE", nil, 0, 0, { type = "SkillType", skillType = SkillType.Triggerable }),
 		},
 	},
 	baseMods = {

--- a/Export/Skills/act_int.txt
+++ b/Export/Skills/act_int.txt
@@ -1181,13 +1181,13 @@ local skills, mod, flag, skill = ...
 #skill SupportBrandSupport
 	statMap = {
 		["support_brand_damage_+%_final"] = {
-			mod("Damage", "MORE", nil),
+			mod("TriggeredDamage", "MORE", nil),
 		},
 		["support_brand_area_of_effect_+%_final"] = {
 			mod("AreaOfEffect", "MORE", nil),
 		},
 		["trigger_brand_support_hit_ailment_damage_+%_final_vs_branded_enemy"] = {
-			mod("Damage", "MORE", nil, 0, 0, { type = "Condition", var = "TargetingBrandedEnemy"}),
+			mod("TriggeredDamage", "MORE", nil, 0, 0, { type = "Condition", var = "TargetingBrandedEnemy"}),
 		},
 	},
 	addSkillTypes = { SkillType.Brand, },

--- a/Export/Skills/sup_int.txt
+++ b/Export/Skills/sup_int.txt
@@ -79,7 +79,7 @@ local skills, mod, flag, skill = ...
 #skill SupportCastWhileChannelling
 	statMap = {
 		["cast_while_channelling_time_ms"] = {
-			skill("triggerTime", nil),
+			skill("triggerTime", nil, { type = "SkillType", skillType = SkillType.Channelled } ),
 			div = 1000,
 		},
 	},
@@ -88,7 +88,7 @@ local skills, mod, flag, skill = ...
 #skill SupportCastWhileChannellingTriggered
 	statMap = {
 		["support_cast_while_channelling_triggered_skill_damage_+%_final"] = {
-			mod("Damage", "MORE", nil, 0, 0, { type = "SkillType", skillType = SkillType.Triggerable }),
+			mod("TriggeredDamage", "MORE", nil, 0, 0, { type = "SkillType", skillType = SkillType.Triggerable }),
 		},
 	},
 #baseMod skill("triggeredWhileChannelling", true)
@@ -97,7 +97,7 @@ local skills, mod, flag, skill = ...
 #skill SupportCastWhileChannellingPlus
 	statMap = {
 		["cast_while_channelling_time_ms"] = {
-			skill("triggerTime", nil),
+			skill("triggerTime", nil, { type = "SkillType", skillType = SkillType.Channelled } ),
 			div = 1000,
 		},
 	},
@@ -106,7 +106,7 @@ local skills, mod, flag, skill = ...
 #skill SupportCastWhileChannellingTriggeredPlus
 	statMap = {
 		["support_cast_while_channelling_triggered_skill_damage_+%_final"] = {
-			mod("Damage", "MORE", nil, 0, 0, { type = "SkillType", skillType = SkillType.Triggerable }),
+			mod("TriggeredDamage", "MORE", nil, 0, 0, { type = "SkillType", skillType = SkillType.Triggerable }),
 		},
 	},
 #baseMod skill("triggeredWhileChannelling", true)

--- a/Modules/CalcOffence-3_0.lua
+++ b/Modules/CalcOffence-3_0.lua
@@ -996,7 +996,7 @@ function calcs.offence(env, actor, activeSkill, skillLookupOnly)
 			output.Time = skillData.triggerTime / (1 + skillModList:Sum("INC", cfg, "CooldownRecovery") / 100) * (skillModList:Sum("BASE", cfg, "CastWhileChannellingSpellsLinked") or 1)
 			output.TriggerTime = output.Time
 			output.Speed = 1 / output.Time
-		elseif skillData.triggeredByBrand then
+		elseif skillData.triggeredByBrand and skillData.triggered then
 			output.Time = 1 / (1 + skillModList:Sum("INC", cfg, "Speed", "BrandActivationFrequency") / 100) / skillModList:More(cfg, "BrandActivationFrequency") * (skillModList:Sum("BASE", cfg, "ArcanistSpellsLinked") or 1)
 			output.TriggerTime = output.Time
 			output.Speed = 1 / output.Time

--- a/Modules/CalcPerform.lua
+++ b/Modules/CalcPerform.lua
@@ -737,7 +737,7 @@ function calcs.perform(env)
 			activeSkill.skillModList:NewMod("ArcanistSpellsLinked", "BASE", spellCount, "Skill")
 			activeSkill.skillModList:NewMod("BrandActivationFrequency", "INC", quality, "Skill")
 		end
-		if activeSkill.skillData.triggeredWhileChannelling then
+		if activeSkill.skillData.triggeredWhileChannelling and not activeSkill.skillFlags.minion then
 			local spellCount, trigTime = 0
 			for _, skill in ipairs(env.player.activeSkillList) do
 				if skill.socketGroup == activeSkill.socketGroup and skill.skillData.triggerTime or 0 > 0 then
@@ -746,6 +746,12 @@ function calcs.perform(env)
 				if skill.socketGroup == activeSkill.socketGroup and skill.skillData.triggeredWhileChannelling then
 					spellCount = spellCount + 1
 				end
+			end
+			for i, value in ipairs(activeSkill.skillModList:Tabulate("INC", env.player.mainSkill.skillCfg, "TriggeredDamage")) do
+				activeSkill.skillModList:NewMod("Damage", "INC", value.mod.value, value.mod.source, value.mod.flags, value.mod.keywordFlags, unpack(value.mod))
+			end
+			for i, value in ipairs(activeSkill.skillModList:Tabulate("MORE", env.player.mainSkill.skillCfg, "TriggeredDamage")) do
+				activeSkill.skillModList:NewMod("Damage", "MORE", value.mod.value, value.mod.source, value.mod.flags, value.mod.keywordFlags, unpack(value.mod))
 			end
 			activeSkill.skillModList:NewMod("CastWhileChannellingSpellsLinked", "BASE", spellCount, "Skill")
 			activeSkill.skillData.triggerTime = trigTime

--- a/Modules/CalcPerform.lua
+++ b/Modules/CalcPerform.lua
@@ -724,7 +724,8 @@ function calcs.perform(env)
 				end
 			end
 		end
-		if activeSkill.skillData.triggeredByBrand then
+		if activeSkill.skillData.triggeredByBrand and not activeSkill.skillFlags.minion then
+			activeSkill.skillData.triggered = true
 			local spellCount, quality = 0
 			for _, skill in ipairs(env.player.activeSkillList) do
 				if skill.socketGroup == activeSkill.socketGroup and skill.skillData.triggeredByBrand then
@@ -734,10 +735,17 @@ function calcs.perform(env)
 					quality = skill.activeEffect.quality / 2
 				end
 			end
+			for i, value in ipairs(activeSkill.skillModList:Tabulate("INC", env.player.mainSkill.skillCfg, "TriggeredDamage")) do
+				activeSkill.skillModList:NewMod("Damage", "INC", value.mod.value, value.mod.source, value.mod.flags, value.mod.keywordFlags, unpack(value.mod))
+			end
+			for i, value in ipairs(activeSkill.skillModList:Tabulate("MORE", env.player.mainSkill.skillCfg, "TriggeredDamage")) do
+				activeSkill.skillModList:NewMod("Damage", "MORE", value.mod.value, value.mod.source, value.mod.flags, value.mod.keywordFlags, unpack(value.mod))
+			end
 			activeSkill.skillModList:NewMod("ArcanistSpellsLinked", "BASE", spellCount, "Skill")
 			activeSkill.skillModList:NewMod("BrandActivationFrequency", "INC", quality, "Skill")
 		end
 		if activeSkill.skillData.triggeredWhileChannelling and not activeSkill.skillFlags.minion then
+			activeSkill.skillData.triggered = true
 			local spellCount, trigTime = 0
 			for _, skill in ipairs(env.player.activeSkillList) do
 				if skill.socketGroup == activeSkill.socketGroup and skill.skillData.triggerTime or 0 > 0 then


### PR DESCRIPTION
- Fixes weird infinite DPS bug
- Stops the damage multiplier from applying to minions

My solution is a little hacky but works. Now CwC gives a useless INC/BASE on the support, then actual damage mods are applied based on the useless values in CalcPerform after filtering out minion skills. Tested on a few builds with a few different minion types, all worked correctly. Those useless mods could actually be used in the future if there's ever a full triggered spells rework, for something like Mjolner's lightning damage for socketed triggered spells mod.