### PR TITLE
Fix Charged Dash DPS

### DIFF
--- a/src/Data/Skills/act_dex.lua
+++ b/src/Data/Skills/act_dex.lua
@@ -1763,13 +1763,31 @@ skills["ChargedDash"] = {
 	},
 	statDescriptionScope = "skill_stat_descriptions",
 	castTime = 1,
-	statMap = {
-		["charged_dash_damage_+%_maximum"] = {
-			mod("Damage", "MORE", nil, 0, bit.bor(KeywordFlag.Hit, KeywordFlag.Ailment), { type = "Multiplier", var = "ChargedDashDistance" }),
-		},
-		["base_skill_show_average_damage_instead_of_dps"] = {
-		},
-	},
+parts = {
+    {
+        name = "Channelling, No Stages",
+    },
+    {
+        name = "Channelling, Max Stages",
+    },
+    {
+        name = "Release",
+    },
+},
+preDamageFunc = function(activeSkill, output)
+    local stageDamageMultiplier
+       if activeSkill.skillPart == 3 and activeSkill.activeStageCount then
+           stageDamageMultiplier = 75 * math.min(activeSkill.activeStageCount, 15)
+           activeSkill.skillModList:NewMod("Damage", "MORE", stageDamageMultiplier - 100, "Skill:ChargedDash", ModFlag.Attack, { type = "SkillPart", skillPart = 3})
+       elseif activeSkill.skillPart == 3 then
+           stageDamageMultiplier = 75
+           activeSkill.skillModList:NewMod("Damage", "MORE", stageDamageMultiplier - 100, "Skill:ChargedDash", ModFlag.Attack, { type = "SkillPart", skillPart = 3})
+       end
+end,
+statMap = {
+    ["base_skill_show_average_damage_instead_of_dps"] = {
+    },
+},
 	baseFlags = {
 		attack = true,
 		melee = true,
@@ -1780,6 +1798,10 @@ skills["ChargedDash"] = {
 		skill("radiusLabel", "Start of Dash:"),
 		skill("radiusSecondary", 26),
 		skill("radiusSecondaryLabel", "End of Dash:"),
+		skill("hitTimeMultiplier", 2, { type = "Skill", skillPartList = {1, 2} }),
+		mod("Damage", "MORE", 150, 0, KeywordFlag.Hit, { type = "SkillPart", skillPart = 2 }),
+		mod("Multiplier:ChargedDashMaxStages", "BASE", 15),
+		skill("showAverage", true, { type = "SkillPart", skillPart = 3 }),
 	},
 	qualityStats = {
 		Default = {

--- a/src/Data/Skills/act_dex.lua
+++ b/src/Data/Skills/act_dex.lua
@@ -1775,17 +1775,22 @@ parts = {
     },
 },
 preDamageFunc = function(activeSkill, output)
-    local stageDamageMultiplier
-       if activeSkill.skillPart == 3 and activeSkill.activeStageCount then
-           stageDamageMultiplier = 75 * math.min(activeSkill.activeStageCount, 15)
-           activeSkill.skillModList:NewMod("Damage", "MORE", stageDamageMultiplier - 100, "Skill:ChargedDash", ModFlag.Attack, { type = "SkillPart", skillPart = 3})
-       elseif activeSkill.skillPart == 3 then
-           stageDamageMultiplier = 75
-           activeSkill.skillModList:NewMod("Damage", "MORE", stageDamageMultiplier - 100, "Skill:ChargedDash", ModFlag.Attack, { type = "SkillPart", skillPart = 3})
+       if activeSkill.skillPart == 3 then
+           local finalWaveDamageModifier = activeSkill.skillModList:Sum("INC", activeSkill.skillCfg, "chargedDashFinalDamageModifier")
+           activeSkill.skillModList:NewMod("Damage", "MORE", finalWaveDamageModifier, "Skill:ChargedDash", ModFlag.Attack, { type = "Release Damage", skillPart = 3})
        end
 end,
 statMap = {
     ["base_skill_show_average_damage_instead_of_dps"] = {
+    },
+    ["charged_dash_damage_+%_final"] = {
+        mod("chargedDashFinalDamageModifier", "INC", nil, 0, 0, {type="BaseReleaseDamage", skillPart = 3}),
+    },
+    ["charged_dash_damage_+%_final_per_stack"] = {
+        mod("chargedDashFinalDamageModifier", "INC", nil, 0, 0, {type="Multiplier", skillPart = 3, var = "ChargedDashStage"}),
+    },
+    ["charged_dash_channelling_damage_at_full_stacks_+%_final"] = {
+        mod("Damage", "MORE", nil, 0, 0, { type= "SkillPart", skillPart = 2 }),
     },
 },
 	baseFlags = {
@@ -1799,7 +1804,6 @@ statMap = {
 		skill("radiusSecondary", 26),
 		skill("radiusSecondaryLabel", "End of Dash:"),
 		skill("hitTimeMultiplier", 2, { type = "Skill", skillPartList = {1, 2} }),
-		mod("Damage", "MORE", 150, 0, KeywordFlag.Hit, { type = "SkillPart", skillPart = 2 }),
 		mod("Multiplier:ChargedDashMaxStages", "BASE", 15),
 		skill("showAverage", true, { type = "SkillPart", skillPart = 3 }),
 	},

--- a/src/Data/Skills/act_dex.lua
+++ b/src/Data/Skills/act_dex.lua
@@ -1765,14 +1765,17 @@ skills["ChargedDash"] = {
 	castTime = 1,
 	parts = {
 		{
-			name = "Channelling",
+			name = "Channelling, No Stages",
+		},
+		{
+			name = "Channelling, Max Stages",
 		},
 		{
 			name = "Release",
 		},
 	},
 	preDamageFunc = function(activeSkill, output)
-		   if activeSkill.skillPart == 2 then
+		   if activeSkill.skillPart == 3 then
 			   local finalWaveDamageModifier = activeSkill.skillModList:Sum("INC", activeSkill.skillCfg, "chargedDashFinalDamageModifier")
 			   activeSkill.skillModList:NewMod("Damage", "MORE", finalWaveDamageModifier, "Skill:ChargedDash", ModFlag.Attack, { type = "Release Damage", skillPart = 3 })
 		   end
@@ -1781,13 +1784,13 @@ skills["ChargedDash"] = {
 		["base_skill_show_average_damage_instead_of_dps"] = {
 		},
 		["charged_dash_damage_+%_final"] = {
-			mod("chargedDashFinalDamageModifier", "INC", nil, 0, 0, { type="BaseReleaseDamage", skillPart = 2 }),
+			mod("chargedDashFinalDamageModifier", "INC", nil, 0, 0, { type="BaseReleaseDamage", skillPart = 3 }),
 		},
 		["charged_dash_damage_+%_final_per_stack"] = {
-			mod("chargedDashFinalDamageModifier", "INC", nil, 0, 0, { type="Multiplier", skillPart = 2, var = "ChargedDashStage" }),
+			mod("chargedDashFinalDamageModifier", "INC", nil, 0, 0, { type="Multiplier", skillPart = 3, var = "ChargedDashStage" }),
 		},
 		["charged_dash_channelling_damage_at_full_stacks_+%_final"] = {
-			mod("Damage", "MORE", nil, 0, 0, { type= "MultiplierThreshold", var= "ChargedDashStage", threshold = 15 }, { type = "SkillPart", skillPart = 1 }),
+			mod("Damage", "MORE", nil, 0, 0, { type = "SkillPart", skillPart = 2 }),
 		},
 	},
 	baseFlags = {
@@ -1800,9 +1803,9 @@ skills["ChargedDash"] = {
 		skill("radiusLabel", "Start of Dash:"),
 		skill("radiusSecondary", 26),
 		skill("radiusSecondaryLabel", "End of Dash:"),
-		skill("hitTimeMultiplier", 2, { type = "Skill", skillPart = 1 }),
+		skill("hitTimeMultiplier", 2, { type = "Skill", skillPartList = { 1, 2 } }),
 		mod("Multiplier:ChargedDashMaxStages", "BASE", 15),
-		skill("showAverage", true, { type = "SkillPart", skillPart = 2 }),
+		skill("showAverage", true, { type = "SkillPart", skillPart = 3 }),
 	},
 	qualityStats = {
 		Default = {

--- a/src/Data/Skills/act_dex.lua
+++ b/src/Data/Skills/act_dex.lua
@@ -1763,36 +1763,32 @@ skills["ChargedDash"] = {
 	},
 	statDescriptionScope = "skill_stat_descriptions",
 	castTime = 1,
-parts = {
-    {
-        name = "Channelling, No Stages",
-    },
-    {
-        name = "Channelling, Max Stages",
-    },
-    {
-        name = "Release",
-    },
-},
-preDamageFunc = function(activeSkill, output)
-       if activeSkill.skillPart == 3 then
-           local finalWaveDamageModifier = activeSkill.skillModList:Sum("INC", activeSkill.skillCfg, "chargedDashFinalDamageModifier")
-           activeSkill.skillModList:NewMod("Damage", "MORE", finalWaveDamageModifier, "Skill:ChargedDash", ModFlag.Attack, { type = "Release Damage", skillPart = 3})
-       end
-end,
-statMap = {
-    ["base_skill_show_average_damage_instead_of_dps"] = {
-    },
-    ["charged_dash_damage_+%_final"] = {
-        mod("chargedDashFinalDamageModifier", "INC", nil, 0, 0, {type="BaseReleaseDamage", skillPart = 3}),
-    },
-    ["charged_dash_damage_+%_final_per_stack"] = {
-        mod("chargedDashFinalDamageModifier", "INC", nil, 0, 0, {type="Multiplier", skillPart = 3, var = "ChargedDashStage"}),
-    },
-    ["charged_dash_channelling_damage_at_full_stacks_+%_final"] = {
-        mod("Damage", "MORE", nil, 0, 0, { type= "SkillPart", skillPart = 2 }),
-    },
-},
+	parts = {
+		{
+			name = "Channelling",
+		{
+			name = "Release",
+		},
+	},
+	preDamageFunc = function(activeSkill, output)
+		   if activeSkill.skillPart == 2 then
+			   local finalWaveDamageModifier = activeSkill.skillModList:Sum("INC", activeSkill.skillCfg, "chargedDashFinalDamageModifier")
+			   activeSkill.skillModList:NewMod("Damage", "MORE", finalWaveDamageModifier, "Skill:ChargedDash", ModFlag.Attack, { type = "Release Damage", skillPart = 3 })
+		   end
+	end,
+	statMap = {
+		["base_skill_show_average_damage_instead_of_dps"] = {
+		},
+		["charged_dash_damage_+%_final"] = {
+			mod("chargedDashFinalDamageModifier", "INC", nil, 0, 0, { type="BaseReleaseDamage", skillPart = 2 }),
+		},
+		["charged_dash_damage_+%_final_per_stack"] = {
+			mod("chargedDashFinalDamageModifier", "INC", nil, 0, 0, { type="Multiplier", skillPart = 2, var = "ChargedDashStage" }),
+		},
+		["charged_dash_channelling_damage_at_full_stacks_+%_final"] = {
+			mod("Damage", "MORE", nil, 0, 0, { type= "MultiplierThreshold", var= "ChargedDashStage", threshold = 15 }, { type = "SkillPart", skillPart = 1 }),
+		},
+	},
 	baseFlags = {
 		attack = true,
 		melee = true,
@@ -1803,9 +1799,9 @@ statMap = {
 		skill("radiusLabel", "Start of Dash:"),
 		skill("radiusSecondary", 26),
 		skill("radiusSecondaryLabel", "End of Dash:"),
-		skill("hitTimeMultiplier", 2, { type = "Skill", skillPartList = {1, 2} }),
+		skill("hitTimeMultiplier", 2, { type = "Skill", skillPart = 1 }),,
 		mod("Multiplier:ChargedDashMaxStages", "BASE", 15),
-		skill("showAverage", true, { type = "SkillPart", skillPart = 3 }),
+		skill("showAverage", true, { type = "SkillPart", skillPart = 2 }),
 	},
 	qualityStats = {
 		Default = {

--- a/src/Data/Skills/act_dex.lua
+++ b/src/Data/Skills/act_dex.lua
@@ -1766,6 +1766,7 @@ skills["ChargedDash"] = {
 	parts = {
 		{
 			name = "Channelling",
+		},
 		{
 			name = "Release",
 		},
@@ -1799,7 +1800,7 @@ skills["ChargedDash"] = {
 		skill("radiusLabel", "Start of Dash:"),
 		skill("radiusSecondary", 26),
 		skill("radiusSecondaryLabel", "End of Dash:"),
-		skill("hitTimeMultiplier", 2, { type = "Skill", skillPart = 1 }),,
+		skill("hitTimeMultiplier", 2, { type = "Skill", skillPart = 1 }),
 		mod("Multiplier:ChargedDashMaxStages", "BASE", 15),
 		skill("showAverage", true, { type = "SkillPart", skillPart = 2 }),
 	},

--- a/src/Export/Skills/act_dex.txt
+++ b/src/Export/Skills/act_dex.txt
@@ -326,17 +326,22 @@ parts = {
     },
 },
 preDamageFunc = function(activeSkill, output)
-    local stageDamageMultiplier
-       if activeSkill.skillPart == 3 and activeSkill.activeStageCount then
-           stageDamageMultiplier = 75 * math.min(activeSkill.activeStageCount, 15)
-           activeSkill.skillModList:NewMod("Damage", "MORE", stageDamageMultiplier - 100, "Skill:ChargedDash", ModFlag.Attack, { type = "SkillPart", skillPart = 3})
-       elseif activeSkill.skillPart == 3 then
-           stageDamageMultiplier = 75
-           activeSkill.skillModList:NewMod("Damage", "MORE", stageDamageMultiplier - 100, "Skill:ChargedDash", ModFlag.Attack, { type = "SkillPart", skillPart = 3})
+       if activeSkill.skillPart == 3 then
+           local finalWaveDamageModifier = activeSkill.skillModList:Sum("INC", activeSkill.skillCfg, "chargedDashFinalDamageModifier")
+           activeSkill.skillModList:NewMod("Damage", "MORE", finalWaveDamageModifier, "Skill:ChargedDash", ModFlag.Attack, { type = "Release Damage", skillPart = 3})
        end
 end,
 statMap = {
     ["base_skill_show_average_damage_instead_of_dps"] = {
+    },
+    ["charged_dash_damage_+%_final"] = {
+        mod("chargedDashFinalDamageModifier", "INC", nil, 0, 0, {type="BaseReleaseDamage", skillPart = 3}),
+    },
+    ["charged_dash_damage_+%_final_per_stack"] = {
+        mod("chargedDashFinalDamageModifier", "INC", nil, 0, 0, {type="Multiplier", skillPart = 3, var = "ChargedDashStage"}),
+    },
+    ["charged_dash_channelling_damage_at_full_stacks_+%_final"] = {
+        mod("Damage", "MORE", nil, 0, 0, { type= "SkillPart", skillPart = 2 }),
     },
 },
 #baseMod skill("radius", 14)
@@ -344,7 +349,6 @@ statMap = {
 #baseMod skill("radiusSecondary", 26)
 #baseMod skill("radiusSecondaryLabel", "End of Dash:")
 #baseMod skill("hitTimeMultiplier", 2, { type = "Skill", skillPartList = {1, 2} })
-#baseMod mod("Damage", "MORE", 150, 0, KeywordFlag.Hit, { type = "SkillPart", skillPart = 2 })
 #baseMod mod("Multiplier:ChargedDashMaxStages", "BASE", 15)
 #baseMod skill("showAverage", true, { type = "SkillPart", skillPart = 3 })
 #mods

--- a/src/Export/Skills/act_dex.txt
+++ b/src/Export/Skills/act_dex.txt
@@ -316,14 +316,17 @@ local skills, mod, flag, skill = ...
 #flags attack melee area
 	parts = {
 		{
-			name = "Channelling",
+			name = "Channelling, No Stages",
+		},
+		{
+			name = "Channelling, Max Stages",
 		},
 		{
 			name = "Release",
 		},
 	},
 	preDamageFunc = function(activeSkill, output)
-		   if activeSkill.skillPart == 2 then
+		   if activeSkill.skillPart == 3 then
 			   local finalWaveDamageModifier = activeSkill.skillModList:Sum("INC", activeSkill.skillCfg, "chargedDashFinalDamageModifier")
 			   activeSkill.skillModList:NewMod("Damage", "MORE", finalWaveDamageModifier, "Skill:ChargedDash", ModFlag.Attack, { type = "Release Damage", skillPart = 3 })
 		   end
@@ -332,22 +335,22 @@ local skills, mod, flag, skill = ...
 		["base_skill_show_average_damage_instead_of_dps"] = {
 		},
 		["charged_dash_damage_+%_final"] = {
-			mod("chargedDashFinalDamageModifier", "INC", nil, 0, 0, { type="BaseReleaseDamage", skillPart = 2 }),
+			mod("chargedDashFinalDamageModifier", "INC", nil, 0, 0, { type="BaseReleaseDamage", skillPart = 3 }),
 		},
 		["charged_dash_damage_+%_final_per_stack"] = {
-			mod("chargedDashFinalDamageModifier", "INC", nil, 0, 0, { type="Multiplier", skillPart = 2, var = "ChargedDashStage" }),
+			mod("chargedDashFinalDamageModifier", "INC", nil, 0, 0, { type="Multiplier", skillPart = 3, var = "ChargedDashStage" }),
 		},
 		["charged_dash_channelling_damage_at_full_stacks_+%_final"] = {
-			mod("Damage", "MORE", nil, 0, 0, { type= "MultiplierThreshold", var= "ChargedDashStage", threshold = 15 }, { type = "SkillPart", skillPart = 1 }),
+			mod("Damage", "MORE", nil, 0, 0, { type = "SkillPart", skillPart = 2 }),
 		},
 	},
 #baseMod skill("radius", 14)
 #baseMod skill("radiusLabel", "Start of Dash:")
 #baseMod skill("radiusSecondary", 26)
 #baseMod skill("radiusSecondaryLabel", "End of Dash:")
-#baseMod skill("hitTimeMultiplier", 2, { type = "Skill", skillPart = 1 })
+#baseMod skill("hitTimeMultiplier", 2, { type = "Skill", skillPartList = { 1, 2 } })
 #baseMod mod("Multiplier:ChargedDashMaxStages", "BASE", 15)
-#baseMod skill("showAverage", true, { type = "SkillPart", skillPart = 2 })
+#baseMod skill("showAverage", true, { type = "SkillPart", skillPart = 3 })
 #mods
 
 #skill CobraLash

--- a/src/Export/Skills/act_dex.txt
+++ b/src/Export/Skills/act_dex.txt
@@ -317,6 +317,7 @@ local skills, mod, flag, skill = ...
 	parts = {
 		{
 			name = "Channelling",
+		},
 		{
 			name = "Release",
 		},
@@ -344,7 +345,7 @@ local skills, mod, flag, skill = ...
 #baseMod skill("radiusLabel", "Start of Dash:")
 #baseMod skill("radiusSecondary", 26)
 #baseMod skill("radiusSecondaryLabel", "End of Dash:")
-#baseMod skill("hitTimeMultiplier", 2, { type = "Skill", skillPart = 1 }),
+#baseMod skill("hitTimeMultiplier", 2, { type = "Skill", skillPart = 1 })
 #baseMod mod("Multiplier:ChargedDashMaxStages", "BASE", 15)
 #baseMod skill("showAverage", true, { type = "SkillPart", skillPart = 2 })
 #mods

--- a/src/Export/Skills/act_dex.txt
+++ b/src/Export/Skills/act_dex.txt
@@ -314,43 +314,39 @@ local skills, mod, flag, skill = ...
 
 #skill ChargedDash
 #flags attack melee area
-parts = {
-    {
-        name = "Channelling, No Stages",
-    },
-    {
-        name = "Channelling, Max Stages",
-    },
-    {
-        name = "Release",
-    },
-},
-preDamageFunc = function(activeSkill, output)
-       if activeSkill.skillPart == 3 then
-           local finalWaveDamageModifier = activeSkill.skillModList:Sum("INC", activeSkill.skillCfg, "chargedDashFinalDamageModifier")
-           activeSkill.skillModList:NewMod("Damage", "MORE", finalWaveDamageModifier, "Skill:ChargedDash", ModFlag.Attack, { type = "Release Damage", skillPart = 3})
-       end
-end,
-statMap = {
-    ["base_skill_show_average_damage_instead_of_dps"] = {
-    },
-    ["charged_dash_damage_+%_final"] = {
-        mod("chargedDashFinalDamageModifier", "INC", nil, 0, 0, {type="BaseReleaseDamage", skillPart = 3}),
-    },
-    ["charged_dash_damage_+%_final_per_stack"] = {
-        mod("chargedDashFinalDamageModifier", "INC", nil, 0, 0, {type="Multiplier", skillPart = 3, var = "ChargedDashStage"}),
-    },
-    ["charged_dash_channelling_damage_at_full_stacks_+%_final"] = {
-        mod("Damage", "MORE", nil, 0, 0, { type= "SkillPart", skillPart = 2 }),
-    },
-},
+	parts = {
+		{
+			name = "Channelling",
+		{
+			name = "Release",
+		},
+	},
+	preDamageFunc = function(activeSkill, output)
+		   if activeSkill.skillPart == 2 then
+			   local finalWaveDamageModifier = activeSkill.skillModList:Sum("INC", activeSkill.skillCfg, "chargedDashFinalDamageModifier")
+			   activeSkill.skillModList:NewMod("Damage", "MORE", finalWaveDamageModifier, "Skill:ChargedDash", ModFlag.Attack, { type = "Release Damage", skillPart = 3 })
+		   end
+	end,
+	statMap = {
+		["base_skill_show_average_damage_instead_of_dps"] = {
+		},
+		["charged_dash_damage_+%_final"] = {
+			mod("chargedDashFinalDamageModifier", "INC", nil, 0, 0, { type="BaseReleaseDamage", skillPart = 2 }),
+		},
+		["charged_dash_damage_+%_final_per_stack"] = {
+			mod("chargedDashFinalDamageModifier", "INC", nil, 0, 0, { type="Multiplier", skillPart = 2, var = "ChargedDashStage" }),
+		},
+		["charged_dash_channelling_damage_at_full_stacks_+%_final"] = {
+			mod("Damage", "MORE", nil, 0, 0, { type= "MultiplierThreshold", var= "ChargedDashStage", threshold = 15 }, { type = "SkillPart", skillPart = 1 }),
+		},
+	},
 #baseMod skill("radius", 14)
 #baseMod skill("radiusLabel", "Start of Dash:")
 #baseMod skill("radiusSecondary", 26)
 #baseMod skill("radiusSecondaryLabel", "End of Dash:")
-#baseMod skill("hitTimeMultiplier", 2, { type = "Skill", skillPartList = {1, 2} })
+#baseMod skill("hitTimeMultiplier", 2, { type = "Skill", skillPart = 1 }),
 #baseMod mod("Multiplier:ChargedDashMaxStages", "BASE", 15)
-#baseMod skill("showAverage", true, { type = "SkillPart", skillPart = 3 })
+#baseMod skill("showAverage", true, { type = "SkillPart", skillPart = 2 })
 #mods
 
 #skill CobraLash

--- a/src/Export/Skills/act_dex.txt
+++ b/src/Export/Skills/act_dex.txt
@@ -314,17 +314,39 @@ local skills, mod, flag, skill = ...
 
 #skill ChargedDash
 #flags attack melee area
-	statMap = {
-		["charged_dash_damage_+%_maximum"] = {
-			mod("Damage", "MORE", nil, 0, bit.bor(KeywordFlag.Hit, KeywordFlag.Ailment), { type = "Multiplier", var = "ChargedDashDistance" }),
-		},
-		["base_skill_show_average_damage_instead_of_dps"] = {
-		},
-	},
+parts = {
+    {
+        name = "Channelling, No Stages",
+    },
+    {
+        name = "Channelling, Max Stages",
+    },
+    {
+        name = "Release",
+    },
+},
+preDamageFunc = function(activeSkill, output)
+    local stageDamageMultiplier
+       if activeSkill.skillPart == 3 and activeSkill.activeStageCount then
+           stageDamageMultiplier = 75 * math.min(activeSkill.activeStageCount, 15)
+           activeSkill.skillModList:NewMod("Damage", "MORE", stageDamageMultiplier - 100, "Skill:ChargedDash", ModFlag.Attack, { type = "SkillPart", skillPart = 3})
+       elseif activeSkill.skillPart == 3 then
+           stageDamageMultiplier = 75
+           activeSkill.skillModList:NewMod("Damage", "MORE", stageDamageMultiplier - 100, "Skill:ChargedDash", ModFlag.Attack, { type = "SkillPart", skillPart = 3})
+       end
+end,
+statMap = {
+    ["base_skill_show_average_damage_instead_of_dps"] = {
+    },
+},
 #baseMod skill("radius", 14)
 #baseMod skill("radiusLabel", "Start of Dash:")
 #baseMod skill("radiusSecondary", 26)
 #baseMod skill("radiusSecondaryLabel", "End of Dash:")
+#baseMod skill("hitTimeMultiplier", 2, { type = "Skill", skillPartList = {1, 2} })
+#baseMod mod("Damage", "MORE", 150, 0, KeywordFlag.Hit, { type = "SkillPart", skillPart = 2 })
+#baseMod mod("Multiplier:ChargedDashMaxStages", "BASE", 15)
+#baseMod skill("showAverage", true, { type = "SkillPart", skillPart = 3 })
 #mods
 
 #skill CobraLash

--- a/src/Launch.lua
+++ b/src/Launch.lua
@@ -15,11 +15,6 @@ launch = { }
 SetMainObject(launch)
 
 function launch:OnInit()
-package.cpath = package.cpath .. ';C:/Users/trevo/AppData/Roaming/JetBrains/PyCharmCE2021.1/plugins/EmmyLua/classes/debugger/emmy/windows/x86/?.dll'
-local dbg = require('emmy_core')
-dbg.tcpListen('localhost', 9966)
---dbg.waitIDE()
-
 	self.devMode = false
 	self.installedMode = false
 	self.versionNumber = "?"

--- a/src/Launch.lua
+++ b/src/Launch.lua
@@ -15,6 +15,11 @@ launch = { }
 SetMainObject(launch)
 
 function launch:OnInit()
+package.cpath = package.cpath .. ';C:/Users/trevo/AppData/Roaming/JetBrains/PyCharmCE2021.1/plugins/EmmyLua/classes/debugger/emmy/windows/x86/?.dll'
+local dbg = require('emmy_core')
+dbg.tcpListen('localhost', 9966)
+--dbg.waitIDE()
+
 	self.devMode = false
 	self.installedMode = false
 	self.versionNumber = "?"

--- a/src/Modules/CalcOffence.lua
+++ b/src/Modules/CalcOffence.lua
@@ -1365,6 +1365,9 @@ function calcs.offence(env, actor, activeSkill)
 			if skillFlags.brand then
 				output.BrandTicks = m_floor(output.Duration * output.HitSpeed)
 			end
+		elseif skillData.hitTimeMultiplier and output.Time and not skillData.triggeredOnDeath then
+			output.HitTime = output.Time * skillData.hitTimeMultiplier
+			output.HitSpeed = 1 / output.HitTime
 		end
 	end
 


### PR DESCRIPTION
Fixes the broken Charged Dash DPS Calculation by replacing it with calculations for each of the 3 phases of channelling, allowing the user to specify the number of stages for the release.

It also adds a "hitTimeMultiplier" similar to "hitTimeOverride" in CalcOffence, due to CD only hitting every other attack, which I thought could be useful for some other skills.

I'm brand new to the code base, and this is my first PR, so lmk if there's anything I should be doing differently.


![MaxStages](https://user-images.githubusercontent.com/88598802/128690022-23663d04-b335-40d5-bb2b-5560dbee13dc.PNG)
![NoStages](https://user-images.githubusercontent.com/88598802/128690024-4b3d2911-9acb-40c6-8cdf-4db687a4ce45.PNG)
![Release](https://user-images.githubusercontent.com/88598802/128690025-e3da0f33-8541-470a-b095-3e582b62a463.PNG)
