### PR TITLE
Add radius numbers for a number of skills

### DIFF
--- a/src/Data/Skills/act_dex.lua
+++ b/src/Data/Skills/act_dex.lua
@@ -682,6 +682,7 @@ skills["BladeTrap"] = {
 		trap = true,
 	},
 	baseMods = {
+		skill("radius", 16),
 	},
 	qualityStats = {
 		Default = {
@@ -6127,6 +6128,10 @@ skills["StormRain"] = {
 		projectile = true,
 	},
 	baseMods = {
+		skill("radius", 10, { type = "SkillPart", skillPart = 1 }),
+		skill("radiusLabel", "Arrow Explosion:", { type = "SkillPart", skillPart = 1 }),
+		skill("radiusSecondary", 12, { type = "SkillPart", skillPart = 2 }),
+		skill("radiusSecondaryLabel", "Beam Width:", { type = "SkillPart", skillPart = 2 }),
 	},
 	qualityStats = {
 		Default = {

--- a/src/Data/Skills/act_int.lua
+++ b/src/Data/Skills/act_int.lua
@@ -2010,6 +2010,7 @@ skills["Disintegrate"] = {
 		area = true,
 	},
 	baseMods = {
+		skill("radius", 10),
 	},
 	qualityStats = {
 		Default = {
@@ -4294,6 +4295,7 @@ skills["FrostGlobe"] = {
 		duration = true,
 	},
 	baseMods = {
+		skill("radius", 22),
 	},
 	qualityStats = {
 		Default = {
@@ -4945,6 +4947,7 @@ skills["DoomBlast"] = {
 		area = true,
 	},
 	baseMods = {
+		skill("radius", 29),
 		skill("showAverage", true),
 		flag("ChaosDamageUsesLowestResistance"),
 		flag("PhysicalCanIgnite"),
@@ -6523,6 +6526,10 @@ skills["Manabond"] = {
 		arcane = true,
 	},
 	baseMods = {
+		skill("radius", 18),
+		skill("radiusLabel", "Circle area:"),
+		skill("radiusSecondary", 23),
+		skill("radiusSecondaryLabel", "Rectangle area:"),
 		mod("LightningMin", "BASE", 1, 0, 0, { type = "Multiplier", var = "ManabondUnreservedMana" }),
 		mod("LightningMax", "BASE", 1, 0, 0, { type = "Multiplier", var = "ManabondUnreservedMana" }),
 	},
@@ -8022,6 +8029,7 @@ skills["CircleOfPower"] = {
 		duration = true,
 	},
 	baseMods = {
+		skill("radius", 30),
 		skill("buffAllies", true),
 	},
 	qualityStats = {
@@ -10251,6 +10259,7 @@ skills["BlackHole"] = {
 		duration = true,
 	},
 	baseMods = {
+		skill("radius", 38),
 	},
 	qualityStats = {
 		Default = {
@@ -10516,6 +10525,7 @@ skills["VoltaxicBurst"] = {
 		duration = true,
 	},
 	baseMods = {
+		skill("radius", 22),
 	},
 	qualityStats = {
 		Default = {
@@ -10929,6 +10939,7 @@ skills["ImmolationSigil"] = {
 		brand = true,
 	},
 	baseMods = {
+		skill("radius", 20),
 	},
 	qualityStats = {
 		Default = {

--- a/src/Data/Skills/act_str.lua
+++ b/src/Data/Skills/act_str.lua
@@ -34,6 +34,7 @@ skills["Absolution"] = {
 		area = true,
 	},
 	baseMods = {
+		skill("radius", 25),
 	},
 	qualityStats = {
 		Default = {
@@ -1388,7 +1389,17 @@ skills["Boneshatter"] = {
 	},
 	statDescriptionScope = "skill_stat_descriptions",
 	castTime = 1,
-statMap = {
+	parts = {
+		{
+			name = "Attack",
+			area = false,
+		},
+		{
+			name = "Pulse",
+			area = true,
+		},
+	},
+	statMap = {
 		["trauma_strike_damage_+%_final_per_trauma"] = {
 			mod("Damage", "MORE", nil, 0, 0, { type = "Multiplier", var = "TraumaStacks" }),
 		},
@@ -1404,6 +1415,7 @@ statMap = {
 		duration = true,
 	},
 	baseMods = {
+		skill("radius", 14, { type = "SkillPart", skillPart = 2 }),
 	},
 	qualityStats = {
 		Default = {
@@ -5370,6 +5382,7 @@ skills["RageVortex"] = {
 		duration = true,
 	},
 	baseMods = {
+		skill("radius", 18),
 	},
 	qualityStats = {
 		Default = {
@@ -6443,6 +6456,7 @@ skills["Bloodreap"] = {
 		duration = true,
 	},
 	baseMods = {
+		skill("radius", 25),
 		skill("debuff", true),
 	},
 	qualityStats = {
@@ -6533,6 +6547,7 @@ skills["ShieldCrush"] = {
 		shieldAttack = true,
 	},
 	baseMods = {
+		skill("radius", 29),
 		skill("dpsMultiplier", 2, { type = "SkillPart", skillPart = 2 }),
 	},
 	qualityStats = {

--- a/src/Data/Skills/sup_int.lua
+++ b/src/Data/Skills/sup_int.lua
@@ -2634,6 +2634,7 @@ skills["ViciousHexExplosion"] = {
 		area = true,
 	},
 	baseMods = {
+		skill("radius", 20),
 		skill("showAverage", true),
 	},
 	qualityStats = {

--- a/src/Export/Skills/act_dex.txt
+++ b/src/Export/Skills/act_dex.txt
@@ -123,6 +123,7 @@ local skills, mod, flag, skill = ...
 
 #skill BladeTrap
 #flags attack area trap
+#baseMod skill("radius", 16)
 #mods
 
 #skill ChargedAttack
@@ -1103,6 +1104,10 @@ local skills, mod, flag, skill = ...
 			mod("StormRainBeamFrequency", "INC", nil),
 		},
 	},
+#baseMod skill("radius", 10, { type = "SkillPart", skillPart = 1 })
+#baseMod skill("radiusLabel", "Arrow Explosion:", { type = "SkillPart", skillPart = 1 })
+#baseMod skill("radiusSecondary", 12, { type = "SkillPart", skillPart = 2 })
+#baseMod skill("radiusSecondaryLabel", "Beam Width:", { type = "SkillPart", skillPart = 2 })
 #mods
 
 #skill Puncture

--- a/src/Export/Skills/act_int.txt
+++ b/src/Export/Skills/act_int.txt
@@ -333,6 +333,7 @@ local skills, mod, flag, skill = ...
 			mod("Damage", "MORE", nil, 0, 0, { type = "Multiplier", var = "Intensity", limitVar = "IntensityLimit" }),
 		},
 	},
+#baseMod skill("radius", 10)
 #mods
 
 #skill DarkPact
@@ -801,6 +802,7 @@ local skills, mod, flag, skill = ...
 			div = 60,
 		},
 	},
+#baseMod skill("radius", 22)
 #mods
 
 #skill FrostWall
@@ -921,6 +923,7 @@ local skills, mod, flag, skill = ...
 			area = true,
 		},
 	},
+#baseMod skill("radius", 29)
 #baseMod skill("showAverage", true)
 #baseMod flag("ChaosDamageUsesLowestResistance")
 #baseMod flag("PhysicalCanIgnite")
@@ -1181,6 +1184,10 @@ local skills, mod, flag, skill = ...
 			div = 100,
 		},
 	},
+#baseMod skill("radius", 18)
+#baseMod skill("radiusLabel", "Circle area:")
+#baseMod skill("radiusSecondary", 23)
+#baseMod skill("radiusSecondaryLabel", "Rectangle area:")
 #baseMod mod("LightningMin", "BASE", 1, 0, 0, { type = "Multiplier", var = "ManabondUnreservedMana" })
 #baseMod mod("LightningMax", "BASE", 1, 0, 0, { type = "Multiplier", var = "ManabondUnreservedMana" })
 #mods
@@ -1478,6 +1485,7 @@ local skills, mod, flag, skill = ...
 			mod("LightningMax", "BASE", nil, 0, 0, { type = "Multiplier", actor = "parent", var = "SigilOfPowerStage", limit = 4 }, { type = "GlobalEffect", effectType = "Buff", effectName = "Sigil of Power" }),
 		},
 	},
+#baseMod skill("radius", 30)
 #baseMod skill("buffAllies", true)
 #mods
 
@@ -1817,6 +1825,7 @@ local skills, mod, flag, skill = ...
 			div = 1000,
 		},
 	},
+#baseMod skill("radius", 38)
 #mods
 
 #skill Skitterbots
@@ -1851,6 +1860,7 @@ local skills, mod, flag, skill = ...
 		local duration = math.floor(activeSkill.skillData.duration * output.DurationMod * 10)
 		activeSkill.skillModList:NewMod("Damage", "INC", activeSkill.skillModList:Sum("INC", activeSkill.skillCfg, "VoltaxicDurationIncDamage") * duration, "Skill:VoltaxicBurst")
 	end,
+#baseMod skill("radius", 22)
 #mods
 
 #skill FrostBoltNova
@@ -1935,6 +1945,7 @@ local skills, mod, flag, skill = ...
 			mod("BrandsAttachedLimit", "BASE", nil),
 		},
 	},
+#baseMod skill("radius", 20)
 #mods
 
 #skill Wither

--- a/src/Export/Skills/act_str.txt
+++ b/src/Export/Skills/act_str.txt
@@ -19,6 +19,7 @@ local skills, mod, flag, skill = ...
 			mod("MinionModifier", "LIST", { mod = mod("SkillPhysicalDamageConvertToLightning", "BASE", nil, 0, 0) })
 		},
 	},
+#baseMod skill("radius", 25)
 #mods
 
 #skill AbyssalCry
@@ -267,7 +268,17 @@ local skills, mod, flag, skill = ...
 
 #skill Boneshatter
 #flags attack melee strike area duration
-statMap = {
+	parts = {
+		{
+			name = "Attack",
+			area = false,
+		},
+		{
+			name = "Pulse",
+			area = true,
+		},
+	},
+	statMap = {
 		["trauma_strike_damage_+%_final_per_trauma"] = {
 			mod("Damage", "MORE", nil, 0, 0, { type = "Multiplier", var = "TraumaStacks" }),
 		},
@@ -275,6 +286,7 @@ statMap = {
 			mod("Speed", "INC", nil, ModFlag.Attack, 0, { type = "Multiplier", var = "TraumaStacks" }),
 		},
 	},
+#baseMod skill("radius", 14, { type = "SkillPart", skillPart = 2 })
 #mods
 
 #skill ChainStrike
@@ -947,6 +959,7 @@ statMap = {
 			mod("Speed", "MORE", nil, 0, 0, { type = "SkillPart", skillPart = 2 }),
 		},
 	},
+#baseMod skill("radius", 18)
 #mods
 
 #skill RallyingCry
@@ -1123,6 +1136,7 @@ end,
 			mod("LifeCost", "MORE", nil, 0, 0, { type = "Multiplier", var = "BloodCharge" }),
 		},
 	},
+#baseMod skill("radius", 25)
 #baseMod skill("debuff", true)
 #mods
 
@@ -1136,6 +1150,7 @@ end,
 			name = "2 Overlapping Waves",
 		},
 	},
+#baseMod skill("radius", 29)
 #baseMod skill("dpsMultiplier", 2, { type = "SkillPart", skillPart = 2 })
 #mods
 

--- a/src/Export/Skills/sup_int.txt
+++ b/src/Export/Skills/sup_int.txt
@@ -321,6 +321,7 @@ local skills, mod, flag, skill = ...
 			mod("Damage", "MORE", nil, 0, 0, { type = "Multiplier", var = "HexDoom", div = 5 }),
 		},
 	},
+#baseMod skill("radius", 20)
 #baseMod skill("showAverage", true)
 #mods
 


### PR DESCRIPTION
Numbers given by Openarl

ImmolationSigil - Wintertide Brand: 20
BlackHole - Void Sphere: 38
Disintegrate - Crackling Lance: 10? I think?
FrostGlobe - Frost Shield: 22
CircleOfPower - Sigil of Power: 30
Firewall - Flame Wall: A little birdie tells me this is a stat on the skill
ViciousHexExplosion - Impending Doom: 20
DoomBlast - Hexblast: 29
Bloodreap - Reap: 25
VoltaxicBurst: 22
RageVortex: 18
Absolution: 25? Not 100% sure
ForbiddenRite: 8
Manabond: 18 (circle) 23 (rectangle)
BladeTrap: 16
StormRain: 10 (explosion) 12 (beam)
ShieldCrush: 29
Boneshatter: 14
ExplosiveConcoction: 18