### PR TITLE
Add improvements to multiple passive tree jewel socket management

### DIFF
--- a/src/Classes/ItemListControl.lua
+++ b/src/Classes/ItemListControl.lua
@@ -45,18 +45,19 @@ local ItemListClass = newClass("ItemListControl", "ListControl", function(self, 
 	end)
 end)
 
-function ItemListClass:FindSocketedJewel(itemId, excludeActiveSpec)
+function ItemListClass:FindSocketedJewel(jewelId, excludeActiveSpec)
 	local treeTab = self.itemsTab.build.treeTab
 	local matchActive = false
 	local outputString = ""
-	for i = #treeTab.specList, 1, -1 do
-		for _, v in pairs(treeTab.specList[i].jewels) do
-			if v == itemId then
-				if excludeActiveSpec and (i == treeTab.activeSpec or matchActive) then
+	for specId = #treeTab.specList, 1, -1 do
+		local spec = treeTab.specList[specId]
+		for nodeId, itemId in pairs(spec.jewels) do
+			if itemId == jewelId and spec.nodes[nodeId] and spec.nodes[nodeId].alloc then
+				if excludeActiveSpec and (specId == treeTab.activeSpec or matchActive) then
 					matchActive = true
 					outputString = ""
 				else
-					outputString = treeTab.specList[i].title
+					outputString = spec.title
 				end
 			end
 		end
@@ -160,9 +161,18 @@ function ItemListClass:OnSelDelete(index, itemId)
 			self.selValue = nil
 		end)
 	else
-		self.itemsTab:DeleteItem(item)
-		self.selIndex = nil
-		self.selValue = nil
+		local equipTree = self:FindSocketedJewel(itemId, true)
+		if equipTree ~= "" then
+			main:OpenConfirmPopup("Delete Item", item.name.." is currently equipped in passive tree '"..equipTree.."'.\nAre you sure you want to delete it?", "Delete", function()
+				self.itemsTab:DeleteItem(item)
+				self.selIndex = nil
+				self.selValue = nil
+			end)
+		else
+			self.itemsTab:DeleteItem(item)
+			self.selIndex = nil
+			self.selValue = nil
+		end
 	end
 end
 

--- a/src/Classes/ItemListControl.lua
+++ b/src/Classes/ItemListControl.lua
@@ -57,7 +57,7 @@ function ItemListClass:FindSocketedJewel(jewelId, excludeActiveSpec)
 					matchActive = true
 					outputString = ""
 				else
-					outputString = spec.title
+					outputString = spec.title or "Default"
 				end
 			end
 		end

--- a/src/Classes/ItemListControl.lua
+++ b/src/Classes/ItemListControl.lua
@@ -45,15 +45,38 @@ local ItemListClass = newClass("ItemListControl", "ListControl", function(self, 
 	end)
 end)
 
+function ItemListClass:FindSocketedJewel(itemId, excludeActiveSpec)
+	local treeTab = self.itemsTab.build.treeTab
+	local matchActive = false
+	local outputString = ""
+	for i = #treeTab.specList, 1, -1 do
+		for _, v in pairs(treeTab.specList[i].jewels) do
+			if v == itemId then
+				if excludeActiveSpec and (i == treeTab.activeSpec or matchActive) then
+					matchActive = true
+					outputString = ""
+				else
+					outputString = treeTab.specList[i].title
+				end
+			end
+		end
+	end
+	return outputString
+end
+
 function ItemListClass:GetRowValue(column, index, itemId)
 	local item = self.itemsTab.items[itemId]
 	if column == 1 then
-		local used = ""
-		local slot, itemSet = self.itemsTab:GetEquippedSlotForItem(item)
-		if not slot then
-			used = "  ^9(Unused)"
-		elseif itemSet then
-			used = "  ^9(Used in '" .. (itemSet.title or "Default") .. "')"
+		local used = self:FindSocketedJewel(itemId, true)
+		if used == "" then
+			local slot, itemSet = self.itemsTab:GetEquippedSlotForItem(item)
+			if not slot then
+				used = "  ^9(Unused)"
+			elseif itemSet then
+				used = "  ^9(Used in '" .. (itemSet.title or "Default") .. "')"
+			end
+		else
+			used = "  ^9(Used in '" .. used .. "')"
 		end
 		return colorCodes[item.rarity] .. item.name .. used
 	end

