### PR TITLE
Add support for using existing release notes link to work off of

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -12,6 +12,15 @@ changelog:
     - title: Implemented Enhancements
       labels:
         - enhancement
+    - title: User Interface
+      labels:
+        - user-interface
+    - title: New Calculations
+      labels:
+        - new-calculations
+    - title: Accuracy Improvements
+      labels:
+        - accuracy
     - title: Fixed Bugs
       labels:
         - bug

--- a/.github/workflows/beta.yml
+++ b/.github/workflows/beta.yml
@@ -2,6 +2,9 @@ name: Push beta branch
 on: 
   schedule:
     - cron: '0 0 * * 5'
+  push:
+    branches:
+      - 'master'
   workflow_dispatch:
 jobs:
   push-beta:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,9 @@ on:
               description: 'Version number to use for this release'
               required: true
               default: '2.x.x'
+          releaseNoteUrl:
+              description: 'Enter the location of edited release notes to use'
+              required: false
 jobs:
   release:
     runs-on: ubuntu-latest
@@ -15,24 +18,32 @@ jobs:
               with:
                 ref: 'dev'
             - name: Generate Release notes
+              if: ${{ github.event.inputs.releaseNoteUrl == '' }}
               run: >
                 echo "${{ secrets.GITHUB_TOKEN }}" | gh auth login --with-token;
                 gh release view $(basename $(gh release create v${{ github.event.inputs.releaseVersion }} --title "Release ${{ github.event.inputs.releaseVersion }}" --draft --generate-notes)) > temp_change.md
+            - name: Use existing Release notes
+              if: ${{ github.event.inputs.releaseNoteUrl != '' }}
+              run: >
+                echo "${{ secrets.GITHUB_TOKEN }}" | gh auth login --with-token;
+                gh release view $(basename ${{ github.event.inputs.releaseNoteUrl }}) > temp_change.md
             - name: Tweak changelogs
               run: >
                 sed -i '1,8d' temp_change.md;
                 sed -i '1h;1d;$!H;$!d;G' temp_change.md;
                 sed -i -re 's/\*\*Full Changelog\*\*: (.*)/\[Full Changelog\]\(\1\)\n/' temp_change.md;
                 sed -i '/## New Contributors/,$d' temp_change.md;
+                sed -i -re 's/^\*(.*)\sby\s@(.*)\sin\s(.*\/pull\/)(.*)/-\1 [\\#\4](\3\4) ([\2](https:\/\/github.com\/\2))/' temp_change.md
+                sed -i 's/\[Quotae/\[Quote_a/' temp_change.md;
+                sed -i 's/\[learn2draw/\[Lexy/' temp_change.md;
+                sed -i 's/\[Voronoff/\[Tom Clancy Is Dead/' temp_change.md;
+                sed -i 's/\[PJacek/\[TPlant/' temp_change.md;
                 cp temp_change.md changelog_temp.txt;
                 cat CHANGELOG.md | sed '1d' >> temp_change.md;
                 printf "# Changelog\n\n## [v${{ github.event.inputs.releaseVersion }}](https://github.com/PathOfBuildingCommunity/PathOfBuilding/tree/v${{ github.event.inputs.releaseVersion }}) ($(date +'%Y/%m/%d'))\n\n" | cat - temp_change.md > CHANGELOG.md;
 
-                sed -i 's/Quotae/Quote_a/' changelog_temp.txt;
-                sed -i 's/learn2draw/Lexy/' changelog_temp.txt;
-                sed -i 's/Voronoff/Tom Clancy Is Dead/' changelog_temp.txt;
-                sed -i 's/PJacek/TPlant/' changelog_temp.txt;
-                echo "VERSION[${{ github.event.inputs.releaseVersion }}][`date +'%Y/%m/%d'`]" | cat - changelog_temp.txt | sed '2,4d' | sed -e '/^##.*/,+1 d' | sed -r 's/by @(.*) in http.*/\(\1\)/' | cat - changelog.txt > changelog_new.txt;
+                sed -i -re 's/^- (.*) \[.*\) \(\[(.*)\]\(.*/* \1 (\2)/' changelog_temp.txt
+                echo "VERSION[${{ github.event.inputs.releaseVersion }}][`date +'%Y/%m/%d'`]" | cat - changelog_temp.txt | sed '2,4d' | sed -e '/^##.*/,+1 d' | cat - changelog.txt > changelog_new.txt;
                 rm temp_change.md;
                 rm changelog_temp.txt;
                 mv changelog_new.txt changelog.txt


### PR DESCRIPTION
This also builds in the regex used to massage the release notes into the format our users are used to.  I've also added the extra labeling we want to use to differentiate different types of issues