### PR TITLE
Swap subtext and appname positions in window title

### DIFF
--- a/src/Modules/Main.lua
+++ b/src/Modules/Main.lua
@@ -1092,7 +1092,7 @@ function main:SetWindowTitleSubtext(subtext)
 	if not subtext or not self.showTitlebarName then
 		SetWindowTitle(APP_NAME)
 	else
-		SetWindowTitle(APP_NAME.." - "..subtext)
+		SetWindowTitle(subtext.." - "..APP_NAME)
 	end
 end
 


### PR DESCRIPTION
Fixes #4202.

### Description of the problem being solved:
Build names should appear in the window title first as listing them after the app name makes differentiating multiple PoB instances somewhat tedious and has no benefit.

Displaying build names in the window title is already configurable so anyone that (for whatever reason) wants the window title to always display "Path of Building" first can simply turn the "build name in window title" option off.

### Before screenshot:
![](http://puu.sh/ILIry/611a548176.png)
### After screenshot:
![](http://puu.sh/ILIrm/4e2901eec4.png)