### PR TITLE
Add new base types to rare template, modify existing rare templates

### DIFF
--- a/src/Data/Rares.lua
+++ b/src/Data/Rares.lua
@@ -754,7 +754,7 @@ Suffix: LocalCriticalMultiplier4
 Elemental Bow
 Thicket Bow
 Crafted: true
-Prefix: WeaponElementalDamageOnWeapons4
+Prefix: WeaponElementalDamageOnTwohandWeapon4
 Suffix: LocalIncreasedAttackSpeed2
 Suffix: LocalCriticalStrikeChance3
 Suffix: LocalCriticalMultiplier4

--- a/src/Data/Rares.lua
+++ b/src/Data/Rares.lua
@@ -3,6 +3,27 @@
 return {
 -- Helmet
 [[
+Armour/Evasion Helmet
+Penitent Mask
+Crafted: true
+Prefix: LocalBaseArmourAndEvasionRating3
+Prefix: LocalIncreasedArmourAndEvasion5
+Prefix: IncreasedLife7
+]],[[
+Evasion/Energy Shield Helmet
+Blizzard Crown
+Crafted: true
+Prefix: LocalBaseEvasionRatingAndEnergyShield3
+Prefix: LocalIncreasedEvasionAndEnergyShield5_
+Prefix: IncreasedLife7
+]],[[
+Armour/Energy Shield Helmet
+Archdemon Crown
+Crafted: true
+Prefix: LocalBaseArmourAndEnergyShield3
+Prefix: LocalIncreasedArmourAndEnergyShield5
+Prefix: IncreasedLife7
+]],[[
 Armour Helmet
 Eternal Burgonet
 Crafted: true
@@ -49,11 +70,46 @@ Evasion/Energy Shield Helmet
 Deicide Mask
 Crafted: true
 Prefix: LocalBaseEvasionRatingAndEnergyShield3
-Prefix: LocalIncreasedEvasionAndEnergyShield5
+Prefix: LocalIncreasedEvasionAndEnergyShield5_
+Prefix: IncreasedLife7
+]],[[
+Ward Helmet
+Runic Crown
+Crafted: true
+Prefix: LocalIncreasedWardPercent3
+Prefix: LocalIncreasedWard5___
 Prefix: IncreasedLife7
 ]],
 -- Gloves
 [[
+Evasion Gloves
+Sinistral Gloves
+Crafted: true
+Prefix: LocalIncreasedPhysicalDamageReductionRating2
+Prefix: LocalIncreasedPhysicalDamageReductionRatingPercent5
+Prefix: IncreasedLife6
+]],[[
+Energy Shield Gloves
+Nexus Gloves
+Crafted: true
+Prefix: IncreasedLife6
+Prefix: LocalIncreasedEnergyShieldPercent5
+Prefix: LocalIncreasedEnergyShield6
+]],[[
+Armour Gloves
+Debilitation Gauntlets
+Crafted: true
+Prefix: LocalIncreasedPhysicalDamageReductionRating2
+Prefix: LocalIncreasedPhysicalDamageReductionRatingPercent5
+Prefix: IncreasedLife6
+]],[[
+Armour/Energy Shield Gloves
+Apothecary's Gloves
+Crafted: true
+Prefix: LocalBaseArmourAndEnergyShield2_
+Prefix: LocalIncreasedArmourAndEnergyShield5
+Prefix: IncreasedLife6
+]],[[
 Armour Gloves
 Titan Gauntlets
 Crafted: true
@@ -116,6 +172,13 @@ Crafted: true
 Prefix: LocalBaseEvasionRatingAndEnergyShield2
 Prefix: LocalIncreasedEvasionAndEnergyShield5_
 Prefix: IncreasedLife6
+]],[[
+Ward Gloves
+Runic Gauntlets
+Crafted: true
+Prefix: LocalIncreasedWardPercent3
+Prefix: LocalIncreasedWard5___
+Prefix: IncreasedLife7
 ]],
 -- Body Armour
 [[
@@ -177,6 +240,35 @@ Prefix: IncreasedLife9
 ]],
 -- Boots
 [[
+Evasion/Energy Shield Boots
+Blessed Boots
+Crafted: true
+Prefix: LocalIncreasedEvasionAndEnergyShield5_
+Prefix: IncreasedLife6
+Prefix: MovementVelocity5
+Suffix: ChaosResist4
+]],[[
+Evasion Boots
+Stormrider Boots
+Crafted: true
+Prefix: LocalIncreasedEvasionRatingPercent5
+Prefix: IncreasedLife6
+Prefix: MovementVelocity5
+]],[[
+Energy Shield Boots
+Dreamquest Slippers
+Crafted: true
+Prefix: LocalIncreasedEnergyShieldPercent5
+Prefix: IncreasedLife6
+Prefix: MovementVelocity5
+]],[[
+Armour Boots
+Brimstone Treads
+Crafted: true
+Prefix: LocalIncreasedPhysicalDamageReductionRatingPercent5
+Prefix: IncreasedLife6
+Prefix: MovementVelocity5
+]],[[
 Armour Boots
 Titan Greaves
 Crafted: true
@@ -239,9 +331,37 @@ Crafted: true
 Prefix: LocalIncreasedEvasionAndEnergyShield5_
 Prefix: IncreasedLife6
 Prefix: MovementVelocity5
+]],[[
+Ward Boots
+Runic Sabatons
+Crafted: true
+Prefix: LocalIncreasedWardPercent3
+Prefix: LocalIncreasedWard5___
+Prefix: IncreasedLife7
 ]],
 -- Shields
 [[
+Energy Shield Shield
+Transfer-attuned Spirit Shield
+Crafted: true
+Prefix: IncreasedLife8
+Prefix: LocalIncreasedEnergyShieldPercent5
+Prefix: LocalIncreasedEnergyShield9
+]],[[
+Evasion Shield
+Cold-attuned Buckler
+Crafted: true
+Prefix: LocalIncreasedEvasionRating5
+Prefix: LocalIncreasedEvasionRatingPercent5
+Prefix: IncreasedLife8
+]],[[
+Armour Shield
+Heat-attuned Tower Shield
+Crafted: true
+Prefix: LocalIncreasedPhysicalDamageReductionRating5
+Prefix: LocalIncreasedPhysicalDamageReductionRatingPercent5
+Prefix: IncreasedLife8
+]],[[
 Armour Shield
 Pinnacle Tower Shield
 Crafted: true
@@ -286,94 +406,162 @@ Prefix: IncreasedLife8
 ]],
 -- Amulets
 [[
+Energy Shield Amulet
+Seaglass Amulet
+Crafted: true
+Prefix: IncreasedEnergyShield7
+Prefix: IncreasedEnergyShieldPercent5
+Suffix: Intelligence5
+]],[[
 Amulet
 Amber Amulet
 Crafted: true
+Suffix: Strength5
 ]],[[
 Amulet
 Jade Amulet
 Crafted: true
+Suffix: Dexterity5
 ]],[[
 Amulet
 Lapis Amulet
 Crafted: true
+Suffix: Intelligence5
 ]],[[
 Amulet
 Onyx Amulet
 Crafted: true
+Suffix: AllAttributes5
 ]],[[
 Amulet
 Agate Amulet
 Crafted: true
+Suffix: Strength5
+Suffix: Intelligence5
 ]],[[
 Amulet
 Turquoise Amulet
 Crafted: true
+Suffix: Dexterity5
+Suffix: Intelligence5
 ]],[[
 Amulet
 Citrine Amulet
 Crafted: true
+Suffix: Dexterity5
+Suffix: Strength5
 ]],[[
-Amulet
+Mana Amulet
 Paua Amulet
 Crafted: true
+Prefix: IncreasedMana7
+Suffix: Intelligence5
+Suffix: ManaRegeneration4
 ]],[[
 Amulet
 Marble Amulet
 Crafted: true
 ]],[[
-Amulet
+Mana Amulet
 Blue Pearl Amulet
+Crafted: true
+Prefix: IncreasedMana7
+Suffix: Intelligence5
+Suffix: ManaRegeneration4
+]],[[
+Influence Amulet
+Astrolabe Amulet
+Crafted: true
+]],[[
+Amulet
+Simplex Amulet
 Crafted: true
 ]],
 -- Rings
 [[
 Ring
-Paua Ring
+Geodesic Ring
 Crafted: true
 ]],[[
-Ring
+Resistance Ring
+Cogwork Ring
+Crafted: true
+Suffix: FireResist4
+Suffix: ColdResist4
+Suffix: LightningResist4
+]],[[
+Mana Ring
+Paua Ring
+Crafted: true
+Prefix: IncreasedMana7
+Suffix: Intelligence5
+Suffix: ManaRegeneration4
+]],[[
+Energy Shield Ring
 Moonstone Ring
 Crafted: true
+Prefix: IncreasedEnergyShield6
+Suffix: Intelligence5
 ]],[[
 Ring
 Diamond Ring
 Crafted: true
 ]],[[
-Ring
+Resistance Ring
 Ruby Ring
 Crafted: true
+Suffix: FireResist4
+Suffix: ColdResist4
+Suffix: LightningResist4
 ]],[[
-Ring
+Resistance Ring
 Sapphire Ring
 Crafted: true
+Suffix: FireResist4
+Suffix: ColdResist4
+Suffix: LightningResist4
 ]],[[
-Ring
+Resistance Ring
 Topaz Ring
 Crafted: true
+Suffix: FireResist4
+Suffix: ColdResist4
+Suffix: LightningResist4
 ]],[[
-Ring
+Chaos Resistance Ring
 Amethyst Ring
 Crafted: true
+Suffix: ChaosResist4
 ]],[[
-Ring
+Resistance Ring
 Ruby Ring
 Crafted: true
+Suffix: FireResist4
+Suffix: ColdResist4
+Suffix: LightningResist4
 ]],[[
-Ring
+Life Ring
 Coral Ring
 Crafted: true
+Prefix: IncreasedLife4
+Suffix: Strength6
 ]],[[
-Ring
+Resistance Ring
 Prismatic Ring
 Crafted: true
+Suffix: FireResist4
+Suffix: ColdResist4
+Suffix: LightningResist4
 ]],[[
-Ring
+Resistance Ring
 Two-Stone Ring
 Variant: Fire and Cold
 Variant: Cold and Lightning
 Variant: Fire and Lightning
 Crafted: true
+Suffix: FireResist4
+Suffix: ColdResist4
+Suffix: LightningResist4
 Implicits: 3
 {variant:1}+(12 to 16)% to Fire and Cold Resistances
 {variant:2}+(12 to 16)% to Cold and Lightning Resistances
@@ -382,22 +570,35 @@ Implicits: 3
 Ring
 Unset Ring
 Crafted: true
+Prefix: LocalIncreaseSocketedGemUnsetRing2
 ]],[[
 Ring
 Steel Ring
+Crafted: true
+Prefix: AddedPhysicalDamage4
+Suffix: IncreasedAccuracyNew3
+Suffix: IncreasedAttackSpeed1
+]],[[
+Ring
+Iolite Ring
 Crafted: true
 ]],[[
 Ring
 Opal Ring
 Crafted: true
 ]],[[
-Ring
+Mana Ring
 Cerulean Ring
 Crafted: true
+Prefix: IncreasedMana7
+Suffix: Intelligence5
+Suffix: ManaRegeneration4
 ]],[[
-Ring
+Life Ring
 Vermillion Ring
 Crafted: true
+Prefix: IncreasedLife4
+Suffix: Strength6
 ]],
 -- Belts
 [[
@@ -405,24 +606,42 @@ Belt
 Rustic Sash
 Crafted: true
 ]],[[
-Belt
+Energy Shield Belt
 Chain Belt
 Crafted: true
+Prefix: IncreasedEnergyShield6
 ]],[[
 Belt
 Leather Belt
 Crafted: true
+Prefix: IncreasedLife4
+Suffix: Strength6
 ]],[[
 Belt
 Heavy Belt
 Crafted: true
+Prefix: IncreasedLife4
+Suffix: Strength6
 ]],[[
-Belt
+Energy Shield Belt
 Crystal Belt
 Crafted: true
+Prefix: IncreasedEnergyShield6
 ]],[[
 Belt
 Vanguard Belt
+Crafted: true
+Prefix: IncreasedPhysicalDamageReductionRating5
+Prefix: IncreasedLife5
+]],[[
+Flask Belt
+Micro-Distillery Belt
+Crafted: true
+Suffix: BeltReducedFlaskChargesUsed1
+Suffix: BeltIncreasedFlaskDuration1
+]],[[
+Belt
+Mechalarm Belt
 Crafted: true
 ]],
 -- Quivers
@@ -434,8 +653,19 @@ Prefix: AddedPhysicalDamage3
 Prefix: IncreasedLife7
 Prefix: WeaponElementalDamage3
 Suffix: IncreasedAttackSpeed1
-Suffix: CriticalStrikeChance4
-Suffix: CriticalMultiplier4
+Suffix: CriticalStrikeChanceWithBows4
+Suffix: CriticalMultiplierWithBows3
+]],
+[[
+Quiver
+Artillery Quiver
+Crafted: true
+Prefix: AddedPhysicalDamage3
+Prefix: IncreasedLife7
+Prefix: WeaponElementalDamage3
+Suffix: IncreasedAttackSpeed1
+Suffix: CriticalStrikeChanceWithBows4   
+Suffix: CriticalMultiplierWithBows3
 ]],
 -- Weapons
 [[
@@ -457,6 +687,24 @@ Suffix: LocalIncreasedAttackSpeed3
 Suffix: LocalCriticalStrikeChance3
 Suffix: LocalCriticalMultiplier4
 ]],[[
+Physical 1H Axe
+Psychotic Axe
+Crafted: true
+Prefix: LocalIncreasedPhysicalDamagePercent5
+Prefix: LocalIncreasedPhysicalDamagePercentAndAccuracyRating5
+Prefix: LocalAddedPhysicalDamage6
+Suffix: LocalIncreasedAttackSpeed3
+Suffix: LocalCriticalStrikeChance3
+Suffix: LocalCriticalMultiplier4
+]],[[
+Elemental 1H Axe
+Psychotic Axe
+Crafted: true
+Prefix: WeaponElementalDamageOnWeapons4
+Suffix: LocalIncreasedAttackSpeed3
+Suffix: LocalCriticalStrikeChance3
+Suffix: LocalCriticalMultiplier4
+]],[[
 Physical 2H Axe
 Fleshripper
 Crafted: true
@@ -470,7 +718,25 @@ Suffix: LocalCriticalMultiplier4
 Elemental 2H Axe
 Despot Axe
 Crafted: true
-Prefix: WeaponElementalDamageOnWeapons4
+Prefix: WeaponElementalDamageOnTwohandWeapon4
+Suffix: LocalIncreasedAttackSpeed3
+Suffix: LocalCriticalStrikeChance3
+Suffix: LocalCriticalMultiplier4
+]],[[
+Physical 2H Axe
+Apex Cleaver
+Crafted: true
+Prefix: LocalIncreasedPhysicalDamagePercent5
+Prefix: LocalIncreasedPhysicalDamagePercentAndAccuracyRating5
+Prefix: LocalAddedPhysicalDamageTwoHand6
+Suffix: LocalIncreasedAttackSpeed3
+Suffix: LocalCriticalStrikeChance3
+Suffix: LocalCriticalMultiplier4
+]],[[
+Elemental 2H Axe
+Apex Cleaver
+Crafted: true
+Prefix: WeaponElementalDamageOnTwohandWeapon4
 Suffix: LocalIncreasedAttackSpeed3
 Suffix: LocalCriticalStrikeChance3
 Suffix: LocalCriticalMultiplier4
@@ -488,6 +754,15 @@ Suffix: LocalCriticalMultiplier4
 Elemental Bow
 Thicket Bow
 Crafted: true
+Prefix: WeaponElementalDamageOnWeapons4
+Suffix: LocalIncreasedAttackSpeed2
+Suffix: LocalCriticalStrikeChance3
+Suffix: LocalCriticalMultiplier4
+]],[[
+Fire Bow
+Solarine Bow 
+Crafted: true
+Prefix: LocalAddedFireDamageRanged6
 Prefix: WeaponElementalDamageOnWeapons4
 Suffix: LocalIncreasedAttackSpeed2
 Suffix: LocalCriticalStrikeChance3
@@ -514,6 +789,16 @@ Elemental Claw
 Imperial Claw
 Crafted: true
 Prefix: WeaponElementalDamageOnWeapons4
+Suffix: LocalIncreasedAttackSpeed3
+Suffix: LocalCriticalStrikeChance3
+Suffix: LocalCriticalMultiplier4
+]],[[
+Chaos Claw
+Void Fangs
+Crafted: true
+Prefix: LocalIncreasedPhysicalDamagePercent5
+Prefix: LocalAddedChaosDamage1
+Prefix: LocalAddedPhysicalDamage6
 Suffix: LocalIncreasedAttackSpeed3
 Suffix: LocalCriticalStrikeChance3
 Suffix: LocalCriticalMultiplier4
@@ -545,6 +830,33 @@ Suffix: LocalIncreasedAttackSpeed3
 Suffix: SpellCriticalStrikeChance3
 Suffix: LocalCriticalMultiplier4
 ]],[[
+Physical Dagger
+Pneumatic Dagger
+Crafted: true
+Prefix: LocalIncreasedPhysicalDamagePercent5
+Prefix: LocalIncreasedPhysicalDamagePercentAndAccuracyRating5
+Prefix: LocalAddedPhysicalDamage6
+Suffix: LocalIncreasedAttackSpeed3
+Suffix: LocalCriticalStrikeChance3
+Suffix: LocalCriticalMultiplier4
+]],[[
+Elemental Dagger
+Pneumatic Dagger
+Crafted: true
+Prefix: WeaponElementalDamageOnWeapons4
+Suffix: LocalIncreasedAttackSpeed3
+Suffix: LocalCriticalStrikeChance3
+Suffix: LocalCriticalMultiplier4
+]],[[
+Spell Dagger
+Infernal Blade
+Crafted: true
+Prefix: SpellDamageOnWeapon5
+Prefix: SpellDamageAndManaOnWeapon4
+Suffix: LocalIncreasedAttackSpeed3
+Suffix: SpellCriticalStrikeChance3
+Suffix: LocalCriticalMultiplier4
+]],[[
 Vagan Dagger
 Royal Skean
 Crafted: true
@@ -561,8 +873,16 @@ Prefix: SpellDamageAndManaOnWeapon4
 Suffix: SpellCriticalStrikeChance3
 Suffix: LocalCriticalMultiplier4
 ]],[[
-Physical 1H Mace
-Behemoth Mace
+Elemental Sceptre
+Void Sceptre
+Crafted: true
+Prefix: WeaponElementalDamageOnWeapons4
+Suffix: LocalIncreasedAttackSpeed3
+Suffix: LocalCriticalStrikeChance3
+Suffix: LocalCriticalMultiplier4
+]],[[
+Physical Sceptre
+Void Sceptre
 Crafted: true
 Prefix: LocalIncreasedPhysicalDamagePercent5
 Prefix: LocalIncreasedPhysicalDamagePercentAndAccuracyRating5
@@ -571,8 +891,66 @@ Suffix: LocalIncreasedAttackSpeed3
 Suffix: LocalCriticalStrikeChance3
 Suffix: LocalCriticalMultiplier4
 ]],[[
+Spell Sceptre
+Oscillating Sceptre
+Crafted: true
+Prefix: SpellDamageOnWeapon5
+Prefix: SpellDamageAndManaOnWeapon4
+Suffix: SpellCriticalStrikeChance3
+Suffix: LocalCriticalMultiplier4
+]],[[
+Elemental Sceptre
+Oscillating Sceptre
+Crafted: true
+Prefix: WeaponElementalDamageOnWeapons4
+Suffix: LocalIncreasedAttackSpeed3
+Suffix: LocalCriticalStrikeChance3
+Suffix: LocalCriticalMultiplier4
+]],[[
+Spell Sceptre
+Stabilising Sceptre
+Crafted: true
+Prefix: SpellDamageOnWeapon5
+Prefix: SpellDamageAndManaOnWeapon4
+Suffix: SpellCriticalStrikeChance3
+Suffix: LocalCriticalMultiplier4
+]],[[
+Elemental Sceptre
+Stabilising Sceptre
+Crafted: true
+Prefix: WeaponElementalDamageOnWeapons4
+Suffix: LocalIncreasedAttackSpeed3
+Suffix: LocalCriticalStrikeChance3
+Suffix: LocalCriticalMultiplier4
+]],[[
+Spell Sceptre
+Alternating Sceptre
+Crafted: true
+Prefix: SpellDamageOnWeapon5
+Prefix: SpellDamageAndManaOnWeapon4
+Suffix: SpellCriticalStrikeChance3
+Suffix: LocalCriticalMultiplier4
+]],[[
+Elemental Sceptre
+Alternating Sceptre
+Crafted: true
+Prefix: WeaponElementalDamageOnWeapons4
+Suffix: LocalIncreasedAttackSpeed3
+Suffix: LocalCriticalStrikeChance3
+Suffix: LocalCriticalMultiplier4
+]],[[
 Physical Sceptre
-Void Sceptre
+Alternating Sceptre
+Crafted: true
+Prefix: LocalIncreasedPhysicalDamagePercent5
+Prefix: LocalIncreasedPhysicalDamagePercentAndAccuracyRating5
+Prefix: LocalAddedPhysicalDamage6
+Suffix: LocalIncreasedAttackSpeed3
+Suffix: LocalCriticalStrikeChance3
+Suffix: LocalCriticalMultiplier4
+]],[[
+Physical 1H Mace
+Behemoth Mace
 Crafted: true
 Prefix: LocalIncreasedPhysicalDamagePercent5
 Prefix: LocalIncreasedPhysicalDamagePercentAndAccuracyRating5
@@ -589,8 +967,18 @@ Suffix: LocalIncreasedAttackSpeed3
 Suffix: LocalCriticalStrikeChance3
 Suffix: LocalCriticalMultiplier4
 ]],[[
-Elemental Sceptre
-Void Sceptre
+Physical 1H Mace
+Boom Mace
+Crafted: true
+Prefix: LocalIncreasedPhysicalDamagePercent5
+Prefix: LocalIncreasedPhysicalDamagePercentAndAccuracyRating5
+Prefix: LocalAddedPhysicalDamage6
+Suffix: LocalIncreasedAttackSpeed3
+Suffix: LocalCriticalStrikeChance3
+Suffix: LocalCriticalMultiplier4
+]],[[
+Elemental 1H Mace
+Boom Mace
 Crafted: true
 Prefix: WeaponElementalDamageOnWeapons4
 Suffix: LocalIncreasedAttackSpeed3
@@ -610,13 +998,31 @@ Suffix: LocalCriticalMultiplier4
 Elemental 2H Mace
 Coronal Maul
 Crafted: true
-Prefix: WeaponElementalDamageOnWeapons4
+Prefix: WeaponElementalDamageOnTwohandWeapon4
+Suffix: LocalIncreasedAttackSpeed3
+Suffix: LocalCriticalStrikeChance3
+Suffix: LocalCriticalMultiplier4
+]],[[
+Physical 2H Mace
+Impact Force Propagator
+Crafted: true
+Prefix: LocalIncreasedPhysicalDamagePercent5
+Prefix: LocalIncreasedPhysicalDamagePercentAndAccuracyRating5
+Prefix: LocalAddedPhysicalDamageTwoHand6
+Suffix: LocalIncreasedAttackSpeed3
+Suffix: LocalCriticalStrikeChance3
+Suffix: LocalCriticalMultiplier4
+]],[[
+Elemental 2H Mace
+Impact Force Propagator
+Crafted: true
+Prefix: WeaponElementalDamageOnTwohandWeapon4
 Suffix: LocalIncreasedAttackSpeed3
 Suffix: LocalCriticalStrikeChance3
 Suffix: LocalCriticalMultiplier4
 ]],[[
 Physical Staff
-Eclipse Staff
+Maelstrom Staff
 Crafted: true
 Prefix: LocalIncreasedPhysicalDamagePercent5
 Prefix: LocalIncreasedPhysicalDamagePercentAndAccuracyRating5
@@ -626,9 +1032,27 @@ Suffix: LocalCriticalStrikeChance3
 Suffix: LocalCriticalMultiplier4
 ]],[[
 Elemental Staff
-Eclipse Staff
+Maelstrom Staff
 Crafted: true
-Prefix: WeaponElementalDamageOnWeapons4
+Prefix: WeaponElementalDamageOnTwohandWeapon6
+Suffix: LocalIncreasedAttackSpeed3
+Suffix: LocalCriticalStrikeChance3
+Suffix: LocalCriticalMultiplier4
+]],[[
+Physical Staff
+Eventuality Rod
+Crafted: true
+Prefix: LocalIncreasedPhysicalDamagePercent5
+Prefix: LocalIncreasedPhysicalDamagePercentAndAccuracyRating5
+Prefix: LocalAddedPhysicalDamageTwoHand6
+Suffix: LocalIncreasedAttackSpeed3
+Suffix: LocalCriticalStrikeChance3
+Suffix: LocalCriticalMultiplier4
+]],[[
+Elemental Staff
+Eventuality Rod
+Crafted: true
+Prefix: WeaponElementalDamageOnTwohandWeapon6
 Suffix: LocalIncreasedAttackSpeed3
 Suffix: LocalCriticalStrikeChance3
 Suffix: LocalCriticalMultiplier4
@@ -642,7 +1066,7 @@ Suffix: SpellCriticalStrikeChance3
 Suffix: LocalCriticalMultiplier4
 ]],[[
 +5 Physical Staff
-Maelstrom Staff
+Eclipse Staff
 Crafted: true
 Prefix: GlobalSpellGemsLevelTwoHand1
 Prefix: GlobalPhysicalSpellGemsLevelTwoHand2_
@@ -651,7 +1075,7 @@ Suffix: SpellCriticalStrikeChance3
 Suffix: LocalCriticalMultiplier4
 ]],[[
 +5 Fire Staff
-Maelstrom Staff
+Eclipse Staff
 Crafted: true
 Prefix: GlobalSpellGemsLevelTwoHand1
 Prefix: GlobalFireSpellGemsLevelTwoHand2
@@ -660,7 +1084,7 @@ Suffix: SpellCriticalStrikeChance3
 Suffix: LocalCriticalMultiplier4
 ]],[[
 +5 Cold Staff
-Maelstrom Staff
+Eclipse Staff
 Crafted: true
 Prefix: GlobalSpellGemsLevelTwoHand1
 Prefix: GlobalColdSpellGemsLevelTwoHand2
@@ -669,7 +1093,7 @@ Suffix: SpellCriticalStrikeChance3
 Suffix: LocalCriticalMultiplier4
 ]],[[
 +5 Lightning Staff
-Maelstrom Staff
+Eclipse Staff
 Crafted: true
 Prefix: GlobalSpellGemsLevelTwoHand1
 Prefix: GlobalLightningSpellGemsLevelTwoHand2
@@ -678,7 +1102,60 @@ Suffix: SpellCriticalStrikeChance3
 Suffix: LocalCriticalMultiplier4
 ]],[[
 +5 Chaos Staff
-Maelstrom Staff
+Eclipse Staff
+Crafted: true
+Prefix: GlobalSpellGemsLevelTwoHand1
+Prefix: GlobalChaosSpellGemsLevelTwoHand2
+Prefix: SpellDamageOnTwoHandWeapon5
+Suffix: SpellCriticalStrikeChance3
+Suffix: LocalCriticalMultiplier4
+]],[[
+Spell Staff
+Battery Staff
+Crafted: true
+Prefix: SpellDamageOnTwoHandWeapon5
+Prefix: SpellDamageAndManaOnTwoHandWeapon4
+Suffix: SpellCriticalStrikeChance3
+Suffix: LocalCriticalMultiplier4
+]],[[
++5 Physical Staff
+Battery Staff
+Crafted: true
+Prefix: GlobalSpellGemsLevelTwoHand1
+Prefix: GlobalPhysicalSpellGemsLevelTwoHand2_
+Prefix: SpellDamageOnTwoHandWeapon5
+Suffix: SpellCriticalStrikeChance3
+Suffix: LocalCriticalMultiplier4
+]],[[
++5 Fire Staff
+Battery Staff
+Crafted: true
+Prefix: GlobalSpellGemsLevelTwoHand1
+Prefix: GlobalFireSpellGemsLevelTwoHand2
+Prefix: SpellDamageOnTwoHandWeapon5
+Suffix: SpellCriticalStrikeChance3
+Suffix: LocalCriticalMultiplier4
+]],[[
++5 Cold Staff
+Battery Staff
+Crafted: true
+Prefix: GlobalSpellGemsLevelTwoHand1
+Prefix: GlobalColdSpellGemsLevelTwoHand2
+Prefix: SpellDamageOnTwoHandWeapon5
+Suffix: SpellCriticalStrikeChance3
+Suffix: LocalCriticalMultiplier4
+]],[[
++5 Lightning Staff
+Battery Staff
+Crafted: true
+Prefix: GlobalSpellGemsLevelTwoHand1
+Prefix: GlobalLightningSpellGemsLevelTwoHand2
+Prefix: SpellDamageOnTwoHandWeapon5
+Suffix: SpellCriticalStrikeChance3
+Suffix: LocalCriticalMultiplier4
+]],[[
++5 Chaos Staff
+Battery Staff
 Crafted: true
 Prefix: GlobalSpellGemsLevelTwoHand1
 Prefix: GlobalChaosSpellGemsLevelTwoHand2
@@ -714,6 +1191,24 @@ Suffix: LocalIncreasedAttackSpeed3
 Suffix: LocalCriticalStrikeChance3
 Suffix: LocalCriticalMultiplier4
 ]],[[
+Physical 1H Sword
+Anarchic Spiritblade
+Crafted: true
+Prefix: LocalIncreasedPhysicalDamagePercent5
+Prefix: LocalIncreasedPhysicalDamagePercentAndAccuracyRating5
+Prefix: LocalAddedPhysicalDamage6
+Suffix: LocalIncreasedAttackSpeed3
+Suffix: LocalCriticalStrikeChance3
+Suffix: LocalCriticalMultiplier4
+]],[[
+Elemental 1H Sword
+Anarchic Spiritblade
+Crafted: true
+Prefix: WeaponElementalDamageOnWeapons4
+Suffix: LocalIncreasedAttackSpeed3
+Suffix: LocalCriticalStrikeChance3
+Suffix: LocalCriticalMultiplier4
+]],[[
 Elemental 1H Sword
 Jewelled Foil
 Crafted: true
@@ -735,7 +1230,15 @@ Suffix: LocalCriticalMultiplier4
 Elemental 2H Sword
 Reaver Sword
 Crafted: true
-Prefix: WeaponElementalDamageOnWeapons4
+Prefix: WeaponElementalDamageOnTwohandWeapon4
+Suffix: LocalIncreasedAttackSpeed3
+Suffix: LocalCriticalStrikeChance3
+Suffix: LocalCriticalMultiplier4
+]],[[
+Elemental 2H Sword
+Banishing Blade
+Crafted: true
+Prefix: WeaponElementalDamageOnTwohandWeapon4
 Suffix: LocalIncreasedAttackSpeed3
 Suffix: LocalCriticalStrikeChance3
 Suffix: LocalCriticalMultiplier4
@@ -760,6 +1263,32 @@ Suffix: LocalCriticalMultiplier4
 ]],[[
 Spell Wand
 Prophecy Wand
+Crafted: true
+Prefix: SpellDamageOnWeapon5
+Prefix: SpellDamageAndManaOnWeapon4
+Suffix: SpellCriticalStrikeChance3
+Suffix: LocalCriticalMultiplier4
+]],[[
+Physical Wand
+Accumulator Wand
+Crafted: true
+Prefix: LocalIncreasedPhysicalDamagePercent5
+Prefix: LocalIncreasedPhysicalDamagePercentAndAccuracyRating5
+Prefix: LocalAddedPhysicalDamage6
+Suffix: LocalIncreasedAttackSpeed2
+Suffix: LocalCriticalStrikeChance3
+Suffix: LocalCriticalMultiplier4
+]],[[
+Elemental Wand
+Accumulator Wand
+Crafted: true
+Prefix: WeaponElementalDamageOnWeapons4
+Suffix: LocalIncreasedAttackSpeed2
+Suffix: LocalCriticalStrikeChance3
+Suffix: LocalCriticalMultiplier4
+]],[[
+Spell Wand
+Accumulator Wand
 Crafted: true
 Prefix: SpellDamageOnWeapon5
 Prefix: SpellDamageAndManaOnWeapon4


### PR DESCRIPTION
This feature adds new base types from heist, ritual, and expedition league into the rare templates, since rare templates haven't been updated in awhile.

Also to help with the convenience of creating your rare items from the rare template section, added some affixes that stack with the implicit of the base type. 
      Ex. Vermillion ring's template now has life and strength stat. Useful for the user to stack a specific stat or scaling with fewer clicks.

This also fixes some rare templates that weren't possible in-game such as the affixes of +5 staffs not being possible to get on a warstaves, and 2H weapons not using the 2H affix for elemental damage with attacks.