### PR TITLE
Update wording for Darkness Enthroned

### DIFF
--- a/src/Data/Uniques/belt.lua
+++ b/src/Data/Uniques/belt.lua
@@ -188,8 +188,8 @@ Variant: Current
 Implicits: 1
 Has 1 Abyssal Socket
 Has 1 Abyssal Socket
-{variant:1}50% increased Effect of Socketed Jewels
-{variant:2}75% increased Effect of Socketed Jewels
+{variant:1}50% increased Effect of Socketed Abyss Jewels
+{variant:2}75% increased Effect of Socketed Abyss Jewels
 ]],[[
 Doryani's Invitation
 Heavy Belt

--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -602,6 +602,7 @@ local modNameList = {
 	["strength and intelligence requirement"] = { "StrRequirement", "IntRequirement" },
 	["attribute requirements"] = { "StrRequirement", "DexRequirement", "IntRequirement" },
 	["effect of socketed jewels"] = "SocketedJewelEffect",
+	["effect of socketed abyss jewels"] = "SocketedJewelEffect",
 	["to inflict fire exposure on hit"] = "FireExposureChance",
 	["to apply fire exposure on hit"] = "FireExposureChance",
 	["to inflict cold exposure on hit"] = "ColdExposureChance",


### PR DESCRIPTION
Fixes #3708 .

### Description of the problem being solved:
Darkness Enthroned has a new "Abyss" word added to the mod

### Steps taken to verify a working solution:
- Saw red wording before the fix
- Verified the mod is now parsed again after the fix
- Checked for other mods that gave increased effect of normal jewels

### Link to a build that showcases this PR:
https://pastebin.com/Zs5uTYg8

### Before screenshot:


### After screenshot:

![image](https://user-images.githubusercontent.com/1209372/140001924-cf778dda-c150-44b6-9b40-29fbb3e6636d.png)
