### PR TITLE
Fix missing catalyst on 'Mark of the Elder' ring

### DIFF
--- a/src/Data/Uniques/ring.lua
+++ b/src/Data/Uniques/ring.lua
@@ -632,7 +632,7 @@ Implicits: 1
 {tags:jewellery_elemental,attack}Adds (26-32) to (42-48) Cold Damage to Attacks
 {tags:jewellery_defense}(6-10)% increased maximum Energy Shield
 {tags:life}(6-10)% increased maximum Life
-(60-80)% increased Attack Damage if your other Ring is a Shaper Item
+{tags:attack}(60-80)% increased Attack Damage if your other Ring is a Shaper Item
 Cannot be Stunned by Attacks if your other Ring is an Elder Item
 20% chance to Trigger Level 20 Tentacle Whip on Kill
 Elder Item


### PR DESCRIPTION
LINK: https://poedb.tw/us/Mark_of_the_Elder

This modifier: `(60-80)% increased Attack Damage if your other Ring is a Shaper Item` should be scalable by `Abrasive Catalyst (attack)`