### PR TITLE
Prevent saving useless minion data to XML

### DIFF
--- a/src/Classes/SkillsTab.lua
+++ b/src/Classes/SkillsTab.lua
@@ -317,31 +317,71 @@ function SkillsTabClass:Save(xml)
 			mainActiveSkill = tostring(socketGroup.mainActiveSkill),
 			mainActiveSkillCalcs = tostring(socketGroup.mainActiveSkillCalcs),
 		} }
+		-- Prevent saving useless minion data to XML for socket groups that do not create minions
+		local socketGroupCreatesMinion = false
 		for _, gemInstance in ipairs(socketGroup.gemList) do
-			t_insert(node, { elem = "Gem", attrib = {
-				nameSpec = gemInstance.nameSpec,
-				skillId = gemInstance.skillId,
-				gemId = gemInstance.gemId,
-				level = tostring(gemInstance.level),
-				quality = tostring(gemInstance.quality),
-				qualityId = gemInstance.qualityId,
-				enabled = tostring(gemInstance.enabled),
-				enableGlobal1 = tostring(gemInstance.enableGlobal1),
-				enableGlobal2 = tostring(gemInstance.enableGlobal2),
-				count = tostring(gemInstance.count),
-				skillPart = gemInstance.skillPart and tostring(gemInstance.skillPart),
-				skillPartCalcs = gemInstance.skillPartCalcs and tostring(gemInstance.skillPartCalcs),
-				skillStageCount = gemInstance.skillStageCount and tostring(gemInstance.skillStageCount),
-				skillStageCountCalcs = gemInstance.skillStageCountCalcs and tostring(gemInstance.skillStageCountCalcs),
-				skillMineCount = gemInstance.skillMineCount and tostring(gemInstance.skillMineCount),
-				skillMineCountCalcs = gemInstance.skillMineCountCalcs and tostring(gemInstance.skillMineCountCalcs),
-				skillMinion = gemInstance.skillMinion,
-				skillMinionCalcs = gemInstance.skillMinionCalcs,
-				skillMinionItemSet = gemInstance.skillMinionItemSet and tostring(gemInstance.skillMinionItemSet),
-				skillMinionItemSetCalcs = gemInstance.skillMinionItemSetCalcs and tostring(gemInstance.skillMinionItemSetCalcs),
-				skillMinionSkill = gemInstance.skillMinionSkill and tostring(gemInstance.skillMinionSkill),
-				skillMinionSkillCalcs = gemInstance.skillMinionSkillCalcs and tostring(gemInstance.skillMinionSkillCalcs),
-			} })
+			local gemData = data.skills[gemInstance.skillId]
+			if gemData.skillTypes and gemData.skillTypes[SkillType.CreatesMinion] then
+				socketGroupCreatesMinion = true
+				break
+			elseif gemData.addSkillTypes then
+				for i = 1, #gemData.addSkillTypes do
+					if gemData.addSkillTypes[i] == SkillType.CreatesMinion then
+						socketGroupCreatesMinion = true
+						break
+					end
+				end
+				if socketGroupCreatesMinion then
+					break
+				end
+			end
+		end
+		for _, gemInstance in ipairs(socketGroup.gemList) do
+			if socketGroupCreatesMinion then
+				t_insert(node, { elem = "Gem", attrib = {
+					nameSpec = gemInstance.nameSpec,
+					skillId = gemInstance.skillId,
+					gemId = gemInstance.gemId,
+					level = tostring(gemInstance.level),
+					quality = tostring(gemInstance.quality),
+					qualityId = gemInstance.qualityId,
+					enabled = tostring(gemInstance.enabled),
+					enableGlobal1 = tostring(gemInstance.enableGlobal1),
+					enableGlobal2 = tostring(gemInstance.enableGlobal2),
+					count = tostring(gemInstance.count),
+					skillPart = gemInstance.skillPart and tostring(gemInstance.skillPart),
+					skillPartCalcs = gemInstance.skillPartCalcs and tostring(gemInstance.skillPartCalcs),
+					skillStageCount = gemInstance.skillStageCount and tostring(gemInstance.skillStageCount),
+					skillStageCountCalcs = gemInstance.skillStageCountCalcs and tostring(gemInstance.skillStageCountCalcs),
+					skillMineCount = gemInstance.skillMineCount and tostring(gemInstance.skillMineCount),
+					skillMineCountCalcs = gemInstance.skillMineCountCalcs and tostring(gemInstance.skillMineCountCalcs),
+					skillMinion = gemInstance.skillMinion,
+					skillMinionCalcs = gemInstance.skillMinionCalcs,
+					skillMinionItemSet = gemInstance.skillMinionItemSet and tostring(gemInstance.skillMinionItemSet),
+					skillMinionItemSetCalcs = gemInstance.skillMinionItemSetCalcs and tostring(gemInstance.skillMinionItemSetCalcs),
+					skillMinionSkill = gemInstance.skillMinionSkill and tostring(gemInstance.skillMinionSkill),
+					skillMinionSkillCalcs = gemInstance.skillMinionSkillCalcs and tostring(gemInstance.skillMinionSkillCalcs),
+				} })
+			else
+				t_insert(node, { elem = "Gem", attrib = {
+					nameSpec = gemInstance.nameSpec,
+					skillId = gemInstance.skillId,
+					gemId = gemInstance.gemId,
+					level = tostring(gemInstance.level),
+					quality = tostring(gemInstance.quality),
+					qualityId = gemInstance.qualityId,
+					enabled = tostring(gemInstance.enabled),
+					enableGlobal1 = tostring(gemInstance.enableGlobal1),
+					enableGlobal2 = tostring(gemInstance.enableGlobal2),
+					count = tostring(gemInstance.count),
+					skillPart = gemInstance.skillPart and tostring(gemInstance.skillPart),
+					skillPartCalcs = gemInstance.skillPartCalcs and tostring(gemInstance.skillPartCalcs),
+					skillStageCount = gemInstance.skillStageCount and tostring(gemInstance.skillStageCount),
+					skillStageCountCalcs = gemInstance.skillStageCountCalcs and tostring(gemInstance.skillStageCountCalcs),
+					skillMineCount = gemInstance.skillMineCount and tostring(gemInstance.skillMineCount),
+					skillMineCountCalcs = gemInstance.skillMineCountCalcs and tostring(gemInstance.skillMineCountCalcs),
+				} })
+			end
 		end
 		t_insert(xml, node)
 	end


