### PR TITLE
Fix Multistrike not applying attack speed to certain skills

### DIFF
--- a/src/Data/Skills/sup_str.lua
+++ b/src/Data/Skills/sup_str.lua
@@ -3058,7 +3058,7 @@ skills["SupportMultistrike"] = {
 			mod("Damage", "MORE", nil, ModFlag.Attack),
 		},
 		["support_multiple_attacks_melee_attack_speed_+%_final"] = {
-			mod("Speed", "MORE", nil, bit.bor(ModFlag.Attack, ModFlag.Melee)),
+			mod("Speed", "MORE", nil, ModFlag.Attack),
 		},
 		["multistrike_area_of_effect_+%_per_repeat"] = {
 			mod("AreaOfEffect", "INC", nil)
@@ -3149,7 +3149,7 @@ skills["SupportMultistrikePlus"] = {
 			mod("Damage", "MORE", nil, ModFlag.Attack),
 		},
 		["support_multiple_attacks_melee_attack_speed_+%_final"] = {
-			mod("Speed", "MORE", nil, bit.bor(ModFlag.Attack, ModFlag.Melee)),
+			mod("Speed", "MORE", nil, ModFlag.Attack),
 		},
 	},
 	baseMods = {

--- a/src/Export/Skills/sup_str.txt
+++ b/src/Export/Skills/sup_str.txt
@@ -343,7 +343,7 @@ local skills, mod, flag, skill = ...
 			mod("Damage", "MORE", nil, ModFlag.Attack),
 		},
 		["support_multiple_attacks_melee_attack_speed_+%_final"] = {
-			mod("Speed", "MORE", nil, bit.bor(ModFlag.Attack, ModFlag.Melee)),
+			mod("Speed", "MORE", nil, ModFlag.Attack),
 		},
 		["multistrike_area_of_effect_+%_per_repeat"] = {
 			mod("AreaOfEffect", "INC", nil)
@@ -362,7 +362,7 @@ local skills, mod, flag, skill = ...
 			mod("Damage", "MORE", nil, ModFlag.Attack),
 		},
 		["support_multiple_attacks_melee_attack_speed_+%_final"] = {
-			mod("Speed", "MORE", nil, bit.bor(ModFlag.Attack, ModFlag.Melee)),
+			mod("Speed", "MORE", nil, ModFlag.Attack),
 		},
 	},
 #mods


### PR DESCRIPTION
The Multistrike gem was always looking for the melee flag to apply the attack speed multiplier to a skill. For skills such as Molten Strike, Lightning Strike, Wild Strike, Static Strike and Frost Blades that had skill parts that disabled the melee flag, this also disabled the attack speed bonus

Closes #964, #1949, #2695