### PR TITLE
General's Cry improvements

### DIFF
--- a/Data/SkillStatMap.lua
+++ b/Data/SkillStatMap.lua
@@ -1434,6 +1434,12 @@ return {
 ["warcry_grant_damage_+%_to_exerted_attacks"] = {
 	mod("ExertIncrease", "INC", nil, ModFlag.Attack, 0)
 },
+["is_empowered"] = {
+	flag("CountAsExerted"),
+},
+["triggered_by_spiritual_cry"] = {
+	skill("showAverage", true),
+},
 -- Curse
 ["curse_effect_+%"] = {
 	mod("CurseEffect", "INC", nil),

--- a/Modules/CalcOffence.lua
+++ b/Modules/CalcOffence.lua
@@ -1282,7 +1282,7 @@ function calcs.offence(env, actor, activeSkill)
 
 		if env.mode_buffs then
 			-- Iterative over all the active skills to account for exerted attacks provided by warcries
-			if not activeSkill.skillTypes[SkillType.Vaal] and not activeSkill.skillTypes[SkillType.Channelled] and not activeSkill.skillModList:Flag(cfg, "SupportedByMultistrike") then
+			if not activeSkill.skillTypes[SkillType.Vaal] and not activeSkill.skillTypes[SkillType.Channelled] and not activeSkill.skillModList:Flag(cfg, "SupportedByMultistrike") and not activeSkill.skillModList:Flag(cfg, "CountAsExerted") then
 				for index, value in ipairs(actor.activeSkillList) do
 					if value.activeEffect.grantedEffect.name == "Ancestral Cry" and activeSkill.skillTypes[SkillType.MeleeSingleTarget] and not globalOutput.AncestralCryCalculated then
 						globalOutput.AncestralCryDuration = calcSkillDuration(value.skillModList, value.skillCfg, value.skillData, env, enemyDB)
@@ -1558,6 +1558,10 @@ function calcs.offence(env, actor, activeSkill)
 						}
 					end
 				end
+			elseif skillModList:Flag(cfg, "CountAsExerted") then
+				skillModList:NewMod("Damage", "INC", skillModList:Sum("INC", cfg, "ExertIncrease"), "Exerted Attacks")
+				skillModList:NewMod("Damage", "MORE", skillModList:Sum("MORE", cfg, "ExertIncrease"), "Exerted Attacks")
+				skillModList:NewMod("Damage", "MORE", skillModList:Sum("BASE", cfg, "GeneralsCryMirageWarriorLessDamage"), "Generals Cry")
 			end
 		end
 


### PR DESCRIPTION
* Count the supported skill as exerted
* Apply General's Cry -30% more damage
* Show average for the supported skill since attack rate becomes meaningless
* Prevent other warcries from interacting with the supported skill

TODO:
* Factor in "Exerted attacks have x% chance to deal double damage"
(seems broken even for regular exerted attacks)
* More complex simulation that factors in General's cry cooldown and amount of mirages to compute DPS
* Automatically translate GeneralsCryMirageWarriorLessDamage as a MORE damage mod.
Didn't want to touch act_str.lua so I parsed it in CalcOffence.lua, maybe I did it the wrong way?