### PR TITLE
Support SOCKS5 Host Name Mode Proxy

### DIFF
--- a/Modules/Main.lua
+++ b/Modules/Main.lua
@@ -529,6 +529,7 @@ function main:OpenOptionsPopup()
 	controls.proxyType = new("DropDownControl", {"TOPLEFT",nil,"TOPLEFT"}, 150, 20, 80, 18, {
 		{ label = "HTTP", scheme = "http" },
 		{ label = "SOCKS", scheme = "socks5" },
+		{ label = "SOCKS5H", scheme = "socks5h" },
 	})
 	controls.proxyLabel = new("LabelControl", {"RIGHT",controls.proxyType,"LEFT"}, -4, 0, 0, 16, "^7Proxy server:")
 	controls.proxyURL = new("EditControl", {"LEFT",controls.proxyType,"RIGHT"}, 4, 0, 206, 18)


### PR DESCRIPTION
Default SOCKS5 proxy mode does name resolving locally. This will not work under some network conditions. This merge request adds the support of SOCKS5 host name mode which allows cURL to send the host name to the proxy server and resolve it remotely.