### PR TITLE
Add full breakdown details to non-hit chill skills

### DIFF
--- a/src/Data/Skills/act_dex.lua
+++ b/src/Data/Skills/act_dex.lua
@@ -205,6 +205,10 @@ skills["ArcticArmour"] = {
 	statDescriptionScope = "buff_skill_stat_descriptions",
 	castTime = 0,
 	statMap = {
+		["arctic_armour_chill_when_hit_duration"] = {
+			mod("ChillDurationBase", "OVERRIDE", nil),
+			div = 1000,
+		},
 		["new_arctic_armour_physical_damage_taken_when_hit_+%_final"] = {
 			mod("PhysicalDamageTakenWhenHit", "MORE", nil, 0, 0, { type = "Condition", var = "Stationary" }, { type = "GlobalEffect", effectType = "Buff" }),
 		},

--- a/src/Export/Skills/act_dex.txt
+++ b/src/Export/Skills/act_dex.txt
@@ -46,6 +46,10 @@ local skills, mod, flag, skill = ...
 #skill ArcticArmour
 #flags spell duration
 	statMap = {
+		["arctic_armour_chill_when_hit_duration"] = {
+			mod("ChillDurationBase", "OVERRIDE", nil),
+			div = 1000,
+		},
 		["new_arctic_armour_physical_damage_taken_when_hit_+%_final"] = {
 			mod("PhysicalDamageTakenWhenHit", "MORE", nil, 0, 0, { type = "Condition", var = "Stationary" }, { type = "GlobalEffect", effectType = "Buff" }),
 		},


### PR DESCRIPTION
This is meant specifically for Arctic Armour, but who knows maybe it applies to something else as well.

Fixes # .

### Description of the problem being solved:
https://www.youtube.com/watch?v=2SuWJzGJefA

### Link to a build that showcases this PR:
https://pobb.in/B4IY8N05uGg4
### Before screenshot:
![](http://puu.sh/ILCxQ/305d9bc282.png)
### After screenshot:
![](http://puu.sh/ILCy7/07b7d712d0.png)