### PR TITLE
Move columns vertically when screen width is too low

### DIFF
--- a/src/Classes/ConfigTab.lua
+++ b/src/Classes/ConfigTab.lua
@@ -346,7 +346,7 @@ function ConfigTabClass:Draw(viewPort, inputEvents)
 		if doShow then
 			local width, height = section:GetSize()
 			local col
-			if section.col and (colY[section.col] or 0) + height + 28 <= viewPort.height then
+			if section.col and (colY[section.col] or 0) + height + 28 <= viewPort.height and 10 + section.col * 370 <= viewPort.width then
 				col = section.col
 			else
 				col = 1


### PR DESCRIPTION
Fixes #4179 .

### Description of the problem being solved:
On lower widths, the "Enemy Stats" section on the Config tab wouldn't move and would thus be unusable.
### Steps taken to verify a working solution:
- Resized app, saw sections moved appropriately

### Link to a build that showcases this PR:
N/A
### After screenshot:
![image](https://user-images.githubusercontent.com/1209372/155643519-e2f39486-8caa-4dc7-811e-2df419a92397.png)
