### PR TITLE
Add support for skills granted by tree nodes

### DIFF
--- a/Classes/SkillsTab.lua
+++ b/Classes/SkillsTab.lua
@@ -133,15 +133,15 @@ local SkillsTabClass = newClass("SkillsTab", "UndoHandler", "ControlHost", "Cont
 		return self.displayGroup.source ~= nil
 	end
 	self.controls.sourceNote.label = function()
-		local item = self.displayGroup.sourceItem or { rarity = "NORMAL", name = "?" }
-		local itemName = colorCodes[item.rarity]..item.name.."^7"
+		local source = self.displayGroup.sourceItem or (self.displayGroup.sourceNode and { rarity = "NORMAL", name = self.displayGroup.sourceNode.name }) or { rarity = "NORMAL", name = "?" }
+		local sourceName = colorCodes[source.rarity]..source.name.."^7"
 		local activeGem = self.displayGroup.gemList[1]
 		local label = [[^7This is a special group created for the ']]..activeGem.color..(activeGem.grantedEffect and activeGem.grantedEffect.name or activeGem.nameSpec)..[[^7' skill,
-which is being provided by ']]..itemName..[['.
-You cannot delete this group, but it will disappear if you un-equip the item.]]
+which is being provided by ']]..sourceName..[['.
+You cannot delete this group, but it will disappear if you ]]..(self.displayGroup.sourceNode and [[un-allocate the node.]] or [[un-equip the item.]])
 		if not self.displayGroup.noSupports then
 			label = label .. "\n\n" .. [[You cannot add support gems to this group, but support gems in
-any other group socketed into ']]..itemName..[['
+any other group socketed into ']]..sourceName..[['
 will automatically apply to the skill.]]
 		end
 		return label
@@ -787,8 +787,9 @@ function SkillsTabClass:AddSocketGroupTooltip(tooltip, socketGroup)
 	if socketGroup.enabled and not socketGroup.slotEnabled then
 		tooltip:AddLine(16, "^7Note: this group is disabled because it is socketed in the inactive weapon set.")
 	end
-	if socketGroup.sourceItem then
-		tooltip:AddLine(18, "^7Source: "..colorCodes[socketGroup.sourceItem.rarity]..socketGroup.sourceItem.name)
+	local source = socketGroup.sourceItem or socketGroup.sourceNode
+	if source then
+		tooltip:AddLine(18, "^7Source: "..colorCodes[source.rarity or "NORMAL"]..source.name)
 		tooltip:AddSeparator(10)
 	end
 	local gemShown = { }

