### PR TITLE
Supreme Ego now works with non-skill Auras

### DIFF
--- a/Data/ModCache.lua
+++ b/Data/ModCache.lua
@@ -3404,7 +3404,7 @@ c["-80 Physical Damage taken from Projectile Attacks"]={{[1]={flags=0,keywordFla
 c["-10 Physical Damage taken from Projectile Attacks -80 Physical Damage taken from Projectile Attacks"]={{[1]={flags=0,keywordFlags=0,name="PhysicalDamageTaken",type="BASE",value=-10}},"  from Projectile Attacks -80 Physical Damage taken from Projectile Attacks "}
 c["+6% to Chaos Resistance"]={{[1]={flags=0,keywordFlags=0,name="ChaosResist",type="BASE",value=6}},nil}
 c["-10 Physical Damage taken from Projectile Attacks"]={{[1]={flags=0,keywordFlags=0,name="PhysicalDamageTaken",type="BASE",value=-10}},"  from Projectile Attacks "}
-c["Placed Banners also grant 30% increased Attack Damage to you and Allies"]={{[1]={[1]={type="Condition",var="BannerPlanted"},flags=0,keywordFlags=0,name="ExtraAura",type="LIST",value={mod={flags=1,keywordFlags=0,name="Damage",type="INC",value=30}}}},nil}
+c["Placed Banners also grant 30% increased Attack Damage to you and Allies"]={{[1]={[1]={type="Condition",var="BannerPlanted"},flags=0,keywordFlags=0,name="ExtraAuraEffect",type="LIST",value={mod={flags=1,keywordFlags=0,name="Damage",type="INC",value=30}}}},nil}
 c["Fire Arrow Quiver"]={nil,"Fire Arrow Quiver "}
 c["Mace or Sceptre Attacks deal 18% increased Damage with Ailments"]={{[1]={flags=1050624,keywordFlags=0,name="Damage",type="INC",value=18}},nil}
 c["Gain a Frenzy, Endurance, or Power Charge once per second while you are Stationary"]={nil,"Gain a Frenzy, Endurance, or Power Charge once per second while you are Stationary "}
@@ -8764,7 +8764,7 @@ c["If you've Cast a Spell Recently, you"]={nil,"If you've Cast a Spell Recently,
 c["+10 to maximum Divine Charges"]={{}," maximum Divine Charges "}
 c["24% increased Physical Damage with One Handed Melee Weapons"]={{[1]={flags=167772164,keywordFlags=0,name="PhysicalDamage",type="INC",value=24}},nil}
 c["100% increased Critical Strike Chance against Enemies that are affected"]={{[1]={flags=0,keywordFlags=0,name="CritChance",type="INC",value=100}},"  against Enemies that are affected "}
-c["Auras from your Skills do not affect Allies"]={{[1]={flags=0,keywordFlags=0,name="SelfAurasCannotAffectAllies",type="FLAG",value=true}},nil}
+c["Auras from your Skills do not affect Allies"]={{[1]={flags=0,keywordFlags=0,name="SelfAuraSkillsCannotAffectAllies",type="FLAG",value=true}},nil}
 c["Deal no Physical Damage"]={{[1]={flags=0,keywordFlags=0,name="DealNoPhysical",type="FLAG",value=true}},nil}
 c["2% of Damage dealt by your Totems is Leeched to you as Life"]={{[1]={flags=0,keywordFlags=16384,name="DamageLifeLeechToPlayer",type="BASE",value=2}},nil}
 c["Sadist Garb Requires Level 68, 103 Dex, 109 Int"]={nil,"Sadist Garb Requires Level 68, 103 Dex, 109 Int "}

--- a/Modules/CalcPerform.lua
+++ b/Modules/CalcPerform.lua
@@ -1258,7 +1258,7 @@ function calcs.perform(env)
 						srcList:ScaleAddList(extraAuraModList, (1 + inc / 100) * more)
 						mergeBuff(srcList, buffs, buff.name)
 					end
-					if env.minion and not modDB:Flag(nil, "SelfAurasCannotAffectAllies") then
+					if env.minion and not (modDB:Flag(nil, "SelfAurasCannotAffectAllies") or modDB:Flag(nil, "SelfAuraSkillsCannotAffectAllies")) then
 						activeSkill.minionBuffSkill = true
 						affectedByAura[env.minion] = true
 						env.minion.modDB.conditions["AffectedBy"..buff.name:gsub(" ","")] = true

--- a/Modules/ModParser.lua
+++ b/Modules/ModParser.lua
@@ -2499,7 +2499,7 @@ local specialModList = {
 	["mana reservation of herald skills is always (%d+)%%"] = function(num) return { mod("SkillData", "LIST", { key = "manaCostForced", value = num }, { type = "SkillType", skillType = SkillType.Herald }) } end,
 	["([%a%s]+) reserves no mana"] = function(_, name) return { mod("SkillData", "LIST", { key = "manaCostForced", value = 0 }, { type = "SkillId", skillId = gemIdLookup[name] }) } end,
 	["banner skills reserve no mana"] = { mod("SkillData", "LIST", { key = "manaCostForced", value = 0 }, { type = "SkillName", skillNameList = { "Dread Banner", "War Banner" } }) },
-	["placed banners also grant (%d+)%% increased attack damage to you and allies"] = function(num) return { mod("ExtraAura", "LIST", { mod = mod("Damage", "INC", num, nil, ModFlag.Attack) }, { type = "Condition", var = "BannerPlanted" }) } end,
+	["placed banners also grant (%d+)%% increased attack damage to you and allies"] = function(num) return { mod("ExtraAuraEffect", "LIST", { mod = mod("Damage", "INC", num, nil, ModFlag.Attack) }, { type = "Condition", var = "BannerPlanted" }) } end,
 	["your aura skills are disabled"] = { flag("DisableSkill", { type = "SkillType", skillType = SkillType.Aura }) },
 	["your spells are disabled"] = { flag("DisableSkill", { type = "SkillType", skillType = SkillType.Spell }) },
 	["strength's damage bonus instead grants (%d+)%% increased melee physical damage per (%d+) strength"] = function(num, _, perStr) return { mod("StrDmgBonusRatioOverride", "BASE", num / tonumber(perStr)) } end,

--- a/Modules/ModParser.lua
+++ b/Modules/ModParser.lua
@@ -1387,7 +1387,7 @@ local specialModList = {
 		mod("ColdEnergyShieldBypass", "BASE", 100),
 		mod("FireEnergyShieldBypass", "BASE", 100),
 	},
-	["auras from your skills do not affect allies"] = { flag("SelfAurasCannotAffectAllies") },
+	["auras from your skills do not affect allies"] = { flag("SelfAuraSkillsCannotAffectAllies") },
 	["auras from your skills have (%d+)%% more effect on you"] = function(num) return { mod("SkillAuraEffectOnSelf", "MORE", num) } end,
 	["increases and reductions to mana regeneration rate instead apply to rage regeneration rate"] = { flag("ManaRegenToRageRegen") },
 	["maximum energy shield is (%d+)"] = function(num) return { mod("EnergyShield", "OVERRIDE", num ) } end,


### PR DESCRIPTION
#2176 

Previously Supreme Ego was using the same implementation as Ichimonji even though they have different wordings and effects.

"Your Aura Buffs do not affect allies" vs "Auras from your Skills do not affect Allies"

I separated out Supreme Ego with its own, new flag "SelfAuraSkillsCannotAffectAllies" and added it to the ExtraAuraEffect logic in ClacPerform but not the ExtraAura logic so it doesn't disable non-skill auras now.

I then checked all 85 references to ExtraAura in ModCache to make sure I wasn't breaking anything and found one Banner node erroneously tagged as an ExtraAura and not ExtraAuraEffect.