### PR TITLE
Add button to show passive allocation order to passive tree tab (rebranch)

### DIFF
--- a/src/Classes/PassiveSpec.lua
+++ b/src/Classes/PassiveSpec.lua
@@ -120,15 +120,19 @@ function PassiveSpecClass:Load(xml, dbFileName)
 				masteryEffects[tonumber(mastery)] = tonumber(effect)
 			end
 		end
-		self:ImportFromNodeList(tonumber(xml.attrib.classId), tonumber(xml.attrib.ascendClassId), hashList, masteryEffects)
-        for nodeId in string.gmatch(xml.attrib.allocationOrder, ("%d+")) do
-            table.insert(self.allocationOrder, tonumber(nodeId))
-        end
-		for nodeId in string.gmatch(xml.attrib.ascendancyAllocationOrder, ("%d+")) do
-			table.insert(self.ascendancyAllocationOrder, tonumber(nodeId))
+		self:ImportFromNodeList(tonumber(xml.attrib.classId), tonumber(xml.attrib.ascendClassId), hashList)
+		if xml.attrib.allocationOrder then
+			for nodeId in string.gmatch(xml.attrib.allocationOrder, ("%d+")) do
+				table.insert(self.allocationOrder, tonumber(nodeId))
+			end
+			self:ReIndexAllocationOrder("allocationOrder")
 		end
-		self:ReIndexAllocationOrder("allocationOrder")
-		self:ReIndexAllocationOrder("ascendancyAllocationOrder")
+		if xml.attrib.ascendancyAllocationOrder then
+			for nodeId in string.gmatch(xml.attrib.ascendancyAllocationOrder, ("%d+")) do
+				table.insert(self.ascendancyAllocationOrder, tonumber(nodeId))
+			end
+			self:ReIndexAllocationOrder("ascendancyAllocationOrder")
+		end
 	elseif url then
 		self:DecodeURL(url)
 	end
@@ -347,8 +351,10 @@ function PassiveSpecClass:SelectAscendClass(ascendClassId)
 		if node.ascendancyName and node.ascendancyName ~= ascendClass.name then
 			node.alloc = false
 			self.allocNodes[id] = nil
+			self:RemoveFromAllocationOrder(node)
 		end
 	end
+	self:ReIndexAllocationOrder("ascendancyAllocationOrder")
 
 	if ascendClass.startNodeId then
 		-- Allocate the new ascendancy class's start node
@@ -388,13 +394,18 @@ end
 
 -- Clear the allocated status of all non-class-start nodes
 function PassiveSpecClass:ResetNodes()
+	ConPrintf("reset")
 	for id, node in pairs(self.nodes) do
 		if node.type ~= "ClassStart" and node.type ~= "AscendClassStart" then
 			node.alloc = false
+			node.allocationOrder = nil
+			node.ascendancyAllocationOrder = nil
 			self.allocNodes[id] = nil
 		end
 	end
 	wipeTable(self.masterySelections)
+	self.allocationOrder = { }
+	self.ascendancyAllocationOrder = { }
 end
 
 function PassiveSpecClass:SetAllocationOrder(node)
@@ -423,10 +434,39 @@ function PassiveSpecClass:ReIndexAllocationOrder(allocationOrder)
 	end
 end
 
+function PassiveSpecClass:SortNodesForRemovingFromAllocationOrder(node, depNodes)
+	if node.ascendancyName then
+		table.sort(depNodes, function(a, b)
+			if a.ascendancyAllocationOrder == nil and b.ascendancyAllocationOrder == nil then
+				return false
+			elseif a.ascendancyAllocationOrder == nil then
+				return true
+			elseif b.ascendancyAllocationOrder == nil then
+				return false
+			else
+				return a.ascendancyAllocationOrder > b.ascendancyAllocationOrder
+			end
+		end)
+	else
+		table.sort(depNodes, function(a, b)
+			if a.allocationOrder == nil and b.allocationOrder == nil then
+				return false
+			elseif a.allocationOrder == nil then
+				return true
+			elseif b.allocationOrder == nil then
+				return false
+			else
+				return a.allocationOrder > b.allocationOrder
+			end
+		end)
+	end
+end
+
 -- Allocate the given node, if possible, and all nodes along the path to the node
 -- An alternate path to the node may be provided, otherwise the default path will be used
 -- The path must always contain the given node, as will be the case for the default path
 function PassiveSpecClass:AllocNode(node, altPath)
