### PR TITLE
Fix: remove 'add bench craft' options from items that cannot be bench crafted

### DIFF
--- a/Classes/ItemsTab.lua
+++ b/Classes/ItemsTab.lua
@@ -2101,7 +2101,7 @@ function ItemsTabClass:AddCustomModifierToDisplayItem()
 			end)
 		end
 	end
-	if self.displayItem.base.subType ~= "Abyss" or (self.displayItem.type ~= "Jewel" and self.displayItem.type ~= "Flask") then
+	if self.displayItem.type ~= "Jewel" then
 		t_insert(sourceList, { label = "Crafting Bench", sourceId = "MASTER" })
 	end
 	if self.displayItem.type ~= "Jewel" and self.displayItem.type ~= "Flask" then


### PR DESCRIPTION
This PR fixes an (unwanted) interaction in the crafting menu that could reliably crash Path of Building. It removes the bench craft option for any jewel type.

![Path_of_Building_8UbO6t2zBK](https://user-images.githubusercontent.com/54453318/109430621-97c93000-7a02-11eb-96ab-70a358cd1c19.png)

To reproduce this error: Craft an item, select any type of  jewel, for example a cluster jewel. Press 'Add modifier'. Then with the source being the bench craft, click in the modifier section. Can take up to 10+ seconds and several clicks.

Afaik
Jewels cannot be bench nor essence crafted.
Flasks can be bench crafted (catarina) but not essence crafted.

'if self.displayItem.base.subType ~= "Abyss" or (self.displayItem.type ~= "Jewel" and self.displayItem.type ~= "Flask") then'

![Code_pMZ4hGJdzl](https://user-images.githubusercontent.com/54453318/109430761-38b7eb00-7a03-11eb-8862-de5c9ec14742.png)

This condition always evaluated to 'true' apart from when the item was an actual abyss jewel, which then in turn enabled the bench crafting option with an empty craft list.

https://pastebin.com/WxMKt1WU for testing purposes.