### PR TITLE
Better Skill Trigger Rate Breakdown

### DIFF
--- a/src/Modules/CalcPerform.lua
+++ b/src/Modules/CalcPerform.lua
@@ -141,103 +141,82 @@ local function calcActualTriggerRate(env, source, sourceAPS, spellCount, output,
 	if sourceAPS ~= nil then
 		output.SourceTriggerRate = sourceAPS / skillRotationImpact
 		if dualWield then
-			if #spellCount > 1 then
-				output.SourceTriggerRate, simBreakdown = calcMultiSpellRotationImpact(env, spellCount, sourceAPS)
-				if breakdown then
-					breakdown.SourceTriggerRate = {
-						s_format("(%.2f ^8(%s attacks per second)", sourceAPS * 2, source.activeEffect.grantedEffect.name),
-						s_format("/ 2) ^8(due to dual wielding)"),
-						s_format("/ %.2f ^8(simulated impact of linked spells)", sourceAPS / output.SourceTriggerRate),
-						s_format("= %.2f ^8per second", output.SourceTriggerRate),
-						s_format(""),
-						s_format("Simulation Breakdown"),
-						s_format("Simulation Duration: %.2f", simBreakdown.simTime),
-					}
-					if simBreakdown.extraSimInfo then
-						t_insert(breakdown.SourceTriggerRate, "")
-						t_insert(breakdown.SourceTriggerRate, simBreakdown.extraSimInfo)
-					end
-					breakdown.SimData = {
-						rowList = { },
-						colList = {
-							{ label = "Rate", key = "rate" },
-							{ label = "Skill Name", key = "skillName" },
-							{ label = "Slot Name", key = "slotName" },
-							{ label = "Gem Index", key = "gemIndex" },
-						},
-					}
-					for _, rateData in ipairs(simBreakdown.rates) do
-						local t = { }
-						for str in string.gmatch(rateData.name, "([^_]+)") do
-							t_insert(t, str)
-						end
-
-						local row = {
-							rate = rateData.rate,
-							skillName = t[1],
-							slotName = t[2],
-							gemIndex = t[3],
-						}
-						t_insert(breakdown.SimData.rowList, row)
-					end
+			output.SourceTriggerRate, simBreakdown = calcMultiSpellRotationImpact(env, spellCount, sourceAPS)
+			if breakdown then
+				breakdown.SourceTriggerRate = {
+					s_format("(%.2f ^8(%s attacks per second)", sourceAPS * 2, source.activeEffect.grantedEffect.name),
+					s_format("/ 2) ^8(due to dual wielding)"),
+					s_format("/ %.2f ^8(simulated impact of linked spells)", sourceAPS / output.SourceTriggerRate),
+					s_format("= %.2f ^8per second", output.SourceTriggerRate),
+					s_format(""),
+					s_format("Simulation Breakdown"),
+					s_format("Simulation Duration: %.2f", simBreakdown.simTime),
+				}
+				if simBreakdown.extraSimInfo then
+					t_insert(breakdown.SourceTriggerRate, "")
+					t_insert(breakdown.SourceTriggerRate, simBreakdown.extraSimInfo)
 				end
-			else
-				if breakdown then
-					breakdown.SourceTriggerRate = {
-						s_format("(%.2f ^8(%s attacks per second)", sourceAPS * 2, source.activeEffect.grantedEffect.name),
-						s_format("/ 2) ^8(due to dual wielding)"),
-						s_format("/ %.2f ^8(number of linked active spells to trigger)", skillRotationImpact),
-						s_format("= %.2f ^8per second", output.SourceTriggerRate),
+				breakdown.SimData = {
+					rowList = { },
+					colList = {
+						{ label = "Rate", key = "rate" },
+						{ label = "Skill Name", key = "skillName" },
+						{ label = "Slot Name", key = "slotName" },
+						{ label = "Gem Index", key = "gemIndex" },
+					},
+				}
+				for _, rateData in ipairs(simBreakdown.rates) do
+					local t = { }
+					for str in string.gmatch(rateData.name, "([^_]+)") do
+						t_insert(t, str)
+					end
+
+					local row = {
+						rate = rateData.rate,
+						skillName = t[1],
+						slotName = t[2],
+						gemIndex = t[3],
 					}
+					t_insert(breakdown.SimData.rowList, row)
 				end
 			end
 		else
-			if #spellCount > 1 then
-				output.SourceTriggerRate, simBreakdown = calcMultiSpellRotationImpact(env, spellCount, sourceAPS)
-				if breakdown then
-					breakdown.SourceTriggerRate = {
-						s_format("%.2f ^8(%s attacks per second)", sourceAPS, source.activeEffect.grantedEffect.name),
-						s_format("/ %.2f ^8(simulated impact of linked spells)", sourceAPS / output.SourceTriggerRate),
-						s_format("= %.2f ^8per second", output.SourceTriggerRate),
-						s_format(""),
-						s_format("Simulation Breakdown"),
-						s_format("Simulation Duration: %.2f", simBreakdown.simTime),
-					}
-					if simBreakdown.extraSimInfo then
-						t_insert(breakdown.SourceTriggerRate, "")
-						t_insert(breakdown.SourceTriggerRate, simBreakdown.extraSimInfo)
-					end
-					breakdown.SimData = {
-						rowList = { },
-						colList = {
-							{ label = "Rate", key = "rate" },
-							{ label = "Skill Name", key = "skillName" },
-							{ label = "Slot Name", key = "slotName" },
-							{ label = "Gem Index", key = "gemIndex" },
-						},
-					}
-					for _, rateData in ipairs(simBreakdown.rates) do
-						local t = { }
-						for str in string.gmatch(rateData.name, "([^_]+)") do
-							t_insert(t, str)
-						end
-
-						local row = {
-							rate = rateData.rate,
-							skillName = t[1],
-							slotName = t[2],
-							gemIndex = t[3],
-						}
-						t_insert(breakdown.SimData.rowList, row)
-					end
+			output.SourceTriggerRate, simBreakdown = calcMultiSpellRotationImpact(env, spellCount, sourceAPS)
+			if breakdown then
+				breakdown.SourceTriggerRate = {
+					s_format("%.2f ^8(%s attacks per second)", sourceAPS, source.activeEffect.grantedEffect.name),
+					s_format("/ %.2f ^8(simulated impact of linked spells)", sourceAPS / output.SourceTriggerRate),
+					s_format("= %.2f ^8per second", output.SourceTriggerRate),
+					s_format(""),
+					s_format("Simulation Breakdown"),
+					s_format("Simulation Duration: %.2f", simBreakdown.simTime),
+				}
+				if simBreakdown.extraSimInfo then
+					t_insert(breakdown.SourceTriggerRate, "")
+					t_insert(breakdown.SourceTriggerRate, simBreakdown.extraSimInfo)
 				end
-			else
-				if breakdown then
-					breakdown.SourceTriggerRate = {
-						s_format("%.2f ^8(%s attacks per second)", sourceAPS, source.activeEffect.grantedEffect.name),
-						s_format("/ %.2f ^8(number of linked active spells to trigger)", skillRotationImpact),
-						s_format("= %.2f ^8per second", output.SourceTriggerRate),
+				breakdown.SimData = {
+					rowList = { },
+					colList = {
+						{ label = "Rate", key = "rate" },
+						{ label = "Skill Name", key = "skillName" },
+						{ label = "Slot Name", key = "slotName" },
+						{ label = "Gem Index", key = "gemIndex" },
+					},
+				}
+				for _, rateData in ipairs(simBreakdown.rates) do
+					local t = { }
+					for str in string.gmatch(rateData.name, "([^_]+)") do
+						t_insert(t, str)
+					end
+
+					local row = {
+						rate = rateData.rate,
+						skillName = t[1],
+						slotName = t[2],
+						gemIndex = t[3],
 					}
+					t_insert(breakdown.SimData.rowList, row)
 				end
 			end
 		end


### PR DESCRIPTION
Relates to Reddit Discussion: https://www.reddit.com/r/pathofexile/comments/mkgczk/path_of_building_community_200_coc_generals_cry/gtmgbix

It just removes the `if #spellCount > 1 then` logic to always do a simulation and provide enriched breakdown