### PR TITLE
Refactor manifest updater

### DIFF
--- a/manifest.cfg
+++ b/manifest.cfg
@@ -1,0 +1,19 @@
+[default]
+path =
+include-files = changelog.txt,LICENSE.md
+include-directories =
+
+[runtime]
+path = runtime
+exclude-files = lua-profiler.lua,msvcr100.dll,SimpleGraphic.cfg,Update.exe
+exclude-directories =
+
+[src]
+path = src
+exclude-files = HeadlessWrapper.lua,LaunchInstall.lua,Settings.xml
+exclude-directories = src/Export,src/TreeData
+
+[tree]
+path = src
+exclude-files =
+include-directories = src/TreeData

--- a/manifest.cfg
+++ b/manifest.cfg
@@ -8,7 +8,7 @@ path = runtime
 exclude-files = lua-profiler.lua,msvcr100.dll,SimpleGraphic.cfg,Update.exe
 exclude-directories =
 
-[src]
+[program]
 path = src
 exclude-files = HeadlessWrapper.lua,LaunchInstall.lua,Settings.xml
 exclude-directories = src/Export,src/TreeData

--- a/update_manifest.py
+++ b/update_manifest.py
@@ -1,16 +1,15 @@
 import hashlib
 import logging
 import pathlib
-from typing import Optional
 import xml.etree.ElementTree
 
-"""This script requires at least Python 3.7.0 to run."""
+"""This script requires at least Python 3.10.0 to run."""
 
 logger = logging.getLogger(__name__)
 logger.addHandler(logging.NullHandler())
 
 
-def update_manifest(version: Optional[str] = None, replace: bool = False):
+def update_manifest(version: str | None = None, replace: bool = False):
     """Update SHA1 hashes and version number for Path of Building's manifest file.
 
     :param version: Three-part version number following https://semver.org/.

--- a/update_manifest.py
+++ b/update_manifest.py
@@ -55,8 +55,7 @@ def cli():
         description="Update Path of Building's manifest file for a new release.",
         allow_abbrev=False,
     )
-    parser.version = "1.1.0"
-    parser.add_argument("--version", action="version")
+    parser.add_argument("--version", action="version", version="1.1.0")
     logging_level = parser.add_mutually_exclusive_group()
     logging_level.add_argument(
         "-v", "--verbose", action="store_true", help="Print more logging information"

--- a/update_manifest.py
+++ b/update_manifest.py
@@ -5,9 +5,6 @@ import xml.etree.ElementTree
 
 """This script requires at least Python 3.10.0 to run."""
 
-logger = logging.getLogger(__name__)
-logger.addHandler(logging.NullHandler())
-
 
 def update_manifest(version: str | None = None, replace: bool = False):
     """Update SHA1 hashes and version number for Path of Building's manifest file.
@@ -20,7 +17,7 @@ def update_manifest(version: str | None = None, replace: bool = False):
     try:
         manifest = xml.etree.ElementTree.parse(base_path / "manifest.xml")
     except FileNotFoundError:
-        logger.critical(f"Manifest file not found in path '{base_path}'")
+        logging.critical(f"Manifest file not found in path '{base_path}'")
         return
     root = manifest.getroot()
 
@@ -36,14 +33,14 @@ def update_manifest(version: str | None = None, replace: bool = False):
         try:
             data = path.read_bytes()
         except FileNotFoundError:
-            logger.error(f"File not found, skipping {path}")
+            logging.error(f"File not found, skipping {path}")
             continue
         sha1_hash = hashlib.sha1(data).hexdigest()
         file.set("sha1", sha1_hash)
-        logger.info(f"Path: {path} hash: {sha1_hash}")
+        logging.info(f"Path: {path} hash: {sha1_hash}")
     if version is not None:
         root.find("Version").set("number", version)
-        logger.info(f"Updated to version {version}")
+        logging.info(f"Updated to version {version}")
 
     file_name = "manifest.xml" if replace else "manifest-updated.xml"
     manifest.write(base_path / file_name, encoding="UTF-8", xml_declaration=True)
