### PR TITLE
Fix missing physical damage reduction caps

### DIFF
--- a/src/Modules/CalcDefence.lua
+++ b/src/Modules/CalcDefence.lua
@@ -79,8 +79,8 @@ function calcs.defence(env, actor)
 
 	-- Resistances
 	output.DamageReductionMax = modDB:Override(nil, "DamageReductionMax") or data.misc.DamageReductionCap
-	output.PhysicalResist = m_min(output.DamageReductionMax, modDB:Sum("BASE", nil, "PhysicalDamageReduction"))
-	output.PhysicalResistWhenHit = m_min(output.DamageReductionMax, output.PhysicalResist + modDB:Sum("BASE", nil, "PhysicalDamageReductionWhenHit"))
+	output.PhysicalResist = m_min(m_max(0, modDB:Sum("BASE", nil, "PhysicalDamageReduction")), output.DamageReductionMax)
+	output.PhysicalResistWhenHit = m_min(m_max(0, output.PhysicalResist + modDB:Sum("BASE", nil, "PhysicalDamageReductionWhenHit")), output.DamageReductionMax)
 
 	-- Highest Maximum Elemental Resistance for Melding of the Flesh
 	if modDB:Flag(nil, "ElementalResistMaxIsHighestResistMax") then

--- a/src/Modules/CalcOffence.lua
+++ b/src/Modules/CalcOffence.lua
@@ -2889,7 +2889,7 @@ function calcs.offence(env, actor, activeSkill)
 				skillFlags.duration = true
 				local effMult = 1
 				if env.mode_effective then
-					local resist = m_max(0, enemyDB:Sum("BASE", nil, "PhysicalDamageReduction"))
+					local resist = m_min(m_max(0, enemyDB:Sum("BASE", nil, "PhysicalDamageReduction")), data.misc.DamageReductionCap)
 					local takenInc = enemyDB:Sum("INC", dotCfg, "DamageTaken", "DamageTakenOverTime", "PhysicalDamageTaken", "PhysicalDamageTakenOverTime")
 					local takenMore = enemyDB:More(dotCfg, "DamageTaken", "DamageTakenOverTime", "PhysicalDamageTaken", "PhysicalDamageTakenOverTime")
 					effMult = (1 - resist / 100) * (1 + takenInc / 100) * takenMore
@@ -3715,7 +3715,7 @@ function calcs.offence(env, actor, activeSkill)
 
             local enemyArmour = calcLib.val(enemyDB, "Armour")
             local impaleArmourReduction = calcs.armourReductionF(enemyArmour, impaleHitDamageMod * output.impaleStoredHitAvg)
-            local impaleResist = m_max(0, enemyDB:Sum("BASE", nil, "PhysicalDamageReduction") + skillModList:Sum("BASE", cfg, "EnemyImpalePhysicalDamageReduction") + impaleArmourReduction)
+            local impaleResist = m_min(m_max(0, enemyDB:Sum("BASE", nil, "PhysicalDamageReduction") + skillModList:Sum("BASE", cfg, "EnemyImpalePhysicalDamageReduction") + impaleArmourReduction), data.misc.DamageReductionCap)
 
             local impaleDMGModifier = impaleHitDamageMod * (1 - impaleResist / 100) * impaleChance
 
@@ -3892,7 +3892,7 @@ function calcs.offence(env, actor, activeSkill)
 				local takenInc = enemyDB:Sum("INC", dotTakenCfg, "DamageTaken", "DamageTakenOverTime", damageType.."DamageTaken", damageType.."DamageTakenOverTime")
 				local takenMore = enemyDB:More(dotTakenCfg, "DamageTaken", "DamageTakenOverTime", damageType.."DamageTaken", damageType.."DamageTakenOverTime")
 				if damageType == "Physical" then
-					resist = enemyDB:Sum("BASE", nil, "PhysicalDamageReduction")
+					resist = m_max(0, m_min(enemyDB:Sum("BASE", nil, "PhysicalDamageReduction"), data.misc.DamageReductionCap))
 				else
 					if env.modDB:Flag(nil, "Enemy"..damageType.."ResistEqualToYours") then
 						resist = env.player.output[damageType.."Resist"]


