### PR TITLE
20 Quality gem DPS tooltip comparison (aka. Is GCP vendor recipe worth doing?)

### DIFF
--- a/src/Classes/SkillsTab.lua
+++ b/src/Classes/SkillsTab.lua
@@ -645,6 +645,23 @@ function SkillsTabClass:CreateGemSlot(index)
 		self:AddUndoState()
 		self.build.buildFlag = true
 	end)
+	slot.quality.tooltipFunc = function(tooltip)
+		if tooltip:CheckForUpdate(self.build.outputRevision, self.displayGroup) then
+			if self.displayGroup.gemList[index] then
+				local calcFunc, calcBase = self.build.calcsTab:GetMiscCalculator(self.build)
+				if calcFunc then
+					local storedQuality = self.displayGroup.gemList[index].quality
+					self.displayGroup.gemList[index].quality = 20;
+					local storedGlobalCacheDPSView = GlobalCache.useFullDPS
+					GlobalCache.useFullDPS = calcBase.FullDPS ~= nil
+					local output = calcFunc({}, {})
+					GlobalCache.useFullDPS = storedGlobalCacheDPSView
+					self.displayGroup.gemList[index].quality = storedQuality
+					self.build:AddStatComparesToTooltip(tooltip, calcBase, output, "^7Setting to 20 quality will give you:")
+				end
+			end
+		end
+	end
 	slot.quality:AddToTabGroup(self.controls.groupLabel)
 	slot.quality.enabled = function()
 		return index <= #self.displayGroup.gemList

--- a/src/Classes/SkillsTab.lua
+++ b/src/Classes/SkillsTab.lua
@@ -651,7 +651,7 @@ function SkillsTabClass:CreateGemSlot(index)
 				local calcFunc, calcBase = self.build.calcsTab:GetMiscCalculator(self.build)
 				if calcFunc then
 					local storedQuality = self.displayGroup.gemList[index].quality
-					self.displayGroup.gemList[index].quality = 20;
+					self.displayGroup.gemList[index].quality = 20
 					local storedGlobalCacheDPSView = GlobalCache.useFullDPS
 					GlobalCache.useFullDPS = calcBase.FullDPS ~= nil
 					local output = calcFunc({}, {})


### PR DESCRIPTION
Many times when using PoB I want to know if the Gemcutter's prism vendor recipe is worth doing. That is, I'd like to compare the 0 quality gem DPS to the 20 quality gem DPS. Currently, this can be accomplished by adding another gem with the same level and 20 quality, and using the "enabled" tooltip to compare the DPS:
![image](https://user-images.githubusercontent.com/5494304/118780587-36269e00-b85a-11eb-8337-4ea14df941f0.png)

However, this gets a little tedious when you want to compare every gem in a six link. 

This commit creates a simple tooltip for the quality field which allows people see the DPS difference at a glance. It uses the exact same statCompare tooltip that the "enabled" field uses, so it's a very small change.
![image](https://user-images.githubusercontent.com/5494304/118781265-e1375780-b85a-11eb-8f71-bf39f6ba1a0e.png)


I only saw #2687 after making my own version. But the main difference is that this change doesn't add new fields (only a tooltip), and only compares with 20 quality, rather than a user inputted quality.
