### PR TITLE
Fixes #1377 - Moves tree viewer inset when the screen is too small

### DIFF
--- a/Classes/ItemSlotControl.lua
+++ b/Classes/ItemSlotControl.lua
@@ -126,8 +126,13 @@ function ItemSlotClass:Draw(viewPort)
 	self:DrawControls(viewPort)
 	if not main.popups[1] and self.nodeId and (self.dropped or (self:IsMouseOver() and (self.otherDragSource or not self.itemsTab.selControl))) then
 		SetDrawLayer(nil, 15)
+		local viewerY
+		if self.DropDownControl.dropUp and self.DropDownControl.dropped then
+			viewerY = y + 20
+		else
+			viewerY = m_min(y - 300 - 5, viewPort.y + viewPort.height - 304)
+		end
 		local viewerX = x
-		local viewerY = m_min(y - 300 - 5, viewPort.y + viewPort.height - 304)
 		SetDrawColor(1, 1, 1)
 		DrawImage(nil, viewerX, viewerY, 304, 304)
 		local viewer = self.itemsTab.socketViewer


### PR DESCRIPTION
Not enough room for all the tooltips we need, so it falls off the screen on the bottom if there isn't space.  Tried to put it on the left side, but apparently nothing can be drawn on top of the sidebar.