### PR TITLE
Fixed copying magic Two-Toned Boots from trade

### DIFF
--- a/src/Classes/Item.lua
+++ b/src/Classes/Item.lua
@@ -374,7 +374,7 @@ function ItemClass:ParseRaw(raw)
 						local s, e = self.name:find("Two-Toned Boots", 1, true)
 						if s then
 							-- Hack for Two-Toned Boots
-							self.baseName = "Two-Toned Boots (Armour/Energy Shield)"
+							baseName = "Two-Toned Boots (Armour/Energy Shield)"
 							self.namePrefix = self.name:sub(1, s - 1)
 							self.nameSuffix = self.name:sub(e + 1)
 						end


### PR DESCRIPTION
### Description of the problem being solved:
This item wasn't recognizing magic two-toned boots as a proper base

```Item Class: Boots
Rarity: Magic
Two-Toned Boots of the Brute
--------
Armour: 126
Energy Shield: 26
--------
Requirements:
Level: 70
Str: 62
Int: 62
--------
Sockets: B 
--------
Item Level: 73
--------
+9% to Fire and Lightning Resistances (implicit)
--------
+12 to Strength
```

### Steps taken to verify a working solution:
- Created the above item in PoB
