### PR TITLE
Update ProjectileCount formula for accuracy, parse Spectral Shield Throw helmet enchantment

### DIFF
--- a/Modules/CalcOffence-3_0.lua
+++ b/Modules/CalcOffence-3_0.lua
@@ -575,7 +575,7 @@ function calcs.offence(env, actor, activeSkill)
 		else
 			local projBase = skillModList:Sum("BASE", skillCfg, "ProjectileCount")
 			local projMore = skillModList:More(skillCfg, "ProjectileCount")
-			output.ProjectileCount = round((projBase - 1) * projMore + 1)
+			output.ProjectileCount = m_floor(projBase * projMore)
 		end
 		if skillModList:Flag(skillCfg, "CannotFork") then
 			output.ForkCountString = "Cannot fork"

--- a/Modules/ModParser-3_0.lua
+++ b/Modules/ModParser-3_0.lua
@@ -2684,6 +2684,7 @@ for gemId, gemData in pairs(data["3_0"].gems) do
 		if gemData.tags.bow or gemData.tags.projectile then
 			specialModList["^"..skillName:lower().." fires an additional projectile"] = { mod("ExtraSkillMod", "LIST", { mod = mod("ProjectileCount", "BASE", 1) }, { type = "SkillName", skillName = skillName }) }
 			specialModList["^"..skillName:lower().." fires (%d+) additional projectiles"] = function(num) return { mod("ExtraSkillMod", "LIST", { mod = mod("ProjectileCount", "BASE", num) }, { type = "SkillName", skillName = skillName }) } end
+			specialModList["^"..skillName:lower().." fires (%d+) additional shard projectiles"] = function(num) return { mod("ExtraSkillMod", "LIST", { mod = mod("ProjectileCount", "BASE", num) }, { type = "SkillName", skillName = skillName }) } end
 		end
 	end	
 end


### PR DESCRIPTION
- Fixes the Projectile Count output to be accurate when there's a more/less modifier (ie Molten Strike/Spectral Shield Throw threshold jewels)
- Adds parsing for Spectral Shield Throw's additional shards helmet enchantment. Will also parse any future skill that happens to use "additional shard projectiles"

The new formula is correct on Molten Strike and Spectral Shield Throw in the following situations I tested:
- Base
- LMP
- GMP
- GMP + Dying Sun
- GMP + Dying Sun + Beltimber Blade x2
- GMP + Dying Sun + Beltimber Blade x2 + SST's +3 Shards helmet enchantment