### PR TITLE
Warcries have infinite power

### DIFF
--- a/src/Modules/CalcPerform.lua
+++ b/src/Modules/CalcPerform.lua
@@ -708,6 +708,9 @@ local function doActorMisc(env, actor)
 	if modDB:Flag(nil, "CryWolfMinimumPower") and modDB:Sum("BASE", nil, "WarcryPower") < 10 then
 		modDB:NewMod("WarcryPower", "OVERRIDE", 10, "Minimum Warcry Power from CryWolf")
 	end
+	if modDB:Flag(nil, "WarcryInfinitePower") then
+		modDB:NewMod("WarcryPower", "OVERRIDE", 999999, "Warcries have infinite power")
+	end
 	output.BloodCharges = m_min(modDB:Override(nil, "BloodCharges") or output.BloodChargesMax, output.BloodChargesMax)
 
 	output.WarcryPower = modDB:Override(nil, "WarcryPower") or modDB:Sum("BASE", nil, "WarcryPower") or 0

--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -2180,6 +2180,7 @@ local specialModList = {
 	["enemies taunted by your warcries take (%d+)%% increased damage"] = function(num) return { mod("EnemyModifier", "LIST", { mod = mod("DamageTaken", "INC", num, { type = "Condition", var = "Taunted" }) }, { type = "Condition", var = "UsedWarcryRecently" }) } end,
 	["warcries share their cooldown"] = { flag("WarcryShareCooldown") },
 	["warcries have minimum of (%d+) power"] = { flag("CryWolfMinimumPower") },
+	["warcries have infinite power"] = { flag("WarcryInfinitePower") },
 	["(%d+)%% chance to inflict withered for (%d+) seconds on hit"] = { flag("Condition:CanWither") },
 	["(%d+)%% chance to inflict withered for (%d+) seconds on hit with this weapon"] = { flag("Condition:CanWither") },
 	["(%d+)%% chance to inflict withered for two seconds on hit if there are (%d+) or fewer withered debuffs on enemy"] = { flag("Condition:CanWither") },


### PR DESCRIPTION
This implements the Redblade Banner's "Warcries have infinite power" mod

What i still don't like about this, is that the 
![image](https://user-images.githubusercontent.com/54453318/117720411-e9e6b880-b1de-11eb-9e45-b869fc60b445.png)
is shown as empty. But the calculations are happening correctly under the hood. Is it possible to populate this box when equipping the shield? The other problem is, that the warcry power box only shows in the configuration tab when a Warcry is added as a skill, so its invisible with only the shield equipped.

![image](https://user-images.githubusercontent.com/54453318/117720870-7d1fee00-b1df-11eb-8635-33d65316baa4.png)

