### PR TITLE
Remove crafted text on multiline mods

### DIFF
--- a/Classes/Item.lua
+++ b/Classes/Item.lua
@@ -412,7 +412,8 @@ function ItemClass:ParseRaw(raw)
 				local modList, extra = modLib.parseMod(rangedLine or line)
 				if (not modList or extra) and self.rawLines[l+1] then
 					-- Try to combine it with the next line
-					local combLine = line.." "..self.rawLines[l+1]:gsub("%b{}", ""):gsub(" %(fractured%)",""):gsub(" %(crafted%)",""):gsub(" %(implicit%)",""):gsub(" %(enchant%)","")
+					local nextLine = self.rawLines[l+1]:gsub("%b{}", ""):gsub(" ?%(fractured%)",""):gsub(" ?%(crafted%)",""):gsub(" ?%(implicit%)",""):gsub(" ?%(enchant%)","")
+					local combLine = line.." "..nextLine
 					if combLine:match("%(%d+%-%d+ to %d+%-%d+%)") or combLine:match("%(%-?[%d%.]+ to %-?[%d%.]+%)") or combLine:match("%(%-?[%d%.]+%-[%d%.]+%)") then
 						rangedLine = itemLib.applyRange(combLine, 1, catalystScalar)
 					elseif catalystScalar ~= 1 then
@@ -420,7 +421,7 @@ function ItemClass:ParseRaw(raw)
 					end
 					modList, extra = modLib.parseMod(rangedLine or combLine, true)
 					if modList and not extra then
-						line = line.."\n"..self.rawLines[l+1]
+						line = line.."\n"..nextLine
 						l = l + 1
 					else
 						modList, extra = modLib.parseMod(rangedLine or line)


### PR DESCRIPTION
Take items like this cluster jewel for example:

````Cataclysm Glimmer
Large Cluster Jewel
Unique ID: f974de4732542e96894c8a41a6e15b2d81bdca1cf02bc3bb14cff9eb57c3d111
Item Level: 71
LevelReq: 54
Implicits: 4
{crafted}Adds 8 Passive Skills
{crafted}2 Added Passive Skills are Jewel Sockets
{crafted}Added Small Passive Skills grant: Mace or Sceptre Attacks deal 12% increased Damage with Hits and Ailments
{crafted}Added Small Passive Skills grant: Staff Attacks deal 12% increased Damage with Hits and Ailments
Added Small Passive Skills also grant: +5 to Dexterity
1 Added Passive Skill is Calamitous
1 Added Passive Skill is Martial Prowess
1 Added Passive Skill is Weight Advantage
````
The `{crafted}` text shows up on the second line.  This PR removes that.  I tested a few other multiline things, and they look correct, but I'd like to import some builds that have multiline fractured items to be sure, but multiline mods are hard to find in general.
