### PR TITLE
Fix Mirage Archer Duration Flag

### DIFF
--- a/src/Data/Skills/sup_dex.lua
+++ b/src/Data/Skills/sup_dex.lua
@@ -2629,9 +2629,6 @@ skills["SupportGemMirageArcher"] = {
 			mod("MirageArcherMaxCount", "BASE", 1),
 		},
 	},
-	baseFlags = {
-		duration = true,
-	},
 	baseMods = {
 	},
 	qualityStats = {

--- a/src/Export/Skills/sup_dex.txt
+++ b/src/Export/Skills/sup_dex.txt
@@ -282,7 +282,6 @@ local skills, mod, flag, skill = ...
 #mods
 
 #skill SupportGemMirageArcher
-#flags duration
 	statMap = {
 		["support_mirage_archer_base_duration"] = {
 			mod("MirageArcherDuration", "BASE", nil),


### PR DESCRIPTION
Removed duration flag from Mirage Archer as it adds it natively anyways from the Mirage Archer Gem Support

```
	requireSkillTypes = { SkillType.SkillCanMirageArcher, },
	addSkillTypes = { SkillType.Duration, },
	excludeSkillTypes = { SkillType.Vaal, SkillType.Totem, SkillType.Trap, SkillType.Mine, SkillType.Minion, },
```