### PR TITLE
Cap Explosive Arrow Bonus Explosion Radius

### DIFF
--- a/src/Data/Skills/act_dex.lua
+++ b/src/Data/Skills/act_dex.lua
@@ -3286,7 +3286,7 @@ skills["ExplosiveArrow"] = {
 			mod("Damage", "MORE", nil, ModFlag.Hit, 0, { type = "Multiplier", var = "ExplosiveArrowFuse" }),
 		},
 		["explosive_arrow_maximum_bonus_explosion_radius"] = {
-			mod("Multiplier:ExplosiveArrowMaxBonusRadius", "BASE", nil, 0, 0, { type = "GlobalEffect", effectType = "Buff" }),
+			mod("Multiplier:ExplosiveArrowMaxBonusRadius", "BASE", nil),
 		},
 	},
 	baseFlags = {

--- a/src/Data/Skills/act_dex.lua
+++ b/src/Data/Skills/act_dex.lua
@@ -3276,7 +3276,7 @@ skills["ExplosiveArrow"] = {
 			mod("FireMax", "BASE", nil, 0, 0, { type = "SkillPart", skillPartList = { 1, 2, 3, 4, 5 } }),
 		},
 		["fuse_arrow_explosion_radius_+_per_fuse_arrow_orb"] = {
-			skill("radiusExtra", nil, { type = "Multiplier", var = "ExplosiveArrowFuse" }),
+			skill("radiusExtra", nil, { type = "Multiplier", var = "ExplosiveArrowFuse", limitVar = "ExplosiveArrowMaxBonusRadius", limitTotal = true }),
 		},
 		["explosive_arrow_explosion_base_damage_+permyriad"] = {
 			skill("baseMultiplier", nil, { type = "SkillPart", skillPartList = { 1, 2, 3, 4, 5 } }),
@@ -3284,6 +3284,9 @@ skills["ExplosiveArrow"] = {
 		},
 		["explosive_arrow_hit_damage_+%_final_per_stack"] = {
 			mod("Damage", "MORE", nil, ModFlag.Hit, 0, { type = "Multiplier", var = "ExplosiveArrowFuse" }),
+		},
+		["explosive_arrow_maximum_bonus_explosion_radius"] = {
+			mod("Multiplier:ExplosiveArrowMaxBonusRadius", "BASE", nil, 0, 0, { type = "GlobalEffect", effectType = "Buff" }),
 		},
 	},
 	baseFlags = {

--- a/src/Export/Skills/act_dex.txt
+++ b/src/Export/Skills/act_dex.txt
@@ -625,7 +625,7 @@ local skills, mod, flag, skill = ...
 			mod("FireMax", "BASE", nil, 0, 0, { type = "SkillPart", skillPartList = { 1, 2, 3, 4, 5 } }),
 		},
 		["fuse_arrow_explosion_radius_+_per_fuse_arrow_orb"] = {
-			skill("radiusExtra", nil, { type = "Multiplier", var = "ExplosiveArrowFuse" }),
+			skill("radiusExtra", nil, { type = "Multiplier", var = "ExplosiveArrowFuse", limitVar = "ExplosiveArrowMaxBonusRadius", limitTotal = true }),
 		},
 		["explosive_arrow_explosion_base_damage_+permyriad"] = {
 			skill("baseMultiplier", nil, { type = "SkillPart", skillPartList = { 1, 2, 3, 4, 5 } }),
@@ -633,6 +633,9 @@ local skills, mod, flag, skill = ...
 		},
 		["explosive_arrow_hit_damage_+%_final_per_stack"] = {
 			mod("Damage", "MORE", nil, ModFlag.Hit, 0, { type = "Multiplier", var = "ExplosiveArrowFuse" }),
+		},
+		["explosive_arrow_maximum_bonus_explosion_radius"] = {
+			mod("Multiplier:ExplosiveArrowMaxBonusRadius", "BASE", nil, 0, 0, { type = "GlobalEffect", effectType = "Buff" }),
 		},
 	},
 #baseMod skill("radius", 15)

--- a/src/Export/Skills/act_dex.txt
+++ b/src/Export/Skills/act_dex.txt
@@ -635,7 +635,7 @@ local skills, mod, flag, skill = ...
 			mod("Damage", "MORE", nil, ModFlag.Hit, 0, { type = "Multiplier", var = "ExplosiveArrowFuse" }),
 		},
 		["explosive_arrow_maximum_bonus_explosion_radius"] = {
-			mod("Multiplier:ExplosiveArrowMaxBonusRadius", "BASE", nil, 0, 0, { type = "GlobalEffect", effectType = "Buff" }),
+			mod("Multiplier:ExplosiveArrowMaxBonusRadius", "BASE", nil),
 		},
 	},
 #baseMod skill("radius", 15)


### PR DESCRIPTION
Fixes #2434.

### Description of the problem being solved:
Explosive Arrow gains: ``+2 to Explosion Radius per Explosive Arrow on Target, up to +12`` -- we had the +2 Explosion Radius per Fuse but *did not have any cap* meaning at 20 fuses you gained +40 radius instead of the expected +12 radius.

### After screenshot:
![](http://puu.sh/IGwh9/fa3b713138.png)