### PR TITLE
Parse new "for spell damage" mod

### DIFF
--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -688,6 +688,7 @@ local modFlagList = {
 	["with spells"] = { flags = ModFlag.Spell },
 	["with spell damage"] = { flags = ModFlag.Spell },
 	["for spells"] = { flags = ModFlag.Spell },
+	["for spell damage"] = { flags = ModFlag.Spell },
 	["with attacks"] = { keywordFlags = KeywordFlag.Attack },
 	["with attack skills"] = { keywordFlags = KeywordFlag.Attack },
 	["for attacks"] = { flags = ModFlag.Attack },


### PR DESCRIPTION
Fixes #4058.

GGG changed how some critical strike multiplier spell nodes were written on the 3.17 tree. I'm not sure whether or not they were attempting to exclude Poison Damage applied by Spells with this change. It's not immediately obvious anyway, and all of the 3.16 nodes affected by this change **did** apply to Poison Damage.. so pending further testing I'm leaving it as-is.
### Before screenshot:
![](http://puu.sh/IGTJs/b1c563c7dd.png)
### After screenshot:
![](http://puu.sh/IGTJG/d82ca28313.png)