### PR TITLE
Fix Spell Suppression mastery giving double Crit chance

### DIFF
--- a/src/Modules/CalcOffence.lua
+++ b/src/Modules/CalcOffence.lua
@@ -1878,13 +1878,6 @@ function calcs.offence(env, actor, activeSkill)
 			end
 		end
 
-		if modDB:Flag(nil, "CritChanceIncreasedBySuppressionChance") then
-			local SpellSuppressionChance = modDB:Sum("BASE", nil, "SpellSuppressionChance")
-			if modDB:Override("OVERRIDE", nil, "SpellSuppressionChance") then
-				SpellSuppressionChance = modDB:Sum("OVERRIDE", nil, "SpellSuppressionChance")
-			end
-			modDB:NewMod("CritChance", "INC", SpellSuppressionChance, "Spell Suppression Mastery")
-		end
 		-- Calculate crit chance, crit multiplier, and their combined effect
 		if skillModList:Flag(nil, "NeverCrit") then
 			output.PreEffectiveCritChance = 0

--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -2295,7 +2295,7 @@ local specialModList = {
 	["your chance to suppressed spell damage is lucky"] = { flag("SpellSuppressionChanceIsLucky") },
 	["your chance to suppressed spell damage is unlucky"] = { flag("SpellSuppressionChanceIsUnlucky") },
 	["prevent +(%+%d+)%% of suppressed spell damage"] = function(num) return { mod("SpellSuppressionEffect", "BASE", num) } end,
-	["critical strike chance is increased by chance to suppress spell damage"] = { flag("CritChanceIncreasedBySuppressionChance") }, 
+	["critical strike chance is increased by chance to suppress spell damage"] = { mod("CritChance", "INC", 1, { type = "PerStat", stat = "SpellSuppressionChance", div = 1 }) },
 	["you take (%d+)%% reduced extra damage from suppressed critical strikes"] = function(num) return { mod("ReduceSuppressedCritExtraDamage", "BASE", num) } end,
 	["+(%d+)%% chance to suppress spell damage if your boots, helmet and gloves have evasion"] = function(num) return { 
 		mod("SpellSuppressionChance", "BASE", tonumber(num), 


### PR DESCRIPTION
Closes #3461

Should have been done as a per stat in the first place as it removes unneeded code in calc offence