### PR TITLE
fix: battlemage's cry spell damage to attacks not applying

### DIFF
--- a/src/Modules/CalcPerform.lua
+++ b/src/Modules/CalcPerform.lua
@@ -1328,7 +1328,7 @@ function calcs.perform(env, avoidCache)
 					modDB:NewMod("SpellDamageAppliesToAttacks", "FLAG", true)
 				end
 				env.player.modDB:NewMod("CritChance", "INC", battlemageCritChance * uptime, "Battlemage's Cry", { type = "Multiplier", var = "WarcryPower", div = 5, limit = battlemageCritChanceMax, limitTotal = true })
-				--env.player.modDB:NewMod("ImprovedSpellDamageAppliesToAttacks", "INC", battlemageSpellToAttack * uptime, "Battlemage's Cry", { type = "Multiplier", var = "WarcryPower", div = 5, limit = battlemageSpellToAttackMax, limitTotal = true })
+				env.player.modDB:NewMod("ImprovedSpellDamageAppliesToAttacks", "MAX", battlemageSpellToAttack * uptime, "Battlemage's Cry", { type = "Multiplier", var = "WarcryPower", div = 5, limit = battlemageSpellToAttackMax, limitTotal = true })
 				modDB:NewMod("BattlemageActive", "FLAG", true) -- Prevents effect from applying multiple times
 			elseif activeSkill.activeEffect.grantedEffect.name == "Intimidating Cry" and not modDB:Flag(nil, "IntimidatingActive") then
 				local intimidatingOverwhelmEffect = activeSkill.skillModList:Sum("BASE", env.player.mainSkill.skillCfg, "IntimidatingPDRPer5MP")


### PR DESCRIPTION
Fixes #4165 (comment within) .

### Description of the problem being solved:
Battlemage's Cry had the spell damage conversion commented out and wasn't applying.  Didn't see problems with it, so this PR simply uncomments it and converts to using the same 'MAX' calculation as other spell damage conversions.
### Steps taken to verify a working solution:
- Tested with Phantasmal Earthquake to ensure only the highest one applies

