### PR TITLE
Fix bug where maximum Life could be negative

### DIFF
--- a/src/Modules/CalcPerform.lua
+++ b/src/Modules/CalcPerform.lua
@@ -570,7 +570,7 @@ local function doActorAttribsPoolsConditions(env, actor)
 		local inc = modDB:Sum("INC", nil, "Life")
 		local more = modDB:More(nil, "Life")
 		local conv = modDB:Sum("BASE", nil, "LifeConvertToEnergyShield")
-		output.Life = round(base * (1 + inc/100) * more * (1 - conv/100))
+		output.Life = m_max(round(base * (1 + inc/100) * more * (1 - conv/100)), 1)
 		if breakdown then
 			if inc ~= 0 or more ~= 1 or conv ~= 0 then
 				breakdown.Life = { }


### PR DESCRIPTION
Fixes #3734.

### Description of the problem being solved:
Players can get negative maximum Life modifiers on Scourged items. With enough of these items equipped PoB throws various different errors and fails to load the build. PoE handles this by enforcing a lower bound of 1 for player maximum Life, and this PR adds the same functionality to PoB.

### Link to a build that showcases this PR:
https://pastebin.com/KqPukQKa

### Before screenshot:
![](http://puu.sh/IDlp2/5670877c2c.png)

### After screenshot:
![](http://puu.sh/IDloN/8b0b88ebc4.png)