### PR TITLE
Add ability to search skills using multiple tags

### DIFF
--- a/src/Classes/GemSelectControl.lua
+++ b/src/Classes/GemSelectControl.lua
@@ -11,7 +11,7 @@ local m_min = math.min
 local m_max = math.max
 local m_floor = math.floor
 
-local toolTipText = "If used, prefix tag searches with a colon and exclude tags with a dash. e.g. :fire:lightning:-cold:area"
+local toolTipText = "Prefix tag searches with a colon and exclude tags with a dash. e.g. :fire:lightning:-cold:area"
 local altQualMap = {
 	["Default"] = "",
 	["Alternate1"] = "Anomalous ",

--- a/src/Classes/GemSelectControl.lua
+++ b/src/Classes/GemSelectControl.lua
@@ -90,17 +90,6 @@ function GemSelectClass:FilterSupport(gemId, gemData)
 end
 
 function GemSelectClass:BuildList(buf)
-	function string:split(sep)
-		-- Initially from http://lua-users.org/wiki/SplitJoin
-		-- function will ignore duplicate separators
-		local sep, fields = sep or ":", {}
-		local pattern = string.format("([^%s]+)", sep)
-		-- inject a blank entry if self begins with a colon
-		if string.sub(self, 1, 1) == ":" then t_insert(fields, "") end
-		self:gsub(pattern, function(c) fields[#fields+1] = c end)
-		return fields
-	end
-
 	local searchTerm = ""
 	local tagsList = {}
 

--- a/src/Classes/GemSelectControl.lua
+++ b/src/Classes/GemSelectControl.lua
@@ -11,7 +11,7 @@ local m_min = math.min
 local m_max = math.max
 local m_floor = math.floor
 
-local toolTipText = "Prefix tag searches with a colon. EG. ice:melee or :spell:fire"
+local toolTipText = "If used, prefix tag searches with a colon and exclude tags with a dash. e.g. :fire:lightning:-cold:area"
 local altQualMap = {
 	["Default"] = "",
 	["Alternate1"] = "Anomalous ",
@@ -96,7 +96,6 @@ function GemSelectClass:BuildList(buf)
 	self.controls.scrollBar.offset = 0
 	wipeTable(self.list)
 	self.searchStr = buf
-	-- if self.searchStr:match("%S") then
 	if #self.searchStr > 0 then
 		local added = { }
 
@@ -120,8 +119,8 @@ function GemSelectClass:BuildList(buf)
 					if self:FilterSupport(gemId, gemData) and not added[gemId] and ((" "..gemData.name:lower()):match(pattern) or altQualMap[self:GetQualityType(gemId)]:lower():match(pattern)) then
 						addThisGem = true
 						if #tagsList > 0 then
-							for i, v in ipairs(tagsList) do
-								local tagName = string.gsub(v, "%s+", ""):lower()
+							for _, tag in ipairs(tagsList) do
+								local tagName = string.gsub(tag, "%s+", ""):lower()
 								local negateTag = string.sub(tagName, 1, 1) == '-'
 								if negateTag then tagName = tagName:sub(2) end
 								if tagName == "active" then

--- a/src/Modules/Common.lua
+++ b/src/Modules/Common.lua
@@ -756,3 +756,19 @@ function supportEnabled(skillName, activeSkill)
 	end
 	return true
 end
+
+-- Class function to split a string on a single character (??) separator.
+  -- returns a list of fields, not including the separator.
+  -- Will return the first field as blank if the first character of the string is the separator
+  -- Separator defaults to colon
+function string:split(sep)
+	-- Initially from http://lua-users.org/wiki/SplitJoin
+	-- function will ignore duplicate separators
+	local sep, fields = sep or ":", {}
+	local pattern = string.format("([^%s]+)", sep)
+	-- inject a blank entry if self begins with a colon
+	if string.sub(self, 1, 1) == ":" then t_insert(fields, "") end
+	self:gsub(pattern, function(c) fields[#fields+1] = c end)
+	return fields
+end
+


### PR DESCRIPTION
### Description of the problem being solved:
To find skills by using multiple skills tags

The solution keeps the previous ability to search for a skill name or a skill tag just using a simple search term
This adds the ability use a search term to find a skill name and add multiple skill tags. 
All tag search terms start with colon (:)
Use minus (-) to remove a tag.
All searches are case insensitive

EG: 
- to find all spells with fire in their name, use; `fire:spell `
- to find all fire spells, of any name, use;` :fire:spell `
- to find all fire spells, of any name, but no auras, use; `:fire:spell:-aura`
 
`int` can be used for intelligence
`dex` can be used for dexterity
`str` can be used for strength

Illogical searches can be used that will result in "No Matches"
EG: 
- `anger:-aura`

All tag terms are 'AND'd together. There is no 'OR' operation.
This commit is to start things off. If people want more complex searches, then this can be added too 

### Steps taken to verify a working solution:
- Open any build
- On the skill tab, search for a skill.
- Use combination of search terms and tags to limit the list of shown skills

### Link to a build that showcases this PR:
N/A

### Before screenshot:
searching for fire shows skills with fire in their name as well as skills with the fire tag
![image](https://user-images.githubusercontent.com/4302241/150123006-8a4c3849-2d45-4590-900b-4d283240cccd.png)

### After screenshot:
![image](https://user-images.githubusercontent.com/4302241/150122624-2b732fe0-01eb-4c8c-a215-da327b8020bb.png)
![image](https://user-images.githubusercontent.com/4302241/150122738-0045a3b8-4f63-45a7-a467-8a5f02b87e30.png)
![image](https://user-images.githubusercontent.com/4302241/150122827-b4467f4d-5b6c-47ea-99be-8cf0c72b019e.png)
![image](https://user-images.githubusercontent.com/4302241/150122542-362ef460-b3f1-4871-ad2f-c953dd8987ab.png)
