### PR TITLE
Negative accuracy fix

### DIFF
--- a/Modules/CalcDefence-3_0.lua
+++ b/Modules/CalcDefence-3_0.lua
@@ -25,6 +25,7 @@ local resistTypeList = { "Fire", "Cold", "Lightning", "Chaos" }
 
 -- Calculate hit chance
 function calcs.hitChance(evasion, accuracy)
+	accuracy = m_max(accuracy, 0) -- Negative accuracy is the same as 0 accuracy for this case
 	local rawChance = accuracy / (accuracy + (evasion / 4) ^ 0.8) * 115
 	return m_max(m_min(round(rawChance), 100), 5)	
 end

--- a/Modules/CalcDefence-3_0.lua
+++ b/Modules/CalcDefence-3_0.lua
@@ -25,7 +25,9 @@ local resistTypeList = { "Fire", "Cold", "Lightning", "Chaos" }
 
 -- Calculate hit chance
 function calcs.hitChance(evasion, accuracy)
-	accuracy = m_max(accuracy, 0) -- Negative accuracy is the same as 0 accuracy for this case
+	if (accuracy < 0) then
+		return 5
+	end
 	local rawChance = accuracy / (accuracy + (evasion / 4) ^ 0.8) * 115
 	return m_max(m_min(round(rawChance), 100), 5)	
 end

--- a/Modules/CalcDefence-3_0.lua
+++ b/Modules/CalcDefence-3_0.lua
@@ -25,7 +25,7 @@ local resistTypeList = { "Fire", "Cold", "Lightning", "Chaos" }
 
 -- Calculate hit chance
 function calcs.hitChance(evasion, accuracy)
-	if (accuracy < 0) then
+	if accuracy < 0 then
 		return 5
 	end
 	local rawChance = accuracy / (accuracy + (evasion / 4) ^ 0.8) * 115


### PR DESCRIPTION
Negative accuracy behaved the same as positive accuracy of the same value for the chance to hit calculation.  I've simply treated it as zero for that calculation to make it accurate again.