### PR TITLE
Fix for Shockwave secondary trigger rate

### DIFF
--- a/Data/Skills/sup_str.lua
+++ b/Data/Skills/sup_str.lua
@@ -3368,13 +3368,15 @@ skills["SupportBluntWeaponShockwave"] = {
 	},
 	statDescriptionScope = "skill_stat_descriptions",
 	castTime = 1,
+	preDamageFunc = function(activeSkill, output)
+		activeSkill.skillData.hitTimeOverride = output.Cooldown
+	end,
 	baseFlags = {
 		attack = true,
 		melee = true,
 		area = true,
 	},
 	baseMods = {
-		skill("showAverage", true),
 	},
 	qualityStats = {
 		Default = {

--- a/Export/Skills/sup_str.txt
+++ b/Export/Skills/sup_str.txt
@@ -410,7 +410,9 @@ local skills, mod, flag, skill = ...
 
 #skill SupportBluntWeaponShockwave
 #flags attack melee area
-#baseMod skill("showAverage", true)
+	preDamageFunc = function(activeSkill, output)
+		activeSkill.skillData.hitTimeOverride = output.Cooldown
+	end,
 #mods
 
 #skill SupportSpellTotem


### PR DESCRIPTION
Shockwave secondaryGrantedEffect "SupportBluntWeaponShockwave" was not calculating proper DPS due to using attack rate rather than trigger cooldown. This fixes it.