### PR TITLE
Add admiral lowest resist

### DIFF
--- a/Modules/CalcBreakdown.lua
+++ b/Modules/CalcBreakdown.lua
@@ -112,12 +112,10 @@ end
 function breakdown.effMult(damageType, resist, pen, taken, mult, takenMore, sourceRes)
 	local out = { }
 	local resistForm = (damageType == "Physical") and "physical damage reduction" or "resistance"
-	if resist ~= 0 then
-		if sourceRes and sourceRes ~= 0 then
-			t_insert(out, s_format("Enemy %s: %d%% ^8(%s)", resistForm, resist, sourceRes))
-		else
-			t_insert(out, s_format("Enemy %s: %d%%", resistForm, resist))
-		end
+	if sourceRes and sourceRes ~= 0 and sourceRes ~= damageType then
+		t_insert(out, s_format("Enemy %s: %d%% ^8(%s)", resistForm, resist, sourceRes))
+	elseif resist ~= 0 then
+		t_insert(out, s_format("Enemy %s: %d%%", resistForm, resist))
 	end
 	if pen ~= 0 then
 		t_insert(out, "Effective resistance:")

--- a/Modules/CalcOffence.lua
+++ b/Modules/CalcOffence.lua
@@ -1906,34 +1906,42 @@ function calcs.offence(env, actor, activeSkill)
 							local armourReduction = calcs.armourReductionF(enemyArmour, damageTypeHitAvg)
 							resist = m_max(0, enemyDB:Sum("BASE", nil, "PhysicalDamageReduction") + skillModList:Sum("BASE", cfg, "EnemyPhysicalDamageReduction") + armourReduction)
 						else
-							resist = enemyDB:Sum("BASE", nil, damageType.."Resist")
-							if isElemental[damageType] then
+							if (skillModList:Flag(cfg, "ChaosDamageUsesLowestResistance") and damageType == "Chaos") or 
+							   (skillModList:Flag(cfg, "ElementalDamageUsesLowestResistance") and isElemental[damageType]) then
+								-- Default to using the current damage type 
+								local elementUsed = damageType
+								if isElemental[damageType] then
+									resist = m_min(enemyDB:Sum("BASE", nil, damageType.."Resist", "ElementalResist") * calcLib.mod(enemyDB, nil, damageType.."Resist", "ElementalResist"), data.misc.EnemyMaxResist)
+								elseif damageType == "Chaos" then
+									resist = m_min(enemyDB:Sum("BASE", nil, "ChaosResist") * calcLib.mod(enemyDB, nil, "ChaosResist"), data.misc.EnemyMaxResist)
+								end
+								-- Find the lowest resist of all the elements and use that if it's lower
+								for _, eleDamageType in ipairs(dmgTypeList) do
+									if isElemental[eleDamageType] and useThisResist(eleDamageType) and damageType ~= eleDamageType then
+										local currentElementResist = m_min(enemyDB:Sum("BASE", nil, eleDamageType.."Resist", "ElementalResist") * calcLib.mod(enemyDB, nil, eleDamageType.."Resist", "ElementalResist"), data.misc.EnemyMaxResist)
+										-- If it's explicitly lower, then use the resist and update which element we're using to account for penetration
+										if resist > currentElementResist then
+											resist = currentElementResist
+											elementUsed = eleDamageType
+										end
+									end
+								end
+								-- Update the penetration based on the element used
+								if isElemental[elementUsed] then
+									pen = skillModList:Sum("BASE", cfg, elementUsed.."Penetration", "ElementalPenetration")
+								elseif elementUsed == "Chaos" then
+									pen = skillModList:Sum("BASE", cfg, "ChaosPenetration")
+								end
+								sourceRes = elementUsed
+							elseif isElemental[damageType] then
+								resist = enemyDB:Sum("BASE", nil, damageType.."Resist")
 								local base = resist + enemyDB:Sum("BASE", nil, "ElementalResist")
 								resist = base * calcLib.mod(enemyDB, nil, damageType.."Resist")
 								pen = skillModList:Sum("BASE", cfg, damageType.."Penetration", "ElementalPenetration")
 								takenInc = takenInc + enemyDB:Sum("INC", cfg, "ElementalDamageTaken")
 							elseif damageType == "Chaos" then
+								resist = enemyDB:Sum("BASE", nil, damageType.."Resist")
 								pen = skillModList:Sum("BASE", cfg, "ChaosPenetration")
