### PR TITLE
Fix elemental damage taken when using The Admiral

### DIFF
--- a/src/Modules/CalcOffence.lua
+++ b/src/Modules/CalcOffence.lua
@@ -2217,9 +2217,11 @@ function calcs.offence(env, actor, activeSkill)
 								if isElemental[elementUsed] then
 									pen = skillModList:Sum("BASE", cfg, elementUsed.."Penetration", "ElementalPenetration")
 									takenInc = enemyDB:Sum("INC", cfg, "DamageTaken", elementUsed.."DamageTaken", "ElementalDamageTaken")
+									takenMore = enemyDB:More(cfg, "DamageTaken", elementUsed.."DamageTaken", "ElementalDamageTaken")
 								elseif elementUsed == "Chaos" then
 									pen = skillModList:Sum("BASE", cfg, "ChaosPenetration")
 									takenInc = enemyDB:Sum("INC", cfg, "DamageTaken", "ChaosDamageTaken")
+									takenMore = enemyDB:More(cfg, "DamageTaken", "ChaosDamageTaken")
 								end
 								sourceRes = elementUsed
 							elseif isElemental[damageType] then

--- a/src/Modules/CalcOffence.lua
+++ b/src/Modules/CalcOffence.lua
@@ -2213,11 +2213,13 @@ function calcs.offence(env, actor, activeSkill)
 										end
 									end
 								end
-								-- Update the penetration based on the element used
+								-- Update the penetration (and damage taken) based on the element used
 								if isElemental[elementUsed] then
 									pen = skillModList:Sum("BASE", cfg, elementUsed.."Penetration", "ElementalPenetration")
+									takenInc = enemyDB:Sum("INC", cfg, "DamageTaken", elementUsed.."DamageTaken", "ElementalDamageTaken")
 								elseif elementUsed == "Chaos" then
 									pen = skillModList:Sum("BASE", cfg, "ChaosPenetration")
+									takenInc = enemyDB:Sum("INC", cfg, "DamageTaken", "ChaosDamageTaken")
 								end
 								sourceRes = elementUsed
 							elseif isElemental[damageType] then

--- a/src/Modules/CalcOffence.lua
+++ b/src/Modules/CalcOffence.lua
@@ -2199,6 +2199,7 @@ function calcs.offence(env, actor, activeSkill)
 								local elementUsed = damageType
 								if isElemental[damageType] then
 									resist = m_min(enemyDB:Sum("BASE", nil, damageType.."Resist", "ElementalResist") * calcLib.mod(enemyDB, nil, damageType.."Resist", "ElementalResist"), data.misc.EnemyMaxResist)
+									takenInc = takenInc + enemyDB:Sum("INC", cfg, "ElementalDamageTaken")
 								elseif damageType == "Chaos" then
 									resist = m_min(enemyDB:Sum("BASE", nil, "ChaosResist") * calcLib.mod(enemyDB, nil, "ChaosResist"), data.misc.EnemyMaxResist)
 								end
@@ -2213,15 +2214,11 @@ function calcs.offence(env, actor, activeSkill)
 										end
 									end
 								end
-								-- Update the penetration (and damage taken) based on the element used
+								-- Update the penetration based on the element used
 								if isElemental[elementUsed] then
 									pen = skillModList:Sum("BASE", cfg, elementUsed.."Penetration", "ElementalPenetration")
-									takenInc = enemyDB:Sum("INC", cfg, "DamageTaken", elementUsed.."DamageTaken", "ElementalDamageTaken")
-									takenMore = enemyDB:More(cfg, "DamageTaken", elementUsed.."DamageTaken", "ElementalDamageTaken")
 								elseif elementUsed == "Chaos" then
 									pen = skillModList:Sum("BASE", cfg, "ChaosPenetration")
-									takenInc = enemyDB:Sum("INC", cfg, "DamageTaken", "ChaosDamageTaken")
-									takenMore = enemyDB:More(cfg, "DamageTaken", "ChaosDamageTaken")
 								end
 								sourceRes = elementUsed
 							elseif isElemental[damageType] then


### PR DESCRIPTION
Fixes #2886.

### Description of the problem being solved:
Equipping The Admiral disables generic Elemental Damage taken modifiers, and can use the wrong (specific) Element Damage taken modifier (e.g. Lightning instead of Fire in situations where The Admiral should pick Fire, but you're dealing Lightning damage).

### Link to a build that showcases this PR:
https://pastebin.com/ePjVp82H
### Before screenshot:
![](http://puu.sh/IDnT0/6a46e7b95c.png)
![](http://puu.sh/IDnTf/4bb19006ae.png)
### After screenshot:
![](http://puu.sh/IDnS4/e339b82640.png)
![](http://puu.sh/IDnTE/02c0f076a6.png)