### PR TITLE
Fix Seismic Cry damage and Fist of War ailment calculations

### DIFF
--- a/Data/3_0/Skills/sup_str.lua
+++ b/Data/3_0/Skills/sup_str.lua
@@ -1310,7 +1310,7 @@ skills["AncestralSlamSupport"] = {
 			mod("FistOfWarHitMultiplier", "BASE", nil, ModFlag.Melee),
 		},
 		["support_ancestral_slam_big_hit_ailment_damage_+%_final"] = {
-			mod("FistOfWarAilmentMultiplier", "BASE", nil, bit.bor(ModFlag.Melee, ModFlag.Ailment)),
+			mod("FistOfWarAilmentMultiplier", "BASE", nil, ModFlag.Melee),
 		},
 		["ancestral_slam_interval_duration"] = {
 			mod("FistOfWarCooldown", "BASE", nil),

--- a/Export/Skills/sup_str.txt
+++ b/Export/Skills/sup_str.txt
@@ -157,7 +157,7 @@ local skills, mod, flag, skill = ...
 			mod("FistOfWarHitMultiplier", "BASE", nil, ModFlag.Melee),
 		},
 		["support_ancestral_slam_big_hit_ailment_damage_+%_final"] = {
-			mod("FistOfWarAilmentMultiplier", "BASE", nil, bit.bor(ModFlag.Melee, ModFlag.Ailment)),
+			mod("FistOfWarAilmentMultiplier", "BASE", nil, ModFlag.Melee),
 		},
 		["ancestral_slam_interval_duration"] = {
 			mod("FistOfWarCooldown", "BASE", nil),

--- a/Modules/CalcOffence-3_0.lua
+++ b/Modules/CalcOffence-3_0.lua
@@ -1304,7 +1304,7 @@ function calcs.offence(env, actor, activeSkill)
 						local MaxSingleHitDmgImpact = 0
 						local MaxSingleAoEImpact = 0
 						for i = 1, globalOutput.SeismicExertsCount do
-							ThisSeismicDmgImpact = SeismicMoreDmgAndAoEPerExert + (1 + SeismicMoreDmgAndAoEPerExert / 100) * LastSeismicImpact
+							ThisSeismicDmgImpact = SeismicMoreDmgAndAoEPerExert + (1 + SeismicMoreDmgAndAoEPerExert) * LastSeismicImpact
 							MaxSingleHitDmgImpact = m_max(MaxSingleHitDmgImpact, ThisSeismicDmgImpact)
 							LastSeismicImpact = LastSeismicImpact + SeismicMoreDmgAndAoEPerExert
 							TotalSeismicDmgImpact = TotalSeismicDmgImpact + ThisSeismicDmgImpact
@@ -1421,7 +1421,7 @@ function calcs.offence(env, actor, activeSkill)
 			-- If Fist of War & Active Skill is a Slam Skill & NOT a Vaal Skill
 			if globalOutput.FistOfWarCooldown ~= 0 and activeSkill.skillTypes[SkillType.SlamSkill] and not activeSkill.skillTypes[SkillType.Vaal] then
 				globalOutput.FistOfWarHitMultiplier = skillModList:Sum("BASE", cfg, "FistOfWarHitMultiplier") / 100
-				globalOutput.FistOfWarAilmentMultiplier = 1 + skillModList:Sum("BASE", cfg, "FistOfWarAilmentMultiplier") / 100
+				globalOutput.FistOfWarAilmentMultiplier = skillModList:Sum("BASE", cfg, "FistOfWarAilmentMultiplier") / 100
 				globalOutput.FistOfWarUptimeRatio = m_min( (1 / output.Speed) / globalOutput.FistOfWarCooldown, 1) * 100
 				if globalBreakdown then
 					globalBreakdown.FistOfWarUptimeRatio = {


### PR DESCRIPTION
Seismic Cry was dividing the same number by 100 when it should have only been divided once.
Fist of War didn't have the correct ModFlag on the gem and was had an incorrect multiplier applied