### PR TITLE
Fix gem levels not being properly limited

### DIFF
--- a/src/Modules/CalcSetup.lua
+++ b/src/Modules/CalcSetup.lua
@@ -884,6 +884,8 @@ function calcs.initEnv(build, mode, override, specEnv)
 									end
 								end
 							end
+							-- Validate support gem level in case there is no active skill (and no full calculation)
+							calcLib.validateGemLevel(supportEffect)
 							local add = true
 							for index, otherSupport in ipairs(supportList) do
 								-- Check if there's another support with the same name already present

--- a/src/Modules/CalcTools.lua
+++ b/src/Modules/CalcTools.lua
@@ -42,20 +42,19 @@ end
 function calcLib.validateGemLevel(gemInstance)
 	local grantedEffect = gemInstance.grantedEffect or gemInstance.gemData.grantedEffect
 	if not grantedEffect.levels[gemInstance.level] then
-		if gemInstance.gemData and gemInstance.gemData.defaultLevel then
-			gemInstance.level = gemInstance.gemData.defaultLevel
-		else
-			-- Try limiting to the level range of the skill
-			gemInstance.level = m_max(1, gemInstance.level)
-			if #grantedEffect.levels > 0 then
-				gemInstance.level = m_min(#grantedEffect.levels, gemInstance.level)
-			end
-			if not grantedEffect.levels[gemInstance.level] then
-				-- That failed, so just grab any level
-				gemInstance.level = next(grantedEffect.levels)
-			end
+		-- Try limiting to the level range of the skill
+		gemInstance.level = m_max(1, gemInstance.level)
+		if #grantedEffect.levels > 0 then
+			gemInstance.level = m_min(#grantedEffect.levels, gemInstance.level)
 		end
-	end	
+	end
+	if not grantedEffect.levels[gemInstance.level] and gemInstance.gemData and gemInstance.gemData.defaultLevel then
+		gemInstance.level = gemInstance.gemData.defaultLevel
+	end
+	if not grantedEffect.levels[gemInstance.level] then
+		-- That failed, so just grab any level
+		gemInstance.level = next(grantedEffect.levels)
+	end
 end
 
 -- Evaluate a skill type postfix expression


### PR DESCRIPTION
Normally there is an active skill gem in a socket group which creates a skill and `calcLib.validateGemLevel` is called on it and all supports. If there is no active gem, the calculation is not run. This resulted in no validation taking place.
Fixes #2921 
I also switched the logic to prefer the highest available level up to the requested one over the default level. For example, if you manage to get a lvl 42 active skill it'll be clamped to 40, where before it would get set to 20.
The validation logic seems very pessimistic but at least it should be correct for non-sequential tables. 