### PR TITLE
Add feature to guess the main socket group when importing a character

### DIFF
--- a/src/Classes/ImportTab.lua
+++ b/src/Classes/ImportTab.lua
@@ -528,7 +528,7 @@ function ImportTabClass:ImportItemsAndSkills(json)
 		end
 	end
 
-	local mainSkillEmpty = #self.build.controls.mainSocketGroup.list == 1 and self.build.controls.mainSocketGroup.list[1]["label"] == "<No skills added yet>"
+	local mainSkillEmpty = #self.build.skillsTab.socketGroupList == 0
 	local skillOrder
 	if self.controls.charImportItemsClearSkills.state then
 		skillOrder = { }
@@ -917,8 +917,8 @@ function ImportTabClass:GuessMainSocketGroup()
 	local largestGroupSize = 0
 	local largestGroupIndex = 1
 	for i, socketGroup in ipairs(self.build.skillsTab.socketGroupList) do
-		if #socketGroup["gemList"] > largestGroupSize then
-			largestGroupSize = #socketGroup["gemList"]
+		if #socketGroup.gemList > largestGroupSize then
+			largestGroupSize = #socketGroup.gemList
 			largestGroupIndex = i
 		end
 	end

--- a/src/Classes/ImportTab.lua
+++ b/src/Classes/ImportTab.lua
@@ -527,6 +527,8 @@ function ImportTabClass:ImportItemsAndSkills(json)
 			end
 		end
 	end
+
+	local mainSkillEmpty = #self.build.controls.mainSocketGroup.list == 1 and self.build.controls.mainSocketGroup.list[1]["label"] == "<No skills added yet>"
 	local skillOrder
 	if self.controls.charImportItemsClearSkills.state then
 		skillOrder = { }
@@ -580,6 +582,9 @@ function ImportTabClass:ImportItemsAndSkills(json)
 				return orderA
 			end
 		end)
+	end
+	if mainSkillEmpty then
+		self.build.mainSocketGroup = self:GuessMainSocketGroup()
 	end
 	self.build.itemsTab:PopulateSlots()
 	self.build.itemsTab:AddUndoState()
@@ -830,7 +835,6 @@ function ImportTabClass:ImportItem(itemData, slotName)
 	end
 end
 
-
 function ImportTabClass:ImportSocketedItems(item, socketedItems, slotName)
 	-- Build socket group list
 	local itemSocketGroupList = { }
@@ -906,6 +910,19 @@ function ImportTabClass:ImportSocketedItems(item, socketedItems, slotName)
 		end
 		self.build.skillsTab:ProcessSocketGroup(itemSocketGroup)
 	end
+end
+
+-- Return the index of the group with the most gems
+function ImportTabClass:GuessMainSocketGroup()
+	local largestGroupSize = 0
+	local largestGroupIndex = 1
+	for i, socketGroup in ipairs(self.build.skillsTab.socketGroupList) do
+		if #socketGroup["gemList"] > largestGroupSize then
+			largestGroupSize = #socketGroup["gemList"]
+			largestGroupIndex = i
+		end
+	end
+	return largestGroupIndex
 end
 
 function HexToChar(x)


### PR DESCRIPTION
### Description of the problem being solved:

Importing a character for the first time sets the main skill to the first one. This instead sets the main socket group to the one with the most gems (only when importing a character onto a build with no skills).

### Steps taken to verify a working solution:
- Imported a character and confirmed a reasonable skill got chosen
- Imported from a code and confirmed the saved skill (which was not the largest socket group) was restored

### Before screenshot:
![image](https://user-images.githubusercontent.com/90059/149702612-9421e00f-228e-499d-be18-535495925342.png)

### After screenshot:
![image](https://user-images.githubusercontent.com/90059/149711446-dd2450a5-99fe-491f-a158-675fae389849.png)

It looks like there's a bug since the CoC triggering skill isn't set correctly, but, AFAICT, that's an existing issue on `dev` at 6a356a5f ( but not on 2.13.0; see #3900)