### PR TITLE
Fix Lifetap not changing mana cost

### DIFF
--- a/src/Data/SkillStatMap.lua
+++ b/src/Data/SkillStatMap.lua
@@ -157,8 +157,7 @@ return {
 	flag("BloodMagicReserved"),
 },
 ["base_skill_cost_life_instead_of_mana"] = {
-	mod("ManaCostAsLifeCost", "BASE", nil, 0, 0),
-	value = 100,
+	flag("CostLifeInsteadOfMana"),
 },
 ["base_active_skill_totem_level"] = {
 	skill("totemLevel", nil),

--- a/src/Data/SkillStatMap.lua
+++ b/src/Data/SkillStatMap.lua
@@ -157,7 +157,8 @@ return {
 	flag("BloodMagicReserved"),
 },
 ["base_skill_cost_life_instead_of_mana"] = {
-	flag("BloodMagicCost"),
+	mod("ManaCostAsLifeCost", "BASE", nil, 0, 0),
+	value = 100,
 },
 ["base_active_skill_totem_level"] = {
 	skill("totemLevel", nil),

--- a/src/Modules/CalcOffence.lua
+++ b/src/Modules/CalcOffence.lua
@@ -982,11 +982,12 @@ function calcs.offence(env, actor, activeSkill)
 		end
 		output[resource.."Cost"] = cost
 	end
+	if skillModList:Flag(skillCfg, "CostLifeInsteadOfMana") then
+		output["LifeCost"] = output["LifeCost"] + output["ManaCost"]
+		output["ManaCost"] = 0
+	end
 	if skillModList:Sum("BASE", skillCfg, "ManaCostAsLifeCost") then
 		output["LifeCost"] = output["LifeCost"] + output["ManaCost"] * skillModList:Sum("BASE", skillCfg, "ManaCostAsLifeCost") / 100
-		if skillModList:Sum("BASE", skillCfg, "ManaCostAsLifeCost") >= 100 then
-			output["ManaCost"] = 0
-		end
 	end
 	for resource, name in pairs(names) do
 		local percent = resource == "ManaPercent" or resource == "LifePercent"

--- a/src/Modules/CalcOffence.lua
+++ b/src/Modules/CalcOffence.lua
@@ -984,6 +984,9 @@ function calcs.offence(env, actor, activeSkill)
 	end
 	if skillModList:Sum("BASE", skillCfg, "ManaCostAsLifeCost") then
 		output["LifeCost"] = output["LifeCost"] + output["ManaCost"] * skillModList:Sum("BASE", skillCfg, "ManaCostAsLifeCost") / 100
+		if skillModList:Sum("BASE", skillCfg, "ManaCostAsLifeCost") >= 100 then
+			output["ManaCost"] = 0
+		end
 	end
 	for resource, name in pairs(names) do
 		local percent = resource == "ManaPercent" or resource == "LifePercent"

--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -1434,7 +1434,7 @@ local specialModList = {
 	} end,
 	["removes all mana%. spend life instead of mana for skills"] = { mod("Mana", "MORE", -100), flag("BloodMagic") },
 	["removes all mana"] = { mod("Mana", "MORE", -100) },
-	["skills cost life instead of mana"] = { mod("ManaCostAsLifeCost", "BASE", 100, 0, 0) },
+	["skills cost life instead of mana"] = { flag("CostLifeInsteadOfMana") },
 	["skills reserve life instead of mana"] = { flag("BloodMagicReserved") },
 	["spend life instead of mana for effects of skills"] = { },
 	["skills cost %+(%d+) rage"] = function(num) return { mod("RageCostBase", "BASE", num) } end,

--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -1434,7 +1434,7 @@ local specialModList = {
 	} end,
 	["removes all mana%. spend life instead of mana for skills"] = { mod("Mana", "MORE", -100), flag("BloodMagic") },
 	["removes all mana"] = { mod("Mana", "MORE", -100) },
-	["skills cost life instead of mana"] = { flag("BloodMagicCost") },
+	["skills cost life instead of mana"] = { mod("ManaCostAsLifeCost", "BASE", 100, 0, 0) },
 	["skills reserve life instead of mana"] = { flag("BloodMagicReserved") },
 	["spend life instead of mana for effects of skills"] = { },
 	["skills cost %+(%d+) rage"] = function(num) return { mod("RageCostBase", "BASE", num) } end,


### PR DESCRIPTION
This gets a bit wonky when allocating blood magic + Lifetap in that it double counts the base mana cost, but I can't cap it at 100% converted, either, because of petrified blood.  No one should be taking Lifetap + Blood Magic anyway, I'd assume, so I left it alone