### PR TITLE
Fix Summon Raging Spirit to 100% fire conversion

### DIFF
--- a/src/Data/Minions.lua
+++ b/src/Data/Minions.lua
@@ -181,6 +181,7 @@ minions["SummonedRagingSpirit"] = {
 		mod("PhysicalMax", "BASE", 5, ModFlag.Attack), -- RagingSpiritAddedPhys [attack_minimum_added_physical_damage = 4] [attack_maximum_added_physical_damage = 5]
 		-- CannotGainAfflictedMods [cannot_have_affliction_mods = 1]
 		mod("Speed", "MORE", 40, ModFlag.Attack), -- MonsterSummonedSkullFastAttack1 [active_skill_attack_speed_+%_final = 40]
+		mod("SkillPhysicalDamageConvertToFire", "BASE", 100),
 	},
 }
 

--- a/src/Export/Minions/Minions.txt
+++ b/src/Export/Minions/Minions.txt
@@ -30,6 +30,7 @@ local minions, mod = ...
 #emit
 
 #monster Metadata/Monsters/SummonedSkull/SummonedSkull SummonedRagingSpirit
+#mod mod("SkillPhysicalDamageConvertToFire", "BASE", 100)
 #limit ActiveRagingSpiritLimit
 #emit
 


### PR DESCRIPTION
### Description of the problem being solved:

Current POB has SRS as 100% physical damage and no conversion. But 3.16 patch notes says 'Summoned Raging Spirits now convert all of their Damage to Fire Damage.'

### Steps taken to verify a working solution:

1. Added summon raging spirit as skill by itself
2. Checked the dropdown box to see if conversion worked

### Link to a build that showcases this PR:

https://pastebin.com/Y304YR0Z

### Before screenshot:

![srs before](https://user-images.githubusercontent.com/70760126/143666339-672c35bf-811a-4c81-8e95-5e08596dc6a1.png)

### After screenshot:

![srs after](https://user-images.githubusercontent.com/70760126/143666348-6e179fae-75c2-4b3e-8abb-5a436308e48c.png)


