### PR TITLE
Add documentation for color codes to Notes tab

### DIFF
--- a/src/Classes/NotesTab.lua
+++ b/src/Classes/NotesTab.lua
@@ -14,7 +14,7 @@ local NotesTabClass = newClass("NotesTab", "ControlHost", "Control", function(se
 	self.lastContent = ""
 
 	local function getColorString(color, string) return color:gsub("%^", "^7")..": "..color..string end
-	local colorDesc = [[^7This field supports different colors.  Using the caret symbol (^) followed by a Hex code or a number will set the color.
+	local colorDesc = [[^7This field supports different colors.  Using the caret symbol (^) followed by a Hex code or a number (0-9) will set the color.
 Below are some common color codes PoB uses:	]]
 	self.controls.colorDoc = new("LabelControl", {"TOPLEFT",self,"TOPLEFT"}, 8, 8, 150, 16, colorDesc)
 	self.controls.normal = new("LabelControl", {"TOPLEFT",self.controls.colorDoc,"TOPLEFT"}, 0, 32, 50, 16, getColorString(colorCodes.NORMAL, "NORMAL"))

--- a/src/Classes/NotesTab.lua
+++ b/src/Classes/NotesTab.lua
@@ -13,7 +13,7 @@ local NotesTabClass = newClass("NotesTab", "ControlHost", "Control", function(se
 
 	self.lastContent = ""
 
-	local colorDesc = [[^7This field supports different colors.  Using the caret symbol (^) followed by a Hex code or a number will set the color.  Below are some common color codes PoB uses
+	local colorDesc = [[^7This field supports different colors.  Using the caret symbol (^) followed by a Hex code or a number will set the color.  Below are some common color codes PoB uses:
 ^7xC8C8C8: ^xC8C8C8Normal    ^7x8888FF: ^x8888FFMagic    ^7xFFFF77: ^xFFFF77Rare    ^7xAF6025: ^xAF6025Unique
 ^7xB97123: ^xB97123Fire     ^7x3F6DB3: ^x3F6DB3Cold    ^7xADAA47: ^xADAA47Lightning     ^7xD02090: ^xD02090Chaos
 	]]

--- a/src/Classes/NotesTab.lua
+++ b/src/Classes/NotesTab.lua
@@ -13,12 +13,23 @@ local NotesTabClass = newClass("NotesTab", "ControlHost", "Control", function(se
 
 	self.lastContent = ""
 
-	local colorDesc = [[^7This field supports different colors.  Using the caret symbol (^) followed by a Hex code or a number will set the color.  Below are some common color codes PoB uses:
-^7xC8C8C8: ^xC8C8C8Normal    ^7x8888FF: ^x8888FFMagic    ^7xFFFF77: ^xFFFF77Rare    ^7xAF6025: ^xAF6025Unique
-^7xB97123: ^xB97123Fire     ^7x3F6DB3: ^x3F6DB3Cold    ^7xADAA47: ^xADAA47Lightning     ^7xD02090: ^xD02090Chaos
-	]]
-	self.controls.colorDoc = new("LabelControl", {"TOPLEFT",self,"TOPLEFT"}, 8, 8, 200, 16, colorDesc)
-	self.controls.edit = new("EditControl", {"TOPLEFT",self.controls.colorDoc,"TOPLEFT"}, 0, 48, 0, 0, "", nil, "^%C\t\n", nil, nil, 16)
+	local function getColorString(color, string) return color:gsub("%^", "^7")..": "..color..string end
+	local colorDesc = [[^7This field supports different colors.  Using the caret symbol (^) followed by a Hex code or a number will set the color.
+Below are some common color codes PoB uses:	]]
+	self.controls.colorDoc = new("LabelControl", {"TOPLEFT",self,"TOPLEFT"}, 8, 8, 150, 16, colorDesc)
+	self.controls.normal = new("LabelControl", {"TOPLEFT",self.controls.colorDoc,"TOPLEFT"}, 0, 32, 50, 16, getColorString(colorCodes.NORMAL, "NORMAL"))
+	self.controls.magic = new("LabelControl", {"TOPLEFT",self.controls.normal,"TOPLEFT"}, 150, 0, 50, 16, getColorString(colorCodes.MAGIC, "MAGIC"))
+	self.controls.rare = new("LabelControl", {"TOPLEFT",self.controls.magic,"TOPLEFT"}, 150, 0, 50, 16, getColorString(colorCodes.RARE, "RARE"))
+	self.controls.unique = new("LabelControl", {"TOPLEFT",self.controls.rare,"TOPLEFT"}, 150, 0, 50, 16, getColorString(colorCodes.UNIQUE, "UNIQUE"))
+	self.controls.fire = new("LabelControl", {"TOPLEFT",self.controls.normal,"TOPLEFT"}, 0, 16, 50, 16, getColorString(colorCodes.FIRE, "FIRE"))
+	self.controls.cold = new("LabelControl", {"TOPLEFT",self.controls.fire,"TOPLEFT"}, 150, 0, 50, 16, getColorString(colorCodes.COLD, "COLD"))
+	self.controls.lightning = new("LabelControl", {"TOPLEFT",self.controls.cold,"TOPLEFT"}, 150, 0, 50, 16, getColorString(colorCodes.LIGHTNING, "LIGHTNING"))
+	self.controls.chaos = new("LabelControl", {"TOPLEFT",self.controls.lightning,"TOPLEFT"}, 150, 0, 50, 16, getColorString(colorCodes.CHAOS, "CHAOS"))
+	self.controls.strength = new("LabelControl", {"TOPLEFT",self.controls.fire,"TOPLEFT"}, 0, 16, 50, 16, getColorString(colorCodes.STRENGTH, "STRENGTH"))
+	self.controls.dexterity = new("LabelControl", {"TOPLEFT",self.controls.strength,"TOPLEFT"}, 150, 0, 50, 16, getColorString(colorCodes.DEXTERITY, "DEXTERITY"))
+	self.controls.intelligence = new("LabelControl", {"TOPLEFT",self.controls.dexterity,"TOPLEFT"}, 150, 0, 50, 16, getColorString(colorCodes.INTELLIGENCE, "INTELLIGENCE"))
+
+	self.controls.edit = new("EditControl", {"TOPLEFT",self.controls.fire,"TOPLEFT"}, 0, 48, 0, 0, "", nil, "^%C\t\n", nil, nil, 16)
 	self.controls.edit.width = function()
 		return self.width - 16
 	end

--- a/src/Classes/NotesTab.lua
+++ b/src/Classes/NotesTab.lua
@@ -13,12 +13,17 @@ local NotesTabClass = newClass("NotesTab", "ControlHost", "Control", function(se
 
 	self.lastContent = ""
 
-	self.controls.edit = new("EditControl", {"TOPLEFT",self,"TOPLEFT"}, 8, 8, 0, 0, "", nil, "^%C\t\n", nil, nil, 16)
+	local colorDesc = [[^7This field supports different colors.  Using the caret symbol (^) followed by a Hex code or a number will set the color.  Below are some common color codes PoB uses
+^7xC8C8C8: ^xC8C8C8Normal    ^7x8888FF: ^x8888FFMagic    ^7xFFFF77: ^xFFFF77Rare    ^7xAF6025: ^xAF6025Unique
+^7xB97123: ^xB97123Fire     ^7x3F6DB3: ^x3F6DB3Cold    ^7xADAA47: ^xADAA47Lightning     ^7xD02090: ^xD02090Chaos
+	]]
+	self.controls.colorDoc = new("LabelControl", {"TOPLEFT",self,"TOPLEFT"}, 8, 8, 200, 16, colorDesc)
+	self.controls.edit = new("EditControl", {"TOPLEFT",self.controls.colorDoc,"TOPLEFT"}, 0, 48, 0, 0, "", nil, "^%C\t\n", nil, nil, 16)
 	self.controls.edit.width = function()
 		return self.width - 16
 	end
 	self.controls.edit.height = function()
-		return self.height - 16
+		return self.height - 64
 	end
 	self:SelectControl(self.controls.edit)
 end)


### PR DESCRIPTION
I'm not a huge fan of how this looks right now, so I'm open to suggestions on how to display this better.  Another option would be a group of buttons that would change the color.  More user-friendly, but also a lot more work.

![image](https://user-images.githubusercontent.com/1209372/126667296-fc1aee00-5197-4d7c-9f94-5f80bb9e4a4e.png)
