### PR TITLE
Add configuration option for showing tooltips for all slots

### DIFF
--- a/src/Classes/ItemsTab.lua
+++ b/src/Classes/ItemsTab.lua
@@ -2858,19 +2858,21 @@ function ItemsTabClass:AddItemTooltip(tooltip, item, slot, dbMode)
 		end)
 
 		-- Add comparisons for each slot
-		for _, slot in pairs(compareSlots) do
-			local selItem = self.items[slot.selItemId]
-			local storedGlobalCacheDPSView = GlobalCache.useFullDPS
-			GlobalCache.useFullDPS = GlobalCache.numActiveSkillInFullDPS > 0
-			local output = calcFunc({ repSlotName = slot.slotName, repItem = item ~= selItem and item }, {})
-			GlobalCache.useFullDPS = storedGlobalCacheDPSView
-			local header
-			if item == selItem then
-				header = "^7Removing this item from "..slot.label.." will give you:"
-			else
-				header = string.format("^7Equipping this item in %s will give you:%s", slot.label, selItem and "\n(replacing "..colorCodes[selItem.rarity]..selItem.name.."^7)" or "")
+		for _, compareSlot in pairs(compareSlots) do
+			if not main.slotOnlyTooltips or (slot and (slot.nodeId == compareSlot.nodeId or slot.slotName == compareSlot.slotName)) or not slot or slot == compareSlot then
+				local selItem = self.items[compareSlot.selItemId]
+				local storedGlobalCacheDPSView = GlobalCache.useFullDPS
+				GlobalCache.useFullDPS = GlobalCache.numActiveSkillInFullDPS > 0
+				local output = calcFunc({ repSlotName = compareSlot.slotName, repItem = item ~= selItem and item }, {})
+				GlobalCache.useFullDPS = storedGlobalCacheDPSView
+				local header
+				if item == selItem then
+					header = "^7Removing this item from "..compareSlot.label.." will give you:"
+				else
+					header = string.format("^7Equipping this item in %s will give you:%s", compareSlot.label, selItem and "\n(replacing "..colorCodes[selItem.rarity]..selItem.name.."^7)" or "")
+				end
+				self.build:AddStatComparesToTooltip(tooltip, calcBase, output, header)
 			end
-			self.build:AddStatComparesToTooltip(tooltip, calcBase, output, header)
 		end
 	end
 

--- a/src/Modules/Main.lua
+++ b/src/Modules/Main.lua
@@ -204,6 +204,7 @@ the "Releases" section of the GitHub page.]])
 	self.decimalSeparator = "."
 	self.showTitlebarName = true
 	self.showWarnings = true
+	self.slotOnlyTooltips = true
 
 	local ignoreBuild
 	if arg[1] then
@@ -524,6 +525,9 @@ function main:LoadSettings(ignoreBuild)
 				if node.attrib.showWarnings then
 					self.showWarnings = node.attrib.showWarnings == "true"
 				end
+				if node.attrib.slotOnlyTooltips then
+					self.slotOnlyTooltips = node.attrib.slotOnlyTooltips == "true"
+				end
 			end
 		end
 	end
@@ -576,6 +580,7 @@ function main:SaveSettings()
 		defaultCharLevel = tostring(self.defaultCharLevel or 1),
 		lastExportWebsite = self.lastExportWebsite,
 		showWarnings = tostring(self.showWarnings),
+		slotOnlyTooltips = tostring(self.slotOnlyTooltips),
 	} })
 	local res, errMsg = common.xml.SaveXMLFile(setXML, self.userPath.."Settings.xml")
 	if not res then
@@ -708,10 +713,15 @@ function main:OpenOptionsPopup()
 	controls.showWarnings = new("CheckBoxControl", {"TOPLEFT",nil,"TOPLEFT"}, defaultLabelPlacementX, currentY, 20, "^7Show build warnings:", function(state)
 		self.showWarnings = state
 	end)
+	nextRow()
+	controls.slotOnlyTooltips = new("CheckBoxControl", {"TOPLEFT",nil,"TOPLEFT"}, defaultLabelPlacementX, currentY, 20, "^7Show tooltips only for affected slots:", function(state)
+		self.slotOnlyTooltips = state
+	end)
 
 	controls.betaTest.state = self.betaTest
 	controls.titlebarName.state = self.showTitlebarName
 	controls.showWarnings.state = self.showWarnings
+	controls.slotOnlyTooltips.state = self.slotOnlyTooltips
 	local initialNodePowerTheme = self.nodePowerTheme
 	local initialThousandsSeparatorDisplay = self.showThousandsSeparators
 	local initialTitlebarName = self.showTitlebarName
@@ -721,6 +731,7 @@ function main:OpenOptionsPopup()
 	local initialDefaultGemQuality = self.defaultGemQuality or 0
 	local initialDefaultCharLevel = self.defaultCharLevel or 1
 	local initialshowWarnings = self.showWarnings
+	local initialSlotOnlyTooltips = self.slotOnlyTooltips
 
 	-- last line with buttons has more spacing
 	nextRow(1.5)
@@ -759,6 +770,7 @@ function main:OpenOptionsPopup()
 		self.defaultGemQuality = initialDefaultGemQuality
 		self.defaultCharLevel = initialDefaultCharLevel
 		self.showWarnings = initialshowWarnings
+		self.slotOnlyTooltips = initialSlotOnlyTooltips
 		main:ClosePopup()
 	end)
 	nextRow(1.5)


### PR DESCRIPTION
Add "Show tooltips only for affected slots" configuration option that
will show tooltips only affected slot instead of all slots (this
significantly reduces clutter when viewing jewel sockets for example).

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>

Without config enabled (current behaviour)

![image](https://user-images.githubusercontent.com/5115805/158893934-8d5122ab-b6d1-45d3-a68f-1e21c94d004b.png)

With config enabled:

![image](https://user-images.githubusercontent.com/5115805/158893871-89466ea1-2ac8-40a7-a424-29e8d7fbe4b9.png)

Config window:

![image](https://user-images.githubusercontent.com/5115805/158893983-0799d33c-8b05-4f32-90cb-41a9be05566a.png)
