### PR TITLE
Combined Socket Group DPS

### DIFF
--- a/Modules/Build.lua
+++ b/Modules/Build.lua
@@ -1129,11 +1129,16 @@ function buildMode:AddDisplayStatList(statList, actor)
 					end
 					if statData.skillDPSStat then
 						labelColor = colorCodes.RELIC
-						for skillName, skillDPS in pairs(actor.output.SkillDPS) do
+						local sorted = {}
+						for k, v in pairs(actor.output.SkillDPS) do
+							table.insert(sorted,{k,v})
+						end
+						table.sort(sorted, function(a,b) return a[2] > b[2] end)
+						for _, skillData in ipairs(sorted) do
 							t_insert(statBoxList, {
 								height = 16,
-								labelColor..skillName..":",
-								self:FormatStat({fmt = "1.f"}, skillDPS)
+								labelColor..skillData[1]..":",
+								self:FormatStat({fmt = "1.f"}, skillData[2])
 							})
 						end
 					elseif not (statData.hideStat) then

--- a/Modules/Build.lua
+++ b/Modules/Build.lua
@@ -1129,16 +1129,12 @@ function buildMode:AddDisplayStatList(statList, actor)
 					end
 					if statData.skillDPSStat then
 						labelColor = colorCodes.RELIC
-						local sorted = {}
-						for k, v in pairs(actor.output.SkillDPS) do
-							table.insert(sorted,{k,v})
-						end
-						table.sort(sorted, function(a,b) return a[2] > b[2] end)
-						for _, skillData in ipairs(sorted) do
+						table.sort(actor.output.SkillDPS, function(a,b) return a.dps > b.dps end)
+						for _, skillData in ipairs(actor.output.SkillDPS) do
 							t_insert(statBoxList, {
 								height = 16,
-								labelColor..skillData[1]..":",
-								self:FormatStat({fmt = "1.f"}, skillData[2])
+								labelColor..skillData.name..":",
+								self:FormatStat({fmt = "1.f"}, skillData.dps)
 							})
 						end
 					elseif not (statData.hideStat) then

--- a/Modules/Build.lua
+++ b/Modules/Build.lua
@@ -1131,9 +1131,13 @@ function buildMode:AddDisplayStatList(statList, actor)
 						labelColor = colorCodes.CUSTOM
 						table.sort(actor.output.SkillDPS, function(a,b) return (a.dps * a.count) > (b.dps * b.count) end)
 						for _, skillData in ipairs(actor.output.SkillDPS) do
-							local lhsString = labelColor..skillData.name..":"
+							local srcString = ""
+							if skillData.source then
+								srcString = " ("..skillData.source..")"
+							end
+							local lhsString = labelColor..skillData.name..srcString..":"
 							if skillData.count >= 2 then
