### PR TITLE
Update mod used by Touch of Anguish.

### DIFF
--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -2098,7 +2098,7 @@ local specialModList = {
 	["your physical damage can shock"] = { flag("PhysicalCanShock") },
 	["your physical damage can freeze"] = { flag("PhysicalCanFreeze") },
 	["you always ignite while burning"] = { mod("EnemyIgniteChance", "BASE", 100, { type = "Condition", var = "Burning" }) },
-	["critical strikes do not always freeze"] = { flag("CritsDontAlwaysFreeze") },
+	["critical strikes do not a?l?w?a?y?s?i?n?h?e?r?e?n?t?l?y? freeze"] = { flag("CritsDontAlwaysFreeze") },
 	["you can inflict up to (%d+) ignites on an enemy"] = { flag("IgniteCanStack") },
 	["you can inflict an additional ignite on an enemy"] = { flag("IgniteCanStack"), mod("IgniteStacks", "BASE", 1) },
 	["enemies chilled by you take (%d+)%% increased burning damage"] = function(num) return { mod("EnemyModifier", "LIST", { mod = mod("FireDamageTakenOverTime", "INC", num) }, { type = "ActorCondition", actor = "enemy", var = "Chilled" }) } end,


### PR DESCRIPTION
Mod used to be:
 > Critical Strikes do not always Freeze
Now it's:
 > Critical Strikes do not inherently Freeze

Ref:
 * old: https://www.pathofexile.com/forum/view-thread/1659666/page/1
 * new: https://www.poewiki.net/wiki/Touch_of_Anguish