### PR TITLE
Fix infinite reservation error with Relic of the Pact

### DIFF
--- a/src/Data/Skills/other.lua
+++ b/src/Data/Skills/other.lua
@@ -371,7 +371,7 @@ skills["BloodSacramentUnique"] = {
 	fromItem = true,
 	initialFunc = function(activeSkill, output)
 		local lifeReservedPercent = activeSkill.skillData["LifeReservedPercent"] or 3
-		local lifeReserved = activeSkill.skillData["LifeReservedBase"]
+		local lifeReserved = activeSkill.skillData["LifeReservedBase"] or math.huge
 		activeSkill.skillModList:NewMod("Multiplier:ChannelledLifeReservedPercentPerStage", "BASE", lifeReservedPercent, "Blood Sacrament")
 		activeSkill.skillModList:NewMod("Multiplier:ChannelledLifeReservedPerStage", "BASE", lifeReserved, "Blood Sacrament")
 	end,

--- a/src/Export/Skills/other.txt
+++ b/src/Export/Skills/other.txt
@@ -137,7 +137,7 @@ local skills, mod, flag, skill = ...
 	fromItem = true,
 	initialFunc = function(activeSkill, output)
 		local lifeReservedPercent = activeSkill.skillData["LifeReservedPercent"] or 3
-		local lifeReserved = activeSkill.skillData["LifeReservedBase"]
+		local lifeReserved = activeSkill.skillData["LifeReservedBase"] or math.huge
 		activeSkill.skillModList:NewMod("Multiplier:ChannelledLifeReservedPercentPerStage", "BASE", lifeReservedPercent, "Blood Sacrament")
 		activeSkill.skillModList:NewMod("Multiplier:ChannelledLifeReservedPerStage", "BASE", lifeReserved, "Blood Sacrament")
 	end,


### PR DESCRIPTION
Fixes #3796.

### Description of the problem being solved:
``activeSkill.skillData["LifeReservedBase"]`` in ``skills["BloodSacramentUnique"] `` returns ``nil`` with 2x Essence Worm equipped. The correct value is ``math.huge``, as the in-game behavior with 2x Essence Worm equipped is all reservation values are set to ``2^32-1``:
![](http://puu.sh/IF2IL/f7b081e360.png)

### Link to a build that showcases this PR:
https://pastebin.com/Rb3DwUyL
### Before screenshot:
![](https://i.imgur.com/zxBIBKD.png)
### After screenshot:
![](http://puu.sh/IF2An/363d834033.png)