--- a/Data/Skills/other.lua
+++ b/Data/Skills/other.lua
@@ -292,8 +292,10 @@ skills["SummonMirageChieftain"] = {
 	skillTypes = { [SkillType.Spell] = true, [SkillType.Triggerable] = true, [SkillType.Triggered] = true, [SkillType.TriggeredGrantedSkill] = true, [SkillType.Instant] = true, },
 	statDescriptionScope = "skill_stat_descriptions",
 	castTime = 0,
+	fromTree = true,
 	baseFlags = {
 		spell = true,
+		duration = true,
 	},
 	baseMods = {
 	},
@@ -435,6 +437,7 @@ skills["BoneArmour"] = {
 	skillTypes = { [SkillType.Spell] = true, [SkillType.Buff] = true, [SkillType.Instant] = true, [SkillType.Duration] = true, [SkillType.Triggerable] = true, [SkillType.GuardSkill] = true, [SkillType.Minion] = true, [SkillType.Type96] = true, },
 	statDescriptionScope = "buff_skill_stat_descriptions",
 	castTime = 0,
+	fromTree = true,
 	baseFlags = {
 		duration = true,
 		spell = true,

--- a/Export/Skills/other.txt
+++ b/Export/Skills/other.txt
@@ -51,7 +51,8 @@ local skills, mod, flag, skill = ...
 #mods
 
 #skill SummonMirageChieftain
-#flags spell
+#flags spell duration
+	fromTree = true,
 #mods
 
 #skill SupportUniqueMjolnerLightningSpellsCastOnHit Mjolner
@@ -91,6 +92,7 @@ local skills, mod, flag, skill = ...
 #noGem
 #skill BoneArmour
 #flags duration spell
+	fromTree = true,
 #mods
 
 #skill BirdAspect

--- a/Modules/CalcSetup.lua
+++ b/Modules/CalcSetup.lua
@@ -102,6 +102,18 @@ function calcs.buildModListForNode(env, node)
 		end
 	end
 
+	node.grantedSkills = { }
+	for _, skill in ipairs(modList:List(nil, "ExtraSkill")) do
+		if skill.name ~= "Unknown" then
+			t_insert(node.grantedSkills, {
+				skillId = skill.skillId,
+				level = skill.level,
+				noSupports = true,
+				source = "Tree:"..node.id
+			})
+		end
+	end
+
 	return modList
 end
 
@@ -319,7 +331,7 @@ function calcs.initEnv(build, mode, override)
 	env.radiusJewelList = wipeTable(env.radiusJewelList)
 	env.extraRadiusNodeList = wipeTable(env.extraRadiusNodeList)
 	env.player.itemList = { }
-	env.itemGrantedSkills = { }
+	env.grantedSkills = { }
 	env.flasks = { }
 	for _, slot in pairs(build.itemsTab.orderedSlots) do
 		local slotName = slot.slotName
@@ -341,7 +353,7 @@ function calcs.initEnv(build, mode, override)
 				local grantedSkill = copyTable(skill)
 				grantedSkill.sourceItem = item
 				grantedSkill.slotName = slotName
-				t_insert(env.itemGrantedSkills, grantedSkill)
+				t_insert(env.grantedSkills, grantedSkill)
 			end
 		end
 		if slot.weaponSet and slot.weaponSet ~= (build.itemsTab.activeItemSet.useSecondWeaponSet and 2 or 1) then
@@ -535,11 +547,37 @@ function calcs.initEnv(build, mode, override)
 			env.flasks[override.toggleFlask] = true
 		end
 	end
-	
+
+	-- Add granted passives
+	env.grantedPassives = { }
+	for _, passive in pairs(env.modDB:List(nil, "GrantedPassive")) do
+		local node = env.spec.tree.notableMap[passive]
+		if node then
+			if env.spec.nodes[node.id] and env.spec.nodes[node.id].conqueredBy and env.spec.tree.legion.editedNodes and env.spec.tree.legion.editedNodes[env.spec.nodes[node.id].conqueredBy.id] then
+				nodes[node.id] = env.spec.tree.legion.editedNodes[env.spec.nodes[node.id].conqueredBy.id][node.id] or node
+			else
+				nodes[node.id] = node
+			end
+			env.grantedPassives[node.id] = true
+		end
+	end
+
+	-- Merge modifiers for allocated passives
+	env.modDB:AddList(calcs.buildModListForNodeList(env, nodes, true))
+
+	-- Find skills granted by tree nodes
+	for _, node in pairs(env.allocNodes) do
+		for _, skill in ipairs(node.grantedSkills) do
+			local grantedSkill = copyTable(skill)
+			grantedSkill.sourceNode = node
+			t_insert(env.grantedSkills, grantedSkill)
+		end
+	end
+
 	if env.mode == "MAIN" then
-		-- Process extra skills granted by items
+		-- Process extra skills granted by items or tree nodes
 		local markList = wipeTable(tempTable1)
-		for _, grantedSkill in ipairs(env.itemGrantedSkills) do	
+		for _, grantedSkill in ipairs(env.grantedSkills) do
 			-- Check if a matching group already exists
 			local group
 			for index, socketGroup in pairs(build.skillsTab.socketGroupList) do
@@ -560,6 +598,7 @@ function calcs.initEnv(build, mode, override)
 			
 			-- Update the group
 			group.sourceItem = grantedSkill.sourceItem
+			group.sourceNode = grantedSkill.sourceNode
 			local activeGemInstance = group.gemList[1] or {
 				skillId = grantedSkill.skillId,
 				quality = 0,
@@ -609,23 +648,6 @@ function calcs.initEnv(build, mode, override)
 	else
 		env.player.weaponData2 = env.player.itemList["Weapon 2"] and env.player.itemList["Weapon 2"].weaponData and env.player.itemList["Weapon 2"].weaponData[2] or { }
 	end
-
-	-- Add granted passives
-	env.grantedPassives = { }
-	for _, passive in pairs(env.modDB:List(nil, "GrantedPassive")) do
-		local node = env.spec.tree.notableMap[passive]
-		if node then
-			if env.spec.nodes[node.id] and env.spec.nodes[node.id].conqueredBy and env.spec.tree.legion.editedNodes and env.spec.tree.legion.editedNodes[env.spec.nodes[node.id].conqueredBy.id] then
-				nodes[node.id] = env.spec.tree.legion.editedNodes[env.spec.nodes[node.id].conqueredBy.id][node.id] or node
-			else
-				nodes[node.id] = node
-			end
-			env.grantedPassives[node.id] = true
-		end
-	end
-
-	-- Merge modifiers for allocated passives
-	env.modDB:AddList(calcs.buildModListForNodeList(env, nodes, true))
 
 	-- Determine main skill group
 	if env.mode == "CALCS" then

--- a/Modules/ModParser.lua
+++ b/Modules/ModParser.lua
@@ -1268,7 +1268,7 @@ local gemIdLookup = {
 	["power charge on critical strike"] = "SupportPowerChargeOnCrit",
 }
 for name, grantedEffect in pairs(data.skills) do
-	if not grantedEffect.hidden or grantedEffect.fromItem then
+	if not grantedEffect.hidden or grantedEffect.fromItem or grantedEffect.fromTree then
 		gemIdLookup[grantedEffect.name:lower()] = grantedEffect.id
 	end
 end
@@ -1452,6 +1452,7 @@ local specialModList = {
 		mod("Damage", "MORE", num, { type = "Multiplier", var = "EnduranceChargesLostRecently", limit = tonumber(limit), limitTotal = true }),
 	} end,
 	["(%d+)%% more damage if you've lost an endurance charge in the past 8 seconds"] = function(num) return { mod("Damage", "MORE", num, { type = "Condition", var = "LostEnduranceChargeInPast8Sec" })	} end,
+	["trigger level (%d+) (.+) when you attack with a non%-vaal slam skill near an enemy"] = function(num, _, skill) return extraSkill(skill, num) end,
 	-- Deadeye
 	["projectiles pierce all nearby targets"] = { flag("PierceAllTargets") },
 	["gain %+(%d+) life when you hit a bleeding enemy"] = function(num) return { mod("LifeOnHit", "BASE", num, { type = "ActorCondition", actor = "enemy", var = "Bleeding" }) } end,


### PR DESCRIPTION
Supersedes #929 
![1](https://user-images.githubusercontent.com/18018499/82826028-9d5e7c00-9eac-11ea-8e22-5fc1d9f95d4b.png)
![2](https://user-images.githubusercontent.com/18018499/87675567-d2ce6a00-c777-11ea-9917-b76b219f687c.png)
Doesn't work with keystones as they are treated differently than other nodes.
Fixes #88 
Requires `ModCache` rebuild