### PR TITLE
Add Special Case modifier for Pure Talent jewel and Marauder

### DIFF
--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -2903,6 +2903,7 @@ local specialModList = {
 	["added small passive skills have (%d+)%% increased effect"] = function(num) return { mod("JewelData", "LIST", { key = "clusterJewelIncEffect", value = num }) } end,
 	["this jewel's socket has (%d+)%% increased effect per allocated passive skill between it and your class' starting location"] = function(num) return { mod("JewelData", "LIST", { key = "jewelIncEffectFromClassStart", value = num }) } end,
 	-- Misc
+	["marauder: melee skills have 15%% increased area of effect[ ]?"] = { mod("AreaOfEffect", "INC", 15, { type = "Condition", var = "ConnectedToMarauderStart" }, { type = "SkillType", skillType = SkillType.Melee }) },
 	["intelligence provides no inherent bonus to energy shield"] = { flag("NoIntBonusToES") },
 	["intelligence is added to accuracy rating with wands"] = { mod("Accuracy", "BASE", 1, nil, ModFlag.Wand, { type = "PerStat", stat = "Int" } ) },
 	["dexterity's accuracy bonus instead grants %+(%d+) to accuracy rating per dexterity"] = function(num) return { mod("DexAccBonusOverride", "OVERRIDE", num ) } end,


### PR DESCRIPTION
### Fixes
"Pure Talent Viridian Jewel" not working for Marauder.  #3830

### Description of the problem being solved:
"Marauder: Melee Skills have 15% increased Area of Effect" is red when hovering over jewel
and no AoE is affected.

### Steps taken to verify a working solution, Using build below:
- Check that Pure Talent's Marauder text is no longer Red.

Select the Marauder Tree
- Check that Smite's AoE changes from 17 to 18 and back to17 when Jewel is added and removed.
- Check that Vitality's AoE doesn't change when Jewel is added and removed. 

Select the Duelist tree. 
- Check that Vitality's and Smite's AoE don't change when Jewel is added and removed.

Checks should show Melee only skills are affected by Marauder only.

### Link to a build that showcases this PR:
https://pastebin.com/JhS5TSTN


