### PR TITLE
Modify Elusive effect

### DIFF
--- a/src/Modules/CalcPerform.lua
+++ b/src/Modules/CalcPerform.lua
@@ -807,7 +807,7 @@ local function doActorMisc(env, actor)
 			local effect = 1 + modDB:Sum("INC", nil, "ElusiveEffect", "BuffEffectOnSelf") / 100
 			-- Override elusive effect if set.			
 			if modDB:Override(nil, "ElusiveEffect") then 
-				effect = modDB:Override(nil, "ElusiveEffect") / 100
+				effect = m_min(modDB:Override(nil, "ElusiveEffect") / 100, effect)
 			end
 			condList["Elusive"] = true
 			modDB:NewMod("AttackDodgeChance", "BASE", m_floor(15 * effect), "Elusive")

--- a/src/Modules/CalcPerform.lua
+++ b/src/Modules/CalcPerform.lua
@@ -805,6 +805,10 @@ local function doActorMisc(env, actor)
 		end
 		if modDB:Flag(nil, "Elusive") then
 			local effect = 1 + modDB:Sum("INC", nil, "ElusiveEffect", "BuffEffectOnSelf") / 100
+			-- Override elusive effect if set.			
+			if modDB:Override(nil, "ElusiveEffect") then 
+				effect = modDB:Override(nil, "ElusiveEffect") / 100
+			end
 			condList["Elusive"] = true
 			modDB:NewMod("AttackDodgeChance", "BASE", m_floor(15 * effect), "Elusive")
 			modDB:NewMod("SpellDodgeChance", "BASE", m_floor(15 * effect), "Elusive")

--- a/src/Modules/ConfigOptions.lua
+++ b/src/Modules/ConfigOptions.lua
@@ -591,8 +591,8 @@ return {
 		modList:NewMod("Condition:Elusive", "FLAG", true, "Config", { type = "Condition", var = "Combat" }, { type = "Condition", var = "CanBeElusive" })
 		modList:NewMod("Elusive", "FLAG", true, "Config", { type = "Condition", var = "Combat" }, { type = "Condition", var = "CanBeElusive" })
 	end },
-	{ var = "buffDivinity", type = "check", label = "Do you have Divinity?", ifCond = "Divinity", tooltip = "This will enable the Divinity buff, which grants:\n\t50% more Elemental Damage\n\t20% less Elemental Damage taken", apply = function(val, modList, enemyModList)
-		modList:NewMod("Condition:Divinity", "FLAG", true, "Config", { type = "Condition", var = "Combat" })
+	{ var = "overrideBuffElusive", type = "count", label = "Effect of Elusive:", ifOption = "buffElusive", tooltip = "If you have a guaranteed source of Elusive,\nthe strongest one will apply instead unless this option would apply a stronger Elusive.", apply = function(val, modList, enemyModList)
+		modList:NewMod("ElusiveEffect", "OVERRIDE", val, "Config", {type = "GlobalEffect", effectType = "Buff" })
 	end },
 	{ var = "multiplierDefiance", type = "count", label = "Defiance:", ifMult = "Defiance", apply = function(val, modList, enemyModList)
 		modList:NewMod("Multiplier:Defiance", "BASE", m_min(val, 10), "Config", { type = "Condition", var = "Combat" })

--- a/src/Modules/ConfigOptions.lua
+++ b/src/Modules/ConfigOptions.lua
@@ -591,7 +591,7 @@ return {
 		modList:NewMod("Condition:Elusive", "FLAG", true, "Config", { type = "Condition", var = "Combat" }, { type = "Condition", var = "CanBeElusive" })
 		modList:NewMod("Elusive", "FLAG", true, "Config", { type = "Condition", var = "Combat" }, { type = "Condition", var = "CanBeElusive" })
 	end },
-	{ var = "overrideBuffElusive", type = "count", label = "Effect of Elusive:", ifOption = "buffElusive", tooltip = "If you have a guaranteed source of Elusive,\nthe strongest one will apply instead unless this option would apply a stronger Elusive.", apply = function(val, modList, enemyModList)
+	{ var = "overrideBuffElusive", type = "count", label = "Effect of Elusive (if not maximum):", ifOption = "buffElusive", tooltip = "If you have a guaranteed source of Elusive, the strongest one will apply. \nYou can change this see decaying buff values", apply = function(val, modList, enemyModList)
 		modList:NewMod("ElusiveEffect", "OVERRIDE", val, "Config", {type = "GlobalEffect", effectType = "Buff" })
 	end },
 	{ var = "buffDivinity", type = "check", label = "Do you have Divinity?", ifCond = "Divinity", tooltip = "This will enable the Divinity buff, which grants:\n\t50% more Elemental Damage\n\t20% less Elemental Damage taken", apply = function(val, modList, enemyModList)

--- a/src/Modules/ConfigOptions.lua
+++ b/src/Modules/ConfigOptions.lua
@@ -594,6 +594,9 @@ return {
 	{ var = "overrideBuffElusive", type = "count", label = "Effect of Elusive:", ifOption = "buffElusive", tooltip = "If you have a guaranteed source of Elusive,\nthe strongest one will apply instead unless this option would apply a stronger Elusive.", apply = function(val, modList, enemyModList)
 		modList:NewMod("ElusiveEffect", "OVERRIDE", val, "Config", {type = "GlobalEffect", effectType = "Buff" })
 	end },
+	{ var = "buffDivinity", type = "check", label = "Do you have Divinity?", ifCond = "Divinity", tooltip = "This will enable the Divinity buff, which grants:\n\t50% more Elemental Damage\n\t20% less Elemental Damage taken", apply = function(val, modList, enemyModList)
+		modList:NewMod("Condition:Divinity", "FLAG", true, "Config", { type = "Condition", var = "Combat" })
+	end },
 	{ var = "multiplierDefiance", type = "count", label = "Defiance:", ifMult = "Defiance", apply = function(val, modList, enemyModList)
 		modList:NewMod("Multiplier:Defiance", "BASE", m_min(val, 10), "Config", { type = "Condition", var = "Combat" })
 	end },


### PR DESCRIPTION
Since Elusive is a decaying buff and you cannot always have it at full effect, this new config option allows you to set a lower elusive buff effect than the automatic maximum calculated buff effect.

![image](https://user-images.githubusercontent.com/17045310/127715919-0addeb45-7ac0-4353-b0c3-a6758a0d4dcf.png)
