### PR TITLE
Generals Cry crash fixes

### DIFF
--- a/src/Classes/GemSelectControl.lua
+++ b/src/Classes/GemSelectControl.lua
@@ -53,15 +53,17 @@ function GemSelectClass:PopulateGemList()
 	local showAwakened = self.skillsTab.showSupportGemTypes == "AWAKENED"
 	local showNormal = self.skillsTab.showSupportGemTypes == "NORMAL"
 	for gemId, gemData in pairs(self.skillsTab.build.data.gems) do
-		if (showAwakened or showAll) and gemData.grantedEffect.plusVersionOf then
-			self.gems["Default:" .. gemId] = gemData
-		elseif showNormal or showAll then
-			if self.skillsTab.showAltQualityGems and self.skillsTab.defaultGemQuality or 0 > 0 then
-				for _, altQual in ipairs(self.skillsTab:getGemAltQualityList(gemData)) do
-					self.gems[altQual.type .. ":" .. gemId] = gemData
-				end
-			else
+		if gemData.grantedEffect and not gemData.grantedEffect.fromItem then
+			if (showAwakened or showAll) and gemData.grantedEffect.plusVersionOf then
 				self.gems["Default:" .. gemId] = gemData
+			elseif showNormal or showAll then
+				if self.skillsTab.showAltQualityGems and self.skillsTab.defaultGemQuality or 0 > 0 then
+					for _, altQual in ipairs(self.skillsTab:getGemAltQualityList(gemData)) do
+						self.gems[altQual.type .. ":" .. gemId] = gemData
+					end
+				else
+					self.gems["Default:" .. gemId] = gemData
+				end
 			end
 		end
 	end
@@ -187,7 +189,7 @@ function GemSelectClass:UpdateSortCache()
 	GlobalCache.useFullDPS = dpsField == "FullDPS"
 	local calcFunc, calcBase = self.skillsTab.build.calcsTab:GetMiscCalculator(self.build)
 	-- Check for nil because some fields may not be populated, default to 0
-	local baseDPS = (calcBase.Minion and calcBase.Minion.CombinedDPS) or (calcBase[dpsField] ~= nil and calcBase[dpsField]) or 0
+	local baseDPS = (dpsField == "FullDPS" and calcBase[dpsField] ~= nil and calcBase[dpsField]) or (calcBase.Minion and calcBase.Minion.CombinedDPS) or (calcBase[dpsField] ~= nil and calcBase[dpsField]) or 0
 
 	for gemId, gemData in pairs(self.gems) do
 		sortCache.dps[gemId] = baseDPS
@@ -209,7 +211,7 @@ function GemSelectClass:UpdateSortCache()
 				gemInstance.level = gemData.defaultLevel
 			end
 			--Calculate the impact of using this gem
-			local output = calcFunc({}, { allocNodes = true, requirementsItems = true, requirementsGems = true })
+			local output = calcFunc({}, { allocNodes = true, requirementsItems = true })
 			if oldGem then
 				gemInstance.gemData = oldGem.gemData
 				gemInstance.level = oldGem.level
@@ -217,7 +219,7 @@ function GemSelectClass:UpdateSortCache()
 				gemList[self.index] = nil
 			end
 			-- Check for nil because some fields may not be populated, default to 0
-			sortCache.dps[gemId] = (output.Minion and output.Minion.CombinedDPS) or (output[dpsField] ~= nil and output[dpsField]) or 0
+			sortCache.dps[gemId] = (dpsField == "FullDPS" and calcBase[dpsField] ~= nil and calcBase[dpsField]) or (output.Minion and output.Minion.CombinedDPS) or (output[dpsField] ~= nil and output[dpsField]) or 0
 		end
 		--Color based on the dps
 		if sortCache.dps[gemId] > baseDPS then

--- a/src/Classes/GemSelectControl.lua
+++ b/src/Classes/GemSelectControl.lua
@@ -219,7 +219,7 @@ function GemSelectClass:UpdateSortCache()
 				gemList[self.index] = nil
 			end
 			-- Check for nil because some fields may not be populated, default to 0
-			sortCache.dps[gemId] = (dpsField == "FullDPS" and calcBase[dpsField] ~= nil and calcBase[dpsField]) or (output.Minion and output.Minion.CombinedDPS) or (output[dpsField] ~= nil and output[dpsField]) or 0
+			sortCache.dps[gemId] = (dpsField == "FullDPS" and output[dpsField] ~= nil and output[dpsField]) or (output.Minion and output.Minion.CombinedDPS) or (output[dpsField] ~= nil and output[dpsField]) or 0
 		end
 		--Color based on the dps
 		if sortCache.dps[gemId] > baseDPS then

--- a/src/Classes/GemSelectControl.lua
+++ b/src/Classes/GemSelectControl.lua
@@ -53,17 +53,15 @@ function GemSelectClass:PopulateGemList()
 	local showAwakened = self.skillsTab.showSupportGemTypes == "AWAKENED"
 	local showNormal = self.skillsTab.showSupportGemTypes == "NORMAL"
 	for gemId, gemData in pairs(self.skillsTab.build.data.gems) do
-		if gemData.grantedEffect and not gemData.grantedEffect.fromItem then
-			if (showAwakened or showAll) and gemData.grantedEffect.plusVersionOf then
-				self.gems["Default:" .. gemId] = gemData
-			elseif showNormal or showAll then
-				if self.skillsTab.showAltQualityGems and self.skillsTab.defaultGemQuality or 0 > 0 then
-					for _, altQual in ipairs(self.skillsTab:getGemAltQualityList(gemData)) do
-						self.gems[altQual.type .. ":" .. gemId] = gemData
-					end
-				else
-					self.gems["Default:" .. gemId] = gemData
+		if (showAwakened or showAll) and gemData.grantedEffect.plusVersionOf then
+			self.gems["Default:" .. gemId] = gemData
+		elseif showNormal or showAll then
+			if self.skillsTab.showAltQualityGems and self.skillsTab.defaultGemQuality or 0 > 0 then
+				for _, altQual in ipairs(self.skillsTab:getGemAltQualityList(gemData)) do
+					self.gems[altQual.type .. ":" .. gemId] = gemData
 				end
+			else
+				self.gems["Default:" .. gemId] = gemData
 			end
 		end
 	end

--- a/src/Classes/PassiveTreeView.lua
+++ b/src/Classes/PassiveTreeView.lua
@@ -931,15 +931,15 @@ function PassiveTreeViewClass:AddNodeTooltip(tooltip, node, build)
 		local nodeOutput, pathOutput
 		if node.alloc then
 			-- Calculate the differences caused by deallocating this node and its dependent nodes
-			nodeOutput = calcFunc({ removeNodes = { [node] = true } }, {})
+			nodeOutput = calcFunc({ removeNodes = { [node] = true } })
 			if pathLength > 1 then
-				pathOutput = calcFunc({ removeNodes = pathNodes }, {})
+				pathOutput = calcFunc({ removeNodes = pathNodes })
 			end
 		else
 			-- Calculated the differences caused by allocating this node and all nodes along the path to it
-			nodeOutput = calcFunc({ addNodes = { [node] = true } }, {})
+			nodeOutput = calcFunc({ addNodes = { [node] = true } })
 			if pathLength > 1 then
