### PR TITLE
Fix Dark Pact radius

### DIFF
--- a/Data/Skills/act_int.lua
+++ b/Data/Skills/act_int.lua
@@ -2124,7 +2124,7 @@ skills["DarkPact"] = {
 		area = true,
 	},
 	baseMods = {
-		skill("radius", 24),
+		skill("radius", 26),
 	},
 	qualityStats = {
 		Default = {

--- a/Export/Skills/act_int.txt
+++ b/Export/Skills/act_int.txt
@@ -367,7 +367,7 @@ local skills, mod, flag, skill = ...
 			mod("Damage", "MORE", nil, 0, bit.bor(KeywordFlag.Hit, KeywordFlag.Ailment), { type = "SkillPart", skillPart = 1 }),
 		},
 	},
-#baseMod skill("radius", 24)
+#baseMod skill("radius", 26)
 #mods
 
 #skill Despair


### PR DESCRIPTION
In game version 3.6.0, Dark Pact's base radius was changed from 24 to 26 units.