### PR TITLE
Add QoL improvements for import tab

### DIFF
--- a/src/Classes/ImportTab.lua
+++ b/src/Classes/ImportTab.lua
@@ -240,6 +240,11 @@ You can get this from your web browser's cookies while logged into the Path of E
 			self.controls.importCodeMode.selIndex = 2
 		end
 	end)
+	self.controls.importCodeIn.enterFunc = function()
+		if self.importCodeState == "VALID" then
+			self.controls.importCodeGo.onClick()
+		end
+	end
 	self.controls.importCodeState = new("LabelControl", {"LEFT",self.controls.importCodeIn,"RIGHT"}, 4, 0, 0, 16)
 	self.controls.importCodeState.label = function()
 		return (self.importCodeState == "VALID" and colorCodes.POSITIVE.."Code is valid") or (self.importCodeState == "INVALID" and colorCodes.NEGATIVE.."Invalid code") or ""

--- a/src/Classes/ImportTab.lua
+++ b/src/Classes/ImportTab.lua
@@ -944,6 +944,7 @@ function ImportTabClass:OpenImportFromWebsitePopup()
 			else
 				self.controls.importCodeIn:SetText(page, true)
 				main:ClosePopup()
+				main:SelectControl(self.controls.importCodeIn)
 			end
 		end)
 	end)


### PR DESCRIPTION
This is a complementary improvement to PR #3813

Pressing the Return key in the import field (marked below) checks if the code is valid and emulates the import button click.

![image](https://user-images.githubusercontent.com/5316261/144526982-9722dd2c-94b3-4db7-be18-3e415ddbbc50.png)

Also, the import field is automatically selected when the import popup fills it. 
This way we can just quickly paste build link into the popup, press Return to submit popup, press Return again to import build from the import field. Overall smoother keyboard experience.