### PR TITLE
Fix rounding on base percentiles

### DIFF
--- a/src/Classes/Item.lua
+++ b/src/Classes/Item.lua
@@ -1038,19 +1038,19 @@ function ItemClass:BuildModListForSlotNum(baseList, slotNum)
 		-- base percentiles need to differ for each armour type, as they're weighted differently
 		if armourData.Armour and armourData.Armour > 0 and not armourData.ArmourBasePercentile then
 			armourData.ArmourBasePercentile = ((armourData.Armour / (1 + (armourInc + armourEvasionInc + armourEnergyShieldInc + defencesInc + qualityScalar) / 100) - armourBase)) / armourVariance
-			armourData.ArmourBasePercentile = round(m_max(m_min(armourData.ArmourBasePercentile, 1), 0), 2)
+			armourData.ArmourBasePercentile = round(m_max(m_min(armourData.ArmourBasePercentile, 1), 0), 4)
 		end
 		if armourData.Evasion and armourData.Evasion > 0 and not armourData.EvasionBasePercentile then
 			armourData.EvasionBasePercentile = ((armourData.Evasion / (1 + (evasionInc + armourEvasionInc + evasionEnergyShieldInc + defencesInc + qualityScalar) / 100) - evasionBase)) / evasionVariance
-			armourData.EvasionBasePercentile = round(m_max(m_min(armourData.EvasionBasePercentile, 1), 0), 2)
+			armourData.EvasionBasePercentile = round(m_max(m_min(armourData.EvasionBasePercentile, 1), 0), 4)
 		end
 		if armourData.EnergyShield and armourData.EnergyShield > 0 and not armourData.EnergyShieldBasePercentile then
 			armourData.EnergyShieldBasePercentile = ((armourData.EnergyShield / (1 + (energyShieldInc + armourEnergyShieldInc + evasionEnergyShieldInc + defencesInc + qualityScalar) / 100) - energyShieldBase)) / energyShieldVariance
-			armourData.EnergyShieldBasePercentile = round(m_max(m_min(armourData.EnergyShieldBasePercentile, 1), 0), 2)
+			armourData.EnergyShieldBasePercentile = round(m_max(m_min(armourData.EnergyShieldBasePercentile, 1), 0), 4)
 		end
 		if armourData.Ward and armourData.Ward > 0 and not armourData.WardBasePercentile then
 			armourData.WardBasePercentile = ((armourData.Ward / (1 + (wardInc + defencesInc + qualityScalar) / 100) - wardBase)) / wardVariance
-			armourData.WardBasePercentile = round(m_max(m_min(armourData.WardBasePercentile, 1), 0),2)
+			armourData.WardBasePercentile = round(m_max(m_min(armourData.WardBasePercentile, 1), 0),4)
 		end
 
 		armourData.Armour = round((armourBase + armourEvasionBase + armourEnergyShieldBase + armourVariance * (armourData.ArmourBasePercentile or 1)) * (1 + (armourInc + armourEvasionInc + armourEnergyShieldInc + defencesInc + qualityScalar) / 100))


### PR DESCRIPTION
Fixes #3703 .

### Description of the problem being solved:
Base evasion percentile was rounding a couple times to add one more evasion
### Steps taken to verify a working solution:
This item should stay at evasion rating 898, where it rounded up to 899 before

```
Cataclysm Guardian
Zodiac Leather
Evasion: 898
Unique ID: d837fa50e819dabad1b1d63f824a1b629d5686b2c0e533db5a269655df32d09c
Item Level: 72
Quality: 20
Sockets: G G-G-R-R-G
LevelReq: 65
Implicits: 2
{crafted}Quality does not increase Defences
{crafted}Grants +1 to Maximum Life per 2% Quality
+24% chance to Suppress Spell Damage
+19 to Evasion Rating
+139 to maximum Life
10% increased maximum Life
+22% to Fire Resistance
{crafted}Gain 9% of Maximum Life as Extra Maximum Energy Shield
```