### PR TITLE
Escape file names in URLs the updater visits

### DIFF
--- a/UpdateCheck.lua
+++ b/UpdateCheck.lua
@@ -19,8 +19,8 @@ local function downloadFileText(source, file)
 		end
 		local text = ""
 		local easy = curl.easy()
-		local escaped_url = source..easy:escape(file)
-		easy:setopt_url(escaped_url)
+		local escapedUrl = source..easy:escape(file)
+		easy:setopt_url(escapedUrl)
 		easy:setopt(curl.OPT_ACCEPT_ENCODING, "")
 		if proxyURL then
 			easy:setopt(curl.OPT_PROXY, proxyURL)


### PR DESCRIPTION
Preparatory update for 2.0.0.

With the runtime files no longer being located in a zip file, whitespace is file names like `Path of Building.exe` becomes an issue.
This PR ensures that file names will always be URL safe.
I've taken care to test this PR in various update scenarios, including updating the runtime, vendored libraries and the updater itself.

My main motivation for modifying the downloader function signatures is that string splitting/slicing in Lua is painful.
Since there are no more zip files in this repo to be downloaded, I'd like to remove the respective parts from the updater in a future PR.