### PR TITLE
Relabel character import "Cancel" button to "Close"

### DIFF
--- a/src/Classes/ImportTab.lua
+++ b/src/Classes/ImportTab.lua
@@ -148,7 +148,7 @@ You can get this from your web browser's cookies while logged into the Path of E
 	self.controls.charImportItemsClearItems.tooltipText = "Delete all equipped items when importing."
 	self.controls.charBanditNote = new("LabelControl", {"TOPLEFT",self.controls.charImportHeader,"BOTTOMLEFT"}, 0, 50, 200, 14, "^7Tip: After you finish importing a character, make sure you update the bandit choice,\nas it cannot be imported.")
 
-	self.controls.charCancel = new("ButtonControl", {"TOPLEFT",self.controls.charImportHeader,"BOTTOMLEFT"}, 0, 90, 60, 20, "Cancel", function()
+	self.controls.charClose = new("ButtonControl", {"TOPLEFT",self.controls.charImportHeader,"BOTTOMLEFT"}, 0, 90, 60, 20, "Close", function()
 		self.charImportMode = "GETACCOUNTNAME"
 		self.charImportStatus = "Idle"
 	end)


### PR DESCRIPTION
### Description of the problem being solved:
Some people (@pHiney, @zao) didn't like the new label (introduced in #3898) because it implied it would undo the import

### Steps taken to verify a working solution:
- Started importing a character and clicked close

### Before screenshot:
![image](https://user-images.githubusercontent.com/90059/150664459-96da5dea-4d19-4028-bd61-9fd8f9430fd9.png)

### After screenshot:
![image](https://user-images.githubusercontent.com/90059/150664441-cfc1f6a0-4ad2-42d6-8e96-d7947edf920b.png)