### PR TITLE
Add support for gem level modifiers of socketed active skill gems

### DIFF
--- a/src/Modules/CalcTools.lua
+++ b/src/Modules/CalcTools.lua
@@ -104,6 +104,7 @@ function calcLib.gemIsType(gem, type)
 			(type == "elemental" and (gem.tags.fire or gem.tags.cold or gem.tags.lightning)) or 
 			(type == "aoe" and gem.tags.area) or
 			(type == "trap or mine" and (gem.tags.trap or gem.tags.mine)) or
+			(type == "active skill" and gem.tags.active_skill) or
 			(type == gem.name:lower()) or
 			gem.tags[type])
 end


### PR DESCRIPTION
Fixes #3648.

### Description of the problem being solved:
`+1 to Level of Socketed Active Skill Gems` modifier not applying +1 level to gems with matching tags (active_skill)

### Steps taken to verify a working solution:
- Create new build
- Add Body Armour with `+1 to Level of Socketed Active Skill Gems` mod on it
- Add `Wave of Conviction` to skills, socket it into Body Armour
- Confirm that the gem is getting a +1 to it's level from Body Armour

### Link to a build that showcases this PR:
https://pastebin.com/nPixCag5

### Before screenshot:
![изображение](https://user-images.githubusercontent.com/5415811/139360853-000f7b7b-ff7d-419c-b82b-2cdcc52b4246.png)


### After screenshot:
![изображение](https://user-images.githubusercontent.com/5415811/139360893-60f5f78e-1781-45e7-b1db-6d0c716af0b4.png)
