### PR TITLE
Updated Kraityn's passive attributes based on 3.16

### DIFF
--- a/src/Modules/Build.lua
+++ b/src/Modules/Build.lua
@@ -15,7 +15,7 @@ local s_format = string.format
 local banditDropList = {
 	{ label = "2 Passive Points", id = "None" },
 	{ label = "Oak (Life Regen, Phys.Dmg. Reduction, Phys.Dmg)", id = "Oak" },
-	{ label = "Kraityn (Attack/Cast Speed, Avoid.Ele.Ailments, Move Speed)", id = "Kraityn" },
+	{ label = "Kraityn (Attack/Cast Speed, Avoid Elemental Ailments, Move Speed)", id = "Kraityn" },
 	{ label = "Alira (Mana Regen, Crit Multiplier, Resists)", id = "Alira" },
 }
 
@@ -501,6 +501,9 @@ function buildMode:Init(dbFileName, buildName, buildXML, convertBuild)
 		self.modFlag = true
 		self.buildFlag = true
 	end)
+	self.controls.bandit.maxDroppedWidth = 500
+	self.controls.bandit.enableDroppedWidth = true
+	self.controls.bandit:CheckDroppedWidth(true)
 	self.controls.banditLabel = new("LabelControl", {"BOTTOMLEFT",self.controls.bandit,"TOPLEFT"}, 0, 0, 0, 14, "^7Bandit:")
 	-- The Pantheon
 	local function applyPantheonDescription(tooltip, mode, index, value)

--- a/src/Modules/Build.lua
+++ b/src/Modules/Build.lua
@@ -502,7 +502,6 @@ function buildMode:Init(dbFileName, buildName, buildXML, convertBuild)
 		self.buildFlag = true
 	end)
 	self.controls.bandit.maxDroppedWidth = 500
-	self.controls.bandit.enableDroppedWidth = true
 	self.controls.bandit:CheckDroppedWidth(true)
 	self.controls.banditLabel = new("LabelControl", {"BOTTOMLEFT",self.controls.bandit,"TOPLEFT"}, 0, 0, 0, 14, "^7Bandit:")
 	-- The Pantheon

--- a/src/Modules/Build.lua
+++ b/src/Modules/Build.lua
@@ -15,7 +15,7 @@ local s_format = string.format
 local banditDropList = {
 	{ label = "2 Passive Points", id = "None" },
 	{ label = "Oak (Life Regen, Phys.Dmg. Reduction, Phys.Dmg)", id = "Oak" },
-	{ label = "Kraityn (Attack/Cast Speed, Attack Dodge, Move Speed)", id = "Kraityn" },
+	{ label = "Kraityn (Attack/Cast Speed, Avoid.Ele.Ailments, Move Speed)", id = "Kraityn" },
 	{ label = "Alira (Mana Regen, Crit Multiplier, Resists)", id = "Alira" },
 }
 

--- a/src/Modules/CalcSetup.lua
+++ b/src/Modules/CalcSetup.lua
@@ -418,7 +418,10 @@ function calcs.initEnv(build, mode, override, specEnv)
 			modDB:NewMod("ElementalResist", "BASE", 15, "Bandit")
 		elseif build.bandit == "Kraityn" then
 			modDB:NewMod("Speed", "INC", 6, "Bandit")
-			modDB:NewMod("AttackDodgeChance", "BASE", 3, "Bandit")
+			modDB:NewMod("AvoidShock", "BASE", 10, "Bandit")
+			modDB:NewMod("AvoidFreeze", "BASE", 10, "Bandit")
+			modDB:NewMod("AvoidChill", "BASE", 10, "Bandit")
+			modDB:NewMod("AvoidIgnite", "BASE", 10, "Bandit")
 			modDB:NewMod("MovementSpeed", "INC", 6, "Bandit")
 		elseif build.bandit == "Oak" then
 			modDB:NewMod("LifeRegenPercent", "BASE", 1, "Bandit")


### PR DESCRIPTION
### Description of the problem being solved:
The bandit Kraityn's passives were updated from 3% Attack Dodge Chance to 10% Chance to Avoid Elemental Ailments in 3.16.
Wiki for reference: https://www.poewiki.net/wiki/Deal_with_the_Bandits#Version_history

This change updates Kraityn's passive to be in line with the latest patch.

### Steps taken to verify a working solution:
- Ran PathOfBuilding locally with introduced change
- Verified that ignite, shock, chill, and freeze ailment avoidance had a line with value 10 / Bandit when Kraityn was selected.
- Verified that the bandit dropdown worked as intended and that the text fit in space available as much as possible.

### Link to a build that showcases this PR:

https://pastebin.com/E1jvWMJt

### Before screenshot:
![image](https://user-images.githubusercontent.com/1152648/151276234-63e0cf93-0163-4c35-a7b2-bdffc1acf2c1.png)
![image](https://user-images.githubusercontent.com/1152648/151276273-426d1353-4f40-4bfc-a11e-a6b3586aa23e.png)

### After screenshot:
![image](https://user-images.githubusercontent.com/1152648/151276053-37326ecb-4973-4908-87eb-f124c04b6dc7.png)
![image](https://user-images.githubusercontent.com/1152648/151283963-94dc2c46-aa3b-456c-9eb6-bacad708a933.png)


