### PR TITLE
Fixes #1991 - Flame wall secondary damage isn't affected by area damage

### DIFF
--- a/Export/Skills/act_int.txt
+++ b/Export/Skills/act_int.txt
@@ -580,9 +580,11 @@ local skills, mod, flag, skill = ...
 	parts = {
 		{
 			name = "Primary Debuff",
+			area = true,
 		},
 		{
 			name = "Secondary Debuff",
+			area = false,
 		},
 	},
 	statMap = {

--- a/Modules/CalcOffence.lua
+++ b/Modules/CalcOffence.lua
@@ -3457,7 +3457,7 @@ function calcs.offence(env, actor, activeSkill)
 		skillPart = skillCfg.skillPart,
 		skillTypes = skillCfg.skillTypes,
 		slotName = skillCfg.slotName,
-		flags = skillCfg.flags,
+		flags = bor(ModFlag.Dot, skillCfg.flags),
 		keywordFlags = band(skillCfg.keywordFlags, bnot(KeywordFlag.Hit)),
 	}
 	if bor(dotCfg.flags, ModFlag.Area) == dotCfg.flags and not skillData.dotIsArea then

--- a/Modules/CalcOffence.lua
+++ b/Modules/CalcOffence.lua
@@ -3457,9 +3457,18 @@ function calcs.offence(env, actor, activeSkill)
 		skillPart = skillCfg.skillPart,
 		skillTypes = skillCfg.skillTypes,
 		slotName = skillCfg.slotName,
-		flags = bor(ModFlag.Dot, skillData.dotIsSpell and ModFlag.Spell or 0, skillData.dotIsArea and ModFlag.Area or 0, skillData.dotIsProjectile and ModFlag.Projectile or 0),
+		flags = skillCfg.flags,
 		keywordFlags = band(skillCfg.keywordFlags, bnot(KeywordFlag.Hit)),
 	}
+	if bor(dotCfg.flags, ModFlag.Area) == dotCfg.flags and not skillData.dotIsArea then
+		dotCfg.flags = band(dotCfg.flags, bnot(ModFlag.Area))
+	end
+	if bor(dotCfg.flags, ModFlag.Projectile) == dotCfg.flags and not skillData.dotIsProjectile then
+		dotCfg.flags = band(dotCfg.flags, bnot(ModFlag.Projectile))
+	end
+	if bor(dotCfg.flags, ModFlag.Spell) == dotCfg.flags and not skillData.dotIsSpell then
+		dotCfg.flags = band(dotCfg.flags, bnot(ModFlag.Spell))
+	end
 
 	-- spell_damage_modifiers_apply_to_skill_dot does not apply to enemy damage taken
 	local dotTakenCfg = copyTable(dotCfg, true)


### PR DESCRIPTION
Tested with Essence Drain and Creeping Frost, they're still behaving the same.

Previous code was assuming all skills with dotIsArea had identical skillFlags for each part.