### PR TITLE
Add partial support for Fleshcrafter

### DIFF
--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -2589,6 +2589,8 @@ local specialModList = {
 		mod("MinionModifier", "LIST", { mod = mod("Speed", "INC", 50, { type = "Condition", neg = true, var = "NeverCrit"}) }),
 		mod("MinionModifier", "LIST", { mod = mod("ChaosDegen", "BASE", 1, {type = "PercentStat", stat = "Life", percent = 20},{ type = "Condition", neg = true, var = "NeverCrit"}) }),
 	} end,
+	["chaos damage does not bypass minions' energy shield"] = function(num, _, div) return { mod("MinionModifier", "LIST", { mod = flag("ChaosNotBypassEnergyShield") }) } end,
+	["while minions have energy shield, their hits ignore monster elemental resistances"] = function(num) return { mod("MinionModifier", "LIST", { mod = flag("IgnoreElementalResistances", { type = "StatThreshold", stat = "EnergyShield", threshold = 1 }) }) } end,
 	-- Projectiles
 	["skills chain %+(%d) times"] = function(num) return { mod("ChainCountMax", "BASE", num) } end,
 	["skills chain an additional time while at maximum frenzy charges"] = { mod("ChainCountMax", "BASE", 1, { type = "StatThreshold", stat = "FrenzyCharges", thresholdStat = "FrenzyChargesMax" }) },


### PR DESCRIPTION
Fixes #3673 

### Description of the problem being solved:
Fleshcrafter unique has several minion related modifiers. This adds support for ignoring enemy resistances and not bypassing ES.
The conversion mod is not easily supportable. The current calculation order is: conversion > reservation > defence(resists) while it needs to know the resists before conversion.

### Steps taken to verify a working solution:
- Equip Fleshcrafter and a minion spell
- Check minion stats

### Link to a build that showcases this PR:
https://pastebin.com/9HDdd0Bc
### Before screenshot:
![image](https://user-images.githubusercontent.com/18018499/151253671-a287db5a-ac22-4079-8377-e1f112b85ec5.png)
![image](https://user-images.githubusercontent.com/18018499/151253693-e11e5031-8b2d-40b7-9dc3-4c52656d46a3.png)

### After screenshot:
![image](https://user-images.githubusercontent.com/18018499/151253227-c6dd121b-f28d-4645-9edf-60c46fe5940b.png)
![image](https://user-images.githubusercontent.com/18018499/151253287-f96cde07-123f-4af2-8787-7a5e9d73caab.png)
