### PR TITLE
Fix/importing of alt gems

### DIFF
--- a/Classes/ImportTab.lua
+++ b/Classes/ImportTab.lua
@@ -809,7 +809,6 @@ function ImportTabClass:ImportSocketedItems(item, socketedItems, slotName)
 	local itemSocketGroupList = { }
 	local abyssalSocketId = 1
 	for _, socketedItem in ipairs(socketedItems) do
-		ConPrintf("socketed item id="..socketedItem.id..", name="..socketedItem.name..", typeline="..socketedItem.typeLine)
 		if socketedItem.abyssJewel then
 			self:ImportItem(socketedItem, slotName .. " Abyssal Socket "..abyssalSocketId)
 			abyssalSocketId = abyssalSocketId + 1

--- a/Classes/ImportTab.lua
+++ b/Classes/ImportTab.lua
@@ -536,10 +536,6 @@ function ImportTabClass:ImportItemsAndSkills(json)
 		table.sort(self.build.skillsTab.socketGroupList, function(a, b)
 			local orderA
 			for _, gem in ipairs(a.gemList) do
-				ConPrintf("~~~~~~~~~~~~~")
-
-				ConPrintf(gem.nameSpec)
-
 				if gem.grantedEffect and not gem.grantedEffect.support then
 					local i = isValueInArray(skillOrder, gem.grantedEffect.name)
 					if i and (not orderA or i < orderA) then

--- a/Classes/SkillsTab.lua
+++ b/Classes/SkillsTab.lua
@@ -224,7 +224,7 @@ function SkillsTabClass:Load(xml, fileName)
 				gemInstance.level = tonumber(child.attrib.level)
 				gemInstance.quality = tonumber(child.attrib.quality)
 				gemInstance.qualityId = SkillsTabClass:ParseGemAltQuality(gemInstance.nameSpec, child.attrib.qualityId)
-				gemInstance.nameSpec=SkillsTabClass:ParseBaseGemName(gemInstance)
+				gemInstance.nameSpec = SkillsTabClass:ParseBaseGemName(gemInstance)
 
 				if gemInstance.gemData then
 					gemInstance.qualityId.list = self:getGemAltQualityList(gemInstance.gemData)

--- a/Classes/SkillsTab.lua
+++ b/Classes/SkillsTab.lua
@@ -891,3 +891,7 @@ function SkillsTabClass:RestoreUndoState(state)
 		self.controls.groupList.selValue = self.socketGroupList[self.controls.groupList.selIndex]
 	end
 end
+
+function SkillsTabClass:getAlternateGemQualityList()
+	return alternateGemQualityList
+end

--- a/Classes/SkillsTab.lua
+++ b/Classes/SkillsTab.lua
@@ -158,6 +158,28 @@ will automatically apply to the skill.]]
 	self.controls.gemEnableHeader = new("LabelControl", {"BOTTOMLEFT",self.gemSlots[1].enabled,"TOPLEFT"}, -16, -2, 0, 16, "^7Enabled:")
 end)
 
+-- parse alt qual from existing quality list
+function SkillsTabClass:ParseGemAltQuality(gemName, qualityId)
+	if qualityId then
+		return qualityId
+	end if gemName then
+		for indx, entry in ipairs(alternateGemQualityList) do
+			if gemName:sub(1, #entry.label) == entry.label then
+				return entry.type
+			end
+		end
+	end
+end
+
+-- parse real gem name by ommiting the first word if alt qual is set
+function SkillsTabClass:ParseBaseGemName(gemInstance)
+	if gemInstance.qualityId and gemInstance.nameSpec then
+		_, gemName = gemInstance.nameSpec:match("(%w+)(.+)")
+		return gemName
+	end
+	return gemInstance.nameSpec
+end
+
 function SkillsTabClass:Load(xml, fileName)
 	self.defaultGemLevel = tonumber(xml.attrib.defaultGemLevel)
 	self.defaultGemQuality = tonumber(xml.attrib.defaultGemQuality)
@@ -201,7 +223,9 @@ function SkillsTabClass:Load(xml, fileName)
 				end
 				gemInstance.level = tonumber(child.attrib.level)
 				gemInstance.quality = tonumber(child.attrib.quality)
-				gemInstance.qualityId = child.attrib.qualityId
+				gemInstance.qualityId = SkillsTabClass:ParseGemAltQuality(gemInstance.nameSpec, child.attrib.qualityId)
+				gemInstance.nameSpec=SkillsTabClass:ParseBaseGemName(gemInstance)
+
 				if gemInstance.gemData then
 					gemInstance.qualityId.list = self:getGemAltQualityList(gemInstance.gemData)
 				end

--- a/Classes/SkillsTab.lua
+++ b/Classes/SkillsTab.lua
@@ -174,8 +174,10 @@ end
 -- parse real gem name by ommiting the first word if alt qual is set
 function SkillsTabClass:ParseBaseGemName(gemInstance)
 	if gemInstance.qualityId and gemInstance.nameSpec then
-		_, gemName = gemInstance.nameSpec:match("(%w+)(.+)")
-		return gemName
+		_, gemName = gemInstance.nameSpec:match("(%w+)%s(.+)")
+		if gemName then
+			return gemName
+		end
 	end
 	return gemInstance.nameSpec
 end


### PR DESCRIPTION
Hi I've added support for importing non default gem quality from GGGs (2. - 4. Commit) Site as well as Poe.Ninja (1. Commit).

Basic Idea was to obtain the quality type from the name via the existing dictionary and then set that in turn for the gem. For GGG Import it was necessary to adapt the base name so the import would happen.

Tested with:
- https://www.pathofexile.com/account/view-profile/FaustVIII/characters GraveDiggersChant has alt qual haste and withering step in the chest
- https://poe.ninja/challenge/builds/char/SpiritKinay/SpiritShrapnel?i=1&search=skill%3DShrapnel-Ballista - alt qual shrapnel ballista in the bow

I'm a rookie in lua so feel free to make it nicer :)