### PR TITLE
Fixes #1741 - Adding separation of rune daggers, warstaves, and convoking wand

### DIFF
--- a/Data/Bases/dagger.lua
+++ b/Data/Bases/dagger.lua
@@ -5,7 +5,7 @@ local itemBases = ...
 itemBases["Glass Shank"] = {
 	type = "Dagger",
 	socketLimit = 3,
-	tags = { default = true, weapon = true, onehand = true, dagger = true, one_hand_weapon = true, },
+	tags = { default = true, weapon = true, onehand = true, attack_dagger = true, one_hand_weapon = true, },
 	implicit = "30% increased Global Critical Strike Chance",
 	implicitModTypes = { { "critical" }, },
 	weapon = { PhysicalMin = 6, PhysicalMax = 10, CritChanceBase = 6, AttackRateBase = 1.5, Range = 10, },
@@ -14,14 +14,124 @@ itemBases["Glass Shank"] = {
 itemBases["Skinning Knife"] = {
 	type = "Dagger",
 	socketLimit = 3,
-	tags = { default = true, weapon = true, onehand = true, dagger = true, one_hand_weapon = true, },
+	tags = { default = true, weapon = true, onehand = true, attack_dagger = true, one_hand_weapon = true, },
 	implicit = "30% increased Global Critical Strike Chance",
 	implicitModTypes = { { "critical" }, },
 	weapon = { PhysicalMin = 4, PhysicalMax = 17, CritChanceBase = 6, AttackRateBase = 1.45, Range = 10, },
 	req = { level = 5, dex = 16, int = 11, },
 }
+itemBases["Stiletto"] = {
+	type = "Dagger",
+	socketLimit = 3,
+	tags = { default = true, weapon = true, onehand = true, attack_dagger = true, one_hand_weapon = true, },
+	implicit = "30% increased Global Critical Strike Chance",
+	implicitModTypes = { { "critical" }, },
+	weapon = { PhysicalMin = 7, PhysicalMax = 27, CritChanceBase = 6.1, AttackRateBase = 1.5, Range = 10, },
+	req = { level = 15, dex = 30, int = 30, },
+}
+itemBases["Prong Dagger"] = {
+	type = "Dagger",
+	socketLimit = 3,
+	tags = { default = true, weapon = true, onehand = true, attack_dagger = true, one_hand_weapon = true, not_for_sale = true, maraketh = true, },
+	implicit = "4% Chance to Block Attack Damage",
+	implicitModTypes = { { "block" }, },
+	weapon = { PhysicalMin = 14, PhysicalMax = 54, CritChanceBase = 6.2, AttackRateBase = 1.35, Range = 10, },
+	req = { level = 36, dex = 55, int = 77, },
+}
+itemBases["Flaying Knife"] = {
+	type = "Dagger",
+	socketLimit = 3,
+	tags = { default = true, weapon = true, onehand = true, attack_dagger = true, one_hand_weapon = true, },
+	implicit = "30% increased Global Critical Strike Chance",
+	implicitModTypes = { { "critical" }, },
+	weapon = { PhysicalMin = 11, PhysicalMax = 45, CritChanceBase = 6, AttackRateBase = 1.4, Range = 10, },
+	req = { level = 30, dex = 64, int = 44, },
+}
+itemBases["Poignard"] = {
+	type = "Dagger",
+	socketLimit = 3,
+	tags = { default = true, weapon = true, onehand = true, attack_dagger = true, one_hand_weapon = true, },
+	implicit = "30% increased Global Critical Strike Chance",
+	implicitModTypes = { { "critical" }, },
+	weapon = { PhysicalMin = 13, PhysicalMax = 52, CritChanceBase = 6.1, AttackRateBase = 1.5, Range = 10, },
+	req = { level = 41, dex = 72, int = 72, },
+}
+itemBases["Trisula"] = {
+	type = "Dagger",
+	socketLimit = 3,
+	tags = { default = true, weapon = true, onehand = true, attack_dagger = true, one_hand_weapon = true, not_for_sale = true, maraketh = true, },
+	implicit = "4% Chance to Block Attack Damage",
+	implicitModTypes = { { "block" }, },
+	weapon = { PhysicalMin = 19, PhysicalMax = 74, CritChanceBase = 6.5, AttackRateBase = 1.35, Range = 10, },
+	req = { level = 51, dex = 83, int = 99, },
+}
+itemBases["Gutting Knife"] = {
+	type = "Dagger",
+	socketLimit = 3,
+	tags = { default = true, weapon = true, onehand = true, attack_dagger = true, one_hand_weapon = true, },
+	implicit = "30% increased Global Critical Strike Chance",
+	implicitModTypes = { { "critical" }, },
+	weapon = { PhysicalMin = 19, PhysicalMax = 76, CritChanceBase = 6.5, AttackRateBase = 1.4, Range = 10, },
+	req = { level = 56, dex = 113, int = 78, },
+}
+itemBases["Ambusher"] = {
+	type = "Dagger",
+	socketLimit = 3,
+	tags = { default = true, weapon = true, onehand = true, attack_dagger = true, one_hand_weapon = true, },
+	implicit = "30% increased Global Critical Strike Chance",
+	implicitModTypes = { { "critical" }, },
+	weapon = { PhysicalMin = 19, PhysicalMax = 74, CritChanceBase = 6.1, AttackRateBase = 1.5, Range = 10, },
+	req = { level = 60, dex = 113, int = 113, },
+}
+itemBases["Sai"] = {
+	type = "Dagger",
+	socketLimit = 3,
+	tags = { default = true, weapon = true, onehand = true, attack_dagger = true, one_hand_weapon = true, not_for_sale = true, maraketh = true, },
+	implicit = "6% Chance to Block Attack Damage",
+	implicitModTypes = { { "block" }, },
+	weapon = { PhysicalMin = 22, PhysicalMax = 88, CritChanceBase = 6.2, AttackRateBase = 1.35, Range = 10, },
+	req = { level = 70, dex = 121, int = 121, },
+}
+itemBases["Hollowpoint Dagger"] = {
+	type = "Dagger",
+	socketLimit = 3,
+	tags = { default = true, weapon = true, onehand = true, attack_dagger = true, one_hand_weapon = true, not_for_sale = true, },
+	implicit = "All Damage from Hits with This Weapon can Poison",
+	implicitModTypes = { {  }, },
+	weapon = { PhysicalMin = 12, PhysicalMax = 46, CritChanceBase = 6.3, AttackRateBase = 1.4, Range = 10, },
+	req = { level = 30, dex = 54, int = 54, },
+}
+itemBases["Pressurised Dagger"] = {
+	type = "Dagger",
+	socketLimit = 3,
+	tags = { default = true, weapon = true, onehand = true, attack_dagger = true, one_hand_weapon = true, not_for_sale = true, },
+	implicit = "All Damage from Hits with This Weapon can Poison",
+	implicitModTypes = { {  }, },
+	weapon = { PhysicalMin = 18, PhysicalMax = 71, CritChanceBase = 6.3, AttackRateBase = 1.4, Range = 10, },
+	req = { level = 50, dex = 86, int = 86, },
+}
+itemBases["Pneumatic Dagger"] = {
+	type = "Dagger",
+	socketLimit = 3,
+	tags = { default = true, weapon = true, onehand = true, attack_dagger = true, one_hand_weapon = true, not_for_sale = true, },
+	implicit = "All Damage from Hits with This Weapon can Poison",
+	implicitModTypes = { {  }, },
+	weapon = { PhysicalMin = 20, PhysicalMax = 79, CritChanceBase = 6.3, AttackRateBase = 1.4, Range = 10, },
+	req = { level = 70, dex = 121, int = 121, },
+}
+itemBases["Ethereal Blade"] = {
+	type = "Dagger",
+	hidden = true,
+	socketLimit = 3,
+	tags = { default = true, weapon = true, onehand = true, attack_dagger = true, one_hand_weapon = true, not_for_sale = true, },
+	implicitModTypes = { },
+	weapon = { PhysicalMin = 4, PhysicalMax = 8, CritChanceBase = 6, AttackRateBase = 1.5, Range = 10, },
+	req = { dex = 9, int = 6, },
+}
+
 itemBases["Carving Knife"] = {
 	type = "Dagger",
+	subType = "Rune",
 	socketLimit = 3,
 	tags = { default = true, weapon = true, onehand = true, dagger = true, one_hand_weapon = true, },
 	implicit = "30% increased Global Critical Strike Chance",
@@ -29,17 +139,9 @@ itemBases["Carving Knife"] = {
 	weapon = { PhysicalMin = 3, PhysicalMax = 26, CritChanceBase = 6.3, AttackRateBase = 1.45, Range = 10, },
 	req = { level = 10, dex = 18, int = 26, },
 }
-itemBases["Stiletto"] = {
-	type = "Dagger",
-	socketLimit = 3,
-	tags = { default = true, weapon = true, onehand = true, dagger = true, one_hand_weapon = true, },
-	implicit = "30% increased Global Critical Strike Chance",
-	implicitModTypes = { { "critical" }, },
-	weapon = { PhysicalMin = 7, PhysicalMax = 27, CritChanceBase = 6.1, AttackRateBase = 1.5, Range = 10, },
-	req = { level = 15, dex = 30, int = 30, },
-}
 itemBases["Boot Knife"] = {
 	type = "Dagger",
+	subType = "Rune",
 	socketLimit = 3,
 	tags = { default = true, weapon = true, onehand = true, dagger = true, one_hand_weapon = true, },
 	implicit = "30% increased Global Critical Strike Chance",
@@ -49,6 +151,7 @@ itemBases["Boot Knife"] = {
 }
 itemBases["Copper Kris"] = {
 	type = "Dagger",
+	subType = "Rune",
 	socketLimit = 3,
 	tags = { default = true, weapon = true, onehand = true, dagger = true, one_hand_weapon = true, },
 	implicit = "50% increased Global Critical Strike Chance",
@@ -58,6 +161,7 @@ itemBases["Copper Kris"] = {
 }
 itemBases["Skean"] = {
 	type = "Dagger",
+	subType = "Rune",
 	socketLimit = 3,
 	tags = { default = true, weapon = true, onehand = true, dagger = true, one_hand_weapon = true, },
 	implicit = "30% increased Global Critical Strike Chance",
@@ -67,6 +171,7 @@ itemBases["Skean"] = {
 }
 itemBases["Imp Dagger"] = {
 	type = "Dagger",
+	subType = "Rune",
 	socketLimit = 3,
 	tags = { default = true, weapon = true, onehand = true, dagger = true, one_hand_weapon = true, },
 	implicit = "40% increased Global Critical Strike Chance",
@@ -74,26 +179,9 @@ itemBases["Imp Dagger"] = {
 	weapon = { PhysicalMin = 15, PhysicalMax = 59, CritChanceBase = 6.5, AttackRateBase = 1.2, Range = 10, },
 	req = { level = 32, dex = 36, int = 78, },
 }
-itemBases["Prong Dagger"] = {
-	type = "Dagger",
-	socketLimit = 3,
-	tags = { default = true, weapon = true, onehand = true, dagger = true, one_hand_weapon = true, not_for_sale = true, maraketh = true, },
-	implicit = "4% Chance to Block Attack Damage",
-	implicitModTypes = { { "block" }, },
-	weapon = { PhysicalMin = 14, PhysicalMax = 54, CritChanceBase = 6.2, AttackRateBase = 1.35, Range = 10, },
-	req = { level = 36, dex = 55, int = 77, },
-}
-itemBases["Flaying Knife"] = {
-	type = "Dagger",
-	socketLimit = 3,
-	tags = { default = true, weapon = true, onehand = true, dagger = true, one_hand_weapon = true, },
-	implicit = "30% increased Global Critical Strike Chance",
-	implicitModTypes = { { "critical" }, },
-	weapon = { PhysicalMin = 11, PhysicalMax = 45, CritChanceBase = 6, AttackRateBase = 1.4, Range = 10, },
-	req = { level = 30, dex = 64, int = 44, },
-}
 itemBases["Butcher Knife"] = {
 	type = "Dagger",
+	subType = "Rune",
 	socketLimit = 3,
 	tags = { default = true, weapon = true, onehand = true, dagger = true, one_hand_weapon = true, },
 	implicit = "30% increased Global Critical Strike Chance",
@@ -101,17 +189,9 @@ itemBases["Butcher Knife"] = {
 	weapon = { PhysicalMin = 7, PhysicalMax = 62, CritChanceBase = 6.3, AttackRateBase = 1.4, Range = 10, },
 	req = { level = 38, dex = 55, int = 79, },
 }
-itemBases["Poignard"] = {
-	type = "Dagger",
-	socketLimit = 3,
-	tags = { default = true, weapon = true, onehand = true, dagger = true, one_hand_weapon = true, },
-	implicit = "30% increased Global Critical Strike Chance",
-	implicitModTypes = { { "critical" }, },
-	weapon = { PhysicalMin = 13, PhysicalMax = 52, CritChanceBase = 6.1, AttackRateBase = 1.5, Range = 10, },
-	req = { level = 41, dex = 72, int = 72, },
-}
 itemBases["Boot Blade"] = {
 	type = "Dagger",
+	subType = "Rune",
 	socketLimit = 3,
 	tags = { default = true, weapon = true, onehand = true, dagger = true, one_hand_weapon = true, },
 	implicit = "30% increased Global Critical Strike Chance",
@@ -121,6 +201,7 @@ itemBases["Boot Blade"] = {
 }
 itemBases["Golden Kris"] = {
 	type = "Dagger",
+	subType = "Rune",
 	socketLimit = 3,
 	tags = { default = true, weapon = true, onehand = true, dagger = true, one_hand_weapon = true, },
 	implicit = "50% increased Global Critical Strike Chance",
@@ -130,6 +211,7 @@ itemBases["Golden Kris"] = {
 }
 itemBases["Royal Skean"] = {
 	type = "Dagger",
+	subType = "Rune",
 	socketLimit = 3,
 	tags = { default = true, weapon = true, onehand = true, dagger = true, one_hand_weapon = true, },
 	implicit = "30% increased Global Critical Strike Chance",
@@ -139,6 +221,7 @@ itemBases["Royal Skean"] = {
 }
 itemBases["Fiend Dagger"] = {
 	type = "Dagger",
+	subType = "Rune",
 	socketLimit = 3,
 	tags = { default = true, weapon = true, onehand = true, dagger = true, one_hand_weapon = true, },
 	implicit = "40% increased Global Critical Strike Chance",
@@ -146,26 +229,9 @@ itemBases["Fiend Dagger"] = {
 	weapon = { PhysicalMin = 22, PhysicalMax = 87, CritChanceBase = 6.5, AttackRateBase = 1.2, Range = 10, },
 	req = { level = 53, dex = 58, int = 123, },
 }
-itemBases["Trisula"] = {
-	type = "Dagger",
-	socketLimit = 3,
-	tags = { default = true, weapon = true, onehand = true, dagger = true, one_hand_weapon = true, not_for_sale = true, maraketh = true, },
-	implicit = "4% Chance to Block Attack Damage",
-	implicitModTypes = { { "block" }, },
-	weapon = { PhysicalMin = 19, PhysicalMax = 74, CritChanceBase = 6.5, AttackRateBase = 1.35, Range = 10, },
-	req = { level = 51, dex = 83, int = 99, },
-}
-itemBases["Gutting Knife"] = {
-	type = "Dagger",
-	socketLimit = 3,
-	tags = { default = true, weapon = true, onehand = true, dagger = true, one_hand_weapon = true, },
-	implicit = "30% increased Global Critical Strike Chance",
-	implicitModTypes = { { "critical" }, },
-	weapon = { PhysicalMin = 19, PhysicalMax = 76, CritChanceBase = 6.5, AttackRateBase = 1.4, Range = 10, },
-	req = { level = 56, dex = 113, int = 78, },
-}
 itemBases["Slaughter Knife"] = {
 	type = "Dagger",
+	subType = "Rune",
 	socketLimit = 3,
 	tags = { default = true, weapon = true, onehand = true, dagger = true, one_hand_weapon = true, },
 	implicit = "30% increased Global Critical Strike Chance",
@@ -173,17 +239,9 @@ itemBases["Slaughter Knife"] = {
 	weapon = { PhysicalMin = 10, PhysicalMax = 86, CritChanceBase = 6.3, AttackRateBase = 1.4, Range = 10, },
 	req = { level = 58, dex = 81, int = 117, },
 }
-itemBases["Ambusher"] = {
-	type = "Dagger",
-	socketLimit = 3,
-	tags = { default = true, weapon = true, onehand = true, dagger = true, one_hand_weapon = true, },
-	implicit = "30% increased Global Critical Strike Chance",
-	implicitModTypes = { { "critical" }, },
-	weapon = { PhysicalMin = 19, PhysicalMax = 74, CritChanceBase = 6.1, AttackRateBase = 1.5, Range = 10, },
-	req = { level = 60, dex = 113, int = 113, },
-}
 itemBases["Ezomyte Dagger"] = {
 	type = "Dagger",
+	subType = "Rune",
 	socketLimit = 3,
 	tags = { default = true, weapon = true, onehand = true, dagger = true, one_hand_weapon = true, },
 	implicit = "30% increased Global Critical Strike Chance",
@@ -193,6 +251,7 @@ itemBases["Ezomyte Dagger"] = {
 }
 itemBases["Platinum Kris"] = {
 	type = "Dagger",
+	subType = "Rune",
 	socketLimit = 3,
 	tags = { default = true, weapon = true, onehand = true, dagger = true, one_hand_weapon = true, },
 	implicit = "50% increased Global Critical Strike Chance",
@@ -202,6 +261,7 @@ itemBases["Platinum Kris"] = {
 }
 itemBases["Imperial Skean"] = {
 	type = "Dagger",
+	subType = "Rune",
 	socketLimit = 3,
 	tags = { default = true, weapon = true, onehand = true, dagger = true, one_hand_weapon = true, },
 	implicit = "30% increased Global Critical Strike Chance",
@@ -211,6 +271,7 @@ itemBases["Imperial Skean"] = {
 }
 itemBases["Demon Dagger"] = {
 	type = "Dagger",
+	subType = "Rune",
 	socketLimit = 3,
 	tags = { default = true, weapon = true, onehand = true, dagger = true, one_hand_weapon = true, },
 	implicit = "40% increased Global Critical Strike Chance",
@@ -218,44 +279,9 @@ itemBases["Demon Dagger"] = {
 	weapon = { PhysicalMin = 24, PhysicalMax = 97, CritChanceBase = 6.5, AttackRateBase = 1.2, Range = 10, },
 	req = { level = 68, dex = 76, int = 149, },
 }
-itemBases["Sai"] = {
-	type = "Dagger",
-	socketLimit = 3,
-	tags = { default = true, weapon = true, onehand = true, dagger = true, one_hand_weapon = true, not_for_sale = true, maraketh = true, },
-	implicit = "6% Chance to Block Attack Damage",
-	implicitModTypes = { { "block" }, },
-	weapon = { PhysicalMin = 22, PhysicalMax = 88, CritChanceBase = 6.2, AttackRateBase = 1.35, Range = 10, },
-	req = { level = 70, dex = 121, int = 121, },
-}
-itemBases["Hollowpoint Dagger"] = {
-	type = "Dagger",
-	socketLimit = 3,
-	tags = { default = true, weapon = true, onehand = true, dagger = true, one_hand_weapon = true, not_for_sale = true, },
-	implicit = "All Damage from Hits with This Weapon can Poison",
-	implicitModTypes = { {  }, },
-	weapon = { PhysicalMin = 12, PhysicalMax = 46, CritChanceBase = 6.3, AttackRateBase = 1.4, Range = 10, },
-	req = { level = 30, dex = 54, int = 54, },
-}
-itemBases["Pressurised Dagger"] = {
-	type = "Dagger",
-	socketLimit = 3,
-	tags = { default = true, weapon = true, onehand = true, dagger = true, one_hand_weapon = true, not_for_sale = true, },
-	implicit = "All Damage from Hits with This Weapon can Poison",
-	implicitModTypes = { {  }, },
-	weapon = { PhysicalMin = 18, PhysicalMax = 71, CritChanceBase = 6.3, AttackRateBase = 1.4, Range = 10, },
-	req = { level = 50, dex = 86, int = 86, },
-}
-itemBases["Pneumatic Dagger"] = {
-	type = "Dagger",
-	socketLimit = 3,
-	tags = { default = true, weapon = true, onehand = true, dagger = true, one_hand_weapon = true, not_for_sale = true, },
-	implicit = "All Damage from Hits with This Weapon can Poison",
-	implicitModTypes = { {  }, },
-	weapon = { PhysicalMin = 20, PhysicalMax = 79, CritChanceBase = 6.3, AttackRateBase = 1.4, Range = 10, },
-	req = { level = 70, dex = 121, int = 121, },
-}
 itemBases["Flickerflame Blade"] = {
 	type = "Dagger",
+	subType = "Rune",
 	socketLimit = 3,
 	tags = { default = true, weapon = true, onehand = true, dagger = true, one_hand_weapon = true, not_for_sale = true, },
 	implicit = "Trigger Level 10 Flame Dash when you use a Socketed Skill",
@@ -265,6 +291,7 @@ itemBases["Flickerflame Blade"] = {
 }
 itemBases["Flashfire Blade"] = {
 	type = "Dagger",
+	subType = "Rune",
 	socketLimit = 3,
 	tags = { default = true, weapon = true, onehand = true, dagger = true, one_hand_weapon = true, not_for_sale = true, },
 	implicit = "Trigger Level 20 Flame Dash when you use a Socketed Skill",
@@ -274,6 +301,7 @@ itemBases["Flashfire Blade"] = {
 }
 itemBases["Infernal Blade"] = {
 	type = "Dagger",
+	subType = "Rune",
 	socketLimit = 3,
 	tags = { default = true, weapon = true, onehand = true, dagger = true, one_hand_weapon = true, not_for_sale = true, },
 	implicit = "Trigger Level 30 Flame Dash when you use a Socketed Skill",

--- a/Data/Bases/staff.lua
+++ b/Data/Bases/staff.lua
@@ -29,24 +29,6 @@ itemBases["Long Staff"] = {
 	weapon = { PhysicalMin = 24, PhysicalMax = 41, CritChanceBase = 6, AttackRateBase = 1.3, Range = 13, },
 	req = { level = 18, str = 35, int = 35, },
 }
-itemBases["Iron Staff"] = {
-	type = "Staff",
-	socketLimit = 6,
-	tags = { default = true, weapon = true, twohand = true, staff = true, two_hand_weapon = true, warstaff = true, },
-	implicit = "+18% Chance to Block Attack Damage while wielding a Staff",
-	implicitModTypes = { { "block" }, },
-	weapon = { PhysicalMin = 14, PhysicalMax = 42, CritChanceBase = 6.4, AttackRateBase = 1.3, Range = 13, },
-	req = { level = 13, str = 27, int = 27, },
-}
-itemBases["Coiled Staff"] = {
-	type = "Staff",
-	socketLimit = 6,
-	tags = { default = true, weapon = true, twohand = true, staff = true, two_hand_weapon = true, warstaff = true, },
-	implicit = "+20% Chance to Block Attack Damage while wielding a Staff",
-	implicitModTypes = { { "block" }, },
-	weapon = { PhysicalMin = 27, PhysicalMax = 57, CritChanceBase = 6.2, AttackRateBase = 1.3, Range = 13, },
-	req = { level = 23, str = 43, int = 43, },
-}
 itemBases["Royal Staff"] = {
 	type = "Staff",
 	socketLimit = 6,
@@ -55,15 +37,6 @@ itemBases["Royal Staff"] = {
 	implicitModTypes = { { "block" }, },
 	weapon = { PhysicalMin = 27, PhysicalMax = 81, CritChanceBase = 6.5, AttackRateBase = 1.15, Range = 13, },
 	req = { level = 28, str = 51, int = 51, },
-}
-itemBases["Vile Staff"] = {
-	type = "Staff",
-	socketLimit = 6,
-	tags = { default = true, weapon = true, twohand = true, staff = true, two_hand_weapon = true, warstaff = true, },
-	implicit = "+18% Chance to Block Attack Damage while wielding a Staff",
-	implicitModTypes = { { "block" }, },
-	weapon = { PhysicalMin = 41, PhysicalMax = 76, CritChanceBase = 6.1, AttackRateBase = 1.3, Range = 13, },
-	req = { level = 33, str = 59, int = 59, },
 }
 itemBases["Crescent Staff"] = {
 	type = "Staff",
@@ -92,24 +65,6 @@ itemBases["Quarterstaff"] = {
 	weapon = { PhysicalMin = 51, PhysicalMax = 86, CritChanceBase = 6, AttackRateBase = 1.3, Range = 13, },
 	req = { level = 45, str = 78, int = 78, },
 }
-itemBases["Military Staff"] = {
-	type = "Staff",
-	socketLimit = 6,
-	tags = { default = true, weapon = true, twohand = true, staff = true, two_hand_weapon = true, warstaff = true, },
-	implicit = "+18% Chance to Block Attack Damage while wielding a Staff",
-	implicitModTypes = { { "block" }, },
-	weapon = { PhysicalMin = 38, PhysicalMax = 114, CritChanceBase = 6.6, AttackRateBase = 1.25, Range = 13, },
-	req = { level = 41, str = 72, int = 72, },
-}
-itemBases["Serpentine Staff"] = {
-	type = "Staff",
-	socketLimit = 6,
-	tags = { default = true, weapon = true, twohand = true, staff = true, two_hand_weapon = true, warstaff = true, },
-	implicit = "+20% Chance to Block Attack Damage while wielding a Staff",
-	implicitModTypes = { { "block" }, },
-	weapon = { PhysicalMin = 56, PhysicalMax = 117, CritChanceBase = 6.3, AttackRateBase = 1.25, Range = 13, },
-	req = { level = 49, str = 85, int = 85, },
-}
 itemBases["Highborn Staff"] = {
 	type = "Staff",
 	socketLimit = 6,
@@ -118,15 +73,6 @@ itemBases["Highborn Staff"] = {
 	implicitModTypes = { { "block" }, },
 	weapon = { PhysicalMin = 48, PhysicalMax = 145, CritChanceBase = 6.5, AttackRateBase = 1.15, Range = 13, },
 	req = { level = 52, str = 89, int = 89, },
-}
-itemBases["Foul Staff"] = {
-	type = "Staff",
-	socketLimit = 6,
-	tags = { default = true, weapon = true, twohand = true, staff = true, two_hand_weapon = true, warstaff = true, },
-	implicit = "+18% Chance to Block Attack Damage while wielding a Staff",
-	implicitModTypes = { { "block" }, },
-	weapon = { PhysicalMin = 65, PhysicalMax = 121, CritChanceBase = 6.1, AttackRateBase = 1.3, Range = 13, },
-	req = { level = 55, str = 94, int = 94, },
 }
 itemBases["Moon Staff"] = {
 	type = "Staff",
@@ -155,24 +101,6 @@ itemBases["Lathi"] = {
 	weapon = { PhysicalMin = 72, PhysicalMax = 120, CritChanceBase = 6, AttackRateBase = 1.3, Range = 13, },
 	req = { level = 62, str = 113, int = 113, },
 }
-itemBases["Ezomyte Staff"] = {
-	type = "Staff",
-	socketLimit = 6,
-	tags = { default = true, weapon = true, twohand = true, staff = true, two_hand_weapon = true, warstaff = true, },
-	implicit = "+20% Chance to Block Attack Damage while wielding a Staff",
-	implicitModTypes = { { "block" }, },
-	weapon = { PhysicalMin = 53, PhysicalMax = 160, CritChanceBase = 7.3, AttackRateBase = 1.25, Range = 13, },
-	req = { level = 60, str = 113, int = 113, },
-}
-itemBases["Maelstrom Staff"] = {
-	type = "Staff",
-	socketLimit = 6,
-	tags = { default = true, weapon = true, twohand = true, staff = true, two_hand_weapon = true, warstaff = true, },
-	implicit = "+25% Chance to Block Attack Damage while wielding a Staff",
-	implicitModTypes = { { "block" }, },
-	weapon = { PhysicalMin = 71, PhysicalMax = 147, CritChanceBase = 6.8, AttackRateBase = 1.25, Range = 13, },
-	req = { level = 64, str = 113, int = 113, },
-}
 itemBases["Imperial Staff"] = {
 	type = "Staff",
 	socketLimit = 6,
@@ -181,15 +109,6 @@ itemBases["Imperial Staff"] = {
 	implicitModTypes = { { "block" }, },
 	weapon = { PhysicalMin = 57, PhysicalMax = 171, CritChanceBase = 7, AttackRateBase = 1.15, Range = 13, },
 	req = { level = 66, str = 113, int = 113, },
-}
-itemBases["Judgement Staff"] = {
-	type = "Staff",
-	socketLimit = 6,
-	tags = { default = true, weapon = true, twohand = true, staff = true, two_hand_weapon = true, warstaff = true, },
-	implicit = "+20% Chance to Block Spell Damage while wielding a Staff",
-	implicitModTypes = { { "block" }, },
-	weapon = { PhysicalMin = 73, PhysicalMax = 136, CritChanceBase = 6.5, AttackRateBase = 1.3, Range = 13, },
-	req = { level = 68, str = 113, int = 113, },
 }
 itemBases["Eclipse Staff"] = {
 	type = "Staff",
@@ -227,10 +146,102 @@ itemBases["Battery Staff"] = {
 	weapon = { PhysicalMin = 65, PhysicalMax = 120, CritChanceBase = 6, AttackRateBase = 1.25, Range = 13, },
 	req = { level = 70, str = 117, int = 117, },
 }
+
+itemBases["Iron Staff"] = {
+	type = "Staff",
+	subType = "Warstaff",
+	socketLimit = 6,
+	tags = { default = true, weapon = true, twohand = true, two_hand_weapon = true, attack_staff = true, warstaff = true, },
+	implicit = "+18% Chance to Block Attack Damage while wielding a Staff",
+	implicitModTypes = { { "block" }, },
+	weapon = { PhysicalMin = 14, PhysicalMax = 42, CritChanceBase = 6.4, AttackRateBase = 1.3, Range = 13, },
+	req = { level = 13, str = 27, int = 27, },
+}
+itemBases["Coiled Staff"] = {
+	type = "Staff",
+	subType = "Warstaff",
+	socketLimit = 6,
+	tags = { default = true, weapon = true, twohand = true, two_hand_weapon = true, attack_staff = true, warstaff = true, },
+	implicit = "+20% Chance to Block Attack Damage while wielding a Staff",
+	implicitModTypes = { { "block" }, },
+	weapon = { PhysicalMin = 27, PhysicalMax = 57, CritChanceBase = 6.2, AttackRateBase = 1.3, Range = 13, },
+	req = { level = 23, str = 43, int = 43, },
+}
+itemBases["Vile Staff"] = {
+	type = "Staff",
+	subType = "Warstaff",
+	socketLimit = 6,
+	tags = { default = true, weapon = true, twohand = true, two_hand_weapon = true, attack_staff = true, warstaff = true, },
+	implicit = "+18% Chance to Block Attack Damage while wielding a Staff",
+	implicitModTypes = { { "block" }, },
+	weapon = { PhysicalMin = 41, PhysicalMax = 76, CritChanceBase = 6.1, AttackRateBase = 1.3, Range = 13, },
+	req = { level = 33, str = 59, int = 59, },
+}
+itemBases["Military Staff"] = {
+	type = "Staff",
+	subType = "Warstaff",
+	socketLimit = 6,
+	tags = { default = true, weapon = true, twohand = true, two_hand_weapon = true, attack_staff = true, warstaff = true, },
+	implicit = "+18% Chance to Block Attack Damage while wielding a Staff",
+	implicitModTypes = { { "block" }, },
+	weapon = { PhysicalMin = 38, PhysicalMax = 114, CritChanceBase = 6.6, AttackRateBase = 1.25, Range = 13, },
+	req = { level = 41, str = 72, int = 72, },
+}
+itemBases["Serpentine Staff"] = {
+	type = "Staff",
+	subType = "Warstaff",
+	socketLimit = 6,
+	tags = { default = true, weapon = true, twohand = true, two_hand_weapon = true, attack_staff = true, warstaff = true, },
+	implicit = "+20% Chance to Block Attack Damage while wielding a Staff",
+	implicitModTypes = { { "block" }, },
+	weapon = { PhysicalMin = 56, PhysicalMax = 117, CritChanceBase = 6.3, AttackRateBase = 1.25, Range = 13, },
+	req = { level = 49, str = 85, int = 85, },
+}
+itemBases["Foul Staff"] = {
+	type = "Staff",
+	subType = "Warstaff",
+	socketLimit = 6,
+	tags = { default = true, weapon = true, twohand = true, two_hand_weapon = true, attack_staff = true, warstaff = true, },
+	implicit = "+18% Chance to Block Attack Damage while wielding a Staff",
+	implicitModTypes = { { "block" }, },
+	weapon = { PhysicalMin = 65, PhysicalMax = 121, CritChanceBase = 6.1, AttackRateBase = 1.3, Range = 13, },
+	req = { level = 55, str = 94, int = 94, },
+}
+itemBases["Ezomyte Staff"] = {
+	type = "Staff",
+	subType = "Warstaff",
+	socketLimit = 6,
+	tags = { default = true, weapon = true, twohand = true, two_hand_weapon = true, attack_staff = true, warstaff = true, },
+	implicit = "+20% Chance to Block Attack Damage while wielding a Staff",
+	implicitModTypes = { { "block" }, },
+	weapon = { PhysicalMin = 53, PhysicalMax = 160, CritChanceBase = 7.3, AttackRateBase = 1.25, Range = 13, },
+	req = { level = 60, str = 113, int = 113, },
+}
+itemBases["Maelstrom Staff"] = {
+	type = "Staff",
+	subType = "Warstaff",
+	socketLimit = 6,
+	tags = { default = true, weapon = true, twohand = true, two_hand_weapon = true, attack_staff = true, warstaff = true, },
+	implicit = "+25% Chance to Block Attack Damage while wielding a Staff",
+	implicitModTypes = { { "block" }, },
+	weapon = { PhysicalMin = 71, PhysicalMax = 147, CritChanceBase = 6.8, AttackRateBase = 1.25, Range = 13, },
+	req = { level = 64, str = 113, int = 113, },
+}
+itemBases["Judgement Staff"] = {
+	type = "Staff",
+	subType = "Warstaff",
+	socketLimit = 6,
+	tags = { default = true, weapon = true, twohand = true, two_hand_weapon = true, attack_staff = true, warstaff = true, },
+	implicit = "+20% Chance to Block Spell Damage while wielding a Staff",
+	implicitModTypes = { { "block" }, },
+	weapon = { PhysicalMin = 73, PhysicalMax = 136, CritChanceBase = 6.5, AttackRateBase = 1.3, Range = 13, },
+	req = { level = 68, str = 113, int = 113, },
+}
 itemBases["Capacity Rod"] = {
 	type = "Staff",
+	subType = "Warstaff",
 	socketLimit = 6,
-	tags = { default = true, weapon = true, twohand = true, staff = true, two_hand_weapon = true, not_for_sale = true, },
+	tags = { default = true, weapon = true, twohand = true, two_hand_weapon = true, attack_staff = true, not_for_sale = true, },
 	implicit = "1 to Maximum Power Charges and Maximum Endurance Charges",
 	implicitModTypes = { {  }, },
 	weapon = { PhysicalMin = 39, PhysicalMax = 73, CritChanceBase = 7, AttackRateBase = 1.25, Range = 13, },
@@ -238,8 +249,9 @@ itemBases["Capacity Rod"] = {
 }
 itemBases["Potentiality Rod"] = {
 	type = "Staff",
+	subType = "Warstaff",
 	socketLimit = 6,
-	tags = { default = true, weapon = true, twohand = true, staff = true, two_hand_weapon = true, not_for_sale = true, },
+	tags = { default = true, weapon = true, twohand = true, two_hand_weapon = true, attack_staff = true, not_for_sale = true, },
 	implicit = "1 to Maximum Power Charges and Maximum Endurance Charges",
 	implicitModTypes = { {  }, },
 	weapon = { PhysicalMin = 61, PhysicalMax = 113, CritChanceBase = 7, AttackRateBase = 1.25, Range = 13, },
@@ -247,8 +259,9 @@ itemBases["Potentiality Rod"] = {
 }
 itemBases["Eventuality Rod"] = {
 	type = "Staff",
+	subType = "Warstaff",
 	socketLimit = 6,
-	tags = { default = true, weapon = true, twohand = true, staff = true, two_hand_weapon = true, not_for_sale = true, },
+	tags = { default = true, weapon = true, twohand = true, two_hand_weapon = true, attack_staff = true, not_for_sale = true, },
 	implicit = "1 to Maximum Power Charges and Maximum Endurance Charges",
 	implicitModTypes = { {  }, },
 	weapon = { PhysicalMin = 78, PhysicalMax = 144, CritChanceBase = 7, AttackRateBase = 1.25, Range = 13, },

--- a/Data/Bases/wand.lua
+++ b/Data/Bases/wand.lua
@@ -209,3 +209,13 @@ itemBases["Convoking Wand"] = {
 	weapon = { PhysicalMin = 30, PhysicalMax = 56, CritChanceBase = 7, AttackRateBase = 1.4, Range = 120, },
 	req = { level = 72, int = 242, },
 }
+
+itemBases["Convoking Wand"] = {
+	type = "Wand",
+	socketLimit = 3,
+	tags = { default = true, weapon = true, onehand = true, wand = true, ranged = true, one_hand_weapon = true, weapon_can_roll_minion_modifiers = true, not_for_sale = true, atlas_base_type = true, wandatlas1 = true, },
+	implicit = "Can roll Minion Modifiers",
+	implicitModTypes = { { "minion" }, },
+	weapon = { PhysicalMin = 30, PhysicalMax = 56, CritChanceBase = 7, AttackRateBase = 1.4, Range = 120, },
+	req = { level = 72, int = 242, },
+}

--- a/Data/Bases/wand.lua
+++ b/Data/Bases/wand.lua
@@ -200,15 +200,6 @@ itemBases["Accumulator Wand"] = {
 	weapon = { PhysicalMin = 29, PhysicalMax = 54, CritChanceBase = 7.5, AttackRateBase = 1.4, Range = 120, },
 	req = { level = 70, int = 237, },
 }
-itemBases["Convoking Wand"] = {
-	type = "Wand",
-	socketLimit = 3,
-	tags = { default = true, weapon = true, onehand = true, wand = true, ranged = true, one_hand_weapon = true, not_for_sale = true, atlas_base_type = true, wandatlas1 = true, },
-	implicit = "Can roll Minion Modifiers",
-	implicitModTypes = { { "minion" }, },
-	weapon = { PhysicalMin = 30, PhysicalMax = 56, CritChanceBase = 7, AttackRateBase = 1.4, Range = 120, },
-	req = { level = 72, int = 242, },
-}
 
 itemBases["Convoking Wand"] = {
 	type = "Wand",

--- a/Export/Bases/dagger.txt
+++ b/Export/Bases/dagger.txt
@@ -4,10 +4,10 @@ local itemBases = ...
 #type Dagger
 #baseTags weapon onehand attack_dagger one_hand_weapon
 #socketLimit 3
-#baseMatch Metadata/Items/Weapons/OneHandWeapons/Daggers/AbstractDagger
+#baseMatch BaseType Metadata/Items/Weapons/OneHandWeapons/Daggers/AbstractDagger
 
 #type Dagger
 #subType Rune
 #baseTags weapon onehand dagger one_hand_weapon
 #socketLimit 3
-#baseMatch Metadata/Items/Weapons/OneHandWeapons/Daggers/AbstractRuneDagger
+#baseMatch BaseType Metadata/Items/Weapons/OneHandWeapons/Daggers/AbstractRuneDagger

--- a/Export/Bases/dagger.txt
+++ b/Export/Bases/dagger.txt
@@ -2,7 +2,12 @@
 local itemBases = ...
 
 #type Dagger
+#baseTags weapon onehand attack_dagger one_hand_weapon
+#socketLimit 3
+#baseMatch Metadata/Items/Weapons/OneHandWeapons/Daggers/AbstractDagger
+
+#type Dagger
+#subType Rune
 #baseTags weapon onehand dagger one_hand_weapon
 #socketLimit 3
-#baseMatch Metadata/Items/Weapons/OneHandWeapons/Daggers/Dagger
-#baseMatch Metadata/Items/Weapons/OneHandWeapons/Daggers/RuneDaggerE%d+
+#baseMatch Metadata/Items/Weapons/OneHandWeapons/Daggers/AbstractRuneDagger

--- a/Export/Bases/staff.txt
+++ b/Export/Bases/staff.txt
@@ -4,5 +4,10 @@ local itemBases = ...
 #type Staff
 #baseTags weapon twohand staff two_hand_weapon
 #socketLimit 6
-#baseMatch Metadata/Items/Weapons/TwoHandWeapons/Staves/Staff
-#baseMatch Metadata/Items/Weapons/TwoHandWeapons/Staves/WarstaffE%d+
+#baseMatch Metadata/Items/Weapons/TwoHandWeapons/Staves/AbstractStaff
+
+#type Staff
+#subType Warstaff
+#baseTags weapon twohand two_hand_weapon attack_staff
+#socketLimit 6
+#baseMatch Metadata/Items/Weapons/TwoHandWeapons/Staves/AbstractWarstaff

--- a/Export/Bases/staff.txt
+++ b/Export/Bases/staff.txt
@@ -4,10 +4,10 @@ local itemBases = ...
 #type Staff
 #baseTags weapon twohand staff two_hand_weapon
 #socketLimit 6
-#baseMatch Metadata/Items/Weapons/TwoHandWeapons/Staves/AbstractStaff
+#baseMatch BaseType Metadata/Items/Weapons/TwoHandWeapons/Staves/AbstractStaff
 
 #type Staff
 #subType Warstaff
 #baseTags weapon twohand two_hand_weapon attack_staff
 #socketLimit 6
-#baseMatch Metadata/Items/Weapons/TwoHandWeapons/Staves/AbstractWarstaff
+#baseMatch BaseType Metadata/Items/Weapons/TwoHandWeapons/Staves/AbstractWarstaff

--- a/Export/Bases/wand.txt
+++ b/Export/Bases/wand.txt
@@ -4,7 +4,7 @@ local itemBases = ...
 #type Wand
 #baseTags weapon onehand wand ranged one_hand_weapon
 #socketLimit 3
-#baseMatch Metadata/Items/Weapons/OneHandWeapons/Wands/Wand
+#baseMatch Metadata/Items/Weapons/OneHandWeapons/Wands/Wand[ME]?%d+
 
 #type Wand
 #baseTags weapon onehand wand ranged one_hand_weapon weapon_can_roll_minion_modifiers

--- a/Export/Bases/wand.txt
+++ b/Export/Bases/wand.txt
@@ -5,3 +5,8 @@ local itemBases = ...
 #baseTags weapon onehand wand ranged one_hand_weapon
 #socketLimit 3
 #baseMatch Metadata/Items/Weapons/OneHandWeapons/Wands/Wand
+
+#type Wand
+#baseTags weapon onehand wand ranged one_hand_weapon weapon_can_roll_minion_modifiers
+#socketLimit 3
+#base Metadata/Items/Weapons/OneHandWeapons/Wands/WandAtlas1

--- a/Export/Scripts/bases.lua
+++ b/Export/Scripts/bases.lua
@@ -163,12 +163,20 @@ directiveTable.base = function(state, args, out)
 	out:write('},\n}\n')
 end
 
-directiveTable.baseMatch = function(state, args, out)
+directiveTable.baseMatch = function(state, argstr, out)
+	-- Default to look at the Id column for matching
 	local key = "Id"
-	if args:match("Abstract") then
-		key = "BaseType"
+	local args = {}
+	for i in string.gmatch(argstr, "%S+") do
+	   table.insert(args, i)
 	end
-	for i, baseItemType in ipairs(dat("BaseItemTypes"):GetRowList(key, args, true)) do
+	local value = args[1]
+	-- If column name is specified, use that
+	if args[2] then
+		key = args[1]
+		value = args[2]
+	end
+	for i, baseItemType in ipairs(dat("BaseItemTypes"):GetRowList(key, value, true)) do
 		directiveTable.base(state, baseItemType.Id, out)
 	end
 end

--- a/Export/Scripts/bases.lua
+++ b/Export/Scripts/bases.lua
@@ -164,7 +164,11 @@ directiveTable.base = function(state, args, out)
 end
 
 directiveTable.baseMatch = function(state, args, out)
-	for i, baseItemType in ipairs(dat("BaseItemTypes"):GetRowList("Id", args, true)) do
+	local key = "Id"
+	if args:match("Abstract") then
+		key = "BaseType"
+	end
+	for i, baseItemType in ipairs(dat("BaseItemTypes"):GetRowList(key, args, true)) do
 		directiveTable.base(state, baseItemType.Id, out)
 	end
 end


### PR DESCRIPTION
This takes care of many mod issues laid out in the issue.  The only remaining issue is Convoking Wand appears twice, but PoB takes the last one so it still works.  It's easily fixed, but I have to specify each and every type to do so