### PR TITLE
Fix: string find uses Lua Patterns, need to escape '-'

### DIFF
--- a/src/Classes/Item.lua
+++ b/src/Classes/Item.lua
@@ -387,7 +387,7 @@ function ItemClass:ParseRaw(raw)
 						end
 					end
 					if not baseName then
-						local s, e = self.name:find("Two-Toned Boots", 1, true)
+						local s, e = self.name:find("Two%-Toned Boots", 1, true)
 						if s then
 							-- Hack for Two-Toned Boots
 							baseName = "Two-Toned Boots (Armour/Energy Shield)"


### PR DESCRIPTION
Fix to code that doesn't work as `string.find()` accepts Lua pattern as argument meaning the `-` needs to be escaped. There is no chance it's correct as written. @Wires77 