### PR TITLE
BUGFIX: autowidth for the tree spec dropdown blocks the use of controls to the right of it

### DIFF
--- a/src/Classes/DropDownControl.lua
+++ b/src/Classes/DropDownControl.lua
@@ -162,12 +162,16 @@ function DropDownClass:IsMouseOver()
 	local cursorX, cursorY = GetCursorPos()
 	local dropExtra = self.dropped and self.dropHeight + 2 or 0
 	local mOver
-	width = m_max(width, self.droppedWidth)
 
-	if self.dropUp then
-		mOver = cursorX >= x and cursorY >= y - dropExtra and cursorX < x + width and cursorY < y + height
+	if self.dropped then
+		width = m_max(width, self.droppedWidth)
+		if self.dropUp then
+			mOver = cursorX >= x and cursorY >= y - dropExtra and cursorX < x + width and cursorY < y + height
+		else
+			mOver = cursorX >= x and cursorY >= y and cursorX < x + width and cursorY < y + height + dropExtra
+		end
 	else
-		mOver = cursorX >= x and cursorY >= y and cursorX < x + width and cursorY < y + height + dropExtra
+		mOver = cursorX >= x and cursorY >= y and cursorX < x + width and cursorY < y + height
 	end
 	local mOverComp
 	if mOver then


### PR DESCRIPTION
### Steps taken to verify a working solution:
- Change the width of tree spec names and confirm compare button is still clickable when the tree spec dropdown is closed or open 

### Link to a build that showcases this PR:
Just create a tree name of some length eg: XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
and note that the compare button is not usable as the tooltip remains over it. if the name is really long, more controls are affected.

