### PR TITLE
Refactor keystone data

### DIFF
--- a/Data/Generated.lua
+++ b/Data/Generated.lua
@@ -80,7 +80,6 @@ local skinOfTheLords = {
 local excludedKeystones = {
 	"Chaos Inoculation", -- to prevent infinite loop
 	"Corrupted Soul", -- exclusive to specific unique
-	"Doomsday", -- possibly an oversight on GGG's end
 	"Hollow Palm Technique", -- exclusive to specific unique
 	"Immortal Ambition", -- exclusive to specific unique
 	"Necromantic Aegis", -- to prevent infinite loop

--- a/Data/Generated.lua
+++ b/Data/Generated.lua
@@ -77,7 +77,21 @@ local skinOfTheLords = {
 	"League: Breach",
 	"Source: Upgraded from unique{Skin of the Loyal} using currency{Blessing of Chayula}",
 }
+local excludedKeystones = {
+	"Chaos Inoculation", -- to prevent infinite loop
+	"Corrupted Soul", -- exclusive to specific unique
+	"Doomsday", -- possibly an oversight on GGG's end
+	"Hollow Palm Technique", -- exclusive to specific unique
+	"Immortal Ambition", -- exclusive to specific unique
+	"Necromantic Aegis", -- to prevent infinite loop
+}
+local keystones = {}
 for _, name in ipairs(data.keystones) do
+	if not isValueInArray(excludedKeystones, name) then
+		table.insert(keystones, name)
+	end
+end
+for _, name in ipairs(keystones) do
 	table.insert(skinOfTheLords, "Variant: "..name)
 end
 table.insert(skinOfTheLords, "Implicits: 0")
@@ -85,7 +99,7 @@ table.insert(skinOfTheLords, "Sockets cannot be modified")
 table.insert(skinOfTheLords, "+1 to Level of Socketed Gems")
 table.insert(skinOfTheLords, "100% increased Global Defences")
 table.insert(skinOfTheLords, "You can only Socket Corrupted Gems in this item")
-for index, name in ipairs(data.keystones) do
+for index, name in ipairs(keystones) do
 	table.insert(skinOfTheLords, "{variant:"..index.."}"..name)
 end
 table.insert(skinOfTheLords, "Corrupted")

--- a/Modules/Data.lua
+++ b/Modules/Data.lua
@@ -214,7 +214,7 @@ data.specialBaseTags = {
 	["Sceptre"] = { shaper = "sceptre_shaper", elder = "sceptre_elder", adjudicator = "sceptre_adjudicator", basilisk = "sceptre_basilisk", crusader = "sceptre_crusader", eyrie = "sceptre_eyrie", },
 }
 
----@type string[] @List of keystones that can be found on unique items.
+---@type string[] @List of all keystones not exclusive to timeless jewels.
 data.keystones = {
 	"Acrobatics",
 	"Ancestral Bond",
@@ -222,9 +222,11 @@ data.keystones = {
 	"Avatar of Fire",
 	"Blood Magic",
 	"Call to Arms",
+	"Chaos Inoculation",
 	"Conduit",
 	"Corrupted Soul",
 	"Crimson Dance",
+	"Doomsday",
 	"Eldritch Battery",
 	"Elemental Equilibrium",
 	"Elemental Overload",
@@ -239,6 +241,7 @@ data.keystones = {
 	"Mind Over Matter",
 	"Minion Instability",
 	"Mortal Conviction",
+	"Necromantic Aegis",
 	"Pain Attunement",
 	"Perfect Agony",
 	"Phase Acrobatics",


### PR DESCRIPTION
Complete requested refactoring of keystone data. Now all non-timeless jewel exclusive keystones are present and the ones that cannot roll on Skin of the Lords are excluded before generating it instead.