### PR TITLE
Add Infernal Sentinel Spectre

### DIFF
--- a/Data/Skills/spectre.lua
+++ b/Data/Skills/spectre.lua
@@ -5264,3 +5264,38 @@ skills["SecretDesecrateMonsterMultiSlash"] = {
 		[1] = { attackSpeedMultiplier = -33, levelRequirement = 0, statInterpolation = { }, },
 	},
 }
+skills["SpellNovaFireRibbons"] = {
+    name = "SpellNovaFireRibbons",
+    hidden = true,
+    color = 4,
+    baseEffectiveness = 3.3333,
+    incrementalEffectiveness = 0.03,
+    skillTypes = {
+        [SkillType.Spell] = true,
+        [SkillType.Hit] = true,
+        [SkillType.Area] = true,
+        [SkillType.Duration] = true,
+        [SkillType.Triggerable] = true,
+        [SkillType.AreaSpell] = true,
+    },
+    statDescriptionScope = "skill_stat_descriptions",
+    castTime = 1,
+    baseFlags = {
+        area = true,
+        spell = true,
+        duration = true,
+    },
+    baseMods = {
+    },
+    qualityStats = {
+    },
+    stats = {
+        "spell_minimum_base_fire_damage",
+        "spell_maximum_base_fire_damage",
+        "cast_on_trigger_cascade_event_%",
+        "is_area_damage",
+    },
+    levels = {
+        [1] = {0.8, 1.2, 100, levelRequirement = 1, statInterpolation = {3, 3, 1},  },
+    },
+}

--- a/Data/Spectres.lua
+++ b/Data/Spectres.lua
@@ -1028,25 +1028,26 @@ minions["Metadata/Monsters/Guardians/GuardianFire"] = {
 }
 -- Infernal Sentinel
 minions["Metadata/Monsters/Guardians/GuardianFire2_"] = {
-	name = "Infernal Sentinel",
-	life = 2.7,
-	fireResist = 75,
-	coldResist = 0,
-	lightningResist = 0,
-	chaosResist = 0,
-	damage = 1.8,
-	damageSpread = 0.2,
-	attackTime = 1.5,
-	attackRange = 8,
-	accuracy = 1,
-	skillList = {
-		"GuardianTriggerCascade1",
-		"GuardianTriggerCascade2",
-		"SpellNovaFireRibbons",
-		"GuardianTriggerCascade3",
-	},
-	modList = {
-	},
+    name = "Infernal Sentinel",
+    life = 2.7,
+    energyShield = 1,
+    fireResist = 75,
+    coldResist = 0,
+    lightningResist = 0,
+    chaosResist = 0,
+    damage = 1.8,
+    damageSpread = 0.2,
+    attackTime = 1.5,
+    attackRange = 8,
+    accuracy = 1,
+    skillList = {
+        "SpellNovaFireRibbons",
+        "GuardianTriggerCascade1",
+        "GuardianTriggerCascade2",
+        "GuardianTriggerCascade3",
+    },
+    modList = {
+    },
 }
 minions["Metadata/Monsters/Guardians/GuardianFire_BlueMaps"] = {
 	name = "Frost Sentinel",

--- a/Data/Spectres.lua
+++ b/Data/Spectres.lua
@@ -1026,6 +1026,28 @@ minions["Metadata/Monsters/Guardians/GuardianFire"] = {
 		-- MonsterCastsAugmentedFireballsText [monster_casts_augmented_fireballs_text = 1]
 	},
 }
+-- Infernal Sentinel
+minions["Metadata/Monsters/Guardians/GuardianFire2_"] = {
+	name = "Infernal Sentinel",
+	life = 2.7,
+	fireResist = 75,
+	coldResist = 0,
+	lightningResist = 0,
+	chaosResist = 0,
+	damage = 1.8,
+	damageSpread = 0.2,
+	attackTime = 1.5,
+	attackRange = 8,
+	accuracy = 1,
+	skillList = {
+		"GuardianTriggerCascade1",
+		"GuardianTriggerCascade2",
+		"SpellNovaFireRibbons",
+		"GuardianTriggerCascade3",
+	},
+	modList = {
+	},
+}
 minions["Metadata/Monsters/Guardians/GuardianFire_BlueMaps"] = {
 	name = "Frost Sentinel",
 	life = 1.8,

--- a/Export/Minions/Spectres.txt
+++ b/Export/Minions/Spectres.txt
@@ -194,3 +194,5 @@ local minions, mod = ...
 #spectre Metadata/Monsters/AtlasExiles/EyrieInfluenceMonsters/EyrieArmouredBirdSpectre__
 -- Flickershade
 #spectre Metadata/Monsters/Maligaro/SecretDesecrateMonster
+-- Infernal Sentinel
+#spectre Metadata/Monsters/Guardians/GuardianFire2_

--- a/Export/Skills/spectre.txt
+++ b/Export/Skills/spectre.txt
@@ -823,3 +823,7 @@ local skills, mod, flag, skill = ...
 #skill SecretDesecrateMonsterMultiSlash Multi Slash
 #flags attack hit area triggerable
 #mods
+
+#skill SpellNovaFireRibbons Nova
+#flags area spell duration
+#mods


### PR DESCRIPTION
First time adding a spectre. In reference to #1769 

https://poedb.tw/us/Infernal_Sentinel#Metadata_Monsters_Guardians_GuardianFire2_

There are three types of Infernal Sentinels, depending where you find them, but they have the same specs, so i would group them together:

Metadata_Monsters_Guardians_GuardianFire2_
Metadata_Monsters_Guardians_GuardianFire2_Schism
Metadata_Monsters_Guardians_GuardianFire2_RedNewTeam

Question, there is no 'traditional' Name for SpellNovaFireRibbons skill. Do i leave it as that or change it to something like Spell Fire Nova?

![image](https://user-images.githubusercontent.com/54453318/108982262-e2a71880-768d-11eb-89bb-208dae3c4cad.png)
