### PR TITLE
Mod tag conversion

### DIFF
--- a/Modules/CalcOffence-3_0.lua
+++ b/Modules/CalcOffence-3_0.lua
@@ -331,7 +331,7 @@ function calcs.offence(env, actor, activeSkill)
 	end
 
 	-- Correct the tags on conversion with multipliers so they carry over correctly
-	local getConvertedModTags = function(mod, minionMods)
+	local getConvertedModTags = function(mod, multiplier, minionMods)
 		local modifiers = modLib.extractModTags(mod)
 		for k, value in ipairs(modifiers) do
 			if minionMods and value.type == "ActorCondition" and value.actor == "parent" then
@@ -349,7 +349,7 @@ function calcs.offence(env, actor, activeSkill)
 		for _, value in ipairs(skillModList:List(skillCfg, "MinionModifier")) do
 			if value.mod.name == "Damage" and value.mod.type == "INC" then
 				local mod = value.mod
-				local modifiers = getConvertedModTags(mod, true)
+				local modifiers = getConvertedModTags(mod, multiplier, true)
 				skillModList:NewMod("Damage", "INC", mod.value * multiplier, mod.source, mod.flags, mod.keywordFlags, unpack(modifiers))
 			end
 		end
@@ -360,7 +360,7 @@ function calcs.offence(env, actor, activeSkill)
 		-- Minion Attack Speed conversion from Spiritual Command
 		for _, value in ipairs(skillModList:List(skillCfg, "MinionModifier")) do
 			if value.mod.name == "Speed" and value.mod.type == "INC" and (value.mod.flags == 0 or band(value.mod.flags, ModFlag.Attack) ~= 0) then
-				local modifiers = getConvertedModTags(value.mod, true)
+				local modifiers = getConvertedModTags(value.mod, multiplier, true)
 				skillModList:NewMod("Speed", "INC", value.mod.value * multiplier, value.mod.source, ModFlag.Attack, value.mod.keywordFlags, unpack(modifiers))
 			end
 		end
@@ -371,7 +371,7 @@ function calcs.offence(env, actor, activeSkill)
 		for i, value in ipairs(skillModList:Tabulate("INC", { flags = ModFlag.Spell }, "Damage")) do
 			local mod = value.mod
 			if band(mod.flags, ModFlag.Spell) ~= 0 then
-				local modifiers = getConvertedModTags(mod)
+				local modifiers = getConvertedModTags(mod, multiplier)
 				skillModList:NewMod("Damage", "INC", mod.value * multiplier, mod.source, bor(band(mod.flags, bnot(ModFlag.Spell)), ModFlag.Attack), mod.keywordFlags, unpack(modifiers))
 			end
 		end
@@ -385,7 +385,7 @@ function calcs.offence(env, actor, activeSkill)
 			-- Add a new mod for all mods that are cast only
 			-- Replace this with a single mod for the sum?
 			if band(mod.flags, ModFlag.Cast) ~= 0 then
-				local modifiers = getConvertedModTags(mod)
+				local modifiers = getConvertedModTags(mod, multiplier)
 				skillModList:NewMod("Speed", "INC", mod.value * multiplier, mod.source, bor(band(mod.flags, bnot(ModFlag.Cast)), ModFlag.Attack), mod.keywordFlags, unpack(modifiers))
 			end
 		end

--- a/Modules/CalcOffence-3_0.lua
+++ b/Modules/CalcOffence-3_0.lua
@@ -336,8 +336,11 @@ function calcs.offence(env, actor, activeSkill)
 		for k, value in ipairs(modifiers) do
 			if minionMods and value.type == "ActorCondition" and value.actor == "parent" then
 				modifiers[k] = { type = "Condition", var = value.var }
-			elseif value.type == "Multiplier" and value.limitTotal then
-				modifiers[k] = { type = "Multiplier", div = value.div, var = value.var, limitTotal = value.limitTotal, limit = value.limit * multiplier }
+			elseif value.limitTotal then
+				-- LimitTotal can apply to 'per stat' or 'multiplier', so just copy the whole and update the limit
+				local copy = copyTable(value)
+				copy.limit = copy.limit * multiplier
+				modifiers[k] = copy
 			end
 		end
 		return modifiers

--- a/Modules/CalcOffence-3_0.lua
+++ b/Modules/CalcOffence-3_0.lua
@@ -314,57 +314,79 @@ function calcs.offence(env, actor, activeSkill)
 		skillModList:NewMod("Damage", "INC", m_floor(skillModList:Sum("INC", nil, "EnergyShield") * data.misc.Transfiguration), "Transfiguration of Soul", ModFlag.Spell)
 	end
 
-	if skillModList:Flag(nil, "MinionDamageAppliesToPlayer")  or skillModList:Flag(nil, "ImprovedMinionDamageAppliesToPlayer") then
-		-- Minion Damage conversion from The Scourge
+	-- modType: To look for "INC" or "BASE" for getting the percent conversion
+	-- modName: Mod name to look for getting the percent conversion
+	local getConversionMultiplier = function(modType, modName)
+		-- Default to 100% conversion
 		local multiplier = 1
