### PR TITLE
Add support for Petrified Blood's extra life cost buff

### DIFF
--- a/src/Data/Skills/act_str.lua
+++ b/src/Data/Skills/act_str.lua
@@ -4456,10 +4456,14 @@ skills["PetrifiedBlood"] = {
 	skillTypes = { [SkillType.Spell] = true, [SkillType.Buff] = true, [SkillType.Instant] = true, [SkillType.Type91] = true, [SkillType.Type92] = true, [SkillType.ManaCostReserved] = true, [SkillType.SecondWindSupport] = true, },
 	statDescriptionScope = "buff_skill_stat_descriptions",
 	castTime = 0,
+	statMap = {
+		["skill_grants_life_cost_%_mana_cost_while_not_on_low_life"] = {
+			mod("BaseManaCostAsExtraBaseLifeCost", "BASE", nil, 0, 0, { type = "GlobalEffect", effectType = "Buff", unscalable = true }, { type = "Condition", var = "LowLife", neg = true }),
+		},
+	},
 	baseFlags = {
 	},
 	baseMods = {
-		mod("LifeCost", "MORE", -60, 0, 0, { type = "GlobalEffect", effectType = "Buff", unscalable = true }),
 	},
 	qualityStats = {
 		Default = {

--- a/src/Data/Skills/act_str.lua
+++ b/src/Data/Skills/act_str.lua
@@ -4458,7 +4458,7 @@ skills["PetrifiedBlood"] = {
 	castTime = 0,
 	statMap = {
 		["skill_grants_life_cost_%_mana_cost_while_not_on_low_life"] = {
-			mod("ManaCostAsExtraLifeCost", "BASE", nil, 0, 0, { type = "GlobalEffect", effectType = "Buff", unscalable = true }, { type = "Condition", var = "LowLife", neg = true }),
+			mod("BaseManaCostAsExtraBaseLifeCost", "BASE", nil, 0, 0, { type = "GlobalEffect", effectType = "Buff", unscalable = true }, { type = "Condition", var = "LowLife", neg = true }),
 		},
 	},
 	baseFlags = {

--- a/src/Data/Skills/act_str.lua
+++ b/src/Data/Skills/act_str.lua
@@ -4458,7 +4458,7 @@ skills["PetrifiedBlood"] = {
 	castTime = 0,
 	statMap = {
 		["skill_grants_life_cost_%_mana_cost_while_not_on_low_life"] = {
-			mod("BaseManaCostAsExtraBaseLifeCost", "BASE", nil, 0, 0, { type = "GlobalEffect", effectType = "Buff", unscalable = true }, { type = "Condition", var = "LowLife", neg = true }),
+			mod("ManaCostAsExtraLifeCost", "BASE", nil, 0, 0, { type = "GlobalEffect", effectType = "Buff", unscalable = true }, { type = "Condition", var = "LowLife", neg = true }),
 		},
 	},
 	baseFlags = {

--- a/src/Export/Skills/act_str.txt
+++ b/src/Export/Skills/act_str.txt
@@ -790,7 +790,7 @@ local skills, mod, flag, skill = ...
 #skill PetrifiedBlood
 	statMap = {
 		["skill_grants_life_cost_%_mana_cost_while_not_on_low_life"] = {
-			mod("BaseManaCostAsExtraBaseLifeCost", "BASE", nil, 0, 0, { type = "GlobalEffect", effectType = "Buff", unscalable = true }, { type = "Condition", var = "LowLife", neg = true }),
+			mod("ManaCostAsExtraLifeCost", "BASE", nil, 0, 0, { type = "GlobalEffect", effectType = "Buff", unscalable = true }, { type = "Condition", var = "LowLife", neg = true }),
 		},
 	},
 #mods

--- a/src/Export/Skills/act_str.txt
+++ b/src/Export/Skills/act_str.txt
@@ -788,7 +788,11 @@ local skills, mod, flag, skill = ...
 #mods
 
 #skill PetrifiedBlood
-#baseMod mod("LifeCost", "MORE", -60, 0, 0, { type = "GlobalEffect", effectType = "Buff", unscalable = true })
+	statMap = {
+		["skill_grants_life_cost_%_mana_cost_while_not_on_low_life"] = {
+			mod("BaseManaCostAsExtraBaseLifeCost", "BASE", nil, 0, 0, { type = "GlobalEffect", effectType = "Buff", unscalable = true }, { type = "Condition", var = "LowLife", neg = true }),
+		},
+	},
 #mods
 
 #skill PhysicalDamageAura

--- a/src/Export/Skills/act_str.txt
+++ b/src/Export/Skills/act_str.txt
@@ -790,7 +790,7 @@ local skills, mod, flag, skill = ...
 #skill PetrifiedBlood
 	statMap = {
 		["skill_grants_life_cost_%_mana_cost_while_not_on_low_life"] = {
-			mod("ManaCostAsExtraLifeCost", "BASE", nil, 0, 0, { type = "GlobalEffect", effectType = "Buff", unscalable = true }, { type = "Condition", var = "LowLife", neg = true }),
+			mod("BaseManaCostAsExtraBaseLifeCost", "BASE", nil, 0, 0, { type = "GlobalEffect", effectType = "Buff", unscalable = true }, { type = "Condition", var = "LowLife", neg = true }),
 		},
 	},
 #mods

--- a/src/Modules/CalcOffence.lua
+++ b/src/Modules/CalcOffence.lua
@@ -983,6 +983,7 @@ function calcs.offence(env, actor, activeSkill)
 				output[resource.."Cost"] = m_floor(m_abs(inc / 100) * output[resource.."Cost"]) * (inc >= 0 and 1 or -1) + output[resource.."Cost"]
 				output[resource.."Cost"] = m_floor(m_abs(more - 1) * output[resource.."Cost"]) * (more >= 1 and 1 or -1) + output[resource.."Cost"]
 				output[resource.."Cost"] = m_max(0, m_floor(output[resource.."Cost"] + total))
+				output[resource.."CostNoMult"] = m_max(0, m_floor(cost * mult) + total)
 				if resource == "Mana" and skillFlags.totem then
 					local reservedFlat = activeSkill.skillData.manaReservationFlat or activeSkill.activeEffect.grantedEffectLevel.manaReservationFlat or 0
 					output[resource.."Cost"] = output[resource.."Cost"] + reservedFlat
@@ -1027,7 +1028,7 @@ function calcs.offence(env, actor, activeSkill)
 		for res, dummy in pairs(names) do
 			for resExtra, dummy in pairs(names) do
 				local extra = skillModList:Sum("BASE", skillCfg, res.."CostAsExtra"..resExtra.."Cost") / 100
-				output[resExtra.."Cost"] = output[resExtra.."Cost"] + m_floor(output[res.."Cost"] * extra)
+				output[resExtra.."Cost"] = output[resExtra.."Cost"] + m_floor(output[res.."CostNoMult"] * extra)
 			end
 		end
 	end

--- a/src/Modules/CalcOffence.lua
+++ b/src/Modules/CalcOffence.lua
@@ -981,8 +981,10 @@ function calcs.offence(env, actor, activeSkill)
 				for res, dummy in pairs(names) do
 					local extra = skillModList:Sum("BASE", skillCfg, "Base"..res.."CostAsExtraBase"..resource.."Cost") / 100
 					local extraBase = activeSkill.activeEffect.grantedEffectLevel.cost[res] or 0
-					extraBase = extraBase + skillModList:Sum("BASE", skillCfg, res.."CostBase") 
-					cost = cost + m_floor(extraBase * extra)
+					local extraTotal = skillModList:Sum("BASE", skillCfg, res.."Cost")
+					extraBase = extraBase + skillModList:Sum("BASE", skillCfg, res.."CostBase")
+					cost = cost + round(extraBase * extra)
+					total = total + round(extraTotal * extra)
 				end
 				if resource == "Mana" and skillData.baseManaCostIsAtLeastPercentUnreservedMana then
 					cost = m_max(cost, m_floor((output.ManaUnreserved or 0) * skillData.baseManaCostIsAtLeastPercentUnreservedMana / 100))

--- a/src/Modules/CalcOffence.lua
+++ b/src/Modules/CalcOffence.lua
@@ -976,6 +976,14 @@ function calcs.offence(env, actor, activeSkill)
 				local base = skillModList:Sum("BASE", skillCfg, resource.."CostBase")
 				local total = skillModList:Sum("BASE", skillCfg, resource.."Cost")
 				local cost = base + (activeSkill.activeEffect.grantedEffectLevel.cost[resource] or 0)
+
+				-- example: Petrified Blood (% of base mana cost as extra base life cost)
+				for res, dummy in pairs(names) do
+					local extra = skillModList:Sum("BASE", skillCfg, "Base"..res.."CostAsExtraBase"..resource.."Cost") / 100
+					local extraBase = activeSkill.activeEffect.grantedEffectLevel.cost[res] or 0
+					extraBase = extraBase + skillModList:Sum("BASE", skillCfg, res.."CostBase") 
+					cost = cost + m_floor(extraBase * extra)
+				end
 				if resource == "Mana" and skillData.baseManaCostIsAtLeastPercentUnreservedMana then
 					cost = m_max(cost, m_floor((output.ManaUnreserved or 0) * skillData.baseManaCostIsAtLeastPercentUnreservedMana / 100))
 				end

--- a/src/Modules/CalcOffence.lua
+++ b/src/Modules/CalcOffence.lua
@@ -976,6 +976,14 @@ function calcs.offence(env, actor, activeSkill)
 				local base = skillModList:Sum("BASE", skillCfg, resource.."CostBase")
 				local total = skillModList:Sum("BASE", skillCfg, resource.."Cost")
 				local cost = base + (activeSkill.activeEffect.grantedEffectLevel.cost[resource] or 0)
+
+				-- example: Petrified Blood (% of base mana cost as extra base life cost)
+				for res, dummy in pairs(names) do
+					local extra = skillModList:Sum("BASE", skillCfg, "Base"..res.."CostAsExtraBase"..resource.."Cost") / 100
+					local extraBase = activeSkill.activeEffect.grantedEffectLevel.cost[res] or 0
+					extraBase = extraBase + skillModList:Sum("BASE", skillCfg, res.."CostBase") 
+					cost = cost + m_floor(extraBase * extra)
+				end
 				if resource == "Mana" and skillData.baseManaCostIsAtLeastPercentUnreservedMana then
 					cost = m_max(cost, m_floor((output.ManaUnreserved or 0) * skillData.baseManaCostIsAtLeastPercentUnreservedMana / 100))
 				end
@@ -1017,17 +1025,6 @@ function calcs.offence(env, actor, activeSkill)
 					end
 					t_insert(breakdown[resource.."Cost"], s_format("= %d"..(percent and "%%" or ""), output[resource.."Cost"]))
 				end
-			end
-		end
-	end
-
-	-- Resource cost as another extra resource cost
-	-- example: Petrified Blood (% of mana cost as extra life cost)
-	if not isTriggered and not activeSkill.activeEffect.grantedEffect.triggered then
-		for res, dummy in pairs(names) do
-			for resExtra, dummy in pairs(names) do
-				local extra = skillModList:Sum("BASE", skillCfg, res.."CostAsExtra"..resExtra.."Cost") / 100
-				output[resExtra.."Cost"] = output[resExtra.."Cost"] + m_floor(output[res.."Cost"] * extra)
 			end
 		end
 	end

--- a/src/Modules/CalcOffence.lua
+++ b/src/Modules/CalcOffence.lua
@@ -983,7 +983,6 @@ function calcs.offence(env, actor, activeSkill)
 				output[resource.."Cost"] = m_floor(m_abs(inc / 100) * output[resource.."Cost"]) * (inc >= 0 and 1 or -1) + output[resource.."Cost"]
 				output[resource.."Cost"] = m_floor(m_abs(more - 1) * output[resource.."Cost"]) * (more >= 1 and 1 or -1) + output[resource.."Cost"]
 				output[resource.."Cost"] = m_max(0, m_floor(output[resource.."Cost"] + total))
-				output[resource.."CostNoMult"] = m_max(0, m_floor(cost * mult) + total)
 				if resource == "Mana" and skillFlags.totem then
 					local reservedFlat = activeSkill.skillData.manaReservationFlat or activeSkill.activeEffect.grantedEffectLevel.manaReservationFlat or 0
 					output[resource.."Cost"] = output[resource.."Cost"] + reservedFlat
@@ -1028,7 +1027,7 @@ function calcs.offence(env, actor, activeSkill)
 		for res, dummy in pairs(names) do
 			for resExtra, dummy in pairs(names) do
 				local extra = skillModList:Sum("BASE", skillCfg, res.."CostAsExtra"..resExtra.."Cost") / 100
-				output[resExtra.."Cost"] = output[resExtra.."Cost"] + m_floor(output[res.."CostNoMult"] * extra)
+				output[resExtra.."Cost"] = output[resExtra.."Cost"] + m_floor(output[res.."Cost"] * extra)
 			end
 		end
 	end

--- a/src/Modules/CalcOffence.lua
+++ b/src/Modules/CalcOffence.lua
@@ -976,14 +976,6 @@ function calcs.offence(env, actor, activeSkill)
 				local base = skillModList:Sum("BASE", skillCfg, resource.."CostBase")
 				local total = skillModList:Sum("BASE", skillCfg, resource.."Cost")
 				local cost = base + (activeSkill.activeEffect.grantedEffectLevel.cost[resource] or 0)
-
-				-- example: Petrified Blood (% of base mana cost as extra base life cost)
-				for res, dummy in pairs(names) do
-					local extra = skillModList:Sum("BASE", skillCfg, "Base"..res.."CostAsExtraBase"..resource.."Cost") / 100
-					local extraBase = activeSkill.activeEffect.grantedEffectLevel.cost[res] or 0
-					extraBase = extraBase + skillModList:Sum("BASE", skillCfg, res.."CostBase") 
-					cost = cost + m_floor(extraBase * extra)
-				end
 				if resource == "Mana" and skillData.baseManaCostIsAtLeastPercentUnreservedMana then
 					cost = m_max(cost, m_floor((output.ManaUnreserved or 0) * skillData.baseManaCostIsAtLeastPercentUnreservedMana / 100))
 				end
@@ -1025,6 +1017,17 @@ function calcs.offence(env, actor, activeSkill)
 					end
 					t_insert(breakdown[resource.."Cost"], s_format("= %d"..(percent and "%%" or ""), output[resource.."Cost"]))
 				end
+			end
+		end
+	end
+
+	-- Resource cost as another extra resource cost
+	-- example: Petrified Blood (% of mana cost as extra life cost)
+	if not isTriggered and not activeSkill.activeEffect.grantedEffect.triggered then
+		for res, dummy in pairs(names) do
+			for resExtra, dummy in pairs(names) do
+				local extra = skillModList:Sum("BASE", skillCfg, res.."CostAsExtra"..resExtra.."Cost") / 100
+				output[resExtra.."Cost"] = output[resExtra.."Cost"] + m_floor(output[res.."Cost"] * extra)
 			end
 		end
 	end


### PR DESCRIPTION
Specific line:
`Skills gain a Base Life Cost equal to 40% of Base Mana Cost while not on Low Life`

This is coded as a generic way to add extra base costs from root base costs.

The commit also removes this baseMod from the gem which I believe is incorrect:
` mod("LifeCost", "MORE", -60, 0, 0, { type = "GlobalEffect", effectType = "Buff", unscalable = true })`
(Petrified blood does not grant 60% less life cost of skills)


Screenshot showing Earthquake + Petrified Blood, mouse hovers the alternate quality that reduces this extra cost (40 -> 30%)
![image](https://user-images.githubusercontent.com/67038113/115106929-08eb8500-9f68-11eb-942a-cf47099be71c.png)
