### PR TITLE
Remove SkillParts from Cyclone

### DIFF
--- a/Data/Skills/act_dex.lua
+++ b/Data/Skills/act_dex.lua
@@ -1914,14 +1914,6 @@ skills["Cyclone"] = {
 	},
 	statDescriptionScope = "skill_stat_descriptions",
 	castTime = 1,
-	parts = {
-		{
-			name = "No Stages",
-		},
-		{
-			name = "Max Stages",
-		},
-	},
 	statMap = {
 		["cyclone_max_number_of_stages"] = {
 			mod("Multiplier:CycloneMaxStages", "BASE", nil),

--- a/Export/Skills/act_dex.txt
+++ b/Export/Skills/act_dex.txt
@@ -365,14 +365,6 @@ local skills, mod, flag, skill = ...
 
 #skill Cyclone
 #flags attack melee area
-	parts = {
-		{
-			name = "No Stages",
-		},
-		{
-			name = "Max Stages",
-		},
-	},
 	statMap = {
 		["cyclone_max_number_of_stages"] = {
 			mod("Multiplier:CycloneMaxStages", "BASE", nil),


### PR DESCRIPTION
- Removes the No Stages/Max Stages skill parts from Cyclone, as the stages box takes care of that function now