--- a/src/Classes/ItemsTab.lua
+++ b/src/Classes/ItemsTab.lua
@@ -1297,6 +1297,8 @@ function ItemsTabClass:DeleteItem(item)
 						depNode.alloc = false
 						spec.allocNodes[depNodeId] = nil
 					end
+					spec.nodes[nodeId].alloc = false
+					spec.allocNodes[nodeId] = nil
 				end
 			end
 		end

--- a/src/Classes/ItemsTab.lua
+++ b/src/Classes/ItemsTab.lua
@@ -1291,8 +1291,19 @@ function ItemsTabClass:DeleteItem(item)
 		for nodeId, itemId in pairs(spec.jewels) do
 			if itemId == item.id then
 				spec.jewels[nodeId] = 0
+				-- Deallocate all nodes that required this jewel
+				if spec.nodes[nodeId] then
+					for depNodeId, depNode in ipairs(spec.nodes[nodeId].depends) do
+						depNode.alloc = false
+						spec.allocNodes[depNodeId] = nil
+					end
+					spec.nodes[nodeId].alloc = false
+					spec.allocNodes[nodeId] = nil
+				end
 			end
 		end
+		-- Rebuild cluster jewel graphs
+		spec:BuildClusterJewelGraphs()
 	end
 	self.items[item.id] = nil
 	self:PopulateSlots()

