### PR TITLE
Add generic mod parsing for enemy modifiers

### DIFF
--- a/Modules/ModParser.lua
+++ b/Modules/ModParser.lua
@@ -818,6 +818,14 @@ local preFlagList = {
 	["^socketed golem gems [hgd][ae][via][enl] "] = { addToSkill = { type = "SocketedIn", slotName = "{SlotName}", keyword = "golem" } },
 	["^socketed golem skills [hgd][ae][via][enl] "] = { addToSkill = { type = "SocketedIn", slotName = "{SlotName}", keyword = "golem" } },
 	["^socketed golem skills have minions "] = { addToSkill = { type = "SocketedIn", slotName = "{SlotName}", keyword = "golem" } },
+	-- Enemy modifiers
+	["^enemies withered by you [th]a[vk]e "] = { tag = { type = "MultiplierThreshold", var = "WitheredStack", threshold = 1 }, applyToEnemy = true },
+	["^enemies (%a+) by you ([th]a[vk]e) "] = function(cond, takeOrHave)
+		return { tag = { type = "Condition", var = cond:gsub("^%a", string.upper) }, applyToEnemy = true, modSuffix = takeOrHave == "take" and "Taken" or "" }
+	end,
+	["^enemies affected by your spider's webs [th]a[vk]e "] = { tag = { type = "MultiplierThreshold", var = "Spider's WebStack", threshold = 1 }, applyToEnemy = true },
+	["^nearby enemies take "] = { modSuffix = "Taken", applyToEnemy = true },
+	["^nearby enemies have "] = { applyToEnemy = true },
 	-- Other
 	["^your flasks grant "] = { },
 	["^when hit, "] = { },
@@ -1461,7 +1469,6 @@ local specialModList = {
 	["exerted attacks deal (%d+)%% more damage if a warcry sacrificed rage recently"] = function(num) return { mod("ExertIncrease", "MORE", num, nil, ModFlag.Attack, 0) } end,
 	-- Champion
 	["cannot be stunned while you have fortify"] = { mod("AvoidStun", "BASE", 100, { type = "Condition", var = "Fortify" }) },
-	["enemies taunted by you take (%d+)%% increased damage"] = function(num) return { mod("EnemyModifier", "LIST", { mod = mod("DamageTaken", "INC", num, { type = "Condition", var = "Taunted" }) }) } end,
 	["enemies taunted by you cannot evade attacks"] = { mod("EnemyModifier", "LIST", { mod = flag("CannotEvade", { type = "Condition", var = "Taunted" }) }) },
 	["if you've impaled an enemy recently, you and nearby allies have %+(%d+) to armour"] = function (num) return { mod("ExtraAura", "LIST", { mod = mod("Armour", "BASE", num) }, { type = "Condition", var = "ImpaledRecently" }) } end,
 	-- Chieftain
@@ -1573,7 +1580,6 @@ local specialModList = {
 		flag("ChaosCanShock"),
 	},
 	-- Gladiator
-	["enemies maimed by you take (%d+)%% increased physical damage"] = function(num) return { mod("EnemyModifier", "LIST", { mod = mod("PhysicalDamageTaken", "INC", num, { type = "Condition", var = "Maimed" }) }) } end,
 	["chance to block spell damage is equal to chance to block attack damage"] = { flag("SpellBlockChanceIsBlockChance") },
 	["maximum chance to block spell damage is equal to maximum chance to block attack damage"] = { flag("SpellBlockChanceMaxIsBlockChanceMax") },
 	["your counterattacks deal double damage"] = {
@@ -1607,7 +1613,6 @@ local specialModList = {
 	["critical strikes ignore enemy monster elemental resistances"] = { flag("IgnoreElementalResistances", { type = "Condition", var = "CriticalStrike" }) },
 	["non%-critical strikes penetrate (%d+)%% of enemy elemental resistances"] = function(num) return { mod("ElementalPenetration", "BASE", num, { type = "Condition", var = "CriticalStrike", neg = true }) } end,
 	["consecrated ground you create applies (%d+)%% increased damage taken to enemies"] = function(num) return { mod("EnemyModifier", "LIST", { mod = mod("DamageTaken", "INC", num, { type = "Condition", var = "OnConsecratedGround" }) }) } end,
-	["nearby enemies take (%d+)%% increased elemental damage"] = function(num) return { mod("EnemyModifier", "LIST", { mod = mod("ElementalDamageTaken", "INC", num) }) } end,
 	["you have consecrated ground around you while stationary"] = { flag("Condition:OnConsecratedGround", { type = "Condition", var = "Stationary" }) },
 	["consecrated ground you create grants immunity to elemental ailments to you and allies"] = {
 		mod("AvoidChill", "BASE", 100, { type = "Condition", var = "OnConsecratedGround" }),
@@ -1925,7 +1930,6 @@ local specialModList = {
 	["you can inflict up to (%d+) ignites on an enemy"] = { flag("IgniteCanStack") },
 	["you can inflict an additional ignite on an enemy"] = { flag("IgniteCanStack"), mod("IgniteStacks", "BASE", 1) },
 	["enemies chilled by you take (%d+)%% increased burning damage"] = function(num) return { mod("EnemyModifier", "LIST", { mod = mod("FireDamageTakenOverTime", "INC", num) }, { type = "ActorCondition", actor = "enemy", var = "Chilled" }) } end,
-	["enemies frozen by you take (%d+)%% increased damage"] = function(num) return { mod("EnemyModifier", "LIST", { mod = mod("DamageTaken", "INC", num) }, { type = "ActorCondition", actor = "enemy", var = "Frozen" }) } end,
 	["damaging ailments deal damage (%d+)%% faster"] = function(num) return { mod("IgniteBurnFaster", "INC", num), mod("BleedFaster", "INC", num), mod("PoisonFaster", "INC", num) } end,
 	["damaging ailments you inflict deal damage (%d+)%% faster while affected by malevolence"] = function(num) return {
 		mod("IgniteBurnFaster", "INC", num, { type = "Condition", var = "AffectedByMalevolence" }),
@@ -1938,9 +1942,8 @@ local specialModList = {
 	["ignites you inflict with attacks deal damage (%d+)%% faster"] = function(num) return { mod("IgniteBurnFaster", "INC", num, nil, ModFlag.Attack) } end,
 	["ignites you inflict deal damage (%d+)%% faster"] = function(num) return { mod("IgniteBurnFaster", "INC", num) } end,
 	["enemies ignited by you during flask effect take (%d+)%% increased damage"] = function(num) return { mod("EnemyModifier", "LIST", { mod = mod("DamageTaken", "INC", num) }, { type = "ActorCondition", actor = "enemy", var = "Ignited" }) } end,
-	["enemies ignited by you have (%-%d+)%% to fire resistance"] = function(num) return { mod("EnemyModifier", "LIST", { mod = mod("FireResist", "BASE", num) }, { type = "ActorCondition", actor = "enemy", var = "Ignited" }) } end,
 	["enemies ignited by you take chaos damage instead of fire damage from ignite"] = { flag("IgniteToChaos") },
-	["enemies chilled by your hits are shocked"] = { 
+	["enemies chilled by your hits are shocked"] = {
 		mod("ShockBase", "BASE", 15, { type = "ActorCondition", actor = "enemy", var = "ChilledByYourHits" } ),
 		mod("EnemyModifier", "LIST", { mod = mod("Condition:Shocked", "FLAG", true, { type = "Condition", var = "ChilledByYourHits" } ) } )
 	},
@@ -2001,7 +2004,6 @@ local specialModList = {
 		mod("Damage", "MORE", tonumber(more) * num / 200, nil, 0, KeywordFlag.Poison, { type = "Condition", var = "DualWielding"}, { type = "SkillType", skillType = SkillType.Attack }),
 		mod("Damage", "MORE", tonumber(more) * num / 100, nil, 0, KeywordFlag.Poison, { type = "Condition", var = "DualWielding", neg = true }, { type = "SkillType", skillType = SkillType.Attack })
 	} end,
-	["enemies poisoned by you have (%-%d+)%% to chaos resistance"] = function(num) return { mod("EnemyModifier", "LIST", { mod = mod("ChaosResist", "BASE", num) }, { type = "ActorCondition", actor = "enemy", var = "Poisoned" }) } end,
 	-- Buffs/debuffs
 	["phasing"] = { flag("Condition:Phasing") },
 	["onslaught"] = { flag("Condition:Onslaught") },
@@ -2039,10 +2041,6 @@ local specialModList = {
 	["([%+%-][%d%.]+) seconds to avian's flight duration"] = function(num) return { mod("SecondaryDuration", "BASE", num, { type = "SkillName", skillName = "Aspect of the Avian" }) } end,
 	["aspect of the spider can inflict spider's web on enemies an additional time"] = { mod("ExtraSkillMod", "LIST", { mod = mod("Multiplier:SpiderWebApplyStackMax", "BASE", 1) }, { type = "SkillName", skillName = "Aspect of the Spider" }) },
 	["aspect of the avian also grants avian's might and avian's flight to nearby allies"] = { mod("ExtraSkillMod", "LIST", { mod = mod("BuffEffectOnMinion", "MORE", 100) }, { type = "SkillName", skillName = "Aspect of the Avian" }) },
-	["enemies affected by your spider's webs have (%-%d+)%% to all resistances"] = function(num) return {
-		mod("EnemyModifier", "LIST", { mod = mod("ElementalResist", "BASE", num, { type = "MultiplierThreshold", var = "Spider's WebStack", threshold = 1 }) }),
-		mod("EnemyModifier", "LIST", { mod = mod("ChaosResist", "BASE", num, { type = "MultiplierThreshold", var = "Spider's WebStack", threshold = 1 }) }),
-	} end,
 	["marked enemy takes (%d+)%% increased damage"] = function(num) return {
 		mod("EnemyModifier", "LIST", { mod = mod("DamageTaken", "INC", num) }, {type = "ActorCondition", actor = "enemy", var = "Marked"}),
 	} end,
@@ -2077,7 +2075,6 @@ local specialModList = {
 	["when you warcry, you and nearby allies gain onslaught for 4 seconds"] = { mod("ExtraAura", "LIST", { mod = flag("Onslaught") }, { type = "Condition", var = "UsedWarcryRecently" }) },
 	["enemies in your chilling areas take (%d+)%% increased lightning damage"] = function(num) return { mod("EnemyModifier", "LIST", { mod = mod("LightningDamageTaken", "INC", num) }, { type = "ActorCondition", actor = "enemy", var = "InChillingArea" }) } end,
 	["(%d+)%% chance to sap enemies in chilling areas"] = function(num) return { mod("SapChance", "BASE", num, { type = "ActorCondition", actor = "enemy", var = "InChillingArea" } ) } end,
-	["enemies hindered by you take (%d+)%% increased chaos damage"] = function(num) return { mod("EnemyModifier", "LIST", { mod = mod("ChaosDamageTaken", "INC", num) }, { type = "ActorCondition", actor = "enemy", var = "Hindered" }) } end,
 	["warcries count as having (%d+) additional nearby enemies"] = function(num) return {
 		mod("Multiplier:WarcryNearbyEnemies", "BASE", num),
 	} end,
@@ -2579,9 +2576,6 @@ local specialModList = {
 		flag("Condition:CreateProfaneGround"),
 		mod("Dummy", "DUMMY", 1, { type = "Condition", var = "CreateProfaneGround" }), -- Make the Configuration option appear
 	},
-	["nearby enemies have (%-%d+)%% to fire resistance"] = function(num) return { mod("EnemyModifier", "LIST", { mod = mod("FireResist", "BASE", num) }) } end,
-	["nearby enemies have (%-%d+)%% to lightning resistance"] = function(num) return { mod("EnemyModifier", "LIST", { mod = mod("LightningResist", "BASE", num) }) } end,
-	["nearby enemies take (%d+)%% increased physical damage"] = function(num) return { mod("EnemyModifier", "LIST", { mod = mod("PhysicalDamageTaken", "INC", num) }) } end,
 	["you count as dual wielding while you are unencumbered"] = { flag("Condition:DualWielding", { type = "Condition", var = "Unencumbered" }) },
 	["skills supported by intensify have %+(%d) to maximum intensity"] = function(num) return { mod("Multiplier:IntensityLimit", "BASE", num) } end,
 	["spells which can gain intensity have %+(%d) to maximum intensity"] = function(num) return { mod("Multiplier:IntensityLimit", "BASE", num) } end,
@@ -3206,8 +3200,11 @@ local function parseMod(line, order)
 	line = line .. " "
 
 	-- Check for a flag/tag specification at the start of the line
-	local preFlag
-	preFlag, line = scan(line, preFlagList)
+	local preFlag, preFlagCap
+	preFlag, line, preFlagCap = scan(line, preFlagList)
+	if type(preFlag) == "function" then
+		preFlag = preFlag(unpack(preFlagCap))
+	end
 
 	-- Check for skill name at the start of the line
 	local skillTag
@@ -3401,6 +3398,10 @@ local function parseMod(line, order)
 		elseif misc.convertFortifyEffect then
 			for i, effectMod in ipairs(modList) do
 				modList[i] = mod("convertFortifyBuff", "LIST", { mod = effectMod })
+			end
+		elseif misc.applyToEnemy then
+			for i, effectMod in ipairs(modList) do
+				modList[i] = mod("EnemyModifier", "LIST", { mod = effectMod })
 			end
 		end
 	end

--- a/Modules/ModParser.lua
+++ b/Modules/ModParser.lua
@@ -824,6 +824,8 @@ local preFlagList = {
 		return { tag = { type = "Condition", var = cond:gsub("^%a", string.upper) }, applyToEnemy = true, modSuffix = takeOrHave == "take" and "Taken" or "" }
 	end,
 	["^enemies affected by your spider's webs [th]a[vk]e "] = { tag = { type = "MultiplierThreshold", var = "Spider's WebStack", threshold = 1 }, applyToEnemy = true },
+	["^enemies you curse take "] = { tag = { type = "Condition", var = "Cursed" }, applyToEnemy = true, modSuffix = "Taken" },
+	["^enemies you curse have "] = { tag = { type = "Condition", var = "Cursed" }, applyToEnemy = true },
 	["^nearby enemies take "] = { modSuffix = "Taken", applyToEnemy = true },
 	["^nearby enemies have "] = { applyToEnemy = true },
 	-- Other
@@ -2080,7 +2082,6 @@ local specialModList = {
 	} end,
 	["warcries share their cooldown"] = { flag("WarcryShareCooldown") },
 	["warcries have minimum of (%d+) power"] = { flag("CryWolfMinimumPower") },
-	["enemies you curse take (%d+)%% increased damage"] = function(num) return { mod("EnemyModifier", "LIST", { mod = mod("DamageTaken", "INC", num, { type = "Condition", var = "Cursed" }) }) } end,
 	["(%d+)%% chance to inflict withered for (%d+) seconds on hit"] = { flag("Condition:CanWither") },
 	["(%d+)%% chance to inflict withered for (%d+) seconds on hit with this weapon"] = { flag("Condition:CanWither") },
 	["(%d+)%% chance to inflict withered for two seconds on hit if there are (%d+) or fewer withered debuffs on enemy"] = { flag("Condition:CanWither") },

--- a/Modules/ModParser.lua
+++ b/Modules/ModParser.lua
@@ -820,9 +820,12 @@ local preFlagList = {
 	["^socketed golem skills have minions "] = { addToSkill = { type = "SocketedIn", slotName = "{SlotName}", keyword = "golem" } },
 	-- Enemy modifiers
 	["^enemies withered by you [th]a[vk]e "] = { tag = { type = "MultiplierThreshold", var = "WitheredStack", threshold = 1 }, applyToEnemy = true },
-	["^enemies (%a+) by you ([th]a[vk]e) "] = function(cond, takeOrHave)
-		return { tag = { type = "Condition", var = cond:gsub("^%a", string.upper) }, applyToEnemy = true, modSuffix = takeOrHave == "take" and "Taken" or "" }
+	["^enemies (%a+) by you take "] = function(cond)
+		return { tag = { type = "Condition", var = cond:gsub("^%a", string.upper) }, applyToEnemy = true, modSuffix = "Taken" }
 	end,
+	["^enemies (%a+) by you have "] = function(cond)
+		return { tag = { type = "Condition", var = cond:gsub("^%a", string.upper) }, applyToEnemy = true }
+	end,	
 	["^enemies affected by your spider's webs [th]a[vk]e "] = { tag = { type = "MultiplierThreshold", var = "Spider's WebStack", threshold = 1 }, applyToEnemy = true },
 	["^enemies you curse take "] = { tag = { type = "Condition", var = "Cursed" }, applyToEnemy = true, modSuffix = "Taken" },
 	["^enemies you curse have "] = { tag = { type = "Condition", var = "Cursed" }, applyToEnemy = true },


### PR DESCRIPTION
This is the diff for `Data/ModCache.lua` after this change (note some of the added lines are because my dev branch is behind upstream, I believe)

```diff
7920a7921
> c["Cannot Recharge or Regenerate Energy Shield"]={{[1]={flags=0,keywordFlags=0,name="NoEnergyShieldRecharge",type="FLAG",value=true},[2]={flags=0,keywordFlags=0,name="NoEnergyShieldRegen",type="FLAG",value=true}},nil}
9008,9011c9009,9012
< c["Enemies Cursed by you have Malediction if 33% of Curse Duration expired"]={nil,"Enemies Cursed by you have Malediction if 33% of Curse Duration expired "}
< c["Enemies Cursed by you take 25% increased Damage if 75% of Curse Duration expired"]={nil,"Enemies Cursed by you take 25% increased Damage if 75% of Curse Duration expired "}
< c["Enemies Frozen by you take 20% increased Damage"]={{[1]={[1]={actor="enemy",type="ActorCondition",var="Frozen"},flags=0,keywordFlags=0,name="EnemyModifier",type="LIST",value={mod={flags=0,keywordFlags=0,name="DamageTaken",type="INC",value=20}}}},nil}
< c["Enemies Hindered by you take 10% increased Chaos Damage"]={{[1]={[1]={actor="enemy",type="ActorCondition",var="Hindered"},flags=0,keywordFlags=0,name="EnemyModifier",type="LIST",value={mod={flags=0,keywordFlags=0,name="ChaosDamageTaken",type="INC",value=10}}}},nil}
---
> c["Enemies Cursed by you have Malediction if 33% of Curse Duration expired"]={nil,"Malediction if 33% of Curse Duration expired "}
> c["Enemies Cursed by you take 25% increased Damage if 75% of Curse Duration expired"]={{[1]={flags=0,keywordFlags=0,name="EnemyModifier",type="LIST",value={mod={[1]={type="Condition",var="Cursed"},flags=0,keywordFlags=0,name="DamageTaken",type="INC",value=25}}}},"  if 75% of Curse Duration expired "}
> c["Enemies Frozen by you take 20% increased Damage"]={{[1]={flags=0,keywordFlags=0,name="EnemyModifier",type="LIST",value={mod={[1]={type="Condition",var="Frozen"},flags=0,keywordFlags=0,name="DamageTaken",type="INC",value=20}}}},nil}
> c["Enemies Hindered by you take 10% increased Chaos Damage"]={{[1]={flags=0,keywordFlags=0,name="EnemyModifier",type="LIST",value={mod={[1]={type="Condition",var="Hindered"},flags=0,keywordFlags=0,name="ChaosDamageTaken",type="INC",value=10}}}},nil}
9015,9017c9016,9018
< c["Enemies Ignited by you have -10% to Fire Resistance"]={{[1]={[1]={actor="enemy",type="ActorCondition",var="Ignited"},flags=0,keywordFlags=0,name="EnemyModifier",type="LIST",value={mod={flags=0,keywordFlags=0,name="FireResist",type="BASE",value=-10}}}},nil}
< c["Enemies Ignited by you have 15% of Physical Damage they deal converted to Fire Enemies Shocked by you have 15% of Physical Damage they deal converted to Lightning"]={nil,"Enemies Ignited by you have 15% of Physical Damage they deal converted to Fire Enemies Shocked by you have 15% of Physical Damage they deal converted to Lightning "}
< c["Enemies Ignited by you have 15% of Physical Damage they deal converted to Fire"]={nil,"Enemies Ignited by you have 15% of Physical Damage they deal converted to Fire "}
---
> c["Enemies Ignited by you have -10% to Fire Resistance"]={{[1]={flags=0,keywordFlags=0,name="EnemyModifier",type="LIST",value={mod={[1]={type="Condition",var="Ignited"},flags=0,keywordFlags=0,name="FireResist",type="BASE",value=-10}}}},nil}
> c["Enemies Ignited by you have 15% of Physical Damage they deal converted to Fire Enemies Shocked by you have 15% of Physical Damage they deal converted to Lightning"]={{[1]={flags=0,keywordFlags=0,name="EnemyModifier",type="LIST",value={mod={[1]={type="Condition",var="Ignited"},flags=0,keywordFlags=0,name="PhysicalDamageConvertToFire",type="BASE",value=15}}}},"  they deal  Enemies Shocked by you have 15% of Physical Damage they deal converted to Lightning "}
> c["Enemies Ignited by you have 15% of Physical Damage they deal converted to Fire"]={{[1]={flags=0,keywordFlags=0,name="EnemyModifier",type="LIST",value={mod={[1]={type="Condition",var="Ignited"},flags=0,keywordFlags=0,name="PhysicalDamageConvertToFire",type="BASE",value=15}}}},"  they deal  "}
9027,9028c9028,9029
< c["Enemies Poisoned by you have -5% to Chaos Resistance"]={{[1]={[1]={actor="enemy",type="ActorCondition",var="Poisoned"},flags=0,keywordFlags=0,name="EnemyModifier",type="LIST",value={mod={flags=0,keywordFlags=0,name="ChaosResist",type="BASE",value=-5}}}},nil}
< c["Enemies Shocked by you have 15% of Physical Damage they deal converted to Lightning"]={nil,"Enemies Shocked by you have 15% of Physical Damage they deal converted to Lightning "}
---
> c["Enemies Poisoned by you have -5% to Chaos Resistance"]={{[1]={flags=0,keywordFlags=0,name="EnemyModifier",type="LIST",value={mod={[1]={type="Condition",var="Poisoned"},flags=0,keywordFlags=0,name="ChaosResist",type="BASE",value=-5}}}},nil}
> c["Enemies Shocked by you have 15% of Physical Damage they deal converted to Lightning"]={{[1]={flags=0,keywordFlags=0,name="EnemyModifier",type="LIST",value={mod={[1]={type="Condition",var="Shocked"},flags=0,keywordFlags=0,name="PhysicalDamageConvertToLightning",type="BASE",value=15}}}},"  they deal  "}
9132a9134,9138
> c["Energy Shield starts at zero Cannot Recharge or Regenerate Energy Shield Lose 5% of Energy Shield per second Life Leech effects are not removed at Full Life Life Leech effects Recover Energy Shield instead while on Full Life"]={nil,"Energy Shield starts at zero Cannot Recharge or Regenerate Energy Shield Lose 5% of Energy Shield per second Life Leech effects are not removed at Full Life Life Leech effects Recover Energy Shield instead while on Full Life "}
> c["Energy Shield starts at zero Cannot Recharge or Regenerate Energy Shield Lose 5% of Energy Shield per second Life Leech effects are not removed at Full Life"]={nil,"Energy Shield starts at zero Cannot Recharge or Regenerate Energy Shield Lose 5% of Energy Shield per second Life Leech effects are not removed at Full Life "}
> c["Energy Shield starts at zero Cannot Recharge or Regenerate Energy Shield Lose 5% of Energy Shield per second"]={nil,"Energy Shield starts at zero Cannot Recharge or Regenerate Energy Shield Lose 5% of Energy Shield per second "}
> c["Energy Shield starts at zero Cannot Recharge or Regenerate Energy Shield"]={nil,"Energy Shield starts at zero Cannot Recharge or Regenerate Energy Shield "}
> c["Energy Shield starts at zero"]={nil,"Energy Shield starts at zero "}
10221a10228
> c["Life Leech effects Recover Energy Shield instead while on Full Life"]={{[1]={[1]={type="Condition",var="FullLife"},[2]={type="Condition",var="LeechingLife"},flags=0,keywordFlags=0,name="ImmortalAmbition",type="FLAG",value=true}},nil}
10284a10292
> c["Lose 5% of Energy Shield per second"]={{[1]={[1]={percent=5,stat="EnergyShield",type="PercentStat"},flags=0,keywordFlags=0,name="EnergyShieldDegen",type="BASE",value=1}},nil}
10739,10741c10747,10748
< c["Nearby Enemies have 10% reduced Stun and Block Recovery Hits against Nearby Enemies have 50% increased Critical Strike Chance"]={nil,"Nearby Enemies have 10% reduced Stun and Block Recovery Hits against Nearby Enemies have 50% increased Critical Strike Chance "}
< c["Nearby Enemies have 10% reduced Stun and Block Recovery"]={nil,"Nearby Enemies have 10% reduced Stun and Block Recovery "}
< c["Nearby Enemies have 100% reduced Life Regeneration rate"]={nil,"Nearby Enemies have 100% reduced Life Regeneration rate "}
---
> c["Nearby Enemies have 10% reduced Stun and Block Recovery"]={{[1]={flags=0,keywordFlags=0,name="EnemyModifier",type="LIST",value={mod={flags=0,keywordFlags=0,name="StunRecovery",type="INC",value=-10}}}},nil}
> c["Nearby Enemies have 100% reduced Life Regeneration rate"]={{[1]={flags=0,keywordFlags=0,name="EnemyModifier",type="LIST",value={mod={flags=0,keywordFlags=0,name="Life",type="INC",value=-100}}}},"  Regeneration rate "}
10745c10752
< c["Nearby Enemies have 25% reduced Life Regeneration rate"]={nil,"Nearby Enemies have 25% reduced Life Regeneration rate "}
---
> c["Nearby Enemies have 25% reduced Life Regeneration rate"]={{[1]={flags=0,keywordFlags=0,name="EnemyModifier",type="LIST",value={mod={flags=0,keywordFlags=0,name="Life",type="INC",value=-25}}}},"  Regeneration rate "}
10750,10751c10757,10758
< c["Nearby Enemies have Fire, Cold and Lighting Exposure while you have Phasing, applying -15% to those Resistances Nearby Enemies have 15% less Accuracy Rating while you have Phasing"]={nil,"Nearby Enemies have Fire, Cold and Lighting Exposure while you have Phasing, applying -15% to those Resistances Nearby Enemies have 15% less Accuracy Rating while you have Phasing "}
< c["Nearby Enemies have Fire, Cold and Lighting Exposure while you have Phasing, applying -15% to those Resistances"]={nil,"Nearby Enemies have Fire, Cold and Lighting Exposure while you have Phasing, applying -15% to those Resistances "}
---
> c["Nearby Enemies have Fire, Cold and Lighting Exposure while you have Phasing, applying -15% to those Resistances Nearby Enemies have 15% less Accuracy Rating while you have Phasing"]={nil,"Fire, Cold and Lighting Exposure while you have Phasing, applying -15% to those Resistances Nearby Enemies have 15% less Accuracy Rating while you have Phasing "}
> c["Nearby Enemies have Fire, Cold and Lighting Exposure while you have Phasing, applying -15% to those Resistances"]={nil,"Fire, Cold and Lighting Exposure while you have Phasing, applying -15% to those Resistances "}
10755c10762
< c["Nearby Enemies have Lightning Resistance equal to yours"]={nil,"Nearby Enemies have Lightning Resistance equal to yours "}
---
> c["Nearby Enemies have Lightning Resistance equal to yours"]={nil,"Lightning Resistance equal to yours "}
10763c10770
< c["Nearby enemies have -30% to Critical Strike Multiplier"]={nil,"Nearby enemies have -30% to Critical Strike Multiplier "}
---
> c["Nearby enemies have -30% to Critical Strike Multiplier"]={{[1]={flags=0,keywordFlags=0,name="EnemyModifier",type="LIST",value={mod={flags=0,keywordFlags=0,name="CritMultiplier",type="BASE",value=-30}}}},nil}

```