### PR TITLE
Issue3796. Fix PoB crash for Relic of the Pact and Essence Worm 

### DIFF
--- a/src/Classes/ModList.lua
+++ b/src/Classes/ModList.lua
@@ -79,7 +79,9 @@ function ModListClass:SumInternal(context, modType, cfg, flags, keywordFlags, so
 				if mod[1] then
 					result = result + (context:EvalMod(mod, cfg) or 0)
 				else
-					result = result + mod.value
+					if mod.value then
+						result = result + mod.value
+					end
 				end
 			end
 		end


### PR DESCRIPTION
Fixes #3796.

### Description of the problem being solved:
Fix PoB crash for Relic of the Pact and Essence Worm 

### Steps taken to verify a working solution:
- Follow steps in Issue
- hover over the essence worm ring. No crash should happen

### Link to a build that showcases this PR:
See issue, or build your own/Follow steps in Issue.

This PR goes around the problem. The mod.value occasionally turns up as nil. This **MAY** solve the issue brought up be Sadakandras, it may allow for correct calculations.

The faulty mod is 'Multiplier:ChanneledLifeReservedPerStage'

pH