### PR TITLE
Fixes #2012 - Divergent Fortify Support + Impale Support

### DIFF
--- a/Data/Skills/sup_dex.lua
+++ b/Data/Skills/sup_dex.lua
@@ -2237,6 +2237,10 @@ skills["SupportImpale"] = {
 		["impale_support_physical_damage_+%_final"] = {
 			mod("PhysicalDamage", "MORE", nil),
 		},
+		["impale_phys_reduction_%_penalty"] = {
+			mod("EnemyImpalePhysicalDamageReduction", "BASE", nil),
+			mult = -1,
+		}
 	},
 	baseMods = {
 	},

--- a/Data/Skills/sup_str.lua
+++ b/Data/Skills/sup_str.lua
@@ -1546,6 +1546,7 @@ skills["SupportFortify"] = {
 		},
 		["overwhelm_%_physical_damage_reduction_while_fortified"] = {
 			mod("EnemyPhysicalDamageReduction", "BASE", nil, 0, KeywordFlag.Hit, { type = "Condition", var = "Fortify"}),
+			mult = -1,
 		},
 	},
 	baseMods = {

--- a/Export/Skills/sup_dex.txt
+++ b/Export/Skills/sup_dex.txt
@@ -253,6 +253,10 @@ local skills, mod, flag, skill = ...
 		["impale_support_physical_damage_+%_final"] = {
 			mod("PhysicalDamage", "MORE", nil),
 		},
+		["impale_phys_reduction_%_penalty"] = {
+			mod("EnemyImpalePhysicalDamageReduction", "BASE", nil),
+			mult = -1,
+		}
 	},
 #mods
 

--- a/Export/Skills/sup_str.txt
+++ b/Export/Skills/sup_str.txt
@@ -185,6 +185,7 @@ local skills, mod, flag, skill = ...
 		},
 		["overwhelm_%_physical_damage_reduction_while_fortified"] = {
 			mod("EnemyPhysicalDamageReduction", "BASE", nil, 0, KeywordFlag.Hit, { type = "Condition", var = "Fortify"}),
+			mult = -1,
 		},
 	},
 #mods


### PR DESCRIPTION
Noticed Impale Support also wasn't applying phys damage reduction correctly, so I fixed that as well.  Divergent Intimidating Cry was also having issues, but it seems those are more involved than Impale, so I'll file a separate issue for that.