### PR TITLE
Add missing Bone Offering quality effect

### DIFF
--- a/src/Data/Skills/act_int.lua
+++ b/src/Data/Skills/act_int.lua
@@ -1192,6 +1192,9 @@ skills["BoneOffering"] = {
 	statDescriptionScope = "offering_skill_stat_descriptions",
 	castTime = 1,
 	statMap = {
+		["cast_speed_+%_granted_from_skill"] = {
+			mod("Speed", "INC", nil, ModFlag.Cast, 0, { type = "GlobalEffect", effectType = "Buff" }),
+		},
 		["monster_base_block_%"] = {
 			mod("BlockChance", "BASE", nil, 0, 0, { type = "GlobalEffect", effectType = "Buff" }),
 		},

--- a/src/Export/Skills/act_int.txt
+++ b/src/Export/Skills/act_int.txt
@@ -224,6 +224,9 @@ local skills, mod, flag, skill = ...
 #skill BoneOffering
 #flags spell duration
 	statMap = {
+		["cast_speed_+%_granted_from_skill"] = {
+			mod("Speed", "INC", nil, ModFlag.Cast, 0, { type = "GlobalEffect", effectType = "Buff" }),
+		},
 		["monster_base_block_%"] = {
 			mod("BlockChance", "BASE", nil, 0, 0, { type = "GlobalEffect", effectType = "Buff" }),
 		},


### PR DESCRIPTION
### Description of the problem being solved:
Bone Offering default quality was missing from the statMap and did literally nothing (both for minions, and players with Mistress of Sacrifice).

### Steps taken to verify a working solution:
- Check cast speed of minions (and player with Mistress of Sacrifice) with 20/20 Bone Offering active.
- Apply changes from this PR.
- Check cast speed of minions (and player with Mistress of Sacrifice) with 20/20 Bone Offering active.

### Link to a build that showcases this PR:
https://pastebin.com/m5YRrgJk

### Before screenshot:
![](http://puu.sh/IzJsX/3f38e93dbe.png)
![](http://puu.sh/IzJtY/cb96d14860.png)
### After screenshot:
![](http://puu.sh/IzJtg/b02eaaf206.png)
![](http://puu.sh/IzJtt/87d0542cfa.png)