### PR TITLE
Support "Notable Passive Skills in Radius Instead Grant"

### DIFF
--- a/Modules/CalcSetup.lua
+++ b/Modules/CalcSetup.lua
@@ -99,6 +99,13 @@ function calcs.buildModListForNode(env, node)
 			rad.func(node, modList, rad.data)
 		end
 	end
+	
+	if modList:Flag(nil, "PassiveSkillHasOtherEffect") then
+		for i, mod in ipairs(modList:List(skillCfg, "NodeModifier")) do	
+			if i == 1 then wipeTable(modList) end
+			modList:AddMod(mod.mod)
+		end
+	end
 
 	return modList
 end

--- a/Modules/ModParser-3_0.lua
+++ b/Modules/ModParser-3_0.lua
@@ -2565,6 +2565,25 @@ local jewelOtherFuncs = {
 			end
 		end
 	end,
+	["Notable Passive Skills in Radius are Transformed to instead grant: 10% increased Mana Cost of Skills and 20% increased Spell Damage"] = function(node, out, data)
+		if node and node.type == "Notable" then
+			out:NewMod("PassiveSkillHasOtherEffect", "FLAG", true, data.modSource)
+			out:NewMod("NodeModifier", "LIST", { mod = mod("ManaCost", "INC", 10, data.modSource) }, data.modSource)
+			out:NewMod("NodeModifier", "LIST", { mod = mod("Damage", "INC", 20, data.modSource, ModFlag.Spell) }, data.modSource)
+		end
+	end,
+	["Notable Passive Skills in Radius are Transformed to instead grant: Minions take 20% increased Damage"] = function(node, out, data)
+		if node and node.type == "Notable" then
+			out:NewMod("PassiveSkillHasOtherEffect", "FLAG", true, data.modSource)
+			out:NewMod("NodeModifier", "LIST", { mod = mod("MinionModifier", "LIST", { mod = mod("DamageTaken", "INC", 20, data.modSource) } ) }, data.modSource)
+		end
+	end,
+	["Notable Passive Skills in Radius are Transformed to instead grant: Minions have 25% reduced Movement Speed"] = function(node, out, data)
+		if node and node.type == "Notable" then
+			out:NewMod("PassiveSkillHasOtherEffect", "FLAG", true, data.modSource)
+			out:NewMod("NodeModifier", "LIST", { mod = mod("MinionModifier", "LIST", { mod = mod("MovementSpeed", "INC", -25, data.modSource) } ) }, data.modSource)
+		end
+	end,
 	["Passives in radius are Conquered by the Eternal Empire"] = function(node, out, data)
 		if node and node.type ~= "Keystone" then
 			out:NewMod("PassiveSkillHasNoEffect", "FLAG", true, data.modSource)


### PR DESCRIPTION
- Support mods on the unique jewels Fertile Mind, Fortress Covenant, and Quickening Covenant which say "Notable Passive Skills in Radius Instead Grant:"
![image](https://user-images.githubusercontent.com/39030429/87757795-dfcb7780-c7d0-11ea-9c3f-64ac793974c2.png)

Everything's functional, but one quirk is that the mods don't show the node as the source, but instead the jewel: 
![image](https://user-images.githubusercontent.com/39030429/87757200-dc83bc00-c7cf-11ea-9c5e-4efdd196ae59.png)

This is how other unique jewels like Coated Shrapnel also work, though:
![image](https://user-images.githubusercontent.com/39030429/87757098-af370e00-c7cf-11ea-93d5-0620d80c3ffc.png)

I couldn't get it to show the proper node source to work after fiddling with it for longer than I care to admit, so I decided to leave it as is.