--- a/src/Classes/ItemsTab.lua
+++ b/src/Classes/ItemsTab.lua
@@ -93,7 +93,7 @@ local ItemsTabClass = newClass("ItemsTab", "UndoHandler", "ControlHost", "Contro
 		t_insert(self.controls, slot)
 	end
 	for index, slotName in ipairs(baseSlots) do
-		local slot = new("ItemSlotControl", {"TOPLEFT",prevSlot,"BOTTOMLEFT"}, 0, 0, self, slotName)
+		local slot = new("ItemSlotControl", {"TOPLEFT",prevSlot,"BOTTOMLEFT"}, 0, 2, self, slotName)
 		addSlot(slot)
 		if slotName:match("Weapon") then
 			-- Add alternate weapon slot
@@ -101,14 +101,14 @@ local ItemsTabClass = newClass("ItemsTab", "UndoHandler", "ControlHost", "Contro
 			slot.shown = function()
 				return not self.activeItemSet.useSecondWeaponSet
 			end
-			local swapSlot = new("ItemSlotControl", {"TOPLEFT",prevSlot,"BOTTOMLEFT"}, 0, 0, self, slotName.." Swap", slotName)
+			local swapSlot = new("ItemSlotControl", {"TOPLEFT",prevSlot,"BOTTOMLEFT"}, 0, 2, self, slotName.." Swap", slotName)
 			addSlot(swapSlot)
 			swapSlot.weaponSet = 2
 			swapSlot.shown = function()
 				return self.activeItemSet.useSecondWeaponSet
 			end
 			for i = 1, 6 do
-				local abyssal = new("ItemSlotControl", {"TOPLEFT",prevSlot,"BOTTOMLEFT"}, 0, 0, self, slotName.."Swap Abyssal Socket "..i, "Abyssal #"..i)			
+				local abyssal = new("ItemSlotControl", {"TOPLEFT",prevSlot,"BOTTOMLEFT"}, 0, 2, self, slotName.."Swap Abyssal Socket "..i, "Abyssal #"..i)			
 				addSlot(abyssal)
 				abyssal.parentSlot = swapSlot
 				abyssal.weaponSet = 2
@@ -121,7 +121,7 @@ local ItemsTabClass = newClass("ItemsTab", "UndoHandler", "ControlHost", "Contro
 		if slotName == "Weapon 1" or slotName == "Weapon 2" or slotName == "Helmet" or slotName == "Gloves" or slotName == "Body Armour" or slotName == "Boots" or slotName == "Belt" then
 			-- Add Abyssal Socket slots
 			for i = 1, 6 do
-				local abyssal = new("ItemSlotControl", {"TOPLEFT",prevSlot,"BOTTOMLEFT"}, 0, 0, self, slotName.." Abyssal Socket "..i, "Abyssal #"..i)			
+				local abyssal = new("ItemSlotControl", {"TOPLEFT",prevSlot,"BOTTOMLEFT"}, 0, 2, self, slotName.." Abyssal Socket "..i, "Abyssal #"..i)			
 				addSlot(abyssal)
 				abyssal.parentSlot = slot
 				if slotName:match("Weapon") then
@@ -134,6 +134,23 @@ local ItemsTabClass = newClass("ItemsTab", "UndoHandler", "ControlHost", "Contro
 			end
 		end
 	end
+
+	-- Passive tree dropdown controls
+	self.controls.specSelect = new("DropDownControl", {"TOPLEFT",prevSlot,"BOTTOMLEFT"}, 0, 8, 200, 20, nil, function(index, value)
+		if self.build.treeTab.specList[index] then
+			self.build.modFlag = true
+			self.build.treeTab:SetActiveSpec(index)
+		end
+	end)
+	self.controls.specSelect.enabled = function()
+		return #self.controls.specSelect.list > 1
+	end
+	prevSlot = self.controls.specSelect
+	self.controls.specButton = new("ButtonControl", {"LEFT",prevSlot,"RIGHT"}, 2, 0, 90, 20, "Manage...", function()
+		self.build.treeTab:OpenSpecManagePopup()
+	end)
+	self.controls.specLabel = new("LabelControl", {"RIGHT",prevSlot,"LEFT"}, -2, 0, 0, 16, "^7Passive tree:")
+
 	self.sockets = { }
 	local socketOrder = { }
 	for _, node in pairs(build.latestTree.nodes) do
@@ -145,7 +162,7 @@ local ItemsTabClass = newClass("ItemsTab", "UndoHandler", "ControlHost", "Contro
 		return a.id < b.id
 	end)
 	for _, node in ipairs(socketOrder) do
-		local socketControl = new("ItemSlotControl", {"TOPLEFT",prevSlot,"BOTTOMLEFT"}, 0, 0, self, "Jewel "..node.id, "Socket", node.id)
+		local socketControl = new("ItemSlotControl", {"TOPLEFT",prevSlot,"BOTTOMLEFT"}, 0, 2, self, "Jewel "..node.id, "Socket", node.id)
 		self.sockets[node.id] = socketControl
 		addSlot(socketControl)
 	end

--- a/src/Classes/ItemsTab.lua
+++ b/src/Classes/ItemsTab.lua
@@ -1297,8 +1297,6 @@ function ItemsTabClass:DeleteItem(item)
 						depNode.alloc = false
 						spec.allocNodes[depNodeId] = nil
 					end
-					spec.nodes[nodeId].alloc = false
-					spec.allocNodes[nodeId] = nil
 				end
 			end
 		end

--- a/src/Classes/PassiveSpec.lua
+++ b/src/Classes/PassiveSpec.lua
@@ -510,7 +510,6 @@ end
 
 -- Deallocate the given node, and all nodes which depend on it (i.e. which are only connected to the tree through this node)
 function PassiveSpecClass:DeallocNode(node)
-	local effect
 	for _, depNode in ipairs(node.depends) do
 		self:DeallocSingleNode(depNode)
 	end

--- a/src/Classes/PassiveSpecListControl.lua
+++ b/src/Classes/PassiveSpecListControl.lua
@@ -39,6 +39,7 @@ local PassiveSpecListClass = newClass("PassiveSpecListControl", "ListControl", f
 		newSpec:SelectAscendClass(treeTab.build.spec.curAscendClassId)
 		self:RenameSpec(newSpec, true)
 	end)
+	self:UpdateItemsTabPassiveTreeDropdown()
 end)
 
 function PassiveSpecListClass:RenameSpec(spec, addOnName)
@@ -55,6 +56,7 @@ function PassiveSpecListClass:RenameSpec(spec, addOnName)
 			self.selIndex = #self.list
 			self.selValue = spec
 		end
+		self:UpdateItemsTabPassiveTreeDropdown()
 		main:ClosePopup()
 	end)
 	controls.save.enabled = false
@@ -77,6 +79,7 @@ end
 function PassiveSpecListClass:OnOrderChange()
 	self.treeTab.activeSpec = isValueInArray(self.list, self.treeTab.build.spec)
 	self.treeTab.modFlag = true
+	self:UpdateItemsTabPassiveTreeDropdown()
 end
 
 function PassiveSpecListClass:OnSelClick(index, spec, doubleClick)
@@ -97,6 +100,7 @@ function PassiveSpecListClass:OnSelDelete(index, spec)
 				self.treeTab.activeSpec = isValueInArray(self.list, self.treeTab.build.spec)
 			end
 			self.treeTab.modFlag = true
+			self:UpdateItemsTabPassiveTreeDropdown()
 		end)
 	end
 end
@@ -105,4 +109,15 @@ function PassiveSpecListClass:OnSelKeyDown(index, spec, key)
 	if key == "F2" then
 		self:RenameSpec(spec)
 	end
+end
+
+-- Update the passive tree dropdown control in itemsTab
+function PassiveSpecListClass:UpdateItemsTabPassiveTreeDropdown()
+	local secondarySpecList = self.treeTab.build.itemsTab.controls.specSelect
+	local newSpecList = { }
+	for i = 1, #self.list do
+		newSpecList[i] = self.list[i].title
+	end
+	secondarySpecList:SetList(newSpecList)
+    secondarySpecList.selIndex = self.treeTab.activeSpec
 end

--- a/src/Classes/PassiveSpecListControl.lua
+++ b/src/Classes/PassiveSpecListControl.lua
@@ -116,7 +116,7 @@ function PassiveSpecListClass:UpdateItemsTabPassiveTreeDropdown()
 	local secondarySpecList = self.treeTab.build.itemsTab.controls.specSelect
 	local newSpecList = { }
 	for i = 1, #self.list do
-		newSpecList[i] = self.list[i].title
+		newSpecList[i] = self.list[i].title or "Default"
 	end
 	secondarySpecList:SetList(newSpecList)
         secondarySpecList.selIndex = self.treeTab.activeSpec

--- a/src/Classes/PassiveSpecListControl.lua
+++ b/src/Classes/PassiveSpecListControl.lua
@@ -119,5 +119,5 @@ function PassiveSpecListClass:UpdateItemsTabPassiveTreeDropdown()
 		newSpecList[i] = self.list[i].title
 	end
 	secondarySpecList:SetList(newSpecList)
-    secondarySpecList.selIndex = self.treeTab.activeSpec
+        secondarySpecList.selIndex = self.treeTab.activeSpec
 end

--- a/src/Classes/PassiveSpecListControl.lua
+++ b/src/Classes/PassiveSpecListControl.lua
@@ -119,5 +119,5 @@ function PassiveSpecListClass:UpdateItemsTabPassiveTreeDropdown()
 		newSpecList[i] = self.list[i].title or "Default"
 	end
 	secondarySpecList:SetList(newSpecList)
-        secondarySpecList.selIndex = self.treeTab.activeSpec
+	secondarySpecList.selIndex = self.treeTab.activeSpec
 end

--- a/src/Classes/TreeTab.lua
+++ b/src/Classes/TreeTab.lua
@@ -310,14 +310,6 @@ function TreeTabClass:Save(xml)
 		activeSpec = tostring(self.activeSpec)
 	}
 	for specId, spec in ipairs(self.specList) do
