### PR TITLE
Fix Hollow Palm Technique

### DIFF
--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -75,7 +75,6 @@ local formList = {
 	["adds (%d+) to (%d+) (%a+) attack damage"] = "DMGATTACKS",
 	["adds (%d+)%-(%d+) (%a+) attack damage"] = "DMGATTACKS",
 	["(%d+) to (%d+) added attack (%a+) damage"] = "DMGATTACKS",
-	["adds (%d+) to (%d+) attack (%a+) damage to melee skills"] = "DMGATTACKSMELEE",
 	["adds (%d+) to (%d+) (%a+) damage to spells"] = "DMGSPELLS",
 	["adds (%d+)%-(%d+) (%a+) damage to spells"] = "DMGSPELLS",
 	["adds (%d+) to (%d+) (%a+) spell damage"] = "DMGSPELLS",
@@ -1499,6 +1498,10 @@ local specialModList = {
 	} end,
 	["life leech effects recover energy shield instead while on full life"] = { flag("ImmortalAmbition", { type = "Condition", var = "FullLife" }, { type = "Condition", var = "LeechingLife"}) },
 	["shepherd of souls"] = { mod("Damage", "MORE", -30, { type = "SkillType", skillType = SkillType.Vaal, neg = true }) },
+	["adds (%d+) to (%d+) attack physical damage to melee skills per (%d+) dexterity while you are unencumbered"] = function(_, min, max, dex) return { -- Hollow Palm 3 suffixes
+		mod("PhysicalMin", "BASE", tonumber(min), nil, ModFlag.Melee, KeywordFlag.Attack, { type = "PerStat", stat = "Dex", div = tonumber(dex) }, { type = "Condition", var = "Unencumbered" }),
+		mod("PhysicalMax", "BASE", tonumber(max), nil, ModFlag.Melee, KeywordFlag.Attack, { type = "PerStat", stat = "Dex", div = tonumber(dex) }, { type = "Condition", var = "Unencumbered" }),
+	} end,
 	-- Exerted Attacks
 	["exerted attacks deal (%d+)%% increased damage"] = function(num) return { mod("ExertIncrease", "INC", num, nil, ModFlag.Attack, 0) } end,
 	["exerted attacks have (%d+)%% chance to deal double damage"] = function(num) return { mod("ExertDoubleDamageChance", "BASE", num, nil, ModFlag.Attack, 0) } end,
@@ -3552,14 +3555,6 @@ local function parseMod(line, order)
 		modValue = { tonumber(formCap[1]), tonumber(formCap[2]) }
 		modName = { damageType.."Min", damageType.."Max" }
 		modFlag = modFlag or { keywordFlags = KeywordFlag.Attack }
-	elseif modForm == "DMGATTACKSMELEE" then
-		local damageType = dmgTypes[formCap[3]]
-		if not damageType then
-			return { }, line
-		end
-		modValue = { tonumber(formCap[1]), tonumber(formCap[2]) }
-		modName = { damageType.."Min", damageType.."Max" }
-		modFlag = modFlag or { keywordFlags = KeywordFlag.Attack, flags = ModFlag.Melee }
 	elseif modForm == "DMGSPELLS" then
 		local damageType = dmgTypes[formCap[3]]
 		if not damageType then

--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -75,6 +75,7 @@ local formList = {
 	["adds (%d+) to (%d+) (%a+) attack damage"] = "DMGATTACKS",
 	["adds (%d+)%-(%d+) (%a+) attack damage"] = "DMGATTACKS",
 	["(%d+) to (%d+) added attack (%a+) damage"] = "DMGATTACKS",
+	["adds (%d+) to (%d+) attack (%a+) damage to melee skills"] = "DMGATTACKSMELEE",
 	["adds (%d+) to (%d+) (%a+) damage to spells"] = "DMGSPELLS",
 	["adds (%d+)%-(%d+) (%a+) damage to spells"] = "DMGSPELLS",
 	["adds (%d+) to (%d+) (%a+) spell damage"] = "DMGSPELLS",
@@ -659,6 +660,7 @@ local modFlagList = {
 	["melee"] = { flags = ModFlag.Melee },
 	["with melee attacks"] = { flags = ModFlag.Melee },
 	["with melee critical strikes"] = { flags = ModFlag.Melee, tag = { type = "Condition", var = "CriticalStrike" } },
+	["with melee skills"] = { flags = ModFlag.Melee },
 	["with bow skills"] = { keywordFlags = KeywordFlag.Bow },
 	["on melee hit"] = { flags = ModFlag.Melee },
 	["with hits"] = { keywordFlags = KeywordFlag.Hit },
@@ -3550,6 +3552,14 @@ local function parseMod(line, order)
 		modValue = { tonumber(formCap[1]), tonumber(formCap[2]) }
 		modName = { damageType.."Min", damageType.."Max" }
 		modFlag = modFlag or { keywordFlags = KeywordFlag.Attack }
+	elseif modForm == "DMGATTACKSMELEE" then
+		local damageType = dmgTypes[formCap[3]]
+		if not damageType then
+			return { }, line
+		end
+		modValue = { tonumber(formCap[1]), tonumber(formCap[2]) }
+		modName = { damageType.."Min", damageType.."Max" }
+		modFlag = modFlag or { keywordFlags = KeywordFlag.Attack, flags = ModFlag.Melee }
 	elseif modForm == "DMGSPELLS" then
 		local damageType = dmgTypes[formCap[3]]
 		if not damageType then


### PR DESCRIPTION
Previously:
60% more Attack Speed while you are Unencumbered
14 to 20 Added Attack Physical Damage per 10 Dexterity while you are Unencumbered

Now:
40% more Attack Speed with Melee Skills while you are Unencumbered
Adds 14 to 20 Attack Physical Damage to Melee Skills per 10 Dexterity while you are Unencumbered

Fixes #2934