### PR TITLE
Fix Exsanguinate stacks applying to all DoTs

### DIFF
--- a/src/Data/Skills/act_str.lua
+++ b/src/Data/Skills/act_str.lua
@@ -2372,7 +2372,7 @@ skills["Exsanguinate"] = {
 	baseMods = {
 		skill("debuff", true),
 		mod("Multiplier:ExsanguinateMaxStagesAfterFirst", "BASE", 2),
-		mod("Damage", "MORE", 100, ModFlag.Dot, 0, { type = "Multiplier", var = "ExsanguinateStageAfterFirst"}),
+		mod("PhysicalDamage", "MORE", 100, 0, KeywordFlag.PhysicalDot, { type = "Multiplier", var = "ExsanguinateStageAfterFirst"}),
 	},
 	qualityStats = {
 		Default = {

--- a/src/Export/Skills/act_str.txt
+++ b/src/Export/Skills/act_str.txt
@@ -433,7 +433,7 @@ local skills, mod, flag, skill = ...
 #flags spell duration
 #baseMod skill("debuff", true)
 #baseMod mod("Multiplier:ExsanguinateMaxStagesAfterFirst", "BASE", 2)
-#baseMod mod("Damage", "MORE", 100, ModFlag.Dot, 0, { type = "Multiplier", var = "ExsanguinateStageAfterFirst"})
+#baseMod mod("PhysicalDamage", "MORE", 100, 0, KeywordFlag.PhysicalDot, { type = "Multiplier", var = "ExsanguinateStageAfterFirst"})
 #mods
 
 #skill BloodSandArmour


### PR DESCRIPTION
The Stages box was multiplying damage on all aliments instead of just the phys dots