### PR TITLE
Remove import popup and allow both code and URLs in import

### DIFF
--- a/src/Classes/ImportTab.lua
+++ b/src/Classes/ImportTab.lua
@@ -218,13 +218,41 @@ You can get this from your web browser's cookies while logged into the Path of E
 		return #self.controls.generateCodeOut.buf > 0
 	end
 	self.controls.generateCodeNote = new("LabelControl", {"TOPLEFT",self.controls.generateCodeOut,"BOTTOMLEFT"}, 0, 4, 0, 14, "^7Note: this code can be very long; you can use 'Share' to shrink it.")
-	self.controls.importCodeHeader = new("LabelControl", {"TOPLEFT",self.controls.generateCodeNote,"BOTTOMLEFT"}, 0, 26, 0, 16, "^7To import a build, enter the code here:")
-	self.controls.importCodeIn = new("EditControl", {"TOPLEFT",self.controls.importCodeHeader,"BOTTOMLEFT"}, 0, 4, 250, 20, "", nil, "^%w_%-=", nil, function(buf)
+	self.controls.importCodeHeader = new("LabelControl", {"TOPLEFT",self.controls.generateCodeNote,"BOTTOMLEFT"}, 0, 26, 0, 16, "^7To import a build, enter URL or code here:")
+	self.controls.importCodeIn = new("EditControl", {"TOPLEFT",self.controls.importCodeHeader,"BOTTOMLEFT"}, 0, 4, 328, 20, "", nil, nil, nil, function(buf)
+		self.importCodeSite = nil
+		self.importCodeDetail = ""
+		self.importCodeXML = nil
+		self.importCodeValid = false
+
 		if #buf == 0 then
-			self.importCodeState = nil
 			return
 		end
-		self.importCodeState = "INVALID"
+
+		if not self.build.dbFileName then
+			self.controls.importCodeMode.selIndex = 2
+		end
+
+		self.importCodeDetail = colorCodes.NEGATIVE.."Invalid input"
+		local urlText = buf:gsub("^[%s?]+", ""):gsub("[%s?]+$", "") -- Quick Trim
+		if urlText:match("youtube%.com/redirect%?") then
+			local nested_url = urlText:gsub(".*[?&]q=([^&]+).*", "%1")
+			urlText = UrlDecode(nested_url)
+		end
+
+		for j=1,#buildSites.websiteList do
+			if urlText:match(buildSites.websiteList[j].matchURL) then
+				self.controls.importCodeIn.text = urlText
+				self.importCodeValid = true
+				self.importCodeDetail = colorCodes.POSITIVE.."URL is valid ("..buildSites.websiteList[j].label..")"
+				self.importCodeSite = j
+				if buf ~= urlText then
+					self.controls.importCodeIn:SetText(urlText, false)
+				end
+				return
+			end
+		end
+
 		local xmlText = Inflate(common.base64.decode(buf:gsub("-","+"):gsub("_","/")))
 		if not xmlText then
 			return
@@ -232,24 +260,33 @@ You can get this from your web browser's cookies while logged into the Path of E
 		if launch.devMode and IsKeyDown("SHIFT") then
 			Copy(xmlText)
 		end
-		self.importCodeState = "VALID"
+		self.importCodeValid = true
+		self.importCodeDetail = colorCodes.POSITIVE.."Code is valid"
 		self.importCodeXML = xmlText
-		if not self.build.dbFileName then
-			self.controls.importCodeMode.selIndex = 2
-		end
 	end)
-	self.controls.importCodeState = new("LabelControl", {"LEFT",self.controls.importCodeIn,"RIGHT"}, 4, 0, 0, 16)
+	self.controls.importCodeState = new("LabelControl", {"LEFT",self.controls.importCodeIn,"RIGHT"}, 8, 0, 0, 16)
 	self.controls.importCodeState.label = function()
-		return (self.importCodeState == "VALID" and colorCodes.POSITIVE.."Code is valid") or (self.importCodeState == "INVALID" and colorCodes.NEGATIVE.."Invalid code") or ""
+		return self.importCodeDetail or ""
 	end
-	self.controls.importCodePastebin = new("ButtonControl", {"LEFT",self.controls.importCodeIn,"RIGHT"}, 90, 0, 160, 20, "Import from website...", function()
-		self:OpenImportFromWebsitePopup()
-	end)
 	self.controls.importCodeMode = new("DropDownControl", {"TOPLEFT",self.controls.importCodeIn,"BOTTOMLEFT"}, 0, 4, 160, 20, { "Import to this build", "Import to a new build" })
 	self.controls.importCodeMode.enabled = function()
-		return self.importCodeState == "VALID" and self.build.dbFileName
+		return self.build.dbFileName and self.importCodeValid
 	end
-	self.controls.importCodeGo = new("ButtonControl", {"TOPLEFT",self.controls.importCodeMode,"BOTTOMLEFT"}, 0, 8, 60, 20, "Import", function()
+	self.controls.importCodeGo = new("ButtonControl", {"LEFT",self.controls.importCodeMode,"RIGHT"}, 8, 0, 160, 20, "Import", function()
+		if self.importCodeSite and not self.importCodeXML then
+			self.importCodeFetching = true
+			local selectedWebsite = buildSites.websiteList[self.importCodeSite]
+			buildSites.DownloadBuild(self.controls.importCodeIn.buf, selectedWebsite, function(isSuccess, data)
+				self.importCodeFetching = false
+				if not isSuccess then
+					self.importCodeDetail = colorCodes.NEGATIVE..data
+				else
+					self.controls.importCodeIn:SetText(data, true)
+				end
+			end)
+			return
+		end
+
 		if self.controls.importCodeMode.selIndex == 1 then
 			main:OpenConfirmPopup("Build Import", colorCodes.WARNING.."Warning:^7 Importing to the current build will erase ALL existing data for this build.", "Import", function()
 				self.build:Shutdown()
@@ -262,14 +299,18 @@ You can get this from your web browser's cookies while logged into the Path of E
 			self.build.viewMode = "TREE"
 		end
 	end)
+	self.controls.importCodeGo.label = function ()
+		return self.importCodeSite and not self.importCodeXML and "Load from URL" or self.importCodeFetching and "Retrieving paste.." or "Import"
+	end
 	self.controls.importCodeGo.enabled = function()
-		return self.importCodeState == "VALID"
+		return self.importCodeValid and not self.importCodeFetching
 	end
 	self.controls.importCodeGo.enterFunc = function()
-		if self.importCodeState == "VALID" then
+		if self.importCodeValid then
 			self.controls.importCodeGo.onClick()
 		end
 	end
+	self.controls.importCodeNote = new("LabelControl", {"TOPLEFT",self.controls.importCodeMode,"BOTTOMLEFT"}, 0, 4, 0, 14, "^7Note: when loading from URL press 'Import' after code is loaded.")
 end)
 
 function ImportTabClass:Load(xml, fileName)
@@ -955,57 +996,6 @@ function UrlDecode(url)
 	url = url:gsub("+", " ")
 	url = url:gsub("%%(%x%x)", HexToChar)
 	return url
-end
-
-function ImportTabClass:OpenImportFromWebsitePopup()
-	local controls = { }
-
-	controls.importAnchorPoint = new("Control", nil, 0, 0, 280, 0)
-	controls.importFromLabel = new("LabelControl", { "TOPLEFT", controls.importAnchorPoint, "BOTTOMLEFT"}, 15, 20, 0, 16, "Import from:")
-	controls.importFrom = new("DropDownControl", {"LEFT",controls.importFromLabel,"RIGHT"}, 8, 0, 140, 20, buildSites.websiteList, function(_, selectedWebsite)
-		self.importWebsiteSelected = selectedWebsite.id
-	end)
-	controls.importFrom:SelByValue( self.importWebsiteSelected or "Pastebin", "id" )
-	controls.editLabel = new("LabelControl", { "TOPLEFT", controls.importAnchorPoint, "BOTTOMLEFT"}, 15, 44, 0, 16, "Enter website link:")
-	controls.edit = new("EditControl", nil, 0, 64, 250, 18, "", nil, "^%w%p%s", nil, function(buf)
-		controls.msg.label = ""
-		if #controls.edit.buf > 0 then
-			for j=1,#buildSites.websiteList do
-				if controls.edit.buf:match(buildSites.websiteList[j].matchURL) then
-					controls.importFrom:SelByValue(buildSites.websiteList[j].id, "id")
-				end
-			end
-		end
-	end)
-	controls.msg = new("LabelControl", nil, 0, 82, 0, 16, "")
-	controls.import = new("ButtonControl", nil, -45, 104, 80, 20, "Import", function()
-		local selectedWebsite = buildSites.websiteList[controls.importFrom.selIndex]
-		controls.import.enabled = false
-		controls.msg.label = "Retrieving paste..."
-		controls.edit.buf = controls.edit.buf:gsub("^[%s?]+", ""):gsub("[%s?]+$", "") -- Quick Trim
-		if controls.edit.buf:match("youtube%.com/redirect%?") then
-			local nested_url = controls.edit.buf:gsub(".*[?&]q=([^&]+).*", "%1")
-			controls.edit.buf = UrlDecode(nested_url)
-		end
-		buildSites.DownloadBuild(controls.edit.buf, selectedWebsite, function(isSuccess, data)
-			if not isSuccess then
-				controls.msg.label = "^1"..data
-				controls.import.enabled = true
-			else
-				self.controls.importCodeIn:SetText(data, true)
-				main:SelectControl(self.controls.importCodeGo)
-				main:ClosePopup()
-			end
-		end)
-	end)
-	controls.import.enabled = function()
-		local selectedWebsite = buildSites.websiteList[controls.importFrom.selIndex]
-		return #controls.edit.buf > 0 and (controls.edit.buf:match(selectedWebsite.matchURL) or controls.edit.buf:match("youtube%.com/redirect%?"))
-	end
-	controls.cancel = new("ButtonControl", nil, 45, 104, 80, 20, "Cancel", function()
-		main:ClosePopup()
-	end)
-	main:OpenPopup(280, 130, "Import from website", controls, "import", "edit")
 end
 
 function ImportTabClass:ProcessJSON(json)

--- a/src/Modules/Build.lua
+++ b/src/Modules/Build.lua
@@ -921,11 +921,8 @@ function buildMode:OnFrame(inputEvents)
 				end
 		elseif IsKeyDown("CTRL") then
 				if event.key == "i" then
-					if self.viewMode == "IMPORT" then
-						self.importTab.controls.importCodePastebin:Click()
-					else
 						self.viewMode = "IMPORT"
-					end
+					self.importTab:SelectControl(self.importTab.controls.importCodeIn)
 				elseif event.key == "s" then
 					self:SaveDBFile()
 					inputEvents[id] = nil


### PR DESCRIPTION
With import type autodetection the popup is no longer necessary and this
can be done in a lot more elegant way.

Supersedes #4246
Fixes #4163

No input:

![image](https://user-images.githubusercontent.com/5115805/158929927-be128f4d-dc5b-47fe-a146-be15ae4a25c2.png)

Pasted URL:

![image](https://user-images.githubusercontent.com/5115805/158930313-405a2d61-5764-4b78-b321-f1ceac492a25.png)

Pasted code/after URL is fetched:

![image](https://user-images.githubusercontent.com/5115805/158930000-d940179c-c33a-4101-88e0-7a5b8cfa8980.png)

URL fetch failure:

![image](https://user-images.githubusercontent.com/5115805/158930037-ac7a08af-ff4e-4d75-a5d0-7847d7ded254.png)

Invalid input:

![image](https://user-images.githubusercontent.com/5115805/158930057-726dc880-5c07-4abc-b6d9-5ad3a4fcaab5.png)