@@ -75,12 +72,10 @@ def cli():
         metavar="SEMVER",
     )
     args = parser.parse_args()
-
-    logger.addHandler(logging.StreamHandler())
     if args.verbose:
-        logger.setLevel(logging.INFO)
+        logging.basicConfig(level=logging.INFO)
     elif args.quiet:
-        logger.setLevel(logging.CRITICAL + 1)
+        logging.basicConfig(level=logging.CRITICAL + 1)
     update_manifest(args.set_version or None, args.in_place)
 
 

--- a/update_manifest.py
+++ b/update_manifest.py
@@ -1,52 +1,135 @@
+"""This script requires Python 3.10.0 or higher to run."""
+
+import configparser
+import functools
 import hashlib
 import logging
+import operator
 import pathlib
-import xml.etree.ElementTree
+import re
+import xml.etree.ElementTree as Et
+from typing import Any, Callable
 
-"""This script requires at least Python 3.10.0 to run."""
+alphanumeric_pattern = re.compile(r"([0-9]+)")
 
 
-def update_manifest(version: str | None = None, replace: bool = False):
-    """Update SHA1 hashes and version number for Path of Building's manifest file.
+def _compose(f: Callable[[Any], Any], g: Callable[[Any], Any]) -> Callable[[Any], Any]:
+    """Composition of two functions f and g."""
+    return lambda *args, **kwargs: f(g(*args, **kwargs))
+
+
+def _complement(f: Callable[[Any], bool]) -> Callable[[Any], bool]:
+    """Logical complement of function f."""
+    return _compose(operator.not_, f)
+
+
+def _identity(f: Callable[[Any], Any]) -> Callable[[Any], Any]:
+    """Identity function."""
+    return f
+
+
+def _exclude_file(file_names: set[str], path: pathlib.Path) -> bool:
+    """Whether to exclude a single file."""
+    return path.name in file_names
+
+
+def _exclude_directory(directory_names: set[str], path: pathlib.Path) -> bool:
+    """Whether to exclude a directory. Doesn't consider any files in directories."""
+    return any(
+        len(path.parts) <= 1
+        or all(a == b for a, b in zip(directory.split("/"), path.parts))
+        for directory in directory_names
+    )
+
+
+def _alphanumeric(key: str) -> list[int | str]:
+    """Natural sorting order for numbers, e.g. 10 follows 9."""
+    return [
+        int(character) if character.isdigit() else character.lower()
+        for character in re.split(alphanumeric_pattern, key)
+    ]
+
+
+def create_manifest(version: str | None = None, replace: bool = False) -> None:
+    """Generate new SHA1 hashes and version number for Path of Building's manifest file.
 
     :param version: Three-part version number following https://semver.org/.
     :param replace: Whether to overwrite the existing manifest file.
     :return:
     """
-    base_path = pathlib.Path()
+    base_path = pathlib.Path().absolute()
+    print(base_path)
     try:
-        manifest = xml.etree.ElementTree.parse(base_path / "manifest.xml")
+        old_manifest = Et.parse(base_path / "manifest.xml")
     except FileNotFoundError:
         logging.critical(f"Manifest file not found in path '{base_path}'")
         return
-    root = manifest.getroot()
+    old_root = old_manifest.getroot()
+    if (old_version := old_root.find("Version")) is None:
+        logging.critical(f"Manifest file in {base_path} has no element 'Version'")
+        return
+    if (new_version := version or old_version.get("number")) is None:
+        logging.critical(f"Manifest file in {base_path} has no attribute 'number'")
+        return
 
