### PR TITLE
Fixes #1994 - Config options based on mainEnv skill, not calcsEnv selection

### DIFF
--- a/Classes/ConfigTab.lua
+++ b/Classes/ConfigTab.lua
@@ -166,8 +166,8 @@ local ConfigTabClass = newClass("ConfigTab", "UndoHandler", "ControlHost", "Cont
 				end
 			elseif varData.ifFlag then
 				control.shown = function()
-					local skillModList = self.build.calcsTab.calcsEnv.player.mainSkill.skillModList
-					local skillFlags = self.build.calcsTab.calcsEnv.player.mainSkill.skillFlags
+					local skillModList = self.build.calcsTab.mainEnv.player.mainSkill.skillModList
+					local skillFlags = self.build.calcsTab.mainEnv.player.mainSkill.skillFlags
 					-- Check both the skill mods for flags and flags that are set via calcPerform
 					return skillFlags[varData.ifFlag] or skillModList:Flag(nil, varData.ifFlag)
 				end


### PR DESCRIPTION
I believe the previous commit changed this on accident, as part of #1365 , and we've gotten a few issues related to it, so I changed it back.

Direct link to commit: https://github.com/PathOfBuildingCommunity/PathOfBuilding/pull/1365/commits/1a1ae201e79a5e4b0bfc67bd0124b10c147b7efe