### PR TITLE
Fix new max res range for Brass Dome

### DIFF
--- a/src/Data/Uniques/body.lua
+++ b/src/Data/Uniques/body.lua
@@ -45,7 +45,7 @@ Requires Level 65, 177 Str
 {variant:1}10% reduced Movement Speed
 {variant:1}50% increased Shock Duration on You
 Take no Extra Damage from Critical Strikes
-{variant:2}+(1-5) to all maximum Resistances
+{variant:2}+(1-5) to all maximum Elemental Resistances
 {variant:2}Gain no inherent bonuses from Strength
 ]],[[
 Craiceann's Carapace

--- a/src/Data/Uniques/body.lua
+++ b/src/Data/Uniques/body.lua
@@ -45,7 +45,7 @@ Requires Level 65, 177 Str
 {variant:1}10% reduced Movement Speed
 {variant:1}50% increased Shock Duration on You
 Take no Extra Damage from Critical Strikes
-{variant:2}+(1-2) to all maximum Resistances
+{variant:2}+(1-5) to all maximum Resistances
 {variant:2}Gain no inherent bonuses from Strength
 ]],[[
 Craiceann's Carapace


### PR DESCRIPTION
### Description of the problem being solved:

PoB currently lists Brass Dome's max resistance roll as being from 1% to 2%, when it is actually 1-5% in-game.
![image](https://user-images.githubusercontent.com/5884310/140642152-f1972cd5-beea-40ce-825c-02cd012d45f4.png)

### Before screenshot:
![image](https://user-images.githubusercontent.com/5884310/140642134-e860da8b-645e-4cd0-9d10-fa9c70abab0a.png)

### After screenshot:
![image](https://user-images.githubusercontent.com/5884310/140642110-83ffd884-6ae0-4426-8f82-c3a61cf37bc2.png)
