### PR TITLE
Fixes #1809 - Disables controls before gem is selected

### DIFF
--- a/Classes/SkillsTab.lua
+++ b/Classes/SkillsTab.lua
@@ -459,6 +459,9 @@ function SkillsTabClass:CreateGemSlot(index)
 		self.build.buildFlag = true
 	end)
 	slot.level:AddToTabGroup(self.controls.groupLabel)
+	slot.level.enabled = function()
+		return index <= #self.displayGroup.gemList
+	end
 	self.controls["gemSlot"..index.."Level"] = slot.level
 
 	-- Gem quality id
@@ -476,6 +479,9 @@ function SkillsTabClass:CreateGemSlot(index)
 		self:AddUndoState()
 		self.build.buildFlag = true
 	end)
+	slot.qualityId.enabled = function()
+		return index <= #self.displayGroup.gemList
+	end
 	slot.qualityId.tooltipFunc = function()
 		-- Reset the tooltip
 		slot.qualityId.tooltip:Clear()
@@ -548,6 +554,9 @@ function SkillsTabClass:CreateGemSlot(index)
 		self.build.buildFlag = true
 	end)
 	slot.quality:AddToTabGroup(self.controls.groupLabel)
+	slot.quality.enabled = function()
+		return index <= #self.displayGroup.gemList
+	end
 	self.controls["gemSlot"..index.."Quality"] = slot.quality
 
 	-- Enable gem
@@ -579,6 +588,9 @@ function SkillsTabClass:CreateGemSlot(index)
 				end
 			end
 		end
+	end
+	slot.enabled.enabled = function()
+		return index <= #self.displayGroup.gemList
 	end
 	self.controls["gemSlot"..index.."Enable"] = slot.enabled
 


### PR DESCRIPTION
Fixes #1809 I don't think there is any use case for changing these inputs before selecting a gem.  Please correct me if I'm wrong or if you think of one while reviewing this PR.  I'll also ask in the issue to make sure I'm not removing functionality that the user uses right now.

![image](https://user-images.githubusercontent.com/1209372/103445597-06c11d00-4c3c-11eb-9069-923939e15a2e.png)


