### PR TITLE
Fix EHP double dipping on damage taken modifiers

### DIFF
--- a/src/Modules/CalcDefence.lua
+++ b/src/Modules/CalcDefence.lua
@@ -1225,8 +1225,8 @@ function calcs.defence(env, actor)
 		end
 		output[damageType.."TakenHitMult"] = mult
 		for _, hitType in ipairs(hitSourceList) do
-			local baseTakenInc = modDB:Sum("INC", nil, "DamageTaken", hitType.."DamageTaken")
-			local baseTakenMore = modDB:More(nil, "DamageTaken", hitType.."DamageTaken")
+			local baseTakenInc = modDB:Sum("INC", nil, hitType.."DamageTaken")
+			local baseTakenMore = modDB:More(nil, hitType.."DamageTaken")
 			do
 				-- Hit
 				output[hitType.."TakenHitMult"] = m_max((1 + baseTakenInc / 100) * baseTakenMore)


### PR DESCRIPTION
This fixes a bug introduced in #3295 where damage taken modifiers (such as "90% less Damage taken" and "90% reduced Damage taken") were applying to EHP twice instead of once, resulting in 99% less Damage taken.