### PR TITLE
Fix Sidhebreath missing implicit

### DIFF
--- a/src/Data/Uniques/amulet.lua
+++ b/src/Data/Uniques/amulet.lua
@@ -829,6 +829,7 @@ Paua Amulet
 Variant: Pre 3.0.0
 Variant: Pre 3.8.0
 Variant: Current
+Implicits: 1
 {tags:mana}(20-30)% increased Mana Regeneration Rate
 {tags:jewellery_resistance}+25% to Cold Resistance
 {variant:1,2}0.2% of Physical Attack Damage Leeched as Mana


### PR DESCRIPTION
Fixes (one part of) #3063.

### Description of the problem being solved:
Sidhebreath in ``\Data\Uniques\amulet.lua`` had no Implicit count, showing the implicit as an explicit mod instead.