-		if skillModList:Flag(nil, "ImprovedMinionDamageAppliesToPlayer") then
-			multiplier = 1.5
+		if modType and modName then
+			local maxIncrease = 0
+			for i, value in ipairs(skillModList:Tabulate(modType, skillCfg, modName)) do
+				maxIncrease = m_max(maxIncrease, value.mod.value)
+			end
+			-- Convert from percent to fraction
+			multiplier = maxIncrease / 100.
 		end
+		return multiplier
+	end
+
+	-- Correct the tags on conversion with multipliers so they carry over correctly
+	local getConvertedModTags = function(mod, minionMods)
+		local modifiers = modLib.extractModTags(mod)
+		for k, value in ipairs(modifiers) do
+			if minionMods and value.type == "ActorCondition" and value.actor == "parent" then
+				modifiers[k] = { type = "Condition", var = value.var }
+			elseif value.type == "Multiplier" and value.limitTotal then
+				modifiers[k] = { type = "Multiplier", div = value.div, var = value.var, limitTotal = value.limitTotal, limit = value.limit * multiplier }
+			end
+		end
+		return modifiers
+	end
+
+	if skillModList:Flag(nil, "MinionDamageAppliesToPlayer") then
+		-- Minion Damage conversion from Spiritual Aid and The Scourge
+		local multiplier = getConversionMultiplier("INC", "ImprovedMinionDamageAppliesToPlayer")
 		for _, value in ipairs(skillModList:List(skillCfg, "MinionModifier")) do
-			local mod = value.mod
 			if value.mod.name == "Damage" and value.mod.type == "INC" then
-				skillModList:NewMod("Damage", "INC", mod.value * multiplier, mod.source, mod.flags, mod.keywordFlags, unpack(mod))
+				local mod = value.mod
+				local modifiers = getConvertedModTags(mod, true)
+				skillModList:NewMod("Damage", "INC", mod.value * multiplier, mod.source, mod.flags, mod.keywordFlags, unpack(modifiers))
 			end
 		end
 	end
 	if skillModList:Flag(nil, "MinionAttackSpeedAppliesToPlayer") then
+		-- Minion Damage conversion from Spiritual Command
+		local multiplier = getConversionMultiplier("INC", "ImprovedMinionAttackSpeedAppliesToPlayer")
 		-- Minion Attack Speed conversion from Spiritual Command
 		for _, value in ipairs(skillModList:List(skillCfg, "MinionModifier")) do
 			if value.mod.name == "Speed" and value.mod.type == "INC" and (value.mod.flags == 0 or band(value.mod.flags, ModFlag.Attack) ~= 0) then
-				skillModList:NewMod("Speed", "INC", value.mod.value, value.mod.source, ModFlag.Attack, value.mod.keywordFlags, unpack(value.mod))
+				local modifiers = getConvertedModTags(value.mod, true)
+				skillModList:NewMod("Speed", "INC", value.mod.value * multiplier, value.mod.source, ModFlag.Attack, value.mod.keywordFlags, unpack(modifiers))
 			end
 		end
 	end
 	if skillModList:Flag(nil, "SpellDamageAppliesToAttacks") then
 		-- Spell Damage conversion from Crown of Eyes, Kinetic Bolt, and the Wandslinger notable
-		local maxIncrease = 0
-		for i, value in ipairs(skillModList:Tabulate("INC", skillCfg, "ImprovedSpellDamageAppliesToAttacks")) do
-			maxIncrease = m_max(maxIncrease, value.mod.value)
-		end
-		-- Convert from percent to fraction
-		local multiplier = maxIncrease / 100.
+		local multiplier = getConversionMultiplier("INC", "ImprovedSpellDamageAppliesToAttacks")
 		for i, value in ipairs(skillModList:Tabulate("INC", { flags = ModFlag.Spell }, "Damage")) do
 			local mod = value.mod
 			if band(mod.flags, ModFlag.Spell) ~= 0 then
-				skillModList:NewMod("Damage", "INC", mod.value * multiplier, mod.source, bor(band(mod.flags, bnot(ModFlag.Spell)), ModFlag.Attack), mod.keywordFlags, unpack(mod))
+				local modifiers = getConvertedModTags(mod)
+				skillModList:NewMod("Damage", "INC", mod.value * multiplier, mod.source, bor(band(mod.flags, bnot(ModFlag.Spell)), ModFlag.Attack), mod.keywordFlags, unpack(modifiers))
 			end
 		end
 	end
 
 	if skillModList:Flag(nil, "CastSpeedAppliesToAttacks") then
 		-- Get all increases for this; assumption is that multiple sources would not stack, so find the max
