### PR TITLE
Add ability to show DPS for non-cooldown traps and mines

### DIFF
--- a/src/Modules/CalcOffence.lua
+++ b/src/Modules/CalcOffence.lua
@@ -556,7 +556,7 @@ function calcs.offence(env, actor, activeSkill)
 			end
 		end
 	end
-   if skillModList:Flag(nil, "ClawCritMultiplierAppliesToMinions") then
+	if skillModList:Flag(nil, "ClawCritMultiplierAppliesToMinions") then
 		-- Claw Crit Multi conversion from Law of the Wilds
 		for i, value in ipairs(skillModList:Tabulate("BASE", { flags = bor(ModFlag.Claw, ModFlag.Hit) }, "CritMultiplier")) do
 			local mod = value.mod
@@ -838,11 +838,16 @@ function calcs.offence(env, actor, activeSkill)
 			end
 		end
 	end
-	if activeSkill.skillTypes[SkillType.Hex] or activeSkill.skillTypes[SkillType.Mark]then
+	if activeSkill.skillTypes[SkillType.Hex] or activeSkill.skillTypes[SkillType.Mark] then
 		output.CurseEffectMod = calcLib.mod(skillModList, skillCfg, "CurseEffect")
 		if breakdown then
 			breakdown.CurseEffectMod = breakdown.mod(skillModList, skillCfg, "CurseEffect")
 		end
+	end
+	if (skillFlags.trap or skillFlags.mine) and not (skillData.trapCooldown or skillData.cooldown) then
+		skillFlags.notAverage = true
+		skillFlags.showAverage = false
+		skillData.showAverage = false
 	end
 	if skillFlags.trap then
 		local baseSpeed = 1 / skillModList:Sum("BASE", skillCfg, "TrapThrowingTime")


### PR DESCRIPTION
Fixes #3850.

### Description of the problem being solved:
Trap and Mine skills are flagged ``skill("showAverage", true)`` preventing them from displaying their actual DPS.

This hasn't been necessary for a long time (see #2177) and is making DPS calculations for trap and mine builds unnecessarily tedious &mdash; exceptionally so if you're dealing Poison Damage (see #3850).

Some cooldown traps should display their DPS instead of just Average Hit (Lightning Spire Trap and Seismic Trap have special DPS scaling with Trap Throwing Speed), but adding support for that should probably be a separate PR due to the increased complexity.

### Steps taken to verify a working solution:
- Load example PoB.
- Check all trap and mine skills. Anything with a cooldown should display Average Hit only, and anything without one should display Combined DPS.

### Link to a build that showcases this PR:
https://pastebin.com/DPR7Mrfd

### Before screenshot:
![](http://puu.sh/IDkUU/b3867ff4d2.png)
### After screenshot:
![](http://puu.sh/IDkVd/9ecff9931d.png)