### PR TITLE
Timeless jewel notables' stats apply when anointed

### DIFF
--- a/Classes/TreeTab.lua
+++ b/Classes/TreeTab.lua
@@ -523,6 +523,7 @@ function TreeTabClass:ModifyNodePopup(selectedNode)
 	end
 	controls.save = new("ButtonControl", nil, -90, 75, 80, 20, "Add", function()
 		addModifier(selectedNode)
+		self.build.buildFlag = true
 		main:ClosePopup()
 	end)
 	controls.reset = new("ButtonControl", nil, 0, 75, 80, 20, "Reset Node", function()
@@ -551,6 +552,7 @@ function TreeTabClass:ModifyNodePopup(selectedNode)
 				self.specList[1]:NodeAdditionOrReplacementFromString(selectedNode,"+5 to Devotion")
 			end
 		end
+		self.build.buildFlag = true
 		main:ClosePopup()
 	end)
 	controls.close = new("ButtonControl", nil, 90, 75, 80, 20, "Cancel", function()

--- a/Modules/CalcSetup.lua
+++ b/Modules/CalcSetup.lua
@@ -664,7 +664,11 @@ function calcs.initEnv(build, mode, override)
 	for _, passive in pairs(env.modDB:List(nil, "GrantedPassive")) do
 		local node = env.spec.tree.notableMap[passive]
 		if node then
-			nodes[node.id] = node
+			if env.spec.nodes[node.id] and env.spec.nodes[node.id].conqueredBy and env.spec.tree.legion.editedNodes and env.spec.tree.legion.editedNodes[env.spec.nodes[node.id].conqueredBy.id] then
+				nodes[node.id] = env.spec.tree.legion.editedNodes[env.spec.nodes[node.id].conqueredBy.id][node.id] or node
+			else
+				nodes[node.id] = node
+			end
 			env.grantedPassives[node.id] = true
 		end
 	end


### PR DESCRIPTION
Fixes #1492

The new notable name doesn't show up in the anoint UI, but does grant the new stats instead of what is listed in the anoint UI.  For sorting purposes, that will probably be my next fix.