### PR TITLE
QOL: Allow Modifiers to be shown by prefix or suffix

### DIFF
--- a/src/Classes/ItemsTab.lua
+++ b/src/Classes/ItemsTab.lua
@@ -2310,19 +2310,19 @@ function ItemsTabClass:AddCustomModifierToDisplayItem()
 		item:BuildAndParseRaw()
 		return item
 	end
-	controls.sourceLabel = new("LabelControl", {"TOPRIGHT",nil,"TOPLEFT"}, 95, 20, 0, 16, "^7Source:")
-	controls.source = new("DropDownControl", {"TOPLEFT",nil,"TOPLEFT"}, 100, 20, 150, 18, sourceList, function(index, value)
+	controls.sourceLabel = new("LabelControl", {"TOPRIGHT",nil,"TOPLEFT"}, 100, 20, 0, 16, "^7Source:")
+	controls.source = new("DropDownControl", {"TOPLEFT",nil,"TOPLEFT"}, 105, 20, 150, 18, sourceList, function(index, value)
 		currentSourceId = value.sourceId
 		buildMods()
 		controls.modSelect:SetSel(1)
 	end)
 	controls.source.enabled = #sourceList > 1
-	controls.modSelectLabel = new("LabelControl", {"TOPRIGHT",nil,"TOPLEFT"}, 95, 45, 0, 16, "^7Modifier:")
+	controls.modSelectLabel = new("LabelControl", {"TOPRIGHT",nil,"TOPLEFT"}, 100, 45, 0, 16, "^7Modifier:")
 	controls.modSelectLabel.shown = function()
 		local sourceId = sourceList[controls.source.selIndex].sourceId
 		return sourceId == "CUSTOM" or sourceId == "PREFIX" or sourceId == "SUFFIX"
 	end
-	controls.modSelectDropDown = new("DropDownControl", {"TOPRIGHT",nil,"TOPLEFT"}, 94, 45, 90, 18, modifiersDDList , function(index, value)
+	controls.modSelectDropDown = new("DropDownControl", {"TOPRIGHT",nil,"TOPLEFT"}, 99, 45, 90, 18, modifiersDDList , function(index, value)
 		currentModId = value.modId
 		buildMods()
 		controls.modSelect:SetSel(1)
@@ -2331,7 +2331,7 @@ function ItemsTabClass:AddCustomModifierToDisplayItem()
 		local sourceId = sourceList[controls.source.selIndex].sourceId
 		return sourceId ~= "CUSTOM" and sourceId ~= "PREFIX" and sourceId ~= "SUFFIX"
 	end
-	controls.modSelect = new("DropDownControl", {"TOPLEFT",nil,"TOPLEFT"}, 100, 45, 600, 18, modList)
+	controls.modSelect = new("DropDownControl", {"TOPLEFT",nil,"TOPLEFT"}, 105, 45, 600, 18, modList)
 	controls.modSelect.shown = function()
 		return sourceList[controls.source.selIndex].sourceId ~= "CUSTOM"
 	end
@@ -2343,11 +2343,11 @@ function ItemsTabClass:AddCustomModifierToDisplayItem()
 			end
 		end
 	end
-	controls.custom = new("EditControl", {"TOPLEFT",nil,"TOPLEFT"}, 100, 45, 440, 18)
+	controls.custom = new("EditControl", {"TOPLEFT",nil,"TOPLEFT"}, 105, 45, 440, 18)
 	controls.custom.shown = function()
 		return sourceList[controls.source.selIndex].sourceId == "CUSTOM"
 	end
-	controls.save = new("ButtonControl", nil, -45, 75, 80, 20, "Add", function()
+	controls.save = new("ButtonControl", nil, -50, 75, 80, 20, "Add", function()
 		self:SetDisplayItem(addModifier())
 		main:ClosePopup()
 	end)
@@ -2355,10 +2355,10 @@ function ItemsTabClass:AddCustomModifierToDisplayItem()
 		tooltip:Clear()
 		self:AddItemTooltip(tooltip, addModifier())
 	end	
-	controls.close = new("ButtonControl", nil, 45, 75, 80, 20, "Cancel", function()
+	controls.close = new("ButtonControl", nil, 50, 75, 80, 20, "Cancel", function()
 		main:ClosePopup()
 	end)
-	main:OpenPopup(710, 105, "Add Modifier to Item", controls, "save", sourceList[controls.source.selIndex].sourceId == "CUSTOM" and "custom")
+	main:OpenPopup(718, 105, "Add Modifier to Item", controls, "save", sourceList[controls.source.selIndex].sourceId == "CUSTOM" and "custom")
 end
 
 function ItemsTabClass:AddItemSetTooltip(tooltip, itemSet)

--- a/src/Classes/ItemsTab.lua
+++ b/src/Classes/ItemsTab.lua
@@ -14,7 +14,6 @@ local m_min = math.min
 local m_ceil = math.ceil
 local m_floor = math.floor
 local m_modf = math.modf
-local inspect = LoadModule("inspect")
 
 local rarityDropList = { 
 	{ label = colorCodes.NORMAL.."Normal", rarity = "NORMAL" },


### PR DESCRIPTION
Partial fix of [Crafting Bench modifiers do not respect any of the crafting rules](https://feathub.com/LocalIdentity/PathOfBuilding/+41) . The rest of the request appears to have been solved by adding the '(Prefix) and '(Suffix)' to the modifier list. This should complete the request.

### Description of the problem being solved:
Crafting Modifiers prefix or suffix are joined together.

### Steps taken to verify a working solution:
- Open a build. 
- Edit an item
- Select "Add Modifier ..."
- Choose a Source and Modifier type
- Choose you Modifiers and select Add

### **Doesn't change current functionality, only the presentation of the modifiers**

### Before screenshot:
![image](https://user-images.githubusercontent.com/4302241/149090244-59a4452a-5a35-4f14-a6c5-2274c3416d05.png)

### After screenshot:
The default is still to display all Modifiers
![image](https://user-images.githubusercontent.com/4302241/149090580-3fcaf5dc-4aeb-4dda-8703-e506c6a2c329.png)
(edited picture, you can't have both dropdowns open together)

Selecting prefixes shows only prefixes, suffixes does what you think. The '(Prefix) and '(Suffix) is removed as they are redundant.
![image](https://user-images.githubusercontent.com/4302241/149090750-5749ac90-b7ea-4235-9f18-12cdeb67e3c1.png)
![image](https://user-images.githubusercontent.com/4302241/149092232-da8289a8-ef35-47b3-874b-10ce8eb5653b.png)

The Modifier DropDown disappears when selecting a Source of 'Prefix', 'Suffix', or 'Custom' - and will reappear when other sources are selected.
![image](https://user-images.githubusercontent.com/4302241/149091305-957d2e44-e049-4c3e-9973-bb2778f48590.png)
![image](https://user-images.githubusercontent.com/4302241/149091372-eca7cf48-ab58-4e90-9250-e5a27c01bb6d.png)