-		local maxIncrease = 0
-		for i, value in ipairs(skillModList:Tabulate("INC", skillCfg, "ImprovedCastSpeedAppliesToAttacks")) do
-			maxIncrease = m_max(maxIncrease, value.mod.value)
-		end
-		-- Convert from percent to fraction
-		local multiplier = maxIncrease / 100.
+		local multiplier = getConversionMultiplier("INC", "ImprovedCastSpeedAppliesToAttacks")
 		for i, value in ipairs(skillModList:Tabulate("INC", { flags = ModFlag.Cast }, "Speed")) do
 			local mod = value.mod
 			-- Add a new mod for all mods that are cast only
 			-- Replace this with a single mod for the sum?
 			if band(mod.flags, ModFlag.Cast) ~= 0 then
-				skillModList:NewMod("Speed", "INC", mod.value * multiplier, mod.source, bor(band(mod.flags, bnot(ModFlag.Cast)), ModFlag.Attack), mod.keywordFlags, unpack(mod))
+				local modifiers = getConvertedModTags(mod)
+				skillModList:NewMod("Speed", "INC", mod.value * multiplier, mod.source, bor(band(mod.flags, bnot(ModFlag.Cast)), ModFlag.Attack), mod.keywordFlags, unpack(modifiers))
 			end
 		end
 	end

--- a/Modules/ModParser-3_0.lua
+++ b/Modules/ModParser-3_0.lua
@@ -1761,9 +1761,9 @@ local specialModList = {
 	["trigger level (%d+) (.+) after spending a total of (%d+) mana"] = function(num, _, skill) return extraSkill(skill, num) end,
 	["consumes a void charge to trigger level (%d+) (.+) when you fire arrows"] = function(num, _, skill) return extraSkill(skill, num) end,
 	-- Conversion
-	["increases and reductions to minion damage also affects? you"] = { flag("MinionDamageAppliesToPlayer") },
-	["increases and reductions to minion damage also affects? you at (%d+)%% of their value"] = { flag("ImprovedMinionDamageAppliesToPlayer") },
-	["increases and reductions to minion attack speed also affects? you"] = { flag("MinionAttackSpeedAppliesToPlayer") },
+	["increases and reductions to minion damage also affects? you"] = { flag("MinionDamageAppliesToPlayer"), mod("ImprovedMinionDamageAppliesToPlayer", "INC", 100) },
+	["increases and reductions to minion damage also affects? you at (%d+)%% of their value"] = function(num) return { flag("MinionDamageAppliesToPlayer"), mod("ImprovedMinionDamageAppliesToPlayer", "INC", num) } end,
+	["increases and reductions to minion attack speed also affects? you"] = { flag("MinionAttackSpeedAppliesToPlayer"), mod("ImprovedMinionAttackSpeedAppliesToPlayer", "INC", 100) },
 	["increases and reductions to cast speed apply to attack speed at (%d+)%% of their value"] =  function(num) return { flag("CastSpeedAppliesToAttacks"), mod("ImprovedCastSpeedAppliesToAttacks", "INC", num) } end,
 	["increases and reductions to spell damage also apply to attacks"] = { flag("SpellDamageAppliesToAttacks"), mod("ImprovedSpellDamageAppliesToAttacks", "INC", 100) },
 	["increases and reductions to spell damage also apply to attacks at (%d+)%% of their value"] = function(num) return { flag("SpellDamageAppliesToAttacks"), mod("ImprovedSpellDamageAppliesToAttacks", "INC", num) } end,

--- a/Modules/ModTools.lua
+++ b/Modules/ModTools.lua
@@ -164,3 +164,13 @@ end
 function modLib.formatMod(mod)
 	return modLib.formatValue(mod.value) .. " = " .. modLib.formatModParams(mod)
 end
+
+function modLib.extractModTags(mod)
+	local modIndex = 1
+	local list = {}
+	while mod[modIndex] do
+		list[modIndex] = mod[modIndex]
+		modIndex = modIndex + 1
+	end
+	return list
+end


### PR DESCRIPTION
Minion damage conversion to player is now a flag and mod pair like cast speed/spell damage

Added tag conversion support so minion damage while player affected by herald works, and limits like on Indigon are correctly converted to have a max associated with the conversion rate
Added ModTools method to get the 'tags' from a mod

Herald enabled
![image](https://user-images.githubusercontent.com/48185793/96059529-2ece8a80-0e5c-11eb-8818-af17b148d827.png)
Herald disabled
![image](https://user-images.githubusercontent.com/48185793/96059568-46a60e80-0e5c-11eb-96d4-fcf2f61358f9.png)
Indigon Kinetic Bolt at 16000 mana
16000 / 200 = 80 * .25 = 2000% * 150% conversion = 3000%
![image](https://user-images.githubusercontent.com/48185793/96059660-8836b980-0e5c-11eb-9daa-5e4efd8cb0f5.png)
Prodigal perfection
![image](https://user-images.githubusercontent.com/48185793/96306263-5b55e400-0fcd-11eb-8e91-55680ec10ac0.png)
