### PR TITLE
Fix Vaal BV hit rate override being too high

### DIFF
--- a/src/Data/Skills/act_dex.lua
+++ b/src/Data/Skills/act_dex.lua
@@ -1010,12 +1010,9 @@ skills["VaalBladeVortex"] = {
 	skillTypes = { [SkillType.Spell] = true, [SkillType.Damage] = true, [SkillType.Area] = true, [SkillType.Duration] = true, [SkillType.Totemable] = true, [SkillType.TotemCastsAlone] = true, [SkillType.Vaal] = true, [SkillType.AreaSpell] = true, [SkillType.Physical] = true, },
 	statDescriptionScope = "skill_stat_descriptions",
 	castTime = 0.8,
-	preDamageFunc = function(activeSkill, output)
-		activeSkill.skillData.hitTimeOverride = activeSkill.skillData.hitFrequency
-	end,
 	statMap = {
 		["base_blade_vortex_hit_rate_ms"] = {
-			skill("hitFrequency", nil),
+			skill("hitTimeOverride", nil),
 			div = 1000,
 		},
 	},

--- a/src/Data/Skills/act_dex.lua
+++ b/src/Data/Skills/act_dex.lua
@@ -1016,7 +1016,7 @@ skills["VaalBladeVortex"] = {
 		duration = true,
 	},
 	baseMods = {
-		skill("hitTimeOverride", 0.133),
+		skill("hitTimeOverride", 0.200),
 		skill("radius", 15),
 	},
 	qualityStats = {

--- a/src/Data/Skills/act_dex.lua
+++ b/src/Data/Skills/act_dex.lua
@@ -1010,13 +1010,21 @@ skills["VaalBladeVortex"] = {
 	skillTypes = { [SkillType.Spell] = true, [SkillType.Damage] = true, [SkillType.Area] = true, [SkillType.Duration] = true, [SkillType.Totemable] = true, [SkillType.TotemCastsAlone] = true, [SkillType.Vaal] = true, [SkillType.AreaSpell] = true, [SkillType.Physical] = true, },
 	statDescriptionScope = "skill_stat_descriptions",
 	castTime = 0.8,
+	preDamageFunc = function(activeSkill, output)
+		activeSkill.skillData.hitTimeOverride = activeSkill.skillData.hitFrequency
+	end,
+	statMap = {
+		["base_blade_vortex_hit_rate_ms"] = {
+			skill("hitFrequency", nil),
+			div = 1000,
+		},
+	},
 	baseFlags = {
 		spell = true,
 		area = true,
 		duration = true,
 	},
 	baseMods = {
-		skill("hitTimeOverride", 0.200),
 		skill("radius", 15),
 	},
 	qualityStats = {

--- a/src/Export/Skills/act_dex.txt
+++ b/src/Export/Skills/act_dex.txt
@@ -212,7 +212,15 @@ local skills, mod, flag, skill = ...
 
 #skill VaalBladeVortex
 #flags spell area duration
-#baseMod skill("hitTimeOverride", 0.2)
+	preDamageFunc = function(activeSkill, output)
+		activeSkill.skillData.hitTimeOverride = activeSkill.skillData.hitFrequency
+	end,
+	statMap = {
+		["base_blade_vortex_hit_rate_ms"] = {
+			skill("hitFrequency", nil),
+			div = 1000,
+		},
+	},
 #baseMod skill("radius", 15)
 #mods
 

--- a/src/Export/Skills/act_dex.txt
+++ b/src/Export/Skills/act_dex.txt
@@ -212,12 +212,9 @@ local skills, mod, flag, skill = ...
 
 #skill VaalBladeVortex
 #flags spell area duration
-	preDamageFunc = function(activeSkill, output)
-		activeSkill.skillData.hitTimeOverride = activeSkill.skillData.hitFrequency
-	end,
 	statMap = {
 		["base_blade_vortex_hit_rate_ms"] = {
-			skill("hitFrequency", nil),
+			skill("hitTimeOverride", nil),
 			div = 1000,
 		},
 	},

--- a/src/Export/Skills/act_dex.txt
+++ b/src/Export/Skills/act_dex.txt
@@ -212,7 +212,7 @@ local skills, mod, flag, skill = ...
 
 #skill VaalBladeVortex
 #flags spell area duration
-#baseMod skill("hitTimeOverride", 0.133)
+#baseMod skill("hitTimeOverride", 0.2)
 #baseMod skill("radius", 15)
 #mods
 


### PR DESCRIPTION
Fixes # .

### Description of the problem being solved:


### Steps taken to verify a working solution:
- Open PoB
- Select Vaal Blade Vortex as a gem
- Check the amount of hits/sec in the DPS calculator

### Link to a build that showcases this PR:
N/A

### Before screenshot:
![Test](https://user-images.githubusercontent.com/98837448/152016413-e5cd37ab-6383-464d-989d-05e261650068.png)
### After screenshot:
![NVIDIA_Share_DAMWwL2ZDT](https://user-images.githubusercontent.com/31558976/152077465-261da965-de14-4b0d-80c4-e3af7cdd288c.png)

