### PR TITLE
Add 'Delete Unused' button on the items tab

### DIFF
--- a/src/Classes/ItemListControl.lua
+++ b/src/Classes/ItemListControl.lua
@@ -40,7 +40,24 @@ local ItemListClass = newClass("ItemListControl", "ListControl", function(self, 
 	self.controls.deleteAll.enabled = function()
 		return #self.list > 0
 	end
-	self.controls.sort = new("ButtonControl", {"RIGHT",self.controls.deleteAll,"LEFT"}, -4, 0, 60, 18, "Sort", function()
+	self.controls.deleteUnused = new("ButtonControl", {"RIGHT",self.controls.deleteAll,"LEFT"}, -4, 0, 100, 18, "Delete Unused", function()
+		local delList = {}
+		for _, itemId in pairs(self.list) do
+			local slot, itemSet = self.itemsTab:GetEquippedSlotForItem(self.itemsTab.items[itemId])
+			if not slot then
+				t_insert(delList, itemId)
+			end
+		end
+		-- delete in reverse order so as to not delete the wrong item whilst deleting
+		for i = #delList, 1, -1 do
+			value = delList[i]
+			self.itemsTab:DeleteItem(self.itemsTab.items[delList[i]])
+		end
+	end)
+	self.controls.deleteUnused.enabled = function()
+		return #self.list > 0
+	end
+	self.controls.sort = new("ButtonControl", {"RIGHT",self.controls.deleteUnused,"LEFT"}, -4, 0, 60, 18, "Sort", function()
 		itemsTab:SortItemList()
 	end)
 end)

--- a/src/Classes/ItemListControl.lua
+++ b/src/Classes/ItemListControl.lua
@@ -43,14 +43,19 @@ local ItemListClass = newClass("ItemListControl", "ListControl", function(self, 
 	self.controls.deleteUnused = new("ButtonControl", {"RIGHT",self.controls.deleteAll,"LEFT"}, -4, 0, 100, 18, "Delete Unused", function()
 		local delList = {}
 		for _, itemId in pairs(self.list) do
-			local slot, itemSet = self.itemsTab:GetEquippedSlotForItem(self.itemsTab.items[itemId])
-			if not slot then
-				t_insert(delList, itemId)
+			if self.itemsTab.items[itemId].type == "Jewel" then
+				if self:FindSocketedJewel(itemId, false) == "" then
+					t_insert(delList, itemId)
+				end
+			else
+				local slot, itemSet = self.itemsTab:GetEquippedSlotForItem(self.itemsTab.items[itemId])
+				if not slot then
+					t_insert(delList, itemId)
+				end
 			end
 		end
 		-- delete in reverse order so as to not delete the wrong item whilst deleting
 		for i = #delList, 1, -1 do
-			value = delList[i]
 			self.itemsTab:DeleteItem(self.itemsTab.items[delList[i]])
 		end
 	end)


### PR DESCRIPTION
Fixes #3845.

### Description of the problem being solved:
To clean up POBs, delete all unused items.

### Steps taken to verify a working solution:
- Open any build or start a new one
- Add some items so they are marked unused
- Select 'Delete Unused' button
- Confirm all unused are deleted but no wanted items are deleted.
- Press Ctrl-Z to bring back deleted items one by one if you need (easy way to confirm the previous point)

### Link to a build that showcases this PR:
Any build

### Before screenshot:
![image](https://user-images.githubusercontent.com/4302241/151122131-50043689-3bc0-42c9-9a8a-7f5b6136c4aa.png)

### After screenshot:
![image](https://user-images.githubusercontent.com/4302241/151122256-40a35758-31a7-44b9-92eb-243ee6de7df0.png)
