### PR TITLE
fix: remove duplicate and not pertinent values being saved in XML

### DIFF
--- a/src/Modules/Build.lua
+++ b/src/Modules/Build.lua
@@ -843,11 +843,15 @@ function buildMode:Save(xml)
 	for _, id in ipairs(self.spectreList) do
 		t_insert(xml, { elem = "Spectre", attrib = { id = id } })
 	end
+	local addedStatNames = { SkillDPS = true }
 	for index, statData in ipairs(self.displayStats) do
-		if statData.stat then
-			local statVal = self.calcsTab.mainOutput[statData.stat]
-			if statVal then
-				t_insert(xml, { elem = "PlayerStat", attrib = { stat = statData.stat, value = tostring(statVal) } })
+		if not statData.flag or self.calcsTab.mainEnv.player.mainSkill.skillFlags[statData.flag] then
+			if statData.stat and not addedStatNames[statData.stat] then
+				local statVal = self.calcsTab.mainOutput[statData.stat]
+				if statVal and (statData.condFunc and statData.condFunc(statVal, self.calcsTab.mainOutput) or true) then
+					t_insert(xml, { elem = "PlayerStat", attrib = { stat = statData.stat, value = tostring(statVal) } })
+					addedStatNames[statData.stat] = true
+				end
 			end
 		end
 	end


### PR DESCRIPTION
Fixes repeated XML `PlayerStat` values as well as values that don't meet evaluation conditions from being saved.

### Before screenshot:
```
		<PlayerStat stat="AverageDamage" value="84768.780421338"/>
		<PlayerStat stat="Speed" value="1.6375"/>
		<PlayerStat stat="Speed" value="1.6375"/>
		<PlayerStat stat="Speed" value="1.6375"/>
```

### After screenshot:
```
		<PlayerStat stat="AverageDamage" value="84768.780421338"/>
		<PlayerStat stat="Speed" value="1.6375"/>
```
