### PR TITLE
Add missing Fate/Story of the Vaal modifiers

### DIFF
--- a/src/Data/Uniques/sword.lua
+++ b/src/Data/Uniques/sword.lua
@@ -500,7 +500,7 @@ Implicits: 1
 {variant:2}Hits with this Weapon Shock Enemies as though dealing (150-200)% more Damage
 {variant:2}Ignites inflicted with this Weapon deal (50-75)% more Damage
 50% of Physical Damage from Hits with this Weapon is Converted to a random Element
-Hits with this Weapon always inflict Elemental Ailments
+Hits with this Weapon always Ignite, Freeze, and Shock
 ]],[[
 Fate of the Vaal
 Gemstone Sword
@@ -515,7 +515,7 @@ Implicits: 1
 {variant:2}(180-210)% increased Physical Damage
 (10-15)% increased Attack Speed
 100% of Physical Damage from Hits with this Weapon is Converted to a random Element
-Hits with this Weapon always inflict Elemental Ailments
+Hits with this Weapon always Ignite, Freeze, and Shock
 Hits with this Weapon deal (30-60)% increased Damage to Ignited Enemies
 Hits with this Weapon deal (30-60)% increased Damage to Frozen Enemies
 Hits with this Weapon deal (30-60)% increased Damage to Shocked Enemies

--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -1967,6 +1967,16 @@ local specialModList = {
 		mod("PhysicalDamageGainAsColdOrLightning", "BASE", num / 2, nil, ModFlag.Hit, { type = "Condition", var = "DualWielding"}, { type = "SkillType", skillType = SkillType.Attack }),
 		mod("PhysicalDamageGainAsColdOrLightning", "BASE", num, nil, ModFlag.Hit, { type = "Condition", var = "DualWielding", neg = true}, { type = "SkillType", skillType = SkillType.Attack })
 	} end,
+	["hits with this weapon shock enemies as though dealing (%d+)%% more damage"] = function(num) return { mod("ShockAsThoughDealing", "MORE", num, nil, { type = "Condition", var = "{Hand}Attack" }, { type = "SkillType", skillType = SkillType.Attack }) } end,
+	["hits with this weapon freeze enemies as though dealing (%d+)%% more damage"] = function(num) return { mod("FreezeAsThoughDealing", "MORE", num, nil, { type = "Condition", var = "{Hand}Attack" }, { type = "SkillType", skillType = SkillType.Attack }) } end,
+	["ignites inflicted with this weapon deal (%d+)%% more damage"] = function(num) return {
+		mod("Damage", "MORE", num, nil, 0, KeywordFlag.Ignite, { type = "Condition", var = "{Hand}Attack" }, { type = "SkillType", skillType = SkillType.Attack }),
+	} end,
+	["hits with this weapon always ignite, freeze, and shock"] = {
+		mod("EnemyIgniteChance", "BASE", 100, nil, ModFlag.Hit, { type = "Condition", var = "{Hand}Attack" }, { type = "SkillType", skillType = SkillType.Attack }),
+		mod("EnemyFreezeChance", "BASE", 100, nil, ModFlag.Hit, { type = "Condition", var = "{Hand}Attack" }, { type = "SkillType", skillType = SkillType.Attack }),
+		mod("EnemyShockChance", "BASE", 100, nil, ModFlag.Hit, { type = "Condition", var = "{Hand}Attack" }, { type = "SkillType", skillType = SkillType.Attack }),
+	},
 	["attacks with this weapon deal double damage to chilled enemies"] = { mod("DoubleDamageChance", "BASE", 100, nil, ModFlag.Hit, { type = "Condition", var = "{Hand}Attack" }, { type = "SkillType", skillType = SkillType.Attack }, { type = "ActorCondition", actor = "enemy", var = "Chilled" }) },
 	["life leech from hits with this weapon applies instantly"] = { flag("InstantLifeLeech", { type = "Condition", var = "{Hand}Attack" }) },
 	["life leech from hits with this weapon is instant"] = { flag("InstantLifeLeech", { type = "Condition", var = "{Hand}Attack" }) },


### PR DESCRIPTION
Partially fixes #3063.

### Description of the problem being solved:
Fate of the Vaal and Story of the Vaal had several different modifiers that weren't parsed at all. They also had a modifier that GGG changed at some point to exclude alternate ailments, requiring an update to ``sword.lua``.