### PR TITLE
Hexblast fixes

### DIFF
--- a/Data/3_0/Skills/act_int.lua
+++ b/Data/3_0/Skills/act_int.lua
@@ -4592,6 +4592,16 @@ skills["DoomBlast"] = {
 			mod("Damage", "MORE", nil, 0, KeywordFlag.Ailment, { type = "Multiplier", var = "HexDoom", div = 5 })
 		},
 	},
+	parts = {
+		{
+			name = "Target",
+			area = false,
+		},
+		{
+			name = "Explosion",
+			area = true,
+		},
+	},
 	baseFlags = {
 		spell = true,
 		area = true,

--- a/Export/Skills/act_int.txt
+++ b/Export/Skills/act_int.txt
@@ -804,6 +804,16 @@ local skills, mod, flag, skill = ...
 			mod("Damage", "MORE", nil, 0, KeywordFlag.Ailment, { type = "Multiplier", var = "HexDoom", div = 5 })
 		},
 	},
+	parts = {
+		{
+			name = "Target",
+			area = false,
+		},
+		{
+			name = "Explosion",
+			area = true,
+		},
+	},
 #baseMod skill("showAverage", true)
 #baseMod flag("ChaosDamageUsesLowestResistance")
 #baseMod flag("PhysicalCanIgnite")

--- a/Modules/CalcOffence-3_0.lua
+++ b/Modules/CalcOffence-3_0.lua
@@ -1806,14 +1806,23 @@ function calcs.offence(env, actor, activeSkill)
 							elseif damageType == "Chaos" then
 								pen = skillModList:Sum("BASE", cfg, "ChaosPenetration")
 								if skillModList:Flag(cfg, "ChaosDamageUsesLowestResistance") then
-									--Find the lowest resist of all the elements and use that if it's lower than chaos
+									-- Default to using Chaos
+									local elementUsed = "Chaos"
+									-- Find the lowest resist of all the elements and use that if it's lower than chaos
 									for _, damageTypeForChaos in ipairs(dmgTypeList) do
 										if isElemental[damageTypeForChaos] and useThisResist(damageTypeForChaos) then
 											local elementalResistForChaos = enemyDB:Sum("BASE", nil, damageTypeForChaos.."Resist")
 											local base = elementalResistForChaos + enemyDB:Sum("BASE", dotTypeCfg, "ElementalResist")
-											resist = m_min(resist, base * calcLib.mod(enemyDB, nil, damageType.."Resist"))
+											local currentElementResist = base * calcLib.mod(enemyDB, nil, damageType.."Resist")
+											-- If it's explicitly lower, then use the resist and update which element we're using to account for penetration
+											if resist > currentElementResist then
+												resist = currentElementResist
+												elementUsed = damageTypeForChaos
+											end
 										end
 									end
+									-- Update the penetration based on the element used
+									pen = skillModList:Sum("BASE", cfg, elementUsed.."Penetration", "ElementalPenetration")
 								end
 							end
 							resist = m_min(resist, data.misc.EnemyMaxResist)


### PR DESCRIPTION
#1498 

Now accounts for penetration correctly as being from the resist used
Adding 2 parts for single target vs area so single target does not have the area flag