### PR TITLE
Use correct field for minion skill level requirements

### DIFF
--- a/Modules/CalcActiveSkill.lua
+++ b/Modules/CalcActiveSkill.lua
@@ -671,7 +671,7 @@ function calcs.createMinionSkills(env, activeSkill)
 		}
 		if #activeEffect.grantedEffect.levels > 1 then
 			for level, levelData in ipairs(activeEffect.grantedEffect.levels) do
-				if levelData[1] > minion.level then
+				if levelData.levelRequirement > minion.level then
 					break
 				else
 					activeEffect.level = level


### PR DESCRIPTION
This fix should address my concerns from #2020.

All minion/spectre skill definitions provide the `levelRequirement` entry as they're all generated from the export scripts.