### PR TITLE
Add full support for brand attachment range

### DIFF
--- a/src/Data/Global.lua
+++ b/src/Data/Global.lua
@@ -136,11 +136,6 @@ function MatchKeywordFlags(keywordFlags, modKeywordFlags)
 	return modKeywordFlags == 0 or band(keywordFlags, modKeywordFlags) ~= 0
 end
 
--- As of 3.16.2b, all brand skills have exactly the same base attachment range:
--- https://www.poewiki.net/wiki/File:Brand-attach-distance-0-percent.jpg
--- https://www.poewiki.net/wiki/File:Brand-attach-distance-40-percent.jpg
-baseBrandAttachmentRange = 30
-
 -- Active skill types, used in ActiveSkills.dat and GrantedEffects.dat
 -- Had to reverse engineer this, not sure what all of the values mean
 SkillType = {

--- a/src/Data/Global.lua
+++ b/src/Data/Global.lua
@@ -136,6 +136,11 @@ function MatchKeywordFlags(keywordFlags, modKeywordFlags)
 	return modKeywordFlags == 0 or band(keywordFlags, modKeywordFlags) ~= 0
 end
 
+-- As of 3.16.2b, all brand skills have exactly the same base attachment range:
+-- https://www.poewiki.net/wiki/File:Brand-attach-distance-0-percent.jpg
+-- https://www.poewiki.net/wiki/File:Brand-attach-distance-40-percent.jpg
+baseBrandAttachmentRange = 30
+
 -- Active skill types, used in ActiveSkills.dat and GrantedEffects.dat
 -- Had to reverse engineer this, not sure what all of the values mean
 SkillType = {

--- a/src/Data/Skills/act_int.lua
+++ b/src/Data/Skills/act_int.lua
@@ -8702,6 +8702,9 @@ skills["SupportBrandSupport"] = {
 	excludeSkillTypes = { SkillType.Trap, SkillType.Mine, SkillType.Totem, SkillType.ManaCostReserved, SkillType.TriggeredGrantedSkill, },
 	ignoreMinionTypes = true,
 	statDescriptionScope = "gem_stat_descriptions",
+	addFlags = {
+		brand = true,
+	},
 	statMap = {
 		["support_brand_damage_+%_final"] = {
 			mod("TriggeredDamage", "MORE", nil),

--- a/src/Export/Skills/act_int.txt
+++ b/src/Export/Skills/act_int.txt
@@ -1564,6 +1564,9 @@ local skills, mod, flag, skill = ...
 #mods
 
 #skill SupportBrandSupport
+	addFlags = {
+		brand = true,
+	},
 	statMap = {
 		["support_brand_damage_+%_final"] = {
 			mod("TriggeredDamage", "MORE", nil),

--- a/src/Modules/Build.lua
+++ b/src/Modules/Build.lua
@@ -325,6 +325,7 @@ function buildMode:Init(dbFileName, buildName, buildXML, convertBuild)
 		{ stat = "SealMax", label = "Max Number of Seals", fmt = "d" },
 		{ stat = "TimeMaxSeals", label = "Time to Gain Max Seals", fmt = ".2fs", lowerIsBetter = true },
 		{ stat = "AreaOfEffectRadius", label = "AoE Radius", fmt = "d" },
+		{ stat = "BrandAttachmentRange", label = "Attachment Range", fmt = "d", flag = "brand" },
 		{ stat = "BrandTicks", label = "Activations per Brand", fmt = "d", flag = "brand" },
 		{ stat = "ManaCost", label = "Mana Cost", fmt = "d", compPercent = true, lowerIsBetter = true, condFunc = function(v,o) return v > 0 end },
 		{ stat = "LifeCost", label = "Life Cost", fmt = "d", compPercent = true, lowerIsBetter = true, condFunc = function(v,o) return v > 0 end },

--- a/src/Modules/CalcOffence.lua
+++ b/src/Modules/CalcOffence.lua
@@ -1018,8 +1018,11 @@ function calcs.offence(env, actor, activeSkill)
 		end
 	end
 	if skillFlags.brand then
-		output.BrandAttachmentRange = calcLib.mod(skillModList, skillCfg, "BrandAttachmentRange")
+		output.BrandAttachmentRange = baseBrandAttachmentRange * calcLib.mod(skillModList, skillCfg, "BrandAttachmentRange")
 		output.ActiveBrandLimit = skillModList:Sum("BASE", skillCfg, "ActiveBrandLimit")
+		if breakdown then
+            breakdown.BrandAttachmentRange = { radius = output.BrandAttachmentRange }
+        end
 	end
 	
 	if skillFlags.warcry then

--- a/src/Modules/CalcOffence.lua
+++ b/src/Modules/CalcOffence.lua
@@ -1021,8 +1021,8 @@ function calcs.offence(env, actor, activeSkill)
 		output.BrandAttachmentRange = baseBrandAttachmentRange * calcLib.mod(skillModList, skillCfg, "BrandAttachmentRange")
 		output.ActiveBrandLimit = skillModList:Sum("BASE", skillCfg, "ActiveBrandLimit")
 		if breakdown then
-            breakdown.BrandAttachmentRange = { radius = output.BrandAttachmentRange }
-        end
+			breakdown.BrandAttachmentRange = { radius = output.BrandAttachmentRange }
+		end
 	end
 	
 	if skillFlags.warcry then

--- a/src/Modules/CalcOffence.lua
+++ b/src/Modules/CalcOffence.lua
@@ -1018,7 +1018,7 @@ function calcs.offence(env, actor, activeSkill)
 		end
 	end
 	if skillFlags.brand then
-		output.BrandAttachmentRange = baseBrandAttachmentRange * calcLib.mod(skillModList, skillCfg, "BrandAttachmentRange")
+		output.BrandAttachmentRange = data.misc.BrandAttachmentRangeBase * calcLib.mod(skillModList, skillCfg, "BrandAttachmentRange")
 		output.ActiveBrandLimit = skillModList:Sum("BASE", skillCfg, "ActiveBrandLimit")
 		if breakdown then
 			breakdown.BrandAttachmentRange = { radius = output.BrandAttachmentRange }

--- a/src/Modules/CalcSections.lua
+++ b/src/Modules/CalcSections.lua
@@ -612,7 +612,7 @@ return {
 		{ label = "Area of Effect modifiers", modName = "AreaOfEffectTertiary", cfg = "skill" },
 	}, },
 	{ label = "Weapon Range", haveOutput = "WeaponRange", { format = "{0:output:WeaponRange}", { breakdown = "WeaponRange" }, }, },
-	{ label = "Attachment Range", flag = "brand", { format = "x {2:output:BrandAttachmentRange}",
+	{ label = "Attachment Range", flag = "brand", { format = "{0:output:BrandAttachmentRange}",
 		{ breakdown = "BrandAttachmentRange" },
 		{ modName = "BrandAttachmentRange", cfg = "skill"},
 	}, },

--- a/src/Modules/Data.lua
+++ b/src/Modules/Data.lua
@@ -339,6 +339,7 @@ data.misc = { -- magic numbers
 	MaxEnemyLevel = 84,
 	LowPoolThreshold = 0.5,
 	AccuracyPerDexBase = 2,
+	BrandAttachmentRangeBase = 30,
 }
 
 -- Misc data tables


### PR DESCRIPTION
This adds full support for brand attachment range to the calcs breakdown, skill sidebar, and node/item comparisons.

Previously none of this was calculated, and we simply displayed how much % increased Brand Attachment Range you had in the calcs breakdown (nothing else).

### Link to a build that showcases this PR:
https://pastebin.com/bsnxhrzm
### Before screenshot:
![](http://puu.sh/ICKQc/e203c26522.png)
### After screenshot:
![](http://puu.sh/ICKQh/97dc47d6be.png)
![](http://puu.sh/ICKQo/4222ca5d42.png)
![](http://puu.sh/ICKQy/aa82739cf8.png)