### PR TITLE
Fix nil error when comparing passive tree skill nodes

### DIFF
--- a/src/Classes/PassiveTreeView.lua
+++ b/src/Classes/PassiveTreeView.lua
@@ -939,7 +939,7 @@ function PassiveTreeViewClass:AddNodeTooltip(tooltip, node, build)
 	-- Then continue processing as normal
 	local masteryColor = ""
 	local mNode = node
-	local compareNode = self.compareSpec and self.compareSpec.nodes[node.id].alloc or false
+	local compareNode = self.compareSpec and self.compareSpec.nodes[node.id] and self.compareSpec.nodes[node.id].alloc or false
 	if node.type == "Mastery" then
 		if not node.alloc and compareNode then
 			mNode = self.compareSpec.nodes[node.id]


### PR DESCRIPTION
Fixes #4201.

### Description of the problem being solved:
Comparing a 3.17 passive tree to a 3.12 passive tree and hovering over certain skill nodes causes nil errors to occur, as the nodes being compared don't necessarily *exist* in both trees. The fix for this is fairly simple: check if the node actually exists before checking if the node is allocated.

### Link to a build that showcases this PR:
See linked issue.

### Before screenshot:
![](https://user-images.githubusercontent.com/9058189/154831897-1d9be152-5fc0-4afa-9562-d65ab8bd7ea4.png)

### After screenshot:
No error occurs.