### PR TITLE
FullDPS compare for node hover in Tree View

### DIFF
--- a/src/Modules/Calcs.lua
+++ b/src/Modules/Calcs.lua
@@ -107,7 +107,7 @@ function calcs.getMiscCalculator(build)
 	-- Run base calculation pass
 	local env, cachedPlayerDB, cachedEnemyDB, cachedMinionDB = calcs.initEnv(build, "CALCULATOR")
 	calcs.perform(env)
-	if GlobalCache.useFullDPS then
+	if GlobalCache.useFullDPS or build.viewMode == "TREE" then
 		local fullDPS = calcs.calcFullDPS(build, "CALCULATOR", {}, { cachedPlayerDB = cachedPlayerDB, cachedEnemyDB = cachedEnemyDB, env = env})
 		env.player.output.SkillDPS = fullDPS.skills
 		env.player.output.FullDPS = fullDPS.combinedDPS
@@ -121,7 +121,7 @@ function calcs.getMiscCalculator(build)
 			env, cachedPlayerDB, cachedPlayerDB, cachedMinionDB = calcs.initEnv(build, "CALCULATOR", override)
 		end
 		calcs.perform(env)
-		if GlobalCache.useFullDPS then
+		if GlobalCache.useFullDPS or build.viewMode == "TREE" then
 			-- prevent upcoming calculation from using Cached Data and thus forcing it to re-calculate new FullDPS roll-up 
 			-- without this, FullDPS increase/decrease when for node/item/gem comparison would be all 0 as it would be comparing
 			-- A with A (due to cache reuse) instead of A with B


### PR DESCRIPTION
When we modified to only use FullDPS calculations for support gems, item sorting and power-builder it be default disabled using FullDPS comparison in Tree View when hovering over a node. This fixes that.