### PR TITLE
Update Steel skills

### DIFF
--- a/Data/3_0/Skills/act_dex.lua
+++ b/Data/3_0/Skills/act_dex.lua
@@ -4677,6 +4677,11 @@ skills["LancingSteel"] = {
 	},
 	statDescriptionScope = "skill_stat_descriptions",
 	castTime = 1,
+	statMap = {
+		["number_of_projectiles_to_fire_+%_final_per_steel_ammo_consumed"] = {
+			mod("ProjectileCount", "MORE", nil, 0, 0, { type = "Multiplier", var = "SteelShardConsumed", limit = 4 } )
+		},
+	},
 	baseFlags = {
 		attack = true,
 		projectile = true,
@@ -6520,22 +6525,18 @@ skills["ShatteringSteel"] = {
 	castTime = 1,
 	parts = {
 		{
-			name = "Single Projectile Hit",
+			name = "Projectile",
 			area = false,
 		},
 		{
-			name = "All Projectiles Hit",
-			area = false,
-		},
-		{
-			name = "Single Cone AoE",
+			name = "Cone AoE",
 		},
 	},
-	preDamageFunc = function(activeSkill, output)
-		if activeSkill.skillPart == 2 then
-			activeSkill.skillData.dpsMultiplier = output.ProjectileCount
-		end
-	end,
+	statMap = {
+		["shattering_steel_damage_+%_final_scaled_by_projectile_distance_per_ammo_consumed"] = {
+			mod("Damage", "MORE", nil, 0, bit.bor(KeywordFlag.Hit, KeywordFlag.Ailment), { type = "Multiplier", var = "SteelShardConsumed", limit = 2 }, { type = "DistanceRamp", ramp = {{10,1},{70,0} } } )
+		},
+	},
 	baseFlags = {
 		attack = true,
 		projectile = true,
@@ -7447,6 +7448,22 @@ skills["ImpactingSteel"] = {
 	},
 	statDescriptionScope = "skill_stat_descriptions",
 	castTime = 1,
+	parts = {
+		{
+			name = "Main Projectile",
+		},
+		{
+			name = "Split Projectile",
+		},
+	},
+	statMap = {
+		["impacting_steel_secondary_projectile_damage_+%_final"] = {
+			mod("Damage", "MORE", nil, 0, 0, { type = "SkillPart", skillPart = 2 } )
+		},
+		["splitting_steel_area_+%_final_after_splitting"] = {
+			mod("AreaOfEffect", "MORE", nil, 0, 0, { type = "SkillPart", skillPart = 2 } )
+		},
+	},
 	baseFlags = {
 		attack = true,
 		projectile = true,

--- a/Data/3_0/Skills/act_dex.lua
+++ b/Data/3_0/Skills/act_dex.lua
@@ -4677,6 +4677,19 @@ skills["LancingSteel"] = {
 	},
 	statDescriptionScope = "skill_stat_descriptions",
 	castTime = 1,
+	parts = {
+		{
+			name = "Single Projectile Hit",
+		},
+		{
+			name = "All Projectiles Hit",
+		},
+	},
+	preDamageFunc = function(activeSkill, output)
+		if activeSkill.skillPart == 2 then
+			activeSkill.skillData.dpsMultiplier = 1 + 0.6 * (output.ProjectileCount - 1)
+		end
+	end,
 	statMap = {
 		["number_of_projectiles_to_fire_+%_final_per_steel_ammo_consumed"] = {
 			mod("ProjectileCount", "MORE", nil, 0, 0, { type = "Multiplier", var = "SteelShardConsumed", limit = 4 } )

--- a/Export/Skills/act_dex.txt
+++ b/Export/Skills/act_dex.txt
@@ -778,6 +778,19 @@ local skills, mod, flag, skill = ...
 
 #skill LancingSteel
 #flags attack projectile
+	parts = {
+		{
+			name = "Single Projectile Hit",
+		},
+		{
+			name = "All Projectiles Hit",
+		},
+	},
+	preDamageFunc = function(activeSkill, output)
+		if activeSkill.skillPart == 2 then
+			activeSkill.skillData.dpsMultiplier = 1 + 0.6 * (output.ProjectileCount - 1)
+		end
+	end,
 	statMap = {
 		["number_of_projectiles_to_fire_+%_final_per_steel_ammo_consumed"] = {
 			mod("ProjectileCount", "MORE", nil, 0, 0, { type = "Multiplier", var = "SteelShardConsumed", limit = 4 } )

--- a/Export/Skills/act_dex.txt
+++ b/Export/Skills/act_dex.txt
@@ -778,6 +778,11 @@ local skills, mod, flag, skill = ...
 
 #skill LancingSteel
 #flags attack projectile
+	statMap = {
+		["number_of_projectiles_to_fire_+%_final_per_steel_ammo_consumed"] = {
+			mod("ProjectileCount", "MORE", nil, 0, 0, { type = "Multiplier", var = "SteelShardConsumed", limit = 4 } )
+		},
+	},
 #mods
 
 #skill LightningArrow
@@ -1026,22 +1031,18 @@ local skills, mod, flag, skill = ...
 #flags attack projectile area
 	parts = {
 		{
-			name = "Single Projectile Hit",
+			name = "Projectile",
 			area = false,
 		},
 		{
-			name = "All Projectiles Hit",
-			area = false,
-		},
-		{
-			name = "Single Cone AoE",
+			name = "Cone AoE",
 		},
 	},
-	preDamageFunc = function(activeSkill, output)
-		if activeSkill.skillPart == 2 then
-			activeSkill.skillData.dpsMultiplier = output.ProjectileCount
-		end
-	end,
+	statMap = {
+		["shattering_steel_damage_+%_final_scaled_by_projectile_distance_per_ammo_consumed"] = {
+			mod("Damage", "MORE", nil, 0, bit.bor(KeywordFlag.Hit, KeywordFlag.Ailment), { type = "Multiplier", var = "SteelShardConsumed", limit = 2 }, { type = "DistanceRamp", ramp = {{10,1},{70,0} } } ),
+		},
+	},
 #baseMod skill("radius", 28)
 #mods
 
@@ -1113,6 +1114,22 @@ local skills, mod, flag, skill = ...
 
 #skill ImpactingSteel
 #flags attack projectile area
+	parts = {
+		{
+			name = "Main Projectile",
+		},
+		{
+			name = "Split Projectile",
+		},
+	},
+	statMap = {
+		["impacting_steel_secondary_projectile_damage_+%_final"] = {
+			mod("Damage", "MORE", nil, 0, 0, { type = "SkillPart", skillPart = 2 } )
+		},
+		["splitting_steel_area_+%_final_after_splitting"] = {
+			mod("AreaOfEffect", "MORE", nil, 0, 0, { type = "SkillPart", skillPart = 2 } )
+		},
+	},
 #baseMod flag("NoAdditionalProjectiles")
 #mods
 

--- a/Modules/ConfigOptions.lua
+++ b/Modules/ConfigOptions.lua
@@ -231,6 +231,13 @@ return {
 	{ var = "changedStance", type = "check", label = "Changed Stance recently?", ifCond = "ChangedStanceRecently", apply = function(val, modList, enemyModList)
 		modList:NewMod("Condition:ChangedStanceRecently", "FLAG", true, "Config")
 	end },
+	{ label = "Steel Skills:", ifSkillList = { "Splitting Steel", "Shattering Steel", "Lancing Steel" } },
+	{ var = "shardsConsumed", type = "count", label = "Steel Shards consumed:", ifSkillList = { "Splitting Steel", "Shattering Steel", "Lancing Steel" }, apply = function(val, modList, enemyModList)
+		modList:NewMod("Multiplier:SteelShardConsumed", "BASE", m_min(val, 12), "Config")
+	end },
+	{ var = "steelWards", type = "count", label = "Steel Wards:", ifSkill = "Shattering Steel", tooltip = "Steel Wards are gained from using Shattering Steel with at least 2 Steel Shards.\nYou can have up to 6 Steel Wards, and each grants +4% chance to Block Projectile Attack Damage.", apply = function(val, modList, enemyModList)
+		modList:NewMod("ProjectileBlockChance", "BASE", m_min(val * 4, 24), "Config")
+	end },
 	{ label = "Summon Holy Relic:", ifSkill = "Summon Holy Relic" },
 	{ var = "summonHolyRelicEnableHolyRelicBoon", type = "check", label = "Enable Holy Relic's Boon Aura:", ifSkill = "Summon Holy Relic", apply = function(val, modList, enemyModList)
 		modList:NewMod("SkillData", "LIST", { key = "enable", value = true }, "Config", { type = "SkillId", skillId = "RelicTriggeredNova" })


### PR DESCRIPTION
- Updates Skill Parts on Shattering Steel and the new Splitting Steel
- Adds Steel Shard mechanics to Shattering Steel and Lancing Steel, along with config option
- Adds Steel Wards from Shattering Steel

------------

Notes:
- For Shattering Steel's distance scaling, I assumed that the scaling starts at 10 units and reaches zero at 70 units. I assumed this based on the wording. "At the start of their movement" is used on Point Blank to mean "Less than 10 units", and "as they travel farther" is used on Far Shot and the Longshot notable to mean "Peaks at 70 units".

Missing features:

- Call of Steel is missing entirely, primarily because it's missing from the gem/skill files. Since it can't know impale damage from any skills, it would be pointless to have anyway aside from checking the use time and cooldown. 
- Lancing Steel's extra projectiles are ignored for damage. They deal less damage than the first projectile, and there's no sign of how quickly the secondary projectiles are fired, so calculating DPS for them would be very complicated. Not to mention they'd be inaccurate since you need so many Shards to keep using the skill, and summoning them cuts into your time spent attacking.