### PR TITLE
Fix build list loading crash

### DIFF
--- a/src/Modules/BuildList.lua
+++ b/src/Modules/BuildList.lua
@@ -165,11 +165,14 @@ function listMode:BuildList()
 		if fileHnd then
 			local fileText = fileHnd:read("*a")
 			fileHnd:close()
-			local xml = common.xml.ParseXML(fileText:match("(<Build.->)").."</Build>")
-			if xml and xml[1] then
-				build.level = tonumber(xml[1].attrib.level)
-				build.className = xml[1].attrib.className
-				build.ascendClassName = xml[1].attrib.ascendClassName
+			fileText = fileText:match("(<Build.->)")
+			if fileText then
+				local xml = common.xml.ParseXML(fileText.."</Build>")
+				if xml and xml[1] then
+					build.level = tonumber(xml[1].attrib.level)
+					build.className = xml[1].attrib.className
+					build.ascendClassName = xml[1].attrib.ascendClassName
+				end
 			end
 		end
 		t_insert(self.list, build)


### PR DESCRIPTION
Fixes #3616.

### Description of the problem being solved:
Build list crashing when a build file is missing the `Build` node
### Steps taken to verify a working solution:
- Open folder containing a corrupted build file
### Link to a build that showcases this PR:
https://pastebin.com/Y4r4zn4s
_Paste into a build folder_
### Before screenshot:
![image](https://user-images.githubusercontent.com/18018499/139059971-d65328bd-dc4e-41f2-a92b-91d41d94ad2e.png)
### After screenshot:
![image](https://user-images.githubusercontent.com/18018499/139059394-b61d3027-f348-4662-ba44-9447de65fb2c.png)
