### PR TITLE
fix: corrects edge-cases of raw string parsing of modifier base64 decoding

### DIFF
--- a/src/Classes/Item.lua
+++ b/src/Classes/Item.lua
@@ -319,7 +319,9 @@ function ItemClass:ParseRaw(raw)
 				elseif specName == "CatalystQuality" then
 					self.catalystQuality = tonumber(specVal)
 				elseif specName == "Note" then
-					self.note = specValue
+					self.note = specVal
+				elseif specName == "Str" or specName == "Dex" or specName == "Int" then
+					self.requirements[specName:lower()] = tonumber(specVal)
 				-- Anything else is an explicit with a colon in it (Fortress Covenant, Pure Talent, etc) unless it's part of the custom name
 				elseif not (self.name:match(specName) and self.name:match(specVal)) then
 					foundExplicit = true


### PR DESCRIPTION
Fixes copy/paste from PoE Trade of `Inspired Learning` without implicits.
Fixes copy/paste from PoE Trade that have a price `Note:` in them.

Maintains proper parsing of Pure Talent and Fortress Covenant