### PR TITLE
Fix incorrect curse priority

### DIFF
--- a/src/Modules/CalcPerform.lua
+++ b/src/Modules/CalcPerform.lua
@@ -644,8 +644,9 @@ end
 
 -- Helper function to determine curse priority when processing curses beyond the curse limit
 local function determineCursePriority(curseName, skillTypes, source, slot)
+	local curseName = curseName or ""
 	local slot = slot or ""
-	local basePriority = data.cursePriority[curseName]
+	local basePriority = data.cursePriority[curseName] or 0
 	local typePriority = skillTypes[SkillType.Aura] and data.cursePriority["CurseAura"] or 0
 	local sourcePriority = source and data.cursePriority["CurseFromEquipment"] or data.cursePriority["CurseFromSkillGem"]
 	local slotPriority = data.cursePriority["AnySlotHexType"]

--- a/src/Modules/CalcPerform.lua
+++ b/src/Modules/CalcPerform.lua
@@ -1729,7 +1729,7 @@ function calcs.perform(env, avoidCache)
 					local curse = {
 						name = buff.name,
 						fromPlayer = true,
-						priority = activeSkill.skillTypes[SkillType.Aura] and 3 or 1,
+						priority = env.data.cursePriority[buff.name] + (activeSkill.skillTypes[SkillType.Aura] and 3000 or 1000) + (activeSkill.socketGroup.source ~= nil and 200 or 100),
 						isMark = mark,
 						ignoreHexLimit = modDB:Flag(activeSkill.skillCfg, "CursesIgnoreHexLimit") and not mark or false,
 						socketedCursesHexLimit = modDB:Flag(activeSkill.skillCfg, "SocketedCursesAdditionalLimit")
@@ -1812,7 +1812,7 @@ function calcs.perform(env, avoidCache)
 						if env.mode_effective and activeSkill.skillData.enable and (not enemyDB:Flag(nil, "Hexproof") or activeSkill.skillTypes[SkillType.Mark]) then
 							local curse = {
 								name = buff.name,
-								priority = 1,
+								priority = env.data.cursePriority[buff.name] + 1000 + (activeSkill.socketGroup.source ~= nil and 200 or 100),
 							}
 							local inc = skillModList:Sum("INC", skillCfg, "CurseEffect") + enemyDB:Sum("INC", nil, "CurseEffectOnSelf")
 							local more = skillModList:More(skillCfg, "CurseEffect") * enemyDB:More(nil, "CurseEffectOnSelf")
@@ -1882,7 +1882,7 @@ function calcs.perform(env, avoidCache)
 					local curse = {
 						name = grantedEffect.name,
 						fromPlayer = (dest == curses),
-						priority = 2,
+						priority = env.data.cursePriority[grantedEffect.name] + 2000,
 					}
 					curse.modList = new("ModList")
 					curse.modList:ScaleAddList(curseModList, (1 + enemyDB:Sum("INC", nil, "CurseEffectOnSelf") / 100) * enemyDB:More(nil, "CurseEffectOnSelf"))

--- a/src/Modules/CalcPerform.lua
+++ b/src/Modules/CalcPerform.lua
@@ -1729,7 +1729,7 @@ function calcs.perform(env, avoidCache)
 					local curse = {
 						name = buff.name,
 						fromPlayer = true,
-						priority = env.data.cursePriority[buff.name] + (activeSkill.skillTypes[SkillType.Aura] and 3000 or 1000) + (activeSkill.socketGroup.source ~= nil and 200 or 100),
+						priority = env.data.cursePriority[buff.name] + (activeSkill.skillTypes[SkillType.Aura] and 30000 or 10000) + (string.match(activeSkill.socketGroup.slot or "", "Ring ") and 2000 or 1000) + (activeSkill.socketGroup.source ~= nil and 200 or 100),
 						isMark = mark,
 						ignoreHexLimit = modDB:Flag(activeSkill.skillCfg, "CursesIgnoreHexLimit") and not mark or false,
 						socketedCursesHexLimit = modDB:Flag(activeSkill.skillCfg, "SocketedCursesAdditionalLimit")
@@ -1812,7 +1812,7 @@ function calcs.perform(env, avoidCache)
 						if env.mode_effective and activeSkill.skillData.enable and (not enemyDB:Flag(nil, "Hexproof") or activeSkill.skillTypes[SkillType.Mark]) then
 							local curse = {
 								name = buff.name,
-								priority = env.data.cursePriority[buff.name] + 1000 + (activeSkill.socketGroup.source ~= nil and 200 or 100),
+								priority = env.data.cursePriority[buff.name] + 10000 + (string.match(activeSkill.socketGroup.slot or "", "Ring ") and 2000 or 1000) + (activeSkill.socketGroup.source ~= nil and 200 or 100),
 							}
 							local inc = skillModList:Sum("INC", skillCfg, "CurseEffect") + enemyDB:Sum("INC", nil, "CurseEffectOnSelf")
 							local more = skillModList:More(skillCfg, "CurseEffect") * enemyDB:More(nil, "CurseEffectOnSelf")
@@ -1882,7 +1882,7 @@ function calcs.perform(env, avoidCache)
 					local curse = {
 						name = grantedEffect.name,
 						fromPlayer = (dest == curses),
-						priority = env.data.cursePriority[grantedEffect.name] + 2000,
+						priority = env.data.cursePriority[grantedEffect.name] + 20000,
 					}
 					curse.modList = new("ModList")
 					curse.modList:ScaleAddList(curseModList, (1 + enemyDB:Sum("INC", nil, "CurseEffectOnSelf") / 100) * enemyDB:More(nil, "CurseEffectOnSelf"))

--- a/src/Modules/CalcPerform.lua
+++ b/src/Modules/CalcPerform.lua
@@ -650,10 +650,20 @@ local function determineCursePriority(curseName, skillTypes, source, slot)
 	local typePriority = skillTypes[SkillType.Aura] and data.cursePriority["CurseAura"] or 0
 	local sourcePriority = source and data.cursePriority["CurseFromEquipment"] or data.cursePriority["CurseFromSkillGem"]
 	local slotPriority = data.cursePriority["AnySlotHexType"]
-	if curseName:match("'s Mark") then
+	if slot:match("Ring 1") then
+		if curseName:match("'s Mark") then
+			slotPriority = data.cursePriority["LeftRingSlotMarkType"]
+		else
+			slotPriority = data.cursePriority["LeftRingSlotHexType"]
+		end
+	elseif slot:match("Ring 2") then
+		if curseName:match("'s Mark") then
+			slotPriority = data.cursePriority["RightRingSlotMarkType"]
+		else
+			slotPriority = data.cursePriority["RightRingSlotHexType"]
+		end
+	elseif curseName:match("'s Mark") then
 		slotPriority = data.cursePriority["AnySlotMarkType"]
-	elseif slot:match("Ring %d") then
-		slotPriority = data.cursePriority["RingSlotHexType"]
 	end
 	return basePriority + typePriority + sourcePriority + slotPriority
 end

--- a/src/Modules/CalcPerform.lua
+++ b/src/Modules/CalcPerform.lua
@@ -647,7 +647,7 @@ local function determineCursePriority(curseName, slot, source)
 	local basePriority = data.cursePriority[curseName]
 	local sourcePriority = source ~= nil and 200 or 100
 	local slotPriority = 2000
-	if string.match(curseName or "", "'s Mark") ~= nil then
+	if string.match(curseName, "'s Mark") ~= nil then
 		slotPriority = 1000
 	elseif string.match(slot or "", "Ring ") ~= nil then
 		slotPriority = 3000

--- a/src/Modules/Data.lua
+++ b/src/Modules/Data.lua
@@ -269,11 +269,11 @@ data.cursePriority = {
 	["CurseFromSkillGem"] = 100,
 	["CurseFromEquipment"] = 200,
 	["AnySlotMarkType"] = 1000,
-	["LeftRingSlotMarkType"] = 2000,
-	["RightRingSlotMarkType"] = 3000,
+	["RightRingSlotMarkType"] = 2000,
+	["LeftRingSlotMarkType"] = 3000,
 	["AnySlotHexType"] = 4000,
-	["LeftRingSlotHexType"] = 5000,
-	["RightRingSlotHexType"] = 6000,
+	["RightRingSlotHexType"] = 5000,
+	["LeftRingSlotHexType"] = 6000,
 	["CurseAura"] = 10000,
 }
 

--- a/src/Modules/Data.lua
+++ b/src/Modules/Data.lua
@@ -266,6 +266,12 @@ data.cursePriority = {
 	["Elemental Weakness"] = 11,
 	["Conductivity"] = 12,
 	["Assassin's Mark"] = 13,
+	["CurseFromSkillGem"] = 100,
+	["CurseFromEquipment"] = 200,
+	["AnySlotMarkType"] = 1000,
+	["AnySlotHexType"] = 2000,
+	["RingSlotHexType"] = 3000,
+	["CurseAura"] = 10000,
 }
 
 ---@type string[] @List of all keystones not exclusive to timeless jewels.

--- a/src/Modules/Data.lua
+++ b/src/Modules/Data.lua
@@ -269,8 +269,11 @@ data.cursePriority = {
 	["CurseFromSkillGem"] = 100,
 	["CurseFromEquipment"] = 200,
 	["AnySlotMarkType"] = 1000,
-	["AnySlotHexType"] = 2000,
-	["RingSlotHexType"] = 3000,
+	["LeftRingSlotMarkType"] = 2000,
+	["RightRingSlotMarkType"] = 3000,
+	["AnySlotHexType"] = 4000,
+	["LeftRingSlotHexType"] = 5000,
+	["RightRingSlotHexType"] = 6000,
 	["CurseAura"] = 10000,
 }
 

--- a/src/Modules/Data.lua
+++ b/src/Modules/Data.lua
@@ -252,6 +252,22 @@ data.specialBaseTags = {
 	["Sceptre"] = { shaper = "sceptre_shaper", elder = "sceptre_elder", adjudicator = "sceptre_adjudicator", basilisk = "sceptre_basilisk", crusader = "sceptre_crusader", eyrie = "sceptre_eyrie", },
 }
 
+data.cursePriority = {
+	["Warlord's Mark"] = 1,
+	["Despair"] = 2, -- Vulnerability
+	["Temporal Chains"] = 3,
+	["Sniper's Mark"] = 4,
+	["Punishment"] = 5,
+	["Poacher's Mark"] = 6,
+	["Vulnerability"] = 7, -- NewVulnerability
+	["Frostbite"] = 8,
+	["Flammability"] = 9,
+	["Enfeeble"] = 10,
+	["Elemental Weakness"] = 11,
+	["Conductivity"] = 12,
+	["Assassin's Mark"] = 13,
+}
+
 ---@type string[] @List of all keystones not exclusive to timeless jewels.
 data.keystones = {
 	"Acrobatics",


### PR DESCRIPTION
Fixes #2808.

### Description of the problem being solved:
Curse on Hit from corruption implicits are always applied after Curse On Hit Support gems, and trigger mark when you hit mods on rings. Curses from rings appear to override curses from gloves. The earliest alphabetically-named curse has highest priority, up to the curse limit. Curses are applied in alphabetical order according to their internal name. Despair's internal name is Vulnerability and Vulnerability's internal name is NewVulnerability.

TL;DR:
- If you have Curse on Hit gloves: the curse from your gloves should always override Hextouch + Elemental Weakness.
- If you have a Frostbite on Hit ring, a Vulnerability on Hit ring, and Elemental Weakness on Hit gloves: Frostbite should override Vulnerability, and Vulnerability should override Elemental Weakness.
- If you have Vulnerability + Elemental Weakness on Hit gloves, Elemental Weakness should override Vulnerability.

Almost everything I just listed above PoB gets wrong in 2.13.0, as it makes no attempt to prioritize curses alphabetically, prioritize curse on hit corruptions over anything, or prioritize ring curse on hit effects over glove curse on hit effects.

I'm not 100% confident about how I'm handling triggered Marks. The wiki claims they're prioritized below implicit Curse on Hit gloves, which makes sense.. sort of.. given that the trigger effect has a cooldown, but I'm suspicious about the exact mechanics involved.

### Link to a build that showcases this PR:
https://pastebin.com/N4eu1SBZ