### PR TITLE
Fix Secrets of Suffering from Alternating Scepter

### DIFF
--- a/src/Data/Uniques/Special/Generated.lua
+++ b/src/Data/Uniques/Special/Generated.lua
@@ -235,6 +235,7 @@ local excludedKeystones = {
 	"Hollow Palm Technique", -- exclusive to specific unique
 	"Immortal Ambition", -- exclusive to specific unique
 	"Necromantic Aegis", -- to prevent infinite loop
+	"Secrets of Suffering", -- exclusive to specific items
 }
 local keystones = {}
 for _, name in ipairs(data.keystones) do

--- a/src/Modules/Data.lua
+++ b/src/Modules/Data.lua
@@ -258,6 +258,7 @@ data.keystones = {
 	"Point Blank",
 	"Resolute Technique",
 	"Runebinder",
+	"Secrets of Suffering",
 	"Supreme Ego",
 	"The Agnostic",
 	"The Impaler",


### PR DESCRIPTION
Alternating Scepter has the implicit "Secrets of Suffering" which is currently not parsed. Add it to the list of keystones.

![image](https://user-images.githubusercontent.com/67038113/129034428-3a6bb31f-e6de-45b5-b475-81ef52c52a87.png)
