### PR TITLE
Fix Rage Support with Ancestral Totems

### DIFF
--- a/src/Data/Skills/sup_str.lua
+++ b/src/Data/Skills/sup_str.lua
@@ -3359,8 +3359,7 @@ skills["SupportRage"] = {
 	statDescriptionScope = "gem_stat_descriptions",
 	statMap = {
 		["support_rage_gain_rage_on_melee_hit_cooldown_ms"] = {
-			flag("Condition:CanGainRage", { type = "GlobalEffect", effectType = "Buff" } ),
-			mod("Dummy", "DUMMY", 1, 0, 0, { type = "Condition", var = "CanGainRage" }),
+			flag("Condition:CanGainRage", { type = "GlobalEffect", effectType = "Buff", effectName = "Rage" } ),
 		},
 		["attack_minimum_added_physical_damage_with_at_least_10_rage"] = {
 			mod("PhysicalMin", "BASE", nil, bit.bor(ModFlag.Attack, ModFlag.Weapon), 0, { type = "MultiplierThreshold", var = "Rage", threshold = 10 })

--- a/src/Export/Skills/sup_str.txt
+++ b/src/Export/Skills/sup_str.txt
@@ -389,8 +389,7 @@ local skills, mod, flag, skill = ...
 #skill SupportRage
 	statMap = {
 		["support_rage_gain_rage_on_melee_hit_cooldown_ms"] = {
-			flag("Condition:CanGainRage", { type = "GlobalEffect", effectType = "Buff" } ),
-			mod("Dummy", "DUMMY", 1, 0, 0, { type = "Condition", var = "CanGainRage" }),
+			flag("Condition:CanGainRage", { type = "GlobalEffect", effectType = "Buff", effectName = "Rage" } ),
 		},
 		["attack_minimum_added_physical_damage_with_at_least_10_rage"] = {
 			mod("PhysicalMin", "BASE", nil, bit.bor(ModFlag.Attack, ModFlag.Weapon), 0, { type = "MultiplierThreshold", var = "Rage", threshold = 10 })


### PR DESCRIPTION
### Description of the problem being solved:

Linking Rage Support to Ancestral Totems breaks their unique Buff Effect, this fixes that.

Note that this is still implemented as a buff which means unless you have some other method of gaining Rage the support gem won't do anything on its own for your Ancestral Totems. Divergent Rage Support could allow you to generate Rage while linked to an Ancestral Totem, but that functionality is not yet implemented. This would require Divergent quality to grant ``Condition:CanGainRage`` directly to the player.

### Steps taken to verify a working solution:
- Load showcase build
- Check DPS of Ancestral Protector with/without Rage Support
- Check Aura and Buff Skills under Calcs

### Link to a build that showcases this PR:
https://pastebin.com/zxCDqzCg
### Before screenshot:
![](http://puu.sh/IqNVS/9201bb432d.png)
![](http://puu.sh/IqNXL/f87dd31953.png)
### After screenshot:
![](http://puu.sh/IqNWh/015f5d964c.png)
![](http://puu.sh/IqNXA/a94975395a.png)