-		if specId == self.activeSpec then
-			-- Update this spec's jewels from the socket slots
-			for _, slot in pairs(self.build.itemsTab.slots) do
-				if slot.nodeId then
-					spec.jewels[slot.nodeId] = slot.selItemId
-				end
-			end
-		end
 		local child = {
 			elem = "Spec"
 		}
@@ -344,6 +336,9 @@ function TreeTabClass:SetActiveSpec(specId)
 			if curSpec.jewels[slot.nodeId] then
 				-- Socket the jewel for the new spec
 				slot.selItemId = curSpec.jewels[slot.nodeId]
+			else
+				-- Unsocket the old jewel from the previous spec
+				slot.selItemId = 0
 			end
 		end
 	end

--- a/src/Classes/TreeTab.lua
+++ b/src/Classes/TreeTab.lua
@@ -231,6 +231,7 @@ function TreeTabClass:Draw(viewPort, inputEvents)
 	for id, spec in ipairs(self.specList) do
 		t_insert(newSpecList, (spec.treeVersion ~= latestTreeVersion and ("["..treeVersions[spec.treeVersion].display.."] ") or "")..(spec.title or "Default"))
 	end
+	self.build.itemsTab.controls.specSelect:SetList(copyTable(newSpecList)) -- Update the passive tree dropdown control in itemsTab
 	t_insert(newSpecList, "Manage trees...")
 	self.controls.specSelect:SetList(newSpecList)
 
