### PR TITLE
Add Delirium effect scaling

### DIFF
--- a/src/Modules/ConfigOptions.lua
+++ b/src/Modules/ConfigOptions.lua
@@ -1359,19 +1359,19 @@ Sirus adds the following modifiers:
 	end },
 	{ var = "deliriousPercentage", type = "list", label = "Delirious Effect:", list = {{val=0,label="None"},{val="20Percent",label="20% Delirious"},{val="40Percent",label="40% Delirious"},{val="60Percent",label="60% Delirious"},{val="80Percent",label="80% Delirious"},{val="100Percent",label="100% Delirious"}}, tooltip = "Delirium scales enemy 'less Damage Taken' as well as enemy 'increased Damage dealt'\nAt 100% effect:\nEnemies Deal 30% Increased Damage\nEnemies take 96% Less Damage", apply = function(val, modList, enemyModList)
 		if val == "20Percent" then
-			enemyModList:NewMod("DamageTaken", "MORE", -19, "20% Delirious")
+			enemyModList:NewMod("DamageTaken", "MORE", -19.2, "20% Delirious")
 			enemyModList:NewMod("Damage", "INC", 6, "20% Delirious")
 		end
 		if val == "40Percent" then
-			enemyModList:NewMod("DamageTaken", "MORE", -38, "40% Delirious")
+			enemyModList:NewMod("DamageTaken", "MORE", -38.4, "40% Delirious")
 			enemyModList:NewMod("Damage", "INC", 12, "40% Delirious")
 		end
 		if val == "60Percent" then
-			enemyModList:NewMod("DamageTaken", "MORE", -58, "60% Delirious")
+			enemyModList:NewMod("DamageTaken", "MORE", -57.6, "60% Delirious")
 			enemyModList:NewMod("Damage", "INC", 18, "60% Delirious")
 		end
 		if val == "80Percent" then
-			enemyModList:NewMod("DamageTaken", "MORE", -77, "80% Delirious")
+			enemyModList:NewMod("DamageTaken", "MORE", -76.8, "80% Delirious")
 			enemyModList:NewMod("Damage", "INC", 24, "80% Delirious")
 		end
 		if val == "100Percent" then

--- a/src/Modules/ConfigOptions.lua
+++ b/src/Modules/ConfigOptions.lua
@@ -1357,6 +1357,28 @@ Sirus adds the following modifiers:
 		enemyModList:NewMod("Life", "MORE", 3 * m_min(val, 9), "Config")
 		modList:NewMod("AwakeningLevel", "BASE", m_min(val, 9), "Config")
 	end },
+	{ var = "deliriousPercentage", type = "list", label = "Delirious Effect:", list = {{val=0,label="None"},{val="20Percent",label="20% Delirious"},{val="40Percent",label="40% Delirious"},{val="60Percent",label="60% Delirious"},{val="80Percent",label="80% Delirious"},{val="100Percent",label="100% Delirious"}}, apply = function(val, modList, enemyModList)
+		if val == "20Percent" then
+			modList:NewMod("Damage", "MORE", -19, "20% Delirious")
+			enemyModList:NewMod("Damage", "INC", 6, "20% Delirious")
+		end
+		if val == "40Percent" then
+			modList:NewMod("Damage", "MORE", -38, "40% Delirious")
+			enemyModList:NewMod("Damage", "INC", 12, "40% Delirious")
+		end
+		if val == "60Percent" then
+			modList:NewMod("Damage", "MORE", -58, "60% Delirious")
+			enemyModList:NewMod("Damage", "INC", 18, "60% Delirious")
+		end
+		if val == "80Percent" then
+			modList:NewMod("Damage", "MORE", -77, "80% Delirious")
+			enemyModList:NewMod("Damage", "INC", 24, "80% Delirious")
+		end
+		if val == "100Percent" then
+			modList:NewMod("Damage", "MORE", -96, "100% Delirious")
+			enemyModList:NewMod("Damage", "INC", 30, "100% Delirious")
+		end
+	end },
 	{ var = "enemyPhysicalReduction", type = "integer", label = "Enemy Phys. Damage Reduction:", apply = function(val, modList, enemyModList)
 		enemyModList:NewMod("PhysicalDamageReduction", "BASE", val, "Config")
 	end },

--- a/src/Modules/ConfigOptions.lua
+++ b/src/Modules/ConfigOptions.lua
@@ -1357,25 +1357,25 @@ Sirus adds the following modifiers:
 		enemyModList:NewMod("Life", "MORE", 3 * m_min(val, 9), "Config")
 		modList:NewMod("AwakeningLevel", "BASE", m_min(val, 9), "Config")
 	end },
-	{ var = "deliriousPercentage", type = "list", label = "Delirious Effect:", list = {{val=0,label="None"},{val="20Percent",label="20% Delirious"},{val="40Percent",label="40% Delirious"},{val="60Percent",label="60% Delirious"},{val="80Percent",label="80% Delirious"},{val="100Percent",label="100% Delirious"}}, apply = function(val, modList, enemyModList)
+	{ var = "deliriousPercentage", type = "list", label = "Delirious Effect:", list = {{val=0,label="None"},{val="20Percent",label="20% Delirious"},{val="40Percent",label="40% Delirious"},{val="60Percent",label="60% Delirious"},{val="80Percent",label="80% Delirious"},{val="100Percent",label="100% Delirious"}}, tooltip = "Delirium scales enemy 'less Damage Taken' as well as enemy 'increased Damage dealt'\nAt 100% effect:\nEnemies Deal 30% Increased Damage\nEnemies take 96% Less Damage", apply = function(val, modList, enemyModList)
 		if val == "20Percent" then
-			modList:NewMod("Damage", "MORE", -19, "20% Delirious")
+			enemyModList:NewMod("DamageTaken", "MORE", -19, "20% Delirious")
 			enemyModList:NewMod("Damage", "INC", 6, "20% Delirious")
 		end
 		if val == "40Percent" then
-			modList:NewMod("Damage", "MORE", -38, "40% Delirious")
+			enemyModList:NewMod("DamageTaken", "MORE", -38, "40% Delirious")
 			enemyModList:NewMod("Damage", "INC", 12, "40% Delirious")
 		end
 		if val == "60Percent" then
-			modList:NewMod("Damage", "MORE", -58, "60% Delirious")
+			enemyModList:NewMod("DamageTaken", "MORE", -58, "60% Delirious")
 			enemyModList:NewMod("Damage", "INC", 18, "60% Delirious")
 		end
 		if val == "80Percent" then
-			modList:NewMod("Damage", "MORE", -77, "80% Delirious")
+			enemyModList:NewMod("DamageTaken", "MORE", -77, "80% Delirious")
 			enemyModList:NewMod("Damage", "INC", 24, "80% Delirious")
 		end
 		if val == "100Percent" then
-			modList:NewMod("Damage", "MORE", -96, "100% Delirious")
+			enemyModList:NewMod("DamageTaken", "MORE", -96, "100% Delirious")
 			enemyModList:NewMod("Damage", "INC", 30, "100% Delirious")
 		end
 	end },


### PR DESCRIPTION
Delirium scales mob `Damage taken` and mob `Damage dealt` by certain values discovered in this post
https://www.reddit.com/r/pathofexile/comments/pkgeg8/delirium_scaling/

Changed it to be `Less player damage` as that is effectively the same as `Less damage taken` I believe. I could be wrong here