### PR TITLE
Correct stat on Brass Dome

### DIFF
--- a/src/Data/Uniques/body.lua
+++ b/src/Data/Uniques/body.lua
@@ -46,7 +46,7 @@ Requires Level 65, 177 Str
 {variant:1}50% increased Shock Duration on You
 Take no Extra Damage from Critical Strikes
 {variant:2}+(1-5) to all maximum Elemental Resistances
-{variant:2}Gain no inherent bonuses from Strength
+{variant:2}Strength provides no bonus to Maximum Life 
 ]],[[
 Craiceann's Carapace
 Golden Plate


### PR DESCRIPTION
### Description of the problem being solved:
3.16 variant of Brass Dome had an incorrect stat. Presumably, it was using the statline from a teaser, rather than the actual release.

### Steps taken to verify a working solution:
Launched PoB, equipped brass dome, verified that life went down but melee damage did not.

### Link to a build that showcases this PR: https://pastebin.com/yMWPc6nh
https://www.pathofexile.com/trade/search/Scourge/Ag0aIQ