### PR TITLE
Add pobb.in to website import list

### DIFF
--- a/src/Classes/ImportTab.lua
+++ b/src/Classes/ImportTab.lua
@@ -951,6 +951,7 @@ function ImportTabClass:OpenImportFromWebsitePopup()
 		{ label = "Rentry.co", id = "Rentry", matchURL = "rentry%.co/%w+", regexURL = "rentry%.co/(%w+)%s*$", downloadURL = "rentry.co/paste/%1/raw" },
 		{ label = "TinyPaste", id = "TinyPaste", matchURL = "penyacom%.org/%w+", regexURL = "penyacom%.org/[pr]%?q=(%w+)%s*$", downloadURL = "penyacom.org/r?q=%1" },
 		{ label = "PoeNinja", id = "PoeNinja", matchURL = "poe%.ninja/pob/%w+", regexURL = "poe%.ninja/pob/(%w+)%s*$", downloadURL = "poe.ninja/pob/raw/%1" },
+		{ label = "pobb.in", id = "POBBin", matchURL = "pobb%.in/%w+", regexURL = "pobb%.in/([%w-_]+)%s*$", downloadURL = "pobb.in/pob/%1" },
 	}
 	local controls = { }
 


### PR DESCRIPTION
Adds https://pobb.in to the automatic import list of pob.

* Example build: https://pobb.in/qO1_QpuQLeDd
* POB download URL: https://pobb.in/pob/qO1_QpuQLeDd

Note: IDs can contain `[a-zA-Z0-9_-]` (same character set as base64).

pastebin.com compatible post API is currently not implemented, but as far as I can tell there is no way to share to other pastebins currently anyways.

![image](https://user-images.githubusercontent.com/255721/150829605-4023f87e-9757-4166-b6da-17393840c48b.png)

![image](https://user-images.githubusercontent.com/255721/150830011-35c060e9-8217-45a8-bfa1-6bd09aa13216.png)
(Broken Font is a Linux issue)

