### PR TITLE
Fixed Crown Of Eyes and its Iron Will/spell damage scaling

### DIFF
--- a/src/Data/ModCache.lua
+++ b/src/Data/ModCache.lua
@@ -3779,7 +3779,7 @@ c["+2% Chance to Block Spell Damage while holding a Shield"]={{[1]={[1]={type="C
 c["20% increased Life Recovery Rate if you've taken Fire Damage from an Enemy Hit Recently"]={{[1]={[1]={type="Condition",var="TakenFireDamageFromEnemyHitRecently"},flags=0,keywordFlags=0,name="LifeRecoveryRate",type="INC",value=20}},nil}
 c["30% increased Trap Trigger Area of Effect"]={{[1]={flags=0,keywordFlags=0,name="TrapTriggerAreaOfEffect",type="INC",value=30}},nil}
 c["30% increased Effect of Impales you inflict with Two Handed Weapons on Non-Impaled Enemies"]={{[1]={flags=268435460,keywordFlags=0,name="ImpaleEffect",type="INC",value=30}},"   on Non-Impaled Enemies "}
-c["Increases and Reductions to Spell Damage also apply to Attacks at 150% of their value"]={{[1]={flags=0,keywordFlags=0,name="SpellDamageAppliesToAttacks",type="FLAG",value=true},[2]={flags=0,keywordFlags=0,name="ImprovedSpellDamageAppliesToAttacks",type="INC",value=150}},nil}
+c["Increases and Reductions to Spell Damage also apply to Attacks at 150% of their value"]={{[1]={flags=0,keywordFlags=0,name="SpellDamageAppliesToAttacks",type="FLAG",value=true},[2]={flags=0,keywordFlags=0,name="ImprovedSpellDamageAppliesToAttacks",type="MAX",value=150}},nil}
 c["+5 to maximum Life"]={{[1]={flags=0,keywordFlags=0,name="Life",type="BASE",value=5}},nil}
 c["16% increased Mana Reservation Efficiency of Skills"]={{[1]={flags=0,keywordFlags=0,name="ManaReservationEfficiency",type="INC",value=16}},nil}
 c["Sap Enemies when you Block their Damage"]={nil,"Sap Enemies when you Block their Damage "}


### PR DESCRIPTION
Fixes #3994 .

### Description of the problem being solved:
Looks like the ModCache wasn't updated when the INC to MAX enhancement was done which broke the check for `ImprovedSpellDamageAppliesToAttacks`

### Steps taken to verify a working solution:
- Added Crown Of Eyes with Iron Will and verified both Iron Will and regular spell damage nodes applied to attack damage as expected.

### Link to a build that showcases this PR:
https://pastebin.com/b7tmAw4S

### Before screenshot:
![image](https://user-images.githubusercontent.com/1152648/151695809-c6b9ec5e-af39-43a6-8408-217ea22ae729.png)
![image](https://user-images.githubusercontent.com/1152648/151695912-2087c4ad-ee27-449c-90b4-d7682c192632.png)

### After screenshot:
![image](https://user-images.githubusercontent.com/1152648/151695832-2255b0f3-4d61-4f96-85fe-303e26e080cb.png)
![image](https://user-images.githubusercontent.com/1152648/151695878-5be3d738-099d-4701-a404-be23946d6d29.png)
