### PR TITLE
Fix Small Curse Cluster Jewels rendering on the tree when socketed

### DIFF
--- a/src/Classes/Item.lua
+++ b/src/Classes/Item.lua
@@ -1119,7 +1119,7 @@ function ItemClass:BuildModListForSlotNum(baseList, slotNum)
 			end
 
 			-- Small and Medium Curse Cluster Jewel passive mods are parsed the same so the medium cluster data overwrites small and the skills differ
-			-- This changes small curse clusters to have the correct skill so it renders in the tree
+			-- This changes small curse clusters to have the correct clusterJewelSkill so it passes validation below and works as expected in the tree
 			if jewelData.clusterJewelSkill == "affliction_curse_effect" and jewelData.clusterJewelNodeCount and jewelData.clusterJewelNodeCount < 4 then
 				jewelData.clusterJewelSkill = "affliction_curse_effect_small"
 			end

--- a/src/Classes/Item.lua
+++ b/src/Classes/Item.lua
@@ -1120,7 +1120,7 @@ function ItemClass:BuildModListForSlotNum(baseList, slotNum)
 
 			-- Small and Medium Curse Cluster Jewel passive mods are parsed the same so the medium cluster data overwrites small and the skills differ
 			-- This changes small curse clusters to have the correct skill so it renders in the tree
-			if jewelData.clusterJewelSkill == "affliction_curse_effect" and jewelData.clusterJewelNodeCount < 4 then
+			if jewelData.clusterJewelSkill == "affliction_curse_effect" and jewelData.clusterJewelNodeCount and jewelData.clusterJewelNodeCount < 4 then
 				jewelData.clusterJewelSkill = "affliction_curse_effect_small"
 			end
 

--- a/src/Classes/Item.lua
+++ b/src/Classes/Item.lua
@@ -1118,6 +1118,12 @@ function ItemClass:BuildModListForSlotNum(baseList, slotNum)
 				t_insert(jewelData.clusterJewelAddedMods, line)
 			end
 
+			-- Small and Medium Curse Cluster Jewel passive mods are parsed the same so the medium cluster data overwrites small and the skills differ
+			-- This changes small curse clusters to have the correct skill so it renders in the tree
+			if jewelData.clusterJewelSkill == "affliction_curse_effect" and jewelData.clusterJewelNodeCount < 4 then
+				jewelData.clusterJewelSkill = "affliction_curse_effect_small"
+			end
+
 			-- Validation
 			if jewelData.clusterJewelNodeCount then
 				jewelData.clusterJewelNodeCount = m_min(m_max(jewelData.clusterJewelNodeCount, self.clusterJewel.minNodes), self.clusterJewel.maxNodes)


### PR DESCRIPTION
### Fixes #3647

### Description of the problem being solved:
- Small and medium curse cluster jewels have identical enchants (passives skills grant...) so ModParser reads the small clusterJewel and sets the data in a table and then overwrites this when it loops around to the medium cluster jewel because the key is the same.
- Because of this the small cluster jewel has clusterJewelSkill of "affliction_curse_effect" when it should have "affliction_curse_effect_small" so when we validate cluster jewels, small curses are thrown out because "affliction_curse_effect" is not a valid skill for small and as far as I'm aware we cannot change the skills in ClusterJewels.lua to change/add the skill.

### Notes:
- line 3608 of ModParser is where we are creating the list of skills for cluster jewels, but it seems much messier to throw logic into that rather than right before validation

### Steps taken to verify a working solution:
- Socket small curse cluster jewel to see it expand/render/work in the tree with correct prefixes and suffixes if any
- Socket medium curse cluster to verify normal behavior

### Link to a build that showcases this PR:
<pre>https://pastebin.com/RP7WrWpv</pre>
### Before screenshot:
![image](https://user-images.githubusercontent.com/92683202/139256007-02ebd66f-9123-4893-9865-e33364cc5d73.png)
### After screenshot:
![image](https://user-images.githubusercontent.com/92683202/139255877-525eddbf-4953-49d8-be7c-99989d209ed3.png)
