### PR TITLE
Ability to load a build from commandline.

### DIFF
--- a/Modules/Main.lua
+++ b/Modules/Main.lua
@@ -397,7 +397,7 @@ function main:LoadPastebinBuild()
 			end
 		end
 	end)
-	arg[1] = null; -- Protect against downloading again this session.
+	arg[1] = nil; -- Protect against downloading again this session.
 	return true
 end
 


### PR DESCRIPTION
The idea here is to support custom URI schemes, which pass the URI data to the executable.

The pastebin code is extracted from the second parameter if it's of the form: "^pob:[/\\]*pastebin[/\\]+(%w+)[/\\]*"
 - The build is loaded from pastebin, decompressed, and then loaded at startup instead of the build specified in the Settings.xml

This is best used with the new PathOfBuilding executable which will always pass the lua script as the first parameter (and thus all other params are pushed forward by one)
 - However, this can be tested with the old executable by specifying the path to the Launch.lua as the first parameter, and then the "pob://pastebin/XXXXXXXX/" as the second parameter.

If you have the new [PathOfBuilding.exe](https://drive.google.com/file/d/1r8s6i-smrkqLKY-KJ_pQHsncz_twV8zs/view?usp=sharing) you can test the custom URI by manually registering it.
Save this as `registerpob.reg` and then double-click it.
You may have to replace the path in both places to your installed `Path of Building.exe`
```reg
Windows Registry Editor Version 5.00

[HKEY_CLASSES_ROOT\pob]
"URL Protocol"=""
@="URL:Path of Building"
"DefaultIcon"="\"C:\\Program Files (x86)\\Path of Building\\Path of Building.exe\",1"

[HKEY_CLASSES_ROOT\pob\shell]

[HKEY_CLASSES_ROOT\pob\shell\open]

[HKEY_CLASSES_ROOT\pob\shell\open\command]
@="\"C:\\Program Files (x86)\\Path of Building\\Path of Building.exe\" \"%1\""
```

Then visit `pob://pastebin/qE4pPUF4/` for example.