### PR TITLE
Add Autowidth to dropdown control, dropped text only

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 .vs/
 .vscode/
 *.code-workspace
+inspect.lua
 
 # Development files
 *.lnk

--- a/src/Classes/DropDownControl.lua
+++ b/src/Classes/DropDownControl.lua
@@ -33,6 +33,8 @@ local DropDownClass = newClass("DropDownControl", "Control", "ControlHost", "Too
 	self.list = list or { }
 	self.selIndex = 1
 	self.selFunc = selFunc
+	  -- droppedWidth will allow for the parent to set the width of the dropped component
+	self.droppedWidth = self.width
 end)
 
 -- maps the actual dropdown row index (after eventual filtering) to the original (unfiltered) list index
@@ -160,6 +162,8 @@ function DropDownClass:IsMouseOver()
 	local cursorX, cursorY = GetCursorPos()
 	local dropExtra = self.dropped and self.dropHeight + 2 or 0
 	local mOver
+	width = m_max(width, self.droppedWidth)
+
 	if self.dropUp then
 		mOver = cursorX >= x and cursorY >= y - dropExtra and cursorX < x + width and cursorY < y + height
 	else
@@ -226,7 +230,7 @@ function DropDownClass:Draw(viewPort)
 	DrawImage(nil, x, y, width, height)
 	if self.dropped then
 		SetDrawLayer(nil, 5)
-		DrawImage(nil, x, dropY, width, dropExtra)
+		DrawImage(nil, x, dropY, self.droppedWidth, dropExtra)
 		SetDrawLayer(nil, 0)
 	end
 	if not enabled then
@@ -250,7 +254,7 @@ function DropDownClass:Draw(viewPort)
 	if self.dropped then
 		SetDrawLayer(nil, 5)
 		SetDrawColor(0, 0, 0)
-		DrawImage(nil, x + 1, dropY + 1, width - 2, dropExtra - 2)
+		DrawImage(nil, x + 1, dropY + 1, self.droppedWidth - 2, dropExtra - 2)
 		SetDrawLayer(nil, 0)
 	end
 	if self.otherDragSource then
@@ -291,6 +295,7 @@ function DropDownClass:Draw(viewPort)
 	if self.dropped then
 		SetDrawLayer(nil, 5)
 		self:DrawControls(viewPort)
+		width = self.droppedWidth
 
 		-- draw tooltip for hovered item
 		local cursorX, cursorY = GetCursorPos()

--- a/src/Classes/TreeTab.lua
+++ b/src/Classes/TreeTab.lua
@@ -235,6 +235,10 @@ function TreeTabClass:Draw(viewPort, inputEvents)
 	end
 	  -- no greater than a 1000
 	self.controls.specSelect.droppedWidth = m_min(dWidth, 1000)
+	local boxWidth
+	  -- add 20 to account for the 'down arrow' in the box
+	boxWidth = DrawStringWidth(lineHeight, "VAR", self.controls.specSelect.list[self.controls.specSelect.selIndex]) + 20
+	self.controls.specSelect.width = m_max(m_min(boxWidth, 390), 190)
 
 	if not self.controls.treeSearch.hasFocus then
 		self.controls.treeSearch:SetText(self.viewer.searchStr)

--- a/src/Classes/TreeTab.lua
+++ b/src/Classes/TreeTab.lua
@@ -233,8 +233,8 @@ function TreeTabClass:Draw(viewPort, inputEvents)
 		  -- +10 to stop clipping
 		dWidth = m_max(dWidth, DrawStringWidth(lineHeight, "VAR", self.controls.specSelect.list[j]) + 10)
 	end
-	  -- no greater than a 1500
-	self.controls.specSelect.droppedWidth = m_min(dWidth, 1500)
+	  -- no greater than a 1000
+	self.controls.specSelect.droppedWidth = m_min(dWidth, 1000)
 
 	if not self.controls.treeSearch.hasFocus then
 		self.controls.treeSearch:SetText(self.viewer.searchStr)

--- a/src/Classes/TreeTab.lua
+++ b/src/Classes/TreeTab.lua
@@ -225,6 +225,17 @@ function TreeTabClass:Draw(viewPort, inputEvents)
 	end
 	t_insert(self.controls.specSelect.list, "Manage trees...")
 
+	local dWidth
+	local lineHeight = self.controls.specSelect.height - 4
+	  -- do not be smaller than the created width
+	dWidth = self.controls.specSelect.width
+	for j=1,#self.controls.specSelect.list do
+		  -- +10 to stop clipping
+		dWidth = m_max(dWidth, DrawStringWidth(lineHeight, "VAR", self.controls.specSelect.list[j]) + 10)
+	end
+	  -- no greater than a 1500
+	self.controls.specSelect.droppedWidth = m_min(dWidth, 1500)
+
 	if not self.controls.treeSearch.hasFocus then
 		self.controls.treeSearch:SetText(self.viewer.searchStr)
 	end


### PR DESCRIPTION
Fixes # .
I actively dislike the clipping of text in some areas.
This fix is for the Tree Spec names 
 
### Description of the problem being solved:
I hate this
![image](https://user-images.githubusercontent.com/4302241/139559445-fd4016c2-2f9d-4dcc-a4a9-596411126d1d.png)

### Steps taken to verify a working solution:
- New variable droppedWidth defaults to control width in case the parent doesn't manage the dropped width
- checked that the text is is not clipped
- checked that there was no left over white on screen
- checked that mouse hover went all the way out to the new width
- checked that the tooltip moved out to the new width
- checked that the tree spec could be selected anywhere on the line, all the way out to the new width.
- checked that controls whose parent don't manage the dropped width, are unaffected (sort by name on Items Tab is a good example)

Solution chosen because the parent control manages the list, not the drop down control

### Link to a build that showcases this PR:
N/A

### Before screenshot:
![image](https://user-images.githubusercontent.com/4302241/139559445-fd4016c2-2f9d-4dcc-a4a9-596411126d1d.png)

### After screenshot:
![image](https://user-images.githubusercontent.com/4302241/139559482-d7cad3fe-5220-4176-bc67-b43463d5b0a0.png)
