### PR TITLE
Fix blastchain mine not applying less damage to all gems

### DIFF
--- a/src/Data/Skills/sup_int.lua
+++ b/src/Data/Skills/sup_int.lua
@@ -4286,7 +4286,7 @@ skills["SupportRemoteMine"] = {
 			skill("showAverage", true, { type = "SkillType", skillType = SkillType.Mineable }),
 		},
 		["support_gem_mine_damage_+%_final"] = {
-			mod("Damage", "MORE", nil, 0, KeywordFlag.Mine),
+			mod("Damage", "MORE", nil),
 		},
 	},
 	baseMods = {

--- a/src/Export/Skills/sup_int.txt
+++ b/src/Export/Skills/sup_int.txt
@@ -548,7 +548,7 @@ local skills, mod, flag, skill = ...
 			skill("showAverage", true, { type = "SkillType", skillType = SkillType.Mineable }),
 		},
 		["support_gem_mine_damage_+%_final"] = {
-			mod("Damage", "MORE", nil, 0, KeywordFlag.Mine),
+			mod("Damage", "MORE", nil),
 		},
 	},
 #mods


### PR DESCRIPTION
### Description of the problem being solved:
Despite the internal name of the stat, blastchain mine's less damage applies to all damage on supported skill, not just mine damage. This fixes blastchain mine not properly reducing damage on trap skills it supports.

### Steps taken to verify a working solution:
- Checked damage of Fireball + Blastchain Mine and Explosive Trap + Blastchain Mine before and after change.

### Link to a build that showcases this PR:
https://pobb.in/3EvK8Krq_V1r