+	ConPrintTable(self.allocationOrder)
 	if not node.path then
 		-- Node cannot be connected to the tree as there is no possible path
 		return
@@ -480,31 +520,7 @@ end
 
 -- Deallocate the given node, and all nodes which depend on it (i.e. which are only connected to the tree through this node)
 function PassiveSpecClass:DeallocNode(node)
-	if node.ascendancyName then
-		table.sort(node.depends, function(a, b)
-			if a.ascendancyAllocationOrder == nil and b.ascendancyAllocationOrder == nil then
-				return false
-			elseif a.ascendancyAllocationOrder == nil then
-				return true
-			elseif b.ascendancyAllocationOrder == nil then
-				return false
-			else
-				return a.ascendancyAllocationOrder > b.ascendancyAllocationOrder
-			end
-		end)
-	else
-		table.sort(node.depends, function(a, b)
-			if a.allocationOrder == nil and b.allocationOrder == nil then
-				return false
-			elseif a.allocationOrder == nil then
-				return true
-			elseif b.allocationOrder == nil then
-				return false
-			else
-				return a.allocationOrder > b.allocationOrder
-			end
-		end)
-	end
+	self:SortNodesForRemovingFromAllocationOrder(node, node.depends)
 
 	for _, depNode in ipairs(node.depends) do
 		self:DeallocSingleNode(depNode)
@@ -856,6 +872,7 @@ function PassiveSpecClass:BuildAllDependsAndPaths()
 		if not anyStartFound then
 			-- No start nodes were found through ANY nodes
 			-- Therefore this node and all nodes depending on it are orphans and should be pruned
+			self:SortNodesForRemovingFromAllocationOrder(node, node.depends)
 			for _, depNode in ipairs(node.depends) do
 				local prune = true
 				for nodeId, itemId in pairs(self.jewels) do
@@ -882,6 +899,8 @@ function PassiveSpecClass:BuildAllDependsAndPaths()
 					self:DeallocSingleNode(depNode)
 				end
 			end
+			self:ReIndexAllocationOrder("allocationOrder")
+			self:ReIndexAllocationOrder("ascendancyAllocationOrder")
 		end
 	end
 

--- a/src/Classes/PassiveSpec.lua
+++ b/src/Classes/PassiveSpec.lua
@@ -120,19 +120,19 @@ function PassiveSpecClass:Load(xml, dbFileName)
 				masteryEffects[tonumber(mastery)] = tonumber(effect)
 			end
 		end
-		self:ImportFromNodeList(tonumber(xml.attrib.classId), tonumber(xml.attrib.ascendClassId), hashList)
-		-- if xml.attrib.allocationOrder then
-		-- 	for nodeId in string.gmatch(xml.attrib.allocationOrder, ("%d+")) do
-		-- 		table.insert(self.allocationOrder, tonumber(nodeId))
-		-- 	end
-		-- 	self:ReIndexAllocationOrder("allocationOrder")
-		-- end
-		-- if xml.attrib.ascendancyAllocationOrder then
-		-- 	for nodeId in string.gmatch(xml.attrib.ascendancyAllocationOrder, ("%d+")) do
-		-- 		table.insert(self.ascendancyAllocationOrder, tonumber(nodeId))
-		-- 	end
-		-- 	self:ReIndexAllocationOrder("ascendancyAllocationOrder")
-		-- end
+		self:ImportFromNodeList(tonumber(xml.attrib.classId), tonumber(xml.attrib.ascendClassId), hashList, masteryEffects)
+		if xml.attrib.allocationOrder then
+			for nodeId in string.gmatch(xml.attrib.allocationOrder, ("%d+")) do
+				table.insert(self.allocationOrder, tonumber(nodeId))
+			end
+			self:ReIndexNodeAllocationOrder("allocationOrder")
+		end
+		if xml.attrib.ascendancyAllocationOrder then
+			for nodeId in string.gmatch(xml.attrib.ascendancyAllocationOrder, ("%d+")) do
+				table.insert(self.ascendancyAllocationOrder, tonumber(nodeId))
+			end
+			self:ReIndexNodeAllocationOrder("ascendancyAllocationOrder")
+		end
 	elseif url then
 		self:DecodeURL(url)
 	end
@@ -354,7 +354,7 @@ function PassiveSpecClass:SelectAscendClass(ascendClassId)
 			self:RemoveFromAllocationOrder(node)
 		end
 	end
