### PR TITLE
Swap ailment threshold and effect in breakdown

### DIFF
--- a/src/Modules/CalcOffence.lua
+++ b/src/Modules/CalcOffence.lua
@@ -3383,11 +3383,11 @@ function calcs.offence(env, actor, activeSkill)
 							t_insert(val.effList, desired)
 						end
 						breakdown[ailment.."DPS"].label = "Resulting ailment effect"..((current > 0 and val.ramping) and s_format(" ^8(with a ^7%s%% ^8%s on the enemy)^7", current, ailment) or "")
-						breakdown[ailment.."DPS"].footer = s_format("^8(ailment threshold is about equal to life, except on bosses where it is about half their life)\n(the above table shows that you ^8%s for X when the enemy has Y ailment threshold)", ailment:lower())
+						breakdown[ailment.."DPS"].footer = s_format("^8(ailment threshold is about equal to life, except on bosses where it is about half their life)\n(the above table shows that when the enemy has X ailment threshold, you ^8%s for Y)", ailment:lower())
 						breakdown[ailment.."DPS"].rowList = { }
 						breakdown[ailment.."DPS"].colList = {
-							{ label = ailment.." Effect", key = "effect" },
 							{ label = "Ailment Threshold", key = "thresh" },
+							{ label = ailment.." Effect", key = "effect" },
 						}
 						table.sort(val.effList)
 						for _, value in ipairs(val.effList) do


### PR DESCRIPTION
### Description of the problem being solved:
Swapping the columns in the table makes it more intuitive to read. The new order is read as "X ailment threshold results in Y shock".

### Before screenshot:
![image](https://user-images.githubusercontent.com/5985728/152374781-281ca03f-4baf-41a8-b52c-3925597b1f1b.png)

### After screenshot:
![image](https://user-images.githubusercontent.com/5985728/152374868-55d2dd48-aeed-4270-954f-a5c0e2002e90.png)

