### PR TITLE
In item creator, treat flasks like other items with multiple tiers of mods

### DIFF
--- a/src/Classes/ItemsTab.lua
+++ b/src/Classes/ItemsTab.lua
@@ -1550,9 +1550,6 @@ function ItemsTabClass:UpdateAffixControl(control, item, type, outputTable, outp
 	table.sort(affixList, function(a, b)
 		local modA = item.affixes[a]
 		local modB = item.affixes[b]
-		if item.type == "Flask" then
-			return modA.affix < modB.affix
-		end
 		for i = 1, m_max(#modA, #modB) do
 			if not modA[i] then
 				return true
@@ -1571,7 +1568,7 @@ function ItemsTabClass:UpdateAffixControl(control, item, type, outputTable, outp
 	control.slider.shown = false
 	control.slider.val = 0.5
 	local selAffix = item[outputTable][outputIndex].modId
-	if item.type == "Flask" or (item.type == "Jewel" and item.base.subType ~= "Abyss") then
+	if (item.type == "Jewel" and item.base.subType ~= "Abyss") then
 		for i, modId in pairs(affixList) do
 			local mod = item.affixes[modId]
 			if selAffix == modId then


### PR DESCRIPTION
### Description of the problem being solved:

Now that flask mods have tiers, we should no longer be separating each tier into its own line. Instead, we should use the sliding scale that mods on other item types use.

### Steps taken to verify a working solution:

Opened dev version of PoB, confirmed I was able to create a flask in the new system.

### Link to a build that showcases this PR:

N/A

### Before screenshot:

![image](https://user-images.githubusercontent.com/38334727/160031131-c9ad7333-3d0a-4335-af32-20997f28621b.png)
![image](https://user-images.githubusercontent.com/38334727/160031161-be868c81-871e-432f-9977-0954e6b858d9.png)

### After screenshot:

![image](https://user-images.githubusercontent.com/38334727/160031194-5abb313e-6b5e-4634-96a8-53f9a44c8ead.png)
![image](https://user-images.githubusercontent.com/38334727/160031223-bd4dbdb0-6856-4801-88a6-59a91f596012.png)
