### PR TITLE
Bone armour skill granted by necromancer ascendancy now supported

### DIFF
--- a/Modules/ModParser.lua
+++ b/Modules/ModParser.lua
@@ -1268,6 +1268,7 @@ end
 
 local gemIdLookup = {
 	["power charge on critical strike"] = "SupportPowerChargeOnCrit",
+	["bone armour"] = "BoneArmour",
 }
 for name, grantedEffect in pairs(data.skills) do
 	if not grantedEffect.hidden or grantedEffect.fromItem or grantedEffect.fromTree then


### PR DESCRIPTION
The skill "Bone Armour" granted by the necromancer asendancy node "Bone Barrier" works mechanically very similar to the skill steelskin.

The only change that was necessary to support parsing the skill was mapping the skill name to its id in the mod parser.

![grafik](https://user-images.githubusercontent.com/645185/104109549-5dc79180-52cf-11eb-9e1e-5782f21639d6.png)


Here is the skill view for the added skill:
![grafik](https://user-images.githubusercontent.com/645185/104109575-923b4d80-52cf-11eb-93a5-7853dc2fa48a.png)
