### PR TITLE
Prevent saving default settings to XML

### DIFF
--- a/src/Classes/ConfigTab.lua
+++ b/src/Classes/ConfigTab.lua
@@ -262,16 +262,16 @@ end
 function ConfigTabClass:GetDefaultState(var)
 	for i = 1, #varList do
 		if varList[i].var == var then
-			return varList[i].defaultState
+			return varList[i].defaultState == true
 		end
 	end
-	return nil
+	return false
 end
 
 function ConfigTabClass:Save(xml)
 	for k, v in pairs(self.input) do
 		if v ~= self:GetDefaultState(k) then
-			local child = { elem = "Input", attrib = {name = k} }
+			local child = { elem = "Input", attrib = { name = k } }
 			if type(v) == "number" then
 				child.attrib.number = tostring(v)
 			elseif type(v) == "boolean" then

--- a/src/Classes/ConfigTab.lua
+++ b/src/Classes/ConfigTab.lua
@@ -259,18 +259,30 @@ function ConfigTabClass:Load(xml, fileName)
 	self:ResetUndo()
 end
 
-function ConfigTabClass:GetDefaultState(var)
+function ConfigTabClass:GetDefaultState(var, varType)
 	for i = 1, #varList do
 		if varList[i].var == var then
-			return varList[i].defaultState == true
+			if varType == "number" then
+				return varList[i].defaultState or 0
+			elseif varType == "boolean" then
+				return varList[i].defaultState == true
+			else
+				return varList[i].defaultState
+			end
 		end
 	end
-	return false
+	if varType == "number" then
+		return 0
+	elseif varType == "boolean" then
+		return false
+	else
+		return nil
+	end
 end
 
 function ConfigTabClass:Save(xml)
 	for k, v in pairs(self.input) do
-		if v ~= self:GetDefaultState(k) then
+		if v ~= self:GetDefaultState(k, type(v)) then
 			local child = { elem = "Input", attrib = { name = k } }
 			if type(v) == "number" then
 				child.attrib.number = tostring(v)


### PR DESCRIPTION
### Description of the problem being solved:
Default configuration options were erroneously being saved to build XML data. This fixes that by forcing ``ConfigTabClass:GetDefaultState()`` to return more sensible results instead of ``nil`` whenever it either can't find the requested configuration option or there isn't any ``defaultState`` set.

See also: https://discord.com/channels/676181894152454150/676187672355799062/944201516355567627

### Screenshot:
![](http://puu.sh/IK0vB/5a5fa180dd.png)
