### PR TITLE
fix: Awakened Elemental Focus +1 level

### DIFF
--- a/src/Data/SkillStatMap.lua
+++ b/src/Data/SkillStatMap.lua
@@ -1676,7 +1676,7 @@ return {
 },
 --Elemental
 ["supported_elemental_skill_gem_level_+"] = {
-	mod("SupportedGemProperty", "LIST", { keyword = "active_skill", key = "level", value = nil }, 0, 0, { type = "KeywordFlag", keywordFlags = bit.bor(KeywordFlag.Lightning, KeywordFlag.Cold, KeywordFlag.Fire) }),
+	mod("SupportedGemProperty", "LIST", { keyword = "active_skill", key = "level", value = nil }, 0, bit.bor(KeywordFlag.Lightning, KeywordFlag.Cold, KeywordFlag.Fire)),
 },
 --Minion
 ["supported_minion_skill_gem_level_+"] = {


### PR DESCRIPTION
Fixes Level 5 (or higher) Awakened Elemental Focus that gives +1 level to elemental gems to only apply to elemental gems, it was applying to all gems.
