### PR TITLE
Fix supreme ego more mana reservation of skills to only affect auras

### DIFF
--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -127,7 +127,7 @@ local modNameList = {
 	["cost of skills"] = "Cost",
 	["mana reserved"] = "ManaReserved",
 	["mana reservation"] = "ManaReserved",
-	["mana reservation of skills"] = "ManaReserved",
+	["mana reservation of skills"] = { "ManaReserved", tag = { type = "SkillType", skillType = SkillType.Aura } },
 	["mana reservation efficiency of skills"] = "ManaReservationEfficiency",
 	["life reservation efficiency of skills"] = "LifeReservationEfficiency",
 	["reservation of skills"] = "Reserved",


### PR DESCRIPTION
This is easily verifiable in game and I assume whatever sources left
that apply to all reservation of skills also follow same pattern so I
just edited "mana reservation of skills" directly.

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>

How to verify in game:

Grab herald or anything that isnt aura, allocated Supreme Ego, observe that reservation do not changes. Then grab any aura and observe that reservation changes.