### PR DESCRIPTION
Fixes several cases of physical damage reduction calculations not being capped for max or min.

### Description of the problem being solved:
Physical damage reduction should be capped at 90% and have a minimum of 0%, in some calculations it wasn't being capped leading to inaccuracies
Updated:
-Ailment
-Damage over time
-Impale
-Player
### Steps taken to verify a working solution:
-Verified damage calculations for new min and max on updated formulae

### Link to a build that showcases this PR:
```
eNrVWltz2kgWfg6_oouq2Upqy4AEOB4vnimMsUOVcRhwkt2nVFtqoMctNZFaOGQq_31PdwsQDpijnjzsZqoyQnznfvpcmnR-_xoJsmRJymV8UfVqjSphcSBDHs8uqh_ur0_Oqr__VumMqJq_n15mXOhvfqu86phnItiSiYvqr0CmaDJj6uOaVfMzvFvQWM2ZjIf0T5ncyPCieidjViUPNA65Wn8KBE3TOxqxi-okAOIqoWnA4rC3fW-BEeXxRAaPTN0kMltcVP0qWXL2NJQhYAbD0fvxfUEoj4tCQelXnZGgK5ZMFFUkhb8uql2wnc7YO66AFRUZ8GlU6_uxkwVj4XHYKGH96ZQFii9ZL-GqN6dxwI7TlcUOM6H4QnCWbPBerX2I4l4qKq5Gk-O8LVJuHdJq-K1a6xD8E1dzQBdZHye4FOBKlDYaPZjFXDE0fCR5KuNStuK178nogce7yh-jkCKUT3EhSg2_eQg9pDHtyRSRjrd8ynaQbf8gtj_B8RzDWcAhtZ4jlsA5VXh1SxHkEiYskFALysgoQ1Kww02YA2V_4kLgIGiitrXhcHKM2Zci0GufHUJesa84fkWg1z5YlAaxwvErAhuHtVtKZfoHJnRb_Tz_7IWSH5xr9CAOcGw_xAlLWbIsdIqXBOyS5FHeUjZelDVmM4a09paxYH4D_XNMFcOdim1dOWu96B8NRvlHA_f45wX-uxQl3KMJd93jNWr-S-iSHvpEE8Qs0I9ZMltN5pyJEDVgBOdFEpRXiwTIjCiSlLS7v6Rp8Yx5py9bY-G49GAwFQBByLBj0CiRf-pBS5Qj6yaRzBJkPCwYZcBovkp5AAMFjaCPjlmYBbh6tJkXh3LJIkhxM2rCWLt18yHSSwEDMdZwYCtEKYquUjR4vJLhjJUSUp5iki0WcNB1tmDprnkCXk55oRWenCLQ72Ho79EFYsyW-khhBWzRaAG3fDZXMaxUeCnPSPC2zKlMSxizhaNFXGcCt2KM5BOwnOuNMS2HHtLtYHFwhr5OWPxthea_A0cJ6MdhlugcRct4TvGjmE7drNT6aRAtZKLMyx4VQWpYDuJFpkhs1uH0kQvxOc6iB7382f_rbbj-AzLiafD5IZtO9Y5cBWUSs9n3r6_7vfvBx35OMmGmUpFACkEXKYOleUpFChQcHida3ASqc6BQeNimbQlEoaGTBgkHJ2LAei9FqWx2dQxSr9IoIESFCoZ32P1qwXQGpFif5WUPgzb7Mwppl2GcgWbNxoWBBXSFQm7GCxS6L1iXC90BcV4bQnrb5onDQztL-EOmkNlm9gSUHnpeRhlYHAiRpwMHzIcalBL5DIfB5h0Dl5QwWKDDdsWmDNIdeexNObmnjyzOi-W6MHbMWUtJChXzhkXp5Qo60LV277O7mogqSEQW3eory3up6zANFEtu7RVmLmyHzUVVJRm8DNmUZkK__yOjgquVLvSFtzkL2GBJOpdPepKxbHQJSCE0t7f2m65QOQctYy3U2q_NMDecXTMJms_GSD38ER4HIgthDc177EZhQR-07CqZ6SvRnsxi6DYxF_oelz4I7UdrxDPWmqsW_KoDquTYGyEfqPC3vLd2FQHemqVpQwOQoK9j43AiaFQlX6yBA1MljIdy4IgmytgyY5H-dsgUDami9YECZ9S1R-pGNXjaw9D4_JlNgTUXeOpup8f1tS7E0hrBQx6bK-lJFkUS0mEEdVbRNLKZ91MckIc8bxF7ffCS1ZuEecYAa3OxNf1Me2xHupe23bibtZ8P1jpLTZQkxbZnc-V_9uwYV0L71_ep1qRGCf_3ZJJkCwWz2jWQJOVdn5-jQ3zQrt_QE8vg_8L3aDePJA3mLIFpPHl09vFeJlgH58T_oAuZ_islhsczH-dPptndJ4wRar1h6L28e8CH4q9mWueG9l0KHW6VT0ja2zGsAam-cjtrNqtEAbvCL3be2_zHOEtu3dwPYSgM7zRdXl8-jG_Nw6u5Uov0vF5_enqqLaiayyn7ygWrBTKqL4ANaHlifH2iBdW78Ody1jV_DKP6mlPH_qqXri0Ha4zh2lz9cCdhYtPf6ZfrD8YZHzl7IimDFWI-UYm28JuU0X-M9brjvmNUDelikxr627xdN_NuDSP6FQcPJWYcWQdLA_-9Xug6Juy54_XzhNlAZimz9_GfGEQwNq8LTV1DYctLONWB9-0sk-fvGF6r1Tn5cDf440O_0lXfeMLXeXDF0yldwjxX-UipIN2vDB4Mm3MyShhp1jyv1ti-62UJqK8qdkljIdl842855KMHvGtUcoefk_HJ5r-KccyYfTknb9sV6CmCB1xjvMpfuRHn_ne__QsJNhV5SHlEYGyD9aXyT1-_MUyInBIrAnTJ-wDRp2bLyfv-FyzEM3beqLW_d8MwJa99v3HiN9tvNJvX_lv48GvjDVnfqhE7BBZ1-ZFDo30CXHIObeDwdh-HLdlrzz_xTt_8ogtVwijMncReeRGzQVZ2rQ0oBNx2IV0Sd-y2GUAMa5PTsHGP9Qf7ClKp1rYJ0Fw36oOI1lHE-icVU5BsCRByvfTnqujyq2z9Wl8f5rn7Qt4WU3Qfz8kTXZDuwypNwZ82xKS9FdRYa76H9DmZjyP7wYod1KWUKnVUaJ8tR5S6ZEKVJLmGivpImiiV_H0qNd3ci3OC_5PIWm5KnrpJO3X3pnckwPvy6UgE3jERMVVW0J5MOnWRcyT9YPZZ6hvK8oyb7qfIc5HXcssFzy3zWsfDg3FsWbb70svRcFTdaTvo41ADm8fEhCtib6hKhm-_l53yq-1ChDqSmEA42dl2dqvvEPdTt5PUdEvfZvksa7mXfYec9pyd38QkRAsDclD7bww_yEi6R-HUISvdw_A30gVbkjUt8tTgoQ6eG-t9xHcpMb6zex3LBT6eLuY0EX7y3MPQcvZW28UazHlxT_IjKnWjTOzpbXbnhJXRXNGYmxHzS7WMp3wGiE79-b8W_y_BmKIg
```
### Before screenshot:
![image](https://user-images.githubusercontent.com/7968251/152189910-74bc5eb2-9dcf-4ef9-913f-09d298e76bf4.png)

### After screenshot:
![image](https://user-images.githubusercontent.com/7968251/152189702-c68996a0-03b4-44ab-8b71-be481441b769.png)
