### PR TITLE
Fix Awakened Elemental Focus giving +1 to level of non-elemental gems

### DIFF
--- a/src/Classes/ModStore.lua
+++ b/src/Classes/ModStore.lua
@@ -561,6 +561,13 @@ function ModStoreClass:EvalMod(mod, cfg)
 			if band(cfg.keywordFlags, tag.keywordFlags) ~= tag.keywordFlags then
 				return
 			end
+		elseif tag.type == "KeywordFlag" then
+			if not cfg or not cfg.keywordFlags then
+				return
+			end
+			if band(cfg.keywordFlags, tag.keywordFlags) == 0 then
+				return
+			end
 		end
 	end	
 	return value


### PR DESCRIPTION
Fixes #3709

### Description of the problem being solved:
Awakened Elemental Focus lv. 5 gives +1 to level of skill gems that don't have any elemental tag

### Steps taken to verify a working solution:
Switch between between skill gems that have any elemental tags and no elemental tags and check if Awakened Elemental Focus lv. 5 gives +1 level to those gems
