### PR TITLE
Fix for downloading tree data if missing

### DIFF
--- a/src/Classes/PassiveTree.lua
+++ b/src/Classes/PassiveTree.lua
@@ -73,13 +73,12 @@ local PassiveTreeClass = newClass("PassiveTree", function(self, treeVersion)
 			page = pageFile:read("*a")
 			pageFile:close()
 		else
-			page = getFile("https://www.pathofexile.com/passive-skill-tree/")
+			page = getFile("https://www.pathofexile.com/passive-skill-tree")
 		end
 		local treeData = page:match("var passiveSkillTreeData = (%b{})")
 		if treeData then
 			treeText = "local tree=" .. jsonToLua(page:match("var passiveSkillTreeData = (%b{})"))
-			treeText = treeText .. "tree.classes=" .. jsonToLua(page:match("ascClasses: (%b{})"))
-			treeText = "return tree"
+			treeText = treeText .. "return tree"
 		else
 			treeText = "return " .. jsonToLua(page)
 		end


### PR DESCRIPTION
Did some investigation into these scenarios, found the download of the passive tree wasn't working.  Downloading this way leaves the ascendancies in the wrong locations, so could be worth incorporating that script here