### PR TITLE
Fix an issue where chance to inflict an ailment on a critical strike could be lower than on a non-crit for alternate ailments

### DIFF
--- a/src/Modules/CalcOffence.lua
+++ b/src/Modules/CalcOffence.lua
@@ -2747,7 +2747,7 @@ function calcs.offence(env, actor, activeSkill)
 			end
 			if skillFlags.hit and not skillModList:Flag(cfg, "Cannot"..ailment) then
 				output[ailment.."ChanceOnHit"] = m_min(100, chance)
-				if skillModList:Flag(cfg, "CritsDontAlways"..ailment) and (not ailmentData[ailment] or not ailmentData[ailment].alt) then
+				if skillModList:Flag(cfg, "CritsDontAlways"..ailment) or (ailmentData[ailment] and ailmentData[ailment].alt) then
 					output[ailment.."ChanceOnCrit"] = output[ailment.."ChanceOnHit"]
 				end
 			else

--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -2362,7 +2362,6 @@ local specialModList = {
 		flag("ChaosCanSap", { type = "Condition", var = "TwoHighestAttributesEqual" }),
 	},
 	["critical strikes do not inherently apply non%-damaging ailments"] = {
-		flag("CritsDontAlwaysIgnite"),
 		flag("CritsDontAlwaysChill"),
 		flag("CritsDontAlwaysFreeze"),
 		flag("CritsDontAlwaysShock"),


### PR DESCRIPTION
### Description of the problem being solved:
For things like Rolling Flames, Galesight, Flamesight, and Thundersight, as well as for mods on Touch of Anguish and Painseeker, ailments would have a lower chance than their base chance
### Steps taken to verify a working solution:
- Verified ailment chances stayed the same for existing standard setups
- Ensured crit chances stayed equal to non-crit chances in all cases (until GGG introduces "ailments can't be inflicted with crits")

### Link to a build that showcases this PR:
```bash
eNrdW1tz2kgWfg6_oouqrcpUAOsOuOyZAowddu2EASezOy-pttSAxi01kVq2yVb--57uFiAwl0bJ7sNOphxdzr2_PpeWc_HbS0TRE0nSkMWXVbNhVBGJfRaE8fSy-un-ut6q_vZr5WKI-ezjpJuFVLz5tfLmQl4jSp4IBb4q4jiZEv55Kcn-ApLmOOYzwuI7_BdLblhwWf3AYlJFDzgOQr688ylO0w84IpfVP0Luz6oIpz6Jg976eZ-SiMQc0zDlVRThMB4z_5Hwm4Rlc6n-KSTPdywA2sHd8OPovqA8jIvKwfY3F0OKFyQZc8xRCj8uqx0IAZ6SKxzBT5CGaQaiPK_VsMxWy2saVsu2q2e7mcdzQoIVk9nw9hEOE9KfTIjPwyfSS0Lem-HYX6trNcx9nDuomw27eZD-LqM8nNOQJAXb3H0c718paO-Vfs9gKa6G47Vcw2s3TNcwW03Lce3DfIyv-Ix9lACEWZdCWEtoEbyDaRxyUpJ5yMKUxT_gX5F1r4s9Fj2EcSkP73CMeyxdx3Ev4m7DCdmg3GtOf6xHN4INokcprBySBLYy12MQxp7EkGsYE59BujhFxyksBT_KKSvB2R-XYSihaMwL2cHZR3VFXjSoRuTrBqG7N9kMYl7AvHVA4AblfoFX5IlxKDzHHZZ7tP9-uKK0m07Dctrtlkjxrb07SQUVikkYYXqHX8IoiyBn3uNHstZqWW3Iyu4hPKxo3eaBeuKfC9pB7OuB7FOckJQkT4UytF_8JkMOm8JyHNQ0IlMS6xl1S4g_u4FaPcK8WFMb7aZ3aK8VTDkcIkGsFSJBuCNEB-RvcpwQI8G4GSOz0T5EvDtK-wsjTgKNbBCTZLoYz0JC19S2aRwMZ5FJK6xFBk1cFFlO9Lz_hNPiDjfdw94ocj18EGg1gCEgWy2Qsb-TY3-JPo6extZJIpYlGllZeKCItRwYzhZp6EPvIfvXEQkyXy8brtrRO_YkW2zZy0IjvQ7zPtYuhRZc13EQS-lJHB3Osf94xYIpOUnJ6RzjbD6HnS7Qost3HSYQ5TQsVNi6p0H9EcaMHp7rNIdiS20qsNzj1NoKbsPpjMcwy-m7scWi78sMs1RfTYFcW8V1RqlW0z1kzyByJmbV9DRqKPnrTLrXjoTE3xba8jfItRT04yBLBEa1dWxzvFZzcSZneXE1iOYs4QgGb97xfZbF_D1OZ5dV4roTGEhcTEy_aQW-h7E9Maym38R223J8k9iB25rYVck6IphGEL2eEt_D1E-lcYN4nnEUy5E-ClP_y0M2mYipvQrGJvLIoX993e_dDz73c3-KLOljSOmXOIsexEir_l4nqDGROQ_5jFI8TwkM_BNMU5AdwuVY8I4hz_tcix5au_wwQIcaqrKfhLAcOsRiANYyWR4r6FCKaV-LENYXU6IfsPvFnAgspboxyxOoDrUc77Uo1Tyu56Cc-_WWgfh4oUW5alS0qPuUdEIqaqle1O5gI6gyrEcPhTEJHzKuiTY5c2jZIVpvLQeLzaXm7tAjzNsjLSPyblCHNq89eqCEFkV72a7IhADcNbe9TCdqXlRpd5kYL-ReS1EKufeGRGl3AbXsWoR365QowhyASKJbcep6z0RGxz4nya06hc2VbYi5rPIkg4cBmeCMiue_Z5iGfCFKRuFpLsKCh-mMPYueSIkRKSCFpbm9VW86lOcShI6lUuW_cEOeznZkTynvpZPyiDaMfZoFMNTm1XplMMUPQncVTcVxbk-UnctqHFJxFI0fqIijcmJLtJAqFL-5AFNy2hvKHjC11rLXfhUJzKVIWVMGgajFLOVdCs08FNWvysOBTBMyRDnlECdcOjMlkXh7RzgOMMdnAw7ROBMhOZO2wdUuiTLqW16tBK9D5asYwJWofGIayA1EuTwFOKXq_yD20CDDC_qzAr8t7keivpS1FfH8Sm7f-4QQhFVsJJOZ7we4KX7LEHZbIpIp7NlFnvNF7GNogeCi2bZbNddxnGbNta1mu-aZjtmu2Z7rWDXTMyy7Zjddr10zDdusua12u1WzmoZgalqeUzPbnu3WHLvdrCIONhU-xpjN_DuLsMHOV64fQK0MPgjlZ-rJp9GtvHgz43yenp-dPT8_N-aYz9iEvMCw2_BZdDYHMeBqXUawLhSddeC_7vSu13tp9YzulyfP8eqPab_frf9p4T-bk7S_-NYfG0B1eSkVnS01XagPOalSm9_JgAhLZQAAvVwten7yKIK_5oIbiLNcErEQ4uIDg-oo3omHyxu5TJ9D8oxSAu3abMwTEftvjEX_Ekc6ptlwnbanstx7gvkdnq-gLKjyFNnMMyS0RVchrGEiS8ASVoLwnzDfuM2G2W4pgy8kRnOEiOsxUTDLUqKOFf8geM5i-biQTwUptOpJiAUsLVVG8m03gsd8cY4-fRj8_qlfuWeZP0NsgjrxNAvTWQU6PQKMFAHyniuflZBzNEwIshpew1g_6mUJuMArqjkmAVq9sbak5HkfXhiVfAHO0U0d_lRkbEbk6znyWoKLhn4o3lqVf-cOnJvf31kuEu0ImmJR0tCEJYhgsBs6imiBZiFHDwukBv90zWh9f-d4pzDCuDMl50bD_d4JghS9dYy6a_yCOENvTduom-JmeWKCVFmu2MbfRJJMCIa6jcRAvXxTEPcWuB3jlw1KWAYpB-AUPhKkGuCKBeJ8eSnUCrMRRmrcQ2oQQ9Ao_AM2EEw98hX7RmLlTyVvB4BOsMH_AWxU2MighYcRQc8z2IoIJrxIHUNvCk4r5oZyeEm-kcqWoSkKGGwzjjB9xot0SSU2FwxkI-Eyko5D7my4Cnr2cvvtpVieUMisvMZwKBPfLtwOwcWUkEeSVMYzPAUjYgRV4gm8yDu8c-Q47vKmCzHPD2MhBOfIaLTbTfsAMDeg6TpFaBqvgWJ6dbOtgGK5dQsuRfrfAYR95Htwo8iBOkehbdft1i9odaCyC2oeANXaxFoeBDTCHJj2rmgYz0RS4nSB8HwOP2MW16UGoWo5mxSVDeIJRIXvJoQKhqAAZNMZtItY4vWtaRh1yxDWRWwdoIPQMI-CxzpKcRyAzlEKbz9E7Z0QvYGJORUrBdCi8Ao2Zpj4lPCKGoSQmoQAfG6rUpyNdoC1BdlxJ1i7dfmnCNb2XrC-tSCjWa0tcBSNKVK_W2UtgJ4EqJqHZJ46nNxWv3axXGHLLWaWMIdNF-LFKaQYHCv8qccqpSDI1T1IWFSmpf2yEVQaNCYvYBckJXUsDVDjM8h0wPI_A9c2MFb1114ibBdIRkxl8msKnWNa6Yk-l6O_k2dCDxZf8chuQOuhVZDtTcEjHIQZgOOOwN9R5TaMRD8HK3OOzC3wrItwccVdqIUbC76R7lb1t2ZvcJmGFpv5XfwuhShTFKg4cgw0iDmBOE1FxwTsSDlQQ8smG60_q6SqaHZAg0pAZAE9LYbdgSbQtEOGq6FsLlDobsBKMkAfpLrrYhPxE6xRFEfseefkdGvldgnlfr6Z5IFWUVRhKU6XOgPbZUJwxU5_vZVTn0Fr_N_fbK-z8Jiy5Tmv6oaRuW78V2e8a6L3BMoTX5Mst2_eXx_orYtt9C6142c8R52HRZqK2qoGEnetyFg6t4N1m83SY3vl6AZVlzGowuUM2uXLEaO6BBLMaSyQ9dJHZGuZZO0yyS4XXr0gWD-JzSlnpFdOm1c-muaRBd6FpyMroHbbqYp2IMkro-cI_NTAUEawXX4XmWX0OeWwYJZDnnN8eXQCe6rYXfAq6bhW3nFL2FMiB9rH1AQLpD5gnLh8u6NcCl9uGSatLfmq0O5YiFJ-uqXDapVYd6_cTrLLwdc-HWVO-bRfAtNm6eDbOjvT0SEqYfYPND-aK1l-FbwSqCy_DD8AF92ULHg1d40-aYnIjcR8bZVJMVbp8JZMF_rrWcYdWyNOZvllcEpHyy3jjc5-KQ_yIyZ1ooyS102QGkthZJRfleTXG_mLTCyehFOguDjb_vdQ_wHUdaqk
```
### Before screenshot:
![image](https://user-images.githubusercontent.com/1209372/153532697-ea33d579-f9f1-46b9-9220-68df6c6600bd.png)

### After screenshot:
![image](https://user-images.githubusercontent.com/1209372/153532724-fbf4e06e-e817-4887-8e6e-3154f309d474.png)
