### PR TITLE
Add support for Persistence Notable

### DIFF
--- a/Modules/ModParser.lua
+++ b/Modules/ModParser.lua
@@ -171,6 +171,7 @@ local modNameList = {
 	["physical damage taken"] = "PhysicalDamageTaken",
 	["physical damage from hits taken"] = "PhysicalDamageTaken",
 	["physical damage taken when hit"] = "PhysicalDamageTakenWhenHit",
+	["physical damage taken from hits"] = "PhysicalDamageTakenWhenHit",
 	["physical damage taken over time"] = "PhysicalDamageTakenOverTime",
 	["physical damage over time damage taken"] = "PhysicalDamageTakenOverTime",
 	["reflected physical damage taken"] = "PhysicalReflectedDamageTaken",


### PR DESCRIPTION
Adds support for "Physical Damage taken from Hits" wording found on the Persistence Notable.