### PR TITLE
Updated ServerTickRate; Added ServerTickTime

### DIFF
--- a/Modules/Data.lua
+++ b/Modules/Data.lua
@@ -262,7 +262,8 @@ data.keystones = {
 }
 
 data.misc = { -- magic numbers
-	ServerTickRate = 30,
+	ServerTickTime = 0.033,
+	ServerTickRate = 1 / 0.033,
 	TemporalChainsEffectCap = 75,
 	DamageReductionCap = 90,
 	MaxResistCap = 90,


### PR DESCRIPTION
Previously ServerTickRate was set to `30`. Per GGG the ServerTickTime is actually hardcoded to 0.33 exactly, making the ServerTickRate = 1/0.033 or 30.303030 (repeating).