### PR TITLE
Fix Interation between Agnostic and Pious Path

### DIFF
--- a/src/Modules/CalcDefence.lua
+++ b/src/Modules/CalcDefence.lua
@@ -441,7 +441,7 @@ function calcs.defence(env, actor)
 			output.LifeRegen = 0
 		end
 		-- Don't add life recovery mod for this
-		if output.LifeRegen and modDB:Flag(nil, "LifeRegenerationRecoversEnergyShield") then
+		if output.LifeRegen and modDB:Flag(nil, "LifeRegenerationRecoversEnergyShield") and output.EnergyShield > 0 then
 			modDB:NewMod("EnergyShieldRecovery", "BASE", lifeBase * modDB:More(nil, "LifeRegen"), "Life Regeneration Recovers Energy Shield")
 		end
 	end


### PR DESCRIPTION
The Pious Path node was granting energy shield recovery even though Agnostic sets the maximum energy shield to 0