-				pathOutput = calcFunc({ addNodes = pathNodes }, {})
+				pathOutput = calcFunc({ addNodes = pathNodes })
 			end
 		end
 		local count = build:AddStatComparesToTooltip(tooltip, calcBase, nodeOutput, node.alloc and "^7Unallocating this node will give you:" or "^7Allocating this node will give you:")

--- a/src/Modules/Build.lua
+++ b/src/Modules/Build.lua
@@ -278,7 +278,7 @@ function buildMode:Init(dbFileName, buildName, buildXML, convertBuild)
 		{ stat = "WithImpaleDPS", label = "Damage inc. Impale", fmt = ".1f", compPercent = true, flag = "impale", flag = "showAverage", condFunc = function(v,o) return v ~= o.TotalDPS and (o.TotalDot or 0) == 0 and (o.IgniteDPS or 0) == 0 and (o.PoisonDPS or 0) == 0 and (o.BleedDPS or 0) == 0 end  },
 		{ stat = "ImpaleDPS", label = "Impale DPS", fmt = ".1f", compPercent = true, flag = "impale", flag = "notAverage" },
 		{ stat = "WithImpaleDPS", label = "Total DPS inc. Impale", fmt = ".1f", compPercent = true, flag = "impale", flag = "notAverage", condFunc = function(v,o) return v ~= o.TotalDPS and (o.TotalDot or 0) == 0 and (o.IgniteDPS or 0) == 0 and (o.PoisonDPS or 0) == 0 and (o.BleedDPS or 0) == 0 end },
-		{ stat = "Mirage", label = "Mirage (with Ailments)", fmt = ".1f", compPercent = true, condFunc = function(v,o) return v > 0 end },
+		{ stat = "Mirage", label = "Total Mirage DPS", fmt = ".1f", compPercent = true, condFunc = function(v,o) return v > 0 end },
 		{ stat = "CullingDPS", label = "Culling DPS", fmt = ".1f", compPercent = true, condFunc = function(v,o) return o.CullingDPS or 0 > 0 end },
 		{ stat = "CombinedDPS", label = "Combined DPS", fmt = ".1f", compPercent = true, flag = "notAverage", condFunc = function(v,o) return v ~= ((o.TotalDPS or 0) + (o.TotalDot or 0)) and v ~= o.WithImpaleDPS and v ~= o.WithPoisonDPS and v ~= o.WithIgniteDPS and v ~= o.WithBleedDPS end },
 		{ stat = "CombinedAvg", label = "Combined Total Damage", fmt = ".1f", compPercent = true, flag = "showAverage", condFunc = function(v,o) return (v ~= o.AverageDamage and (o.TotalDot or 0) == 0) and (v ~= o.WithPoisonDPS or v ~= o.WithIgniteDPS or v ~= o.WithBleedDPS) end },

--- a/src/Modules/Build.lua
+++ b/src/Modules/Build.lua
@@ -278,6 +278,7 @@ function buildMode:Init(dbFileName, buildName, buildXML, convertBuild)
 		{ stat = "WithImpaleDPS", label = "Damage inc. Impale", fmt = ".1f", compPercent = true, flag = "impale", flag = "showAverage", condFunc = function(v,o) return v ~= o.TotalDPS and (o.TotalDot or 0) == 0 and (o.IgniteDPS or 0) == 0 and (o.PoisonDPS or 0) == 0 and (o.BleedDPS or 0) == 0 end  },
 		{ stat = "ImpaleDPS", label = "Impale DPS", fmt = ".1f", compPercent = true, flag = "impale", flag = "notAverage" },
 		{ stat = "WithImpaleDPS", label = "Total DPS inc. Impale", fmt = ".1f", compPercent = true, flag = "impale", flag = "notAverage", condFunc = function(v,o) return v ~= o.TotalDPS and (o.TotalDot or 0) == 0 and (o.IgniteDPS or 0) == 0 and (o.PoisonDPS or 0) == 0 and (o.BleedDPS or 0) == 0 end },
+		{ stat = "Mirage", label = "Mirage (with Ailments)", fmt = ".1f", compPercent = true, condFunc = function(v,o) return v > 0 end },
 		{ stat = "CullingDPS", label = "Culling DPS", fmt = ".1f", compPercent = true, condFunc = function(v,o) return o.CullingDPS or 0 > 0 end },
 		{ stat = "CombinedDPS", label = "Combined DPS", fmt = ".1f", compPercent = true, flag = "notAverage", condFunc = function(v,o) return v ~= ((o.TotalDPS or 0) + (o.TotalDot or 0)) and v ~= o.WithImpaleDPS and v ~= o.WithPoisonDPS and v ~= o.WithIgniteDPS and v ~= o.WithBleedDPS end },
 		{ stat = "CombinedAvg", label = "Combined Total Damage", fmt = ".1f", compPercent = true, flag = "showAverage", condFunc = function(v,o) return (v ~= o.AverageDamage and (o.TotalDot or 0) == 0) and (v ~= o.WithPoisonDPS or v ~= o.WithIgniteDPS or v ~= o.WithBleedDPS) end },
