### PR TITLE
Prevent build code from being interpreted as markdown

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -56,6 +56,7 @@ body:
       label: Build code
       description: Always provide a build code that exhibits the bug you want to report, even if it is not specific to a particular build. This helps us greatly to reproduce bugs faster.
       placeholder: Build codes can be either Base64 encoded text, or pastebin.com links to this text.
+      render: shell
     validations:
       required: true
   - type: textarea


### PR DESCRIPTION
Markdown rendering mangles the build code.