### PR TITLE
Fix Hexblast's "All Damage Can X" mods

### DIFF
--- a/Data/3_0/Skills/act_int.lua
+++ b/Data/3_0/Skills/act_int.lua
@@ -4554,10 +4554,22 @@ skills["DoomBlast"] = {
 	},
 	baseMods = {
 		skill("showAverage", true),
-		flag("ChaosCanIgnite"),
-		flag("ChaosCanChill"),
-		flag("ChaosCanShock"),
 		flag("ChaosDamageUsesLowestResistance"),
+		-- All damage can Ignite
+		flag("PhysicalCanIgnite"),
+		flag("LightningCanIgnite"),
+		flag("ColdCanIgnite"),
+		flag("ChaosCanIgnite"),
+		-- All damage can Freeze
+		flag("PhysicalCanFreeze"),
+		flag("LightningCanFreeze"),
+		flag("FireCanFreeze"),
+		flag("ChaosCanFreeze"),
+		-- All damage can Shock
+		flag("PhysicalCanShock"),
+		flag("ColdCanShock"),
+		flag("FireCanShock"),
+		flag("ChaosCanShock"),
 	},
 	qualityStats = {
 		Default = {


### PR DESCRIPTION
Hexblast says "All damage can X", not just "Chaos damage can X". Added appropriate mods.

Also Hexblast says "All damage can Freeze", not "All damage can Chill". Changed the can-chill mods to can-freeze ones.