### PR TITLE
Add missing duration flag to Flame Surge

### DIFF
--- a/src/Data/Skills/act_int.lua
+++ b/src/Data/Skills/act_int.lua
@@ -3798,6 +3798,7 @@ skills["FlameWhip"] = {
 	baseFlags = {
 		spell = true,
 		area = true,
+		duration = true,
 	},
 	baseMods = {
 		skill("radius", 30),

--- a/src/Export/Skills/act_int.txt
+++ b/src/Export/Skills/act_int.txt
@@ -820,7 +820,7 @@ local skills, mod, flag, skill = ...
 #mods
 
 #skill FlameWhip
-#flags spell area
+#flags spell area duration
 	statMap = {
 		["flame_whip_damage_+%_final_vs_burning_enemies"] = {
 			mod("Damage", "MORE", nil, ModFlag.Hit, 0, { type = "ActorCondition", actor = "enemy", var = "Burning" }),


### PR DESCRIPTION
Flame Surge had a duration component (Burning Ground) added in 3.16, but the related duration flag was never added.

### Before screenshot:
![](http://puu.sh/ILx9N/b1674ecefd.png)
### After screenshot:
![](http://puu.sh/ILx9U/7684736765.png)