### PR TITLE
Fix level progress calculations

### DIFF
--- a/src/Modules/Build.lua
+++ b/src/Modules/Build.lua
@@ -160,44 +160,44 @@ function buildMode:Init(dbFileName, buildName, buildXML, convertBuild)
 		local bandit = self.calcsTab.mainOutput.ExtraPoints or 0 
 		local usedMax, ascMax, levelreq, currentAct, banditStr, labSuggest = 99 + 22 + bandit, 8, 1, 1, "", ""
 		local acts = { 
-			[1] = { level = 12, questPoints = 2}, 
-			[2] = { level = 22, questPoints = 3}, 
-			[3] = { level = 32, questPoints = 5},
-			[4] = { level = 40, questPoints = 6},
-			[5] = { level = 44, questPoints = 8},
-			[6] = { level = 50, questPoints = 11},
-			[7] = { level = 54, questPoints = 14},
-			[8] = { level = 60, questPoints = 17},
-			[9] = { level = 64, questPoints = 19},
-			[10] = { level = 67, questPoints = 22}
+			[1] = { level = 1, questPoints = 0 }, 
+			[2] = { level = 12, questPoints = 2 }, 
+			[3] = { level = 22, questPoints = 3 + bandit }, 
+			[4] = { level = 32, questPoints = 5 + bandit },
+			[5] = { level = 40, questPoints = 6 + bandit },
+			[6] = { level = 44, questPoints = 8 + bandit },
+			[7] = { level = 50, questPoints = 11 + bandit },
+			[8] = { level = 54, questPoints = 14 + bandit },
+			[9] = { level = 60, questPoints = 17 + bandit },
+			[10] = { level = 64, questPoints = 19 + bandit },
+			[11] = { level = 67, questPoints = 22 + bandit }
 		}
 				
 		-- loop for how much quest skillpoints are used with the progress
-		while currentAct < 10 and PointsUsed > acts[currentAct].level + acts[currentAct].questPoints do
+		while currentAct < 11 and PointsUsed + 1 - acts[currentAct].questPoints > acts[currentAct + 1].level do
 			currentAct = currentAct + 1
 		end
 
 		-- bandits notification; when considered and in calculation after act 2
-		if currentAct >= 2 and bandit ~= 0 then
-			banditStr = "\nBandits Skillpoints: " .. bandit
+		if currentAct <= 2 and bandit ~= 0 then
+			bandit = 0
 		end
 		
 		-- to prevent a negative level at a blank sheet the level requirement will be set dependent on points invested until catched up with quest skillpoints 
-		levelreq = math.max(PointsUsed - acts[currentAct].questPoints,1)
-		if levelreq <= acts[currentAct].questPoints then levelreq = PointsUsed + 1 end  
+		levelreq = math.max(PointsUsed - acts[currentAct].questPoints + 1, acts[currentAct].level)
 		
 		-- Ascendency points for lab
 		-- this is a recommendation for beginners who are using Path of Building for the first time and trying to map out progress in PoB
 		local labstr = {"\nLabyrinth: Normal Lab", "\nLabyrinth: Cruel Lab", "\nLabyrinth: Merciless Lab", "\nLabyrinth: Uber Lab"}
 		local strAct = "Endgame"
-		if levelreq >= 33 and levelreq < 55 then labSuggest = labstr[1] end
-		if levelreq >= 55 and levelreq < 68 then labSuggest = labstr[2] end
-		if levelreq >= 68 and levelreq < 75 then labSuggest = labstr[3] end
-		if levelreq >= 75 and levelreq < 90 then labSuggest = labstr[4] end
-		if levelreq < 90 then strAct = currentAct end
+		if levelreq >= 33 and levelreq < 55 then labSuggest = labstr[1]
+		elseif levelreq >= 55 and levelreq < 68 then labSuggest = labstr[2]
+		elseif levelreq >= 68 and levelreq < 75 then labSuggest = labstr[3]
+		elseif levelreq >= 75 and levelreq < 90 then labSuggest = labstr[4]
+		elseif levelreq < 90 and currentAct <= 10 then strAct = currentAct end
 		
 		control.str = string.format("%s%3d / %3d   %s%d / %d", PointsUsed > usedMax and "^1" or "^7", PointsUsed, usedMax, AscUsed > ascMax and "^1" or "^7", AscUsed, ascMax)
-		control.req = "Required Level: ".. levelreq .. "\nEstimated Progress:\nAct: ".. strAct .. "\nQuestpoints: " .. acts[currentAct].questPoints .. banditStr .. labSuggest
+		control.req = "Required Level: ".. levelreq .. "\nEstimated Progress:\nAct: ".. strAct .. "\nQuestpoints: " .. acts[currentAct].questPoints - bandit .. "\nBandits Skillpoints: " .. bandit .. labSuggest
 		
 		return DrawStringWidth(16, "FIXED", control.str) + 8
 	end


### PR DESCRIPTION
The new level requirement guide had an off by one error beyond act 10 and strange level dips at the act thresholds