### PR TITLE
Add TotalPoisonDPS to combineStat list for Average Hit attack skills

### DIFF
--- a/Modules/CalcOffence-3_0.lua
+++ b/Modules/CalcOffence-3_0.lua
@@ -3240,12 +3240,12 @@ function calcs.offence(env, actor, activeSkill)
 		combineStat("BleedDPS", "CHANCE", "BleedChance")
 		combineStat("PoisonChance", "AVERAGE")
 		combineStat("PoisonDPS", "CHANCE", "PoisonChance")
+		combineStat("TotalPoisonDPS", "DPS")
 		combineStat("PoisonDamage", "CHANCE", "PoisonChance")
 		if skillData.showAverage then
 			combineStat("TotalPoisonAverageDamage", "DPS")
 		else
 			combineStat("TotalPoisonStacks", "DPS")
-			combineStat("TotalPoisonDPS", "DPS")
 		end
 		combineStat("IgniteChance", "AVERAGE")
 		combineStat("IgniteDPS", "CHANCE", "IgniteChance")


### PR DESCRIPTION
Adds TotalPoisonDPS to the combineStat list for Average Hit attack skills

Before:
![image](https://user-images.githubusercontent.com/39030429/95054324-56cd2980-06b7-11eb-8e40-3d4f7628e91e.png)

After:
![image](https://user-images.githubusercontent.com/39030429/95054359-63ea1880-06b7-11eb-97f9-80b7878314e0.png)

--------

I noticed that if I tried to sort gems by Poison DPS on an Assailum build I'm planning, it wouldn't even attempt to suggest gems and would just sort gems alphabetically. Through some investigation I found out that the gem sorter couldn't see TotalPoisonDPS on Average Hit attack skills(even though that stat was being calculated) because main hand and off hand stats weren't being combined, and the gem sorter was checking for the combined stat. It other words, it was checking for "output.TotalPoisonDPS", but only "MainHand.TotalPoisonDPS" and "OffHand.TotalPoisonDPS" existed. Now the combined stat exists and the gem sorter works properly.