### PR DESCRIPTION
```xml
<Gem enableGlobal2="true" level="5" enableGlobal1="true" skillId="SupportIncreasedAreaOfEffectPlus" qualityId="Default" skillPart="1" gemId="Metadata/Items/Gems/SupportGemIncreasedAreaOfEffectPlus" quality="20" enabled="true" count="1" nameSpec="Awakened Increased Area of Effect" skillMinion="SummonedReaper"/>
<Gem enableGlobal2="true" level="21" enableGlobal1="true" skillId="WaterSphere" qualityId="Default" skillPart="1" gemId="Metadata/Items/Gems/SkillGemHydrosphere" quality="20" enabled="true" count="1" nameSpec="Hydrosphere" skillMinion="SummonedPhantasm"/>
<Gem enableGlobal2="false" level="21" enableGlobal1="true" skillId="BrandSupport" qualityId="Default" skillPart="1" gemId="Metadata/Items/Gems/SkillGemArcanistBrand" quality="20" enabled="true" count="1" nameSpec="Arcanist Brand" skillMinion="SummonedReaper"/>
<Gem enableGlobal2="false" level="21" enableGlobal1="true" skillId="WhirlingBlades" qualityId="Default" gemId="Metadata/Items/Gems/SkillGemWhirlingBlades" quality="20" enabled="true" count="1" nameSpec="Whirling Blades" skillMinion="SummonedPhantasm"/>
<Gem enableGlobal2="false" level="21" enableGlobal1="true" skillId="TotemMelee" qualityId="Alternate3" skillPart="1" gemId="Metadata/Items/Gems/SkillGemMeleeTotem" quality="20" enabled="true" count="1" nameSpec="Ancestral Protector" skillMinion="SummonedReaper"/>
```
Notice how many times ``SummonedPhantasm`` and ``SummonedReaper`` show up in that XML? My build folder has 30+ references to ``SummonedReaper`` and over **500 references** to ``SummonedPhantasm``. I've never played (or even made) a Summon Reaper build, and I haven't touched anything Phantasm-related since 2018.

This PR purges anything minion-related from socket groups when you save your build, unless something in that socket group creates a minion.. in which case it doesn't.