### PR TITLE
Add increased trap damage back as a stat

### DIFF
--- a/src/Data/SkillStatMap.lua
+++ b/src/Data/SkillStatMap.lua
@@ -1364,6 +1364,9 @@ return {
 --
 -- Trap
 ["support_trap_damage_+%_final"] = {
+	mod("Damage", "MORE", nil, 0, KeywordFlag.Trap),
+},
+["trap_damage_+%"] = {
 	mod("Damage", "INC", nil, 0, KeywordFlag.Trap),
 },
 ["number_of_additional_traps_allowed"] = {


### PR DESCRIPTION
Fixes #4222.

### Description of the problem being solved:
3.17 changed trap support from giving increased damage to giving less damage. As part of this, the stat changed name. This did not however remove the old stat from other gems, notably in their quality.

This adds the stat back in, and fixes the less damage mod to actually be less damage, not reduced.

### Steps taken to verify a working solution:
- Created a build with a fireball trap before and after change.
- Verified damage goes down.
- Added cluster traps, verified that damage goes up with quality.

### Link to a build that showcases this PR: https://pobb.in/u__1Gcm4d3D9
