### PR TITLE
Update Replica Alberon's Warpath boot per 3.13 patch note

### DIFF
--- a/Data/Uniques/boots.lua
+++ b/Data/Uniques/boots.lua
@@ -671,7 +671,7 @@ Requires Level 49, 47 Str, 47 Int
 +(9-12)% to Chaos Resistance
 20% increased Movement Speed
 Cannot deal non-Chaos Damage
-Adds 1 to 80 Chaos Damage to Attacks per 50 Strength
+Adds 1 to 80 Chaos Damage to Attacks per 80 Strength
 ]],[[
 Death's Door
 Crusader Boots


### PR DESCRIPTION
> Now grants 1 to 80 Chaos Damage to Attacks per 80 Strength (previously per 50 Strength). This affects all versions of the item.

https://www.pathofexile.com/forum/view-thread/3009157

CTRL + F ``Replica Alberon's Warpath``