-    base_url = min((source.get("url") for source in root.iter("Source")), key=len)
-    parts = {
-        source.get("part"): pathlib.Path(source.get("url")).relative_to(base_url)
-        for source in root.iter("Source")
+    config = configparser.ConfigParser()
+    try:
+        config.read("manifest.cfg")
+    except FileNotFoundError:
+        logging.critical(f"Manifest configuration file not found in path '{base_path}'")
+        return
+
+    base_url = "https://raw.githubusercontent.com/PathOfBuildingCommunity/PathOfBuilding/{branch}/"
+    parts: list[dict[str, str]] = []
+    for part in config.sections():
+        url = base_url + config[part]["path"]
+        url_with_trailing_slash = url if url.endswith("/") else url + "/"
+        attributes = {"part": part, "url": url_with_trailing_slash}
+        if part == "runtime":
+            attributes.update(platform="win32")
+        parts.append(attributes)
+
+    rules = {
+        "include-files": (_complement, _exclude_file),
+        "include-directories": (_complement, _exclude_directory),
+        "exclude-files": (_identity, _exclude_file),
+        "exclude-directories": (_identity, _exclude_directory),
     }
-
-    for file in root.iter("File"):
-        name, part = file.get("name"), file.get("part")
-        path = parts.get(part) / name
-        try:
+    files: list[dict[str, str]] = []
+    for section in config.sections():
+        exclusion_checks = [
+            modifier(functools.partial(check, set(config[section][option].split(","))))
+            for option, (modifier, check) in rules.items()
+            if config.has_option(section, option)
+        ]
+        source = pathlib.Path(config[section]["path"])
+        for path in source.glob("**/*.*"):
+            if any(is_excluded(path) for is_excluded in exclusion_checks):
+                continue
             data = path.read_bytes()
-        except FileNotFoundError:
-            logging.error(f"File not found, skipping {path}")
-            continue
-        sha1_hash = hashlib.sha1(data).hexdigest()
-        file.set("sha1", sha1_hash)
-        logging.info(f"Path: {path} hash: {sha1_hash}")
+            sha1 = hashlib.sha1(data).hexdigest()
+            name = path.relative_to(config[section]["path"]).as_posix()
+            attributes = {"part": section, "sha1": sha1, "name": name}
+            if path.suffix in [".dll", ".exe"]:
+                attributes.update(runtime="win32")
+            files.append(attributes)
+
+    files.sort(key=lambda attr: (attr["part"], _alphanumeric(attr["name"])))
+
+    root = Et.Element("PoBVersion")
+    Et.SubElement(root, "Version", number=new_version)
+    for attributes in parts:
+        Et.SubElement(root, "Source", attributes)
+    for attributes in files:
+        Et.SubElement(root, "File", attributes)
+    file_name = "manifest.xml" if replace else "manifest-updated.xml"
+    tree = Et.ElementTree(root)
+    tree.write(base_path / file_name, encoding="UTF-8", xml_declaration=True)
     if version is not None:
-        root.find("Version").set("number", version)
         logging.info(f"Updated to version {version}")
 
-    file_name = "manifest.xml" if replace else "manifest-updated.xml"
-    manifest.write(base_path / file_name, encoding="UTF-8", xml_declaration=True)
 
-
-def cli():
+def cli() -> None:
     """CLI for conveniently updating Path of Building's manifest file."""
     import argparse
 
@@ -55,7 +138,7 @@ def cli():
         description="Update Path of Building's manifest file for a new release.",
         allow_abbrev=False,
     )
-    parser.add_argument("--version", action="version", version="1.1.0")
+    parser.add_argument("--version", action="version", version="2.0.0")
     logging_level = parser.add_mutually_exclusive_group()
     logging_level.add_argument(
         "-v", "--verbose", action="store_true", help="Print more logging information"
@@ -75,7 +158,7 @@ def cli():
         logging.basicConfig(level=logging.INFO)
     elif args.quiet:
         logging.basicConfig(level=logging.CRITICAL + 1)
-    update_manifest(args.set_version or None, args.in_place)
+    create_manifest(args.set_version or None, args.in_place)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Description of the problem being solved:
Currently, new files have to be added to the manifest manually. This PR automates the inclusion of new files in certain directories, based on the configured include/exclude directives.

### Steps taken to verify a working solution:
Run the script and verify that the output matches the existing script. Note that this only works if no files have changed since the last release. You possibly need to check out a specific commit to test this script.
Might add automatic tests in the future, but this script is hard to mock.
