### PR TITLE
Remove trailing and leading spaces from the import character name

### DIFF
--- a/src/Classes/ImportTab.lua
+++ b/src/Classes/ImportTab.lua
@@ -312,7 +312,8 @@ end
 function ImportTabClass:DownloadCharacterList()
 	self.charImportMode = "DOWNLOADCHARLIST"
 	self.charImportStatus = "Retrieving character list..."
-	local accountName = string.gsub(self.controls.accountName.buf, '%s+', '')  -- Trim Trailing/Leading spaces
+	  -- Trim Trailing/Leading spaces
+	local accountName = self.controls.accountName.buf:gsub('%s+', '')
 	local realm = realmList[self.controls.accountRealm.selIndex]
 	local sessionID = #self.controls.sessionInput.buf == 32 and self.controls.sessionInput.buf or (main.gameAccounts[accountName] and main.gameAccounts[accountName].sessionID)
 	launch:DownloadPage(realm.hostName.."character-window/get-characters?accountName="..accountName.."&realm="..realm.realmCode, function(page, errMsg)

--- a/src/Classes/ImportTab.lua
+++ b/src/Classes/ImportTab.lua
@@ -312,7 +312,7 @@ end
 function ImportTabClass:DownloadCharacterList()
 	self.charImportMode = "DOWNLOADCHARLIST"
 	self.charImportStatus = "Retrieving character list..."
-	local accountName = self.controls.accountName.buf
+	local accountName = string.gsub(self.controls.accountName.buf, '%s+', '')  -- Trim Trailing/Leading spaces
 	local realm = realmList[self.controls.accountRealm.selIndex]
 	local sessionID = #self.controls.sessionInput.buf == 32 and self.controls.sessionInput.buf or (main.gameAccounts[accountName] and main.gameAccounts[accountName].sessionID)
 	launch:DownloadPage(realm.hostName.."character-window/get-characters?accountName="..accountName.."&realm="..realm.realmCode, function(page, errMsg)


### PR DESCRIPTION
Fixes #3870.

### Description of the problem being solved:
Whitespaces were not being removed from the character name on the import tab

### Steps taken to verify a working solution:
- Open a new build
- Select import
- paste in " xyllywyt "
- Select Start
- Note characters are listed
- Select Done
- Note the spaces that were there (in character name) are gone.

### Link to a build that showcases this PR:
N/A

### Before screenshot:
![image](https://user-images.githubusercontent.com/4302241/151109113-e1644e48-2726-4a1a-92d7-436db2ae63f0.png)

### After screenshot:
![image](https://user-images.githubusercontent.com/4302241/151109171-85c04903-c659-4fcb-bf37-7d9daa15d66e.png)

I have not tested special character names cause i don't know one