### PR TITLE
Add separate calculations for Elemental Hit area component

### DIFF
--- a/src/Data/Skills/act_dex.lua
+++ b/src/Data/Skills/act_dex.lua
@@ -2911,13 +2911,28 @@ skills["ElementalHit"] = {
 	castTime = 1,
 	parts = {
 		{
-			name = "Fire",
+			name = "Fire Attack",
+			area = false,
 		},
 		{
-			name = "Cold",
+			name = "Fire AoE",
+			area = true,
 		},
 		{
-			name = "Lightning",
+			name = "Cold Attack",
+			area = false,
+		},
+		{
+			name = "Cold AoE",
+			area = true,
+		},
+		{
+			name = "Lightning Attack",
+			area = false,
+		},
+		{
+			name = "Lightning AoE",
+			area = true,
 		},
 	},
 	baseFlags = {
@@ -2928,15 +2943,15 @@ skills["ElementalHit"] = {
 	baseMods = {
 		flag("DealNoPhysical"),
 		flag("DealNoChaos"),
-		flag("DealNoFire", { type = "SkillPart", skillPart = 2 }),
-		flag("DealNoFire", { type = "SkillPart", skillPart = 3 }),
-		flag("DealNoCold", { type = "SkillPart", skillPart = 1 }),
-		flag("DealNoCold", { type = "SkillPart", skillPart = 3 }),
-		flag("DealNoLightning", { type = "SkillPart", skillPart = 1 }),
-		flag("DealNoLightning", { type = "SkillPart", skillPart = 2 }),
-		mod("AreaOfEffect", "MORE", 80, 0, 0, { type = "ActorCondition", actor = "enemy", varList = { "Ignited", "Scorched" } }, { type = "SkillPart", skillPart = 1 }),
-		mod("AreaOfEffect", "MORE", 80, 0, 0, { type = "ActorCondition", actor = "enemy", varList = { "Chilled", "Frozen", "Brittle" } }, { type = "SkillPart", skillPart = 2 }),
-		mod("AreaOfEffect", "MORE", 80, 0, 0, { type = "ActorCondition", actor = "enemy", varList = { "Shocked", "Sapped" } }, { type = "SkillPart", skillPart = 3 }),
+		flag("DealNoFire", { type = "SkillPart", skillPartList = { 3, 4 } }),
+		flag("DealNoFire", { type = "SkillPart", skillPartList = { 5, 6 } }),
+		flag("DealNoCold", { type = "SkillPart", skillPartList = { 1, 2 } }),
+		flag("DealNoCold", { type = "SkillPart", skillPartList = { 5, 6 } }),
+		flag("DealNoLightning", { type = "SkillPart", skillPartList = { 1, 2 } }),
+		flag("DealNoLightning", { type = "SkillPart", skillPartList = { 3, 4 } }),
+		mod("AreaOfEffect", "MORE", 80, 0, 0, { type = "ActorCondition", actor = "enemy", varList = { "Ignited", "Scorched" } }, { type = "SkillPart", skillPart = 2 }),
+		mod("AreaOfEffect", "MORE", 80, 0, 0, { type = "ActorCondition", actor = "enemy", varList = { "Chilled", "Frozen", "Brittle" } }, { type = "SkillPart", skillPart = 4 }),
+		mod("AreaOfEffect", "MORE", 80, 0, 0, { type = "ActorCondition", actor = "enemy", varList = { "Shocked", "Sapped" } }, { type = "SkillPart", skillPart = 6 }),
 		mod("Multiplier:ElementalHitAilmentOnEnemy", "BASE", 1, 0, 0, { type = "ActorCondition", actor = "enemy", var = "Ignited" }),
 		mod("Multiplier:ElementalHitAilmentOnEnemy", "BASE", 1, 0, 0, { type = "ActorCondition", actor = "enemy", var = "Chilled" }),
 		mod("Multiplier:ElementalHitAilmentOnEnemy", "BASE", 1, 0, 0, { type = "ActorCondition", actor = "enemy", var = "Frozen" }),
@@ -2945,7 +2960,7 @@ skills["ElementalHit"] = {
 		mod("Multiplier:ElementalHitAilmentOnEnemy", "BASE", 1, 0, 0, { type = "ActorCondition", actor = "enemy", var = "Brittle" }),
 		mod("Multiplier:ElementalHitAilmentOnEnemy", "BASE", 1, 0, 0, { type = "ActorCondition", actor = "enemy", var = "Sapped" }),
 		mod("Damage", "MORE", 10, 0, 0, { type = "Multiplier", var = "ElementalHitAilmentOnEnemy" }),
-		skill("radius", 10),
+		skill("radius", 10, { type = "SkillPart", skillPartList = { 2, 4, 6 } }),
 	},
 	qualityStats = {
 		Default = {

--- a/src/Export/Skills/act_dex.txt
+++ b/src/Export/Skills/act_dex.txt
@@ -497,26 +497,41 @@ local skills, mod, flag, skill = ...
 #flags attack melee projectile
 	parts = {
 		{
-			name = "Fire",
+			name = "Fire Attack",
+			area = false,
 		},
 		{
-			name = "Cold",
+			name = "Fire AoE",
+			area = true,
 		},
 		{
-			name = "Lightning",
+			name = "Cold Attack",
+			area = false,
+		},
+		{
+			name = "Cold AoE",
+			area = true,
+		},
+		{
+			name = "Lightning Attack",
+			area = false,
+		},
+		{
+			name = "Lightning AoE",
+			area = true,
 		},
 	},
 #baseMod flag("DealNoPhysical")
 #baseMod flag("DealNoChaos")
-#baseMod flag("DealNoFire", { type = "SkillPart", skillPart = 2 })
-#baseMod flag("DealNoFire", { type = "SkillPart", skillPart = 3 })
-#baseMod flag("DealNoCold", { type = "SkillPart", skillPart = 1 })
-#baseMod flag("DealNoCold", { type = "SkillPart", skillPart = 3 })
-#baseMod flag("DealNoLightning", { type = "SkillPart", skillPart = 1 })
-#baseMod flag("DealNoLightning", { type = "SkillPart", skillPart = 2 })
-#baseMod mod("AreaOfEffect", "MORE", 80, 0, 0, { type = "ActorCondition", actor = "enemy", varList = { "Ignited", "Scorched" } }, { type = "SkillPart", skillPart = 1 })
-#baseMod mod("AreaOfEffect", "MORE", 80, 0, 0, { type = "ActorCondition", actor = "enemy", varList = { "Chilled", "Frozen", "Brittle" } }, { type = "SkillPart", skillPart = 2 })
-#baseMod mod("AreaOfEffect", "MORE", 80, 0, 0, { type = "ActorCondition", actor = "enemy", varList = { "Shocked", "Sapped" } }, { type = "SkillPart", skillPart = 3 })
+#baseMod flag("DealNoFire", { type = "SkillPart", skillPartList = { 3, 4 } })
+#baseMod flag("DealNoFire", { type = "SkillPart", skillPartList = { 5, 6 } })
+#baseMod flag("DealNoCold", { type = "SkillPart", skillPartList = { 1, 2 } })
+#baseMod flag("DealNoCold", { type = "SkillPart", skillPartList = { 5, 6 } })
+#baseMod flag("DealNoLightning", { type = "SkillPart", skillPartList = { 1, 2 } })
+#baseMod flag("DealNoLightning", { type = "SkillPart", skillPartList = { 3, 4 } })
+#baseMod mod("AreaOfEffect", "MORE", 80, 0, 0, { type = "ActorCondition", actor = "enemy", varList = { "Ignited", "Scorched" } }, { type = "SkillPart", skillPart = 2 })
+#baseMod mod("AreaOfEffect", "MORE", 80, 0, 0, { type = "ActorCondition", actor = "enemy", varList = { "Chilled", "Frozen", "Brittle" } }, { type = "SkillPart", skillPart = 4 })
+#baseMod mod("AreaOfEffect", "MORE", 80, 0, 0, { type = "ActorCondition", actor = "enemy", varList = { "Shocked", "Sapped" } }, { type = "SkillPart", skillPart = 6 })
 #baseMod mod("Multiplier:ElementalHitAilmentOnEnemy", "BASE", 1, 0, 0, { type = "ActorCondition", actor = "enemy", var = "Ignited" })
 #baseMod mod("Multiplier:ElementalHitAilmentOnEnemy", "BASE", 1, 0, 0, { type = "ActorCondition", actor = "enemy", var = "Chilled" })
 #baseMod mod("Multiplier:ElementalHitAilmentOnEnemy", "BASE", 1, 0, 0, { type = "ActorCondition", actor = "enemy", var = "Frozen" })
@@ -525,7 +540,7 @@ local skills, mod, flag, skill = ...
 #baseMod mod("Multiplier:ElementalHitAilmentOnEnemy", "BASE", 1, 0, 0, { type = "ActorCondition", actor = "enemy", var = "Brittle" })
 #baseMod mod("Multiplier:ElementalHitAilmentOnEnemy", "BASE", 1, 0, 0, { type = "ActorCondition", actor = "enemy", var = "Sapped" })
 #baseMod mod("Damage", "MORE", 10, 0, 0, { type = "Multiplier", var = "ElementalHitAilmentOnEnemy" })
-#baseMod skill("radius", 10)
+#baseMod skill("radius", 10, { type = "SkillPart", skillPartList = { 2, 4, 6 } })
 #mods
 
 #skill EnsnaringArrow


### PR DESCRIPTION
Fixes #856.

### Description of the problem being solved:
Elemental Hit has two damaging components: the basic attack hit (a strike or projectile), and a secondary AoE hit.

PoB currently only provides calculations for the first part, and ignores the second part. Implementing this fully has.. admittedly limited usefulness, but people **have** requested it and I don't see any harm in accurately representing how the skill actually works in-game. For comparison we already have another skill implemented that does the exact same thing: Wild Strike.

### Before screenshot:
![](http://puu.sh/IDOtZ/4ad40415af.png)
### After screenshot:
![](http://puu.sh/IDOtz/76e026d805.png)