### PR TITLE
Fix: correct two modifiers on Survivor's Guilt (unique belt)

### DIFF
--- a/src/Data/Uniques/belt.lua
+++ b/src/Data/Uniques/belt.lua
@@ -773,8 +773,8 @@ Heavy Belt
 League: Ritual
 Requires Level 52
 Implicits: 1
-{tags:jewellery_attribute}+(25-35)% to Strength
-{tags:jewellery_defense}+(800-1200)% to Armour
+{tags:jewellery_attribute}+(25-35) to Strength
+{tags:jewellery_defense}+(800-1200) to Armour
 {tags:life}Regenerate (50-70) Life per second
 20% increased Stun Threshold
 {tags:jewellery_defense}10% reduced Armour per 50 Strength


### PR DESCRIPTION
Fixes #4046 

URL: https://www.pathofexile.com/trade/search/Standard/85dmBM2cV