@@ -1224,6 +1225,9 @@ function buildMode:CompareStatList(tooltip, statList, actor, baseOutput, compare
 			local statVal1 = compareOutput[statData.stat] or 0
 			local statVal2 = baseOutput[statData.stat] or 0
 			local diff = statVal1 - statVal2
+			if statData.stat == "FullDPS" and not GlobalCache.useFullDPS then
+				diff = 0
+			end
 			if (diff > 0.001 or diff < -0.001) and (not statData.condFunc or statData.condFunc(statVal1,compareOutput) or statData.condFunc(statVal2,baseOutput)) then
 				if count == 0 then
 					tooltip:AddLine(14, header)
@@ -1234,17 +1238,17 @@ function buildMode:CompareStatList(tooltip, statList, actor, baseOutput, compare
 
 				valStr = formatNumSep(valStr)
 
-				local line = string.format("%s%s %s", color, valStr, statData.label)
+				local line = s_format("%s%s %s", color, valStr, statData.label)
 				local pcPerPt = ""
 				if statData.compPercent and statVal1 ~= 0 and statVal2 ~= 0 then
 					local pc = statVal1 / statVal2 * 100 - 100
-					line = line .. string.format(" (%+.1f%%)", pc)
+					line = line .. s_format(" (%+.1f%%)", pc)
 					if nodeCount then
-						pcPerPt = string.format(" (%+.1f%%)", pc / nodeCount)
+						pcPerPt = s_format(" (%+.1f%%)", pc / nodeCount)
 					end
 				end
 				if nodeCount then
-					line = line .. string.format(" ^8[%+"..statData.fmt.."%s per point]", diff * ((statData.pc or statData.mod) and 100 or 1) / nodeCount, pcPerPt)
+					line = line .. s_format(" ^8[%+"..statData.fmt.."%s per point]", diff * ((statData.pc or statData.mod) and 100 or 1) / nodeCount, pcPerPt)
 				end
 				tooltip:AddLine(14, line)
 				count = count + 1

--- a/src/Modules/Build.lua
+++ b/src/Modules/Build.lua
@@ -1225,7 +1225,7 @@ function buildMode:CompareStatList(tooltip, statList, actor, baseOutput, compare
 			local statVal1 = compareOutput[statData.stat] or 0
 			local statVal2 = baseOutput[statData.stat] or 0
 			local diff = statVal1 - statVal2
-			if statData.stat == "FullDPS" and not GlobalCache.useFullDPS then
+			if statData.stat == "FullDPS" and not GlobalCache.useFullDPS and not self.viewMode == "TREE" then
 				diff = 0
 			end
 			if (diff > 0.001 or diff < -0.001) and (not statData.condFunc or statData.condFunc(statVal1,compareOutput) or statData.condFunc(statVal2,baseOutput)) then

--- a/src/Modules/Build.lua
+++ b/src/Modules/Build.lua
@@ -278,7 +278,7 @@ function buildMode:Init(dbFileName, buildName, buildXML, convertBuild)
 		{ stat = "WithImpaleDPS", label = "Damage inc. Impale", fmt = ".1f", compPercent = true, flag = "impale", flag = "showAverage", condFunc = function(v,o) return v ~= o.TotalDPS and (o.TotalDot or 0) == 0 and (o.IgniteDPS or 0) == 0 and (o.PoisonDPS or 0) == 0 and (o.BleedDPS or 0) == 0 end  },
 		{ stat = "ImpaleDPS", label = "Impale DPS", fmt = ".1f", compPercent = true, flag = "impale", flag = "notAverage" },
 		{ stat = "WithImpaleDPS", label = "Total DPS inc. Impale", fmt = ".1f", compPercent = true, flag = "impale", flag = "notAverage", condFunc = function(v,o) return v ~= o.TotalDPS and (o.TotalDot or 0) == 0 and (o.IgniteDPS or 0) == 0 and (o.PoisonDPS or 0) == 0 and (o.BleedDPS or 0) == 0 end },
-		{ stat = "Mirage", label = "Total Mirage DPS", fmt = ".1f", compPercent = true, condFunc = function(v,o) return v > 0 end },
+		{ stat = "MirageDPS", label = "Total Mirage DPS", fmt = ".1f", compPercent = true, condFunc = function(v,o) return v > 0 end },
 		{ stat = "CullingDPS", label = "Culling DPS", fmt = ".1f", compPercent = true, condFunc = function(v,o) return o.CullingDPS or 0 > 0 end },
 		{ stat = "CombinedDPS", label = "Combined DPS", fmt = ".1f", compPercent = true, flag = "notAverage", condFunc = function(v,o) return v ~= ((o.TotalDPS or 0) + (o.TotalDot or 0)) and v ~= o.WithImpaleDPS and v ~= o.WithPoisonDPS and v ~= o.WithIgniteDPS and v ~= o.WithBleedDPS end },
 		{ stat = "CombinedAvg", label = "Combined Total Damage", fmt = ".1f", compPercent = true, flag = "showAverage", condFunc = function(v,o) return (v ~= o.AverageDamage and (o.TotalDot or 0) == 0) and (v ~= o.WithPoisonDPS or v ~= o.WithIgniteDPS or v ~= o.WithBleedDPS) end },

--- a/src/Modules/CalcActiveSkill.lua
+++ b/src/Modules/CalcActiveSkill.lua
@@ -131,12 +131,10 @@ function calcs.copyActiveSkill(env, mode, skill)
 	calcs.buildActiveSkillModList(newEnv, newSkill)
 	newSkill.skillModList = new("ModList", newSkill.baseSkillModList)
 	if newSkill.minion then
-		if newSkill.minion then
-			newSkill.minion.modDB = new("ModDB")
-			newSkill.minion.modDB.actor = newSkill.minion
-			calcs.createMinionSkills(env, newSkill)
-			newSkill.skillPartName = newSkill.minion.mainSkill.activeEffect.grantedEffect.name
-		end
+		newSkill.minion.modDB = new("ModDB")
+		newSkill.minion.modDB.actor = newSkill.minion
+		calcs.createMinionSkills(env, newSkill)
+		newSkill.skillPartName = newSkill.minion.mainSkill.activeEffect.grantedEffect.name
 	end
 	return newSkill, newEnv
 end

--- a/src/Modules/CalcOffence.lua
+++ b/src/Modules/CalcOffence.lua
@@ -3796,22 +3796,27 @@ function calcs.offence(env, actor, activeSkill)
 			end
 			newSkill.skillModList:NewMod("QuantityMultiplier", "BASE", maxMirageWarriors, "The Saviour Mirage Warriors", activeSkill.ModFlags, activeSkill.KeywordFlags)
 
+			if usedSkill.skillPartName then
+				env.player.mainSkill.skillPart = usedSkill.skillPart
+				env.player.mainSkill.skillPartName = usedSkill.skillPartName
+				env.player.mainSkill.infoMessage2 = usedSkill.activeEffect.grantedEffect.name
+			else
+				env.player.mainSkill.skillPartName = usedSkill.activeEffect.grantedEffect.name
+			end
+
 			-- Recalculate the offensive/defensive aspects of this new skill
 			newEnv.player.mainSkill = newSkill
 			calcs.perform(newEnv)
 			env.player.mainSkill = newSkill
 
-			if usedSkill.skillPartName then
-				env.player.mainSkill.skillPart = usedSkill.skillPart
-				env.player.mainSkill.skillPartName = usedSkill.activeEffect.grantedEffect.name .. " " .. usedSkill.skillPartName
-				env.player.mainSkill.infoMessage2 = usedSkill.activeEffect.grantedEffect.name .. " " .. usedSkill.skillPartName
-			else
-				env.player.mainSkill.skillPartName = usedSkill.activeEffect.grantedEffect.name
-			end
 			env.player.mainSkill.infoMessage = tostring(maxMirageWarriors) .. " Mirage Warriors using " .. usedSkill.activeEffect.grantedEffect.name
 
 			-- Re-link over the output
 			env.player.output = newEnv.player.output
+			if newSkill.minion then
+				env.minion = newEnv.player.mainSkill.minion
+				env.minion.output = newEnv.minion.output
+			end
 
 			-- Make any necessary corrections to output
 			env.player.output.ManaCost = 0
@@ -3822,6 +3827,10 @@ function calcs.offence(env, actor, activeSkill)
 
 				-- Make any necessary corrections to breakdown
 				env.player.breakdown.ManaCost = nil
+
+				if newSkill.minion then
+					env.minion.breakdown = newEnv.minion.breakdown
+				end
 			end
 		else
 			activeSkill.infoMessage2 = "No Saviour active skill found"

--- a/src/Modules/CalcOffence.lua
+++ b/src/Modules/CalcOffence.lua
@@ -3712,8 +3712,8 @@ function calcs.offence(env, actor, activeSkill)
 
 			if usedSkill.skillPartName then
 				env.player.mainSkill.skillPart = usedSkill.skillPart
-				env.player.mainSkill.skillPartName = usedSkill.activeEffect.grantedEffect.name .. " " .. usedSkill.skillPartName
-				env.player.mainSkill.infoMessage2 = usedSkill.activeEffect.grantedEffect.name .. " " .. usedSkill.skillPartName
+				env.player.mainSkill.skillPartName = usedSkill.skillPartName
+				env.player.mainSkill.infoMessage2 = usedSkill.activeEffect.grantedEffect.name
 			else
 				env.player.mainSkill.skillPartName = usedSkill.activeEffect.grantedEffect.name
 			end

--- a/src/Modules/CalcOffence.lua
+++ b/src/Modules/CalcOffence.lua
@@ -3727,6 +3727,10 @@ function calcs.offence(env, actor, activeSkill)
 
 			-- Re-link over the output
 			env.player.output = newEnv.player.output
+			if newSkill.minion then
+				env.minion = newEnv.player.mainSkill.minion
+				env.minion.output = newEnv.minion.output
+			end
 
 			-- Make any necessary corrections to output
 			env.player.output.ManaCost = output.ManaCost
@@ -3735,6 +3739,9 @@ function calcs.offence(env, actor, activeSkill)
 			-- Re-link over the breakdown (if present)
 			if newEnv.player.breakdown then
 				env.player.breakdown = newEnv.player.breakdown
+				if newSkill.minion then
+					env.minion.breakdown = newEnv.minion.breakdown
+				end
 
 				-- Make any necessary corrections to breakdown
 			end

--- a/src/Modules/CalcOffence.lua
+++ b/src/Modules/CalcOffence.lua
@@ -3938,8 +3938,9 @@ function calcs.offence(env, actor, activeSkill)
 	output.CombinedDPS = output.CombinedDPS * output.CullMultiplier
 
 	if activeSkill.mirage and activeSkill.mirage.output and activeSkill.mirage.output.TotalDPS then
-		output.Mirage = activeSkill.mirage.output.TotalDPS * (activeSkill.mirage.count or 1)
-		output.CombinedDPS = output.CombinedDPS + activeSkill.mirage.output.TotalDPS * (activeSkill.mirage.count or 1)
+		local mirageCount = activeSkill.skillModList:Sum("BASE", env.player.mainSkill.skillCfg, "MirageArcherMaxCount") or 1
+		output.Mirage = activeSkill.mirage.output.TotalDPS * mirageCount
+		output.CombinedDPS = output.CombinedDPS + activeSkill.mirage.output.TotalDPS * mirageCount
 
 		if activeSkill.mirage.output.IgniteDPS and activeSkill.mirage.output.IgniteDPS > output.IgniteDPS then
 			output.Mirage = output.Mirage + activeSkill.mirage.output.IgniteDPS
@@ -3951,21 +3952,20 @@ function calcs.offence(env, actor, activeSkill)
 		end
 
 		if activeSkill.mirage.output.PoisonDPS then
-			output.Mirage = output.Mirage + activeSkill.mirage.output.PoisonDPS * (activeSkill.mirage.count or 1) 
-			output.CombinedDPS = output.CombinedDPS + activeSkill.mirage.output.PoisonDPS * (activeSkill.mirage.count or 1)
+			output.Mirage = output.Mirage + activeSkill.mirage.output.PoisonDPS * mirageCount
+			output.CombinedDPS = output.CombinedDPS + activeSkill.mirage.output.PoisonDPS * mirageCount
 		end
 		if activeSkill.mirage.output.ImpaleDPS then
-			output.Mirage = output.Mirage + activeSkill.mirage.output.ImpaleDPS * (activeSkill.mirage.count or 1)
-			output.CombinedDPS = output.CombinedDPS + activeSkill.mirage.output.ImpaleDPS * (activeSkill.mirage.count or 1)
+			output.Mirage = output.Mirage + activeSkill.mirage.output.ImpaleDPS * mirageCount
+			output.CombinedDPS = output.CombinedDPS + activeSkill.mirage.output.ImpaleDPS * mirageCount
 		end
 		if activeSkill.mirage.output.DecayDPS then
 			output.Mirage = output.Mirage + activeSkill.mirage.output.DecayDPS
 			output.CombinedDPS = output.CombinedDPS + activeSkill.mirage.output.DecayDPS
 		end
 		if activeSkill.mirage.output.TotalDot then
-			output.Mirage = output.Mirage + activeSkill.mirage.output.TotalDot * (skillFlags.DotCanStack and activeSkill.mirage.count or 1)
-			output.CombinedDPS = output.CombinedDPS + activeSkill.mirage.output.TotalDot * (skillFlags.DotCanStack and activeSkill.mirage.count or 1)
+			output.Mirage = output.Mirage + activeSkill.mirage.output.TotalDot * (skillFlags.DotCanStack and mirageCount or 1)
+			output.CombinedDPS = output.CombinedDPS + activeSkill.mirage.output.TotalDot * (skillFlags.DotCanStack and mirageCount or 1)
 		end
-
 	end
 end

--- a/src/Modules/CalcOffence.lua
+++ b/src/Modules/CalcOffence.lua
@@ -3938,33 +3938,33 @@ function calcs.offence(env, actor, activeSkill)
 	output.CombinedDPS = output.CombinedDPS * output.CullMultiplier
 
 	if activeSkill.mirage and activeSkill.mirage.output and activeSkill.mirage.output.TotalDPS then
-		local mirageCount = activeSkill.skillModList:Sum("BASE", env.player.mainSkill.skillCfg, "MirageArcherMaxCount") or 1
-		output.Mirage = activeSkill.mirage.output.TotalDPS * mirageCount
+		local mirageCount = activeSkill.mirage.count or 1
+		output.MirageDPS = activeSkill.mirage.output.TotalDPS * mirageCount
 		output.CombinedDPS = output.CombinedDPS + activeSkill.mirage.output.TotalDPS * mirageCount
 
 		if activeSkill.mirage.output.IgniteDPS and activeSkill.mirage.output.IgniteDPS > output.IgniteDPS then
-			output.Mirage = output.Mirage + activeSkill.mirage.output.IgniteDPS
+			output.MirageDPS = output.MirageDPS + activeSkill.mirage.output.IgniteDPS
 			output.IgniteDPS = 0
 		end
 		if activeSkill.mirage.output.BleedDPS and activeSkill.mirage.output.BleedDPS > output.BleedDPS then
-			output.Mirage = output.Mirage + activeSkill.mirage.output.BleedDPS
+			output.MirageDPS = output.MirageDPS + activeSkill.mirage.output.BleedDPS
 			output.BleedDPS = 0
 		end
 
 		if activeSkill.mirage.output.PoisonDPS then
-			output.Mirage = output.Mirage + activeSkill.mirage.output.PoisonDPS * mirageCount
+			output.MirageDPS = output.MirageDPS + activeSkill.mirage.output.PoisonDPS * mirageCount
 			output.CombinedDPS = output.CombinedDPS + activeSkill.mirage.output.PoisonDPS * mirageCount
 		end
 		if activeSkill.mirage.output.ImpaleDPS then
-			output.Mirage = output.Mirage + activeSkill.mirage.output.ImpaleDPS * mirageCount
+			output.MirageDPS = output.MirageDPS + activeSkill.mirage.output.ImpaleDPS * mirageCount
 			output.CombinedDPS = output.CombinedDPS + activeSkill.mirage.output.ImpaleDPS * mirageCount
 		end
 		if activeSkill.mirage.output.DecayDPS then
-			output.Mirage = output.Mirage + activeSkill.mirage.output.DecayDPS
+			output.MirageDPS = output.MirageDPS + activeSkill.mirage.output.DecayDPS
 			output.CombinedDPS = output.CombinedDPS + activeSkill.mirage.output.DecayDPS
 		end
 		if activeSkill.mirage.output.TotalDot then
-			output.Mirage = output.Mirage + activeSkill.mirage.output.TotalDot * (skillFlags.DotCanStack and mirageCount or 1)
+			output.MirageDPS = output.MirageDPS + activeSkill.mirage.output.TotalDot * (skillFlags.DotCanStack and mirageCount or 1)
 			output.CombinedDPS = output.CombinedDPS + activeSkill.mirage.output.TotalDot * (skillFlags.DotCanStack and mirageCount or 1)
 		end
 	end

--- a/src/Modules/CalcOffence.lua
+++ b/src/Modules/CalcOffence.lua
@@ -3937,7 +3937,7 @@ function calcs.offence(env, actor, activeSkill)
 	end
 	output.CombinedDPS = output.CombinedDPS * output.CullMultiplier
 
-	if activeSkill.mirage then
+	if activeSkill.mirage and activeSkill.mirage.output and activeSkill.mirage.output.TotalDPS then
 		output.Mirage = activeSkill.mirage.output.TotalDPS * (activeSkill.mirage.count or 1)
 		output.CombinedDPS = output.CombinedDPS + activeSkill.mirage.output.TotalDPS * (activeSkill.mirage.count or 1)
 

--- a/src/Modules/CalcOffence.lua
+++ b/src/Modules/CalcOffence.lua
@@ -3646,6 +3646,7 @@ function calcs.offence(env, actor, activeSkill)
 		end
 	end
 	if skillModList:Flag(nil, "DotCanStack") then
+		skillFlags.DotCanStack = true
 		local speed = output.Speed
 		-- Check if skill is being triggered via Mine (e.g., Blastchain Mine Support) or Trap
 		-- if "yes", you cannot use output.Speed but rather should use output.MineLayingSpeed or output.TrapThrowingSpeed
@@ -3935,4 +3936,36 @@ function calcs.offence(env, actor, activeSkill)
 		output.CullingDPS = output.CombinedDPS * (output.CullMultiplier - 1)
 	end
 	output.CombinedDPS = output.CombinedDPS * output.CullMultiplier
+
+	if activeSkill.mirage then
+		output.Mirage = activeSkill.mirage.output.TotalDPS * (activeSkill.mirage.count or 1)
+		output.CombinedDPS = output.CombinedDPS + activeSkill.mirage.output.TotalDPS * (activeSkill.mirage.count or 1)
+
+		if activeSkill.mirage.output.IgniteDPS and activeSkill.mirage.output.IgniteDPS > output.IgniteDPS then
+			output.Mirage = output.Mirage + activeSkill.mirage.output.IgniteDPS
+			output.IgniteDPS = 0
+		end
+		if activeSkill.mirage.output.BleedDPS and activeSkill.mirage.output.BleedDPS > output.BleedDPS then
+			output.Mirage = output.Mirage + activeSkill.mirage.output.BleedDPS
+			output.BleedDPS = 0
+		end
+
+		if activeSkill.mirage.output.PoisonDPS then
+			output.Mirage = output.Mirage + activeSkill.mirage.output.PoisonDPS * (activeSkill.mirage.count or 1) 
+			output.CombinedDPS = output.CombinedDPS + activeSkill.mirage.output.PoisonDPS * (activeSkill.mirage.count or 1)
+		end
+		if activeSkill.mirage.output.ImpaleDPS then
+			output.Mirage = output.Mirage + activeSkill.mirage.output.ImpaleDPS * (activeSkill.mirage.count or 1)
+			output.CombinedDPS = output.CombinedDPS + activeSkill.mirage.output.ImpaleDPS * (activeSkill.mirage.count or 1)
+		end
+		if activeSkill.mirage.output.DecayDPS then
+			output.Mirage = output.Mirage + activeSkill.mirage.output.DecayDPS
+			output.CombinedDPS = output.CombinedDPS + activeSkill.mirage.output.DecayDPS
+		end
+		if activeSkill.mirage.output.TotalDot then
+			output.Mirage = output.Mirage + activeSkill.mirage.output.TotalDot * (skillFlags.DotCanStack and activeSkill.mirage.count or 1)
+			output.CombinedDPS = output.CombinedDPS + activeSkill.mirage.output.TotalDot * (skillFlags.DotCanStack and activeSkill.mirage.count or 1)
+		end
+
+	end
 end

--- a/src/Modules/CalcPerform.lua
+++ b/src/Modules/CalcPerform.lua
@@ -1203,7 +1203,7 @@ function calcs.perform(env)
 		end
 		-- General's Cry Support
 		--     this exist to infrom display to not show DPS for this skill as it only has damage due to General's Cry
-		if activeSkill.skillData.triggeredByGeneralsCry and not activeSkill.skillFlags.minion then
+		if activeSkill.skillData.triggeredByGeneralsCry then
 			addToFullDpsExclusionList(activeSkill)
 			activeSkill.infoMessage = "Used by General's Cry Mirage Warriors"
 			activeSkill.infoTrigger = "General's Cry"

--- a/src/Modules/CalcPerform.lua
+++ b/src/Modules/CalcPerform.lua
@@ -2079,13 +2079,11 @@ function calcs.perform(env)
 
 			if usedSkill.skillPartName then
 				env.player.mainSkill.skillPart = usedSkill.skillPart
-				env.player.mainSkill.skillPartName = usedSkill.activeEffect.grantedEffect.name .. " " .. usedSkill.skillPartName
-				env.player.mainSkill.infoMessage2 = usedSkill.activeEffect.grantedEffect.name .. " " .. usedSkill.skillPartName
+				env.player.mainSkill.skillPartName = usedSkill.skillPartName
+				env.player.mainSkill.infoMessage2 = usedSkill.activeEffect.grantedEffect.name
 			else
 				env.player.mainSkill.skillPartName = nil
 			end
-			env.player.mainSkill.infoMessage = tostring(maxMirageArchers) .. " Mirage Archers using " .. usedSkill.activeEffect.grantedEffect.name
-			newSkill.infoMessage = tostring(maxMirageArchers) .. " Mirage Archers using " .. usedSkill.activeEffect.grantedEffect.name
 			env.player.mainSkill.infoTrigger = "MA"
 
 			-- Recalculate the offensive/defensive aspects of the Mirage Archer influence on skill
@@ -2094,7 +2092,14 @@ function calcs.perform(env)
 			calcs.perform(newEnv)
 			env.player.mainSkill = newSkill
 
+			env.player.mainSkill.infoMessage = tostring(maxMirageArchers) .. " Mirage Archers using " .. usedSkill.activeEffect.grantedEffect.name
+
+			-- Re-link over the output
 			env.player.output = newEnv.player.output
+			if newSkill.minion then
+				env.minion = newEnv.player.mainSkill.minion
+				env.minion.output = newEnv.minion.output
+			end
 
 			-- Make any necessary corrections to output
 			env.player.output.ManaCost = 0
@@ -2103,6 +2108,9 @@ function calcs.perform(env)
 				env.player.breakdown = newEnv.player.breakdown
 				-- Make any necessary corrections to breakdown
 				env.player.breakdown.ManaCost = nil
+				if newSkill.minion then
+					env.minion.breakdown = newEnv.minion.breakdown
+				end
 			end
 			newEnv.player.mainSkill.marked = true
 		else

--- a/src/Modules/CalcPerform.lua
+++ b/src/Modules/CalcPerform.lua
@@ -2011,10 +2011,10 @@ function calcs.perform(env)
 		local uuid = cacheSkillUUID(env.player.mainSkill)
 		local calcMode = env.mode == "CALCS" and "CALCS" or "MAIN"
 
-		-- if we don't have a processed cached copy of this skill, get one
-		if not GlobalCache.cachedData[calcMode][uuid] then
-			calcs.buildActiveSkill(env, calcMode, env.player.mainSkill, true)
-		end
+		-- cache a new copy of this skill that's affected by Mirage Archer
+		calcs.buildActiveSkill(env, calcMode, env.player.mainSkill, true)
+		env.dontCache = true
+
 		if GlobalCache.cachedData[calcMode][uuid] then
 			usedSkill = GlobalCache.cachedData[calcMode][uuid].ActiveSkill
 		end
@@ -2022,19 +2022,25 @@ function calcs.perform(env)
 		if usedSkill then
 			local moreDamage =  usedSkill.skillModList:Sum("BASE", usedSkill.skillCfg, "MirageArcherLessDamage")
 			local moreAttackSpeed = usedSkill.skillModList:Sum("BASE", usedSkill.skillCfg, "MirageArcherLessAttackSpeed")
+			local mirageCount =  usedSkill.skillModList:Sum("BASE", env.player.mainSkill.skillCfg, "MirageArcherMaxCount")
 
+			-- Make a copy of this skill so we can add new modifiers to the copy affected by Mirage Archers
 			local newSkill, newEnv = calcs.copyActiveSkill(env, calcMode, usedSkill)
 
 			-- Add new modifiers to new skill (which already has all the old skill's modifiers)
 			newSkill.skillModList:NewMod("Damage", "MORE", moreDamage, "Mirage Archer", env.player.mainSkill.ModFlags, env.player.mainSkill.KeywordFlags)
 			newSkill.skillModList:NewMod("Speed", "MORE", moreAttackSpeed, "Mirage Archer", env.player.mainSkill.ModFlags, env.player.mainSkill.KeywordFlags)
+			--[[
 			local maxMirageArchers = 0
 			for i, value in ipairs(env.player.mainSkill.skillModList:Tabulate("BASE", env.player.mainSkill.skillCfg, "MirageArcherMaxCount")) do
 				local mod = value.mod
 				newSkill.skillModList:NewMod("QuantityMultiplier", "BASE", mod.value, mod.source, env.player.mainSkill.ModFlags, env.player.mainSkill.KeywordFlags)
 				maxMirageArchers = maxMirageArchers + mod.value
 			end
+			--]]
 			env.player.mainSkill.mirage = { }
+			env.player.mainSkill.mirage.name = usedSkill.activeEffect.grantedEffect.name
+			env.player.mainSkill.mirage.count = mirageCount
 
 			if usedSkill.skillPartName then
 				env.player.mainSkill.mirage.skillPart = usedSkill.skillPart
@@ -2047,13 +2053,15 @@ function calcs.perform(env)
 
 			-- Recalculate the offensive/defensive aspects of the Mirage Archer influence on skill
 			newEnv.player.mainSkill = newSkill
-			newEnv.player.mainSkill.marked = true
+			-- mark it so we don't recurse infinitely
+			newSkill.marked = true
 			calcs.perform(newEnv)
 
-			env.player.mainSkill.infoMessage = tostring(maxMirageArchers) .. " Mirage Archers using " .. usedSkill.activeEffect.grantedEffect.name
+			env.player.mainSkill.infoMessage = tostring(mirageCount) .. " Mirage Archers using " .. usedSkill.activeEffect.grantedEffect.name
 
 			-- Re-link over the output
 			env.player.mainSkill.mirage.output = newEnv.player.output
+
 			if newSkill.minion then
 				env.player.mainSkill.mirage.minion = {}
 				env.player.mainSkill.mirage.minion.output = newEnv.minion.output
@@ -2062,17 +2070,14 @@ function calcs.perform(env)
 			-- Make any necessary corrections to output
 			env.player.mainSkill.mirage.output.ManaCost = 0
 
-			--[[
 			if newEnv.player.breakdown then
-				env.player.breakdown = newEnv.player.breakdown
+				env.player.mainSkill.mirage.breakdown = newEnv.player.breakdown
 				-- Make any necessary corrections to breakdown
-				env.player.breakdown.ManaCost = nil
+				env.player.mainSkill.mirage.breakdown.ManaCost = nil
 				if newSkill.minion then
-					env.minion.breakdown = newEnv.minion.breakdown
+					env.player.mainSkill.mirage.minion.breakdown = newEnv.minion.breakdown
 				end
 			end
-			newEnv.player.mainSkill.marked = true
-			--]]
 		else
 			env.player.mainSkill.infoMessage2 = "No Mirage Archer active skill found"
 		end

--- a/src/Modules/CalcSetup.lua
+++ b/src/Modules/CalcSetup.lua
@@ -448,7 +448,7 @@ function calcs.initEnv(build, mode, override, specEnv)
 	else
 		env.modDB.parent = cachedPlayerDB
 		env.enemyDB.parent = cachedEnemyDB
-		if cachedMinionDB then
+		if cachedMinionDB and env.minion then
 			env.minion.modDB.parent = cachedMinionDB
 		end
 	end

--- a/src/Modules/Calcs.lua
+++ b/src/Modules/Calcs.lua
@@ -114,11 +114,7 @@ function calcs.getMiscCalculator(build)
 	local baseOutput = env.player.output
 
 	return function(override, accelerate)
-		if accelerate and (accelerate.everything or accelerate.nodeAlloc or accelerate.requirementsItems or accelerate.requirementsGems or accelerate.skills) then
-			env, cachedPlayerDB, cachedPlayerDB, cachedMinionDB = calcs.initEnv(build, "CALCULATOR", override, { cachedPlayerDB = cachedPlayerDB, cachedEnemyDB = cachedEnemyDB, cachedMinionDB = cachedMinionDB, env = env, accelerate = accelerate })
-		else
-			env, cachedPlayerDB, cachedPlayerDB, cachedMinionDB = calcs.initEnv(build, "CALCULATOR", override)
-		end
+		env, cachedPlayerDB, cachedPlayerDB, cachedMinionDB = calcs.initEnv(build, "CALCULATOR", override)
 		calcs.perform(env)
 		if GlobalCache.useFullDPS or build.viewMode == "TREE" then
 			-- prevent upcoming calculation from using Cached Data and thus forcing it to re-calculate new FullDPS roll-up 

--- a/src/Modules/Calcs.lua
+++ b/src/Modules/Calcs.lua
@@ -184,15 +184,13 @@ function calcs.calcFullDPS(build, mode, override, specEnv)
 					fullEnv.player.mainSkill = activeSkill
 					calcs.perform(fullEnv)
 					usedEnv = fullEnv
-				        GlobalCache.dontUseCache = forceCache
+					GlobalCache.dontUseCache = forceCache
 				end
-				if activeSkill.minion then
+				local minionName = nil
+				if activeSkill.minion or usedEnv.minion then
 					if usedEnv.minion.output.TotalDPS and usedEnv.minion.output.TotalDPS > 0 then
-						if not fullDPS.skills[activeSkill.activeEffect.grantedEffect.name] then
-							t_insert(fullDPS.skills, { name = activeSkill.activeEffect.grantedEffect.name, dps = usedEnv.minion.output.TotalDPS, count = activeSkillCount, trigger = activeSkill.infoTrigger, skillPart = activeSkill.skillPartName })
-						else
-							ConPrintf("[Minion] HELP! Numerous same-named effects! '" .. activeSkill.activeEffect.grantedEffect.name .. "'")
-						end
+						minionName = (activeSkill.minion and activeSkill.minion.minionData.name..": ") or (usedEnv.minion and usedEnv.minion.minionData.name..": ") or ""
+						t_insert(fullDPS.skills, { name = activeSkill.activeEffect.grantedEffect.name, dps = usedEnv.minion.output.TotalDPS, count = activeSkillCount, trigger = activeSkill.infoTrigger, skillPart = minionName..activeSkill.skillPartName })
 						fullDPS.combinedDPS = fullDPS.combinedDPS + usedEnv.minion.output.TotalDPS * activeSkillCount
 					end
 					if usedEnv.minion.output.BleedDPS and usedEnv.minion.output.BleedDPS > fullDPS.bleedDPS then
@@ -215,36 +213,33 @@ function calcs.calcFullDPS(build, mode, override, specEnv)
 					if usedEnv.minion.output.TotalDot and usedEnv.minion.output.TotalDot > 0 then
 						fullDPS.dotDPS = fullDPS.dotDPS + usedEnv.minion.output.TotalDot
 					end
-				else
-					if usedEnv.player.output.TotalDPS and usedEnv.player.output.TotalDPS > 0 then
-						if not fullDPS.skills[activeSkill.activeEffect.grantedEffect.name] then
-							t_insert(fullDPS.skills, { name = activeSkill.activeEffect.grantedEffect.name, dps = usedEnv.player.output.TotalDPS, count = activeSkillCount, trigger = activeSkill.infoTrigger, skillPart = activeSkill.skillPartName })
-						else
-							ConPrintf("HELP! Numerous same-named effects! '" .. activeSkill.activeEffect.grantedEffect.name .. "'")
-						end
-						fullDPS.combinedDPS = fullDPS.combinedDPS + usedEnv.player.output.TotalDPS * activeSkillCount
-					end
-					if usedEnv.player.output.BleedDPS and usedEnv.player.output.BleedDPS > fullDPS.bleedDPS then
-						fullDPS.bleedDPS = usedEnv.player.output.BleedDPS
-						bleedSource = activeSkill.activeEffect.grantedEffect.name
-					end
-					if usedEnv.player.output.IgniteDPS and usedEnv.player.output.IgniteDPS > fullDPS.igniteDPS then
-						fullDPS.igniteDPS = usedEnv.player.output.IgniteDPS
-						igniteSource = activeSkill.activeEffect.grantedEffect.name
-					end
-					if usedEnv.player.output.PoisonDPS and usedEnv.player.output.PoisonDPS > 0 then
-						fullDPS.poisonDPS = fullDPS.poisonDPS + usedEnv.player.output.PoisonDPS * (usedEnv.player.output.TotalPoisonStacks or 1) * activeSkillCount
-					end
-					if usedEnv.player.output.ImpaleDPS and usedEnv.player.output.ImpaleDPS > 0 then
-						fullDPS.impaleDPS = fullDPS.impaleDPS + usedEnv.player.output.ImpaleDPS * activeSkillCount
-					end
-					if usedEnv.player.output.DecayDPS and usedEnv.player.output.DecayDPS > 0 then
-						fullDPS.decayDPS = fullDPS.decayDPS + usedEnv.player.output.DecayDPS
-					end
-					if usedEnv.player.output.TotalDot and usedEnv.player.output.TotalDot > 0 then
-						fullDPS.dotDPS = fullDPS.dotDPS + usedEnv.player.output.TotalDot
-					end
 				end
+
+				if usedEnv.player.output.TotalDPS and usedEnv.player.output.TotalDPS > 0 then
+					t_insert(fullDPS.skills, { name = activeSkill.activeEffect.grantedEffect.name, dps = usedEnv.player.output.TotalDPS, count = activeSkillCount, trigger = activeSkill.infoTrigger, skillPart = minionName and activeSkill.infoMessage2 or activeSkill.skillPartName })
+					fullDPS.combinedDPS = fullDPS.combinedDPS + usedEnv.player.output.TotalDPS * activeSkillCount
+				end
+				if usedEnv.player.output.BleedDPS and usedEnv.player.output.BleedDPS > fullDPS.bleedDPS then
+					fullDPS.bleedDPS = usedEnv.player.output.BleedDPS
+					bleedSource = activeSkill.activeEffect.grantedEffect.name
+				end
+				if usedEnv.player.output.IgniteDPS and usedEnv.player.output.IgniteDPS > fullDPS.igniteDPS then
+					fullDPS.igniteDPS = usedEnv.player.output.IgniteDPS
+					igniteSource = activeSkill.activeEffect.grantedEffect.name
+				end
+				if usedEnv.player.output.PoisonDPS and usedEnv.player.output.PoisonDPS > 0 then
+					fullDPS.poisonDPS = fullDPS.poisonDPS + usedEnv.player.output.PoisonDPS * (usedEnv.player.output.TotalPoisonStacks or 1) * activeSkillCount
+				end
+				if usedEnv.player.output.ImpaleDPS and usedEnv.player.output.ImpaleDPS > 0 then
+					fullDPS.impaleDPS = fullDPS.impaleDPS + usedEnv.player.output.ImpaleDPS * activeSkillCount
+				end
+				if usedEnv.player.output.DecayDPS and usedEnv.player.output.DecayDPS > 0 then
+					fullDPS.decayDPS = fullDPS.decayDPS + usedEnv.player.output.DecayDPS
+				end
+				if usedEnv.player.output.TotalDot and usedEnv.player.output.TotalDot > 0 then
+					fullDPS.dotDPS = fullDPS.dotDPS + usedEnv.player.output.TotalDot
+				end
+
 				-- Re-Build env calculator for new run
 				local accelerationTbl = {
 					nodeAlloc = true,

--- a/src/Modules/Calcs.lua
+++ b/src/Modules/Calcs.lua
@@ -215,6 +215,33 @@ function calcs.calcFullDPS(build, mode, override, specEnv)
 					end
 				end
 
+				if activeSkill.mirage then
+					if activeSkill.mirage.output.TotalDPS and activeSkill.mirage.output.TotalDPS > 0 then
+						t_insert(fullDPS.skills, { name = activeSkill.activeEffect.grantedEffect.name, dps = activeSkill.mirage.output.TotalDPS, count = activeSkillCount, trigger = activeSkill.mirage.infoTrigger, skillPart = activeSkill.mirage.skillPartName })
+						fullDPS.combinedDPS = fullDPS.combinedDPS + activeSkill.mirage.output.TotalDPS * activeSkillCount
+					end
+					if activeSkill.mirage.output.BleedDPS and activeSkill.mirage.output.BleedDPS > fullDPS.bleedDPS then
+						fullDPS.bleedDPS = activeSkill.mirage.output.BleedDPS
+						bleedSource = activeSkill.activeEffect.grantedEffect.name
+					end
+					if activeSkill.mirage.output.IgniteDPS and activeSkill.mirage.output.IgniteDPS > fullDPS.igniteDPS then
+						fullDPS.igniteDPS = activeSkill.mirage.output.IgniteDPS
+						igniteSource = activeSkill.activeEffect.grantedEffect.name
+					end
+					if activeSkill.mirage.output.PoisonDPS and activeSkill.mirage.output.PoisonDPS > 0 then
+						fullDPS.poisonDPS = fullDPS.poisonDPS + activeSkill.mirage.output.PoisonDPS * (activeSkill.mirage.output.TotalPoisonStacks or 1) * activeSkillCount
+					end
+					if activeSkill.mirage.output.ImpaleDPS and activeSkill.mirage.output.ImpaleDPS > 0 then
+						fullDPS.impaleDPS = fullDPS.impaleDPS + activeSkill.mirage.output.ImpaleDPS * activeSkillCount
+					end
+					if activeSkill.mirage.output.DecayDPS and activeSkill.mirage.output.DecayDPS > 0 then
+						fullDPS.decayDPS = fullDPS.decayDPS + activeSkill.mirage.output.DecayDPS
+					end
+					if activeSkill.mirage.output.TotalDot and activeSkill.mirage.output.TotalDot > 0 then
+						fullDPS.dotDPS = fullDPS.dotDPS + activeSkill.mirage.output.TotalDot
+					end
+				end
+
 				if usedEnv.player.output.TotalDPS and usedEnv.player.output.TotalDPS > 0 then
 					t_insert(fullDPS.skills, { name = activeSkill.activeEffect.grantedEffect.name, dps = usedEnv.player.output.TotalDPS, count = activeSkillCount, trigger = activeSkill.infoTrigger, skillPart = minionName and activeSkill.infoMessage2 or activeSkill.skillPartName })
 					fullDPS.combinedDPS = fullDPS.combinedDPS + usedEnv.player.output.TotalDPS * activeSkillCount

--- a/src/Modules/Calcs.lua
+++ b/src/Modules/Calcs.lua
@@ -120,7 +120,7 @@ function calcs.getMiscCalculator(build)
 			env, cachedPlayerDB, cachedPlayerDB, cachedMinionDB = calcs.initEnv(build, "CALCULATOR", override)
 		end
 		calcs.perform(env)
-		if GlobalCache.useFullDPS then
+		if GlobalCache.useFullDPS or build.viewMode == "TREE" then
 			-- prevent upcoming calculation from using Cached Data and thus forcing it to re-calculate new FullDPS roll-up 
 			-- without this, FullDPS increase/decrease when for node/item/gem comparison would be all 0 as it would be comparing
 			-- A with A (due to cache reuse) instead of A with B

--- a/src/Modules/Calcs.lua
+++ b/src/Modules/Calcs.lua
@@ -115,13 +115,14 @@ function calcs.getMiscCalculator(build)
 
 	return function(override, accelerate)
 		env, cachedPlayerDB, cachedPlayerDB, cachedMinionDB = calcs.initEnv(build, "CALCULATOR", override)
-		calcs.perform(env)
+		calcs.perform(env, true)
 		if GlobalCache.useFullDPS or build.viewMode == "TREE" then
 			-- prevent upcoming calculation from using Cached Data and thus forcing it to re-calculate new FullDPS roll-up 
 			-- without this, FullDPS increase/decrease when for node/item/gem comparison would be all 0 as it would be comparing
 			-- A with A (due to cache reuse) instead of A with B
 			GlobalCache.dontUseCache = true
 			fullDPS = calcs.calcFullDPS(build, "CALCULATOR", override, { cachedPlayerDB = cachedPlayerDB, cachedEnemyDB = cachedEnemyDB, cachedMinionDB = cachedMinionDB, env = env, accelerate = accelerate })
+			-- reset cache usage
 			GlobalCache.dontUseCache = nil
 			env.player.output.SkillDPS = fullDPS.skills
 			env.player.output.FullDPS = fullDPS.combinedDPS
@@ -177,7 +178,7 @@ function calcs.calcFullDPS(build, mode, override, specEnv)
 						GlobalCache.dontUseCache = nil
 					end
 					fullEnv.player.mainSkill = activeSkill
-					calcs.perform(fullEnv)
+					calcs.perform(fullEnv, true)
 					usedEnv = fullEnv
 					GlobalCache.dontUseCache = forceCache
 				end

--- a/src/Modules/Calcs.lua
+++ b/src/Modules/Calcs.lua
@@ -219,11 +219,11 @@ function calcs.calcFullDPS(build, mode, override, specEnv)
 					end
 					if activeSkill.mirage.output.BleedDPS and activeSkill.mirage.output.BleedDPS > fullDPS.bleedDPS then
 						fullDPS.bleedDPS = activeSkill.mirage.output.BleedDPS
-						bleedSource = activeSkill.activeEffect.grantedEffect.name
+						bleedSource = activeSkill.activeEffect.grantedEffect.name .. " (Mirage)"
 					end
 					if activeSkill.mirage.output.IgniteDPS and activeSkill.mirage.output.IgniteDPS > fullDPS.igniteDPS then
 						fullDPS.igniteDPS = activeSkill.mirage.output.IgniteDPS
-						igniteSource = activeSkill.activeEffect.grantedEffect.name
+						igniteSource = activeSkill.activeEffect.grantedEffect.name .. " (Mirage)"
 					end
 					if activeSkill.mirage.output.PoisonDPS and activeSkill.mirage.output.PoisonDPS > 0 then
 						fullDPS.poisonDPS = fullDPS.poisonDPS + activeSkill.mirage.output.PoisonDPS * (activeSkill.mirage.output.TotalPoisonStacks or 1) * mirageCount

--- a/src/Modules/Common.lua
+++ b/src/Modules/Common.lua
@@ -709,6 +709,7 @@ end
 -- Full DPS related: add to roll-up exclusion list
 -- this is for skills that are used by Mirage Warriors for example
 function addToFullDpsExclusionList(skill)
+	--ConPrintf("ADDING TO FULL DPS EXCLUDE: " .. cacheSkillUUID(skill))
 	GlobalCache.excludeFullDpsList[cacheSkillUUID(skill)] = true
 end
 


### PR DESCRIPTION
General's Cry + Dominating Blow seems to be a troublesome combo that really stress-tests my implementation of creating a copy of an active skill to give to mirage units.

This fixes the latest crash.

TODO - fix General's Cry DPS to not be players, but minions in the case of Dominating Blow