### PR TITLE
Fix converted passive tree save error

### DIFF
--- a/src/Classes/PassiveSpec.lua
+++ b/src/Classes/PassiveSpec.lua
@@ -182,7 +182,7 @@ function PassiveSpecClass:Save(xml)
 					t_insert(editedNode, modLine)
 				end
 				-- Do not save current editedNode data unless the current node is conquered
-				if self.nodes[nodeId].conqueredBy then
+				if self.nodes[nodeId] and self.nodes[nodeId].conqueredBy then
 					-- Do not save current editedNode data unless the current node is allocated
 					for allocNodeId in pairs(self.allocNodes) do
 						if nodeId == allocNodeId then


### PR DESCRIPTION
### Description of the problem being solved:
There is an (apparently very rare) error that can occur when converting old passive trees to the current version where extreme amounts of garbage data exists in the EditedNode section of the XML, but the converted tree is completely empty, causing an error when PoB checks whether or not a (non-existent) node listed under EditedNodes is conquered. Checking if the node actually **exists** first fixes this error.

### Steps taken to verify a working solution:
- Import the build referenced below.
- Convert the passive tree from 3.14 to 3.16.
- Attempt to save the build. Prior to the fix in this PR, the build will fail to save.

### Link to a build that showcases this PR:
https://pastebin.com/pqX8Z44x

### Before screenshot:
![](http://puu.sh/IDnFB/e9fb65fabb.png)