### PR TITLE
add armour and evasion to unqiue sorting

### DIFF
--- a/src/Modules/Data.lua
+++ b/src/Modules/Data.lua
@@ -92,6 +92,8 @@ data.powerStatList = {
 	{ stat="Life", label="Life" },
 	{ stat="LifeRegen", label="Life regen" },
 	{ stat="LifeLeechRate", label="Life leech" },
+	{ stat="Armour", label="Armour" },
+	{ stat="Evasion", label="Evasion" },
 	{ stat="EnergyShield", label="Energy Shield" },
 	{ stat="EnergyShieldRecoveryCap", label="Recoverable ES" },
 	{ stat="EnergyShieldRegen", label="Energy Shield regen" },


### PR DESCRIPTION
### Description of the problem being solved:
My friend wanted an option to sort uniques by evasion.

### Steps taken to verify a working solution:
- Sort by evasion or armour
- See high defensive uniques

### Before screenshot:
![image](https://user-images.githubusercontent.com/17045310/139755910-a2b8c6ef-7754-4c1e-b5c6-955b081fc888.png)

### After screenshot:
![image](https://user-images.githubusercontent.com/17045310/139755865-839b9f4d-75a2-4a0f-873b-9a2bf4fd400b.png)
