### PR TITLE
Fix attack/cast rate cap

### DIFF
--- a/src/Data/SkillStatMap.lua
+++ b/src/Data/SkillStatMap.lua
@@ -223,6 +223,9 @@ return {
 ["base_spell_repeat_count"] = {
 	mod("RepeatCount", "BASE", nil),
 },
+["base_melee_attack_repeat_count"] = {
+	mod("RepeatCount", "BASE", nil),
+},
 ["display_minion_monster_level"] = {
 	skill("minionLevel", nil),
 },

--- a/src/Modules/CalcOffence.lua
+++ b/src/Modules/CalcOffence.lua
@@ -1444,7 +1444,9 @@ function calcs.offence(env, actor, activeSkill)
 				skillFlags.showAverage = false
 				skillData.showAverage = false
 			end
-			output.Speed = m_min(output.Speed, data.misc.ServerTickRate)
+			if not activeSkill.skillTypes[SkillType.Channelled] then
+				output.Speed = m_min(output.Speed, data.misc.ServerTickRate * output.Repeats)
+			end
 			if output.Speed == 0 then 
 				output.Time = 0
 			else 


### PR DESCRIPTION
Fixes #1266 .

The attack speed cap should not apply to channeled skills and should be multiplied by the number of repeats a skill has if the skill is using spell echo or multistrike