### PR TITLE
Fix issue where General's Cry would set attack rate to 1 for certain skills

### DIFF
--- a/src/Modules/CalcOffence.lua
+++ b/src/Modules/CalcOffence.lua
@@ -1041,7 +1041,7 @@ function calcs.offence(env, actor, activeSkill)
 			local cooldown = calcSkillCooldown(mirageActiveSkill.skillModList, mirageActiveSkill.skillCfg, mirageActiveSkill.skillData)
 
 			-- Non-channelled skills only attack once, disregard attack rate
-			if not activeSkill.skillTypes[SkillType.Channelled] then
+			if not activeSkill.skillTypes[SkillType.Channel] then
 				skillData.timeOverride = 1
 			end
 


### PR DESCRIPTION
Fixes #4092, #4113

Recent change to general's cry made all active skills calculate as if they were not channeled.  This fixes this by using the correct 'Channel' skill type.

