### PR TITLE
fix explosive arrows maxium explosion radius

### DIFF
--- a/src/Data/Skills/act_dex.lua
+++ b/src/Data/Skills/act_dex.lua
@@ -3103,9 +3103,9 @@ skills["ExplosiveArrow"] = {
 		mod("Damage", "MORE", 100, 0, 0, { type = "SkillPart", skillPartList = { 1, 2, 3, 4, 5 } }, { type = "Multiplier", var = "ExplosiveArrowFuse", base = -100 }),
 		mod("Multiplier:ExplosiveArrowFuse", "BASE", 1, 0, 0, { type = "SkillPart", skillPart = 1 }),
 		mod("Multiplier:ExplosiveArrowFuse", "BASE", 5, 0, 0, { type = "SkillPart", skillPart = 2 }),
-		mod("Multiplier:ExplosiveArrowFuse", "BASE", 10, 0, 0, { type = "SkillPart", skillPart = 3 }),
-		mod("Multiplier:ExplosiveArrowFuse", "BASE", 15, 0, 0, { type = "SkillPart", skillPart = 4 }),
-		mod("Multiplier:ExplosiveArrowFuse", "BASE", 20, 0, 0, { type = "SkillPart", skillPart = 5 }),
+		mod("Multiplier:ExplosiveArrowFuse", "BASE", 6, 0, 0, { type = "SkillPart", skillPart = 3 }),
+		mod("Multiplier:ExplosiveArrowFuse", "BASE", 6, 0, 0, { type = "SkillPart", skillPart = 4 }),
+		mod("Multiplier:ExplosiveArrowFuse", "BASE", 6, 0, 0, { type = "SkillPart", skillPart = 5 }),
 	},
 	qualityStats = {
 		Default = {

--- a/src/Export/Skills/act_dex.txt
+++ b/src/Export/Skills/act_dex.txt
@@ -593,9 +593,9 @@ local skills, mod, flag, skill = ...
 #baseMod mod("Damage", "MORE", 100, 0, 0, { type = "SkillPart", skillPartList = { 1, 2, 3, 4, 5 } }, { type = "Multiplier", var = "ExplosiveArrowFuse", base = -100 })
 #baseMod mod("Multiplier:ExplosiveArrowFuse", "BASE", 1, 0, 0, { type = "SkillPart", skillPart = 1 })
 #baseMod mod("Multiplier:ExplosiveArrowFuse", "BASE", 5, 0, 0, { type = "SkillPart", skillPart = 2 })
-#baseMod mod("Multiplier:ExplosiveArrowFuse", "BASE", 10, 0, 0, { type = "SkillPart", skillPart = 3 })
-#baseMod mod("Multiplier:ExplosiveArrowFuse", "BASE", 15, 0, 0, { type = "SkillPart", skillPart = 4 })
-#baseMod mod("Multiplier:ExplosiveArrowFuse", "BASE", 20, 0, 0, { type = "SkillPart", skillPart = 5 })
+#baseMod mod("Multiplier:ExplosiveArrowFuse", "BASE", 6, 0, 0, { type = "SkillPart", skillPart = 3 })
+#baseMod mod("Multiplier:ExplosiveArrowFuse", "BASE", 6, 0, 0, { type = "SkillPart", skillPart = 4 })
+#baseMod mod("Multiplier:ExplosiveArrowFuse", "BASE", 6, 0, 0, { type = "SkillPart", skillPart = 5 })
 #mods
 
 #skill ShrapnelTrap


### PR DESCRIPTION
This PR fixes #2434 capping the maximum extra radius to +12

![113762001-6423a900-9718-11eb-833f-3c092f4c2487](https://user-images.githubusercontent.com/54453318/113775211-a8b74080-9728-11eb-9665-4f9278c8e150.png)

![Path_of_Building_BmmOY0CChT](https://user-images.githubusercontent.com/54453318/113775077-760d4800-9728-11eb-80ce-0acdcdab728b.png)
![Path_of_Building_sg4ERl6cqn](https://user-images.githubusercontent.com/54453318/113775099-7efe1980-9728-11eb-9ada-5860bf8b5949.png)
![Path_of_Building_kkdxx8PPqG](https://user-images.githubusercontent.com/54453318/113775120-87eeeb00-9728-11eb-9fd8-402b58832986.png)
![Path_of_Building_hEqGA7TuVR](https://user-images.githubusercontent.com/54453318/113775223-ad7bf480-9728-11eb-8b91-bf67213d028a.png)
![Path_of_Building_vdtClTxBBe](https://user-images.githubusercontent.com/54453318/113775253-b8368980-9728-11eb-9a3a-40e30c810c71.png)
