### PR TITLE
Adding logic to disable alt ailments when ele focus is used

### DIFF
--- a/Data/SkillStatMap.lua
+++ b/Data/SkillStatMap.lua
@@ -759,6 +759,9 @@ return {
 	flag("CannotChill"),
 	flag("CannotFreeze"),
 	flag("CannotIgnite"),
+	flag("CannotScorch"),
+	flag("CannotBrittle"),
+	flag("CannotSap"),
 },
 ["chill_effect_+%"] = {
 	mod("EnemyChillEffect", "INC", nil),

--- a/Modules/CalcOffence.lua
+++ b/Modules/CalcOffence.lua
@@ -2206,14 +2206,14 @@ function calcs.offence(env, actor, activeSkill)
 			output.ChillChanceOnCrit = 100
 		end
 		if skillModList:Flag(cfg, "CritAlwaysAltAilments") and not skillModList:Flag(cfg, "NeverCrit") then
-			skillFlags.inflictScorch = true
-			skillFlags.inflictBrittle = true
-			skillFlags.inflictSap = true
+			skillFlags.inflictScorch = not skillModList:Flag(cfg, "CannotScorch")
+			skillFlags.inflictBrittle = not skillModList:Flag(cfg, "CannotBrittle")
+			skillFlags.inflictSap = not skillModList:Flag(cfg, "CannotSap")
 		end
 		if skillModList:Flag(cfg, "CritAlwaysAltAilments") and not skillModList:Flag(cfg, "NeverCrit") and skillFlags.hit then
-			output.ScorchChanceOnCrit = 100
-			output.BrittleChanceOnCrit = 100
-			output.SapChanceOnCrit = 100
+			output.ScorchChanceOnCrit = not skillModList:Flag(cfg, "CannotScorch") and 100 or 0
+			output.BrittleChanceOnCrit = not skillModList:Flag(cfg, "CannotBrittle") and 100 or 0
+			output.SapChanceOnCrit = not skillModList:Flag(cfg, "CannotSap") and 100 or 0
 		else
 			output.ScorchChanceOnCrit = 0
 			output.BrittleChanceOnCrit = 0
@@ -2265,26 +2265,26 @@ function calcs.offence(env, actor, activeSkill)
 		else
 			output.KnockbackChanceOnHit = skillModList:Sum("BASE", cfg, "EnemyKnockbackChance")
 		end
-		if skillModList:Sum("BASE", cfg, "ScorchChance") > 0 then
+		if skillModList:Sum("BASE", cfg, "ScorchChance") > 0 and not skillModList:Flag(cfg, "CannotScorch") then
 			skillFlags.inflictScorch = true
 		end
-		if skillModList:Sum("BASE", cfg, "ScorchChance") > 0 and skillFlags.hit then
+		if skillModList:Sum("BASE", cfg, "ScorchChance") > 0 and skillFlags.hit and not skillModList:Flag(cfg, "CannotScorch") then
 			output.ScorchChanceOnHit = m_min(100, skillModList:Sum("BASE", cfg, "ScorchChance"))
 		else
 			output.ScorchChanceOnHit = 0
 		end
-		if skillModList:Sum("BASE", cfg, "BrittleChance") > 0 then
+		if skillModList:Sum("BASE", cfg, "BrittleChance") > 0 and not skillModList:Flag(cfg, "CannotBrittle") then
 			skillFlags.inflictBrittle = true
 		end
-		if skillModList:Sum("BASE", cfg, "BrittleChance") > 0 and skillFlags.hit then
+		if skillModList:Sum("BASE", cfg, "BrittleChance") > 0 and skillFlags.hit and not skillModList:Flag(cfg, "CannotBrittle") then
 			output.BrittleChanceOnHit = m_min(100, skillModList:Sum("BASE", cfg, "BrittleChance"))
 		else
 			output.BrittleChanceOnHit = 0
 		end
-		if skillModList:Sum("BASE", cfg, "SapChance") > 0 then
+		if skillModList:Sum("BASE", cfg, "SapChance") > 0 and not skillModList:Flag(cfg, "CannotSap") then
 			skillFlags.inflictSap = true
 		end
-		if skillModList:Sum("BASE", cfg, "SapChance") > 0 and skillFlags.hit then
+		if skillModList:Sum("BASE", cfg, "SapChance") > 0 and skillFlags.hit and not skillModList:Flag(cfg, "CannotSap") then
 			output.SapChanceOnHit = m_min(100, skillModList:Sum("BASE", cfg, "SapChance"))
 		else
 			output.SapChanceOnHit = 0

--- a/Modules/CalcOffence.lua
+++ b/Modules/CalcOffence.lua
@@ -2206,9 +2206,9 @@ function calcs.offence(env, actor, activeSkill)
 			output.ChillChanceOnCrit = 100
 		end
 		if skillModList:Flag(cfg, "CritAlwaysAltAilments") and not skillModList:Flag(cfg, "NeverCrit") then
-			skillFlags.inflictScorch = not skillModList:Flag(cfg, "CannotScorch")
-			skillFlags.inflictBrittle = not skillModList:Flag(cfg, "CannotBrittle")
-			skillFlags.inflictSap = not skillModList:Flag(cfg, "CannotSap")
+			skillFlags.inflictScorch = true
+			skillFlags.inflictBrittle = true
+			skillFlags.inflictSap = true
 		end
 		if skillModList:Flag(cfg, "CritAlwaysAltAilments") and not skillModList:Flag(cfg, "NeverCrit") and skillFlags.hit then
 			output.ScorchChanceOnCrit = not skillModList:Flag(cfg, "CannotScorch") and 100 or 0
@@ -2265,7 +2265,7 @@ function calcs.offence(env, actor, activeSkill)
 		else
 			output.KnockbackChanceOnHit = skillModList:Sum("BASE", cfg, "EnemyKnockbackChance")
 		end
-		if skillModList:Sum("BASE", cfg, "ScorchChance") > 0 and not skillModList:Flag(cfg, "CannotScorch") then
+		if skillModList:Sum("BASE", cfg, "ScorchChance") > 0 then
 			skillFlags.inflictScorch = true
 		end
 		if skillModList:Sum("BASE", cfg, "ScorchChance") > 0 and skillFlags.hit and not skillModList:Flag(cfg, "CannotScorch") then
@@ -2273,7 +2273,7 @@ function calcs.offence(env, actor, activeSkill)
 		else
 			output.ScorchChanceOnHit = 0
 		end
-		if skillModList:Sum("BASE", cfg, "BrittleChance") > 0 and not skillModList:Flag(cfg, "CannotBrittle") then
+		if skillModList:Sum("BASE", cfg, "BrittleChance") > 0 then
 			skillFlags.inflictBrittle = true
 		end
 		if skillModList:Sum("BASE", cfg, "BrittleChance") > 0 and skillFlags.hit and not skillModList:Flag(cfg, "CannotBrittle") then
@@ -2281,7 +2281,7 @@ function calcs.offence(env, actor, activeSkill)
 		else
 			output.BrittleChanceOnHit = 0
 		end
-		if skillModList:Sum("BASE", cfg, "SapChance") > 0 and not skillModList:Flag(cfg, "CannotSap") then
+		if skillModList:Sum("BASE", cfg, "SapChance") > 0 then
 			skillFlags.inflictSap = true
 		end
 		if skillModList:Sum("BASE", cfg, "SapChance") > 0 and skillFlags.hit and not skillModList:Flag(cfg, "CannotSap") then

--- a/Modules/CalcPerform.lua
+++ b/Modules/CalcPerform.lua
@@ -163,14 +163,10 @@ local function doActorAttribsPoolsConditions(env, actor)
 		if actor.mainSkill.skillFlags.mine then
 			condList["DetonatedMinesRecently"] = true
 		end
-		if modDB:Sum("BASE", nil, "ScorchChance") > 0 or modDB:Flag(nil, "CritAlwaysAltAilments") and not modDB:Flag(nil, "NeverCrit") then
-			condList["CanInflictScorch"] = true
-		end
-		if modDB:Sum("BASE", nil, "BrittleChance") > 0 or modDB:Flag(nil, "CritAlwaysAltAilments") and not modDB:Flag(nil, "NeverCrit") then
-			condList["CanInflictBrittle"] = true
-		end
-		if modDB:Sum("BASE", nil, "SapChance") > 0 or modDB:Flag(nil, "CritAlwaysAltAilments") and not modDB:Flag(nil, "NeverCrit") then
-			condList["CanInflictSap"] = true
+		if modDB:Flag(nil, "CritAlwaysAltAilments") and not modDB:Flag(nil, "NeverCrit") then
+			condList["CanInflictScorch"] = modDB:Sum("BASE", nil, "ScorchChance") > 0 and not actor.mainSkill.skillModList:Flag(actor.mainSkill.skillCfg, "CannotScorch")
+			condList["CanInflictBrittle"] = modDB:Sum("BASE", nil, "BrittleChance") > 0 and not actor.mainSkill.skillModList:Flag(env.player.mainSkill.skillCfg, "CannotBrittle")
+			condList["CanInflictSap"] = modDB:Sum("BASE", nil, "SapChance") > 0 and not actor.mainSkill.skillModList:Flag(env.player.mainSkill.skillCfg, "CannotSap")
 		end
 	end
 	if env.mode_effective then

--- a/Modules/CalcPerform.lua
+++ b/Modules/CalcPerform.lua
@@ -164,9 +164,9 @@ local function doActorAttribsPoolsConditions(env, actor)
 			condList["DetonatedMinesRecently"] = true
 		end
 		if modDB:Flag(nil, "CritAlwaysAltAilments") and not modDB:Flag(nil, "NeverCrit") then
-			condList["CanInflictScorch"] = modDB:Sum("BASE", nil, "ScorchChance") > 0 and not actor.mainSkill.skillModList:Flag(actor.mainSkill.skillCfg, "CannotScorch")
-			condList["CanInflictBrittle"] = modDB:Sum("BASE", nil, "BrittleChance") > 0 and not actor.mainSkill.skillModList:Flag(env.player.mainSkill.skillCfg, "CannotBrittle")
-			condList["CanInflictSap"] = modDB:Sum("BASE", nil, "SapChance") > 0 and not actor.mainSkill.skillModList:Flag(env.player.mainSkill.skillCfg, "CannotSap")
+			condList["CanInflictScorch"] = modDB:Sum("BASE", nil, "ScorchChance") > 0
+			condList["CanInflictBrittle"] = modDB:Sum("BASE", nil, "BrittleChance") > 0
+			condList["CanInflictSap"] = modDB:Sum("BASE", nil, "SapChance") > 0
 		end
 	end
 	if env.mode_effective then

--- a/Modules/CalcPerform.lua
+++ b/Modules/CalcPerform.lua
@@ -163,10 +163,14 @@ local function doActorAttribsPoolsConditions(env, actor)
 		if actor.mainSkill.skillFlags.mine then
 			condList["DetonatedMinesRecently"] = true
 		end
-		if modDB:Flag(nil, "CritAlwaysAltAilments") and not modDB:Flag(nil, "NeverCrit") then
-			condList["CanInflictScorch"] = modDB:Sum("BASE", nil, "ScorchChance") > 0
-			condList["CanInflictBrittle"] = modDB:Sum("BASE", nil, "BrittleChance") > 0
-			condList["CanInflictSap"] = modDB:Sum("BASE", nil, "SapChance") > 0
+		if modDB:Sum("BASE", nil, "ScorchChance") > 0 or modDB:Flag(nil, "CritAlwaysAltAilments") and not modDB:Flag(nil, "NeverCrit") then
+			condList["CanInflictScorch"] = true
+		end
+		if modDB:Sum("BASE", nil, "BrittleChance") > 0 or modDB:Flag(nil, "CritAlwaysAltAilments") and not modDB:Flag(nil, "NeverCrit") then
+			condList["CanInflictBrittle"] = true
+		end
+		if modDB:Sum("BASE", nil, "SapChance") > 0 or modDB:Flag(nil, "CritAlwaysAltAilments") and not modDB:Flag(nil, "NeverCrit") then
+			condList["CanInflictSap"] = true
 		end
 	end
 	if env.mode_effective then


### PR DESCRIPTION
When elemental focus is used currently, you can still inflict scorch, brittle, and sapped.  Now that is disabled for your main skill.