### PR TITLE
Search for nodes now reflects how it works in game

### DIFF
--- a/Classes/PassiveTreeView.lua
+++ b/Classes/PassiveTreeView.lua
@@ -700,19 +700,15 @@ function PassiveTreeViewClass:DoesNodeMatchSearchStr(node)
 
 	local delimiter = " "
 	local matches = {}
+	local rest_result = self.searchStr
 
-	local rest_result = self.searchStr:lower()
 	for match in (self.searchStr..delimiter):gmatch("\"(.-)\""..delimiter) do
 		table.insert(matches, match);
 	end
 
-	for key, match in pairs(matches) do
-		print(key, match)
-	end
-
 	for key, stringresult in pairs(matches) do
 		stringToRemove = ("\"" .. stringresult .. "\"")
-		rest_result = string.gsub(rest_result, stringToRemove, "")
+		rest_result = rest_result:gsub(stringToRemove, "")
 	end
 
 	for match in (rest_result..delimiter):gmatch("(.-)"..delimiter) do
@@ -723,7 +719,7 @@ function PassiveTreeViewClass:DoesNodeMatchSearchStr(node)
 		local matched = true
 
 		for key, match in pairs(matches) do
-			errMsg, pre_matched = PCall(string.match, sstring,  match:lower())
+			errMsg, pre_matched = PCall(string.match, sstring, match:lower())
 			matched = matched and pre_matched
 		end
 
@@ -756,7 +752,6 @@ function PassiveTreeViewClass:DoesNodeMatchSearchStr(node)
 	-- Check node modifiers
 	for index, line in ipairs(node.sd) do
 		if not match and node.mods[index].list then
-
 			for _, mod in ipairs(node.mods[index].list) do
 				errMsg, match = PCall(string.match, mod.name, self.searchStr)
 				if match then


### PR DESCRIPTION
How it works in game:
- Multiple keywords separated by name (eg: `Phys crit` will show all nodes that have `phys` and `crit` somewhere in the title and description)
- Quotation marks (`"`) can be used to search for the exact text (eg: `"Phys crit"` will not highlight any node but `"Sword Damage and Critical Strike Multiplier"` will)

How it works on Path of Building:
- It searches the exact text everytime (reflecting quotation marks in game)

What this PR tend to achieve:
- Copy the way that it is used in the game to create a "consistency" between both searchs