### PR TITLE
Add support for flask charge generation

### DIFF
--- a/src/Classes/ItemsTab.lua
+++ b/src/Classes/ItemsTab.lua
@@ -2684,6 +2684,23 @@ function ItemsTabClass:AddItemTooltip(tooltip, item, slot, dbMode)
 		if gainMod ~= 1 then
 			t_insert(stats, s_format("^8Charge gain modifier: ^7%+d%%", gainMod * 100 - 100))
 		end
+
+		-- charge generation
+		local chargesGenerated = modDB:Sum("BASE", nil, "FlaskChargesGenerated")
+		if item.base.flask.life then
+			chargesGenerated = chargesGenerated + modDB:Sum("BASE", nil, "LifeFlaskChargesGenerated")
+		end
+		if item.base.flask.mana then
+			chargesGenerated = chargesGenerated + modDB:Sum("BASE", nil, "ManaFlaskChargesGenerated")
+		end
+		if item.base.flask.utility then
+			chargesGenerated = chargesGenerated + modDB:Sum("BASE", nil, "UtilityFlaskChargesGenerated")
+		end
+		chargesGenerated = chargesGenerated * gainMod
+		if chargesGenerated > 0 then
+			t_insert(stats, s_format("^8Charges generated: ^7%s^8 every ^7%s^8 seconds", chargesGenerated * 3, 3))
+		end
+
 		if stats[1] then
 			tooltip:AddLine(14, "^7Effective flask stats:")
 			for _, stat in ipairs(stats) do

--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -2873,6 +2873,18 @@ local specialModList = {
 	["(%d+)%% less flask charges gained from kills"] = function(num) return {
 		mod("FlaskChargesGained", "MORE", -num,"from Kills")
 	} end,
+	["flasks gain (%d+) charges? every (%d+) seconds"] = function(num, _, div) return {
+		mod("FlaskChargesGenerated", "BASE", num / div)
+	} end,
+	["utility flasks gain (%d+) charges? every (%d+) seconds"] = function(num, _, div) return {
+		mod("UtilityFlaskChargesGenerated", "BASE", num / div)
+	} end,
+	["life flasks gain (%d+) charges? every (%d+) seconds"] = function(num, _, div) return {
+		mod("LifeFlaskChargesGenerated", "BASE", num / div)
+	} end,
+	["mana flasks gain (%d+) charges? every (%d+) seconds"] = function(num, _, div) return {
+		mod("ManaFlaskChargesGenerated", "BASE", num / div)
+	} end,
 	-- Jewels
 	["passives in radius can be allocated without being connected to your tree"] = { mod("JewelData", "LIST", { key = "intuitiveLeapLike", value = true }) },
 	["affects passives in small ring"] = { mod("JewelData", "LIST", { key = "radiusIndex", value = 4 }) },


### PR DESCRIPTION
This adds support for generic/life/mana/utility flask charge generation
(such as Pathfinder, flask charge generation nodes in ranger area and
masteries).

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>

![image](https://user-images.githubusercontent.com/5115805/151671158-8f20ae8e-efb1-4f6a-ae6b-1b655245ff65.png)

Example POB:

https://pastebin.com/vUBSXqZ9