### PR TITLE
Vortex's initial hit is now supported

### DIFF
--- a/src/Data/Skills/act_int.lua
+++ b/src/Data/Skills/act_int.lua
@@ -10141,6 +10141,9 @@ skills["FrostBoltNova"] = {
 		duration = true,
 		forceInstant = true,
 	},
+	preDamageFunc = function(activeSkill, output)
+		activeSkill.skillData.hitTimeOverride = output.Cooldown
+	end,
 	baseMods = {
 		skill("dotIsArea", true),
 		skill("radius", 20),

--- a/src/Export/Skills/act_int.txt
+++ b/src/Export/Skills/act_int.txt
@@ -1765,6 +1765,9 @@ local skills, mod, flag, skill = ...
 
 #skill FrostBoltNova
 #flags spell area duration forceInstant
+	preDamageFunc = function(activeSkill, output)
+		activeSkill.skillData.hitTimeOverride = output.Cooldown
+	end,
 #baseMod skill("dotIsArea", true)
 #baseMod skill("radius", 20)
 #mods


### PR DESCRIPTION
Overrides the cast rate to the Skill Cooldown. Matching functionality on Shockwave Support.

Fixes #1277

The numbers are still off because it's unrealistic that you're casting Vortex perfectly on cooldown timings but it's a whole lot closer than 0.

https://pastebin.com/spzjUTKW For a test build if you need it.