### PR TITLE
Added Evasion to Armour conversion for Divergent Determination

### DIFF
--- a/Data/Skills/act_str.lua
+++ b/Data/Skills/act_str.lua
@@ -1487,6 +1487,9 @@ skills["Determination"] = {
 		["determination_aura_armour_+%_final"] = {
 			mod("Armour", "MORE", nil, 0, 0, { type = "GlobalEffect", effectType = "Aura" }),
 		},
+		["evasion_rating_%_to_add_as_armour"] = {
+			mod("EvasionGainAsArmour", "BASE", nil, 0, 0, { type = "GlobalEffect", effectType = "Aura" }),
+		},
 	},
 	baseFlags = {
 		spell = true,

--- a/Export/Skills/act_str.txt
+++ b/Export/Skills/act_str.txt
@@ -269,6 +269,9 @@ local skills, mod, flag, skill = ...
 		["determination_aura_armour_+%_final"] = {
 			mod("Armour", "MORE", nil, 0, 0, { type = "GlobalEffect", effectType = "Aura" }),
 		},
+		["evasion_rating_%_to_add_as_armour"] = {
+			mod("EvasionGainAsArmour", "BASE", nil, 0, 0, { type = "GlobalEffect", effectType = "Aura" }),
+		},
 	},
 #baseMod skill("radius", 40)
 #mods

--- a/Modules/CalcDefence.lua
+++ b/Modules/CalcDefence.lua
@@ -235,6 +235,15 @@ function calcs.defence(env, actor)
 				breakdown.slot("Conversion", "Life to Energy Shield", nil, energyShieldBase, total, "EnergyShield", "Defences", "Life")
 			end
 		end
+		local convEvasionToArmour = modDB:Sum("BASE", nil, "EvasionGainAsArmour")
+		if convEvasionToArmour > 0 then
+			armourBase = modDB:Sum("BASE", nil, "Evasion") * convEvasionToArmour / 100
+			local total = armourBase * calcLib.mod(modDB, nil, "Evasion", "Armour", "ArmourAndEvasion", "Defences")
+			armour = armour + total
+			if breakdown then
+				breakdown.slot("Conversion", "Evasion to Armour", nil, armourBase, total, "Armour", "ArmourAndEvasion", "Defences", "Evasion")
+			end
+		end
 		output.EnergyShield = modDB:Override(nil, "EnergyShield") or m_max(round(energyShield), 0)
 		output.Armour = m_max(round(armour), 0)
 		output.DoubleArmourChance = m_min(modDB:Sum("BASE", nil, "DoubleArmourChance"), 100)


### PR DESCRIPTION
Fixes #1701 
Should Iron Reflexes get renamed on the Calcs tab to be something other than "Evasion to Armour" or is it fine having 2 "Evasion to Armour" lines when you have both Iron Reflexes and Divergent Determination?