### PR TITLE
Fix issue importing Fobidden Flame/Flesh

### DIFF
--- a/src/Classes/ImportTab.lua
+++ b/src/Classes/ImportTab.lua
@@ -743,6 +743,8 @@ function ImportTabClass:ImportItem(itemData, slotName)
 		for _, req in ipairs(itemData.requirements) do
 			if req.name == "Level" then
 				item.requirements.level = req.values[1][1]
+			elseif req.name == "Class:" then
+				item.classRestriction = req.values[1][1]
 			end
 		end
 	end

--- a/src/Classes/Item.lua
+++ b/src/Classes/Item.lua
@@ -185,6 +185,10 @@ function ItemClass:ParseRaw(raw)
 				specName, specVal = line:match("^(Requires Class) (.+)$")
 			end
 			if not specName then
+				specVal = line:match("^Class:: (.+)$")
+				if specVal then specName = "Requires Class" end
+			end
+			if not specName then
 				specName, specVal = line:match("^(Requires) (.+)$")
 			end
 			if specName then

--- a/src/Data/Uniques/Special/Generated.lua
+++ b/src/Data/Uniques/Special/Generated.lua
@@ -551,7 +551,7 @@ function buildForbidden(classNotables)
 	for _, name in pairs({"Flame", "Flesh"}) do
 		forbidden[name] = { }
 		table.insert(forbidden[name], "Forbidden " .. name)
-		table.insert(forbidden[name], "Prismatic Jewel")
+		table.insert(forbidden[name], (name == "Flame" and "Crimson" or "Cobalt") .. " Jewel")
 		local index = 1
 		for className, notableTable in pairs(classNotables) do
 			for _, notableName in ipairs(notableTable) do

--- a/src/Data/Uniques/Special/Generated.lua
+++ b/src/Data/Uniques/Special/Generated.lua
@@ -570,7 +570,7 @@ function buildForbidden(classNotables)
 		for className, notableTable in pairs(classNotables) do
 			for _, notableName in ipairs(notableTable) do
 				table.insert(forbidden[name], "{variant:" .. index .. "}" .. "Requires Class " .. className)
-				table.insert(forbidden[name], "{variant:" .. index .. "}" .. "Allocates ".. notableName .. " if you have the matching modifiers on Forbidden " .. (name == "Flame" and "Flesh" or "Flame"))
+				table.insert(forbidden[name], "{variant:" .. index .. "}" .. "Allocates ".. notableName .. " if you have the matching modifier on Forbidden " .. (name == "Flame" and "Flesh" or "Flame"))
 				index = index + 1
 			end
 		end

--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -3169,7 +3169,7 @@ local specialModList = {
 	["your critical strike multiplier is (%d+)%%"] = function(num) return { mod("CritMultiplier", "OVERRIDE", num) } end,
 	["base critical strike chance for attacks with weapons is ([%d%.]+)%%"] = function(num) return { mod("WeaponBaseCritChance", "OVERRIDE", num) } end,
 	["critical strike chance is (%d+)%% for hits with this weapon"] = function(num) return { mod("CritChance", "OVERRIDE", num, nil, ModFlag.Hit, { type = "Condition", var = "{Hand}Attack" }, { type = "SkillType", skillType = SkillType.Attack }) } end, 
-	["allocates (.+) if you have the matching modifier on forbidden (.+)"] = function(_, ascendancy, side) return { mod("GrantedAscendancyNode", "LIST", { side = side, name = ascendancy }) } end,
+	["allocates (.+) if you have the matching modifiers? on forbidden (.+)"] = function(_, ascendancy, side) return { mod("GrantedAscendancyNode", "LIST", { side = side, name = ascendancy }) } end,
 	["allocates (.+)"] = function(_, passive) return { mod("GrantedPassive", "LIST", passive) } end,
 	["battlemage"] = { flag("WeaponDamageAppliesToSpells"), mod("ImprovedWeaponDamageAppliesToSpells", "MAX", 100) },
 	["transfiguration of body"] = { flag("TransfigurationOfBody") },

--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -3169,7 +3169,7 @@ local specialModList = {
 	["your critical strike multiplier is (%d+)%%"] = function(num) return { mod("CritMultiplier", "OVERRIDE", num) } end,
 	["base critical strike chance for attacks with weapons is ([%d%.]+)%%"] = function(num) return { mod("WeaponBaseCritChance", "OVERRIDE", num) } end,
 	["critical strike chance is (%d+)%% for hits with this weapon"] = function(num) return { mod("CritChance", "OVERRIDE", num, nil, ModFlag.Hit, { type = "Condition", var = "{Hand}Attack" }, { type = "SkillType", skillType = SkillType.Attack }) } end, 
-	["allocates (.+) if you have the matching modifiers on forbidden (.+)"] = function(_, ascendancy, side) return { mod("GrantedAscendancyNode", "LIST", { side = side, name = ascendancy }) } end,
+	["allocates (.+) if you have the matching modifier on forbidden (.+)"] = function(_, ascendancy, side) return { mod("GrantedAscendancyNode", "LIST", { side = side, name = ascendancy }) } end,
 	["allocates (.+)"] = function(_, passive) return { mod("GrantedPassive", "LIST", passive) } end,
 	["battlemage"] = { flag("WeaponDamageAppliesToSpells"), mod("ImprovedWeaponDamageAppliesToSpells", "MAX", 100) },
 	["transfiguration of body"] = { flag("TransfigurationOfBody") },


### PR DESCRIPTION
Fixes #4117:

Provides Support for:
- Copy/Paste of Forbidden Flame/Flesh from PoE Trade `https://www.pathofexile.com/trade/search/Archnemesis/rjD3VPESQ`
- Parsing of Character Import with from PoE with Forbidden Flame/Flesh item requirements block
- Updated PoE changes to the item (they changed from it being a `Prismatic Jewel` to `Cobalt` for Flesh and `Crimson` for Flame, they changed the modifier string very very slightly

To Test:
Use PoE.Ninja to find a character that has Forbidden Flame or Flesh and import.
