### PR TITLE
Update Survival Jewels

### DIFF
--- a/src/Data/Uniques/jewel.lua
+++ b/src/Data/Uniques/jewel.lua
@@ -1549,33 +1549,36 @@ Projectiles Pierce an additional Target
 ]],[[
 Survival Instincts
 Viridian Jewel
-Limited to: 1
+Limited to: 1 Survival
 Variant: Pre 3.16.0
 Variant: Current
 {variant:1}+20 to Dexterity
 {variant:1}+6% to all Elemental Resistances
-{variant:2}50% chance for Flasks you use to not consume Charges
-{variant:2}70% less Flask Charges gained from Kills
+{variant:2}20% reduced Flask Charges gained
+{variant:2}50% increased Flask Effect Duration
+Survival
 ]],[[
 Survival Secrets
 Cobalt Jewel
-Limited to: 1
+Limited to: 1 Survival
 Variant: Pre 3.16.0
 Variant: Current
 {variant:1}3 Mana Regenerated per second
 {variant:1}10% increased Elemental Damage
-{variant:2}Flasks gain 2 Charges every 3 seconds while they are inactive
-{variant:2}50% less Flask Effect Duration
+{variant:2}Flasks applied to you have 20% reduced Effect
+{variant:2}Flasks gain 3 Charges every 3 seconds while they are inactive
+Survival
 ]],[[
 Survival Skills
 Crimson Jewel
-Limited to: 1
+Limited to: 1 Survival
 Variant: Pre 3.16.0
 Variant: Current
 {variant:1}10% increased Global Physical Damage
 {variant:1}+50 to Armour
 {variant:2}Flasks gain 2 Charges when you hit a Non-Unique Enemy, no more than once per second
 {variant:2}80% less Flask Charges gained from Kills
+Survival
 ]],[[
 Warlord's Reach
 Crimson Jewel

--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -2857,6 +2857,7 @@ local specialModList = {
 	["primordial"] = { mod("Multiplier:PrimordialItem", "BASE", 1) },
 	["spectres have a base duration of (%d+) seconds"] = function(num) return { mod("SkillData", "LIST", { key = "duration", value = 6 }, { type = "SkillName", skillName = "Raise Spectre" }) } end,
 	["flasks applied to you have (%d+)%% increased effect"] = function(num) return { mod("FlaskEffect", "INC", num) } end,
+	["flasks applied to you have (%d+)%% reduced effect"] = function(num) return { mod("FlaskEffect", "INC", -num) } end,
 	["adds (%d+) passive skills"] = function(num) return { mod("JewelData", "LIST", { key = "clusterJewelNodeCount", value = num }) } end,
 	["1 added passive skill is a jewel socket"] = { mod("JewelData", "LIST", { key = "clusterJewelSocketCount", value = 1 }) },
 	["(%d+) added passive skills are jewel sockets"] = function(num) return { mod("JewelData", "LIST", { key = "clusterJewelSocketCount", value = num }) } end,

--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -3152,6 +3152,7 @@ local specialModList = {
 				{key = "conqueredBy", value = {id = num, conqueror = conquerorList[name:lower()] } }) } end,
 	["passives in radius are conquered by the (%D+)"] = { },
 	["historic"] = { },
+	["survival"] = { },
 	["you can have two different banners at the same time"] = { },
 	["can have a second enchantment modifier"] = { },
 	["can have (%d+) additional enchantment modifiers"] = { },


### PR DESCRIPTION
Survival Instincts and Survival Secrets were changed substantially between the initial preview and actual 3.16 patch notes. This commit adds all of the missing changes to the Survival Jewels.

Fixes #3795