### PR TITLE
Corrected spelling of Effective Hit Pool Description

### DIFF
--- a/src/Modules/CalcDefence.lua
+++ b/src/Modules/CalcDefence.lua
@@ -1707,7 +1707,7 @@ function calcs.defence(env, actor)
 	if breakdown then
 		breakdown["TotalEHP"] = {
 			s_format("%.2f ^8(total average number of hits you can take)", output["TotalNumberOfHits"]),
-			s_format("x %d ^8(total incomming damage)", output["totalEnemyDamageIn"]),
+			s_format("x %d ^8(total incoming damage)", output["totalEnemyDamageIn"]),
 			s_format("= %d ^8(total damage you can take)", output["TotalEHP"]),
 		}
 	end


### PR DESCRIPTION
Corrected spelling of Effective Hit Pool Description "Total incomming damage" > "Total incoming damage".

Fixes # .

### Description of the problem being solved:
Spelling of the word 'incoming' was incorrect.

### Steps taken to verify a working solution:
I fixed it by removing one of the extra 'm's.

### Link to a build that showcases this PR:
I guess any build as this section is expanded by default? But here's mine:
[https://pobb.in/qbvAT81qUrA7](https://pobb.in/qbvAT81qUrA7)

### Before screenshot:
![Path_of_Building_7C0UgR42Yf](https://user-images.githubusercontent.com/4233945/154661889-81113c49-4a26-4019-8b6a-2e420c962b7d.png)

### After screenshot:
I..uhmm wait how am I meant to get an after screenshot? It's not fixed yet? Time travel's not real!