-								if skillModList:Flag(cfg, "ChaosDamageUsesLowestResistance") then
-									-- Default to using Chaos
-									local elementUsed = "Chaos"
-									-- Find the lowest resist of all the elements and use that if it's lower than chaos
-									for _, damageTypeForChaos in ipairs(dmgTypeList) do
-										if isElemental[damageTypeForChaos] and useThisResist(damageTypeForChaos) then
-											local elementalResistForChaos = enemyDB:Sum("BASE", nil, damageTypeForChaos.."Resist")
-											local base = elementalResistForChaos + enemyDB:Sum("BASE", dotTypeCfg, "ElementalResist")
-											local currentElementResist = base * calcLib.mod(enemyDB, nil, damageTypeForChaos.."Resist")
-											-- If it's explicitly lower, then use the resist and update which element we're using to account for penetration
-											if resist > currentElementResist then
-												resist = currentElementResist
-												elementUsed = damageTypeForChaos
-											end
-										end
-									end
-									-- Update the penetration based on the element used
-									pen = skillModList:Sum("BASE", cfg, elementUsed.."Penetration", "ElementalPenetration")
-									sourceRes = elementUsed
-								end
 							end
 							resist = m_min(resist, data.misc.EnemyMaxResist)
 						end
@@ -1958,10 +1966,10 @@ function calcs.offence(env, actor, activeSkill)
 						if env.mode == "CALCS" then
 							output[damageType.."EffMult"] = effMult
 						end
-						if pass == 2 and breakdown and effMult ~= 1 and skillModList:Flag(cfg, isElemental[damageType] and "CannotElePenIgnore" or nil) then
+						if pass == 2 and breakdown and (effMult ~= 1 or sourceRes ~= 0) and skillModList:Flag(cfg, isElemental[damageType] and "CannotElePenIgnore" or nil) then
 							t_insert(breakdown[damageType], s_format("x %.3f ^8(effective DPS modifier)", effMult))
 							breakdown[damageType.."EffMult"] = breakdown.effMult(damageType, resist, 0, takenInc, effMult, takenMore, sourceRes)
-						elseif pass == 2 and breakdown and effMult ~= 1 then
+						elseif pass == 2 and breakdown and (effMult ~= 1 or sourceRes ~= 0) then
 							t_insert(breakdown[damageType], s_format("x %.3f ^8(effective DPS modifier)", effMult))
 							breakdown[damageType.."EffMult"] = breakdown.effMult(damageType, resist, pen, takenInc, effMult, takenMore, sourceRes)
 						end

--- a/Modules/ModParser.lua
+++ b/Modules/ModParser.lua
@@ -2094,6 +2094,7 @@ local specialModList = {
 	["enemies take (%d+)%% increased elemental damage from your hits for"] = { flag("Condition:CanElementalWithered") },
 	["each withered you have inflicted on them"] = { },
 	["your hits cannot penetrate or ignore elemental resistances"] = { flag("CannotElePenIgnore") },
+	["elemental damage you deal with hits is resisted by lowest elemental resistance instead"] = { flag("ElementalDamageUsesLowestResistance") },
 	["you take (%d+) chaos damage per second for 3 seconds on kill"] = function(num) return { mod("ChaosDegen", "BASE", num, { type = "Condition", var = "KilledLast3Seconds" }) } end,
 	["regenerate (%d+) life over 1 second for each spell you cast"] = function(num) return { mod("LifeRegen", "BASE", num, { type = "Condition", var = "CastLast1Seconds" }) } end,
 	["and nearby allies regenerate (%d+) life per second"] = function(num) return { mod("LifeRegen", "BASE", num, { type = "Condition", var = "KilledPosionedLast2Seconds" }) } end,


### PR DESCRIPTION
Adds support for admiral lowest resist mod. Also refactors code a little so that Hexblast works with same code.

Hexblast linked with added cold/lightning without EE on Sirus:
![image](https://user-images.githubusercontent.com/3247221/110397263-23604380-8037-11eb-9164-070c4c3a3f2a.png)

Hexblast linked with added cold/lightning with EE hit as fire on Sirus:
![image](https://user-images.githubusercontent.com/3247221/110397421-720ddd80-8037-11eb-9e8e-337f57af46df.png)

Ground slam with added cold/lightning without EE on Sirus:
![image](https://user-images.githubusercontent.com/3247221/110397525-a08bb880-8037-11eb-9957-72f370dac1e9.png)

Ground slam with added cold/lightning with EE hit as cold on Sirus:
![image](https://user-images.githubusercontent.com/3247221/110397593-bbf6c380-8037-11eb-9860-9d158580221b.png)

Ground slam with added cold/lightning with EE hit as cold on Sirus with The Admiral equipped:
![image](https://user-images.githubusercontent.com/3247221/110397665-e9437180-8037-11eb-8c6d-666ed64a6a90.png)
