### PR TITLE
fix(load-quality): when overriding quality also pass existing qual

### DIFF
--- a/Classes/ImportTab.lua
+++ b/Classes/ImportTab.lua
@@ -797,12 +797,12 @@ function ImportTabClass:ImportSocketedItems(item, socketedItems, slotName)
 			self:ImportItem(socketedItem, slotName .. " Abyssal Socket "..abyssalSocketId)
 			abyssalSocketId = abyssalSocketId + 1
 		else
-			local normalizedBasename, qualityType = self.build.skillsTab:GetBaseNameAndQuality(socketedItem.typeLine)
+			local normalizedBasename, qualityType = self.build.skillsTab:GetBaseNameAndQuality(socketedItem.typeLine, nil)
 			local gemId = self.build.data.gemForBaseName[normalizedBasename] 
 			if not gemId and socketedItem.hybrid then
 				-- Dual skill gems (currently just Stormbind) show the second skill as the typeLine, which won't match the actual gem
 				-- Luckily the primary skill name is also there, so we can find the gem using that
-				normalizedBasename, qualityType  = self.build.skillsTab:GetBaseNameAndQuality(socketedItem.hybrid.baseTypeName)
+				normalizedBasename, qualityType  = self.build.skillsTab:GetBaseNameAndQuality(socketedItem.hybrid.baseTypeName, nil)
 				gemId = self.build.data.gemForBaseName[normalizedBasename]
 			end
 			if gemId then

--- a/Classes/SkillsTab.lua
+++ b/Classes/SkillsTab.lua
@@ -160,19 +160,20 @@ end)
 
 -- parse real gem name and quality by ommiting the first word if alt qual is set
 function SkillsTabClass:GetBaseNameAndQuality(gemTypeLine, quality)
+	-- if quality is default or nil check the gem type line if we have alt qual by comparing to the existing list
 	if gemTypeLine and (quality == nil or quality == 'Default') then
 		local firstword, otherwords = gemTypeLine:match("(%w+)%s(.+)")
 		if firstword and otherwords then
 			for _, entry in ipairs(alternateGemQualityList) do
 				if firstword == entry.label then
+					-- return the gem name minus <altqual> without a leading space and the new resolved type
 					return otherwords, entry.type
 				end
 			end
-		else
-			return gemTypeLine, 'Default'
 		end
 	end
-    return gemTypeLine, quality
+	-- no alt qual found, return gemTypeLine as is and either existing quality or Default if none is set
+    return gemTypeLine, quality or 'Default'
 end
 
 function SkillsTabClass:Load(xml, fileName)


### PR DESCRIPTION
- if quality is nil or default try to parse
  - if first word matches any alt qual return gem name minus first word
    and set appropriate quality
  - else set to gem gemTypeLine + Default (this was the missing case!)
- if we dont even have a gem name return whatever we put in

also removed the left over method from my first iteration
Tested with the following snippet:

```lua
local alternateGemQualityList ={
	{label = "Default", type = "Default"},
	{label = "Anomalous", type = "Alternate1"},
	{label = "Divergent", type = "Alternate2"},
	{label = "Phantasmal", type = "Alternate3"},
}

function GetBaseNameAndQuality(gemTypeLine, quality)
	if gemTypeLine and (quality == nil or quality == 'Default') then
		local firstword, otherwords = gemTypeLine:match("(%w+)%s(.+)")
		if firstword and otherwords then
			for _, entry in ipairs(alternateGemQualityList) do
				if firstword == entry.label then
					return otherwords, entry.type
				end
			end
		else
			return gemTypeLine, 'Default'
		end
	end
    return gemTypeLine, quality
end

print(GetBaseNameAndQuality("Haste",nil))
print(GetBaseNameAndQuality("Haste","Default"))

print(GetBaseNameAndQuality("Haste","Alternate1"))
print(GetBaseNameAndQuality("Haste","Alternate2"))
print(GetBaseNameAndQuality("Haste","Alternate3"))

print(GetBaseNameAndQuality("Anomalous Haste",nil))
print(GetBaseNameAndQuality("Divergent Haste",nil))
print(GetBaseNameAndQuality("Phantasmal Haste",nil))
```

Output:
```
$lua main.lua
Haste	Default
Haste	Default
Haste	Alternate1
Haste	Alternate2
Haste	Alternate3
Haste	Alternate1
Haste	Alternate2
Haste	Alternate3
```