### PR TITLE
[WIP] Added Gems Obtained By list

### DIFF
--- a/Classes/SkillObtainedByListControl.lua
+++ b/Classes/SkillObtainedByListControl.lua
@@ -1,0 +1,86 @@
+-- Path of Building
+--
+-- Class: Skill Obtained By List
+-- Skill obtained by list control.
+-- This list will show what level the gem can be obtained at
+-- Future: 
+--		What vendor the gem can be obtained at
+--		Sort the list by gem level
+--		Filter the gems by class
+local ipairs = ipairs
+local t_insert = table.insert
+local t_remove = table.remove
+local m_min = math.min
+local m_max = math.max
+local m_floor = math.floor
+
+local SkillObtainedListClass = newClass("SkillObtainedByListControl", "ListControl", function(self, anchor, x, y, width, height, skillsTab)
+	self.ListControl(anchor, x, y, width, height, 16, false, true, self.list)
+end)
+
+function SkillObtainedListClass:GetRowValue(column, index, gemInstance)
+
+
+	if gemInstance.gemData or gemInstance.grantedEffect then
+		gemInstance.new = nil
+		local grantedEffect = gemInstance.grantedEffect or gemInstance.gemData.grantedEffect
+		if grantedEffect.color == 1 then
+			gemInstance.color = colorCodes.STRENGTH
+		elseif grantedEffect.color == 2 then
+			gemInstance.color = colorCodes.DEXTERITY
+		elseif grantedEffect.color == 3 then
+			gemInstance.color = colorCodes.INTELLIGENCE
+		else
+			gemInstance.color = colorCodes.NORMAL
+		end
+		if prevDefaultLevel and gemInstance.gemData and gemInstance.gemData.defaultLevel ~= prevDefaultLevel then
+			gemInstance.level = m_min(self.defaultGemLevel or gemInstance.gemData.defaultLevel, gemInstance.gemData.defaultLevel + 1)
+			gemInstance.defaultLevel = gemInstance.level
+		end
+		calcLib.validateGemLevel(gemInstance)
+		if gemInstance.gemData then
+			self.reqLevel1 = grantedEffect.levels[1].levelRequirement
+			
+		end
+	end
+
+	if column == 1 then
+		local label = gemInstance.nameSpec or "?"
+		--if not gemInstance.enabled or not gemInstance.slotEnabled then
+		if self.reqLevel1 == nil then 
+			--label = gemInstance.color .. "" .. label
+		else
+			-- to be added when data for act/vendor reward is collected
+			-- label = gemInstance.color .. "("  .. self.reqLevel1 ..  ") ".. label .. " [Act ##" .. " Vendor/Reward]\t"
+			label = gemInstance.color .. "("  .. self.reqLevel1 ..  ") ".. label
+		end
+		return label
+	end
+end
+
+function SkillObtainedListClass:UpdateAllGems(skillsTab)
+	self.list = {}
+	local sortedList = {}
+
+	for _, socketGroup in ipairs (skillsTab.socketGroupList) do
+		for _, gemInstance in ipairs(socketGroup.gemList) do
+			local table = {}
+			if gemInstance.gemData or gemInstance.grantedEffect then
+				gemInstance.new = nil
+				local grantedEffect = gemInstance.grantedEffect or gemInstance.gemData.grantedEffect
+				sortedList[gemInstance] = grantedEffect.levels[1].levelRequirement
+			end
+		end
+	end
+
+	function compare(a,b)
+		return a[1] < b[1]
+	end
+
+	table.sort(sortedList, compare)
+
+	for key, value in next, sortedList do
+		t_insert(self.list,  key)
+	end
+
+end

--- a/Classes/SkillsTab.lua
+++ b/Classes/SkillsTab.lua
@@ -87,6 +87,10 @@ local SkillsTabClass = newClass("SkillsTab", "UndoHandler", "ControlHost", "Cont
 		self.showSupportGemTypes = value.show
 	end)
 	self.controls.showSupportGemTypesLabel = new("LabelControl", {"RIGHT",self.controls.showSupportGemTypes,"LEFT"}, -4, 0, 0, 16, "^7Show support gems:")
+
+	-- Gem obtained by
+	self.controls.gemObtainedBySection = new("SectionControl", {"TOPLEFT",self.controls.groupList,"BOTTOMLEFT"}, 0, 200, 320, 450, "Gems Obtained By")
+	self.controls.gemObtainedByGroupList = new("SkillObtainedByListControl", {"TOPLEFT",self.controls.groupList,"BOTTOMLEFT"}, 10, 215, 300, 420, self)
 	
 	-- Socket group details
 	self.anchorGroupDetail = new("Control", {"TOPLEFT",self.controls.groupList,"TOPRIGHT"}, 20, 0, 0, 0)
@@ -390,6 +394,9 @@ function SkillsTabClass:CreateGemSlot(index)
 		end
 		self:AddUndoState()
 		self.build.buildFlag = true
+		
+		-- Update obtained by list on delete
+		self.controls.gemObtainedByGroupList:UpdateAllGems(self)
 	end)
 	if index == 1 then
 		slot.delete:SetAnchor("TOPLEFT", self.anchorGemSlots, "TOPLEFT", 0, 0)
@@ -628,6 +635,9 @@ function SkillsTabClass:CreateGemSlot(index)
 		return "Enable "..self.displayGroup.gemList[index].gemData.grantedEffectList[2].name..":"
 	end
 	self.controls["gemSlot"..index.."EnableGlobal2"] = slot.enableGlobal2
+
+	-- Update obtained by list on add
+	self.controls.gemObtainedByGroupList:UpdateAllGems(self)
 end
 
 


### PR DESCRIPTION
Is your feature request related to a problem? Please describe.
Having to tab out to figure out where gems come from and compiling a list each league for each build I want to do takes a lot of time. With this it would be on the fly and extremely easy to see what gems come from where.

Describe the solution you'd like
I did a little prototyping with the picture below and found that I can get all the current gems in the build, the level requirement of level 1 version of the gem and display that in a new list type.

What's missing is the data from where you can obtain the gems:

https://docs.google.com/spreadsheets/d/1bm_5CbVppiapbR7BWYjtByKEK8i0xZS9ARDx9tDgUeA/edit#gid=509118471

This google doc has it all laid out and would most likely need to be another separate data set that is manually maintained as GGG does not provide that information from what I can see. This data can then be added to gemInstance data.

Describe alternatives you've considered
Sorting by Act, Gem Requirement level and Gem Type would be useful as well.