### PR TITLE
Fixes #2059 - Implemented automatic generation of base item tags from the ggpk

### DIFF
--- a/Export/Classes/GGPKData.lua
+++ b/Export/Classes/GGPKData.lua
@@ -43,13 +43,16 @@ local GGPKClass = newClass("GGPKData", function(self, path)
 end)
 
 function GGPKClass:ExtractFiles()
-	local datList, txtList = self:GetNeededFiles()
+	local datList, txtList, otList = self:GetNeededFiles()
 	
 	local fileList = ''
 	for _, fname in ipairs(datList) do
 		fileList = fileList .. '"' .. fname .. '" '
 	end
 	for _, fname in ipairs(txtList) do
+		fileList = fileList .. '"' .. fname .. '" '
+	end
+	for _, fname in ipairs(otList) do
 		fileList = fileList .. '"' .. fname .. '" '
 	end
 	
@@ -161,5 +164,45 @@ function GGPKClass:GetNeededFiles()
 		"Metadata/StatDescriptions/stat_descriptions.txt",
 		"Metadata/StatDescriptions/variable_duration_skill_stat_descriptions.txt",
 	}
-	return datFiles, txtFiles
+	local otFiles = {
+		"Metadata/Items/Quivers/AbstractQuiver.ot",
+		"Metadata/Items/Rings/AbstractRing.ot",
+		"Metadata/Items/Belts/AbstractBelt.ot",
+		"Metadata/Items/Flasks/AbstractUtilityFlask.ot",
+		"Metadata/Items/Jewels/AbstractJewel.ot",
+		"Metadata/Items/Flasks/CriticalUtilityFlask.ot",
+		"Metadata/Items/Flasks/AbstractHybridFlask.ot",
+		"Metadata/Items/Flasks/AbstractManaFlask.ot",
+		"Metadata/Items/Weapons/TwoHandWeapons/Staves/AbstractWarstaff.ot",
+		"Metadata/Items/Weapons/OneHandWeapons/OneHandMaces/AbstractSceptre.ot",
+		"Metadata/Items/Weapons/OneHandWeapons/OneHandSwords/AbstractOneHandSwordThrusting.ot",
+		"Metadata/Items/Weapons/OneHandWeapons/Claws/AbstractClaw.ot",
+		"Metadata/Items/Armours/Shields/AbstractShield.ot",
+		"Metadata/Items/Weapons/TwoHandWeapons/Bows/AbstractBow.ot",
+		"Metadata/Items/Weapons/TwoHandWeapons/TwoHandMaces/AbstractTwoHandMace.ot",
+		"Metadata/Items/Armours/Boots/AbstractBoots.ot",
+		"Metadata/Items/Jewels/AbstractAbyssJewel.ot",
+		"Metadata/Items/Armours/BodyArmours/AbstractBodyArmour.ot",
+		"Metadata/Items/Armours/AbstractArmour.ot",
+		"Metadata/Items/Weapons/OneHandWeapons/Daggers/AbstractRuneDagger.ot",
+		"Metadata/Items/Weapons/TwoHandWeapons/Staves/AbstractStaff.ot",
+		"Metadata/Items/Weapons/TwoHandWeapons/TwoHandAxes/AbstractTwoHandAxe.ot",
+		"Metadata/Items/Weapons/OneHandWeapons/OneHandAxes/AbstractOneHandAxe.ot",
+		"Metadata/Items/Weapons/TwoHandWeapons/TwoHandSwords/AbstractTwoHandSword.ot",
+		"Metadata/Items/Weapons/OneHandWeapons/OneHandMaces/AbstractOneHandMace.ot",
+		"Metadata/Items/Armours/Gloves/AbstractGloves.ot",
+		"Metadata/Items/Weapons/OneHandWeapons/Daggers/AbstractDagger.ot",
+		"Metadata/Items/Weapons/OneHandWeapons/OneHandSwords/AbstractOneHandSword.ot",
+		"Metadata/Items/Amulets/AbstractAmulet.ot",
+		"Metadata/Items/Flasks/AbstractLifeFlask.ot",
+		"Metadata/Items/Weapons/OneHandWeapons/Wands/AbstractWand.ot",
+		"Metadata/Items/Armours/Helmets/AbstractHelmet.ot",
+		"Metadata/Items/Flasks/AbstractFlask.ot",
+		"Metadata/Items/Weapons/TwoHandWeapons/AbstractTwoHandWeapon.ot",
+		"Metadata/Items/Item.ot",
+		"Metadata/Items/Weapons/OneHandWeapons/AbstractOneHandWeapon.ot",
+		"Metadata/Items/Equipment.ot",
+		"Metadata/Items/Weapons/AbstractWeapon.ot",
+	}
+	return datFiles, txtFiles, otFiles
 end

--- a/Export/Scripts/bases.lua
+++ b/Export/Scripts/bases.lua
@@ -42,6 +42,30 @@ directiveTable.base = function(state, args, out)
 		printf("Invalid Id %s", baseTypeId)
 		return
 	end
+	local function getBaseItemTags(baseItemType)
+		if baseItemType == "nothing" then -- base case
+			return {}
+		end
+		local file = getFile(baseItemType .. ".ot")
+		if not file then return nil end
+		local text = convertUTF16to8(file)
+		local tags = {}
+		for line in text:gmatch("[^\r\n]+") do
+			local superClass = line:match("extends \"(.+)\"")
+			if superClass then
+				local superClassTags = getBaseItemTags(superClass)
+				if superClassTags then
+					for _, tag in ipairs(superClassTags) do
+						table.insert(tags, tag)
+					end
+				end
+			elseif line:match("tag") then
+				table.insert(tags, line:match("tag = \"(.+)\""))
+			end
+		end
+		return tags
+	end
+	local baseItemTags = getBaseItemTags(baseItemType.BaseType)
 	if not displayName then
 		displayName = baseItemType.Name
 	end
@@ -59,11 +83,18 @@ directiveTable.base = function(state, args, out)
 		out:write('\tsocketLimit = ', state.socketLimit, ',\n')
 	end
 	out:write('\ttags = { ')
+	local combinedTags = { }
 	for _, tag in ipairs(state.baseTags) do
-		out:write(tag, ' = true, ')
+		combinedTags[tag] = tag
+	end
+	for _, tag in ipairs(baseItemTags) do
+		combinedTags[tag] = tag
 	end
 	for _, tag in ipairs(baseItemType.Tags) do
-		out:write(tag.Id, ' = true, ')
+		combinedTags[tag.Id] = tag.Id
+	end
+	for _, tag in pairs(combinedTags) do
+		out:write(tag, ' = true, ')
 	end
 	out:write('},\n')
 	local movementPenalty


### PR DESCRIPTION
This ended up being more involved than the referenced issue, but these changes allow us to avoid human error in setting tags on bases manually.  The actual .lua files that changed as a result of this are mace.lua and flask.lua, the rest got "changes" in that the tags were reordered.

I elected to leave the #baseTags directive in the .txt files there for now (combining the datamined tags with those manually specified), but can be easily be removed in another commit if desired.