### PR TITLE
Divergent Pride Fix

### DIFF
--- a/Data/Skills/act_str.lua
+++ b/Data/Skills/act_str.lua
@@ -4307,7 +4307,7 @@ skills["PhysicalDamageAura"] = {
 			mod("BleedChance", "BASE", nil, ModFlag.Attack, KeywordFlag.Hit, { type = "GlobalEffect", effectType = "AuraDebuff" }),
 		},
 		["base_additional_physical_damage_reduction_%"] = {
-			mod("EnemyPhysicalDamageReduction", "BASE", nil, 0, 0, { type = "GlobalEffect", effectType = "AuraDebuff" }),
+			mod("PhysicalDamageReduction", "BASE", nil, 0, 0, { type = "GlobalEffect", effectType = "AuraDebuff" }),
 		},
 	},
 	baseFlags = {

--- a/Export/Skills/act_str.txt
+++ b/Export/Skills/act_str.txt
@@ -787,7 +787,7 @@ local skills, mod, flag, skill = ...
 			mod("BleedChance", "BASE", nil, ModFlag.Attack, KeywordFlag.Hit, { type = "GlobalEffect", effectType = "AuraDebuff" }),
 		},
 		["base_additional_physical_damage_reduction_%"] = {
-			mod("EnemyPhysicalDamageReduction", "BASE", nil, 0, 0, { type = "GlobalEffect", effectType = "AuraDebuff" }),
+			mod("PhysicalDamageReduction", "BASE", nil, 0, 0, { type = "GlobalEffect", effectType = "AuraDebuff" }),
 		},
 	},
 #mods


### PR DESCRIPTION
Because of it being a debuff the term "Enemy~" causes it to not be applied due to how line [1865 of CalcOffence.lua ](https://github.com/PathOfBuildingCommunity/PathOfBuilding/blob/cbfca046c220c93af5466f7e43cd3c9b150e1304/Modules/CalcOffence.lua#L1865)works.