### PR TITLE
Update Darkness Enthroned Affix Wording for 3.16.0

### DIFF
--- a/src/Data/Uniques/belt.lua
+++ b/src/Data/Uniques/belt.lua
@@ -188,8 +188,8 @@ Variant: Current
 Implicits: 1
 Has 1 Abyssal Socket
 Has 1 Abyssal Socket
-{variant:1}50% increased Effect of Socketed Jewels
-{variant:2}75% increased Effect of Socketed Jewels
+{variant:1}50% increased Effect of Socketed Abyss Jewels
+{variant:2}75% increased Effect of Socketed Abyss Jewels
 ]],[[
 Doryani's Invitation
 Heavy Belt

--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -602,6 +602,7 @@ local modNameList = {
 	["strength and intelligence requirement"] = { "StrRequirement", "IntRequirement" },
 	["attribute requirements"] = { "StrRequirement", "DexRequirement", "IntRequirement" },
 	["effect of socketed jewels"] = "SocketedJewelEffect",
+	["effect of socketed abyss jewels"] = "SocketedJewelEffect",
 	["to inflict fire exposure on hit"] = "FireExposureChance",
 	["to apply fire exposure on hit"] = "FireExposureChance",
 	["to inflict cold exposure on hit"] = "ColdExposureChance",


### PR DESCRIPTION
Fixes #3761 

### Description of the problem being solved:
GGG changed the wording on the Darkness Enthroned unique affix in 3.16 so imported characters using Darkness Enthroned wouldn't have the mod parsed

### Steps taken to verify a working solution:
- Imported characters have blue text for Darkness Enthroned and socketed abyss jewels have increased effects
- The Darkness Enthroned from the builder has the correct version of the mods
- Left the old affix in the mod parser to not break old builds (but all versions of Darkness Enthroned in standard were updated to the new wording)

### Link to a build that showcases this PR:
https://pastebin.com/sUj2W8Sn

### Before screenshot:
![image](https://user-images.githubusercontent.com/7892106/141780947-dd76e519-f25f-4fc1-a8ea-6107da79a333.png)

### After screenshot:
![image](https://user-images.githubusercontent.com/7892106/141780993-c9e922da-a440-4657-a8a5-2f8ecaa9ec63.png)
