### PR TITLE
Add support for ball lightning single target DPS

### DIFF
--- a/Data/3_0/Skills/act_int.lua
+++ b/Data/3_0/Skills/act_int.lua
@@ -504,8 +504,30 @@ skills["BallLightning"] = {
 		spell = true,
 		projectile = true,
 	},
+	preDamageFunc = function(activeSkill, output)
+		if(activeSkill.skillPart == 1) then
+			return
+		end
+
+		local aoe = output.AreaOfEffectRadius
+		local blBaseSpeed = 48
+		local projSpeed = blBaseSpeed * output.ProjectileSpeedMod
+		local enemyRadius = 2
+		local dpsDuration = (aoe * 2 + enemyRadius * 2) / projSpeed
+		local hitsPerCast = math.min(math.floor(dpsDuration / .15), 13)
+
+		activeSkill.skillData.dpsMultiplier = hitsPerCast
+	end,
 	baseMods = {
 		skill("radius", 22),
+	},
+	parts = {
+		{
+			name = "Single Hit"
+		},
+		{
+			name = "Single Target",
+		}
 	},
 	qualityStats = {
 		{ "lightning_damage_+%", 1 },


### PR DESCRIPTION
This adds support for single target ball lightning damage.  My understanding is that the existing DPS is for if each ball hits the enemy once.  In practice, each ball will hit multiple times, so this PR adds a selection that will show the DPS if you cast a ball lightning that perfectly lines up with the enemy, and the enemy is standing still.

I got the formula from [this google sheet DPS calculator](https://docs.google.com/spreadsheets/d/1Hlylu1xZGs7WY8SD4bJdDoEy-9HQH68zqoA-n0U5TmU/edit#gid=272609148).  You need to know the ball lightning aoe, proj speed, and enemy radius.  There is also a hidden cap of 13 hits per BL.

I kind of fumbled my way through it looking at similar PRs, so let me know if I went about this completely wrong, let me know.  I've also know a few things that need to be addressed:

1.  The spreadsheet has the base ball lightning speed as 48, so I just hardcoded that in the formula.  Is there somewhere else we can grab that from?
2.  I also hardcoded the enemy radius to 2 (which is apparently a "humanoid" size.  IDK if that should be dynamic, or if it's fine for now.
3. I went with "Single Hit" and "Single Target" as the dropdown labels, but I think there is probably clearer options.

