### PR TITLE
Properly sort items based on affected slot in tooltips

### DIFF
--- a/src/Classes/ItemsTab.lua
+++ b/src/Classes/ItemsTab.lua
@@ -2841,10 +2841,19 @@ function ItemsTabClass:AddItemTooltip(tooltip, item, slot, dbMode)
 			end
 		end
 		table.sort(compareSlots, function(a, b)
+			if a ~= b then
+				if slot == a then
+					return true
+				end
+				if slot == b then
+					return false
+				end
+			end
 			if a.selItemId ~= b.selItemId then
 				if item == self.items[a.selItemId] then
 					return true
-				elseif item == self.items[b.selItemId] then
+				end
+				if item == self.items[b.selItemId] then
 					return false
 				end
 			end


### PR DESCRIPTION
Before only if selected item was same as slot item it would be
prioritized in tooltip. But if selected slot is same it should be
priorized as well.

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>

Before:

![image](https://user-images.githubusercontent.com/5115805/158885520-ea2537ca-c180-4016-a62b-c3e70c70c5c8.png)

After:

![image](https://user-images.githubusercontent.com/5115805/158885632-af4395f7-7750-448a-ab02-5bad802b81dd.png)

Example pob: https://pastebin.com/kHcpj6gc