### PR TITLE
Fix "defend with X% armour" calcs

### DIFF
--- a/spec/TestBuilds/3.13/Dual Savior.lua
+++ b/spec/TestBuilds/3.13/Dual Savior.lua
@@ -1041,7 +1041,6 @@ Triggers Level 20 Reflection when Equipped
 ["AverageBlockChance"] = 7.5,
 ["ColdResistTotal"] = -60,
 ["FireMindOverMatter"] = 0,
-["MoreArmourChance"] = 0,
 ["LightningTotalPool"] = 92,
 ["TotalPoisonStacks"] = 0,
 ["dontSplitEvade"] = true,

--- a/spec/TestBuilds/3.13/Dual Wield Cospris CoC.lua
+++ b/spec/TestBuilds/3.13/Dual Wield Cospris CoC.lua
@@ -1563,7 +1563,6 @@ Your Maximum Frenzy Charges is equal to your Maximum Power Charges
 ["LightningTakenReflect"] = 1,
 ["FireTakenHitMult"] = 0.2,
 ["LowestOfArmourAndEvasion"] = 45,
-["MoreArmourChance"] = 0,
 ["EnergyShieldLeech"] = 591.4,
 ["ChaosMinBase"] = 0,
 ["FireMindOverMatter"] = 0,

--- a/spec/TestBuilds/3.13/Generals Perforate Zerker.lua
+++ b/spec/TestBuilds/3.13/Generals Perforate Zerker.lua
@@ -1321,7 +1321,6 @@ Gain 50 Life when you Stun an Enemy
 ["TotalDot"] = 0,
 ["ColdGuardAbsorbRate"] = 75,
 ["ManaLeechGainRate"] = 134.4,
-["MoreArmourChance"] = 0,
 ["LightningGuardAbsorb"] = 3444.4,
 ["FireResist"] = 76,
 ["RemovableFrenzyCharges"] = 3,

--- a/spec/TestBuilds/3.13/Mirage Archer Toxic Rain.lua
+++ b/spec/TestBuilds/3.13/Mirage Archer Toxic Rain.lua
@@ -1429,7 +1429,6 @@ Implicits: 0
 ["TotalDotDPS"] = 11807832.8408,
 ["ColdGuardAbsorbRate"] = 0,
 ["RageCost"] = 0,
-["MoreArmourChance"] = 0,
 ["WithIgniteDPS"] = 75852.3487,
 ["FireResist"] = 76,
 ["RemovableFrenzyCharges"] = 4,

--- a/spec/TestBuilds/3.13/OccVortex.lua
+++ b/spec/TestBuilds/3.13/OccVortex.lua
@@ -758,7 +758,6 @@ Implicits: 0
 ["ChillChanceOnCrit"] = 100,
 ["ColdGuardAbsorbRate"] = 0,
 ["EnergyShieldLeechDuration"] = 2.7913,
-["MoreArmourChance"] = 0,
 ["IgniteFireMax"] = 130,
 ["FireResist"] = 75,
 ["RemovableFrenzyCharges"] = 0,

--- a/src/Modules/CalcDefence.lua
+++ b/src/Modules/CalcDefence.lua
@@ -1074,7 +1074,7 @@ function calcs.defence(env, actor)
 			takenFlat = takenFlat + modDB:Sum("BASE", nil, "DamageTakenFromAttacks", damageType.."DamageTakenFromAttacks") / 2
 		end
 		if damageType == "Physical" or modDB:Flag(nil, "ArmourAppliesTo"..damageType.."DamageTaken") then
-			local damage = output[damageType.."TakenDamage"]
+			local damage = output[damageType.."TakenDamage"] * (1 - ((resist + enemyPen) / 100)) + takenFlat
 			local armourReduct = 0
 			local portionArmour = 100
 			if damageType == "Physical" then
@@ -1094,7 +1094,9 @@ function calcs.defence(env, actor)
 			output[damageType.."DamageReduction"] = damageType == "Physical" and resist or m_min(output.DamageReductionMax, armourReduct) * portionArmour / 100
 			if breakdown then
 				breakdown[damageType.."DamageReduction"] = {
-					s_format("Enemy Hit Damage: %d ^8(%s the Configuration tab)", damage, env.configInput.enemyHit and "overridden from" or "can be overridden in"),
+					s_format("Enemy Hit Damage:"),
+					s_format("    %d ^8(%s the Configuration tab)", output[damageType.."TakenDamage"], env.configInput.enemyHit and "overridden from" or "can be overridden in"),
+					s_format("    %d ^8(after all relevant modifiers have been applied)", damage),
 				}
 				if portionArmour < 100 then
 					t_insert(breakdown[damageType.."DamageReduction"], s_format("Portion mitigated by Armour: %d%%", portionArmour))

