### PR TITLE
Fix Explosive Concoction not working with off hand weapons

### DIFF
--- a/src/Data/Skills/act_dex.lua
+++ b/src/Data/Skills/act_dex.lua
@@ -3396,7 +3396,7 @@ skills["ExplosiveConcoction"] = {
 		attack = true,
 		area = true,
 		projectile = true,
-		canStatStick = true,
+		canOffHandWeapon = true,
 	},
 	baseMods = {
 	},

--- a/src/Data/Skills/act_dex.lua
+++ b/src/Data/Skills/act_dex.lua
@@ -3396,6 +3396,7 @@ skills["ExplosiveConcoction"] = {
 		attack = true,
 		area = true,
 		projectile = true,
+		canStatStick = true,
 	},
 	baseMods = {
 	},

--- a/src/Export/Skills/act_dex.txt
+++ b/src/Export/Skills/act_dex.txt
@@ -611,7 +611,7 @@ local skills, mod, flag, skill = ...
 #mods
 
 #skill ExplosiveConcoction
-#flags attack area projectile
+#flags attack area projectile canOffHandWeapon
 	parts = {
 		{
 			name = "No Flasks",

--- a/src/Modules/CalcActiveSkill.lua
+++ b/src/Modules/CalcActiveSkill.lua
@@ -246,6 +246,9 @@ function calcs.buildActiveSkillModList(env, activeSkill)
 			if weapon2Flags then
 				activeSkill.weapon2Flags = weapon2Flags
 				skillFlags.weapon2Attack = true
+			elseif skillFlags.canStatStick then 
+				skillFlags.weapon2Attack = true
+				activeSkill.weapon2Flags = 0
 			elseif skillTypes[SkillType.DualWield] or weapon2Info then
 				-- Skill requires a compatible off hand weapon
 				skillFlags.disable = true

--- a/src/Modules/CalcActiveSkill.lua
+++ b/src/Modules/CalcActiveSkill.lua
@@ -246,7 +246,7 @@ function calcs.buildActiveSkillModList(env, activeSkill)
 			if weapon2Flags then
 				activeSkill.weapon2Flags = weapon2Flags
 				skillFlags.weapon2Attack = true
-			elseif skillFlags.canStatStick then 
+			elseif skillFlags.canOffHandWeapon then
 				skillFlags.weapon2Attack = true
 				activeSkill.weapon2Flags = 0
 			elseif skillTypes[SkillType.DualWield] or weapon2Info then


### PR DESCRIPTION
Currently Explosive Concotion allows for off hand weapons to be used as statsticks when the mainhand weapon is either empty or disabled

Currently PoB will give an error saying `Off Hand weapon is not usable with this skill` which doesn't allow for an accurate representation of actual DPS

This change allows for skills to get the canStatStick flag, which will check the main hand weapon condition first, and then reset the weapon2 flags allowing them to be used.