### PR TITLE
Remove added as from conversion table

### DIFF
--- a/src/Classes/CalcBreakdownControl.lua
+++ b/src/Classes/CalcBreakdownControl.lua
@@ -354,7 +354,7 @@ function CalcBreakdownClass:AddModSection(sectionData, modList)
 			row.displayValue = self:FormatModValue(row.value, row.mod.type)
 		else
 			section.colList[1].right = true
-			row.displayValue = formatRound(row.value, 2)
+			row.displayValue = formatRound(row.value, 2) .. (string.find(row.mod.name, "Convert") and "%" or "")
 		end
 		if modList or type(sectionData.modName) == "table" then
 			-- Multiple stat names specified, add this modifier's stat to the table

--- a/src/Modules/CalcSections.lua
+++ b/src/Modules/CalcSections.lua
@@ -22,23 +22,19 @@ local chaosHitTaken = {
 }
 local physicalConvert = { 
 	"SkillPhysicalDamageConvertToLightning", "SkillPhysicalDamageConvertToCold", "SkillPhysicalDamageConvertToFire", "SkillPhysicalDamageConvertToChaos", 
-	"PhysicalDamageConvertToLightning", "PhysicalDamageConvertToCold", "PhysicalDamageConvertToFire", "PhysicalDamageConvertToChaos", "NonChaosDamageConvertToChaos", 
-	"PhysicalDamageGainAsLightning", "PhysicalDamageGainAsCold", "PhysicalDamageGainAsFire", "PhysicalDamageGainAsChaos", "NonChaosDamageGainAsChaos" 
+	"PhysicalDamageConvertToLightning", "PhysicalDamageConvertToCold", "PhysicalDamageConvertToFire", "PhysicalDamageConvertToChaos", "NonChaosDamageConvertToChaos"
 }
 local lightningConvert = {
 	"SkillLightningDamageConvertToCold", "SkillLightningDamageConvertToFire", "SkillLightningDamageConvertToChaos",
-	"LightningDamageConvertToCold", "LightningDamageConvertToFire", "LightningDamageConvertToChaos", "ElementalDamageConvertToChaos", "NonChaosDamageConvertToChaos", 
-	"LightningDamageGainAsCold", "LightningDamageGainAsFire", "LightningDamageGainAsChaos", "ElementalDamageGainAsChaos", "NonChaosDamageGainAsChaos"
+	"LightningDamageConvertToCold", "LightningDamageConvertToFire", "LightningDamageConvertToChaos", "ElementalDamageConvertToChaos", "NonChaosDamageConvertToChaos"
 }
 local coldConvert = { 
 	"SkillColdDamageConvertToFire", "SkillColdDamageConvertToChaos",
-	"ColdDamageConvertToFire", "ColdDamageConvertToChaos", "ElementalDamageConvertToChaos", "NonChaosDamageConvertToChaos",
-	"ColdDamageGainAsFire", "ColdDamageGainAsChaos", "ElementalDamageGainAsChaos", "NonChaosDamageGainAsChaos"
+	"ColdDamageConvertToFire", "ColdDamageConvertToChaos", "ElementalDamageConvertToChaos", "NonChaosDamageConvertToChaos"
 }
 local fireConvert = {
 	"SkillFireDamageConvertToChaos",
-	"FireDamageConvertToChaos", "ElementalDamageConvertToChaos", "NonChaosDamageConvertToChaos", 
-	"FireDamageGainAsChaos", "ElementalDamageGainAsChaos", "NonChaosDamageGainAsChaos"
+	"FireDamageConvertToChaos", "ElementalDamageConvertToChaos", "NonChaosDamageConvertToChaos"
 }
 
 -- format {width, id, group, color, subection:{default hidden, label, data:{}}}


### PR DESCRIPTION
Fixes #3888.

### Description of the problem being solved:
The breakdown of damage types in the calc tab was showing "X added as Y" under conversions for X. This was confusing, and made some people think it was converting when it wasn't.

Also added a % to the conversion display, it's more intuitive.

### Steps taken to verify a working solution:
- Tested in a build with both conversion and added damage
- See screenshots

### Link to a build that showcases this PR: https://ghostbin.com/tgips

### Before screenshot:
![image](https://user-images.githubusercontent.com/5985728/149230918-281d8e08-720c-4196-8f9e-a878ab95d767.png)

### After screenshot:
![image](https://user-images.githubusercontent.com/5985728/149231044-d1cf06a7-7b2a-46c4-8103-2b4172112756.png)

### Unchanged destination stat for reference:
![image](https://user-images.githubusercontent.com/5985728/149230952-466bbb57-378b-41d4-88f7-03d2426d193a.png)