### PR TITLE
Add support for "Projectiles deal #% increased damage for each enemy pierced"

### DIFF
--- a/Modules/CalcOffence.lua
+++ b/Modules/CalcOffence.lua
@@ -639,6 +639,10 @@ function calcs.offence(env, actor, activeSkill)
 				output.PierceCount = skillModList:Sum("BASE", skillCfg, "PierceCount")
 				output.PierceCountString = output.PierceCount
 			end
+			if output.PierceCount > 0 then
+				skillFlags.piercing = true
+			end
+			output.PiercedCount = m_min(output.PierceCount, skillModList:Sum("BASE", skillCfg, "PiercedCount"))
 		end
 		output.ProjectileSpeedMod = calcLib.mod(skillModList, skillCfg, "ProjectileSpeed")
 		if breakdown then

--- a/Modules/ConfigOptions.lua
+++ b/Modules/ConfigOptions.lua
@@ -1003,6 +1003,9 @@ return {
 	{ var = "skillChainCount", type = "count", label = "# of times Skill has Chained:", ifFlag = "chaining", apply = function(val, modList, enemyModList)
 		modList:NewMod("ChainCount", "BASE", val, "Config", { type = "Condition", var = "Effective" })
 	end },
+	{ var = "skillPierceCount", type = "count", label = "# of times Skill has Pierced:", ifFlag = "piercing", apply = function(val, modList, enemyModList)
+		modList:NewMod("PiercedCount", "BASE", val, "Config", { type = "Condition", var = "Effective" })
+	end },
 	{ var = "meleeDistance", type = "count", label = "Melee distance to enemy:", ifFlag = "melee" },
 	{ var = "projectileDistance", type = "count", label = "Projectile travel distance:", ifFlag = "projectile" },
 	{ var = "conditionAtCloseRange", type = "check", label = "Is the enemy at Close Range?", ifCond = "AtCloseRange", apply = function(val, modList, enemyModList)

--- a/Modules/ModParser.lua
+++ b/Modules/ModParser.lua
@@ -956,6 +956,7 @@ local modTagList = {
 	["for each raised zombie"] = { tag = { type = "PerStat", stat = "ActiveZombieLimit" } },
 	["per raised spectre"] = { tag = { type = "PerStat", stat = "ActiveSpectreLimit" } },
 	["for each remaining chain"] = { tag = { type = "PerStat", stat = "ChainRemaining" } },
+	["for each enemy pierced"] = { tag = { type = "PerStat", stat = "PiercedCount" } },
 	-- Stat conditions
 	["with (%d+) or more strength"] = function(num) return { tag = { type = "StatThreshold", stat = "Str", threshold = num } } end,
 	["with at least (%d+) strength"] = function(num) return { tag = { type = "StatThreshold", stat = "Str", threshold = num } } end,


### PR DESCRIPTION
Did so by implementing the following:
- If you have a source of pierce add a box to the configuration tab "# of times Skill has Pierced:"
- Create a PiercedCount stat that is the minimum between your maximum # of pierces and the value in the configuration box
- "for each enemy pierced" adds a PerStat tag for PiercedCount