### PR TITLE
Fix Pride not working with old builds

### DIFF
--- a/Modules/CalcSetup.lua
+++ b/Modules/CalcSetup.lua
@@ -243,6 +243,7 @@ function calcs.initEnv(build, mode, override)
 		modDB:NewMod("Damage", "MORE", 200, "Base", 0, KeywordFlag.Bleed, { type = "ActorCondition", actor = "enemy", var = "Moving" }, { type = "Condition", var = "NoExtraBleedDamageToMovingEnemy", neg = true })
 	end
 	modDB:NewMod("Condition:BloodStance", "FLAG", true, "Base", { type = "Condition", var = "SandStance", neg = true })
+	modDB:NewMod("Condition:PrideMinEffect", "FLAG", true, "Base", { type = "Condition", var = "PrideMaxEffect", neg = true })
 
 	-- Add bandit mods
 	if build.targetVersion == "2_6" then

--- a/Modules/ConfigOptions.lua
+++ b/Modules/ConfigOptions.lua
@@ -160,9 +160,7 @@ return {
 	end },
 	{ label = "Pride:", ifSkill = "Pride" },
 	{ var = "prideEffect", type = "list", label = "Pride Aura Effect:", ifSkill = "Pride", list = {{val="MIN",label="Initial effect"},{val="MAX",label="Maximum effect"}}, apply = function(val, modList, enemyModList)
-		if val == "MIN" then
-			modList:NewMod("Condition:PrideMinEffect", "FLAG", true, "Config")
-		elseif val == "MAX" then
+		if val == "MAX" then
 			modList:NewMod("Condition:PrideMaxEffect", "FLAG", true, "Config")
 		end
 	end },


### PR DESCRIPTION
Pride was not setting the correct flag for min or max effect when you opened an old build, so it would appear that Pride was not working at all