### PR TITLE
Relabel character import "Done" button to "Cancel" 

### DIFF
--- a/src/Classes/ImportTab.lua
+++ b/src/Classes/ImportTab.lua
@@ -148,7 +148,7 @@ You can get this from your web browser's cookies while logged into the Path of E
 	self.controls.charImportItemsClearItems.tooltipText = "Delete all equipped items when importing."
 	self.controls.charBanditNote = new("LabelControl", {"TOPLEFT",self.controls.charImportHeader,"BOTTOMLEFT"}, 0, 50, 200, 14, "^7Tip: After you finish importing a character, make sure you update the bandit choice,\nas it cannot be imported.")
 
-	self.controls.charDone = new("ButtonControl", {"TOPLEFT",self.controls.charImportHeader,"BOTTOMLEFT"}, 0, 90, 60, 20, "Done", function()
+	self.controls.charCancel = new("ButtonControl", {"TOPLEFT",self.controls.charImportHeader,"BOTTOMLEFT"}, 0, 90, 60, 20, "Cancel", function()
 		self.charImportMode = "GETACCOUNTNAME"
 		self.charImportStatus = "Idle"
 	end)

--- a/src/Classes/ImportTab.lua
+++ b/src/Classes/ImportTab.lua
@@ -46,13 +46,6 @@ local ImportTabClass = newClass("ImportTab", "ControlHost", "Control", function(
 			end)
 		end)
 	end
-	self.controls.accountNameGo = new("ButtonControl", {"LEFT",self.controls.accountName,"RIGHT"}, 8, 0, 60, 20, "Start", function()
-		self.controls.sessionInput.buf = ""
-		self:DownloadCharacterList()
-	end)
-	self.controls.accountNameGo.enabled = function()
-		return self.controls.accountName.buf:match("%S")
-	end
 	-- accountHistory Control
 	if not historyList then
 		historyList = { }
@@ -64,6 +57,13 @@ local ImportTabClass = newClass("ImportTab", "ControlHost", "Control", function(
 			return a:lower() < b:lower()
 		end)
 	end -- don't load the list many times
+	self.controls.accountNameGo = new("ButtonControl", {"LEFT",self.controls.accountName,"RIGHT"}, 8, 0, 60, 20, "Start", function()
+		self.controls.sessionInput.buf = ""
+		self:DownloadCharacterList()
+	end)
+	self.controls.accountNameGo.enabled = function()
+		return self.controls.accountName.buf:match("%S")
+	end
 
 	self.controls.accountHistory = new("DropDownControl", {"LEFT",self.controls.accountNameGo,"RIGHT"}, 8, 0, 200, 20, historyList, function()
 		self.controls.accountName.buf = self.controls.accountHistory.list[self.controls.accountHistory.selIndex]
@@ -151,16 +151,6 @@ You can get this from your web browser's cookies while logged into the Path of E
 	self.controls.charDone = new("ButtonControl", {"TOPLEFT",self.controls.charImportHeader,"BOTTOMLEFT"}, 0, 90, 60, 20, "Done", function()
 		self.charImportMode = "GETACCOUNTNAME"
 		self.charImportStatus = "Idle"
-		-- We only get here if the accountname was correct, found, and not private, so add it to the account history.
-		if not historyList[self.controls.accountName.buf] then
-			t_insert(historyList, self.controls.accountName.buf)
-			historyList[self.controls.accountName.buf] = true
-			self.controls.accountHistory:SelByValue(self.controls.accountName.buf)
-			table.sort(historyList, function(a,b)
-				return a:lower() < b:lower()
-			end)
-			self.controls.accountHistory:CheckDroppedWidth(true)
-		end
 	end)
 
 	-- Build import/export
@@ -389,6 +379,9 @@ function ImportTabClass:DownloadCharacterList()
 			end
 			self.lastCharList = charList
 			self:BuildCharacterList(self.controls.charSelectLeague:GetSelValue("league"))
+
+			-- We only get here if the accountname was correct, found, and not private, so add it to the account history.
+			self:SaveAccountHistory()
 		end, sessionID and "POESESSID="..sessionID)
 	end, sessionID and "POESESSID="..sessionID)
 end
@@ -414,6 +407,18 @@ function ImportTabClass:BuildCharacterList(league)
 				break
 			end
 		end
+	end
+end
+
+function ImportTabClass:SaveAccountHistory()
+	if not historyList[self.controls.accountName.buf] then
+		t_insert(historyList, self.controls.accountName.buf)
+		historyList[self.controls.accountName.buf] = true
+		self.controls.accountHistory:SelByValue(self.controls.accountName.buf)
+		table.sort(historyList, function(a,b)
+			return a:lower() < b:lower()
+		end)
+		self.controls.accountHistory:CheckDroppedWidth(true)
 	end
 end
 


### PR DESCRIPTION
This moves the account history list functionality to "Start".

### Description of the problem being solved:

After walking a few dozen newbies through PoB-ing their character, this is the main point of confusion. Almost all of them see the "Passive Tree and Jewels", "Items and Skills", and "Done" buttons and click "Done" (without clicking the other 2). As far as I'm concerned, this button is a trap.

### Steps taken to verify a working solution:
- Tried importing a character
- Made a new build and confirmed my account was in the account history

### Before screenshot:
![image](https://user-images.githubusercontent.com/90059/149682801-201a5c9a-1cef-40d0-896d-5402f5c7159d.png)

### After screenshot:
![image](https://user-images.githubusercontent.com/90059/149847799-adb308e0-2bbe-4fba-988c-c9317fc035f7.png)