### PR TITLE
fix: rename base type of hrimnor's resolve so it shows up again

### DIFF
--- a/Data/Uniques/helmet.lua
+++ b/Data/Uniques/helmet.lua
@@ -84,7 +84,7 @@ Requires Level 65, 148 Str
 Armour is increased by Uncapped Fire Resistance
 ]],[[
 Hrimnor's Resolve
-Samite Helmet
+Samnite Helmet
 Variant: Pre 2.0.0
 Variant: Pre 2.6.0
 Variant: Current


### PR DESCRIPTION
In patch 3.13.0, the base type of Hrimnor's Resolve got changed from Samite Helmet so Samnite Helmet, causing it to not show up anymore in the unique item database.
Fixes #1972