### PR TITLE
Fixes #2736: ExtraAuraEffect now respects skill config for effects th…

### DIFF
--- a/src/Modules/CalcPerform.lua
+++ b/src/Modules/CalcPerform.lua
@@ -1685,22 +1685,6 @@ function calcs.perform(env, avoidCache)
 		end
 	end
 
-	-- Check for extra modifiers to apply to aura skills
-	local extraAuraModList = { }
-    for _, value in ipairs(modDB:List(nil, "ExtraAuraEffect")) do
-        local add = true
-        for _, mod in ipairs(extraAuraModList) do
-            if modLib.compareModParams(mod, value.mod) then
-                mod.value = mod.value + value.mod.value
-                add = false
-                break
-            end
-        end
-        if add then
-            t_insert(extraAuraModList, copyTable(value.mod, true))
-        end
-    end
-
 	-- Calculate number of active heralds
 	if env.mode_buffs then
 		local heraldList = { }
@@ -1819,6 +1803,21 @@ function calcs.perform(env, avoidCache)
 				end
 			elseif buff.type == "Aura" then
 				if env.mode_buffs then
+					-- Check for extra modifiers to apply to aura skills
+					local extraAuraModList = { }
+					for _, value in ipairs(modDB:List(skillCfg, "ExtraAuraEffect")) do
+						local add = true
+						for _, mod in ipairs(extraAuraModList) do
+							if modLib.compareModParams(mod, value.mod) then
+								mod.value = mod.value + value.mod.value
+								add = false
+								break
+							end
+						end
+						if add then
+							t_insert(extraAuraModList, copyTable(value.mod, true))
+						end
+					end
 					if not activeSkill.skillData.auraCannotAffectSelf then
 						activeSkill.buffSkill = true
 						affectedByAura[env.player] = true

--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -3118,7 +3118,7 @@ local specialModList = {
 		mod("SkillData", "LIST", { key = "manaReservationPercent", value = 0 }, { type = "SkillType", skillType = SkillType.Banner }),
 		mod("SkillData", "LIST", { key = "lifeReservationPercent", value = 0 }, { type = "SkillType", skillType = SkillType.Banner }),
 	},
-	["placed banners also grant (%d+)%% increased attack damage to you and allies"] = function(num) return { mod("ExtraAuraEffect", "LIST", { mod = mod("Damage", "INC", num, nil, ModFlag.Attack) }, { type = "Condition", var = "BannerPlanted" }) } end,
+	["placed banners also grant (%d+)%% increased attack damage to you and allies"] = function(num) return { mod("ExtraAuraEffect", "LIST", { mod = mod("Damage", "INC", num, nil, ModFlag.Attack) }, { type = "Condition", var = "BannerPlanted" }, { type = "SkillType", skillType = SkillType.Banner }) } end,
 	["dread banner grants an additional %+(%d+) to maximum fortification when placing the banner"] = function(num) return { mod("ExtraSkillMod", "LIST", { mod = mod("MaximumFortification", "BASE", num, { type = "GlobalEffect", effectType = "Buff" }) }, { type = "Condition", var = "BannerPlanted" }, { type = "SkillName", skillName = "Dread Banner" }) } end,
 	["your aura skills are disabled"] = { flag("DisableSkill", { type = "SkillType", skillType = SkillType.Aura }) },
 	["your spells are disabled"] = { flag("DisableSkill", { type = "SkillType", skillType = SkillType.Spell }) },


### PR DESCRIPTION
Fixes #2736 .

### Description of the problem being solved:
ExtraAuraEffect took all effects and applied them equally to all auras.  This PR moves this code so it can apply skill configurations and only apply aura effects if they match the type of skill.
### Steps taken to verify a working solution:
- Verified Bannerman only applies to banners
- Verified aura effect still appropriately affects auras
- Verified added aura effects such as Replenishing Presence, Guardian, and Necromancer passive all add their effects properly
-

