### PR TITLE
Add support for Flickershade spectre chaos damage conversion

### DIFF
--- a/Data/Spectres.lua
+++ b/Data/Spectres.lua
@@ -3067,6 +3067,6 @@ minions["Metadata/Monsters/Maligaro/SecretDesecrateMonster"] = {
 	},
 	modList = {
 		-- MonsterOneThirdDamageTaken [base_damage_taken_+% = -67]
-		-- MonsterConvertToChaos1 [base_physical_damage_%_to_convert_to_chaos = 50]
+		mod("PhysicalDamageConvertToChaos", "BASE", 50), -- MonsterConvertToChaos1 [base_physical_damage_%_to_convert_to_chaos = 50]
 	},
 }

--- a/Export/Minions/modmap.ini
+++ b/Export/Minions/modmap.ini
@@ -5,6 +5,8 @@ mod("ProjectileCount", "BASE", 2)
 mod("PhysicalDamageConvertToFire", "BASE", 50)
 [MonsterConvertToColdDamage2]
 mod("PhysicalDamageConvertToCold", "BASE", 50)
+[MonsterConvertToChaos1]
+mod("PhysicalDamageConvertToChaos", "BASE", 50)
 [MonsterPhysicalAddedAsColdSkeletonMaps]
 mod("PhysicalDamageGainAsCold", "BASE", 100)
 [MonsterCurseCastSpeedPenalty]


### PR DESCRIPTION
Seems like we can use `SkillStatMap.lua` for these mods instead of adding them manually, but this works for now