### PR TITLE
Remove Powershell update script

### DIFF
--- a/patch_fork.ps1
+++ b/patch_fork.ps1
@@ -1,8 +1,0 @@
-$fork = "PathOfBuildingCommunity";
-Write-Output "Patching to use the $fork fork...";
-$source = "https://raw.githubusercontent.com/$fork/PathOfBuilding/master/manifest.xml";
-$dest = "$env:ProgramData\Path of Building\manifest.xml";
-
-$cli = New-Object System.Net.WebClient;
-$cli.Headers['User-Agent'] = 'Mozilla/5.0 Powershell';
-$cli.DownloadFile($source, $dest)


### PR DESCRIPTION
Remove old fork patching script as this method of installing the fork is deprecated.