-								lhsString = labelColor.."("..tostring(skillData.count).."x) "..skillData.name..":"
+								lhsString = labelColor.."("..tostring(skillData.count).."x) "..skillData.name..srcString..":"
 							end
 							t_insert(statBoxList, {
 								height = 16,

--- a/Modules/Build.lua
+++ b/Modules/Build.lua
@@ -257,7 +257,7 @@ function buildMode:Init(dbFileName, buildName, buildXML, convertBuild)
 		{ stat = "CritChance", label = "Effective Crit Chance", fmt = ".2f%%", condFunc = function(v,o) return v ~= o.PreEffectiveCritChance end },
 		{ stat = "CritMultiplier", label = "Crit Multiplier", fmt = "d%%", pc = true, condFunc = function(v,o) return (o.CritChance or 0) > 0 end },
 		{ stat = "HitChance", label = "Hit Chance", fmt = ".0f%%", flag = "attack" },
-		{ stat = "TotalDPS", label = "Total DPS", fmt = ".1f", compPercent = true, flag = "notAverage" },
+		{ stat = "TotalDPS", label = "Total DPS", fmt = ".1f", compPercent = true },
 		{ stat = "TotalDot", label = "DoT DPS", fmt = ".1f", compPercent = true },
 		{ stat = "WithDotDPS", label = "Total DPS inc. DoT", fmt = ".1f", compPercent = true, flag = "notAverage", condFunc = function(v,o) return v ~= o.TotalDPS and (o.PoisonDPS or 0) == 0 and (o.IgniteDPS or 0) == 0 and (o.ImpaleDPS or 0) == 0 and (o.BleedDPS or 0) == 0 end },
 		{ stat = "BleedDPS", label = "Bleed DPS", fmt = ".1f", compPercent = true },
@@ -342,15 +342,15 @@ function buildMode:Init(dbFileName, buildName, buildXML, convertBuild)
 		{ stat = "ChaosResist", label = "Chaos Resistance", fmt = "d%%", color = colorCodes.CHAOS, condFunc = function() return true end, resistOverCapStat = "ChaosResistOverCap" },
 		{ stat = "ChaosResistOverCap", label = "Chaos Res. Over Max", fmt = "d%%", hideStat = true },
 		{ },
-		{ stat = "FullDPS", label = "Full DPS", fmt = ".1f", compPercent = true, flag = "notAverage" },
+		{ stat = "SkillDPS", label = "Skill DPS", condFunc = function() return true end, skillDPSStat = true },
 		{ },
-		{ stat = "SkillDPS", label = "Skill DPS", flag = "notAverage", condFunc = function() return true end, skillDPSStat = true },
+		{ stat = "FullDPS", label = "Full DPS", fmt = ".1f", color = colorCodes.CURRENCY, compPercent = true },
 	}
 	self.minionDisplayStats = {
 		{ stat = "AverageDamage", label = "Average Damage", fmt = ".1f", compPercent = true },
 		{ stat = "Speed", label = "Attack/Cast Rate", fmt = ".2f", compPercent = true },
 		{ stat = "HitSpeed", label = "Hit Rate", fmt = ".2f" },
-		{ stat = "TotalDPS", label = "Total DPS", fmt = ".1f", compPercent = true, flag = "notAverage" },
+		{ stat = "TotalDPS", label = "Total DPS", fmt = ".1f", compPercent = true },
 		{ stat = "TotalDot", label = "DoT DPS", fmt = ".1f", compPercent = true },
 		{ stat = "WithDotDPS", label = "Total DPS inc. DoT", fmt = ".1f", compPercent = true, condFunc = function(v,o) return v ~= o.TotalDPS and (o.PoisonDPS or 0) == 0 and (o.IgniteDPS or 0) == 0 and (o.ImpaleDPS or 0) == 0 and (o.BleedDPS or 0) == 0 end },
 		{ stat = "BleedDPS", label = "Bleed DPS", fmt = ".1f", compPercent = true },
@@ -1128,13 +1128,17 @@ function buildMode:AddDisplayStatList(statList, actor)
 						end
 					end
 					if statData.skillDPSStat then
-						labelColor = colorCodes.RELIC
-						table.sort(actor.output.SkillDPS, function(a,b) return a.dps > b.dps end)
+						labelColor = colorCodes.CUSTOM
+						table.sort(actor.output.SkillDPS, function(a,b) return (a.dps * a.count) > (b.dps * b.count) end)
 						for _, skillData in ipairs(actor.output.SkillDPS) do
+							local lhsString = labelColor..skillData.name..":"
+							if skillData.count >= 2 then
+								lhsString = labelColor.."("..tostring(skillData.count).."x) "..skillData.name..":"
+							end
 							t_insert(statBoxList, {
 								height = 16,
-								labelColor..skillData.name..":",
-								self:FormatStat({fmt = "1.f"}, skillData.dps)
+								lhsString,
+								self:FormatStat({fmt = "1.f"}, skillData.dps * skillData.count)
 							})
 						end
 					elseif not (statData.hideStat) then
@@ -1171,7 +1175,9 @@ end
 function buildMode:CompareStatList(tooltip, statList, actor, baseOutput, compareOutput, header, nodeCount)
 	local count = 0
 	for _, statData in ipairs(statList) do
-		if statData.stat and (not statData.flag or actor.mainSkill.skillFlags[statData.flag]) and not statData.skillDPSStat then
+		if statData.skillDPSStat then
+			count = count + self:CompareStatList(tooltip, statData, actor, baseOutput, compareOutput, header, nodeCount)
+		elseif statData.stat and (not statData.flag or actor.mainSkill.skillFlags[statData.flag]) then
 			local statVal1 = compareOutput[statData.stat] or 0
 			local statVal2 = baseOutput[statData.stat] or 0
 			local diff = statVal1 - statVal2

--- a/Modules/Build.lua
+++ b/Modules/Build.lua
@@ -1132,9 +1132,9 @@ function buildMode:AddDisplayStatList(statList, actor)
 						table.sort(actor.output.SkillDPS, function(a,b) return (a.dps * a.count) > (b.dps * b.count) end)
 						for _, skillData in ipairs(actor.output.SkillDPS) do
 							local srcString = ""
-							if skillData.source then
-								srcString = " ("..skillData.source..")"
-							end
+							--if skillData.source then
+							--	srcString = " ("..skillData.source..")"
+							--end
 							local lhsString = labelColor..skillData.name..srcString..":"
 							if skillData.count >= 2 then
 								lhsString = labelColor.."("..tostring(skillData.count).."x) "..skillData.name..srcString..":"

--- a/Modules/Build.lua
+++ b/Modules/Build.lua
@@ -278,6 +278,7 @@ function buildMode:Init(dbFileName, buildName, buildXML, convertBuild)
 		{ stat = "WithImpaleDPS", label = "Total DPS inc. Impale", fmt = ".1f", compPercent = true, flag = "impale", flag = "notAverage", condFunc = function(v,o) return v ~= o.TotalDPS and (o.TotalDot or 0) == 0 and (o.IgniteDPS or 0) == 0 and (o.PoisonDPS or 0) == 0 and (o.BleedDPS or 0) == 0 end },
 		{ stat = "CombinedDPS", label = "Combined DPS", fmt = ".1f", compPercent = true, flag = "notAverage", condFunc = function(v,o) return v ~= ((o.TotalDPS or 0) + (o.TotalDot or 0)) and v ~= o.WithImpaleDPS and v ~= o.WithPoisonDPS and v ~= o.WithIgniteDPS and v ~= o.WithBleedDPS end },
 		{ stat = "CombinedAvg", label = "Combined Total Damage", fmt = ".1f", compPercent = true, flag = "showAverage", condFunc = function(v,o) return (v ~= o.AverageDamage and (o.TotalDot or 0) == 0) and (v ~= o.WithImpaleDPS or v ~= o.WithPoisonDPS or v ~= o.WithIgniteDPS or v ~= o.WithBleedDPS) end },
+		{ stat = "SocketGroupDPS", label = "Socket Group DPS", fmt = ".1f", compPercent = true, flag = "notAverage" },
 		{ stat = "Cooldown", label = "Skill Cooldown", fmt = ".2fs", lowerIsBetter = true },
 		{ stat = "AreaOfEffectRadius", label = "AoE Radius", fmt = "d" },
 		{ stat = "BrandTicks", label = "Activations per Brand", fmt = "d", flag = "brand" },

--- a/Modules/CalcDefence.lua
+++ b/Modules/CalcDefence.lua
@@ -50,15 +50,6 @@ function calcs.armourReductionDouble(armour, damage, doubleChance)
 	return calcs.armourReduction(armour, damage) * (1 - doubleChance) + calcs.armourReduction(armour * 2, damage) * doubleChance
 end
 
-function calcs.actionSpeedMod(actor)
-	local modDB = actor.modDB
-	local actionSpeedMod = 1 + (m_max(-data.misc.TemporalChainsEffectCap, modDB:Sum("INC", nil, "TemporalChainsActionSpeed")) + modDB:Sum("INC", nil, "ActionSpeed")) / 100
-	if modDB:Flag(nil, "ActionSpeedCannotBeBelowBase") then
-		actionSpeedMod = m_max(1, actionSpeedMod)
-	end
-	return actionSpeedMod
-end
-
 -- Performs all defensive calculations
 function calcs.defence(env, actor)
 	local modDB = actor.modDB

--- a/Modules/CalcOffence.lua
+++ b/Modules/CalcOffence.lua
@@ -222,6 +222,11 @@ function calcs.offence(env, actor, activeSkill)
 		return
 	end
 
+	-- set Action Speed if it doesn't exist (calcs.defence()) sets it but if we call offence without defence we need it
+	if not output.ActionSpeedMod then
+		output.ActionSpeedMod = calcs.actionSpeedMod(actor)
+	end
+
 	local function calcAreaOfEffect(skillModList, skillCfg, skillData, skillFlags, output, breakdown)
 		local incArea, moreArea = calcLib.mods(skillModList, skillCfg, "AreaOfEffect")
 		output.AreaOfEffectMod = round(round(incArea * moreArea, 10), 2)

--- a/Modules/CalcOffence.lua
+++ b/Modules/CalcOffence.lua
@@ -167,9 +167,9 @@ local function calcRadiusBreakpoints(baseRadius, incArea, moreArea)
 	return incAreaBreakpoint, moreAreaBreakpoint, redAreaBreakpoint, lessAreaBreakpoint
 end
 
-function calcSkillCooldown(skillModList, skillCfg, skillData)
+function calcSkillCooldown(skillModList, skillCfg, skillData, skillGrantedEffect)
 	local cooldownOverride = skillModList:Override(skillCfg, "CooldownRecovery")
-	local cooldown = cooldownOverride or (skillData.cooldown  + skillModList:Sum("BASE", skillCfg, "CooldownRecovery")) / calcLib.mod(skillModList, skillCfg, "CooldownRecovery")
+	local cooldown = cooldownOverride or ((skillData.cooldown or skillGrantedEffect.castTime) + skillModList:Sum("BASE", skillCfg, "CooldownRecovery")) / calcLib.mod(skillModList, skillCfg, "CooldownRecovery")
 	cooldown = m_ceil(cooldown * data.misc.ServerTickRate) / data.misc.ServerTickRate
 	return cooldown
 end
@@ -1186,6 +1186,10 @@ function calcs.offence(env, actor, activeSkill)
 			output.Time = 1 / (1 + skillModList:Sum("INC", cfg, "Speed", "BrandActivationFrequency") / 100) / skillModList:More(cfg, "BrandActivationFrequency") * (skillModList:Sum("BASE", cfg, "ArcanistSpellsLinked") or 1)
 			output.TriggerTime = output.Time
 			output.Speed = 1 / output.Time
+		elseif activeSkill.skillTypes[SkillType.Triggerable] and activeSkill.skillTypes[SkillType.Triggered] then
+			output.Time = calcSkillCooldown(activeSkill.skillModList, activeSkill.skillCfg, activeSkill.skillData, activeSkill.activeEffect.grantedEffect)
+			output.Speed = 1 / output.Time
+			--ConPrintf("NAME: " .. activeSkill.activeEffect.grantedEffect.name)
 		else
 			local baseTime
 			if isAttack then

--- a/Modules/CalcPerform.lua
+++ b/Modules/CalcPerform.lua
@@ -773,7 +773,7 @@ function calcs.perform(env)
 			modDB:NewMod("AlreadyWithered", "FLAG", true, "Config") -- Prevents effect from applying multiple times
 		end
 		if activeSkill.skillFlags.warcry and not modDB:Flag(nil, "AlreadyGlobalWarcryCooldown") then
-			local cooldown = calcSkillCooldown(activeSkill.skillModList, activeSkill.skillCfg, activeSkill.skillData)
+			local cooldown = calcSkillCooldown(activeSkill.skillModList, activeSkill.skillCfg, activeSkill.skillData, activeSkill.activeEffect.grantedEffect)
 			local warcryList = { }
 			local numWarcries, sumWarcryCooldown = 0
 			for _, activeSkill in ipairs(env.player.activeSkillList) do
@@ -1724,32 +1724,32 @@ function calcs.perform(env)
 		end
 	end
 
-	-- Defence/offence calculations
+	-- Defence calculations
 	calcs.defence(env, env.player)
 
-	--calcs.offence(env, env.player, env.player.mainSkill)
 	-- Calculate the offence of each active skill belonging to the select mainSkill socket group
 	local fullDPS = { combinedDPS = 0, skills = { } }
 	local actorOutput = copyTable(env.player.output)
 	local mainSkillOutput = copyTable(env.player.output)
 	for _, activeSkill in ipairs(env.player.activeSkillList) do
 		calcs.offence(env, env.player, activeSkill)
-		if env.player.output.CombinedDPS > 0 then
+		if env.player.output.TotalDPS > 0 then
 			if not fullDPS.skills[activeSkill.activeEffect.grantedEffect.name] then
-				t_insert(fullDPS.skills, { name = activeSkill.activeEffect.grantedEffect.name, dps = env.player.output.CombinedDPS, count = 1 })
+				t_insert(fullDPS.skills, { name = activeSkill.activeEffect.grantedEffect.name, dps = env.player.output.TotalDPS, count = 1 })
 			else
 				ConPrintf("HELP! Numerous same-named effects! '" .. activeSkill.activeEffect.grantedEffect.name .. "'")
 			end
-			fullDPS.combinedDPS = fullDPS.combinedDPS + env.player.output.CombinedDPS
+			fullDPS.combinedDPS = fullDPS.combinedDPS + env.player.output.TotalDPS
 		end
 		if activeSkill == env.player.mainSkill then
 			mainSkillOutput = copyTable(env.player.output)
 		end
 		env.player.output = copyTable(actorOutput)
 	end
-	env.player.output = copyTable(mainSkillOutput)
+	calcs.offence(env, env.player, env.player.mainSkill)
 	env.player.output.SkillDPS = fullDPS.skills
 	env.player.output.FullDPS = fullDPS.combinedDPS
+
 	if env.minion then
 		calcs.defence(env, env.minion)
 		calcs.offence(env, env.minion, env.minion.mainSkill)

--- a/Modules/CalcPerform.lua
+++ b/Modules/CalcPerform.lua
@@ -1733,7 +1733,7 @@ function calcs.perform(env)
 	local mainSkillOutput = copyTable(env.player.output)
 	for _, activeSkill in ipairs(env.player.activeSkillList) do
 		calcs.offence(env, env.player, activeSkill)
-		if env.player.output.TotalDPS > 0 then
+		if env.player.output.TotalDPS and env.player.output.TotalDPS > 0 then
 			if not fullDPS.skills[activeSkill.activeEffect.grantedEffect.name] then
 				t_insert(fullDPS.skills, { name = activeSkill.activeEffect.grantedEffect.name, dps = env.player.output.TotalDPS, count = 1 })
 			else

--- a/Modules/CalcPerform.lua
+++ b/Modules/CalcPerform.lua
@@ -1733,27 +1733,23 @@ function calcs.perform(env)
 	local actorOutput = copyTable(env.player.output)
 	local mainSkillOutput = copyTable(env.player.output)
 	for _, activeSkill in ipairs(env.player.activeSkillList) do
-		--if env.player.mainSkill.socketGroup == activeSkill.socketGroup then
-			calcs.offence(env, env.player, activeSkill)
-			if env.player.output.CombinedDPS > 0 then
-				--ConPrintf(activeSkill.activeEffect.grantedEffect.name .. " DPS: " .. tostring(env.player.output.CombinedDPS))
-				if not fullDPS.skills[activeSkill.activeEffect.grantedEffect.name] then
-					fullDPS.skills[activeSkill.activeEffect.grantedEffect.name] = env.player.output.CombinedDPS
-				else
-					ConPrintf("HELP! Numerous same-named effects! '" .. activeSkill.activeEffect.grantedEffect.name .. "'")
-				end
-				fullDPS.combinedDPS = fullDPS.combinedDPS + env.player.output.CombinedDPS
+		calcs.offence(env, env.player, activeSkill)
+		if env.player.output.CombinedDPS > 0 then
+			if not fullDPS.skills[activeSkill.activeEffect.grantedEffect.name] then
+				t_insert(fullDPS.skills, { name = activeSkill.activeEffect.grantedEffect.name, dps = env.player.output.CombinedDPS, count = 1 })
+			else
+				ConPrintf("HELP! Numerous same-named effects! '" .. activeSkill.activeEffect.grantedEffect.name .. "'")
 			end
-			if activeSkill == env.player.mainSkill then
-				mainSkillOutput = copyTable(env.player.output)
-			end
-			env.player.output = copyTable(actorOutput)
-		--end
+			fullDPS.combinedDPS = fullDPS.combinedDPS + env.player.output.CombinedDPS
+		end
+		if activeSkill == env.player.mainSkill then
+			mainSkillOutput = copyTable(env.player.output)
+		end
+		env.player.output = copyTable(actorOutput)
 	end
 	env.player.output = copyTable(mainSkillOutput)
 	env.player.output.SkillDPS = fullDPS.skills
 	env.player.output.FullDPS = fullDPS.combinedDPS
-	--ConPrintf("DPS: " .. tostring(env.player.output.FullDPS))
 	if env.minion then
 		calcs.defence(env, env.minion)
 		calcs.offence(env, env.minion, env.minion.mainSkill)

--- a/Modules/CalcPerform.lua
+++ b/Modules/CalcPerform.lua
@@ -1729,23 +1729,31 @@ function calcs.perform(env)
 
 	--calcs.offence(env, env.player, env.player.mainSkill)
 	-- Calculate the offence of each active skill belonging to the select mainSkill socket group
-	local socketGroupDPS = 0
+	local fullDPS = { combinedDPS = 0, skills = { } }
 	local actorOutput = copyTable(env.player.output)
 	local mainSkillOutput = copyTable(env.player.output)
 	for _, activeSkill in ipairs(env.player.activeSkillList) do
-		if env.player.mainSkill.socketGroup == activeSkill.socketGroup then
+		--if env.player.mainSkill.socketGroup == activeSkill.socketGroup then
 			calcs.offence(env, env.player, activeSkill)
-			--ConPrintf(activeSkill.activeEffect.grantedEffect.name .. " DPS: " .. tostring(env.player.output.CombinedDPS))
-			socketGroupDPS = socketGroupDPS + env.player.output.CombinedDPS
+			if env.player.output.CombinedDPS > 0 then
+				--ConPrintf(activeSkill.activeEffect.grantedEffect.name .. " DPS: " .. tostring(env.player.output.CombinedDPS))
+				if not fullDPS.skills[activeSkill.activeEffect.grantedEffect.name] then
+					fullDPS.skills[activeSkill.activeEffect.grantedEffect.name] = env.player.output.CombinedDPS
+				else
+					ConPrintf("HELP! Numerous same-named effects! '" .. activeSkill.activeEffect.grantedEffect.name .. "'")
+				end
+				fullDPS.combinedDPS = fullDPS.combinedDPS + env.player.output.CombinedDPS
+			end
 			if activeSkill == env.player.mainSkill then
 				mainSkillOutput = copyTable(env.player.output)
 			end
 			env.player.output = copyTable(actorOutput)
-		end
+		--end
 	end
 	env.player.output = copyTable(mainSkillOutput)
-	env.player.output.SocketGroupDPS = socketGroupDPS
-	--ConPrintf("DPS: " .. tostring(env.player.output.SocketGroupDPS))
+	env.player.output.SkillDPS = fullDPS.skills
+	env.player.output.FullDPS = fullDPS.combinedDPS
+	--ConPrintf("DPS: " .. tostring(env.player.output.FullDPS))
 	if env.minion then
 		calcs.defence(env, env.minion)
 		calcs.offence(env, env.minion, env.minion.mainSkill)

--- a/Modules/CalcPerform.lua
+++ b/Modules/CalcPerform.lua
@@ -1726,7 +1726,26 @@ function calcs.perform(env)
 
 	-- Defence/offence calculations
 	calcs.defence(env, env.player)
-	calcs.offence(env, env.player, env.player.mainSkill)
+
+	--calcs.offence(env, env.player, env.player.mainSkill)
+	-- Calculate the offence of each active skill belonging to the select mainSkill socket group
+	local socketGroupDPS = 0
+	local actorOutput = copyTable(env.player.output)
+	local mainSkillOutput = copyTable(env.player.output)
+	for _, activeSkill in ipairs(env.player.activeSkillList) do
+		if env.player.mainSkill.socketGroup == activeSkill.socketGroup then
+			calcs.offence(env, env.player, activeSkill)
+			--ConPrintf(activeSkill.activeEffect.grantedEffect.name .. " DPS: " .. tostring(env.player.output.CombinedDPS))
+			socketGroupDPS = socketGroupDPS + env.player.output.CombinedDPS
+			if activeSkill == env.player.mainSkill then
+				mainSkillOutput = copyTable(env.player.output)
+			end
+			env.player.output = copyTable(actorOutput)
+		end
+	end
+	env.player.output = copyTable(mainSkillOutput)
+	env.player.output.SocketGroupDPS = socketGroupDPS
+	--ConPrintf("DPS: " .. tostring(env.player.output.SocketGroupDPS))
 	if env.minion then
 		calcs.defence(env, env.minion)
 		calcs.offence(env, env.minion, env.minion.mainSkill)

--- a/Modules/CalcSections.lua
+++ b/Modules/CalcSections.lua
@@ -307,7 +307,7 @@ return {
 		{ breakdown = "OffHand.AverageDamage" },
 		{ breakdown = "AverageDamage" },
 	}, },
-	{ label = "Skill DPS", flag = "notAverage", { format = "{1:output:TotalDPS}", { breakdown = "TotalDPS" }, }, },
+	{ label = "Skill DPS", { format = "{1:output:TotalDPS}", { breakdown = "TotalDPS" }, }, },
 	{ label = "Mana Cost", { format = "{0:output:ManaCost}", { breakdown = "ManaCost" }, { modName = "ManaCost", cfg = "skill" }, }, },
 } }
 } },