@@ -347,6 +348,8 @@ function TreeTabClass:SetActiveSpec(specId)
 		-- Update item slots if items have been loaded already
 		self.build.itemsTab:PopulateSlots()
 	end
+    -- Update the passive tree dropdown control in itemsTab
+    self.build.itemsTab.controls.specSelect.selIndex = specId
 end
 
 function TreeTabClass:SetCompareSpec(specId)

--- a/src/Classes/TreeTab.lua
+++ b/src/Classes/TreeTab.lua
@@ -348,8 +348,8 @@ function TreeTabClass:SetActiveSpec(specId)
 		-- Update item slots if items have been loaded already
 		self.build.itemsTab:PopulateSlots()
 	end
-    -- Update the passive tree dropdown control in itemsTab
-    self.build.itemsTab.controls.specSelect.selIndex = specId
+	-- Update the passive tree dropdown control in itemsTab
+	self.build.itemsTab.controls.specSelect.selIndex = specId
 end
 
 function TreeTabClass:SetCompareSpec(specId)


### PR DESCRIPTION
This fixes two different bugs involving jewel socket data saving/loading where certain information would erroneously persist across different skill trees.

Socket Bug &numero; 1:
- Load the example PoB provided.
- Switch from the passive tree "First" to the passive tree "Second" using the Passive Tree Manager.
- Save and reload the example PoB.
    In 2.13.0, you'll see this (both bug &numero; 1 and bug &numero; 2 are visible here):
![](http://puu.sh/ICWZe/1f86085c3e.png)
    After my fix is applied, you should see an empty socket (as intended):
![](http://puu.sh/ICWY0/62d795e977.png)
    This bug is caused by some erroneous socket data saving logic in ``TreeTabClass:Save``.

Socket Bug &numero; 2:
- Load the example PoB provided.
- Switch from the passive tree "First" to the passive tree "Second" using the Passive Tree Manager.
- In 2.13.0 you'll see a cluster jewel socketed (bug), but none of the nodes are visible:
![](http://puu.sh/ICWXN/136327c3ba.png)
- After my fix is applied, you should see an empty socket (as intended):
![](http://puu.sh/ICWY0/62d795e977.png)
- This bug is caused by the socketed cluster jewel from passive tree "First" not being unsocketed in ``TreeTabClass:SetActiveSpec``.

### Link to a build that showcases this PR:
https://pastebin.com/6juKtub4