### PR TITLE
Anomalous Quality Minion Life Support

### DIFF
--- a/Data/Skills/sup_int.lua
+++ b/Data/Skills/sup_int.lua
@@ -3799,6 +3799,10 @@ skills["SupportMinionLife"] = {
 		["support_minion_maximum_life_+%_final"] = {
 			mod("MinionModifier", "LIST", { mod = mod("Life", "MORE", nil) }),
 		},
+		["minion_life_regeneration_rate_per_minute_%"] = {
+			mod("MinionModifier", "LIST", { mod = mod("LifeRegenPercent", "BASE", nil) }),
+			div = 60
+		},
 		["minion_damage_+%_on_full_life"] = {
 			mod("MinionModifier", "LIST", { mod = mod("Damage", "INC", nil, 0, 0, {type = "Condition", var = "FullLife"}) }),
 		},

--- a/Export/Skills/sup_int.txt
+++ b/Export/Skills/sup_int.txt
@@ -485,6 +485,10 @@ local skills, mod, flag, skill = ...
 		["support_minion_maximum_life_+%_final"] = {
 			mod("MinionModifier", "LIST", { mod = mod("Life", "MORE", nil) }),
 		},
+		["minion_life_regeneration_rate_per_minute_%"] = {
+			mod("MinionModifier", "LIST", { mod = mod("LifeRegenPercent", "BASE", nil) }),
+			div = 60
+		},
 		["minion_damage_+%_on_full_life"] = {
 			mod("MinionModifier", "LIST", { mod = mod("Damage", "INC", nil, 0, 0, {type = "Condition", var = "FullLife"}) }),
 		},


### PR DESCRIPTION
Added support for the Anomalous Quality Minion Life gem.

The quality was previously adding a flat 1 health per second regeneration instead of 1%

Fixes #2108