### PR TITLE
Fix Dancing Duo Cyclone dealing twice as much damage as it should be

### DIFF
--- a/src/Data/Skills/minion.lua
+++ b/src/Data/Skills/minion.lua
@@ -687,7 +687,6 @@ skills["DancingDervishCycloneChannelled"] = {
 		melee = true,
 	},
 	baseMods = {
-		skill("dpsMultiplier", 2),
 		skill("radiusIsWeaponRange", true),
 	},
 	qualityStats = {

--- a/src/Export/Skills/minion.txt
+++ b/src/Export/Skills/minion.txt
@@ -99,7 +99,6 @@ local skills, mod, flag, skill = ...
 
 #skill DancingDervishCycloneChannelled
 #flags attack area melee
-#baseMod skill("dpsMultiplier", 2)
 #baseMod skill("radiusIsWeaponRange", true)
 #mods
 


### PR DESCRIPTION
Fixes https://www.reddit.com/r/PathOfExileBuilds/comments/t42sth/all_dancing_duo_pobs_out_there_may_be/

### Description of the problem being solved:
Removed the old dps multiplier from dancing dervish cyclone


### Steps taken to verify a working solution:
-
-
-

### Link to a build that showcases this PR:

### Before screenshot:

### After screenshot:
