### PR TITLE
Display session ID box when 401 is encountered on Import

### DIFF
--- a/src/Classes/ImportTab.lua
+++ b/src/Classes/ImportTab.lua
@@ -315,7 +315,11 @@ function ImportTabClass:DownloadCharacterList()
 	local realm = realmList[self.controls.accountRealm.selIndex]
 	local sessionID = #self.controls.sessionInput.buf == 32 and self.controls.sessionInput.buf or (main.gameAccounts[accountName] and main.gameAccounts[accountName].sessionID)
 	launch:DownloadPage(realm.hostName.."character-window/get-characters?accountName="..accountName.."&realm="..realm.realmCode, function(page, errMsg)
-		if errMsg == "Response code: 403" then
+		if errMsg == "Response code: 401" then
+			self.charImportStatus = colorCodes.NEGATIVE.."Sign-in is required."
+			self.charImportMode = "GETSESSIONID"
+			return
+		elseif errMsg == "Response code: 403" then
 			self.charImportStatus = colorCodes.NEGATIVE.."Account profile is private."
 			self.charImportMode = "GETSESSIONID"
 			return


### PR DESCRIPTION
Fixes #4166 .

### Description of the problem being solved:
Tencent added authentication to their character pages, so characters can't be imported without logging in.  This PR adds logic to show the session ID box when this occurs, as @cofedream in the linked issue says using a session ID works to get through.

I couldn't actually test this myself as I don't have a Tencent account, but the fix seems to work for those who need it and is pretty innocuous.