### PR TITLE
Fix Elementalist exposure node not working with exposure mastery

### DIFF
--- a/src/Modules/CalcPerform.lua
+++ b/src/Modules/CalcPerform.lua
@@ -2850,7 +2850,7 @@ function calcs.perform(env, avoidCache)
 			if min ~= math.huge then
 				-- Modify the magnitude of all exposures
 				for _, mod in ipairs(modDB:Tabulate("BASE", nil, "ExtraExposure", "Extra"..element.."Exposure")) do
-					min = min + mod.value
+					min = m_min(min, modDB:Override(nil, "ExposureMin")) + mod.value
 				end
 				enemyDB:NewMod(element.."Resist", "BASE", m_min(min, modDB:Override(nil, "ExposureMin")), source)
 				modDB:NewMod("Condition:AppliedExposureRecently", "FLAG", true, "")


### PR DESCRIPTION
When using the elementalist node for "-x% to affected resistance" it would not stack with the added base exposure from the elemental mastery or tree notables "Exposure you inflict applies an extra x% to Resistance"
Instead it was ignoring it and just using the base exposure from the skill/exposure source