### PR TITLE
feat: Add support for new Precision Technique Keystone

### DIFF
--- a/src/Modules/CalcOffence.lua
+++ b/src/Modules/CalcOffence.lua
@@ -1441,7 +1441,7 @@ function calcs.offence(env, actor, activeSkill)
 		end
 
 		-- Check Precise Technique Keystone condition per pass as MH/OH might have different values
-		local condName = pass.label == "Main Hand" and "MHAccRatingHigherThanMaxLife" or "OHAccRatingHigherThanMaxLife"
+		local condName = pass.label:gsub(" ", "") .. "AccRatingHigherThanMaxLife"
 		skillModList.conditions[condName] = output.Accuracy > env.player.output.LifeUnreserved
 
 		-- Calculate attack/cast speed

--- a/src/Modules/CalcOffence.lua
+++ b/src/Modules/CalcOffence.lua
@@ -1440,6 +1440,10 @@ function calcs.offence(env, actor, activeSkill)
 			end
 		end
 
+		-- Check Precise Technique Keystone condition per pass as MH/OH might have different values
+		local condName = pass.label == "Main Hand" and "MHAccRatingHigherThanMaxLife" or "OHAccRatingHigherThanMaxLife"
+		skillModList.conditions[condName] = output.Accuracy > env.player.output.LifeUnreserved
+
 		-- Calculate attack/cast speed
 		if activeSkill.activeEffect.grantedEffect.castTime == 0 and not skillData.castTimeOverride then
 			output.Time = 0

--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -1605,8 +1605,8 @@ local specialModList = {
 		mod("PhysicalMax", "BASE", tonumber(max), nil, ModFlag.Melee, KeywordFlag.Attack, { type = "PerStat", stat = "Dex", div = tonumber(dex) }, { type = "Condition", var = "Unencumbered" }),
 	} end,
 	["(%d+)%% more attack damage if accuracy rating is higher than maximum life"] = function(num) return { 
-		mod("Damage", "MORE", num, "Damage", ModFlag.Attack, { type = "Condition", var = "MHAccRatingHigherThanMaxLife" }, { type = "Condition", var = "MainHandAttack" }),
-		mod("Damage", "MORE", num, "Damage", ModFlag.Attack, { type = "Condition", var = "OHAccRatingHigherThanMaxLife" }, { type = "Condition", var = "OffHandAttack" }),
+		mod("Damage", "MORE", num, "Damage", ModFlag.Attack, { type = "Condition", var = "MainHandAccRatingHigherThanMaxLife" }, { type = "Condition", var = "MainHandAttack" } ),
+		mod("Damage", "MORE", num, "Damage", ModFlag.Attack, { type = "Condition", var = "OffHandAccRatingHigherThanMaxLife" }, { type = "Condition", var = "OffHandAttack" } ),
 	} end,
 	-- Masteries
 	["off hand accuracy is equal to main hand accuracy while wielding a sword"] = { flag("Condition:OffHandAccuracyIsMainHandAccuracy", { type = "Condition", var = "UsingSword" }) },

--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -1098,7 +1098,7 @@ local modTagList = {
 	["w?h?i[lf]e? you have at least (%d+) strength"] = function(num) return { tag = { type = "StatThreshold", stat = "Str", threshold = num } } end,
 	["w?h?i[lf]e? you have at least (%d+) dexterity"] = function(num) return { tag = { type = "StatThreshold", stat = "Dex", threshold = num } } end,
 	["w?h?i[lf]e? you have at least (%d+) intelligence"] = function(num) return { tag = { type = "StatThreshold", stat = "Int", threshold = num } } end,
-	["at least (%d+) intelligence"] = function(num) return { tag = { type = "StatThreshold", stat = "Int", threshold = num } } end, -- lol
+	["at least (%d+) intelligence"] = function(num) return { tag = { type = "StatThreshold", stat = "Int", threshold = num } } end,
 	["if dexterity is higher than intelligence"] = { tag = { type = "Condition", var = "DexHigherThanInt" } },
 	["if strength is higher than intelligence"] = { tag = { type = "Condition", var = "StrHigherThanInt" } },
 	["w?h?i[lf]e? you have at least (%d+) maximum energy shield"] = function(num) return { tag = { type = "StatThreshold", stat = "EnergyShield", threshold = num } } end,
@@ -1603,6 +1603,10 @@ local specialModList = {
 	["adds (%d+) to (%d+) attack physical damage to melee skills per (%d+) dexterity while you are unencumbered"] = function(_, min, max, dex) return { -- Hollow Palm 3 suffixes
 		mod("PhysicalMin", "BASE", tonumber(min), nil, ModFlag.Melee, KeywordFlag.Attack, { type = "PerStat", stat = "Dex", div = tonumber(dex) }, { type = "Condition", var = "Unencumbered" }),
 		mod("PhysicalMax", "BASE", tonumber(max), nil, ModFlag.Melee, KeywordFlag.Attack, { type = "PerStat", stat = "Dex", div = tonumber(dex) }, { type = "Condition", var = "Unencumbered" }),
+	} end,
+	["(%d+)%% more attack damage if accuracy rating is higher than maximum life"] = function(num) return { 
+		mod("Damage", "MORE", num, "Damage", ModFlag.Attack, { type = "Condition", var = "MHAccRatingHigherThanMaxLife" }, { type = "Condition", var = "MainHandAttack" }),
+		mod("Damage", "MORE", num, "Damage", ModFlag.Attack, { type = "Condition", var = "OHAccRatingHigherThanMaxLife" }, { type = "Condition", var = "OffHandAttack" }),
 	} end,
 	-- Masteries
 	["off hand accuracy is equal to main hand accuracy while wielding a sword"] = { flag("Condition:OffHandAccuracyIsMainHandAccuracy", { type = "Condition", var = "UsingSword" }) },


### PR DESCRIPTION
Adds support for:
`40% more Attack Damage if Accuracy Rating is higher than Maximum Life`

Implementation:
I had to separate the check into MainHand and OffHand as different Accuracy Ratings can exist between the two.

Tested:
- [x] Not Dual Wield - MainHand Accuracy > Max Life
- [x] Not Dual Wield - MainHand Accuracy <= Max Life
- [x] Dual Wield - Main Hand & Off Hand Accuracy > Max Life
- [x] Dual Wield - Main Hand & Off Hand Accuracy < Max Life
- [x] Dual Wield - Main Hand > Max Life & Off Hand Accuracy < Max Life
- [x] Dual Wield - Main Hand < Max Life & Off Hand Accuracy > Max Life

Test Build:
`https://pastebin.com/9En0skth`
Just Use different Weapon and Shield combos in the build.
Stat is added manually to the `Le Heup` ring.