### PR TITLE
Support for wildcard (*) in unique filtering (#2656)

### DIFF
--- a/src/Classes/ItemDBControl.lua
+++ b/src/Classes/ItemDBControl.lua
@@ -121,6 +121,7 @@ function ItemDBClass:DoesItemMatchFilters(item)
 	end
 	local searchStr = self.controls.search.buf:lower()
 	if searchStr:match("%S") then
+		searchStr = searchStr:gsub("([^%w ])", "%%%1"):gsub("%%%*", "%.%*")
 		local found = false
 		local mode = self.controls.searchMode.selIndex
 		if mode == 1 or mode == 2 then
@@ -130,19 +131,19 @@ function ItemDBClass:DoesItemMatchFilters(item)
 		end
 		if mode == 1 or mode == 3 then
 			for _, line in pairs(item.enchantModLines) do
-				if line.line:lower():find(searchStr, 1, true) then
+				if line.line:lower():find(searchStr, 1, false) then
 					found = true
 					break
 				end
 			end
 			for _, line in pairs(item.implicitModLines) do
-				if line.line:lower():find(searchStr, 1, true) then
+				if line.line:lower():find(searchStr, 1, false) then
 					found = true
 					break
 				end
 			end
 			for _, line in pairs(item.explicitModLines) do
-				if line.line:lower():find(searchStr, 1, true) then
+				if line.line:lower():find(searchStr, 1, false) then
 					found = true
 					break
 				end
@@ -150,7 +151,7 @@ function ItemDBClass:DoesItemMatchFilters(item)
 			if not found then
 				searchStr = searchStr:gsub(" ","")
 				for i, mod in ipairs(item.baseModList) do
-					if mod.name:lower():find(searchStr, 1, true) then
+					if mod.name:lower():find(searchStr, 1, false) then
 						found = true
 						break
 					end


### PR DESCRIPTION
This change is to allow an asterisk (*) to be used as a wildcard when filtering uniques by text.

This was done by turning off "plain" string find() to allow for pattern matching. The search string is escaped so that all magic characters are escaped, and then asterisks (\*) are replaced with the appropriate actual wildcard search characters (.*).

Some example tests:
"per * strength" - matches The Baron and Iron Heart despite having different values of strength for their mod
"penetrates\*cold" - matches items with different levels of cold penetration
"gain*on crit" - matches all items that gain something on critical strike
"200%*damage" - still matches the % character, finding everything with 200% and something with damage

Other magic characters should match as if they are just text, only the asterisk (*) is intended to be used for pattern matching.