### PR TITLE
Fix Spectre Errors

### DIFF
--- a/Data/3_0/Skills/spectre.lua
+++ b/Data/3_0/Skills/spectre.lua
@@ -4180,11 +4180,11 @@ skills["AtlasExilesCrusaderMageguardProjectile"] = {
 		[1] = { 127, 0.5, 1.5, critChance = 5, levelRequirement = 0, statInterpolation = { 1, 3, 3, }, },
 	},
 }
-skills["AtlasExileCrusaderMageguardBombExplode"] = {
+skills["AtlasExileCrusaderMageguardBombExplodeSpectre"] = {
 	name = "Bombs",
 	hidden = true,
 	color = 4,
-	baseEffectiveness = 4,
+	baseEffectiveness = 2,
 	incrementalEffectiveness = 0.045000001788139,
 	skillTypes = { [SkillType.Triggerable] = true, },
 	statDescriptionScope = "skill_stat_descriptions",
@@ -4234,11 +4234,11 @@ skills["AtlasCrusaderMageguardBeam"] = {
 		[1] = { 0.5, 1.5, critChance = 5, cooldown = 8, levelRequirement = 0, statInterpolation = { 3, 3, }, },
 	},
 }
-skills["AtlasCrusaderSisterMortar"] = {
+skills["AtlasCrusaderSisterMortarSpectre"] = {
 	name = "Mortar",
 	hidden = true,
 	color = 4,
-	baseEffectiveness = 1.7999999523163,
+	baseEffectiveness = 1.2999999523163,
 	incrementalEffectiveness = 0.03999999910593,
 	description = "Generic monster mortar skill. Like Monster Projectile but has an impact effect.",
 	skillTypes = { [SkillType.Projectile] = true, [SkillType.SkillCanVolley] = true, [SkillType.Spell] = true, [SkillType.Hit] = true, [SkillType.Area] = true, [SkillType.SkillCanTrap] = true, [SkillType.SkillCanTotem] = true, [SkillType.SkillCanMine] = true, [SkillType.SpellCanRepeat] = true, [SkillType.Triggerable] = true, [SkillType.AreaSpell] = true, },
@@ -4267,7 +4267,7 @@ skills["AtlasCrusaderSisterMortar"] = {
 		"projectile_uses_contact_position",
 	},
 	levels = {
-		[1] = { 0.69999998807907, 1.2999999523163, 20, 0, 3, 10, critChance = 5, levelRequirement = 0, statInterpolation = { 3, 3, 1, 1, 1, 1, }, },
+		[1] = { 0.69999998807907, 1.2999999523163, 20, 1, 3, 10, critChance = 5, levelRequirement = 0, statInterpolation = { 3, 3, 1, 1, 1, 1, }, },
 	},
 }
 skills["BreachLightningWhip"] = {

--- a/Data/3_0/Spectres.lua
+++ b/Data/3_0/Spectres.lua
@@ -2296,9 +2296,9 @@ minions["Metadata/Monsters/Skeletons/SkeletonBowProjectileWeaknessCurse"] = {
 		-- MonsterCastsProjectileWeaknessCurseText [monster_casts_projectile_vulnerability_curse_text = 1]
 	},
 }
-minions["Metadata/Monsters/Skeletons/SkeletonMeleeKnightElementalSwordIncursionChampionDelve"] = {
+minions["Metadata/Monsters/Skeletons/SkeletonMeleeKnightElementalSwordIncursionChampion"] = {
 	name = "Enhanced Vaal Fallen",
-	life = 4.5,
+	life = 2.25,
 	armour = 1,
 	fireResist = 35,
 	coldResist = 35,
@@ -2317,6 +2317,7 @@ minions["Metadata/Monsters/Skeletons/SkeletonMeleeKnightElementalSwordIncursionC
 	},
 	modList = {
 		-- MonsterCastsElementalHitText [monster_casts_elemental_hit_text = 1]
+		-- MonsterIncursionDropModifiers__ [monster_slain_experience_+% = 0] [monster_dropped_item_quantity_+% = 35] [monster_dropped_item_rarity_+% = 2500] [monster_no_map_drops = 1]
 	},
 }
 minions["Metadata/Monsters/Skeletons/SkeletonBowKnightElemental"] = {
@@ -2659,7 +2660,7 @@ minions["Metadata/Monsters/WickerMan/WickerMan"] = {
 	},
 }
 -- Redemption Sentry
-minions["Metadata/Monsters/AtlasExiles/EyrieInfluenceMonsters/EyrieSeraphArcher"] = {
+minions["Metadata/Monsters/AtlasExiles/EyrieInfluenceMonsters/EyrieSeraphArcherSpectre"] = {
 	name = "Redemption Sentry",
 	life = 4.05,
 	fireResist = 0,
@@ -2687,7 +2688,7 @@ minions["Metadata/Monsters/AtlasExiles/EyrieInfluenceMonsters/EyrieSeraphArcher"
 	},
 }
 -- Baranite Thaumaturge
-minions["Metadata/Monsters/AtlasExiles/CrusaderInfluenceMonsters/CrusaderMageguardCaster"] = {
+minions["Metadata/Monsters/AtlasExiles/CrusaderInfluenceMonsters/CrusaderMageguardCasterSpectre"] = {
 	name = "Baranite Thaumaturge",
 	life = 4.05,
 	energyShield = 0.8,
@@ -2703,8 +2704,8 @@ minions["Metadata/Monsters/AtlasExiles/CrusaderInfluenceMonsters/CrusaderMagegua
 	skillList = {
 		"AtlasExilesCrusaderMageguardProjectile",
 		"EmptyActionSpellCrusaderMageguard",
-		"AtlasCrusaderMageguardSpawnBomb",
-		"AtlasExileCrusaderMageguardBombExplode",
+		"AtlasCrusaderMageguardSpawnBombSpectre",
+		"AtlasExileCrusaderMageguardBombExplodeSpectre",
 		"AtlasCrusaderMageguardBeam",
 		"WalkEmergeAtlasInfluenceMonster",
 	},
@@ -2712,7 +2713,7 @@ minions["Metadata/Monsters/AtlasExiles/CrusaderInfluenceMonsters/CrusaderMagegua
 	},
 }
 -- Baranite Sister
-minions["Metadata/Monsters/AtlasExiles/CrusaderInfluenceMonsters/CrusaderBlessedSister"] = {
+minions["Metadata/Monsters/AtlasExiles/CrusaderInfluenceMonsters/CrusaderBlessedSisterSpectre"] = {
 	name = "Baranite Sister",
 	life = 1.2,
 	energyShield = 0.4,
@@ -2726,7 +2727,7 @@ minions["Metadata/Monsters/AtlasExiles/CrusaderInfluenceMonsters/CrusaderBlessed
 	attackRange = 8,
 	accuracy = 1,
 	skillList = {
-		"AtlasCrusaderSisterMortar",
+		"AtlasCrusaderSisterMortarSpectre",
 		"WalkEmergeAtlasInfluenceMonster",
 	},
 	modList = {

--- a/Export/Minions/Spectres.txt
+++ b/Export/Minions/Spectres.txt
@@ -139,7 +139,7 @@ local minions, mod = ...
 #spectre Metadata/Monsters/Skeletons/SkeletonCasterLightningSpark
 #spectre Metadata/Monsters/Skeletons/SkeletonBlackCaster1_
 #spectre Metadata/Monsters/Skeletons/SkeletonBowProjectileWeaknessCurse
-#spectre Metadata/Monsters/Skeletons/SkeletonMeleeKnightElementalSwordIncursionChampionDelve
+#spectre Metadata/Monsters/Skeletons/SkeletonMeleeKnightElementalSwordIncursionChampion
 #spectre Metadata/Monsters/Skeletons/SkeletonBowKnightElemental
 #spectre Metadata/Monsters/Skeletons/SkeletonMeleeBlackAbyssBoneLance
 #spectre Metadata/Monsters/SkeletonCannon/SkeletonCannon1
@@ -163,10 +163,10 @@ local minions, mod = ...
 -- Wicker Man
 #spectre Metadata/Monsters/WickerMan/WickerMan
 -- Redemption Sentry
-#spectre Metadata/Monsters/AtlasExiles/EyrieInfluenceMonsters/EyrieSeraphArcher
+#spectre Metadata/Monsters/AtlasExiles/EyrieInfluenceMonsters/EyrieSeraphArcherSpectre
 -- Baranite Thaumaturge
-#spectre Metadata/Monsters/AtlasExiles/CrusaderInfluenceMonsters/CrusaderMageguardCaster
+#spectre Metadata/Monsters/AtlasExiles/CrusaderInfluenceMonsters/CrusaderMageguardCasterSpectre
 -- Baranite Sister
-#spectre Metadata/Monsters/AtlasExiles/CrusaderInfluenceMonsters/CrusaderBlessedSister
+#spectre Metadata/Monsters/AtlasExiles/CrusaderInfluenceMonsters/CrusaderBlessedSisterSpectre
 -- Scale of Esh
 #spectre Metadata/Monsters/SandLeaper/SandLeaperBreachSpectre_

--- a/Export/Skills/spectre.txt
+++ b/Export/Skills/spectre.txt
@@ -675,7 +675,7 @@ local skills, mod, flag, skill = ...
 #flags spell projectile triggerable
 #mods
 
-#skill AtlasExileCrusaderMageguardBombExplode Bombs
+#skill AtlasExileCrusaderMageguardBombExplodeSpectre Bombs
 #flags spell hit triggerable
 #mods
 
@@ -683,7 +683,7 @@ local skills, mod, flag, skill = ...
 #flags spell hit triggerable
 #mods
 
-#skill AtlasCrusaderSisterMortar Mortar
+#skill AtlasCrusaderSisterMortarSpectre Mortar
 #flags spell hit triggerable area projectile
 #mods
 


### PR DESCRIPTION
Some spectres were not using the correct mob to export the skills from
Fix life multiplier on Enhanced Vaal Fallen
Fix bomb base effectiveness on Baranite Thaumaturge
Fix mortar skill on Baranite Sister