### PR TITLE
Add Usurper's Penance

### DIFF
--- a/src/Data/Uniques/helmet.lua
+++ b/src/Data/Uniques/helmet.lua
@@ -98,6 +98,17 @@ Requires Level 55, 114 Str
 {variant:1,2}50% chance to Avoid being Frozen
 {variant:1,2}10% increased Stun and Block Recovery
 {variant:3}Cannot be Frozen or Chilled if you've used a Fire Skill Recently
+]],[[
+Usurper's Penance
+Eternal Burgonet
+League: Expedition
+Requires Level 69, 138 Str
+(50-80)% increased Armour
+Attacks have 15% chance to cause Bleeding
+50% reduced Light Radius
++4% to Damage over Time Multiplier for Bleeding per Frenzy Charge
+Bleeding you inflict deals Damage 4% faster per Frenzy Charge
+(20-30)% chance to gain a Frenzy Charge on Critical Strike at Close Range
 ]],
 -- Helmet: Evasion
 [[

--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -2150,6 +2150,7 @@ local specialModList = {
 		mod("Damage", "MORE", tonumber(more) * num / 200, nil, 0, KeywordFlag.Bleed, { type = "Condition", var = "DualWielding"}, { type = "SkillType", skillType = SkillType.Attack }),
 		mod("Damage", "MORE", tonumber(more) * num / 100, nil, 0, KeywordFlag.Bleed, { type = "Condition", var = "DualWielding", neg = true }, { type = "SkillType", skillType = SkillType.Attack })
 	} end,
+	["bleeding you inflict deals damage (%d+)%% faster per frenzy charge"] = function(num) return { mod("BleedFaster", "INC", num, { type = "Multiplier", var = "FrenzyCharge" }) } end,
 	-- Impale and Bleed
 	["(%d+)%% increased effect of impales inflicted by hits that also inflict bleeding"] = function(num) return {
 		mod("ImpaleEffectOnBleed", "INC", num, nil, 0, KeywordFlag.Hit)


### PR DESCRIPTION
https://www.pathofexile.com/trade/search/Expedition/PWq3z4mhL

Second bleed mod is somehow not parsing, although 'infliction' & 'per frenzy' are in the modparser. I copied the affix directly from trade, so i don't think its a typo.

![unknown](https://user-images.githubusercontent.com/54453318/127458972-9ac11c39-e60a-4509-b7ac-10d42a932ba7.png)


Maybe someone knows what I'm doing wrong?