### PR TITLE
Ctrl I for import

### DIFF
--- a/src/Modules/Build.lua
+++ b/src/Modules/Build.lua
@@ -848,7 +848,13 @@ function buildMode:OnFrame(inputEvents)
 					self:CloseBuild()
 				end
 		elseif IsKeyDown("CTRL") then
-				if event.key == "s" then
+				if event.key == "i" then
+					if self.viewMode == "IMPORT" then
+						self.importTab.controls.importCodePastebin:Click()
+					else
+						self.viewMode = "IMPORT"
+					end
+				elseif event.key == "s" then
 					self:SaveDBFile()
 					inputEvents[id] = nil
 				elseif event.key == "w" then


### PR DESCRIPTION
Fixes # 
Alternating Keying and Mousing

### Description of the problem being solved:
Too much mouse action to get to import

### Steps taken to verify a working solution:
- Have PoB open at file list (not in a build)
- Copy a url from a website (https://pastebin.com/uuqgZPkp is the one i've been using)
- Alt-Tab back to PoB
- Ctrl-N
- Ctrl-I
- Ctrl-I
- Ctrl-V
- <enter> to close popup
![image](https://user-images.githubusercontent.com/4302241/143850619-4d5fb543-4ce7-4653-a58d-02ff770a9f58.png)

Then, groan, we have to go back to the mouse to click 'Import'.

Nobody asked for it, but i'm liking it.

P