### PR TITLE
Fix Punishment Curse doesn't affect the DPS while select "Enemy is on Low Life"

### DIFF
--- a/src/Data/Skills/act_str.lua
+++ b/src/Data/Skills/act_str.lua
@@ -4627,7 +4627,7 @@ skills["Punishment"] = {
 	castTime = 0.5,
 	statMap = {
 		["damage_taken_+%_on_low_life"] = {
-			mod("DamageTaken", "INC", nil, 0, 0, { type = "GlobalEffect", effectType = "CurseBuff" }, { type = "ActorCondition", actor = "enemy", var="LowLife" }),
+			mod("DamageTaken", "INC", nil, 0, 0, { type = "GlobalEffect", effectType = "Curse" }, { type = "Condition", var = "LowLife"}),
 		},
 	},
 	baseFlags = {

--- a/src/Data/Skills/act_str.lua
+++ b/src/Data/Skills/act_str.lua
@@ -4627,7 +4627,7 @@ skills["Punishment"] = {
 	castTime = 0.5,
 	statMap = {
 		["damage_taken_+%_on_low_life"] = {
-			mod("DamageTaken", "INC", nil, 0, 0, { type = "GlobalEffect", effectType = "Curse" }, { type = "Condition", var = "LowLife"}),
+			mod("DamageTaken", "INC", nil, 0, 0, { type = "GlobalEffect", effectType = "CurseBuff" }, { type = "ActorCondition", actor = "enemy", var="LowLife" }),
 		},
 	},
 	baseFlags = {

--- a/src/Export/Skills/act_str.txt
+++ b/src/Export/Skills/act_str.txt
@@ -813,7 +813,7 @@ local skills, mod, flag, skill = ...
 #flags spell curse area duration hex
 	statMap = {
 		["damage_taken_+%_on_low_life"] = {
-			mod("DamageTaken", "INC", nil, 0, 0, { type = "GlobalEffect", effectType = "CurseBuff" }, { type = "ActorCondition", actor = "enemy", var="LowLife" }),
+			mod("DamageTaken", "INC", nil, 0, 0, { type = "GlobalEffect", effectType = "Curse" }, { type = "Condition", var = "LowLife"}),
 		},
 	},
 #baseMod skill("debuff", true)


### PR DESCRIPTION
Fix Punishment Curse doesn't affect the DPS while select "Enemy is on Low Life"

Issue #2607 Punishment Curse DPS calculation/For Effective DPS:Is the enemy on Low Life check bug 