### PR TITLE
Added group restrictions to crafted mods for crafted items

### DIFF
--- a/Classes/ItemsTab.lua
+++ b/Classes/ItemsTab.lua
@@ -2027,8 +2027,8 @@ function ItemsTabClass:AddCustomModifierToDisplayItem()
 		wipeTable(modList)
 		if sourceId == "MASTER" then
 			local excludeGroups = { }
-			for _, modLine in ipairs({self.displayItem.prefixes,self.displayItem.suffixes}) do
-				for i = 1, self.displayItem.affixLimit/2 do
+			for _, modLine in ipairs({ self.displayItem.prefixes, self.displayItem.suffixes }) do
+				for i = 1, self.displayItem.affixLimit / 2 do
 					if modLine[i].modId ~= "None" then
 						excludeGroups[self.displayItem.affixes[modLine[i].modId].group] = true
 					end

--- a/Classes/ItemsTab.lua
+++ b/Classes/ItemsTab.lua
@@ -2026,8 +2026,16 @@ function ItemsTabClass:AddCustomModifierToDisplayItem()
 	local function buildMods(sourceId)
 		wipeTable(modList)
 		if sourceId == "MASTER" then
+			local excludeGroups = { }
+			for _, modLine in ipairs({self.displayItem.prefixes,self.displayItem.suffixes}) do
+				for i = 1, self.displayItem.affixLimit/2 do
+					if modLine[i].modId ~= "None" then
+						excludeGroups[self.displayItem.affixes[modLine[i].modId].group] = true
+					end
+				end
+			end
 			for i, craft in ipairs(self.build.data.masterMods) do
-				if craft.types[self.displayItem.type] then
+				if craft.types[self.displayItem.type] and not excludeGroups[craft.group] then
 					t_insert(modList, {
 						label = table.concat(craft, "/") .. " ^8(" .. craft.type .. ")",
 						mod = craft,


### PR DESCRIPTION
It's impossible to restrict crafted mods for imported/copied items, so with this we should be able to close
https://feathub.com/LocalIdentity/PathOfBuilding/+41