### PR TITLE
Implemented PoE matching search function. Resolves #2173

### DIFF
--- a/Classes/PassiveTreeView.lua
+++ b/Classes/PassiveTreeView.lua
@@ -431,21 +431,21 @@ function PassiveTreeViewClass:Draw(build, viewPort, inputEvents)
 	if self.searchStrCached ~= self.searchStr then
 		self.searchStrCached = self.searchStr
 
-		local function PrepSearch(search)
-			search = search:lower();
-			local searchWords = {};
-			for matchstring,v in search:gmatch('"([^"]*)"') do
-				searchWords[#searchWords+1] = matchstring;
-				search = search:gsub('"'..matchstring..'"',"");
+		local function prepSearch(search)
+			search = search:lower()
+			local searchWords = {}
+			for matchstring, v in search:gmatch('"([^"]*)"') do
+				searchWords[#searchWords+1] = matchstring
+				search = search:gsub('"'..matchstring..'"', "")
 			end
-			for matchstring,v in search:gmatch("(%S*)") do
-				if not matchstring ~= nil and matchstring:match("%S") ~= nil then -- if string is not empty or whitespace
-					searchWords[#searchWords+1] = matchstring;
+			for matchstring, v in search:gmatch("(%S*)") do
+				if matchstring:match("%S") ~= nil then
+					searchWords[#searchWords+1] = matchstring
 				end
 			end
-			return searchWords;
+			return searchWords
 		end
-		self.searchParams = PrepSearch(self.searchStr);
+		self.searchParams = prepSearch(self.searchStr)
 
 		for nodeId, node in pairs(spec.nodes) do
 			self.searchStrResults[nodeId] = #self.searchParams > 0 and self:DoesNodeMatchSearchParams(node)
@@ -791,17 +791,16 @@ function PassiveTreeViewClass:DoesNodeMatchSearchParams(node)
 		return
 	end
 
-	local needMatches = copyTable(self.searchParams);
-	--for _,v in ipairs(self.searchParams) do needMatches[#needMatches+1] = v; end
-	local err;
+	local needMatches = copyTable(self.searchParams)
+	local err
 
 	local function search(haystack, need)
-		for i=#need,1,-1 do
+		for i=#need, 1, -1 do
 			if haystack:match(need[i]) then
-				table.remove(need,i);
+				table.remove(need, i)
 			end
 		end
-		return need;
+		return need
 	end
 
 	-- Check node name

--- a/Classes/PassiveTreeView.lua
+++ b/Classes/PassiveTreeView.lua
@@ -430,8 +430,25 @@ function PassiveTreeViewClass:Draw(build, viewPort, inputEvents)
 	-- Update cached node data
 	if self.searchStrCached ~= self.searchStr then
 		self.searchStrCached = self.searchStr
+
+		local function PrepSearch(search)
+			search = search:lower();
+			local searchWords = {};
+			for matchstring,v in search:gmatch('"([^"]*)"') do
+				searchWords[#searchWords+1] = matchstring;
+				search = search:gsub('"'..matchstring..'"',"");
+			end
+			for matchstring,v in search:gmatch("(%S*)") do
+				if not matchstring ~= nil and matchstring:match("%S") ~= nil then -- if string is not empty or whitespace
+					searchWords[#searchWords+1] = matchstring;
+				end
+			end
+			return searchWords;
+		end
+		self.searchParams = PrepSearch(self.searchStr);
+
 		for nodeId, node in pairs(spec.nodes) do
-			self.searchStrResults[nodeId] = #self.searchStr > 0 and self:DoesNodeMatchSearchStr(node)
+			self.searchStrResults[nodeId] = #self.searchParams > 0 and self:DoesNodeMatchSearchParams(node)
 		end
 	end
 
@@ -769,13 +786,20 @@ function PassiveTreeViewClass:Focus(x, y, viewPort, build)
 	self.zoomY = -y * scale
 end
 
-function PassiveTreeViewClass:DoesNodeMatchSearchStr(node)
+function PassiveTreeViewClass:DoesNodeMatchSearchParams(node)
 	if node.type == "ClassStart" or node.type == "Mastery" then
 		return
 	end
 
+	local function search(haystack)
+		for _,v in ipairs(self.searchParams) do
+			if not haystack:match(v) then return false; end
+		end
+		return true;
+	end
+
 	-- Check node name
-	local errMsg, match = PCall(string.match, node.dn:lower(), self.searchStr:lower())
+	local errMsg, match = PCall(search, node.dn:lower())
 	if match then
 		return true
 	end
@@ -783,14 +807,14 @@ function PassiveTreeViewClass:DoesNodeMatchSearchStr(node)
 	-- Check node description
 	for index, line in ipairs(node.sd) do
 		-- Check display text first
-		errMsg, match = PCall(string.match, line:lower(), self.searchStr:lower())
+		errMsg, match = PCall(search, line:lower())
 		if match then
 			return true
 		end
 		if not match and node.mods[index].list then
 			-- Then check modifiers
 			for _, mod in ipairs(node.mods[index].list) do
-				errMsg, match = PCall(string.match, mod.name, self.searchStr)
+				errMsg, match = PCall(search, mod.name)
 				if match then
 					return true
 				end
@@ -799,7 +823,7 @@ function PassiveTreeViewClass:DoesNodeMatchSearchStr(node)
 	end
 
 	-- Check node type
-	local errMsg, match = PCall(string.match, node.type:lower(), self.searchStr:lower())
+	local errMsg, match = PCall(search, node.type:lower())
 	if match then
 		return true
 	end


### PR DESCRIPTION
Implemented the search changes that were talked about in issue #2173

The only thing I'm not sure about is the search function I had to make, looping over multiple searches. Because of LUA's non-conformance to standard POSIX RegExp, there seems to be no easy way to do a "match all in any order" (Which I didn't realize when starting this project). I did some testing, and it seems to match between in-game search and PoB search.

Please, by all means, compare results and let me know if any inconsistencies are found, or if I missed some hidden functionality of the PoE search bar.