### PR TITLE
fix(alt-qual): unify method to parse quality and name

### DIFF
--- a/Classes/ImportTab.lua
+++ b/Classes/ImportTab.lua
@@ -788,22 +788,6 @@ function ImportTabClass:ImportItem(itemData, slotName)
 end
 
 
--- parse real gem name by ommiting the first word if alt qual is set
-function ImportTabClass:GetBaseNameAndQuality(gemTypeLine)
-	if gemTypeLine then
-		local firstword, otherwords = gemTypeLine:match("(%w+)%s(.+)")
-		if firstword and otherwords then
-			for indx, entry in ipairs(self.build.skillsTab.getAlternateGemQualityList()) do
-				if firstword == entry.label then
-					return otherwords, entry.type
-				end
-			end
-		end
-	end
-
-	return gemTypeLine, "Default"
-end
-
 function ImportTabClass:ImportSocketedItems(item, socketedItems, slotName)
 	-- Build socket group list
 	local itemSocketGroupList = { }
@@ -813,12 +797,12 @@ function ImportTabClass:ImportSocketedItems(item, socketedItems, slotName)
 			self:ImportItem(socketedItem, slotName .. " Abyssal Socket "..abyssalSocketId)
 			abyssalSocketId = abyssalSocketId + 1
 		else
-			local normalizedBasename, qualityType = self:GetBaseNameAndQuality(socketedItem.typeLine)
+			local normalizedBasename, qualityType = self.build.skillsTab:GetBaseNameAndQuality(socketedItem.typeLine)
 			local gemId = self.build.data.gemForBaseName[normalizedBasename] 
 			if not gemId and socketedItem.hybrid then
 				-- Dual skill gems (currently just Stormbind) show the second skill as the typeLine, which won't match the actual gem
 				-- Luckily the primary skill name is also there, so we can find the gem using that
-				normalizedBasename, qualityType  = self:GetBaseNameAndQuality(socketedItem.hybrid.baseTypeName)
+				normalizedBasename, qualityType  = self.build.skillsTab:GetBaseNameAndQuality(socketedItem.hybrid.baseTypeName)
 				gemId = self.build.data.gemForBaseName[normalizedBasename]
 			end
 			if gemId then

--- a/Classes/SkillsTab.lua
+++ b/Classes/SkillsTab.lua
@@ -158,29 +158,20 @@ will automatically apply to the skill.]]
 	self.controls.gemEnableHeader = new("LabelControl", {"BOTTOMLEFT",self.gemSlots[1].enabled,"TOPLEFT"}, -16, -2, 0, 16, "^7Enabled:")
 end)
 
--- parse alt qual from existing quality list
-function SkillsTabClass:ParseGemAltQuality(gemName, qualityId)
-	if qualityId then
-		return qualityId
-	end if gemName then
-		for indx, entry in ipairs(alternateGemQualityList) do
-			if gemName:sub(1, #entry.label) == entry.label then
-				return entry.type
+-- parse real gem name and quality by ommiting the first word if alt qual is set
+function SkillsTabClass:GetBaseNameAndQuality(gemTypeLine)
+	if gemTypeLine then
+		local firstword, otherwords = gemTypeLine:match("(%w+)%s(.+)")
+		if firstword and otherwords then
+			for indx, entry in ipairs(alternateGemQualityList) do
+				if firstword == entry.label then
+					return otherwords, entry.type
+				end
 			end
 		end
 	end
-	return "Default"
-end
 
--- parse real gem name by ommiting the first word if alt qual is set
-function SkillsTabClass:ParseBaseGemName(gemInstance)
-	if gemInstance.qualityId and gemInstance.nameSpec then
-		_, gemName = gemInstance.nameSpec:match("(%w+)%s(.+)")
-		if gemName then
-			return gemName
-		end
-	end
-	return gemInstance.nameSpec
+	return gemTypeLine, "Default"
 end
 
 function SkillsTabClass:Load(xml, fileName)


### PR DESCRIPTION
Poe Ninja internal export format clashed with the way i implemented this the first time around:

> Something has broken the way that I (in poe.ninja) import builds. I guess it is related to the changes around alt qualities. My process involves generating an import for pob that looks like this: 
`<Gem level="19" quality="0" enabled="true" nameSpec="Armageddon Brand" enableGlobal1="true" enableGlobal2="true" />`
and this has worked so far, but now what I get back from pob (and that I put in the pob code on poe.ninja character page) contains this:
`<Gem enableGlobal2="true" quality="0" level="19" enableGlobal1="true" qualityId="Default" enabled="true" nameSpec="Brand"/>`
Notice how the first word is missing from the nameSpec, so Armageddon Brand becomes Brand which is invalid.


Fixed it by using the one function in both places bonus: only one place to maintain it.

Comment chain for the issue:
https://discordapp.com/channels/676181894152454150/676256416218218496/760869608726200321
Rasmuskl: Here's one of my internal pob codes that have the issue: https://pastebin.com/D3pT9rwr
Rasmkuskl: Here's my generated pob code in inflated form: https://pastebin.com/FUzrJPdk

Also verified that it still works for my char on `FaustVIII` > `GraveDiggersChant`
and `Rukakapowed` > `SlenderTeeth`