### PR TITLE
Fix Supreme Ego applying aura effect incorrectly

### DIFF
--- a/Modules/CalcPerform.lua
+++ b/Modules/CalcPerform.lua
@@ -1122,7 +1122,7 @@ function calcs.perform(env)
 						affectedByAura[env.player] = true
 						modDB.conditions["AffectedBy"..buff.name:gsub(" ","")] = true
 						local srcList = new("ModList")
-						local inc = skillModList:Sum("INC", skillCfg, "AuraEffect", "BuffEffect", "BuffEffectOnSelf", "AuraEffectOnSelf", "AuraBuffEffect")
+						local inc = skillModList:Sum("INC", skillCfg, "AuraEffect", "BuffEffect", "BuffEffectOnSelf", "AuraEffectOnSelf", "AuraBuffEffect", "SkillAuraEffectOnSelf")
 
 						-- Take the Purposeful Harbinger buffs into account.
 						-- These are capped to 40% increased buff effect, no matter the amount allocated
@@ -1131,7 +1131,7 @@ function calcs.perform(env)
 							data.misc.PurposefulHarbingerMaxBuffPercent)
 						inc = inc + incFromPurposefulHarbinger
 
-						local more = skillModList:More(skillCfg, "AuraEffect", "BuffEffect", "BuffEffectOnSelf", "AuraEffectOnSelf", "AuraBuffEffect")
+						local more = skillModList:More(skillCfg, "AuraEffect", "BuffEffect", "BuffEffectOnSelf", "AuraEffectOnSelf", "AuraBuffEffect", "SkillAuraEffectOnSelf")
 						srcList:ScaleAddList(buff.modList, (1 + inc / 100) * more)
 						srcList:ScaleAddList(extraAuraModList, (1 + inc / 100) * more)
 						mergeBuff(srcList, buffs, buff.name)

--- a/Modules/ModParser-3_0.lua
+++ b/Modules/ModParser-3_0.lua
@@ -1311,7 +1311,7 @@ local specialModList = {
 		mod("FireEnergyShieldBypass", "BASE", 100),
 	},
 	["auras from your skills do not affect allies"] = { flag("SelfAurasCannotAffectAllies") },
-	["auras from your skills have (%d+)%% more effect on you"] = function(num) return { mod("AuraEffectOnSelf", "MORE", num) } end,
+	["auras from your skills have (%d+)%% more effect on you"] = function(num) return { mod("SkillAuraEffectOnSelf", "MORE", num) } end,
 	["increases and reductions to mana regeneration rate instead apply to rage regeneration rate"] = { flag("ManaRegenToRageRegen") },
 	["maximum energy shield is (%d+)"] = function(num) return { mod("EnergyShield", "OVERRIDE", num ) } end,
 	["while not on full life, sacrifice ([%d%.]+)%% of mana per second to recover that much life"] = function(num) return { 


### PR DESCRIPTION
Supreme Ego was also applying to various aura-like effects. Requires `ModCache` rebuild.

Fixes #1457  