### Link to a build that showcases this PR:
```bash
eNrNW21z2kgS_hx-xRRVe3Vbi7FGIwnB2XslY2yzaxwCjpO9L65BDKBYaIhesNmt_e_XMxIgMOBBcV1dUkWE9PR7T0_3iJz9-2XqozkLI48H52Vc1cqIBS4fesH4vPz5_urELv_719JZl8aTj6OLxPPFk19LH87kNfLZnPnn5TqQxTQcs_hhyYo8wr0ZDeIJ40GHfuPhNR-el-94wMpoQIOhFy-_uT6Nojs6ZeflvgvEZUQjlwXD5vq-I28AtzKaUi_oc_eJxdchT2agdBnNPfbc4UMAtjvdj737nGQvyEsGzT-cdX26YGE_pjGK4AO4gwPomF3SKXwCN-onwMqqW1XbwBgbBjF0o3y6m7g_Y2y4IsJVy8ImsQ35ae4j6oasNRoxN_bmrBl6cXNCA3ctei_dDqxexQfhncSPvZnvsTCn5F6Km1f8DbIPe89j6l92-2u-2KxVbd0mmOiY2IfpeLyi0_Yhv3jx5MIH_xaQ0h4HXszyhKSuVS3TwIZuG6RuHBL6mhibhl01bN0wLc2s2YeIu9yLePADjimgdHs6o_6GwoZVrZumrWGCbcPQD1r7ihjrmlGtiew3TKLvzYBm4vtQD_KUe2PZ5NOBF2yF0qybVYPYulkjNWuvjh0a0CaP1gmD90q59UZsA7oX2eqr4XpQE9SQQs0uC6FSxWoEQtmjCDIJfeZyKI_HyDiGJGdHMWEFKFv9IgQFBPXjXB0099bBHvu-iazvQ16ylxWsph3glwcekNwO1lbYh_jlgZa9X705j-Wm-pZnZPVp3XRzTDWtauqkDkuzTvBej0rvw0brTanfoS_eNJnCNnJPn1iQW7EmqWpk-fdQAq1poPYd2HXdhkC3A1ctLz8HIYtYOM9v1gcEbJJkuZYz5yBhj41ztutQ-w-hbxlzJ9fQ1vRozNSW5zpG2DjoIgFWcpEA7nDRialGsO2gE61qY4MQXTdqplk7xGTTWVirHkQf6awvNBwqFJOAheNFf-IxXwEtHZsnUXJwnmDTZCWSI-1uzWmUX_U1Yh1OlIwgb4qxP1kYNGVAMWTbjeuBjpd_E_2ufySdE055si7EdeONhE_xeTP2t-7dySLyXGi5ZOPfY8PE3SiV-122at47fM6mkPhyCoARZB2Zan1vP3Phw_yy5QFyKN18fxfJXgonjqn7dMmHY6ZKIoUcT9FPZjMoASJzVOmuvBBcHXm5zfqE6G-jP8KQ1qQzlUZTLDBVAWu0soBbbzyJA-h71aVskajbMqE82hZjqcCVRVxBD6_UwHf5M7CciDE_Og4NTcE6z_fqEbLgz4Uy_w24koBWMExCkaPKMrYpXos5O5XnIOIKhigexvJmk_puJFm2g1kSo0CeYUy9yH0cJKOROKkog4hQHrK0rq5azfv2QyvTIk8SPXm-_xgk04GY3tN_oaBlyD6T5Qq53PfpLGLD8_KI-hHw9uCyL2j7UKjdWAkPLVt2AKKChn3VDT1wogpYzPpKKsujFBWkONhQAqajrbrD7hczJjIgUvVZVvZU0PIkQwmZniCoGShPKtTCwFy6UEKumg0ldMtnjueLXVDNax1YCOkGqoaH7Sz0BkmsmG1yhlDSQzTSSgbm20PF1aEGzLobJSWyjk4Fm-0YakkJjYVy2C7ZiEG6Ky57WU7SOTAtlsvCeCbXWoQiqJjXbBpdLGAHuhLu3TonmtIYEpFNb8U58z0XdZi6MQtv03PnTNgGm_NyHCZwc8hGNPHF_U8J9b14IQp97m7GQoeb0YQ_i04mZSNKQAShub1Nnzh-nHEQMpZCU_uFGfJE2pHdoPwujZTH0l7g-skQRtRsj10p7NOBkF1GY3GE3eRJALtN4Pni8J0OfOHH1Igt1oKrEPzhDFTJsNc-H1BfX_Ne25UH4CVLuae0QcL9JOTPwXLo-Z6a2JZ1Qvoog3ZpGEtrxmwqnnZYTIc0pqftGNxxKnxyKpUTrsuxXDf8K-YyAlsWrmSs3eam_oArsQuKrj7t7eOQ-ihljqSkjFocPYhXDqBFDLkx4LFo6rIUTXV7M1r6_3u0ugn02TFj_gUNAtENvEvALkNGh1scd0VpV0gkLVoSvxmJd_HCJQO2Uy-g6Zz2Pj7YyVPZC5vU_xs3XEMVZO9k_iYvVbMzqmLmyrWjbCzsUHwIDbnYFA4lv4KtsC8XTHagXKb6UXVFmvq6sqQeKFxXBOidvHvDoKoOP46caFLYrbt4qDo2pUV8hAT1lm-zK9ky3IeMIZp6QVLibA-GL_kXxkJZLHwG1TJcZH2m8HIAYxdcmDqpVUyM63bF0DDRK0Yd1-Aaa7ZewZpWr8O1SYyKXq8Dsl6vmxVs1zVcMSwTgJZOcL1imZamyU9dfhriU7cqRKunTzFcW7aN5bVd0W1CtIqum6a4UzNSvCavrQo2DWLKa0CCPhVi1kyjQgwDhBBianYFW6YkEvdxHcO1ABpgSQ30JqapEfFUCDE0m1RMW9PBEtvWQWWiEXhKLHHbBgYGaCb0romHWLfkNbiCaDUAYh1boIJhYrg2NNOq2EI2kMJD3dQx2FEDcQYhNaOMYghM7rU_NrI3-iIQWpamrSEMKcM7EYGsLHzu3cqLD5M4nkWN09Pn5-fqjMYTPmIv0DRUXT49nQEbiPeJzNYTIejUgT8XY-fi914Pvzxa7kvHofyGB67VPhl2W0FTCx7i0e2fA_Lt5uniKvnuj792W9FvifGf8TjpObwVtv94uP29x7_Pv066Xjiw7Pq3pz_0k6_TeHE7vw_Gd7fG9bV2P-DtL85v-oM3__7F-Oi0HOfT-KLlXHHns3PRd-4c58G5hH8_Ofr4sul0HOfFcc6lcadL687SXypEqanZN5mJwjsiglAd4nSFZWP9a5iMlgJOJvUaR_bhZHxf42CxrZWFL7Cu5BIUC09c3HGYwMQzcXP5RS7LB489o4jR0J3041CstT85n_5xXj7BGqlXDQKZbkLKpv30DaNxh85Wu57AZs14LevFYQC_9GDlhnLYWJYPAfwqXknYdlU3a3XBNzsNPpNVKSsP4rrP0kKTRCx9P_WF0RkP5O1cAy-gaE5Dj4rCRNK5JevaenA7XjTQ57v2p8-t0i3kN1uwfwCb6F8R6rEpDyNW6npBQF2foXtx4JW1p6V0rmsgbJsk-3JBo-W7UUhveFR6SOU2UDdkSK9aVW3zFqlq-VvNJAR_xKX0TIcN0eoJ2aNFNrY0kK6Vstg2UO8E_pakw3vsewPVtFJ7OvM91xNPcemvzB0N8vdfIQ3GrKFVzb9_-aeunRDtZxRzKK3yHR8Sg3YphwGIdqKb2s8_iR0PukMYCFFq_Jor3uRqa5Aju9gu8VCUNimwBST2DhLzJxSKI3wQujyVR_JEqaRreY36cRJA-FzAhIsSKIyW7wFQOrGiWIysaBTyKVpPMSg9VY9Kv4Cg9NRHqCDnZ7l8OnzYE3oiqa14A2Au8ylbYHsR-psI8iZi-a5CbtDr5E7ZbyR0z-m1SnewZAWg1GFDD1zY9BOxYaLf2DPzS82QjiDFGkisvBIk48h7aaBcHJzRCFJG9LxQCcQmD_MJLAw2SvwbGsIAP2bhik789KrUT0Z7vmyIRnLHbyC6EvA4lFF5fJ5AFB4XPHmc0Dl7pI8T2TpskYs9BsleqoGs9QrQchlvbWQ8Kf3lptb-7QyHEbJQN911Uk2i9WOMAAAJtPEceVB2lqrLNbbBT-TblAJskym0fHLl4o3MzNJPGiockC7zwQIEpG1Saa8Ka_ejtf93ZwM5lA2psj-aDD0281ngRRPQoyteEcNiea9sSN84y3HrkQGd6wH3xWMkFD-QC2R3LhgbuaBv5QLZmwtvh9bKR1YcNULNWWmOWivNReubcd8b3bw_0cqhG-Ht-3z51iDd6lCuZVj-diPbGQ_sivkNcAdP3H-mM-QMFlFEl_mOzLUgbVmmdpBuk-lqZIdRF5zHUUGFdtnyhlIXzI-PJLmCXvgJESWV9F0qkWLuVXOC_k5kRjElrWLSrOLeLJJPb0TghvlTFh8raEcmWUXkvJF-MPfPxbvO4xmT4qsIF5FnFMsFXCzzjLfDo-LYY9nuSq-ChivVHbOAPgVqIHlLzHCRTQJHhm-3lwvll1mESGlJqgSikJ1mYbfqBeJuFVtJpFj6kuOzzChe9gvkNC7sfKKSEIYKqIDaP9D8KEbyVV-pHAWrQFYWD8MPpItqSRa0iqtGHVrAcz0xGOhFSoxe2L0Fy4V6PIuYQxT8hIuHwSjsLbOINSrrpXiSv6GSM038HXtbOnPCyCgPh-W5q_zNGw9G3vjVL9gG8p1Z14eRWPyqfMC5z2iQnehmPwrJKM9Ot_-X4X8BEvLCSQ==
```
### Before screenshot:
See linked issue
### After screenshot:
(uses both banners in this shot)
![image](https://user-images.githubusercontent.com/1209372/154420549-ef3f26f9-2181-4ff8-ba16-c5a82df39e07.png)
