### PR TITLE
feat: support for two Armour Masteries

### DIFF
--- a/spec/TestBuilds/3.13/Dual Savior.lua
+++ b/spec/TestBuilds/3.13/Dual Savior.lua
@@ -1041,7 +1041,7 @@ Triggers Level 20 Reflection when Equipped
 ["AverageBlockChance"] = 7.5,
 ["ColdResistTotal"] = -60,
 ["FireMindOverMatter"] = 0,
-["DoubleArmourChance"] = 0,
+["MoreArmourChance"] = 0,
 ["LightningTotalPool"] = 92,
 ["TotalPoisonStacks"] = 0,
 ["dontSplitEvade"] = true,

--- a/spec/TestBuilds/3.13/Dual Wield Cospris CoC.lua
+++ b/spec/TestBuilds/3.13/Dual Wield Cospris CoC.lua
@@ -1563,7 +1563,7 @@ Your Maximum Frenzy Charges is equal to your Maximum Power Charges
 ["LightningTakenReflect"] = 1,
 ["FireTakenHitMult"] = 0.2,
 ["LowestOfArmourAndEvasion"] = 45,
-["DoubleArmourChance"] = 0,
+["MoreArmourChance"] = 0,
 ["EnergyShieldLeech"] = 591.4,
 ["ChaosMinBase"] = 0,
 ["FireMindOverMatter"] = 0,

--- a/spec/TestBuilds/3.13/Generals Perforate Zerker.lua
+++ b/spec/TestBuilds/3.13/Generals Perforate Zerker.lua
@@ -1321,7 +1321,7 @@ Gain 50 Life when you Stun an Enemy
 ["TotalDot"] = 0,
 ["ColdGuardAbsorbRate"] = 75,
 ["ManaLeechGainRate"] = 134.4,
-["DoubleArmourChance"] = 0,
+["MoreArmourChance"] = 0,
 ["LightningGuardAbsorb"] = 3444.4,
 ["FireResist"] = 76,
 ["RemovableFrenzyCharges"] = 3,

--- a/spec/TestBuilds/3.13/Mirage Archer Toxic Rain.lua
+++ b/spec/TestBuilds/3.13/Mirage Archer Toxic Rain.lua
@@ -1429,7 +1429,7 @@ Implicits: 0
 ["TotalDotDPS"] = 11807832.8408,
 ["ColdGuardAbsorbRate"] = 0,
 ["RageCost"] = 0,
-["DoubleArmourChance"] = 0,
+["MoreArmourChance"] = 0,
 ["WithIgniteDPS"] = 75852.3487,
 ["FireResist"] = 76,
 ["RemovableFrenzyCharges"] = 4,

--- a/spec/TestBuilds/3.13/OccVortex.lua
+++ b/spec/TestBuilds/3.13/OccVortex.lua
@@ -758,7 +758,7 @@ Implicits: 0
 ["ChillChanceOnCrit"] = 100,
 ["ColdGuardAbsorbRate"] = 0,
 ["EnergyShieldLeechDuration"] = 2.7913,
-["DoubleArmourChance"] = 0,
+["MoreArmourChance"] = 0,
 ["IgniteFireMax"] = 130,
 ["FireResist"] = 75,
 ["RemovableFrenzyCharges"] = 0,

--- a/src/Modules/CalcDefence.lua
+++ b/src/Modules/CalcDefence.lua
@@ -45,10 +45,11 @@ end
 --- Calculates Damage Reduction from Armour
 ---@param armour number
 ---@param damage number
----@param doubleChance number @Chance to Defend with Double Armour 
+---@param moreChance number @Chance to Defend with More Armour
+---@param moreValue number multiplier to apply to armour (defaults to 2)
 ---@return number @Damage Reduction
-function calcs.armourReductionDouble(armour, damage, doubleChance)
-	return calcs.armourReduction(armour, damage) * (1 - doubleChance) + calcs.armourReduction(armour * 2, damage) * doubleChance
+function calcs.armourReductionDouble(armour, damage, moreChance, moreValue)
+	return calcs.armourReduction(armour, damage) * (1 - moreChance) + calcs.armourReduction(armour * (moreValue or 2), damage) * moreChance
 end
 
 function calcs.actionSpeedMod(actor)
