### PR TITLE
Fixes Cast Rate for Self-Cast Skills that have Cooldown & Display DPS

### DIFF
--- a/Data/SkillStatMap.lua
+++ b/Data/SkillStatMap.lua
@@ -177,7 +177,7 @@ return {
 	mod("AreaOfEffect", "INC", nil, 0, 0, { type = "Condition", var = "DualWielding", neg = true })
 },
 ["base_spell_repeat_count"] = {
-	skill("repeatCount", nil),
+	mod("RepeatCount", "BASE", nil),
 },
 ["display_minion_monster_level"] = {
 	skill("minionLevel", nil),

--- a/Modules/CalcOffence.lua
+++ b/Modules/CalcOffence.lua
@@ -1208,12 +1208,14 @@ function calcs.offence(env, actor, activeSkill)
 				-- Self-cast skill; apply action speed
 				output.Speed = output.Speed * globalOutput.ActionSpeedMod
 				output.CastRate = output.Speed
-				skillFlags.notAverage = true
-				skillFlags.showAverage = false
-				skillData.showAverage = false
 			end
 			if output.Cooldown then
 				output.Speed = m_min(output.Speed, 1 / output.Cooldown)
+			end
+			if output.Cooldown and skillFlags.selfCast then
+				skillFlags.notAverage = true
+				skillFlags.showAverage = false
+				skillData.showAverage = false
 			end
 			output.Speed = m_min(output.Speed, data.misc.ServerTickRate)
 			if output.Speed == 0 then 

--- a/Modules/CalcOffence.lua
+++ b/Modules/CalcOffence.lua
@@ -1204,14 +1204,13 @@ function calcs.offence(env, actor, activeSkill)
 			local more = skillModList:More(cfg, "Speed")
 			output.Speed = 1 / baseTime * round((1 + inc/100) * more, 2)
 			output.CastRate = output.Speed
-			output.Repeats = 1
+			output.Repeats = 1 + (skillData.repeatCount or 0)
 			if skillFlags.selfCast then
 				-- Self-cast skill; apply action speed
 				output.Speed = output.Speed * globalOutput.ActionSpeedMod
 				output.CastRate = output.Speed
 			end
 			if output.Cooldown then
-				output.Repeats = output.Repeats + skillData.repeatCount
 				output.Speed = m_min(output.Speed, 1 / output.Cooldown * output.Repeats)
 			end
 			if output.Cooldown and skillFlags.selfCast then

--- a/Modules/CalcOffence.lua
+++ b/Modules/CalcOffence.lua
@@ -1204,13 +1204,15 @@ function calcs.offence(env, actor, activeSkill)
 			local more = skillModList:More(cfg, "Speed")
 			output.Speed = 1 / baseTime * round((1 + inc/100) * more, 2)
 			output.CastRate = output.Speed
+			output.Repeats = 1
 			if skillFlags.selfCast then
 				-- Self-cast skill; apply action speed
 				output.Speed = output.Speed * globalOutput.ActionSpeedMod
 				output.CastRate = output.Speed
 			end
 			if output.Cooldown then
-				output.Speed = m_min(output.Speed, 1 / output.Cooldown)
+				output.Repeats = output.Repeats + skillData.repeatCount
+				output.Speed = m_min(output.Speed, 1 / output.Cooldown * output.Repeats)
 			end
 			if output.Cooldown and skillFlags.selfCast then
 				skillFlags.notAverage = true
@@ -1235,7 +1237,10 @@ function calcs.offence(env, actor, activeSkill)
 				if output.Cooldown and (1 / output.Cooldown) < output.CastRate then
 					t_insert(breakdown.Speed, s_format("\n"))
 					t_insert(breakdown.Speed, s_format("1 / %.2f ^8(skill cooldown)", output.Cooldown))
-					t_insert(breakdown.Speed, s_format("= %.2f ^8(casts per second)", 1 / output.Cooldown))
+					if output.Repeats > 1 then
+						t_insert(breakdown.Speed, s_format("x %d ^8(repeat count)", output.Repeats))
+					end
+					t_insert(breakdown.Speed, s_format("= %.2f ^8(casts per second)", output.Repeats / output.Cooldown))
 					t_insert(breakdown.Speed, s_format("\n"))
 					t_insert(breakdown.Speed, s_format("= %.2f ^8(lower of cast rates)", output.Speed))
 				end

--- a/Modules/CalcOffence.lua
+++ b/Modules/CalcOffence.lua
@@ -1204,7 +1204,7 @@ function calcs.offence(env, actor, activeSkill)
 			local more = skillModList:More(cfg, "Speed")
 			output.Speed = 1 / baseTime * round((1 + inc/100) * more, 2)
 			output.CastRate = output.Speed
-			output.Repeats = 1 + (skillData.repeatCount or 0)
+			output.Repeats = 1 + (skillModList:Sum("BASE", cfg, "RepeatCount") or 0)
 			if skillFlags.selfCast then
 				-- Self-cast skill; apply action speed
 				output.Speed = output.Speed * globalOutput.ActionSpeedMod


### PR DESCRIPTION
Fixes self-cast skills not have DPS if linked to an unsatisfied trigger or a support gem that enforces "showAverage" flag.

To Test: make a new build and add Freezing Pulse and Cast on Crit as the skills. See how on `dev` you don't get a DPS in left-hand-side bar or in Calcs.

Retest same setup with this PR and see how it works now.

Additionally, you can see the Cast Rate fix in play for skills like Frost Bomb being incorrect since prior to this PR their cooldown is not considered as a limiting factor to how fast they can be cast.