### PR TITLE
fix: redo how useFullDPS is calculated

### DIFF
--- a/src/Classes/ItemsTab.lua
+++ b/src/Classes/ItemsTab.lua
@@ -2691,7 +2691,7 @@ function ItemsTabClass:AddItemTooltip(tooltip, item, slot, dbMode)
 			end
 		end
 		local storedGlobalCacheDPSView = GlobalCache.useFullDPS
-		GlobalCache.useFullDPS = calcBase.FullDPS ~= nil
+		GlobalCache.useFullDPS = GlobalCache.numActiveSkillInFullDPS > 0
 		local output = calcFunc({ toggleFlask = item }, {})
 		GlobalCache.useFullDPS = storedGlobalCacheDPSView
 		local header
@@ -2731,7 +2731,7 @@ function ItemsTabClass:AddItemTooltip(tooltip, item, slot, dbMode)
 		for _, slot in pairs(compareSlots) do
 			local selItem = self.items[slot.selItemId]
 			local storedGlobalCacheDPSView = GlobalCache.useFullDPS
-			GlobalCache.useFullDPS = calcBase.FullDPS ~= nil
+			GlobalCache.useFullDPS = GlobalCache.numActiveSkillInFullDPS > 0
 			local output = calcFunc({ repSlotName = slot.slotName, repItem = item ~= selItem and item }, {})
 			GlobalCache.useFullDPS = storedGlobalCacheDPSView
 			local header

--- a/src/Classes/SkillsTab.lua
+++ b/src/Classes/SkillsTab.lua
@@ -633,7 +633,7 @@ function SkillsTabClass:CreateGemSlot(index)
 				self.displayGroup.gemList[index].qualityId = hoveredQuality.type
 				self:ProcessSocketGroup(self.displayGroup)
 				local storedGlobalCacheDPSView = GlobalCache.useFullDPS
-				GlobalCache.useFullDPS = calcBase.FullDPS ~= nil
+				GlobalCache.useFullDPS = GlobalCache.numActiveSkillInFullDPS > 0
 				local output = calcFunc({}, {})
 				GlobalCache.useFullDPS = storedGlobalCacheDPSView
 				self.displayGroup.gemList[index].qualityId = tempQual
@@ -668,7 +668,7 @@ function SkillsTabClass:CreateGemSlot(index)
 					local storedQuality = self.displayGroup.gemList[index].quality
 					self.displayGroup.gemList[index].quality = 20
 					local storedGlobalCacheDPSView = GlobalCache.useFullDPS
-					GlobalCache.useFullDPS = calcBase.FullDPS ~= nil
+					GlobalCache.useFullDPS = GlobalCache.numActiveSkillInFullDPS > 0
 					local output = calcFunc({}, {})
 					GlobalCache.useFullDPS = storedGlobalCacheDPSView
 					self.displayGroup.gemList[index].quality = storedQuality
@@ -708,7 +708,7 @@ function SkillsTabClass:CreateGemSlot(index)
 				if calcFunc then
 					self.displayGroup.gemList[index].enabled = not self.displayGroup.gemList[index].enabled
 					local storedGlobalCacheDPSView = GlobalCache.useFullDPS
-					GlobalCache.useFullDPS = calcBase.FullDPS ~= nil
+					GlobalCache.useFullDPS = GlobalCache.numActiveSkillInFullDPS > 0
 					local output = calcFunc({}, {})
 					GlobalCache.useFullDPS = storedGlobalCacheDPSView
 					self.displayGroup.gemList[index].enabled = not self.displayGroup.gemList[index].enabled

--- a/src/Data/Global.lua
+++ b/src/Data/Global.lua
@@ -265,4 +265,5 @@ GlobalCache = {
 	excludeFullDpsList = { },
 	dontUseCache = nil,
 	useFullDPS = false,
+	numActiveSkillInFullDPS = 0,
 }

--- a/src/Modules/Calcs.lua
+++ b/src/Modules/Calcs.lua
@@ -164,8 +164,10 @@ function calcs.calcFullDPS(build, mode, override, specEnv)
 	local fullDPS = { combinedDPS = 0, skills = { }, poisonDPS = 0, impaleDPS = 0, igniteDPS = 0, bleedDPS = 0, decayDPS = 0, dotDPS = 0, cullingMulti = 0 }
 	local bleedSource = ""
 	local igniteSource = ""
+	GlobalCache.numActiveSkillInFullDPS = 0
 	for _, activeSkill in ipairs(fullEnv.player.activeSkillList) do
 		if activeSkill.socketGroup and activeSkill.socketGroup.includeInFullDPS and not isExcludedFromFullDps(activeSkill) then
+			GlobalCache.numActiveSkillInFullDPS = GlobalCache.numActiveSkillInFullDPS + 1
 			local activeSkillCount, enabled = getActiveSkillCount(activeSkill)
 			if enabled then
 				local cacheData = getCachedData(activeSkill, mode)


### PR DESCRIPTION
I noticed a problem with a lot of stat compares with FullDPS stuff. Old system just checked if the baseline had `.FullDPS` value to determine it should use it. But if you added skill to FullDPS and then removed them the baseline would still have the parameter. 

This is a safer way to do it.
