### PR TITLE
Support "enemies taunted by your warcries take x% increased damage"

### DIFF
--- a/Modules/ModParser.lua
+++ b/Modules/ModParser.lua
@@ -2080,6 +2080,7 @@ local specialModList = {
 	["warcries count as having (%d+) additional nearby enemies"] = function(num) return {
 		mod("Multiplier:WarcryNearbyEnemies", "BASE", num),
 	} end,
+	["enemies taunted by your warcries take (%d+)%% increased damage"] = function(num) return { mod("EnemyModifier", "LIST", { mod = mod("DamageTaken", "INC", num, { type = "Condition", var = "Taunted" }) }, { type = "Condition", var = "UsedWarcryRecently" }) } end,
 	["warcries share their cooldown"] = { flag("WarcryShareCooldown") },
 	["warcries have minimum of (%d+) power"] = { flag("CryWolfMinimumPower") },
 	["enemies you curse take (%d+)%% increased damage"] = function(num) return { mod("EnemyModifier", "LIST", { mod = mod("DamageTaken", "INC", num, { type = "Condition", var = "Cursed" }) }) } end,


### PR DESCRIPTION
[v2] Rely on both Condition:Taunted and Condition:UsedWarcryRecently

~~Adding a config entry "is the enemy taunted by your warcries" felt a bit overkill.~~
~~Another option was to check for the presence of any warcry before enabling the mod, but that too felt overkill.~~

~~I decided to simply use the taunted config option already available instead.~~