### PR TITLE
Fix various errors caused by Barrage / Barrage Support ambiguity

### DIFF
--- a/src/Classes/GemSelectControl.lua
+++ b/src/Classes/GemSelectControl.lua
@@ -594,7 +594,7 @@ function GemSelectClass:AddCommonGemInfo(gemInstance, grantedEffect, addReq, mer
 	end
 	self.tooltip:AddSeparator(10)
 	if addReq then
-		local reqLevel = grantedEffect.levels[gemInstance.level] and grantedEffect.levels[gemInstance.level].levelRequirement or 0
+		local reqLevel = grantedEffect.levels[gemInstance.level] and grantedEffect.levels[gemInstance.level].levelRequirement or 1
 		local reqStr = calcLib.getGemStatRequirement(reqLevel, grantedEffect.support, gemInstance.gemData.reqStr)
 		local reqDex = calcLib.getGemStatRequirement(reqLevel, grantedEffect.support, gemInstance.gemData.reqDex)
 		local reqInt = calcLib.getGemStatRequirement(reqLevel, grantedEffect.support, gemInstance.gemData.reqInt)

--- a/src/Classes/GemSelectControl.lua
+++ b/src/Classes/GemSelectControl.lua
@@ -516,7 +516,7 @@ end
 
 function GemSelectClass:AddCommonGemInfo(gemInstance, grantedEffect, addReq, mergeStatsFrom)
 	local displayInstance = gemInstance.displayEffect or gemInstance
-	local grantedEffectLevel = grantedEffect.levels[displayInstance.level]
+	local grantedEffectLevel = grantedEffect.levels[displayInstance.level] or { }
 	if addReq then
 		self.tooltip:AddLine(16, string.format("^x7F7F7FLevel: ^7%d%s%s",
 			gemInstance.level, 
@@ -594,7 +594,7 @@ function GemSelectClass:AddCommonGemInfo(gemInstance, grantedEffect, addReq, mer
 	end
 	self.tooltip:AddSeparator(10)
 	if addReq then
-		local reqLevel = grantedEffect.levels[gemInstance.level].levelRequirement
+		local reqLevel = grantedEffect.levels[gemInstance.level] and grantedEffect.levels[gemInstance.level].levelRequirement or 0
 		local reqStr = calcLib.getGemStatRequirement(reqLevel, grantedEffect.support, gemInstance.gemData.reqStr)
 		local reqDex = calcLib.getGemStatRequirement(reqLevel, grantedEffect.support, gemInstance.gemData.reqDex)
 		local reqInt = calcLib.getGemStatRequirement(reqLevel, grantedEffect.support, gemInstance.gemData.reqInt)

--- a/src/Modules/CalcTools.lua
+++ b/src/Modules/CalcTools.lua
@@ -160,7 +160,7 @@ function calcLib.buildSkillInstanceStats(skillInstance, grantedEffect)
 	end
 	local level = grantedEffect.levels[skillInstance.level] or { }
 	local availableEffectiveness
-	local actorLevel = skillInstance.actorLevel or level.levelRequirement
+	local actorLevel = skillInstance.actorLevel or level.levelRequirement or 1
 	for index, stat in ipairs(grantedEffect.stats) do
 		local statValue
 		if level.statInterpolation and level.statInterpolation[index] == 3 then

--- a/src/Modules/CalcTools.lua
+++ b/src/Modules/CalcTools.lua
@@ -158,12 +158,12 @@ function calcLib.buildSkillInstanceStats(skillInstance, grantedEffect)
 			stats[stat[1]] = (stats[stat[1]] or 0) + math.modf(stat[2] * skillInstance.quality)
 		end
 	end
-	local level = grantedEffect.levels[skillInstance.level]
+	local level = grantedEffect.levels[skillInstance.level] or { }
 	local availableEffectiveness
 	local actorLevel = skillInstance.actorLevel or level.levelRequirement
 	for index, stat in ipairs(grantedEffect.stats) do
 		local statValue
-		if level.statInterpolation[index] == 3 then
+		if level.statInterpolation and level.statInterpolation[index] == 3 then
 			-- Effectiveness interpolation
 			if not availableEffectiveness then
 				availableEffectiveness = 
@@ -171,7 +171,7 @@ function calcLib.buildSkillInstanceStats(skillInstance, grantedEffect)
 					* (1 + (grantedEffect.incrementalEffectiveness or 0)) ^ (actorLevel - 1)
 			end
 			statValue = round(availableEffectiveness * level[index])
-		elseif level.statInterpolation[index] == 2 then
+		elseif level.statInterpolation and level.statInterpolation[index] == 2 then
 			-- Linear interpolation; I'm actually just guessing how this works
 			local nextLevel = m_min(skillInstance.level + 1, #grantedEffect.levels)
 			local nextReq = grantedEffect.levels[nextLevel].levelRequirement


### PR DESCRIPTION
When copying a skill gem group with Barrage Support present PoB doesn't know whether you meant Barrage or Barrage Support, and throws a large number of errors when you attempt to replace the ambiguous Barrage skill gem with anything else via the dropdown list.

### Description of the problem being solved:
https://www.youtube.com/watch?v=OMFPi8oTEgw

### Link to a build that showcases this PR:
https://pastebin.com/k6dJeZGq