### PR TITLE
Add starter race uniques

### DIFF
--- a/src/Data/Uniques/Special/race.lua
+++ b/src/Data/Uniques/Special/race.lua
@@ -5,7 +5,7 @@ return {
 [[
 Ashes of the Sun
 Driftwood Club
-League: Endless Races
+League: Race Events
 Quality: 0
 Sockets: W-W-W
 LevelReq: 1
@@ -19,7 +19,7 @@ Adds 3 to 6 Fire Damage
 ]],[[
 Blood of Summer
 Rusted Sword
-League: Endless Races
+League: Race Events
 Quality: 0
 Sockets: W-W-W
 Implicits: 1
@@ -32,7 +32,7 @@ Adds 2 to 6 Physical Damage
 ]],[[
 Fragment of Eternity
 Glass Shank
-League: Endless Races
+League: Race Events
 Quality: 0
 Sockets: W-W-W
 Implicits: 1
@@ -45,7 +45,7 @@ Adds 1 to 4 Physical Damage
 ]],[[
 Relic of the Cycle
 Crude Bow
-League: Endless Races
+League: Race Events
 Quality: 0
 Sockets: W-W-W
 Implicits: 0
@@ -56,7 +56,7 @@ Projectiles Return to you from Final Target
 ]],[[
 Remnant of Empires
 Goathide Buckler
-League: Endless Races
+League: Race Events
 Evasion: 24
 EvasionBasePercentile: 1
 Quality: 0
@@ -72,7 +72,7 @@ Reflects 4 to 8 Physical Damage to Attackers on Block
 ]],[[
 Rust of Winter
 Rusted Hatchet
-League: Endless Races
+League: Race Events
 Quality: 0
 Sockets: W-W-W
 LevelReq: 1
@@ -84,7 +84,7 @@ Your Physical Damage can Chill
 ]],[[
 Scar of Fate
 Nailed Fist
-League: Endless Races
+League: Race Events
 Quality: 0
 Sockets: W-W-W
 Implicits: 1
@@ -96,7 +96,7 @@ Adds 2 to 6 Physical Damage
 ]],[[
 Slivers of Providence
 Serrated Arrow Quiver
-League: Endless Races
+League: Race Events
 Quality: 0
 LevelReq: 1
 Implicits: 1
@@ -110,7 +110,7 @@ Gain 25% of Weapon Physical Damage as Extra Damage of a Random Element
 ]],[[
 Splinter of the Moon
 Driftwood Wand
-League: Endless Races
+League: Race Events
 Quality: 0
 Sockets: W-W-W
 Implicits: 1
@@ -124,7 +124,7 @@ Regenerate 2 Mana Per Second
 ]],[[
 Thunder of Dawn
 Corroded Blade
-League: Endless Races
+League: Race Events
 Quality: 0
 Sockets: W-W-W
 Implicits: 1
@@ -137,7 +137,7 @@ When you kill a Shocked Enemy, Inflict an Equivalent Shock on Each Nearby Enemy
 ]],[[
 Vestige of Divinity
 Gnarled Branch
-League: Endless Races
+League: Race Events
 Quality: 0
 Sockets: W-W-W
 Implicits: 1

--- a/src/Data/Uniques/Special/race.lua
+++ b/src/Data/Uniques/Special/race.lua
@@ -78,7 +78,7 @@ Sockets: W-W-W
 LevelReq: 1
 Implicits: 0
 Adds 2 to 4 Physical Damage
-Adds 2 to 44 Cold Damage
+Adds 2 to 4 Cold Damage
 50% Chance to avoid being Chilled
 Your Physical Damage can Chill
 ]],[[
@@ -103,9 +103,7 @@ Implicits: 1
 Adds 1 to 4 Physical Damage to Bow Attacks
 +10% To All Elemental Resistances
 50% Increased Duration of Elmental Ailments on Enemies
-10% Chance to Freeze
-10% Chance to Shock
-10% Chance to Ignite
+10% Chance to Freeze, Shock, and Ignite
 Gain 25% of Weapon Physical Damage as Extra Damage of a Random Element
 ]],[[
 Splinter of the Moon
@@ -118,11 +116,9 @@ Implicits: 1
 20% Increased Spell Damage
 12% Increased Cast Speed
 Regenerate 2 Mana Per Second
-4% Chance to Freeze
-4% Chance to Shock
-4% Chance to Ignite
+4% Chance to Freeze, Shock, and Ignite
 ]],[[
-Thunder of Dawn
+Thunder of the Dawn
 Corroded Blade
 League: Race Events
 Quality: 0

--- a/src/Data/Uniques/Special/race.lua
+++ b/src/Data/Uniques/Special/race.lua
@@ -23,7 +23,7 @@ League: Endless Races
 Quality: 0
 Sockets: W-W-W
 Implicits: 1
-{tags:attack}40% increased Global Accuracy Rating
+40% increased Global Accuracy Rating
 Adds 2 to 6 Physical Damage
 2% Increased Movement Speed per Frenzy Charge
 +1 to Maximum Frenzy Charges
@@ -36,7 +36,7 @@ League: Endless Races
 Quality: 0
 Sockets: W-W-W
 Implicits: 1
-{tags:critical}30% increased Global Critical Strike Chance
+30% increased Global Critical Strike Chance
 Adds 1 to 4 Physical Damage
 10% Increased Attack Speed
 100% Increased Critical Strike Chance
@@ -62,7 +62,7 @@ EvasionBasePercentile: 1
 Quality: 0
 Sockets: W-W-W
 Implicits: 1
-{tags:speed}3% increased Movement Speed
+3% increased Movement Speed
 30% Chance to Block Spell Damage
 +15 to Maximum Life
 +3% to All Elemental Resistances per Endurance Charge
@@ -88,7 +88,7 @@ League: Endless Races
 Quality: 0
 Sockets: W-W-W
 Implicits: 1
-{tags:resource,life,attack}+3 Life gained for each Enemy hit by Attacks
++3 Life gained for each Enemy hit by Attacks
 Socketed Gems have 50% Reduced Mana Cost
 Grants Level 20 Hatred Skill
 Adds 2 to 6 Physical Damage
@@ -100,7 +100,7 @@ League: Endless Races
 Quality: 0
 LevelReq: 1
 Implicits: 1
-{tags:physical_damage,damage,physical,attack}Adds 1 to 4 Physical Damage to Bow Attacks
+Adds 1 to 4 Physical Damage to Bow Attacks
 +10% To All Elemental Resistances
 50% Increased Duration of Elmental Ailments on Enemies
 10% Chance to Freeze
@@ -114,7 +114,7 @@ League: Endless Races
 Quality: 0
 Sockets: W-W-W
 Implicits: 1
-{tags:caster_damage,damage,caster}{range:0.5}(8-12)% increased Spell Damage
+(8-12)% increased Spell Damage
 20% Increased Spell Damage
 12% Increased Cast Speed
 Regenerate 2 Mana Per Second
@@ -128,7 +128,7 @@ League: Endless Races
 Quality: 0
 Sockets: W-W-W
 Implicits: 1
-{tags:attack}40% increased Global Accuracy Rating
+40% increased Global Accuracy Rating
 Adds 1 to 9 Lightning Damage
 +40% To Lightning Resistance
 9% Chance to Shock
@@ -141,7 +141,7 @@ League: Endless Races
 Quality: 0
 Sockets: W-W-W
 Implicits: 1
-{tags:block}+18% Chance to Block Attack Damage while wielding a Staff
++18% Chance to Block Attack Damage while wielding a Staff
 16% Chance to Block Attack Damage
 Adds 2 to 4 Physical Damage
 15% Increased Area of Effect

--- a/src/Data/Uniques/race.lua
+++ b/src/Data/Uniques/race.lua
@@ -1,0 +1,151 @@
+-- Item data (c) Grinding Gear Games
+
+return {
+-- Weapon: One Handed Axe
+[[
+Ashes of the Sun
+Driftwood Club
+League: Endless Races
+Quality: 0
+Sockets: W-W-W
+LevelReq: 1
+Implicits: 1
+10% Reduced Enemy Stun Threshold
+Adds 3 to 6 Fire Damage
+20% Increased Attack Speed
+500% Increased Ignite Duration on Enemies
+25% Increased Burning Damage
+30% Chance to Ignite
+]],[[
+Blood of Summer
+Rusted Sword
+League: Endless Races
+Quality: 0
+Sockets: W-W-W
+Implicits: 1
+{tags:attack}40% increased Global Accuracy Rating
+Adds 2 to 6 Physical Damage
+2% Increased Movement Speed per Frenzy Charge
++1 to Maximum Frenzy Charges
+20% Increased Area of Effect
+33% Chance to Gain a Frenzy Charge on Kill
+]],[[
+Fragment of Eternity
+Glass Shank
+League: Endless Races
+Quality: 0
+Sockets: W-W-W
+Implicits: 1
+{tags:critical}30% increased Global Critical Strike Chance
+Adds 1 to 4 Physical Damage
+10% Increased Attack Speed
+100% Increased Critical Strike Chance
++45% to Global Critical Strike Multiplier
+15% Chance to Gain a Power Charge on Kill
+]],[[
+Relic of the Cycle
+Crude Bow
+League: Endless Races
+Quality: 0
+Sockets: W-W-W
+Implicits: 0
+100% Increased Physical Damage
+10% Increased Attack Speed
++30 to Accuracy Rating
+Projectiles Return to you from Final Target
+]],[[
+Remnant of Empires
+Goathide Buckler
+League: Endless Races
+Evasion: 24
+EvasionBasePercentile: 1
+Quality: 0
+Sockets: W-W-W
+Implicits: 1
+{tags:speed}3% increased Movement Speed
+30% Chance to Block Spell Damage
++15 to Maximum Life
++3% to All Elemental Resistances per Endurance Charge
+50% Chance to Gain an Endurance Charge when you Block
++3% Chance to Block
+Reflects 4 to 8 Physical Damage to Attackers on Block
+]],[[
+Rust of Winter
+Rusted Hatchet
+League: Endless Races
+Quality: 0
+Sockets: W-W-W
+LevelReq: 1
+Implicits: 0
+Adds 2 to 4 Physical Damage
+Adds 2 to 44 Cold Damage
+50% Chance to avoid being Chilled
+Your Physical Damage can Chill
+]],[[
+Scar of Fate
+Nailed Fist
+League: Endless Races
+Quality: 0
+Sockets: W-W-W
+Implicits: 1
+{tags:resource,life,attack}+3 Life gained for each Enemy hit by Attacks
+Socketed Gems have 50% Reduced Mana Cost
+Grants Level 20 Hatred Skill
+Adds 2 to 6 Physical Damage
++3 Life Gained for Each Enemy Hit by your Spells
+]],[[
+Slivers of Providence
+Serrated Arrow Quiver
+League: Endless Races
+Quality: 0
+LevelReq: 1
+Implicits: 1
+{tags:physical_damage,damage,physical,attack}Adds 1 to 4 Physical Damage to Bow Attacks
++10% To All Elemental Resistances
+50% Increased Duration of Elmental Ailments on Enemies
+10% Chance to Freeze
+10% Chance to Shock
+10% Chance to Ignite
+Gain 25% of Weapon Physical Damage as Extra Damage of a Random Element
+]],[[
+Splinter of the Moon
+Driftwood Wand
+League: Endless Races
+Quality: 0
+Sockets: W-W-W
+Implicits: 1
+{tags:caster_damage,damage,caster}{range:0.5}(8-12)% increased Spell Damage
+20% Increased Spell Damage
+12% Increased Cast Speed
+Regenerate 2 Mana Per Second
+4% Chance to Freeze
+4% Chance to Shock
+4% Chance to Ignite
+]],[[
+Thunder of Dawn
+Corroded Blade
+League: Endless Races
+Quality: 0
+Sockets: W-W-W
+Implicits: 1
+{tags:attack}40% increased Global Accuracy Rating
+Adds 1 to 9 Lightning Damage
++40% To Lightning Resistance
+9% Chance to Shock
+50% of Physical Damage from Hits Taken as Lightning Damage
+When you kill a Shocked Enemy, Inflict an Equivalent Shock on Each Nearby Enemy
+]],[[
+Vestige of Divinity
+Gnarled Branch
+League: Endless Races
+Quality: 0
+Sockets: W-W-W
+Implicits: 1
+{tags:block}+18% Chance to Block Attack Damage while wielding a Staff
+16% Chance to Block Attack Damage
+Adds 2 to 4 Physical Damage
+15% Increased Area of Effect
+Reflects 8 to 14 Physical Damage to Attacks on Block
++2 to Weapon Range
+]]
+}

--- a/src/Modules/Data.lua
+++ b/src/Modules/Data.lua
@@ -541,7 +541,7 @@ data.uniques = { }
 for _, type in pairs(itemTypes) do
 	data.uniques[type] = LoadModule("Data/Uniques/"..type)
 end
-data.uniques['race'] = LoadModule("Data/Uniques/race")
+data.uniques['race'] = LoadModule("Data/Uniques/Special/race")
 data.uniqueMods = { }
 data.uniqueMods["Watcher's Eye"] = { }
 local unsortedMods = LoadModule("Data/Uniques/Special/WatchersEye")

--- a/src/Modules/Data.lua
+++ b/src/Modules/Data.lua
@@ -541,6 +541,7 @@ data.uniques = { }
 for _, type in pairs(itemTypes) do
 	data.uniques[type] = LoadModule("Data/Uniques/"..type)
 end
+data.uniques['race'] = LoadModule("Data/Uniques/race")
 data.uniqueMods = { }
 data.uniqueMods["Watcher's Eye"] = { }
 local unsortedMods = LoadModule("Data/Uniques/Special/WatchersEye")


### PR DESCRIPTION
Fixes missing race uniques, #3843.

### Description of the problem being solved:
QOL: for adding racing uniques

### Steps taken to verify a working solution:
- open a build or a new one
- go to items
- choose 'Endless Races' from the league dropdown

![image](https://user-images.githubusercontent.com/4302241/148662668-ee909459-9300-49ba-b134-6c662c4e952a.png)

Build from the reddit post
https://pastebin.com/33KXG5WE
