### PR TITLE
Fixed Anomalous Flesh and Stone by adding Increased Armour

### DIFF
--- a/Data/Skills/act_str.lua
+++ b/Data/Skills/act_str.lua
@@ -2280,7 +2280,7 @@ skills["BloodSandArmour"] = {
 		},
 		["evasion_and_physical_damage_reduction_rating_+%"] = {
 			mod("Evasion", "INC", nil, 0, 0, { type = "GlobalEffect", effectType = "Buff" }),
-			mod("Armor", "INC", nil, 0, 0, { type = "GlobalEffect", effectType = "Buff" })
+			mod("Armour", "INC", nil, 0, 0, { type = "GlobalEffect", effectType = "Buff" })
 		},
 		["damage_+%_if_changed_stances_recently"] = {
 			mod("Damage", "INC", nil, 0, 0, { type = "GlobalEffect", effectType = "Buff"}, { type = "Condition", var = "ChangedStanceRecently" })

--- a/Export/Skills/act_str.txt
+++ b/Export/Skills/act_str.txt
@@ -424,7 +424,7 @@ local skills, mod, flag, skill = ...
 		},
 		["evasion_and_physical_damage_reduction_rating_+%"] = {
 			mod("Evasion", "INC", nil, 0, 0, { type = "GlobalEffect", effectType = "Buff" }),
-			mod("Armor", "INC", nil, 0, 0, { type = "GlobalEffect", effectType = "Buff" })
+			mod("Armour", "INC", nil, 0, 0, { type = "GlobalEffect", effectType = "Buff" })
 		},
 		["damage_+%_if_changed_stances_recently"] = {
 			mod("Damage", "INC", nil, 0, 0, { type = "GlobalEffect", effectType = "Buff"}, { type = "Condition", var = "ChangedStanceRecently" })


### PR DESCRIPTION
Anomalous Flesh and Stone grants 10% increased Evasion and Armour at 20% quality

Only the Evasion was working before, now the Armour does as well.