### PR TITLE
Fix Physical Damage Reduction able to go below zero

### DIFF
--- a/Modules/Build.lua
+++ b/Modules/Build.lua
@@ -326,7 +326,7 @@ function buildMode:Init(dbFileName, buildName, buildXML, convertBuild)
 		{ stat = "ProjectileEvadeChance", label = "Projectile Evade Chance", fmt = "d%%", condFunc = function(v,o) return v > 0 and o.MeleeEvadeChance ~= o.ProjectileEvadeChance end },
 		{ stat = "Armour", label = "Armour", fmt = "d", compPercent = true },
 		{ stat = "Spec:ArmourInc", label = "%Inc Armour from Tree", fmt = "d%%" },
-		{ stat = "PhysicalDamageReduction", label = "Phys. Damage Reduction", fmt = "d%%" },
+		{ stat = "PhysicalDamageReduction", label = "Phys. Damage Reduction", fmt = "d%%", condFunc = function() return true end },
 		{ stat = "EffectiveMovementSpeedMod", label = "Movement Speed Modifier", fmt = "+d%%", mod = true, condFunc = function() return true end },
 		{ stat = "BlockChance", label = "Block Chance", fmt = "d%%" },
 		{ stat = "SpellBlockChance", label = "Spell Block Chance", fmt = "d%%" },

--- a/Modules/CalcDefence.lua
+++ b/Modules/CalcDefence.lua
@@ -809,6 +809,9 @@ function calcs.defence(env, actor)
 				takenMore = takenMore * modDB:More(nil, "ElementalDamageTakenOverTime")
 			end
 			local resist = modDB:Flag(nil, "SelfIgnore"..damageType.."Resistance") and 0 or output[damageType.."Resist"]
+			if damageType == "Physical" then
+				resist = m_max(resist, 0)
+			end
 			output[damageType.."TakenDotMult"] = (1 - resist / 100) * (1 + takenInc / 100) * takenMore
 			if breakdown then
 				breakdown[damageType.."TakenDotMult"] = { }
@@ -1021,6 +1024,7 @@ function calcs.defence(env, actor)
 							armourReduct = calcs.armourReductionDouble(output.Armour, damage * portion / 100, doubleArmourChance)
 							resist = m_min(output.DamageReductionMax, resist + armourReduct)
 						end
+						resist = m_max(resist, 0)
 					else
 						portionArmour = 100 - resist
 						armourReduct = calcs.armourReductionDouble(output.Armour, damage * portion / 100 * portionArmour / 100, doubleArmourChance)


### PR DESCRIPTION
Fix phys. damage reduction going below zero. Also show phys damage reduction if it is zero (to avoid confusion and should be a pretty rare case)

As per: https://www.reddit.com/r/pathofexile/comments/fcojvn/question_regarding_enemies_have_to_total_physical/fjcel7v/

With "You are crushed" (and no other source of phys dmg reduction:
![image](https://user-images.githubusercontent.com/3247221/110251850-2cbeb280-7f48-11eb-9b4e-03fb29a5e5dc.png)
![image](https://user-images.githubusercontent.com/3247221/110251857-35af8400-7f48-11eb-9f88-0ae9c2edafd2.png)

With "You are crushed" and four endurance charges:
![image](https://user-images.githubusercontent.com/3247221/110251892-60014180-7f48-11eb-8e28-20aaf2230578.png)
![image](https://user-images.githubusercontent.com/3247221/110251898-6a234000-7f48-11eb-9018-c39549a9e0f0.png)

With "you are crushed", four endurance charges and 40% increased physical damage taken:
![image](https://user-images.githubusercontent.com/3247221/110251946-ace51800-7f48-11eb-9891-cd13a4d97baa.png)

Without "you are crushed" and some armour: 
![image](https://user-images.githubusercontent.com/3247221/110251983-e027a700-7f48-11eb-9b53-d8bb64649073.png)


