### PR TITLE
Bow Proj Speed as damage only applies to hits

### DIFF
--- a/src/Modules/CalcOffence.lua
+++ b/src/Modules/CalcOffence.lua
@@ -533,7 +533,7 @@ function calcs.offence(env, actor, activeSkill)
 		-- Bow mastery projectile speed to damage with bows conversion
 		for i, value in ipairs(skillModList:Tabulate("INC", { }, "ProjectileSpeed")) do
 			local mod = value.mod
-			skillModList:NewMod("Damage", mod.type, mod.value, mod.source, ModFlag.Bow, mod.keywordFlags, unpack(mod))
+			skillModList:NewMod("Damage", mod.type, mod.value, mod.source, bor(ModFlag.Bow, ModFlag.Hit), mod.keywordFlags, unpack(mod))
 		end
 	end
 	if skillModList:Flag(nil, "ClawDamageAppliesToUnarmed") then


### PR DESCRIPTION
Fixes #4123 

### Description of the problem being solved:
The wording "damage with bows" only applies to hits, not DoT. This fixes that.

### Steps taken to verify a working solution:
- Checked build before and after change. Before change, ignite DPS changes. After, it does not. Other DPS is adjusted appropriately.

### Link to a build that showcases this PR: https://pobb.in/ceq8nyVP3O0R