-	self:ReIndexAllocationOrder("ascendancyAllocationOrder")
+	self:ReIndexNodeAllocationOrder("ascendancyAllocationOrder")
 
 	if ascendClass.startNodeId then
 		-- Allocate the new ascendancy class's start node
@@ -427,7 +427,7 @@ function PassiveSpecClass:RemoveFromAllocationOrder(node)
 	end
 end
 
-function PassiveSpecClass:ReIndexAllocationOrder(allocationOrder)
+function PassiveSpecClass:ReIndexNodeAllocationOrder(allocationOrder)
 	for i, nodeId in ipairs(self[allocationOrder]) do
 		self.nodes[nodeId][allocationOrder] = i
 	end
@@ -492,9 +492,9 @@ function PassiveSpecClass:AllocNode(node, altPath)
 			if optNode.isMultipleChoiceOption and optNode.alloc and optNode ~= node then
 				self.DeallocSingleNode(optNode)
 				if optNode.ascendancyName then
-					self:ReIndexAllocationOrder("ascendancyAllocationOrder")
+					self:ReIndexNodeAllocationOrder("ascendancyAllocationOrder")
 				else
-					self:ReIndexAllocationOrder("allocationOrder")
+					self:ReIndexNodeAllocationOrder("allocationOrder")
 				end
 			end
 		end
@@ -524,9 +524,9 @@ function PassiveSpecClass:DeallocNode(node)
 		self:DeallocSingleNode(depNode)
 	end
 	if node.ascendancyName then
-		self:ReIndexAllocationOrder("ascendancyAllocationOrder")
+		self:ReIndexNodeAllocationOrder("ascendancyAllocationOrder")
 	else
-		self:ReIndexAllocationOrder("allocationOrder")
+		self:ReIndexNodeAllocationOrder("allocationOrder")
 	end
 
 	-- Rebuild all paths and dependencies for all allocated nodes
@@ -897,8 +897,8 @@ function PassiveSpecClass:BuildAllDependsAndPaths()
 					self:DeallocSingleNode(depNode)
 				end
 			end
-			self:ReIndexAllocationOrder("allocationOrder")
-			self:ReIndexAllocationOrder("ascendancyAllocationOrder")
+			self:ReIndexNodeAllocationOrder("allocationOrder")
+			self:ReIndexNodeAllocationOrder("ascendancyAllocationOrder")
 		end
 	end
 
@@ -967,7 +967,7 @@ function PassiveSpecClass:BuildClusterJewelGraphs()
 				end
 			end
 		end
-		self:ReIndexAllocationOrder("allocationOrder")
+		self:ReIndexNodeAllocationOrder("allocationOrder")
 		local index = isValueInArray(subGraph.parentSocket.linked, subGraph.entranceNode)
 		assert(index, "Entrance for subGraph not linked to parent socket???")
 		t_remove(subGraph.parentSocket.linked, index)
@@ -1428,16 +1428,24 @@ function PassiveSpecClass:CreateUndoState()
 	for mastery, effect in pairs(self.masterySelections) do
 		selections[mastery] = effect
 	end
+	local allocationOrder = copyTable(self.allocationOrder)
+	local ascendancyAllocationOrder = copyTable(self.ascendancyAllocationOrder)
 	return {
 		classId = self.curClassId,
 		ascendClassId = self.curAscendClassId,
 		hashList = allocNodeIdList,
-		masteryEffects = selections
+		masteryEffects = selections,
+		allocationOrder = allocationOrder,
+		ascendancyAllocationOrder = ascendancyAllocationOrder
 	}
 end
 
 function PassiveSpecClass:RestoreUndoState(state)
 	self:ImportFromNodeList(state.classId, state.ascendClassId, state.hashList, state.masteryEffects)
+	self.allocationOrder = state.allocationOrder
+	self.ascendancyAllocationOrder = state.ascendancyAllocationOrder
+	self:ReIndexNodeAllocationOrder("allocationOrder")
+	self:ReIndexNodeAllocationOrder("ascendancyAllocationOrder")
 	self:SetWindowTitleWithBuildClass()
 end
 

--- a/src/Classes/PassiveSpec.lua
+++ b/src/Classes/PassiveSpec.lua
@@ -349,9 +349,7 @@ function PassiveSpecClass:SelectAscendClass(ascendClassId)
 	-- Deallocate any allocated ascendancy nodes that don't belong to the new ascendancy class
 	for id, node in pairs(self.allocNodes) do
 		if node.ascendancyName and node.ascendancyName ~= ascendClass.name then
