### PR TITLE
update the vigils fortify duration to 8 seconds

### DIFF
--- a/src/Data/Uniques/jewel.lua
+++ b/src/Data/Uniques/jewel.lua
@@ -1261,12 +1261,14 @@ With at least 40 Intelligence in Radius, Raised Spectres have a 50% chance to ga
 The Vigil
 Crimson Jewel
 Variant: Pre 2.6.0
+Variant: Pre 3.14.0
 Variant: Current
 Limited to: 1
 Radius: Medium
 (8-15)% increased Armour
 {variant:1}With at least 40 Strength in Radius, Vigilant Strike also Fortifies Nearby Allies for 3 seconds.
 {variant:2}With at least 40 Strength in Radius, Vigilant Strike Fortifies you and Nearby Allies for 12 seconds
+{variant:3}With at least 40 Strength in Radius, Vigilant Strike Fortifies you and Nearby Allies for 8 seconds
 ]],[[
 Violent Dead
 Cobalt Jewel


### PR DESCRIPTION
The Vigil unique Jewel now grants Fortify with a base duration of 8 seconds (previously 12 seconds)

![image](https://user-images.githubusercontent.com/54453318/114680650-aeef8300-9d0d-11eb-9f0f-c76688e215b2.png)
