### PR TITLE
Fix Kinetic Bolt and Earthquake not fully scaling with Spell Damage/Cast Speed

### DIFF
--- a/src/Data/Skills/act_int.lua
+++ b/src/Data/Skills/act_int.lua
@@ -6024,11 +6024,11 @@ skills["KineticBolt"] = {
 	statMap = {
 		["active_skill_additive_spell_damage_modifiers_apply_to_attack_damage_at_%_value"] = {
 			flag("SpellDamageAppliesToAttacks"),
-			mod("ImprovedSpellDamageAppliesToAttacks", "INC", nil),
+			mod("ImprovedSpellDamageAppliesToAttacks", "MAX", nil),
 		},
 		["cast_speed_+%_applies_to_attack_speed_at_%_of_original_value"] = {
 			flag("CastSpeedAppliesToAttacks"),
-			mod("ImprovedCastSpeedAppliesToAttacks", "INC", nil)
+			mod("ImprovedCastSpeedAppliesToAttacks", "MAX", nil)
 		},
 		["mana_gain_per_target"] = {
 			mod("ManaOnHit", "BASE", nil),

--- a/src/Data/Skills/act_str.lua
+++ b/src/Data/Skills/act_str.lua
@@ -2430,7 +2430,7 @@ skills["Earthquake"] = {
 		},
 		["active_skill_additive_spell_damage_modifiers_apply_to_attack_damage_at_%_value"] = {
 			flag("SpellDamageAppliesToAttacks"),
-			mod("ImprovedSpellDamageAppliesToAttacks", "INC", nil),
+			mod("ImprovedSpellDamageAppliesToAttacks", "MAX", nil),
 		},
 	},
 	baseFlags = {

--- a/src/Export/Skills/act_int.txt
+++ b/src/Export/Skills/act_int.txt
@@ -1296,11 +1296,11 @@ local skills, mod, flag, skill = ...
 	statMap = {
 		["active_skill_additive_spell_damage_modifiers_apply_to_attack_damage_at_%_value"] = {
 			flag("SpellDamageAppliesToAttacks"),
-			mod("ImprovedSpellDamageAppliesToAttacks", "INC", nil),
+			mod("ImprovedSpellDamageAppliesToAttacks", "MAX", nil),
 		},
 		["cast_speed_+%_applies_to_attack_speed_at_%_of_original_value"] = {
 			flag("CastSpeedAppliesToAttacks"),
-			mod("ImprovedCastSpeedAppliesToAttacks", "INC", nil)
+			mod("ImprovedCastSpeedAppliesToAttacks", "MAX", nil)
 		},
 		["mana_gain_per_target"] = {
 			mod("ManaOnHit", "BASE", nil),

--- a/src/Export/Skills/act_str.txt
+++ b/src/Export/Skills/act_str.txt
@@ -434,7 +434,7 @@ local skills, mod, flag, skill = ...
 		},
 		["active_skill_additive_spell_damage_modifiers_apply_to_attack_damage_at_%_value"] = {
 			flag("SpellDamageAppliesToAttacks"),
-			mod("ImprovedSpellDamageAppliesToAttacks", "INC", nil),
+			mod("ImprovedSpellDamageAppliesToAttacks", "MAX", nil),
 		},
 	},
 #baseMod skill("showAverage", true, { type = "SkillPart", skillPart = 2 })


### PR DESCRIPTION
### Description of the problem being solved:
The configuration for Kinetic Bolt was setting the value of the spell damage/cast speed scaling mods as increases, rather than max values as they're read in CalcOffence. This lead to them being always treated at 100% scaling rather than the correct 200% for spell damage and 2.5%*quality for cast speed.

### Steps taken to verify a working solution:
- Add a no-implicit wand with Hits Can't be Evaded (to ignore Accuracy), 100% of Physical Damage Converted to Lightning (to ignore Armour)
- Add Anomalous Kinetic Bolt
- Add custom modifier "100% increased Spell Damage"
- Confirm DPS triples instead of doubles and shows as 200% increased on calc sheet
- Add custom modifier "100% increased Cast Speed"
- Confirm attack speed increases with quality at correct rate
- Verify other similar "applies to" mods are correctly overridden (Crown of Eyes, Wand mastery)

### Link to a build that showcases this PR:
```
eNqtWm1z4jgS_jz8ChVVe98CmLdMsmS3CCGZ1IYMB5mZu09TwhagjSyxlhzC_vpryQY8DCRt7SWpxDZPv7da3XJ6v7_GgrywRHMlr6pBrVElTIYq4nJxVf3ydHv2sfr7b5XemJrl5_l1yoX95LfKh567JoK9MAF0VWJosmDm65ZT6ztwWlFplkzJEf1TJXcquqo-KsmqZEZlxM32LhRU60cas6vqNATiKqE6ZDIa7J9nwJhyOVXhMzN3iUpXTuwLZ-uRigBzPxp_njwVhHJZFAo6f-iNBd2wZGqoIRp-XVX7YDpdsBsaw2_gRkUKrNrdWue8U60fp5muGIt22FYtOIkcJ2w4n7PQ8Bc2SLgZLKkM92LOT9GVxY5SYfhKcJbs8EHtpFaffmIeNBqnwE_KUHEznu6x4JzzIGh23qZQZkdxkvc3bpbXApxZir-lul9IblhpsrHiWkkva4pEJw0apELA8sBhVTzjsqTtIyrpQGlTiNwp6AOfsx-gJ5HDKQ43gSWCQ1o1xyyBRWxwBFbZUgS5hCkLFRSKMjLKkBTs8BPmQTmc-hB4CJqafbVonkTdsFcE6l4aBGrC_ioCg07ntNQXZdxW8J4Vbn0OP413yO55rdVtX1x0L6CqXXRPWu88BXsEj6kY0VcepzEUxif6zPZSW-enq6iN8F5o443NIry02HsZ4tLmi0yYZslLYY_pIgnyRMDUdUs4YQsmcUo9MBYu72D_nVDDcAtnh-q87RyLRTnHAo84p4MkKOEcS3jgnNrFW-CS7vlGkwixsCVLFpvpkjOBQDtfFklQPi0SINOhSFLS7uEL1cVVHXTftiaD45KDQSMBBBE76G0ap5sz9adtzUQ5sn4SqzRBxiMDowwYLzeah9BruFZ0wqI0xFXAXYc5Ui8shgx3_Sn0xHs3nyK9FtBNYw0HtkKUougbQ8PnGxUtWCkh5Smm6WoF69xmC5bulifgZc0LW-VZF4H-DBPDgK4wDZ5dUlgBezRawANfLI2EfhMv5YAEb8uSKl3CmD0cLeIWemdU4zxWa2C5tOOmLoeGbX6_tZ_UI2Hy7w2a_w9wlIChjNLE5ihaxiHFz2J6dTeO26v7eKUS4x4OqAi1Y3kvV6kh0s3SMdfh91k6n9uxuQoiEjfrD29vh4On-6_DXIsiiX7mQnyXaTyzE2b2d19WpsxVKhIqIehKM5i451Ro4M3hcmppp1CdQ4PCQxOWT-MYNOykYcLBiRiwHUpRKrsBH4O0wzcKCFGhguEd9rRZMZsBGuuzvOxh0G7kRiGzeRlnoJvIcWFgId2gkLv2AoUeCtbnwu6AOK-NYCFkmycOD9tZwmepQWabGxBQethmGWVgsSFErg4cMG9qUErkPRwGm-8YuKSExgIdths2Z5DuyGXvykk22WXFclsYe26taaKhYt6xWF9vYAe6te49OJ-JqYFEZPGDPe58UrYO09Cw5CE7_syF_cDmqmqSFB5GbE5TYZ__O6WCm40t9IWnOQuYmoleqrXtZDI2tgRoCM3DQ_ZJX5icg5WxFZrZb81wx6N91wm6e2ekOyPlMhRpBBNovsfuFBZ0ZmVXycKepw5UKmG3kVzYM2A6E9aPmREHrC1XK_hDD1TJsXdCzaho7nnv7SoCgi1Lt6fcg4Q_wMuGh9dKQG_xV2ahfQ72skTCXBHk4DFNjLNnwWILGDFDI2po_d6AQ-rWK3WnHlwdY-pGxUPLdpz37gozP8CV3f1sH79TkjiGWdJlslw-ZWlkL58SxgjNPOUIgzxCcFM81rb6N6xfNRi5yauQjYSETRkuOh8_tlpVYoBd4Ug9OM9PyzPyLATDCApv9Gjp6tmTL5MHd_FhacxKX9br6_W6tqJmqebsFeadWqji-grYgJZnzgFnVlC9D1_Xi777cozqW0697Nhdby0Ha5zh1lx78aigKtrP7MPtjXPGV87WRDPYppdTk1gL_1Yq_i9YeNGqtRvn-U-Q5fgnRs2IrnZJZLH5Amnn6wM2xRsO_kpcAdiG0QL_Az1ps31RO28EHzvZT7beXX7kUbHXU5aFN9UsOwb6xuhKSfe4sKos1BWQPNknFHb7zSWZ9CfDyiOYZQGVm4TPzVqpiHyjMqoMEjqHcFwSq1dlnLA5f70k9g3EGzdT6MYQN_nyvyTNRiUPyCW5PoPvCvQXgofcPmhUoB3QZEDlv8Aq_ashM0bciBtVgkbjF6LmZDtskqw2koGS0KeD3sQoshsSXKytkVkKC7XtBzN_EVtaTLYWt71g7t43XFv06DGe0zVdkf5sozWol1lJOntBeZN8lPSQrIkj-8mKH1DXSoE3_RQ6Zss7Sl0zYUqS3EJFeCYtlErNYyq1_NyLc0Lz_0TW9lOy6yet6-_N4J0AH8undyLwiUFba8oKOpJJXR8576Qf7Osvdootz7jlv4oCH3ltv1wI_DKv_X54MI4ty_ZYenkajqo7HQ99PGpg6z0x0YZkU0zJ8B33sld-dXyIUEsSEwgvOzvebm16xL3rt5JafunbKp9lbf-y75HTgbfzW5iEaGNAHmr_g-YHGUn_KHQ9stI_DP8gXbAl2dIiVw0e6uG5CcwDuE6gdKE46V7PcoGPp485LYSfAv8wtL291fGxBrNe_JP8HZX6cSqO7G3ZzAkjozticMO7e5uh5Jwvfno3EabaqHikIr1_l-HGXC7DhFENM-2AakPcoX7l4BP38pAU3jf06lsxvfrh_zz-D0n-5cU=
```

### Before screenshot:
![image](https://user-images.githubusercontent.com/45536/153767178-a9bf1f17-ab79-47ac-90c4-9c76f6d5ecdc.png)

### After screenshot:
![image](https://user-images.githubusercontent.com/45536/153767140-15bcc184-69e7-4be1-bff0-10671803eef8.png)
