### PR TITLE
Add a "Power Report" Feature: Displays report of passive node efficacy based on currently selected heat map

### DIFF
--- a/Classes/PassiveSpec.lua
+++ b/Classes/PassiveSpec.lua
@@ -688,7 +688,6 @@ function PassiveSpecClass:BuildSubgraph(jewel, parentSocket, id, upSize)
 		local node = {
 			type = "Keystone",
 			id = nodeId,
-			name = keystoneNode.name,
 			dn = keystoneNode.dn,
 			sd = keystoneNode.sd,
 			icon = keystoneNode.icon,
@@ -851,7 +850,6 @@ function PassiveSpecClass:BuildSubgraph(jewel, parentSocket, id, upSize)
 		local node = {
 			type = "Notable",
 			id = nodeId + nodeIndex,
-			name = baseNode.name,
 			dn = baseNode.dn,
 			sd = baseNode.sd,
 			icon = baseNode.icon,

--- a/Classes/PassiveSpec.lua
+++ b/Classes/PassiveSpec.lua
@@ -688,6 +688,7 @@ function PassiveSpecClass:BuildSubgraph(jewel, parentSocket, id, upSize)
 		local node = {
 			type = "Keystone",
 			id = nodeId,
+			name = keystoneNode.name,
 			dn = keystoneNode.dn,
 			sd = keystoneNode.sd,
 			icon = keystoneNode.icon,
@@ -850,6 +851,7 @@ function PassiveSpecClass:BuildSubgraph(jewel, parentSocket, id, upSize)
 		local node = {
 			type = "Notable",
 			id = nodeId + nodeIndex,
+			name = baseNode.name,
 			dn = baseNode.dn,
 			sd = baseNode.sd,
 			icon = baseNode.icon,

--- a/Classes/PassiveTreeView.lua
+++ b/Classes/PassiveTreeView.lua
@@ -693,6 +693,14 @@ function PassiveTreeViewClass:Zoom(level, viewPort)
 	self.zoomY = relY + (self.zoomY - relY) * factor
 end
 
+function PassiveTreeViewClass:Focus(x, y, viewPort, build)
+	local tree = build.spec.tree
+	local scale = m_min(viewPort.width, viewPort.height) / tree.size * self.zoom
+	
+	self.zoomX = -x * scale
+	self.zoomY = -y * scale
+end
+
 function PassiveTreeViewClass:DoesNodeMatchSearchStr(node)
 	if node.type == "ClassStart" or node.type == "Mastery" then
 		return

--- a/Classes/PassiveTreeView.lua
+++ b/Classes/PassiveTreeView.lua
@@ -694,6 +694,9 @@ function PassiveTreeViewClass:Zoom(level, viewPort)
 end
 
 function PassiveTreeViewClass:Focus(x, y, viewPort, build)
+	self.zoomLevel = 12
+	self.zoom = 1.2 ^ self.zoomLevel
+
 	local tree = build.spec.tree
 	local scale = m_min(viewPort.width, viewPort.height) / tree.size * self.zoom
 	

--- a/Classes/PowerReportListControl.lua
+++ b/Classes/PowerReportListControl.lua
@@ -2,7 +2,8 @@
 local PowerReportListClass = newClass("PowerReportListControl", "ListControl", function(self, anchor, x, y, width, height, report, powerLabel, nodeSelectCallback)
 	self.ListControl(anchor, x, y, width, height, 20, false, false, report)
 	self.colList = {
-		{ width = width * 0.75, label = "Node Name" },
+		{ width = width * 0.2, label = "Type" },
+		{ width = width * 0.55, label = "Node Name" },
 		{ width = width * 0.2, label = powerLabel }
 	}
 	self.label = "Double-click to focus on tree"
@@ -18,8 +19,10 @@ end
 
 function PowerReportListClass:GetRowValue(column, index, report)
 	if column == 1 then
-		return report.name
+		return report.type
 	elseif column == 2 then
+		return report.name
+	elseif column == 3 then
 		return report.powerStr
 	else
 		return ""

--- a/Classes/PowerReportListControl.lua
+++ b/Classes/PowerReportListControl.lua
@@ -1,0 +1,27 @@
+
+local PowerReportListClass = newClass("PowerReportListControl", "ListControl", function(self, anchor, x, y, width, height, report, powerLabel, nodeSelectCallback)
+	self.ListControl(anchor, x, y, width, height, 20, false, false, report)
+	self.colList = {
+		{ width = width * 0.75, label = "Node Name" },
+		{ width = width * 0.2, label = powerLabel }
+	}
+	self.label = "Double-click to focus on tree"
+	self.colLabels = true
+	self.nodeSelectCallback = nodeSelectCallback
+end)
+
+function PowerReportListClass:OnSelClick(index, report, doubleClick)
+	if self.nodeSelectCallback then
+		self.nodeSelectCallback(report)
+	end
+end
+
+function PowerReportListClass:GetRowValue(column, index, report)
+	if column == 1 then
+		return report.name
+	elseif column == 2 then
+		return report.powerStr
+	else
+		return ""
+	end
+end

--- a/Classes/PowerReportListControl.lua
+++ b/Classes/PowerReportListControl.lua
@@ -6,7 +6,7 @@ local PowerReportListClass = newClass("PowerReportListControl", "ListControl", f
 		{ width = width * 0.55, label = "Node Name" },
 		{ width = width * 0.2, label = powerLabel }
 	}
-	self.label = "Double-click to focus on tree"
+	self.label = "Click to focus node on tree"
 	self.colLabels = true
 	self.nodeSelectCallback = nodeSelectCallback
 end)

--- a/Classes/TreeTab.lua
+++ b/Classes/TreeTab.lua
@@ -5,7 +5,9 @@
 --
 local ipairs = ipairs
 local t_insert = table.insert
+local t_sort = table.sort
 local m_min = math.min
+local s_format = string.format
 
 local TreeTabClass = newClass("TreeTab", "ControlHost", function(self, build)
 	self.ControlHost()
@@ -116,6 +118,13 @@ local TreeTabClass = newClass("TreeTab", "ControlHost", function(self, build)
 		return "When enabled, node power is divided by the point cost it would take to get there,\nso closer points are considered stronger"
 	end
 
+	self.controls.powerReport = new("ButtonControl", {"LEFT", self.controls.treeHeatMapStatPerPoint, "RIGHT"}, 8, 0, 120, 20, "Power Report", function()
+		self:ShowPowerReport()
+	end)
+	self.controls.powerReport.tooltipText = function()
+		return "View a report of node efficacy based on current heat map selection"
+	end
+
 	self.controls.specConvertText = new("LabelControl", {"BOTTOMLEFT",self.controls.specSelect,"TOPLEFT"}, 0, -14, 0, 16, "^7This is an older tree version, which may not be fully compatible with the current game version.")
 	self.controls.specConvertText.shown = function()
 		return self.showConvert
@@ -131,6 +140,9 @@ local TreeTabClass = newClass("TreeTab", "ControlHost", function(self, build)
 		self.modFlag = true
 		main:OpenMessagePopup("Tree Converted", "The tree has been converted to "..treeVersions[self.build.targetVersionData.latestTreeVersion].short..".\nNote that some or all of the passives may have been de-allocated due to changes in the tree.\n\nYou can switch back to the old tree using the tree selector at the bottom left.")
 	end)
+	self.jumpToNode = false
+	self.jumpToX = 0
+	self.jumpToY = 0
 end)
 
 function TreeTabClass:Draw(viewPort, inputEvents)
@@ -176,6 +188,10 @@ function TreeTabClass:Draw(viewPort, inputEvents)
 	--
 
 	local treeViewPort = { x = viewPort.x, y = viewPort.y, width = viewPort.width, height = viewPort.height - (self.showConvert and 64 + twoLineHeight or 32 + twoLineHeight)}
+	if self.jumpToNode then
+		self.viewer:Focus(self.jumpToX, self.jumpToY, treeViewPort, self.build)
+		self.jumpToNode = false
+	end
 	self.viewer:Draw(self.build, treeViewPort, inputEvents)
 
 	self.controls.specSelect.selIndex = self.activeSpec
@@ -402,4 +418,58 @@ function TreeTabClass:OpenExportPopup()
 		main:ClosePopup()
 	end)
 	popup = main:OpenPopup(380, 100, "Export Tree", controls, "done", "edit")
+end
+
+function TreeTabClass:ShowPowerReport()
+	local report = {}
+	local currentStat = self.build.calcsTab.powerStat
+	
+	-- doesn't support listing the "offense/defense" hybrid heatmap, as it is not a single scalar and im unsure how to quantify numerically
+	-- especially given the heatmap's current approach of using the sqrt() of both components. that number is cryptic to users, i suspect.
+	if not currentStat or not currentStat.stat then
+		main:OpenMessagePopup("Select a specific stat", "This feature does not report for the \"Offense/Defense\" heat map. Select a specific stat from the dropdown.")
+		return
+	end
+
+	local currentStatLabel = currentStat.label
+
+	-- search all nodes, ignoring ascendcies, sockets, etc.
+	for nodeId, node in pairs(self.build.spec.nodes) do
+		local isAlloc = node.alloc or self.build.calcsTab.mainEnv.grantedPassives[nodeId]
+		if not isAlloc and (node.type == "Normal" or node.type == "Keystone" or node.type == "Notable") and not node.ascendancyName then
+			local nodePower = node.power.singleStat or 0
+			local nodePowerStr = s_format("%.1f", nodePower)
+			if main.showThousandsCalcs then
+				nodePowerStr = formatNumSep(nodePowerStr)
+			end
+			
+			t_insert(report, {
+				name = node.name,
+				power = nodePower,
+				powerStr = nodePowerStr,
+				id = nodeId,
+				x = node.x,
+				y = node.y
+			})
+		end
+	end
+
+	-- sort by the power, by default.
+	t_sort(report, function (a,b)
+		return (a.power) > (b.power)
+	end)
+
+	-- present the UI
+	local controls = {}
+	controls.list = new("PowerReportListControl", nil, 0, 40, 450, 400, report, currentStatLabel, function(selectedNode)
+		self.jumpToNode = true
+		self.jumpToX = selectedNode.x
+		self.jumpToY = selectedNode.y
+		main:ClosePopup()
+	end)
+	controls.done = new("ButtonControl", nil, 0, 450, 100, 20, "Close", function()
+		main:ClosePopup()
+	end)
+	
+	popup = main:OpenPopup(500, 500, "Power Report: " .. currentStatLabel, controls, "done", "done")
 end

--- a/Classes/TreeTab.lua
+++ b/Classes/TreeTab.lua
@@ -494,6 +494,6 @@ function TreeTabClass:ShowPowerReport()
 	controls.done = new("ButtonControl", nil, 0, 450, 100, 20, "Close", function()
 		main:ClosePopup()
 	end)
-	
-	popup = main:OpenPopup(500, 500, "Power Report: " .. currentStatLabel, controls, "done", "done")
+		
+	popup = main:OpenPopup(500, 500, "Power Report: " .. currentStatLabel, controls, "done", "list")
 end

--- a/Classes/TreeTab.lua
+++ b/Classes/TreeTab.lua
@@ -424,13 +424,16 @@ function TreeTabClass:ShowPowerReport()
 	local report = {}
 	local currentStat = self.build.calcsTab.powerStat
 	
-	-- doesn't support listing the "offense/defense" hybrid heatmap, as it is not a single scalar and im unsure how to quantify numerically
+	-- the report doesn't support listing the "offense/defense" hybrid heatmap, as it is not a single scalar and im unsure how to quantify numerically
 	-- especially given the heatmap's current approach of using the sqrt() of both components. that number is cryptic to users, i suspect.
 	if not currentStat or not currentStat.stat then
 		main:OpenMessagePopup("Select a specific stat", "This feature does not report for the \"Offense/Defense\" heat map. Select a specific stat from the dropdown.")
 		return
 	end
 
+	-- locate formatting information for the type of heat map being used.
+	-- maybe a better place to find this? At the moment, it is the only place
+	-- in the code that has this information in a tidy place.
 	local currentStatLabel = currentStat.label
 	local displayStat = nil
 
@@ -441,6 +444,10 @@ function TreeTabClass:ShowPowerReport()
 		end
 	end
 
+	-- not every heat map has an associated "stat" in the displayStats table
+	-- this is due to not every stat being displayed in the sidebar, I believe.
+	-- But, we do want to use the formatting knowledge stored in that table rather than duplicating it here.
+	-- If no corresponding stat is found, just default to a generic stat display (>0=good, one digit of precision).
 	if not displayStat then
 		displayStat = {
 			fmt = ".1f"
@@ -476,10 +483,16 @@ function TreeTabClass:ShowPowerReport()
 		end
 	end
 
-	-- sort by the power, by default.
-	t_sort(report, function (a,b)
-		return (a.power) > (b.power)
-	end)
+	-- sort it
+	if displayStat.lowerIsBetter then
+		t_sort(report, function (a,b)
+			return (a.power) < (b.power)
+		end)
+	else
+		t_sort(report, function (a,b)
+			return (a.power) > (b.power)
+		end)
+	end
 
 	-- present the UI
 	local controls = {}
@@ -494,6 +507,6 @@ function TreeTabClass:ShowPowerReport()
 	controls.done = new("ButtonControl", nil, 0, 450, 100, 20, "Close", function()
 		main:ClosePopup()
 	end)
-		
+
 	popup = main:OpenPopup(500, 500, "Power Report: " .. currentStatLabel, controls, "done", "list")
 end

--- a/Classes/TreeTab.lua
+++ b/Classes/TreeTab.lua
@@ -472,7 +472,7 @@ function TreeTabClass:ShowPowerReport()
 			end
 			
 			t_insert(report, {
-				name = node.name,
+				name = node.dn,
 				power = nodePower,
 				powerStr = nodePowerStr,
 				id = nodeId,


### PR DESCRIPTION
## Summary
This PR (my first on PoB) adds a new button to the bottom of the passive tree that displays a sorted table with the efficacy of every node on the tree, given a selected heat map. Clicking a node in the list will focus and zoom-in on the node clicked, to make finding it easier.

Feedback very much appreciated.

I believe this would be helpful to users upvoting this request as well: https://feathub.com/LocalIdentity/PathOfBuilding/+14

## UI
The new button:
![image](https://user-images.githubusercontent.com/5232856/93011743-f2f78b00-f566-11ea-9624-89b71782132f.png)
Once clicked, a report is presented, based on your current heat map. Example:
![image](https://user-images.githubusercontent.com/5232856/93011812-b9734f80-f567-11ea-83ce-ac792a9b9654.png)
Here's a report for a %-based stat:
![image](https://user-images.githubusercontent.com/5232856/93011844-00614500-f568-11ea-810e-ab0e874f1573.png)


## Minor Issues
- The formatting used for numbers in the table relies on formatting rules defined for the sidebar. Not every heat map has a corresponding entry in this table and sometimes it defaults to formatting that is less than optimal. Not a major issue, just occasional readability for less frequently used heat maps.
- Clicking the report while the tree is rebuilding can produce some unexpected results, showing out of date data. Minor issue. Maybe work around by disabling the button during rebuilds? Not easy to do -- the coroutine rebuilding the tree doesn't communicate with the UI. Maybe can check in Draw() if a rebuild is running and disable the button? Don't want to introduce perf issue there.
- The font seems larger than other UI elements in PoB. I think this is caused by not specifying it correctly. Will investigate.

## Future Improvements
- Perhaps show "power per point" somehow, either with another column, or a toggle that switches the list. Would need to add sorting support to the `ListControl` class, which it currently lacks. Right now it is a presorted list with only one interesting column, so there hasn't been a need for dynamic sorting.
- Filtering. It would probably be helpful to filter the list by node type (e.g. only show Notables), for anointing.
- Tooltip. It would be nice if hovering over one of the rows in the report showed the passive node's tooltip. Useful for seeing anointing cost or other bonuses on the node without closing the report window.

