### PR TITLE
Fix: Power Report generating error pop-up

### DIFF
--- a/src/Classes/CalcsTab.lua
+++ b/src/Classes/CalcsTab.lua
@@ -147,6 +147,7 @@ Effective DPS: Curses and enemy properties (such as resistances and status condi
 	self.controls.breakdown = new("CalcBreakdownControl", self)
 
 	self.controls.scrollBar = new("ScrollBarControl", {"TOPRIGHT",self,"TOPRIGHT"}, 0, 0, 18, 0, 50, "VERTICAL", true)
+	self.powerBuilderInitialized = nil
 end)
 
 function CalcsTabClass:Load(xml, dbFileName)
@@ -555,6 +556,7 @@ function CalcsTabClass:PowerBuilder()
 		end
 	end
 	self.powerMax = newPowerMax
+	self.powerBuilderInitialized = true
 	--ConPrintf("Power Build time: %d ms", GetTime() - timer_start)
 end
 

--- a/src/Classes/TreeTab.lua
+++ b/src/Classes/TreeTab.lua
@@ -139,6 +139,17 @@ local TreeTabClass = newClass("TreeTab", "ControlHost", function(self, build)
 		self.showPowerReport = not self.showPowerReport
 		self:TogglePowerReport()
 	end)
+	self.controls.powerReport.enabled = function()
+		return self.build.calcsTab and self.build.calcsTab.powerBuilderInitialized
+	end
+	self.controls.powerReport.tooltipFunc = function(tooltip)
+		tooltip:Clear()
+		if not (self.build.calcsTab and self.build.calcsTab.powerBuilderInitialized) then
+			tooltip:AddLine(14, "Show Power Report is disabled until the first time")
+			tooltip:AddLine(14, "an evaluation of all nodes and clusters completes.")
+			tooltip:AddLine(14, "Thank you for your patience.")
+		end
+	end
 	self.showPowerReport = false
 
 	self.controls.specConvertText = new("LabelControl", {"BOTTOMLEFT",self.controls.specSelect,"TOPLEFT"}, 0, -14, 0, 16, "^7This is an older tree version, which may not be fully compatible with the current game version.")

--- a/src/Classes/TreeTab.lua
+++ b/src/Classes/TreeTab.lua
@@ -147,7 +147,6 @@ local TreeTabClass = newClass("TreeTab", "ControlHost", function(self, build)
 		if not (self.build.calcsTab and self.build.calcsTab.powerBuilderInitialized) then
 			tooltip:AddLine(14, "Show Power Report is disabled until the first time")
 			tooltip:AddLine(14, "an evaluation of all nodes and clusters completes.")
-			tooltip:AddLine(14, "Thank you for your patience.")
 		end
 	end
 	self.showPowerReport = false


### PR DESCRIPTION
Fixes #3895
Fixes #3464 
Fixes #3599 
Fixes #3738 

### Description of the problem being solved:
The button to `Show Power Report` is enabled prior to Cluster Notables power initialization resulting in their `node.power` not existing. The first time a DPS assessment is completed subsequent re-runs or other DPS sorts do not affect it as the cluster notables are now initialized.

It was a race-condition problem.

### Steps taken to verify a working solution:
- Tested builds that I could trigger error on before and after.

### Link to a build that showcases this PR:
https://pastebin.com/Yv86ABaz
