### PR TITLE
Add poe.ninja/pob to import website list

### DIFF
--- a/src/Classes/ImportTab.lua
+++ b/src/Classes/ImportTab.lua
@@ -909,7 +909,7 @@ function ImportTabClass:OpenImportFromWebsitePopup()
 		{ label = "Ghostbin", id = "Ghostbin", matchURL = "ghostbin%.co/paste/%w+", regexURL = "ghostbin%.co/paste/(%w+)%s*$", downloadURL = "ghostbin.co/paste/%1/raw" },
 		{ label = "Rentry.co", id = "Rentry", matchURL = "rentry%.co/%w+", regexURL = "rentry%.co/(%w+)%s*$", downloadURL = "rentry.co/paste/%1/raw" },
 		{ label = "TinyPaste", id = "TinyPaste", matchURL = "penyacom%.org/%w+", regexURL = "penyacom%.org/[pr]%?q=(%w+)%s*$", downloadURL = "penyacom.org/r?q=%1" },
-		{ label = "poe.ninja/pob", id = "PoeNinja", matchURL = "poe%.ninja/pob/%w+", regexURL = "poe%.ninja/pob/(%w+)%s*$", downloadURL = "poe.ninja/pob/raw/%1" },
+		{ label = "PoeNinja", id = "PoeNinja", matchURL = "poe%.ninja/pob/%w+", regexURL = "poe%.ninja/pob/(%w+)%s*$", downloadURL = "poe.ninja/pob/raw/%1" },
 	}
 	local controls = { }
 
@@ -922,6 +922,13 @@ function ImportTabClass:OpenImportFromWebsitePopup()
 	controls.editLabel = new("LabelControl", { "TOPLEFT", controls.importAnchorPoint, "BOTTOMLEFT"}, 15, 44, 0, 16, "Enter website link:")
 	controls.edit = new("EditControl", nil, 0, 64, 250, 18, "", nil, "^%w%p%s", nil, function(buf)
 		controls.msg.label = ""
+		if #controls.edit.buf > 0 then
+			for j=1,#importWebsiteList do
+				if controls.edit.buf:match(importWebsiteList[j].matchURL) then
+					controls.importFrom:SelByValue(importWebsiteList[j].id, "id")
+				end
+			end
+		end
 	end)
 	controls.msg = new("LabelControl", nil, 0, 82, 0, 16, "")
 	controls.import = new("ButtonControl", nil, -45, 104, 80, 20, "Import", function()

--- a/src/Classes/ImportTab.lua
+++ b/src/Classes/ImportTab.lua
@@ -909,6 +909,7 @@ function ImportTabClass:OpenImportFromWebsitePopup()
 		{ label = "Ghostbin", id = "Ghostbin", matchURL = "ghostbin%.co/paste/%w+", regexURL = "ghostbin%.co/paste/(%w+)%s*$", downloadURL = "ghostbin.co/paste/%1/raw" },
 		{ label = "Rentry.co", id = "Rentry", matchURL = "rentry%.co/%w+", regexURL = "rentry%.co/(%w+)%s*$", downloadURL = "rentry.co/paste/%1/raw" },
 		{ label = "TinyPaste", id = "TinyPaste", matchURL = "penyacom%.org/%w+", regexURL = "penyacom%.org/[pr]%?q=(%w+)%s*$", downloadURL = "penyacom.org/r?q=%1" },
+		{ label = "poe.ninja/pob", id = "PoeNinja", matchURL = "poe%.ninja/pob/%w+", regexURL = "poe%.ninja/pob/(%w+)%s*$", downloadURL = "poe.ninja/pob/raw/%1" },
 	}
 	local controls = { }
 


### PR DESCRIPTION
### Description of the problem being solved:

Add `poe.ninja/pob` import urls to supported websites as discussed recently in the #pob-codes-development channel.

Manual upload entry point: https://poe.ninja/pob
Example upload: https://poe.ninja/pob/4

Pastebin compatible API:

GET https://poe.ninja/pob/raw/<id>
Returns text/plain code.

POST https://poe.ninja/pob/api/api_post.php with `api_paste_code=<code>` form encoded in body
Returns text/plain share link.


### Before screenshot:

![image](https://user-images.githubusercontent.com/462451/140582387-fc89d5ed-5003-44d5-bca0-a7e2189b625a.png)

### After screenshot:

![image](https://user-images.githubusercontent.com/462451/140582458-99a2a47d-1d3c-43fb-9044-0a6b3ce65744.png)

