### PR TITLE
Cast Speed conversion from Kinetic Bolt's "Anomalous" alternate quality

### DIFF
--- a/Export/Skills/act_int.txt
+++ b/Export/Skills/act_int.txt
@@ -835,6 +835,9 @@ local skills, mod, flag, skill = ...
 		["active_skill_additive_spell_damage_modifiers_apply_to_attack_damage_at_%_value"] = {
 			flag("ImprovedSpellDamageAppliesToAttacks"),
 		},
+		["cast_speed_+%_applies_to_attack_speed_at_%_of_original_value"] = {
+			mod("CastSpeedAppliesToAttackSpeed", "BASE", nil),
+		},
 	},
 #mods
 

--- a/Modules/CalcOffence-3_0.lua
+++ b/Modules/CalcOffence-3_0.lua
@@ -347,6 +347,16 @@ function calcs.offence(env, actor, activeSkill)
 			end
 		end
 	end
+	if skillModList:Sum("BASE", nil, "CastSpeedAppliesToAttackSpeed") > 0 then
+		-- Cast Speed conversion from Kinetic Bolt's "Anomalous" alternate quality
+		local multiplier = skillModList:Sum("BASE", nil, "CastSpeedAppliesToAttackSpeed")/100
+		for i, value in ipairs(skillModList:Tabulate("INC", { flags = ModFlag.Cast }, "Speed")) do
+			local mod = value.mod
+			if band(mod.flags, ModFlag.Cast) ~= 0 then
+				skillModList:NewMod("Speed", "INC", mod.value * multiplier, mod.source, bor(band(mod.flags, bnot(ModFlag.Cast)), ModFlag.Attack), mod.keywordFlags, unpack(mod))
+			end
+		end
+	end
 	if skillModList:Flag(nil, "ClawDamageAppliesToUnarmed") then
 		-- Claw Damage conversion from Rigwald's Curse
 		for i, value in ipairs(skillModList:Tabulate("INC", { flags = ModFlag.Claw, keywordFlags = KeywordFlag.Hit }, "Damage")) do


### PR DESCRIPTION
This PR adds support for correctly calculating the attack speed of the Kinetic Bolt's "Anomalous" alternate quality (increases and reductions to cast speed apply to attack speed at x% of their value).

I'm not sure about my implementation. It is functional but i don't know if it was done in the correct way. I searched the code base for similar functionality and used that as my reference.