### PR TITLE
Fixing Elemental Equilibrium on Malachai's Artifice so you can't have both it and EE

### DIFF
--- a/Modules/ModParser.lua
+++ b/Modules/ModParser.lua
@@ -1667,18 +1667,7 @@ local specialModList = {
 	["socketed gems reserve no mana"] = { mod("ManaReserved", "MORE", -100, { type = "SocketedIn", slotName = "{SlotName}" }) },
 	["socketed skill gems get a (%d+)%% mana multiplier"] = function(num) return { mod("ExtraSkillMod", "LIST", { mod = mod("SupportManaMultiplier", "MORE", num - 100) }, { type = "SocketedIn", slotName = "{SlotName}" }) } end,
 	["socketed gems have blood magic"] = { flag("SkillBloodMagic", { type = "SocketedIn", slotName = "{SlotName}" }) },
-	["socketed gems have elemental equilibrium"] = function() 
-		--Currently hardcoded to what Elemental Equilibrium node is
-		return {
-			flag("ElementalEquilibrium"),
-			mod("EnemyModifier", "LIST", { mod = mod("FireResist", "BASE", 25, { type = "Condition", var = "HitByFireDamage" }) }),
-			mod("EnemyModifier", "LIST", { mod = mod("FireResist", "BASE", -50, { type = "Condition", var = "HitByFireDamage", neg = true }, { type = "Condition", varList={ "HitByColdDamage","HitByLightningDamage" } }) }),
-			mod("EnemyModifier", "LIST", { mod = mod("ColdResist", "BASE", 25, { type = "Condition", var = "HitByColdDamage" }) }),
-			mod("EnemyModifier", "LIST", { mod = mod("ColdResist", "BASE", -50, { type = "Condition", var = "HitByColdDamage", neg = true }, { type = "Condition", varList={ "HitByFireDamage","HitByLightningDamage" } }) }),
-			mod("EnemyModifier", "LIST", { mod = mod("LightningResist", "BASE", 25, { type = "Condition", var = "HitByLightningDamage" }) }),
-			mod("EnemyModifier", "LIST", { mod = mod("LightningResist", "BASE", -50, { type = "Condition", var = "HitByLightningDamage", neg = true }, { type = "Condition", varList={ "HitByFireDamage","HitByColdDamage" } }) }),
-		}
-	end,
+	["socketed gems have elemental equilibrium"] = { mod("Keystone", "LIST", "Elemental Equilibrium") },
 	["socketed gems have secrets of suffering"] = { 
 		flag("CannotIgnite", { type = "SocketedIn", slotName = "{SlotName}" }), 
 		flag("CannotChill", { type = "SocketedIn", slotName = "{SlotName}" }), 


### PR DESCRIPTION
Tree power was suggesting taking EE when you had Malachai's Artifice.  Until we support the socketed skill getting EE alone, this assumes Malachai's Artifice gives you EE (i.e. exactly what it was doing before, just without letting you have it twice).