### PR TITLE
Fix Hexblast interaction with increased/reduced resistance modifiers

### DIFF
--- a/Modules/CalcOffence-3_0.lua
+++ b/Modules/CalcOffence-3_0.lua
@@ -1817,7 +1817,7 @@ function calcs.offence(env, actor, activeSkill)
 										if isElemental[damageTypeForChaos] and useThisResist(damageTypeForChaos) then
 											local elementalResistForChaos = enemyDB:Sum("BASE", nil, damageTypeForChaos.."Resist")
 											local base = elementalResistForChaos + enemyDB:Sum("BASE", dotTypeCfg, "ElementalResist")
-											local currentElementResist = base * calcLib.mod(enemyDB, nil, damageType.."Resist")
+											local currentElementResist = base * calcLib.mod(enemyDB, nil, damageTypeForChaos.."Resist")
 											-- If it's explicitly lower, then use the resist and update which element we're using to account for penetration
 											if resist > currentElementResist then
 												resist = currentElementResist


### PR DESCRIPTION
Fixes a bug where increased resistance modifiers like on Eye of Malice were not being considered on Hexblast

---------

Simple issue where whoever implemented Hexblast's resistance shenanigans apparently copy/pasted some stuff and forgot to change a "damageType" to "damageTypeForChaos". Basically only affected Eye of Malice, I believe, but it's a big chunk of damage that was missing from builds that tried to use that interaction.

Fixes #1508 