### PR TITLE
Fix incorrect reservation on some legacy builds

### DIFF
--- a/src/Modules/CalcPerform.lua
+++ b/src/Modules/CalcPerform.lua
@@ -1425,13 +1425,13 @@ function calcs.perform(env, avoidCache)
 					values.reservedFlat = activeSkill.skillData[name.."ReservationFlatForced"]
 				else
 					local baseFlatVal = m_floor(values.baseFlat * mult)
-					values.reservedFlat = m_max(round((baseFlatVal - m_modf(baseFlatVal * -m_floor((100 + values.inc) * values.more - 100) / 100)) / (1 + values.efficiency / 100), 2), 0)
+					values.reservedFlat = m_max(round(baseFlatVal * (100 + values.inc) / 100 * values.more / (1 + values.efficiency / 100), 2), 0)
 				end
 				if activeSkill.skillData[name.."ReservationPercentForced"] then
 					values.reservedPercent = activeSkill.skillData[name.."ReservationPercentForced"]
 				else
 					local basePercentVal = values.basePercent * mult
-					values.reservedPercent = m_max(round((basePercentVal - m_modf(basePercentVal * -m_floor((100 + values.inc) * values.more - 100)) / 100) / (1 + values.efficiency / 100), 2), 0)
+					values.reservedPercent = m_max(round(basePercentVal * (100 + values.inc) / 100 * values.more / (1 + values.efficiency / 100), 2), 0)
 				end
 				if activeSkill.activeMineCount then
 					values.reservedFlat = values.reservedFlat * activeSkill.activeMineCount


### PR DESCRIPTION
Fixes #3211.

I checked a few of my own builds and didn't notice any inconsistencies with mana or life reservation values before and after this change, I'd appreciate additional testing on that front though.

### Description of the problem being solved:
Legacy builds with 100% reduced mana reservation end up reserving very small (but non-zero) values. I fixed this by just completely rewriting the ``reservedFlat`` and ``reservedPercent`` formulas to match current behaviour in PoE and fix this edge case. As a bonus the formula is also significantly less confusing to look at.

### Link to a build that showcases this PR:
https://pastebin.com/qVpv8y1b

### Before screenshot:
![](http://puu.sh/IDmG1/a257ccf3cc.png)
### After screenshot:
![](http://puu.sh/IDmFV/60407bcc90.png)