### Link to a build that showcases this PR:
```bash
eNrVWm1z2rgW_tz8Cg0ze-fuDAG_YF6yZHcIIQm7oWUhabefOsIWoI1ssbYcSnf63_dINmBSIELdmTu3H1pjP-f96Jwjqe1fPocMPZM4oTy6LNkVq4RI5POARrPL0uPDzXmz9MvPZ-0hFvN306uUMvnl57M3bfWMGHkmDOhKSOB4RsT7NSf3E3Ba4EjMCY8G-E8e3_LgsvSWR6SEJjgKqFj_8hlOkrc4JJelsQ_EJYQTn0RBd_s-A4aYRmPuPxFxG_N0cVlySuiZkuWAB4DpD4bvRg8FoTQqCgWd37SHDK9IPBZYoAT-uix1wHQ8I9c4hL-BG2YpsHLcSq3eajoNr1l3rEapup94vCAk2BC5lfoh4DAmvemU-II-k25MRXeOI38rzjpEdyp2kDJBF4ySeIO3K94hirtvmLdah7APXGB2PRxvoM1apday3UbLtS235h2n4-J1_T9QMb9i4FADKZK2P4uoIIbEQ04THn2HfUXSwyFKGYPVo4fl4YRGRt7oxAS_m2YJN8IBTZNtNtiHiAY4wl2ebAPlHELe0ynZQR60oTfWw41g7ekhpZZDEkN1EHoEUtmTCHIJY-JzqECnyDiFpGCHmTADyt7YhMBA0Fhsy497MEtH5K8i0PYOIq_J521WWkf4FYGt5iFgP9raYFvH-BWR9eZh9Z65UG3rNceoYtG7G24XtFNx3VqrVXecI-s58z20MxpiNsCfaZiGULsf8BPZCq21Km7DO5Y1G2ijdaSh-RcS2498vVR8jGKSkPi50AcPs98lyJNLJxaScERmBXOhrTWPoe8J8ee3MC-MsCB663GbOtZR_0isln8kcI9_WpoEJ_hHEu76x6k4x8AnuucDjgONehGReLYazylhGmjlyyKJlk-LBLsWa5GcaHfvGSfFlW3Xj1uTwfWSg8CsAwQB0R3whjH_U46Q7DSyThzyNNaMRwbWMmA4XyXUh-FHjc4jEqS-XhXcTMID_kxCyHA1RsMMv3XzIdIrBtO_ruHAlrGTKDpCYP_pmgczcpKQ0ynG6WIB61xmiy7dDY3BywktdODzugb6HexwunihM3HKJaUrYIvWFnBPZ3MRwQCsL-UFib4tc8yTE4zZwrVF3MAwrzXJD_kSWM7l9jg5DQ29fjtIHdQjJtGXlTb_HbiWgF4UpLHMUW0ZLym-FdOuquMD-dQPFzwW6mUXMz9RLPvRIhUoUnv_ZM6XcviRtWXCOSM4uiyJOCW5-B3sE2XsU5SGE7kFzv7dmlZEhjTxP03S6VQeHpRA8VidePRubnrdh_77Xk4yJqqqIZ8zhhcJCS5LU8wSoKDwOJbixlDJfaGFh6ktP2nQQUPX9WMKDtcByz22lsrqzEIHKQ8UtIAQQcyIvsMeVgsisyXR9VleInXQ6gRBC5lt-fUMVEcLemEgPl5pITejiBa6x0iHMtkt9bw2gPTOGq0eHlpfTCep0Mw2tZ_Q0kMO1loGFodHzdWhB8wHIC0l8nlPB5t3F72khCFEO2zXZEog3TWXvSon2VYwK6zrItpWay1BCVTXWxImVyvoVjfSvS8Ol0IsIBFJeC-Pch-4rNnYFyS-z452c2E7bPL6iwIyxSmT739PMaNiJZtC4W3OAjbtSFZxOfVkbGQJSCA09_fZlw4TOQcpYy00s1-aoY5-O2pqVL-VkerYmUY-SwPYsOb9-LIUUVZCDE-k5BKayZPiLk8jkX8hEZ4w6cXMhBeMJU8p9k0bFMmxt4xPMHPWnLc2FT_ba4aqBfVl1LEQjMjwJN14VUJ_ZQb2VZVQHsrBQxwLZcuMhPLrgAgcYIGrfQHOqEqPVJVy8HSAqfL7C8s2vLfO8jM_wJNsgnLiL6r5H7zgyU8Jkoyz3MvE_n-Hobvymbo92Od_DY-_pN_n6n1-XdP9zz0pQf-SL3uQTXPww9OuO2H1kjiCHbVrkNF7eBZVOTWdC-xeeD5_UrXxISYE4cxLiszOiw38KN4-SeUt6dMELFzlDVVGIYKpER4abrNZthteo1V27JZbK9t2zbHKtYbj2WW3Xoc3rluTX-uNmlV2m1atWa67rUa9XHdcq2xbtZZVrltuq1l27WbDK3ue23DLXrPpwt9ey6qXawAHXo1GrYQE6F24YrMb-e1ZpmcW5V4Aw0rwVipYzd48ju7Vw5u5EIvkolpdLpeVBRZzPiWfKSMVn4fVBbABd5wrP59LQdUO_LmadTq9-Rd_9Jt4H9OVn_76bnjL7-_w3fiRDyN-e_ORn6fP6bQ__PgQLGhv7AwXQKMEV9eS29m1XZKpkf9STpSaK0dB5ossW_LtvwzYlgp-QGxUGGXw5MNbDuOK_CZfrn-o0L6nZIkSAvPzfCxiGa8vnIcfL0v1llVpNZys6dwRLAZ4sWlxEpN3rGbesGBKvaYQ9Vh15HUqSuAfsKG07WbFa7iN7FSorZI7zyr5PCZZcqYJyY5wPxCosJF6XWhwEgq7o5himcxu1tfz8jeC12J1gR7f9n9_7J19oBHk4bpOX8n0X5115VoV6FeyJOzsfcbnAg1jgpxKvWLtvnIrbvFVN43BNHGW7WFIgDZf3F2-2T3SBRoQ-Dc8u6ehTDIk-AWyz2ADwKhPBXy3zv7OTbmwv_4Nm8AZubAq3tf_eue29-MPsrrFBMMUg-QBAsrGly2NU3Z3qGxLi8z-Ki_xEGxAYXeYCFSzUB88xRidycABOcoMKGf04wgv0BxDsJDj_YB8tb8AY6C4Ajt4q3bhKNu-Ihi-foM1UdDSXJxnnS7ONRGnWCc7nBNAQh3DAeJTlJ0DbL4s5yRCMIOHsN9EAVVMqVhnmrxR_E59urBzD_gS5lgcoQlBk5UsOBDQyUpXSVUTYLs-kvmBVJZA1at46xWTV42DiPWJuOpCm6UHy_HICi0uxvaY8fXxQQZE9ngJtnUmqyTBDOVlzduWMmut1B7Sl2SOHtlx1BXnEHUzhfbZ8opSVwQqxGkkN9CvnpCrpZKzTyXXzL16TnD-JbKamZJ1M2l1c2-a5NMrEbgjLCTiVEF7MqluIueV9IPR9lmeYZ7O2DVfRbaJvJpZLthmmVd7PTw6jj2V7b70MjRcq-54BvoY1ED3NTHBCmXnUieGb7-XjfLLMyHSWpI6gTCy0zN2q2MQ97rZSnLN0tc9Pctq5mXfIKdtY-e7OglR0wEZqP0dw49mJM2jUDfISvMwfEe66JZkSau5avShBp4b0WimNwmcXCgOutewXOjH08QcV8NPtnkYasbe8kys0Vkv5kn-ikqdMGV7elu2nYQtozqbUmdA6i6bR1M6--baeSnvdFe7d86Dzh_7Lqg3_5db3QOv1CZ5e6ftra97cjnt6sv_ov8P1S0NbQ==
```