### PR TITLE
Fix Second Wind Cooldown

### DIFF
--- a/Data/3_0/SkillStatMap.lua
+++ b/Data/3_0/SkillStatMap.lua
@@ -341,9 +341,6 @@ return {
 ["base_cooldown_speed_+%"] = {
 	mod("CooldownRecovery", "INC", nil),
 },
-["support_added_cooldown_count_if_not_instant"] = {
-	mod("CooldownRecovery", "INC", nil),
-},
 ["additional_weapon_base_attack_time_ms"] = {
 	mod("Speed", "BASE", nil, ModFlag.Attack),
 	div = 1000,


### PR DESCRIPTION
There was an incorrect stat map for Second Wind support that added 1% extra increased CDR to skills supported by it