-			node.alloc = false
-			self.allocNodes[id] = nil
-			self:RemoveFromAllocationOrder(node)
+			self:DeallocNode(node)
 		end
 	end
 	self:ReIndexNodeAllocationOrder("ascendancyAllocationOrder")
@@ -428,12 +426,18 @@ function PassiveSpecClass:RemoveFromAllocationOrder(node)
 end
 
 function PassiveSpecClass:ReIndexNodeAllocationOrder(allocationOrder)
-	for i, nodeId in ipairs(self[allocationOrder]) do
-		self.nodes[nodeId][allocationOrder] = i
+	for i=#self[allocationOrder],1,-1 do
+		nodeId = self[allocationOrder][i]
+		if self.nodes[nodeId] then
+			self.nodes[nodeId][allocationOrder] = i
+		else
+			t_remove(self[allocationOrder], i)
+		end
 	end
 end
 
-function PassiveSpecClass:SortNodesForRemovingFromAllocationOrder(node, depNodes)
+function PassiveSpecClass:SortNodesForRemovingFromAllocationOrder(node)
+	depNodes = node.depends
 	if node.ascendancyName then
 		table.sort(depNodes, function(a, b)
 			if a.ascendancyAllocationOrder == nil and b.ascendancyAllocationOrder == nil then
@@ -518,7 +522,7 @@ end
 
 -- Deallocate the given node, and all nodes which depend on it (i.e. which are only connected to the tree through this node)
 function PassiveSpecClass:DeallocNode(node)
-	self:SortNodesForRemovingFromAllocationOrder(node, node.depends)
+	self:SortNodesForRemovingFromAllocationOrder(node)
 
 	for _, depNode in ipairs(node.depends) do
 		self:DeallocSingleNode(depNode)
@@ -870,7 +874,7 @@ function PassiveSpecClass:BuildAllDependsAndPaths()
 		if not anyStartFound then
 			-- No start nodes were found through ANY nodes
 			-- Therefore this node and all nodes depending on it are orphans and should be pruned
-			self:SortNodesForRemovingFromAllocationOrder(node, node.depends)
+			self:SortNodesForRemovingFromAllocationOrder(node)
 			for _, depNode in ipairs(node.depends) do
 				local prune = true
 				for nodeId, itemId in pairs(self.jewels) do
@@ -894,7 +898,7 @@ function PassiveSpecClass:BuildAllDependsAndPaths()
 					end
 				end
 				if prune then
-					self:DeallocSingleNode(depNode)
+					self:DeallocNode(depNode)
 				end
 			end
 			self:ReIndexNodeAllocationOrder("allocationOrder")
@@ -953,12 +957,22 @@ end
 function PassiveSpecClass:BuildClusterJewelGraphs()
 	-- Remove old subgraphs
 	for id, subGraph in pairs(self.subGraphs) do
-		if type(subGraph.nodes) == "tree" then
-			self:SortNodesForRemovingFromAllocationOrder(subGraph.nodes)
-		end
+		table.sort(subGraph.nodes, function(a, b)
+			if a.allocationOrder == nil and b.allocationOrder == nil then
+				return false
+			elseif a.allocationOrder == nil then
+				return true
+			elseif b.allocationOrder == nil then
+				return false
+			else
+				return a.allocationOrder > b.allocationOrder
+			end
+		end)
 		for _, node in ipairs(subGraph.nodes) do
-			self:RemoveFromAllocationOrder(node)
 			if node.id then
+				if node.alloc then
+					self:RemoveFromAllocationOrder(node)
+				end
 				self.nodes[node.id] = nil
 				if self.allocNodes[node.id] then
 					-- Reserve the allocation in case the node is regenerated

--- a/src/Classes/PassiveTreeView.lua
+++ b/src/Classes/PassiveTreeView.lua
@@ -75,6 +75,9 @@ function PassiveTreeViewClass:Load(xml, fileName)
 	if xml.attrib.searchStr then
 		self.searchStr = xml.attrib.searchStr
 	end
+	if xml.attrib.showAllocationOrder then
+		self.showAllocationOrder = xml.attrib.showAllocationOrder == "true"
+	end
 	if xml.attrib.showHeatMap then
 		self.showHeatMap = xml.attrib.showHeatMap == "true"
 	end
@@ -89,6 +92,7 @@ function PassiveTreeViewClass:Save(xml)
 		zoomX = tostring(self.zoomX),
 		zoomY = tostring(self.zoomY),
 		searchStr = self.searchStr,
+		showAllocationOrder = tostring(self.showAllocationOrder),
 		showHeatMap = tostring(self.showHeatMap),
 		showStatDifferences = tostring(self.showStatDifferences),
 	}
