### PR TITLE
Add modifier form for non-vaal skills craft

### DIFF
--- a/Modules/ModParser-3_0.lua
+++ b/Modules/ModParser-3_0.lua
@@ -35,6 +35,7 @@ local conquerorList = {
 -- List of modifier forms
 local formList = {
 	["^(%d+)%% increased"] = "INC",
+	["^non%-vaal skills deal (%d+)%% increased"] = "INC",
 	["^(%d+)%% faster"] = "INC",
 	["^(%d+)%% reduced"] = "RED",
 	["^(%d+)%% slower"] = "RED",


### PR DESCRIPTION
Addresses #1672 

The existing form `["^(%d+)%% increased"] = "INC"` isn't broad enough, especially considering it has the "line start `^`" qualifier at the beginning of the pattern, which excludes this specific mod form.

I don't know if the authors want this **specific** form for non-vaal skills (I'm not an expert in all things PoE mods), but I've verified the bug and verified that adding this mod form allows the "Do you have soul gain prevention?" combat check box to show up if all I have is the `Non-Vaal Skills deal (51-60)% increased Damage during Soul Gain Prevention` on one piece (gloves or boots) of gear.