### PR TITLE
Fix: BallistaLimit with (Replica) Iron Commander

### DIFF
--- a/Modules/CalcPerform.lua
+++ b/Modules/CalcPerform.lua
@@ -690,11 +690,6 @@ function calcs.perform(env)
 	end
 
 	for _, activeSkill in ipairs(env.player.activeSkillList) do
-		if activeSkill.skillFlags.totem then
-			local limit = env.player.mainSkill.skillModList:Sum("BASE", env.player.mainSkill.skillCfg, "ActiveTotemLimit", "ActiveBallistaLimit" )
-			output.ActiveTotemLimit = m_max(limit, output.ActiveTotemLimit or 0)
-			output.TotemsSummoned = modDB:Override(nil, "TotemsSummoned") or output.ActiveTotemLimit
-		end
 		if activeSkill.skillFlags.brand then
 			local attachLimit = env.player.mainSkill.skillModList:Sum("BASE", env.player.mainSkill.skillCfg, "BrandsAttachedLimit")
 			if activeSkill.activeEffect.grantedEffect.name == "Arcanist Brand" then
@@ -1685,6 +1680,14 @@ function calcs.perform(env)
 		doActorMisc(env, env.minion)
 	end
 	doActorMisc(env, env.enemy)
+
+	for _, activeSkill in ipairs(env.player.activeSkillList) do
+		if activeSkill.skillFlags.totem then
+			local limit = env.player.mainSkill.skillModList:Sum("BASE", env.player.mainSkill.skillCfg, "ActiveTotemLimit", "ActiveBallistaLimit" )
+			output.ActiveTotemLimit = m_max(limit, output.ActiveTotemLimit or 0)
+			output.TotemsSummoned = modDB:Override(nil, "TotemsSummoned") or output.ActiveTotemLimit
+		end
+	end
 
 	-- Apply exposures
 	for _, element in pairs({"Fire", "Cold", "Lightning"}) do


### PR DESCRIPTION
This PR fixes the calculation for the amount of ballistas summoned while wielding any type of Iron Commander. #2269 

Test PoB: https://pastebin.com/zEWqd9zY with 28 active ballistas.

**Before**
![beforeFix](https://user-images.githubusercontent.com/54453318/109415987-fd45fe00-79bb-11eb-9ec6-4265d0453e9a.png)

**After**
![afterFix](https://user-images.githubusercontent.com/54453318/109416008-164eaf00-79bc-11eb-8acf-1e23867c917d.png)

The calculation for activeTotemLimit happens too early in CalcPerform.lua thats why bonuses from Hierophant's Ritual of Awakening or the Iron Wood notable only took +1 summoned totems/ballistas into account that are found in the skill-tree.