@@ -669,6 +673,20 @@ function PassiveTreeViewClass:Draw(build, viewPort, inputEvents)
 			SetDrawColor(1, 0, 0)
 			local size = 175 * scale / self.zoom ^ 0.4
 			DrawImage(self.highlightRing, scrX - size, scrY - size, size * 2, size * 2)
+		end
+		if self.showAllocationOrder and node.allocationOrder ~= nil then
+			SetDrawLayer(nile, 29)
+			SetDrawColor(1, 0, 0)
+			local size = 100 * scale
+			local offset = node.size * 1.8 * scale
+			DrawString(m_floor(scrX - offset), m_floor(scrY - offset), "LEFT", size, "VAR", tostring(node.allocationOrder))
+		end
+		if self.showAllocationOrder and node.ascendancyAllocationOrder ~= nil then
+			SetDrawLayer(nile, 29)
+			SetDrawColor(1, 0, 0)
+			local size = 100 * scale
+			local offset = node.size * 1.8 * scale
+			DrawString(m_floor(scrX - offset), m_floor(scrY - offset), "LEFT", size, "VAR", tostring(node.ascendancyAllocationOrder))
 		end
 		if node == hoverNode and (node.type ~= "Socket" or not IsKeyDown("SHIFT")) and (node.type ~= "Mastery" or node.masteryEffects) and not IsKeyDown("CTRL") and not main.popups[1] then
 			-- Draw tooltip

--- a/src/Classes/TreeTab.lua
+++ b/src/Classes/TreeTab.lua
@@ -107,8 +107,11 @@ local TreeTabClass = newClass("TreeTab", "ControlHost", function(self, build)
 	self.controls.treeSearch = new("EditControl", {"LEFT",self.controls.export,"RIGHT"}, 8, 0, main.portraitMode and 200 or 300, 20, "", "Search", "%c%(%)", 100, function(buf)
 		self.viewer.searchStr = buf
 	end)
-  self.controls.treeSearch.tooltipText = "Uses Lua pattern matching for complex searches"
-	self.controls.treeHeatMap = new("CheckBoxControl", {"LEFT",self.controls.treeSearch,"RIGHT"}, 130, 0, 20, "Show Node Power:", function(state)
+  	self.controls.treeSearch.tooltipText = "Uses Lua pattern matching for complex searches"
+  	self.controls.treeAllocationOrder = new("CheckBoxControl", {"LEFT",self.controls.treeSearch,"RIGHT"}, 194, 0, 20, "Show Node Allocation Order:", function(state)
+		self.viewer.showAllocationOrder = state
+	end)
+	self.controls.treeHeatMap = new("CheckBoxControl", {"LEFT",self.controls.treeAllocationOrder,"RIGHT"}, 130, 0, 20, "Show Node Power:", function(state)
 		self.viewer.showHeatMap = state
 		self.controls.treeHeatMapStatSelect.shown = state
 	end)
@@ -227,6 +230,8 @@ function TreeTabClass:Draw(viewPort, inputEvents)
 	if not self.controls.treeSearch.hasFocus then
 		self.controls.treeSearch:SetText(self.viewer.searchStr)
 	end
+
+	self.controls.treeAllocationOrder.state = self.viewer.showAllocationOrder
 
 	self.controls.treeHeatMap.state = self.viewer.showHeatMap
 	self.controls.treeHeatMapStatSelect.list = self.powerStatList


### PR DESCRIPTION
Rebranch of https://github.com/PathOfBuildingCommunity/PathOfBuilding/pull/3318 at @Wires77 request

### Description of the feature added:
A button to show the order that passive nodes have been allocated on the tree for the build. This lets build creators have a single tree that people can follow the order of unless there are big respecs. Main tree and ascendency are tracked separately. Supports cluster jewel swapping, class switching, tree reset, and undo/redo.

### Steps taken to verify a working solution:
Created testing builds with cluster jewels to swap around, tested old builds without existing allocation order for crashes, including swapping cluster jewels.

### Screenshot:
https://imgur.com/aMppNoO