@@ -390,7 +391,7 @@ function calcs.defence(env, actor)
 		end
 		output.EnergyShield = modDB:Override(nil, "EnergyShield") or m_max(round(energyShield), 0)
 		output.Armour = m_max(round(armour), 0)
-		output.DoubleArmourChance = m_min(modDB:Sum("BASE", nil, "DoubleArmourChance"), 100)
+		output.MoreArmourChance = m_min(modDB:Sum("BASE", nil, "MoreArmourChance"), 100)
 		output.Evasion = m_max(round(evasion), 0)
 		output.LowestOfArmourAndEvasion = m_min(output.Armour, output.Evasion)
 		output.Ward = m_max(round(ward), 0)
@@ -1115,7 +1116,7 @@ function calcs.defence(env, actor)
 	end
 
 	-- Incoming hit damage multipliers
-	local doubleArmourChance = (output.DoubleArmourChance == 100 or env.configInput.armourCalculationMode == "MAX") and 1 or env.configInput.armourCalculationMode == "MIN" and 0 or output.DoubleArmourChance / 100
+	local moreArmourChance = (output.MoreArmourChance == 100 or env.configInput.armourCalculationMode == "MAX") and 1 or env.configInput.armourCalculationMode == "MIN" and 0 or output.MoreArmourChance / 100
 	actor.damageShiftTable = wipeTable(actor.damageShiftTable)
 	for _, damageType in ipairs(dmgTypeList) do
 		-- Build damage shift table
@@ -1172,13 +1173,13 @@ function calcs.defence(env, actor)
 					local portionArmour = 100
 					if destType == "Physical" then
 						if not modDB:Flag(nil, "ArmourDoesNotApplyToPhysicalDamageTaken") then
-							armourReduct = calcs.armourReductionDouble(output.Armour, damage * portion / 100, doubleArmourChance)
+							armourReduct = calcs.armourReductionDouble(output.Armour, damage * portion / 100, moreArmourChance)
 							resist = m_min(output.DamageReductionMax, resist + armourReduct)
 						end
 						resist = m_max(resist, 0)
 					else
 						portionArmour = 100 - resist
-						armourReduct = calcs.armourReductionDouble(output.Armour, damage * portion / 100 * portionArmour / 100, doubleArmourChance)
+						armourReduct = calcs.armourReductionDouble(output.Armour, damage * portion / 100 * portionArmour / 100, moreArmourChance)
 						resist = resist + m_min(output.DamageReductionMax, armourReduct) * portionArmour / 100
 					end
 					if damageType == destType then

