### PR TITLE
Don't set max inspiration charges for minions

### DIFF
--- a/src/Modules/CalcPerform.lua
+++ b/src/Modules/CalcPerform.lua
@@ -701,7 +701,9 @@ local function doActorMisc(env, actor)
 	if modDB:Flag(nil, "UseBlitzCharges") then
 		output.BlitzCharges = modDB:Override(nil, "BlitzCharges") or output.BlitzChargesMax
 	end
-	output.InspirationCharges = modDB:Override(nil, "InspirationCharges") or output.InspirationChargesMax
+	if not env.player.mainSkill.minion then 
+		output.InspirationCharges = modDB:Override(nil, "InspirationCharges") or output.InspirationChargesMax
+	end 
 	if modDB:Flag(nil, "UseGhostShrouds") then
 		output.GhostShrouds = modDB:Override(nil, "GhostShrouds") or 3
 	end


### PR DESCRIPTION
Fix for issue https://github.com/PathOfBuildingCommunity/PathOfBuilding/issues/3057

With this it no longer sets maximum inspiration charges for the minions, it however still lowers the mana cost for the player to cast it like intended.

Non-minion skills still keep their default maximum inspiration charges as well.

(redo of https://github.com/PathOfBuildingCommunity/PathOfBuilding/pull/3059 as it was based of master, not dev)