### PR TITLE
fix: Enemy Physical Damage Reduction should be capped at 90%

### DIFF
--- a/src/Modules/CalcOffence.lua
+++ b/src/Modules/CalcOffence.lua
@@ -2149,7 +2149,7 @@ function calcs.offence(env, actor, activeSkill)
 							if skillModList:Flag(cfg, "IgnoreEnemyPhysicalDamageReduction") then
 								resist = 0
 							else
-								resist = m_max(0, enemyDB:Sum("BASE", nil, "PhysicalDamageReduction") + skillModList:Sum("BASE", cfg, "EnemyPhysicalDamageReduction") + armourReduction)
+								resist = m_min(m_max(0, enemyDB:Sum("BASE", nil, "PhysicalDamageReduction") + skillModList:Sum("BASE", cfg, "EnemyPhysicalDamageReduction") + armourReduction), data.misc.DamageReductionCap)
 							end
 						else
 							if (skillModList:Flag(cfg, "ChaosDamageUsesLowestResistance") and damageType == "Chaos") or 


### PR DESCRIPTION
Fixes #3756.

### Description of the problem being solved:
Enemy Physical Damage Reduction was not capped and could result in over 100% mitigation leading to negative numbers in DPS later in the damage calculation.

### Steps taken to verify a working solution:
Followed steps of #3756 to see problem and apply solution and check solution fixes problem.
