### PR TITLE
Add support for flask charge generation and uptime

### DIFF
--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -2873,6 +2873,21 @@ local specialModList = {
 	["(%d+)%% less flask charges gained from kills"] = function(num) return {
 		mod("FlaskChargesGained", "MORE", -num,"from Kills")
 	} end,
+	["flasks gain (%d+) charges? every (%d+) seconds"] = function(num, _, div) return {
+		mod("FlaskChargesGenerated", "BASE", num / div)
+	} end,
+	["utility flasks gain (%d+) charges? every (%d+) seconds"] = function(num, _, div) return {
+		mod("UtilityFlaskChargesGenerated", "BASE", num / div)
+	} end,
+	["life flasks gain (%d+) charges? every (%d+) seconds"] = function(num, _, div) return {
+		mod("LifeFlaskChargesGenerated", "BASE", num / div)
+	} end,
+	["mana flasks gain (%d+) charges? every (%d+) seconds"] = function(num, _, div) return {
+		mod("ManaFlaskChargesGenerated", "BASE", num / div)
+	} end,
+	["flasks gain (%d+) charges? per empty flask slot every (%d+) seconds"] = function(num, _, div) return {
+		mod("FlaskChargesGeneratedPerEmptyFlask", "BASE", num / div)
+	} end,
 	-- Jewels
 	["passives in radius can be allocated without being connected to your tree"] = { mod("JewelData", "LIST", { key = "intuitiveLeapLike", value = true }) },
 	["affects passives in small ring"] = { mod("JewelData", "LIST", { key = "radiusIndex", value = 4 }) },


### PR DESCRIPTION
This adds support for generic/life/mana/utility flask charge generation
(such as Pathfinder, flask charge generation nodes in ranger area and
masteries) and also Traitor keystone.

It also adds support for uptime what accounts for duration breakpoints
so it is accurate.

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>

![image](https://user-images.githubusercontent.com/5115805/151713663-e45af717-1bcd-48a8-8e37-a3174dd0ec49.png)

Example POB:

https://pastebin.com/2DdA2JZt