--- a/src/Modules/CalcDefence.lua
+++ b/src/Modules/CalcDefence.lua
@@ -1082,14 +1082,12 @@ function calcs.defence(env, actor)
 					armourReduct = calcs.armourReduction(output.Armour * (1 + output.ArmourDefense), damage)
 					resist = m_min(output.DamageReductionMax, resist - enemyPen + armourReduct)
 				end
+				-- Physical damage "resistance" can never go below 0%
 				resist = m_max(resist, 0)
 			else
-				portionArmour = 100 - (resist - enemyPen)
+				portionArmour = m_min(100 - (resist - enemyPen), 100)
 				armourReduct = calcs.armourReduction(output.Armour * (1 + output.ArmourDefense), damage * portionArmour / 100)
 				resist = resist + m_min(output.DamageReductionMax, armourReduct) * portionArmour / 100
-			end
-			if resist ~= resist then -- resist == nan (caused sometimes by a div by 0 in armour calcs if damage passed in is 0)
-				resist = 0
 			end
 			output[damageType.."DamageReduction"] = damageType == "Physical" and resist or m_min(output.DamageReductionMax, armourReduct) * portionArmour / 100
 			if breakdown then

--- a/src/Modules/CalcDefence.lua
+++ b/src/Modules/CalcDefence.lua
@@ -1074,7 +1074,7 @@ function calcs.defence(env, actor)
 			takenFlat = takenFlat + modDB:Sum("BASE", nil, "DamageTakenFromAttacks", damageType.."DamageTakenFromAttacks") / 2
 		end
 		if damageType == "Physical" or modDB:Flag(nil, "ArmourAppliesTo"..damageType.."DamageTaken") then
-			local damage = output[damageType.."TakenDamage"] * (1 - (resist + enemyPen) / 100)
+			local damage = m_max(output[damageType.."TakenDamage"] * (1 + (enemyPen - resist) / 100), 0)
 			local armourReduct = 0
 			local portionArmour = 100
 			if damageType == "Physical" then
@@ -1085,13 +1085,13 @@ function calcs.defence(env, actor)
 				-- Physical damage "resistance" can never go below 0%
 				resist = m_max(resist, 0)
 			else
-				portionArmour = m_min(100 - (resist - enemyPen), 100)
+				portionArmour = m_max(0, m_min(100 - resist + enemyPen, 100))
 				armourReduct = m_min(output.DamageReductionMax, calcs.armourReduction(output.Armour * (1 + output.ArmourDefense), damage * portionArmour / 100))
 				-- This splits the resistance calculation in to two parts; one half is just pure resistance scaling, and the other is resistance plus damage reduction from armour
 				-- At some point resistances and damage reduction from armour should be completely seperated, this is mostly just a stop-gap measure to avoid incorrect effective health values
 				resist = 100 - ((1 - resist / 100) * (1 - portionArmour / 100) + (1 - resist / 100) * (portionArmour / 100) * (1 - armourReduct / 100)) * 100
 			end
