### PR TITLE
Fix Assassin's Mark, added + base Crit Multiplier.

### DIFF
--- a/Data/3_0/Skills/act_int.lua
+++ b/Data/3_0/Skills/act_int.lua
@@ -450,9 +450,8 @@ skills["AssassinsMark"] = {
 	statDescriptionScope = "curse_skill_stat_descriptions",
 	castTime = 0.5,
 	statMap = {
-		["base_self_critical_strike_multiplier_-%"] = {
-			mod("SelfCritMultiplier", "INC", nil, 0, 0, { type = "GlobalEffect", effectType = "Curse" }),
-			mult = -1,
+		["enemy_additional_critical_strike_multiplier_against_self"] = {
+			mod("SelfCritMultiplier", "BASE", nil, 0, 0, { type = "GlobalEffect", effectType = "Curse" }),
 		},
 		["enemy_additional_critical_strike_chance_against_self"] = {
 			mod("SelfCritChance", "BASE", nil, 0, 0, { type = "GlobalEffect", effectType = "Curse" }),

--- a/Modules/CalcOffence-3_0.lua
+++ b/Modules/CalcOffence-3_0.lua
@@ -1548,7 +1548,7 @@ function calcs.offence(env, actor, activeSkill)
 			if skillModList:Flag(cfg, "NoCritMultiplier") then
 				output.CritMultiplier = 1
 			else
-				local extraDamage = skillModList:Sum("BASE", cfg, "CritMultiplier") / 100
+				local extraDamage = (skillModList:Sum("BASE", cfg, "CritMultiplier") + (env.mode_effective and enemyDB:Sum("BASE", nil, "SelfCritMultiplier") or 0)) / 100
 				local multiOverride = skillModList:Override(skillCfg, "CritMultiplier")
 				if multiOverride then
 					extraDamage = (multiOverride - 100) / 100


### PR DESCRIPTION
Enemies cursed by Assassin's Mark now correctly gain base critical strike multiplier to hits against them