### PR TITLE
General's Cry: keep manacost & cooldown information

### DIFF
--- a/src/Modules/CalcOffence.lua
+++ b/src/Modules/CalcOffence.lua
@@ -3727,7 +3727,8 @@ function calcs.offence(env, actor, activeSkill)
 			env.player.output = newEnv.player.output
 
 			-- Make any necessary corrections to output
-			env.player.output.ManaCost = 0
+			env.player.output.ManaCost = output.ManaCost
+			env.player.output.Cooldown = output.Cooldown
 
 			-- Re-link over the breakdown (if present)
 			if newEnv.player.breakdown then


### PR DESCRIPTION
GC's mana cost and cooldown are important information that shouldn't be left out.

The cooldown is a direct impact on long-term dps and is especially important for non-channeled skills that don't rely on attack speed with GC. It's also a nice thing to know if your charge generation depends on GC via the cluster node "Mob Mentality", or if you use "Escalation" for life recovery on warcry, etc.. many things depend on cooldown.

Mana cost is less important but still, if you are tight on mana, it's important to know if you have enough to cast GC.

![image](https://user-images.githubusercontent.com/67038113/113521791-05392500-959c-11eb-98ce-f26fc7092f73.png)

@Nostrademous 