-			output[damageType.."DamageReduction"] = damageType == "Physical" and resist or m_min(output.DamageReductionMax, armourReduct) * portionArmour / 100
+			output[damageType.."DamageReduction"] = damageType == "Physical" and resist or armourReduct * portionArmour / 100
 			if breakdown then
 				breakdown[damageType.."DamageReduction"] = {
 					s_format("Enemy Hit Damage:"),

--- a/src/Modules/CalcDefence.lua
+++ b/src/Modules/CalcDefence.lua
@@ -1080,7 +1080,7 @@ function calcs.defence(env, actor)
 			if damageType == "Physical" then
 				if not modDB:Flag(nil, "ArmourDoesNotApplyToPhysicalDamageTaken") then
 					armourReduct = m_min(output.DamageReductionMax, calcs.armourReduction(output.Armour * (1 + output.ArmourDefense), damage))
-					resist = resist - enemyPen + armourReduct
+					resist = m_min(output.DamageReductionMax, resist - enemyPen + armourReduct)
 				end
 				-- Physical damage "resistance" can never go below 0%
 				resist = m_max(resist, 0)

--- a/src/Modules/CalcDefence.lua
+++ b/src/Modules/CalcDefence.lua
@@ -1074,7 +1074,7 @@ function calcs.defence(env, actor)
 			takenFlat = takenFlat + modDB:Sum("BASE", nil, "DamageTakenFromAttacks", damageType.."DamageTakenFromAttacks") / 2
 		end
 		if damageType == "Physical" or modDB:Flag(nil, "ArmourAppliesTo"..damageType.."DamageTaken") then
-			local damage = output[damageType.."TakenDamage"] * (1 - ((resist + enemyPen) / 100)) + takenFlat
+			local damage = output[damageType.."TakenDamage"] * (1 - ((resist + enemyPen) / 100))
 			local armourReduct = 0
 			local portionArmour = 100
 			if damageType == "Physical" then

--- a/src/Modules/CalcDefence.lua
+++ b/src/Modules/CalcDefence.lua
@@ -1074,7 +1074,7 @@ function calcs.defence(env, actor)
 			takenFlat = takenFlat + modDB:Sum("BASE", nil, "DamageTakenFromAttacks", damageType.."DamageTakenFromAttacks") / 2
 		end
 		if damageType == "Physical" or modDB:Flag(nil, "ArmourAppliesTo"..damageType.."DamageTaken") then
-			local damage = output[damageType.."TakenDamage"] * (1 - ((resist + enemyPen) / 100))
+			local damage = output[damageType.."TakenDamage"] * (1 - (resist + enemyPen) / 100)
 			local armourReduct = 0
 			local portionArmour = 100
 			if damageType == "Physical" then

--- a/src/Modules/CalcDefence.lua
+++ b/src/Modules/CalcDefence.lua
@@ -1095,7 +1095,7 @@ function calcs.defence(env, actor)
 			if breakdown then
 				breakdown[damageType.."DamageReduction"] = {
 					s_format("Enemy Hit Damage:"),
-					s_format("    %d ^8(%s the Configuration tab)", output[damageType.."TakenDamage"], env.configInput.enemyHit and "overridden from" or "can be overridden in"),
+					s_format("    %d ^8(can be overridden in the Configuration tab)", output[damageType.."TakenDamage"]),
 					s_format("    %d ^8(after all relevant modifiers have been applied)", damage),
 				}
 				if portionArmour < 100 then

--- a/src/Modules/CalcDefence.lua
+++ b/src/Modules/CalcDefence.lua
@@ -1080,7 +1080,7 @@ function calcs.defence(env, actor)
 			if damageType == "Physical" then
 				if not modDB:Flag(nil, "ArmourDoesNotApplyToPhysicalDamageTaken") then
 					armourReduct = m_min(output.DamageReductionMax, calcs.armourReduction(output.Armour * (1 + output.ArmourDefense), damage))
-					resist = resist * (1 + enemyPen - armourReduct)
+					resist = resist - enemyPen + armourReduct
 				end
 				-- Physical damage "resistance" can never go below 0%
 				resist = m_max(resist, 0)

--- a/src/Modules/CalcSections.lua
+++ b/src/Modules/CalcSections.lua
@@ -1273,7 +1273,6 @@ return {
 	{ label = "Total Increased", { format = "{0:mod:1}%", { modName = { "Armour", "ArmourAndEvasion", "Defences" }, modType = "INC" }, }, },
 	{ label = "Total More", { format = "{0:mod:1}%", { modName = { "Armour", "ArmourAndEvasion", "Defences" }, modType = "MORE" }, }, },
 	{ label = "Total", { format = "{0:output:Armour}", { breakdown = "Armour" }, }, },
-	{ label = "More Armour Ch.", haveOutput = "MoreArmourChance", { format = "{0:output:MoreArmourChance}%", { modName = "MoreArmourChance" }, }, },
 	{ label = "Armour Defense", haveOutput = "RawArmourDefense", { format = "{0:output:RawArmourDefense}%", { modName = "ArmourDefense" }, }, },
 	{ label = "Phys. Dmg. Reduct", { format = "{0:output:PhysicalDamageReduction}%", 
 		{ breakdown = "PhysicalDamageReduction" },

--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -144,7 +144,6 @@ local modNameList = {
 	["start of energy shield recharge"] = "EnergyShieldRechargeFaster",
 	["restoration of ward"] = "WardRechargeFaster",
 	["armour"] = "Armour",
-	["to defend with double armour"] = "MoreArmourChance", --legacy support
 	["evasion"] = "Evasion",
 	["evasion rating"] = "Evasion",
 	["energy shield"] = "EnergyShield",
@@ -1633,16 +1632,22 @@ local specialModList = {
 		mod("Damage", "MORE", num, "Damage", ModFlag.Attack, { type = "Condition", var = "MainHandAccRatingHigherThanMaxLife" }, { type = "Condition", var = "MainHandAttack" } ),
 		mod("Damage", "MORE", num, "Damage", ModFlag.Attack, { type = "Condition", var = "OffHandAccRatingHigherThanMaxLife" }, { type = "Condition", var = "OffHandAttack" } ),
 	} end,
+	-- Legacy support
+	["(%d+)%% chance to defend with double armour"] = function(numChance) return {
+		mod("ArmourDefense", "MAX", 100, "Armour Mastery: Max Calc", { type = "Condition", var = "ArmourMax" }),
+		mod("ArmourDefense", "MAX", math.min(numChance / 100, 1.0) * 100, "Armour Mastery: Average Calc", { type = "Condition", var = "ArmourAvg" }),
+		mod("ArmourDefense", "MAX", math.min(math.floor(numChance / 100), 1.0) * 100, "Armour Mastery: Min Calc", { type = "Condition", var = "ArmourMax", neg = true }, { type = "Condition", var = "ArmourAvg", neg = true }),
+	} end,
 	-- Masteries
 	["off hand accuracy is equal to main hand accuracy while wielding a sword"] = { flag("Condition:OffHandAccuracyIsMainHandAccuracy", { type = "Condition", var = "UsingSword" }) },
 	["(%d+)%% chance to defend with (%d+)%% of armour"] = function(numChance, _, numArmourMultiplier) return {
-		mod("ArmourDefense", "MAX", tonumber(numArmourMultiplier) - 100, "Armour Mastery: Max Calc", { type = "Condition", var = "ArmourMax"}),
-		mod("ArmourDefense", "MAX", math.min(numChance / 100, 1.0) * (tonumber(numArmourMultiplier) - 100), "Armour Mastery: Average Calc", { type = "Condition", var = "ArmourAvg"}),
-		mod("ArmourDefense", "MAX", math.min(math.floor(numChance / 100), 1.0) * (tonumber(numArmourMultiplier) - 100), "Armour Mastery: Min Calc", { type = "Condition", var = "ArmourMax" , neg = true}, { type = "Condition", var = "ArmourAvg" , neg = true}),
-	 } end,
-	 ["defend with (%d+)%% of armour while not on low energy shield"] = function(num) return {
+		mod("ArmourDefense", "MAX", tonumber(numArmourMultiplier) - 100, "Armour Mastery: Max Calc", { type = "Condition", var = "ArmourMax" }),
+		mod("ArmourDefense", "MAX", math.min(numChance / 100, 1.0) * (tonumber(numArmourMultiplier) - 100), "Armour Mastery: Average Calc", { type = "Condition", var = "ArmourAvg" }),
+		mod("ArmourDefense", "MAX", math.min(math.floor(numChance / 100), 1.0) * (tonumber(numArmourMultiplier) - 100), "Armour Mastery: Min Calc", { type = "Condition", var = "ArmourMax", neg = true }, { type = "Condition", var = "ArmourAvg", neg = true }),
+	} end,
+	["defend with (%d+)%% of armour while not on low energy shield"] = function(num) return {
 		mod("ArmourDefense", "MAX", num - 100, "Armour and Energy Shield Mastery", { type = "Condition", var = "LowEnergyShield", neg = true }),
-	 } end,
+	} end,
 	-- Exerted Attacks
 	["exerted attacks deal (%d+)%% increased damage"] = function(num) return { mod("ExertIncrease", "INC", num, nil, ModFlag.Attack, 0) } end,
 	["exerted attacks have (%d+)%% chance to deal double damage"] = function(num) return { mod("ExertDoubleDamageChance", "BASE", num, nil, ModFlag.Attack, 0) } end,


### PR DESCRIPTION
This removes some legacy code related to "chance to defend with double armour" and rolls that behavior into the updated "chance to defend with X% armour" calculations, treating it as "chance to defend with 200% armour" instead.

It also simplifies how armour is applied to physical damage reduction by directly multiplying the armour value by the "armour defense" property.

This fixes a few bugs, including one where Imbalanced Guard was not providing any Physical Damage Reduction at all unless you set the armour calculation mode to maximum (which should not be necessary for something with a 100% chance).

### Link to a build that showcases this PR:
https://pobb.in/CmJn7gLB6dUe

### Before screenshot:
![](http://puu.sh/ILxYj/8bfde18fef.png)
### After screenshot:
![](http://puu.sh/ILxYs/281be8f5d1.png)
![](http://puu.sh/ILzPL/c83d000577.png)