### PR TITLE
Fixes #1887 - Allowing colons when naming a magic item

### DIFF
--- a/Classes/Item.lua
+++ b/Classes/Item.lua
@@ -21,6 +21,7 @@ local catalystTags = {
 	{ "jewellery_defense", "defences" },
 	{ "jewellery_elemental" ,"elemental_damage" },
 }
+local classNames = {"Marauder", "Duelist", "Ranger", "Shadow", "Witch", "Templar", "Scion"}
 
 local function getCatalystScalar(catalystId, tags, quality)
 	if not catalystId or type(catalystId) ~= "number" or not catalystTags[catalystId] or not tags or type(tags) ~= "table" or #tags == 0 then
@@ -292,7 +293,7 @@ function ItemClass:ParseRaw(raw)
 					end
 				elseif specName == "CatalystQuality" then
 					self.catalystQuality = tonumber(specVal)
-				else
+				elseif classNames[specName] then
 					foundExplicit = true
 					gameModeStage = "EXPLICIT"
 				end

--- a/Classes/Item.lua
+++ b/Classes/Item.lua
@@ -21,7 +21,7 @@ local catalystTags = {
 	{ "jewellery_defense", "defences" },
 	{ "jewellery_elemental" ,"elemental_damage" },
 }
-local classNames = {"Marauder", "Duelist", "Ranger", "Shadow", "Witch", "Templar", "Scion"}
+local classNames = { "Marauder", "Duelist", "Ranger", "Shadow", "Witch", "Templar", "Scion" }
 
 local function getCatalystScalar(catalystId, tags, quality)
 	if not catalystId or type(catalystId) ~= "number" or not catalystTags[catalystId] or not tags or type(tags) ~= "table" or #tags == 0 then


### PR DESCRIPTION
This else statement was put in specifically for Pure Talent, so I made that more explicit.