### PR TITLE
Fix various item parsing bugs

### DIFF
--- a/src/Classes/Item.lua
+++ b/src/Classes/Item.lua
@@ -488,7 +488,7 @@ function ItemClass:ParseRaw(raw)
 
 				if data.itemBases[line] then
 					self.baseLines = self.baseLines or { }
-					self.baseLines[line] = { line = line, variantList = variantList}
+					self.baseLines[line] = { line = line, variantList = variantList }
 				end
 
 				local modLines
@@ -516,7 +516,7 @@ function ItemClass:ParseRaw(raw)
 						foundExplicit = true
 					end
 				elseif mode == "GAME" then
-					if gameModeStage == "IMPLICIT" or gameModeStage == "EXPLICIT" then
+					if gameModeStage == "IMPLICIT" or gameModeStage == "EXPLICIT" or (gameModeStage == "FINDIMPLICIT" and not data.itemBases[line]) then
 						t_insert(modLines, { line = line, extra = line, modList = { }, modTags = { }, variantList = variantList, scourge = scourge, crafted = crafted, custom = custom, fractured = fractured, implicit = implicit })
 					elseif gameModeStage == "FINDEXPLICIT" then
 						gameModeStage = "DONE"

--- a/src/Classes/Item.lua
+++ b/src/Classes/Item.lua
@@ -515,6 +515,7 @@ function ItemClass:ParseRaw(raw)
 					else
 						foundExplicit = true
 					end
+				elseif line == "Requirements:" then
 				elseif mode == "GAME" then
 					if gameModeStage == "IMPLICIT" or gameModeStage == "EXPLICIT" then
 						t_insert(modLines, { line = line, extra = line, modList = { }, modTags = { }, variantList = variantList, scourge = scourge, crafted = crafted, custom = custom, fractured = fractured, implicit = implicit })

--- a/src/Classes/Item.lua
+++ b/src/Classes/Item.lua
@@ -323,7 +323,7 @@ function ItemClass:ParseRaw(raw)
 					self.note = specVal
 				elseif specName == "Str" or specName == "Dex" or specName == "Int" then
 					self.requirements[specName:lower()] = tonumber(specVal)
-				elseif specName == "Critical Strike Range" or specName == "Attacks per Second" or "Weapon Range" or
+				elseif specName == "Critical Strike Range" or specName == "Attacks per Second" or specName == "Weapon Range" or
 				       specName == "Physical Damage" or specName == "Elemental Damage" or specName == "Chaos Damage" then
 					self.hidden_specs = true
 				-- Anything else is an explicit with a colon in it (Fortress Covenant, Pure Talent, etc) unless it's part of the custom name

--- a/src/Classes/Item.lua
+++ b/src/Classes/Item.lua
@@ -149,6 +149,8 @@ function ItemClass:ParseRaw(raw)
 			self.synthesised = true
 		elseif processInfluenceLine(line) then
 			-- self already updated within the helper function
+		elseif line == "Requirements:" then
+			-- nothing to do
 		else
 			if self.checkSection then
 				if gameModeStage == "IMPLICIT" then
@@ -515,28 +517,9 @@ function ItemClass:ParseRaw(raw)
 					else
 						foundExplicit = true
 					end
-				elseif line == "Requirements:" then
 				elseif mode == "GAME" then
-					if gameModeStage == "IMPLICIT" or gameModeStage == "EXPLICIT" then
+					if gameModeStage == "IMPLICIT" or gameModeStage == "EXPLICIT" or (gameModeStage == "FINDIMPLICIT" and not data.itemBases[line]) then
 						t_insert(modLines, { line = line, extra = line, modList = { }, modTags = { }, variantList = variantList, scourge = scourge, crafted = crafted, custom = custom, fractured = fractured, implicit = implicit })
-					elseif gameModeStage == "FINDIMPLICIT" then
-						local foundAnchor = 0
-						local foundImplicit = 0
-						for index, l in pairs(self.rawLines) do
-							if line == l then
-								foundAnchor = index
-							end
-							if l:find("Implicits:") then
-								foundImplicit = index
-							end
-						end
-						if not data.itemBases[line] then
-							if foundImplicit > 0 and (foundImplicit - foundAnchor == 0) then
-								gameModeStage = "IMPLICIT"
-							elseif foundImplicit == 0 then
-								t_insert(modLines, { line = line, extra = line, modList = { }, modTags = { }, variantList = variantList, scourge = scourge, crafted = crafted, custom = custom, fractured = fractured, implicit = implicit })
-							end
-						end
 					elseif gameModeStage == "FINDEXPLICIT" then
 						gameModeStage = "DONE"
 					end

--- a/src/Classes/Item.lua
+++ b/src/Classes/Item.lua
@@ -516,8 +516,26 @@ function ItemClass:ParseRaw(raw)
 						foundExplicit = true
 					end
 				elseif mode == "GAME" then
-					if gameModeStage == "IMPLICIT" or gameModeStage == "EXPLICIT" or (gameModeStage == "FINDIMPLICIT" and not data.itemBases[line]) then
+					if gameModeStage == "IMPLICIT" or gameModeStage == "EXPLICIT" then
 						t_insert(modLines, { line = line, extra = line, modList = { }, modTags = { }, variantList = variantList, scourge = scourge, crafted = crafted, custom = custom, fractured = fractured, implicit = implicit })
+					elseif gameModeStage == "FINDIMPLICIT" then
+						local foundAnchor = 0
+						local foundImplicit = 0
+						for index, l in pairs(self.rawLines) do
+							if line == l then
+								foundAnchor = index
+							end
+							if l:find("Implicits:") then
+								foundImplicit = index
+							end
+						end
+						if not data.itemBases[line] then
+							if foundImplicit > 0 and (foundImplicit - foundAnchor == 0) then
+								gameModeStage = "IMPLICIT"
+							elseif foundImplicit == 0 then
+								t_insert(modLines, { line = line, extra = line, modList = { }, modTags = { }, variantList = variantList, scourge = scourge, crafted = crafted, custom = custom, fractured = fractured, implicit = implicit })
+							end
+						end
 					elseif gameModeStage == "FINDEXPLICIT" then
 						gameModeStage = "DONE"
 					end

--- a/src/Data/Uniques/boots.lua
+++ b/src/Data/Uniques/boots.lua
@@ -554,9 +554,6 @@ Variant: Two-Toned Boots (Evasion/Energy Shield)
 {variant:3}Two-Toned Boots (Evasion/Energy Shield)
 League: Delirium
 Source: Drops from the Simulacrum Encounter
-{variant:1}Requires Level 70, 62 Str, 62 Dex
-{variant:2}Requires Level 70, 62 Str, 62 Int
-{variant:3}Requires Level 70, 62 Dex, 62 Int
 Implicits: 3
 {variant:1}+(8-12)% to Fire and Cold Resistances
 {variant:2}+(8-12)% to Fire and Lightning Resistances


### PR DESCRIPTION
Fixes a typo that prevented internal modifier representation for Pure Talent from parsing correctly (web-based copy/paste worked).

Fixes logic to prevent internal modifier representation on items if the modifier cannot be parsed and no implicits exist (e.g., Inspired Learning).