### PR TITLE
Fix Energy Blade incompatibility with new Fobidden Prismatic Jewels

### DIFF
--- a/src/Modules/CalcSetup.lua
+++ b/src/Modules/CalcSetup.lua
@@ -633,6 +633,7 @@ function calcs.initEnv(build, mode, override, specEnv)
 						item.name = name
 						item.base = data.itemBases[name]
 						item.baseName = name
+						item.classRequirementModLines = { }
 						item.buffModLines = { }
 						item.enchantModLines = { }
 						item.scourgeModLines = { }


### PR DESCRIPTION
Fixes #4093 

### Description of the problem being solved:
As described in the issue, with a sword equipped and Energy Blade gem skilled if you go to Config Tab and checkmark "Is Energy Blade active?" you would get a Lua error. This was a result of two different PRs working off each other where one changes the item form to include class restrictions, the other not accounting for new form when spoofing an item to support Energy Blade.

`https://pastebin.com/PmcZ9BMk`