--- a/src/Modules/CalcSections.lua
+++ b/src/Modules/CalcSections.lua
@@ -1198,7 +1198,7 @@ return {
 	{ label = "Total Increased", { format = "{0:mod:1}%", { modName = { "Armour", "ArmourAndEvasion", "Defences" }, modType = "INC" }, }, },
 	{ label = "Total More", { format = "{0:mod:1}%", { modName = { "Armour", "ArmourAndEvasion", "Defences" }, modType = "MORE" }, }, },
 	{ label = "Total", { format = "{0:output:Armour}", { breakdown = "Armour" }, }, },
-	{ label = "Double Armour Ch.", haveOutput = "DoubleArmourChance", { format = "{0:output:DoubleArmourChance}%", { modName = "DoubleArmourChance" }, }, },
+	{ label = "More Armour Ch.", haveOutput = "MoreArmourChance", { format = "{0:output:MoreArmourChance}%", { modName = "MoreArmourChance" }, }, },
 	{ label = "Phys. Dmg. Reduct", { format = "{0:output:PhysicalDamageReduction}%", 
 		{ breakdown = "PhysicalDamageReduction" },
 		{ modName = { "PhysicalDamageReduction", "PhysicalDamageReductionWhenHit", "ArmourDoesNotApplyToPhysicalDamageTaken", "DamageReductionMax" } }, 

--- a/src/Modules/ConfigOptions.lua
+++ b/src/Modules/ConfigOptions.lua
@@ -47,6 +47,9 @@ return {
 	{ var = "conditionFullEnergyShield", type = "check", label = "Are you always on Full Energy Shield?", ifCond = "FullEnergyShield", apply = function(val, modList, enemyModList)
 		modList:NewMod("Condition:FullEnergyShield", "FLAG", true, "Config")
 	end },
+	{ var = "conditionLowEnergyShield", type = "check", label = "Are you always on Low Energy Shield?", tooltip = "You will automatically be considered to be on Low Energy Shield if you have at least 50% ES reserved,\nbut you can use this option to force it if necessary.", apply = function(val, modList, enemyModList)
+		modList:NewMod("Condition:LowEnergyShield", "FLAG", true, "Config")
+	end },
 	{ var = "conditionHaveEnergyShield", type = "check", label = "Do you always have Energy Shield?", ifCond = "HaveEnergyShield", apply = function(val, modList, enemyModList)
 		modList:NewMod("Condition:HaveEnergyShield", "FLAG", true, "Config")
 	end },
@@ -65,7 +68,13 @@ return {
 			modList:NewMod("Condition:LifeRegenBurstFull", "FLAG", true, "Config")
 		end
 	end },
-	{ var = "armourCalculationMode", type = "list", label = "Armour calculation mode:", tooltip = "Controls how Defending with Double Armour is calculated:\n\tMinimum: never Defend with Double Armour\n\tAverage: Damage Reduction from Defending with Double Armour is proportional to chance\n\tMaximum: always Defend with Double Armour\nThis setting has no effect if you have 100% chance to Defend with Double Armour.", list = {{val="MIN",label="Minimum"},{val="AVERAGE",label="Average"},{val="MAX",label="Maximum"}} },
+	{ var = "armourCalculationMode", type = "list", label = "Armour calculation mode:", tooltip = "Controls how Defending with Double Armour is calculated:\n\tMinimum: never Defend with Double Armour\n\tAverage: Damage Reduction from Defending with Double Armour is proportional to chance\n\tMaximum: always Defend with Double Armour\nThis setting has no effect if you have 100% chance to Defend with Double Armour.", list = {{val="MIN",label="Minimum"},{val="AVERAGE",label="Average"},{val="MAX",label="Maximum"}}, apply = function(val, modList, enemyModList)
+		if val == "MAX" then
+			modList:NewMod("Condition:ArmourMax", "FLAG", true, "Config")
+		elseif val == "AVERAGE" then
+			modList:NewMod("Condition:ArmourAvg", "FLAG", true, "Config")
+		end
+	end },
 	{ var = "EhpCalcMode", type = "list", label = "EHP calculation mode:", tooltip = "Controls which types of damage the EHP calculation uses:\n\tAverage: uses the Average of all damage types\n\tMinimum: calculates each one and uses the worst\nIf a specific damage type is selected, that will be the only type used.", list = {{val="Average",label="Average"},{val="Minimum",label="Minimum"},{val="Melee",label="Melee"},{val="Projectile",label="Projectile"},{val="Spell",label="Spell"},{val="SpellProjectile",label="Projectile Spell"}} },
 	{ var = "warcryMode", type = "list", label = "Warcry calculation mode:", ifSkillList = { "Infernal Cry", "Ancestral Cry", "Enduring Cry", "General's Cry", "Intimidating Cry", "Rallying Cry", "Seismic Cry", "Battlemage's Cry" }, tooltip = "Controls how exerted attacks from Warcries are calculated:\nAverage: Averages out Warcry usage with cast time, attack speed and warcry cooldown .\nMax Hit: Shows maximum hit for lining up all warcries.", list = {{val="AVERAGE",label="Average"},{val="MAX",label="Max Hit"}}, apply = function(val, modList, enemyModList)
 		if val == "MAX" then

--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -1601,7 +1601,8 @@ local specialModList = {
 	["off hand accuracy is equal to main hand accuracy while wielding a sword"] = { flag("Condition:OffHandAccuracyIsMainHandAccuracy", { type = "Condition", var = "UsingSword" }) },
 	["(%d+)%% chance to defend with (%d+)%% of armour"] = function(numChance, _, numArmourMultiplier) return {
 		mod("Armour", "MORE", tonumber(numArmourMultiplier) - 100, "Armour Mastery: Max Calc", { type = "Condition", var = "ArmourMax"}),
-		mod("Armour", "MORE", (numChance / 100) * (tonumber(numArmourMultiplier) - 100), "Armour Mastery: Average Calc", { type = "Condition", var = "ArmourAvg"}),
+		mod("Armour", "MORE", math.min(numChance / 100, 1.0) * (tonumber(numArmourMultiplier) - 100), "Armour Mastery: Average Calc", { type = "Condition", var = "ArmourAvg"}),
+		mod("Armour", "MORE", math.min(math.floor(numChance / 100), 1.0) * (tonumber(numArmourMultiplier) - 100), "Armour Mastery: Min Calc", { type = "Condition", var = "ArmourMax" , neg = true}, { type = "Condition", var = "ArmourAvg" , neg = true}),
 	 } end,
 	 ["defend with (%d+)%% of armour while not on low energy shield"] = function(num) return {
 		mod("Armour", "MORE", num - 100, "Armour and Energy Shield Mastery", { type = "Condition", var = "LowEnergyShield", neg = true }),

--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -143,7 +143,7 @@ local modNameList = {
 	["start of energy shield recharge"] = "EnergyShieldRechargeFaster",
 	["restoration of ward"] = "WardRechargeFaster",
 	["armour"] = "Armour",
-	["to defend with double armour"] = "DoubleArmourChance",
+	["to defend with double armour"] = "MoreArmourChance", --legacy support
 	["evasion"] = "Evasion",
 	["evasion rating"] = "Evasion",
 	["energy shield"] = "EnergyShield",
@@ -1599,6 +1599,13 @@ local specialModList = {
 	} end,
 	-- Masteries
 	["off hand accuracy is equal to main hand accuracy while wielding a sword"] = { flag("Condition:OffHandAccuracyIsMainHandAccuracy", { type = "Condition", var = "UsingSword" }) },
+	["(%d+)%% chance to defend with (%d+)%% of armour"] = function(numChance, _, numArmourMultiplier) return {
+		mod("Armour", "MORE", tonumber(numArmourMultiplier) - 100, "Armour Mastery: Max Calc", { type = "Condition", var = "ArmourMax"}),
+		mod("Armour", "MORE", (numChance / 100) * (tonumber(numArmourMultiplier) - 100), "Armour Mastery: Average Calc", { type = "Condition", var = "ArmourAvg"}),
+	 } end,
+	 ["defend with (%d+)%% of armour while not on low energy shield"] = function(num) return {
+		mod("Armour", "MORE", num - 100, "Armour and Energy Shield Mastery", { type = "Condition", var = "LowEnergyShield", neg = true }),
+	 } end,
 	-- Exerted Attacks
 	["exerted attacks deal (%d+)%% increased damage"] = function(num) return { mod("ExertIncrease", "INC", num, nil, ModFlag.Attack, 0) } end,
 	["exerted attacks have (%d+)%% chance to deal double damage"] = function(num) return { mod("ExertDoubleDamageChance", "BASE", num, nil, ModFlag.Attack, 0) } end,


### PR DESCRIPTION
### Description of the problem being solved:
Implements support for 'X% chance to defend with Y% armour' and 'defend with Y% armour while not on low energy shield' masteries. Leaves old "20% chance to defend with 200% armour" intact although I updated the armour calc function to be better scalable.

### Steps taken to verify a working solution:
- Set Config Tab "Armour calculation mode" to Average or Max (and verify Calcs Armour "MORE" output)
- Set Config Tab "Armour calculation mode" to Minimum (and verify Calcs Armour "MORE" output not included)
- Set Config Tab "Are you always on Low Energy Shield"

### Link to a build that showcases this PR:
https://pastebin.com/FNAVbwC6
