### PR TITLE
Use brand limit from the Arcanist Brand instead of the main skill

### DIFF
--- a/Modules/CalcPerform.lua
+++ b/Modules/CalcPerform.lua
@@ -665,7 +665,9 @@ function calcs.perform(env)
 		end
 		if activeSkill.skillFlags.brand then
 			local attachLimit = env.player.mainSkill.skillModList:Sum("BASE", env.player.mainSkill.skillCfg, "BrandsAttachedLimit")
-			if activeSkill.activeEffect.grantedEffect.name == "Wintertide Brand" then
+			if activeSkill.activeEffect.grantedEffect.name == "Arcanist Brand" then
+				attachLimit = activeSkill.skillModList:Sum("BASE", activeSkill.skillCfg, "BrandsAttachedLimit")
+			elseif activeSkill.activeEffect.grantedEffect.name == "Wintertide Brand" then
 				attachLimit = attachLimit + 1
 			end
 			local attached = modDB:Sum("BASE", nil, "Multiplier:ConfigBrandsAttachedToEnemy")


### PR DESCRIPTION
Addresses cases when Arcanist Brand is used as a support with Runesmith, or Brand Loyalty and Runebinder.
Makes damage increase per brand attached scale properly (10% for two brands attached to the enemy instead of 5% as previously).

STR: 
1. Take minimal reproducible build: https://pastebin.com/FY4bQej3
2. Set `# of brands attached to the enemy` to `2`
3. Check `Effective DPS Mod`

Please, let me know if I missed something