### PR TITLE
Add hotkey to edit equipped item

### DIFF
--- a/src/Classes/ItemsTab.lua
+++ b/src/Classes/ItemsTab.lua
@@ -15,6 +15,9 @@ local m_ceil = math.ceil
 local m_floor = math.floor
 local m_modf = math.modf
 
+local inspect = LoadModule("inspect")
+
+
 local rarityDropList = { 
 	{ label = colorCodes.NORMAL.."Normal", rarity = "NORMAL" },
 	{ label = colorCodes.MAGIC.."Magic", rarity = "MAGIC" },
@@ -969,6 +972,12 @@ function ItemsTabClass:Draw(viewPort, inputEvents)
 				local newItem = Paste()
 				if newItem then
 					self:CreateDisplayItemFromRaw(newItem, true)
+				end
+			elseif event.key == "e" then
+				local mOverControl = self:GetMouseOverControl()
+				if mOverControl and mOverControl._className == "ItemSlotControl" and mOverControl.selItemId ~= 0 then
+					-- Trigger itemList's double click procedure
+					self.controls.itemList:OnSelClick(0, mOverControl.selItemId, true)
 				end
 			elseif event.key == "z" and IsKeyDown("CTRL") then
 				self:Undo()

--- a/src/Classes/ItemsTab.lua
+++ b/src/Classes/ItemsTab.lua
@@ -15,9 +15,6 @@ local m_ceil = math.ceil
 local m_floor = math.floor
 local m_modf = math.modf
 
-local inspect = LoadModule("inspect")
-
-
 local rarityDropList = { 
 	{ label = colorCodes.NORMAL.."Normal", rarity = "NORMAL" },
 	{ label = colorCodes.MAGIC.."Magic", rarity = "MAGIC" },


### PR DESCRIPTION
Fixes #3812 .

### Description of the problem being solved:
QOL: Add hotkey to edit equipped item

### Steps taken to verify a working solution:
- Open a build. Supplied build has an abyssal jewel.
- On the item tab, hover over an equipped item and type _**e**_ and the item will be opened for editing.
- Only triggers on 'e'. Ctrl-E appears to be the DropDownControl's reset command.
- Check that _**e**_ doesn't respond on any other control(s) on the tab.
- Works on any item that the item list will allow to be edited (leverages it's double click method)
- Won't work if item slot is 'None'.

### Link to a build that showcases this PR:
https://pastebin.com/4NMG77XY

Is there a good way to notify people to the functionality ?
