### PR TITLE
Fix Issue 1263

### DIFF
--- a/Modules/CalcOffence-3_0.lua
+++ b/Modules/CalcOffence-3_0.lua
@@ -297,10 +297,10 @@ function calcs.offence(env, actor, activeSkill)
 
 	-- Add addition stat bonuses
 	if skillModList:Flag(nil, "IronGrip") then
-		skillModList:NewMod("PhysicalDamage", "INC", actor.strDmgBonus, "Strength", bor(ModFlag.Attack, ModFlag.Projectile))
+		skillModList:NewMod("PhysicalDamage", "INC", actor.strDmgBonus or 0, "Strength", bor(ModFlag.Attack, ModFlag.Projectile))
 	end
 	if skillModList:Flag(nil, "IronWill") then
-		skillModList:NewMod("Damage", "INC", actor.strDmgBonus, "Strength", ModFlag.Spell)
+		skillModList:NewMod("Damage", "INC", actor.strDmgBonus or 0, "Strength", ModFlag.Spell)
 	end
 	
 	if skillModList:Flag(nil, "TransfigurationOfBody") then


### PR DESCRIPTION
Issue was that `actor.strDmgBonus` is never initialized in the event that the Conditional Flag "NoAttributeBonuses" is set. This caused a crash when considering all support gems for a spell when "Iron Grip" or "Iron Will" was considered.

#1263 