### PR TITLE
Fix Two-Toned boots getting the wrong base type

### DIFF
--- a/src/Classes/Item.lua
+++ b/src/Classes/Item.lua
@@ -216,7 +216,20 @@ function ItemClass:ParseRaw(raw)
 					end
 				elseif specName == "Talisman Tier" then
 					self.talismanTier = tonumber(specVal)
-				elseif specName == "Armour" or specName == "Evasion" or specName == "Energy Shield" or specName == "Ward" then
+				elseif specName == "Armour" or specName == "Evasion Rating" or specName == "Energy Shield" or specName == "Ward" then
+					if specName == "Evasion Rating" then
+						if self.baseName == "Two-Toned Boots (Armour/Energy Shield)" then
+							-- Another hack for Two-Toned Boots
+							self.baseName = "Two-Toned Boots (Armour/Evasion)"
+							self.base = data.itemBases[self.baseName]
+						end
+					elseif specName == "Energy Shield" then
+						if self.baseName == "Two-Toned Boots (Armour/Evasion)" then
+							-- Yet another hack for Two-Toned Boots
+							self.baseName = "Two-Toned Boots (Evasion/Energy Shield)"
+							self.base = data.itemBases[self.baseName]
+						end
+					end
 					self.armourData = self.armourData or { }
 					self.armourData[specName:gsub(" ", "")] = tonumber((specVal:gsub(" (augmented)", "")))
 				elseif specName:match("BasePercentile") then
@@ -279,18 +292,6 @@ function ItemClass:ParseRaw(raw)
 					t_insert(self.upgradePaths, specVal)
 				elseif specName == "Source" then
 					self.source = specVal
-				elseif specName == "Evasion Rating" then
-					if self.baseName == "Two-Toned Boots (Armour/Energy Shield)" then
-						-- Another hack for Two-Toned Boots
-						self.baseName = "Two-Toned Boots (Armour/Evasion)"
-						self.base = data.itemBases[self.baseName]
-					end
-				elseif specName == "Energy Shield" then
-					if self.baseName == "Two-Toned Boots (Armour/Evasion)" then
-						-- Yet another hack for Two-Toned Boots
-						self.baseName = "Two-Toned Boots (Evasion/Energy Shield)"
-						self.base = data.itemBases[self.baseName]
-					end
 				elseif specName == "Cluster Jewel Skill" then
 					if self.clusterJewel and self.clusterJewel.skills[specVal] then
 						self.clusterJewelSkill = specVal

--- a/src/Classes/Item.lua
+++ b/src/Classes/Item.lua
@@ -216,7 +216,7 @@ function ItemClass:ParseRaw(raw)
 					end
 				elseif specName == "Talisman Tier" then
 					self.talismanTier = tonumber(specVal)
-				elseif specName == "Armour" or specName == "Evasion Rating" or specName == "Energy Shield" or specName == "Ward" then
+				elseif specName == "Armour" or specName == "Evasion Rating" or specName == "Evasion" or specName == "Energy Shield" or specName == "Ward" then
 					if specName == "Evasion Rating" then
 						if self.baseName == "Two-Toned Boots (Armour/Energy Shield)" then
 							-- Another hack for Two-Toned Boots
@@ -231,7 +231,8 @@ function ItemClass:ParseRaw(raw)
 						end
 					end
 					self.armourData = self.armourData or { }
-					self.armourData[specName:gsub(" ", "")] = tonumber((specVal:gsub(" (augmented)", "")))
+					specName = specName:gsub("Rating", ""):gsub(" ", "")
+					self.armourData[specName] = tonumber((specVal:gsub(" (augmented)", "")))
 				elseif specName:match("BasePercentile") then
 					self.armourData = self.armourData or { }
 					self.armourData[specName] = tonumber(specVal) or 0


### PR DESCRIPTION
Fixes #3713 .

### Description of the problem being solved:
Two-Toned boots had a special hack that got overridden when updating items for the base percentile values
### Steps taken to verify a working solution:
- Paste the provided boots text into PoB custom items
- Verify the armour values match the resistance implicit

### Link to a build that showcases this PR:
N/A

### Before screenshot:

### After screenshot:
![image](https://user-images.githubusercontent.com/1209372/140099932-6f2dbfdd-5092-441b-9510-4b2139d5fa5f.png)
