### PR TITLE
Death wish now uses it's own config instead of corpse life

### DIFF
--- a/src/Data/Skills/other.lua
+++ b/src/Data/Skills/other.lua
@@ -724,8 +724,10 @@ skills["DeathWish"] = {
 	preDamageFunc = function(activeSkill, output)
 		if activeSkill.skillPart == 2 then
 			local skillData = activeSkill.skillData
-			skillData.FireBonusMin = output.Life * skillData.selfFireExplosionLifeMultiplier
-			skillData.FireBonusMax = output.Life * skillData.selfFireExplosionLifeMultiplier
+			local life = activeSkill.skillData.targetMinionLife or 0
+
+			activeSkill.skillData.FireBonusMin = life * activeSkill.skillData.selfFireExplosionLifeMultiplier
+			activeSkill.skillData.FireBonusMax = life * activeSkill.skillData.selfFireExplosionLifeMultiplier
 		end
 	end,
 	statMap = {
@@ -756,7 +758,6 @@ skills["DeathWish"] = {
 		area = true,
 	},
 	baseMods = {
-		skill("explodeCorpse", true, { type = "SkillPart", skillPart = 2 }),
 		skill("radius", 10, { type = "SkillPart", skillPart = 2 }),
 		skill("buffMinions", true),
 		skill("buffNotPlayer", true),

--- a/src/Modules/ConfigOptions.lua
+++ b/src/Modules/ConfigOptions.lua
@@ -164,6 +164,10 @@ return {
 	{ var = "darkPactSkeletonLife", type = "count", label = "Skeleton ^xE05030Life:", ifSkill = "Dark Pact", tooltip = "Sets the maximum ^xE05030Life ^7of the Skeleton that is being targeted.", apply = function(val, modList, enemyModList)
 		modList:NewMod("SkillData", "LIST", { key = "skeletonLife", value = val }, "Config", { type = "SkillName", skillName = "Dark Pact" })
 	end },
+	{ label = "Death Wish:", ifSkill = "Death Wish" },
+	{ var = "deathWishMinionLife", type = "count", label = "Minion ^xE05030Life:", ifSkill = "Death Wish", tooltip = "Sets the maximum ^xE05030Life ^7of the minion that is being targeted.", apply = function(val, modList, enemyModList)
+		modList:NewMod("SkillData", "LIST", { key = "targetMinionLife", value = val }, "Config", { type = "SkillName", skillName = "Death Wish" })
+	end },
 	{ label = "Predator:", ifSkill = "Predator" },
 	{ var = "deathmarkDeathmarkActive", type = "check", label = "Is the enemy marked with Signal Prey?", ifSkill = "Predator", apply = function(val, modList, enemyModList)
 		modList:NewMod("Condition:EnemyHasDeathmark", "FLAG", true, "Config")


### PR DESCRIPTION
Fixes #2372

### Description of the problem being solved:
Death Wish targets your minions. However in PoB it uses the Enemy Corpse Life field to determine it's damage. With this PR whenever you have Death Wish a Skill Option is added in the Configuration tab with a "Death wise: Minion Life" field. This is practically identical to the way Dark Pact configures it's damage.

### Steps taken to verify a working solution:
- Equip "Maw of Mischief" unique helmet
- Select "Death Wish" as main skill
- Select "Minion Explosion" as skillPart
- Go to Configuration tab
- increase the newly added "Minion Life" field.
- Check if the skill's damage increases.

### Link to a build that showcases this PR:
https://pastebin.com/ksuBneXA

### Before screenshot:
![image](https://user-images.githubusercontent.com/22032197/154332615-95e7a6e6-855c-4f00-8cda-1eb550e22e8a.png)


### After screenshot:
![image](https://user-images.githubusercontent.com/22032197/154332895-30e2e6e4-deba-49bb-b747-216554eec173.png)