--- a/Modules/Data.lua
+++ b/Modules/Data.lua
@@ -81,6 +81,7 @@ data.powerStatList = {
 	{ stat="CombinedDPS", label="Combined DPS" },
 	{ stat="TotalDPS", label="Total DPS" },
 	{ stat="WithImpaleDPS", label="Impale + Total DPS" },
+	{ stat="SocketGroupDPS", label="Socket Group DPS" },
 	{ stat="AverageDamage", label="Average Hit" },
 	{ stat="Speed", label="Attack/Cast Speed" },
 	{ stat="TotalDot", label="DoT DPS" },

--- a/Modules/Data.lua
+++ b/Modules/Data.lua
@@ -81,7 +81,7 @@ data.powerStatList = {
 	{ stat="CombinedDPS", label="Combined DPS" },
 	{ stat="TotalDPS", label="Total DPS" },
 	{ stat="WithImpaleDPS", label="Impale + Total DPS" },
-	{ stat="SocketGroupDPS", label="Socket Group DPS" },
+	{ stat="FullDPS", label="Full DPS" },
 	{ stat="AverageDamage", label="Average Hit" },
 	{ stat="Speed", label="Attack/Cast Speed" },
 	{ stat="TotalDot", label="DoT DPS" },


### PR DESCRIPTION
For a given Socket Group (selected in Left-Hand-Side drop-down) this PR is a WIP for combining all active DPS components of a Socket Group into a single number.

Example: Cyclone with Shockwave support currently (via drop-down located just below the "Main Skill:") allow for selection of each active skill in that skill group and display DPS and Total Damage independently for each gem. This PR combines those two values into a single number so a PoB user does not have to track the DPS/Damage of each individual gem in the socket group separately.

Benefits:
1) This allows better Tree planning as we could use the SocketGroupDPS value to make better node recommendation during tree planning and recommendations (e.g., a specific node greatly increases Shockwave's DPS but we have Cyclone selected as the Main Skill and hence the Tree node recommendation service knows nothing about it)
2) This PR is a start for possibly combining DPS across numerous Socket Groups to get a true DPS number when fighting bosses when I have all my active abilities simultaneously active (e.g., I'm Cyclone + Shockwave spinning with Ancestral Warchief Totems and Ancestral Protector Totem out)