### PR TITLE
Fix Eye of Malice not applying to Ignite damage

### DIFF
--- a/Modules/CalcOffence-3_0.lua
+++ b/Modules/CalcOffence-3_0.lua
@@ -2330,7 +2330,7 @@ function calcs.offence(env, actor, activeSkill, skillLookupOnly)
 				skillFlags.duration = true
 				local effMult = 1
 				if env.mode_effective then
-					local resist = m_min(enemyDB:Sum("BASE", nil, "ChaosResist"), data.misc.EnemyMaxResist)
+					local resist = m_min(enemyDB:Sum("BASE", nil, "ChaosResist") * calcLib.mod(enemyDB, nil, "ChaosResist"), data.misc.EnemyMaxResist)
 					local takenInc = enemyDB:Sum("INC", dotCfg, "DamageTaken", "DamageTakenOverTime", "ChaosDamageTaken", "ChaosDamageTakenOverTime")
 					local takenMore = enemyDB:More(dotCfg, "DamageTaken", "DamageTakenOverTime", "ChaosDamageTaken", "ChaosDamageTakenOverTime")
 					effMult = (1 - resist / 100) * (1 + takenInc / 100) * takenMore
@@ -2490,7 +2490,7 @@ function calcs.offence(env, actor, activeSkill, skillLookupOnly)
 				skillFlags.ignite = true
 				local effMult = 1
 				if env.mode_effective then
-					local resist = m_min(enemyDB:Sum("BASE", nil, "FireResist", "ElementalResist"), data.misc.EnemyMaxResist)
+					local resist = m_min(enemyDB:Sum("BASE", nil, "FireResist", "ElementalResist") * calcLib.mod(enemyDB, nil, "FireResist", "ElementalResist"), data.misc.EnemyMaxResist)
 					local takenInc = enemyDB:Sum("INC", dotCfg, "DamageTaken", "DamageTakenOverTime", "FireDamageTaken", "FireDamageTakenOverTime", "ElementalDamageTaken")
 					local takenMore = enemyDB:More(dotCfg, "DamageTaken", "DamageTakenOverTime", "FireDamageTaken", "FireDamageTakenOverTime", "ElementalDamageTaken")
 					effMult = (1 - resist / 100) * (1 + takenInc / 100) * takenMore
@@ -2991,7 +2991,7 @@ function calcs.offence(env, actor, activeSkill, skillLookupOnly)
 		local dotCfg = activeSkill.decayCfg
 		local effMult = 1
 		if env.mode_effective then
-			local resist = m_min(enemyDB:Sum("BASE", nil, "ChaosResist"), data.misc.EnemyMaxResist)
+			local resist = m_min(enemyDB:Sum("BASE", nil, "ChaosResist") * calcLib.mod(enemyDB, nil, "ChaosResist"), data.misc.EnemyMaxResist)
 			local takenInc = enemyDB:Sum("INC", nil, "DamageTaken", "DamageTakenOverTime", "ChaosDamageTaken", "ChaosDamageTakenOverTime")
 			local takenMore = enemyDB:More(nil, "DamageTaken", "DamageTakenOverTime", "ChaosDamageTaken", "ChaosDamageTakenOverTime")
 			effMult = (1 - resist / 100) * (1 + takenInc / 100) * takenMore


### PR DESCRIPTION
- Woops

In my original Eye of Malice PR, I tested with a Cold DoT build and then added Fire Trap to that build to test the fire resistance calculation. Had no idea that resistance for ignite is calculated elsewhere. Figured it out when I tried to use it on an ignite build. Now it works.

![image](https://user-images.githubusercontent.com/39030429/87840319-b2c8a480-c864-11ea-9aeb-9eaa63af3c74.png)

I went ahead and did the same change to Poison and Decay, which also had their own separate resistance calculations. So now if there are ever sources of "Nearby Enemies have x% increased Chaos Resistance", it should apply without any work beyond the mod parsing.