### PR TITLE
fix: Fix Elusive Buff effect from Skills with Withering Step

### DIFF
--- a/src/Data/SkillStatMap.lua
+++ b/src/Data/SkillStatMap.lua
@@ -403,6 +403,9 @@ return {
 ["elusive_effect_+%"] = {
 	mod("ElusiveEffect", "INC", nil, 0, 0, { type = "GlobalEffect", effectType = "Buff" }),
 },
+["display_removes_and_grants_elusive_when_used"] = {
+	flag("HasRemovableElusiveBuff", { type = "GlobalEffect", effectType = "Buff" }),
+},
 ["cannot_be_stunned_while_leeching"] = {
 	mod("AvoidStun", "BASE", 100, { type = "Condition", var = "Leeching"}),
 },

--- a/src/Data/SkillStatMap.lua
+++ b/src/Data/SkillStatMap.lua
@@ -401,10 +401,7 @@ return {
 	mod("AuraEffect", "INC", nil),
 },
 ["elusive_effect_+%"] = {
-	mod("ElusiveEffect", "INC", nil, 0, 0, { type = "GlobalEffect", effectType = "Buff" }),
-},
-["display_removes_and_grants_elusive_when_used"] = {
-	flag("HasRemovableElusiveBuff", { type = "GlobalEffect", effectType = "Buff" }),
+	mod("ElusiveEffect", "MAX", nil, 0, 0, { type = "GlobalEffect", effectType = "Buff" }),
 },
 ["cannot_be_stunned_while_leeching"] = {
 	mod("AvoidStun", "BASE", 100, { type = "Condition", var = "Leeching"}),

--- a/src/Data/Skills/sup_dex.lua
+++ b/src/Data/Skills/sup_dex.lua
@@ -2889,9 +2889,6 @@ skills["SupportPuncturingWeapon"] = {
 	},
 	statDescriptionScope = "gem_stat_descriptions",
 	statMap = {
-		["elusive_effect_+%"] = {
-			mod("ElusiveEffect", "INC", nil, 0, 0, { type = "GlobalEffect", effectType = "Buff", effectName = "Nightblade" }),
-		},
 	},
 	baseMods = {
 		flag("SupportedByNightblade"),

--- a/src/Export/Skills/sup_dex.txt
+++ b/src/Export/Skills/sup_dex.txt
@@ -328,11 +328,6 @@ local skills, mod, flag, skill = ...
 #mods
 
 #skill SupportPuncturingWeapon
-	statMap = {
-		["elusive_effect_+%"] = {
-			mod("ElusiveEffect", "INC", nil, 0, 0, { type = "GlobalEffect", effectType = "Buff", effectName = "Nightblade" }),
-		},
-	},
 #baseMod flag("SupportedByNightblade")
 #baseMod flag("Condition:CanBeElusive", { type = "GlobalEffect", effectType = "Buff" })
 #baseMod mod("Dummy", "DUMMY", 1, 0, 0, { type = "Condition", var = "CanBeElusive" })

--- a/src/Modules/CalcPerform.lua
+++ b/src/Modules/CalcPerform.lua
@@ -829,7 +829,6 @@ local function doActorMisc(env, actor)
 		if modDB:Flag(nil, "Elusive") then
 			if modDB:Flag(nil, "HasRemovableElusiveBuff") then
 				local inc = 0
-				local more = 0
 				local skillCount = 0
 				local avgSkillInc = 0
 				for _, value in ipairs(modDB:Tabulate("INC", nil, "ElusiveEffect", "BuffEffectOnSelf")) do

--- a/src/Modules/CalcPerform.lua
+++ b/src/Modules/CalcPerform.lua
@@ -827,30 +827,12 @@ local function doActorMisc(env, actor)
 			modDB.multipliers["BuffOnSelf"] = (modDB.multipliers["BuffOnSelf"] or 0) + (output.ActivePhantasmLimit or 1) - 1 -- slight hack to not double count the initial buff
 		end
 		if modDB:Flag(nil, "Elusive") then
-			if modDB:Flag(nil, "HasRemovableElusiveBuff") then
-				local inc = 0
-				local maxSkillInc = 0
-				for indx, value in ipairs(modDB:Tabulate("INC", nil, "ElusiveEffect")) do
-					if value.mod.source:find("Skill") then
-						if value.mod.value > maxSkillInc then
-							maxSkillInc = value.mod.value
-						end
-						-- if we want to remove the skills from being displayed, uncomment below
-						--modDB.mods[value.mod.name][indx] = nil
-					else
-						inc = inc + value.mod.value
-					end
-				end
-				for _, value in ipairs(modDB:Tabulate("INC", nil, "BuffEffectOnSelf")) do
-					inc = inc + value.mod.value
-				end
-				inc = inc + maxSkillInc
-				output.ElusiveEffectMod = (1 + inc / 100) * modDB:More(nil, "ElusiveEffect", "BuffEffectOnSelf") * 100
-				-- if we want the max skill to not be noted as its own breakdown table entry, comment out below
-				modDB:NewMod("ElusiveEffect", "INC", maxSkillInc, "Max Skill Effect")
-			else
-				output.ElusiveEffectMod = calcLib.mod(modDB, nil, "ElusiveEffect", "BuffEffectOnSelf") * 100
-			end
+			local maxSkillInc = modDB:Max({ source = "Skill" }, "ElusiveEffect")
+			local inc = modDB:Sum("INC", nil, "ElusiveEffect", "BuffEffectOnSelf")
+			inc = inc + maxSkillInc
+			output.ElusiveEffectMod = (1 + inc / 100) * modDB:More(nil, "ElusiveEffect", "BuffEffectOnSelf") * 100
+			-- if we want the max skill to not be noted as its own breakdown table entry, comment out below
+			modDB:NewMod("ElusiveEffect", "INC", maxSkillInc, "Max Skill Effect")
 			-- Override elusive effect if set.
 			if modDB:Override(nil, "ElusiveEffect") then
 				output.ElusiveEffectMod = m_min(modDB:Override(nil, "ElusiveEffect"), output.ElusiveEffectMod)

--- a/src/Modules/CalcPerform.lua
+++ b/src/Modules/CalcPerform.lua
@@ -829,13 +829,14 @@ local function doActorMisc(env, actor)
 		if modDB:Flag(nil, "Elusive") then
 			if modDB:Flag(nil, "HasRemovableElusiveBuff") then
 				local inc = 0
-				local skillCount = 0
-				local avgSkillInc = 0
+				local maxSkillInc = 0
 				for indx, value in ipairs(modDB:Tabulate("INC", nil, "ElusiveEffect")) do
 					if value.mod.source:find("Skill") then
-						avgSkillInc = avgSkillInc + value.mod.value
-						skillCount = skillCount + 1
-						modDB.mods[value.mod.name][indx] = nil
+						if value.mod.value > maxSkillInc then
+							maxSkillInc = value.mod.value
+						end
+						-- if we want to remove the skills from being displayed, uncomment below
+						--modDB.mods[value.mod.name][indx] = nil
 					else
 						inc = inc + value.mod.value
 					end
@@ -843,9 +844,10 @@ local function doActorMisc(env, actor)
 				for _, value in ipairs(modDB:Tabulate("INC", nil, "BuffEffectOnSelf")) do
 					inc = inc + value.mod.value
 				end
-				inc = inc + avgSkillInc / skillCount
+				inc = inc + maxSkillInc
 				output.ElusiveEffectMod = (1 + inc / 100) * modDB:More(nil, "ElusiveEffect", "BuffEffectOnSelf") * 100
-				modDB:NewMod("ElusiveEffect", "INC", avgSkillInc / skillCount, "Skill Avg Effect")
+				-- if we want the max skill to not be noted as its own breakdown table entry, comment out below
+				modDB:NewMod("ElusiveEffect", "INC", maxSkillInc, "Max Skill Effect")
 			else
 				output.ElusiveEffectMod = calcLib.mod(modDB, nil, "ElusiveEffect", "BuffEffectOnSelf") * 100
 			end

--- a/src/Modules/CalcPerform.lua
+++ b/src/Modules/CalcPerform.lua
@@ -827,7 +827,24 @@ local function doActorMisc(env, actor)
 			modDB.multipliers["BuffOnSelf"] = (modDB.multipliers["BuffOnSelf"] or 0) + (output.ActivePhantasmLimit or 1) - 1 -- slight hack to not double count the initial buff
 		end
 		if modDB:Flag(nil, "Elusive") then
-			output.ElusiveEffectMod = calcLib.mod(modDB, nil, "ElusiveEffect", "BuffEffectOnSelf") * 100
+			if modDB:Flag(nil, "HasRemovableElusiveBuff") then
+				local inc = 0
+				local more = 0
+				local skillCount = 0
+				local avgSkillInc = 0
+				for _, value in ipairs(modDB:Tabulate("INC", nil, "ElusiveEffect", "BuffEffectOnSelf")) do
+					if value.mod.source:find("Skill") then
+						avgSkillInc = avgSkillInc + value.mod.value
+						skillCount = skillCount + 1
+					else
+						inc = inc + value.mod.value
+					end
+				end
+				inc = inc + avgSkillInc / skillCount
+				output.ElusiveEffectMod = (1 + inc / 100) * modDB:More(nil, "ElusiveEffect", "BuffEffectOnSelf") * 100
+			else
+				output.ElusiveEffectMod = calcLib.mod(modDB, nil, "ElusiveEffect", "BuffEffectOnSelf") * 100
+			end
 			-- Override elusive effect if set.
 			if modDB:Override(nil, "ElusiveEffect") then
 				output.ElusiveEffectMod = m_min(modDB:Override(nil, "ElusiveEffect"), output.ElusiveEffectMod)

--- a/src/Modules/CalcPerform.lua
+++ b/src/Modules/CalcPerform.lua
@@ -831,16 +831,21 @@ local function doActorMisc(env, actor)
 				local inc = 0
 				local skillCount = 0
 				local avgSkillInc = 0
-				for _, value in ipairs(modDB:Tabulate("INC", nil, "ElusiveEffect", "BuffEffectOnSelf")) do
+				for indx, value in ipairs(modDB:Tabulate("INC", nil, "ElusiveEffect")) do
 					if value.mod.source:find("Skill") then
 						avgSkillInc = avgSkillInc + value.mod.value
 						skillCount = skillCount + 1
+						modDB.mods[value.mod.name][indx] = nil
 					else
 						inc = inc + value.mod.value
 					end
 				end
+				for _, value in ipairs(modDB:Tabulate("INC", nil, "BuffEffectOnSelf")) do
+					inc = inc + value.mod.value
+				end
 				inc = inc + avgSkillInc / skillCount
 				output.ElusiveEffectMod = (1 + inc / 100) * modDB:More(nil, "ElusiveEffect", "BuffEffectOnSelf") * 100
+				modDB:NewMod("ElusiveEffect", "INC", avgSkillInc / skillCount, "Skill Avg Effect")
 			else
 				output.ElusiveEffectMod = calcLib.mod(modDB, nil, "ElusiveEffect", "BuffEffectOnSelf") * 100
 			end


### PR DESCRIPTION
Fixes #2618. 

### Description of the problem being solved:
Withering Step removes the Elusive Buff from other skills that grant it (e.g., Nightblade support) and hence only one skill-based Elusive Effect buff should be present when Withering Step is part of the build.

Added support for `display_removes_and_grants_elusive_when_used` SkillStatMap which created a global flag that is checked in CalcPerform to handle the calculation separately when present.
