### PR TITLE
Fix tulfall wand missing stat

### DIFF
--- a/src/Data/Uniques/wand.lua
+++ b/src/Data/Uniques/wand.lua
@@ -301,13 +301,11 @@ Requires Level 65, 212 Int
 Implicits: 1
 (35-39)% increased Spell Damage
 (10-15)% increased Cast Speed
-{variant:1}50% chance to gain a Power Charge on Killing a Frozen Enemy
-{variant:2}Gain a Power Charge on Killing a Frozen Enemy
+Gain a Power Charge on Killing a Frozen Enemy
 Adds 15 to 25 Cold Damage to Spells per Power Charge
 Lose all Power Charges on reaching Maximum Power Charges
 Gain a Frenzy Charge on reaching Maximum Power Charges
-{variant:1}(10-15)% increased Cold Damage per Frenzy Charge
-{variant:1}(15-20)% increased Cold Damage per Frenzy Charge
+(15-20)% increased Cold Damage per Frenzy Charge
 ]],[[
 Replica Tulfall
 Tornado Wand


### PR DESCRIPTION
Fixes #4108 .

### Description of the problem being solved:

### Steps taken to verify a working solution:
- Compare the item in PoB with the item on PoEDB and PoEWiki

### Link to a build that showcases this PR:
N/A

### Before screenshot:

![NVIDIA_Share_y4cAw87hfZ](https://user-images.githubusercontent.com/31558976/153105697-d490d99f-e222-41bc-a80d-01b1d549c9b0.png)

### After screenshot:
![NVIDIA_Share_zCfGeS73zS](https://user-images.githubusercontent.com/31558976/153105739-b144cc82-dbc6-47eb-8c1c-62c040c6f44a.png)

