### PR TITLE
Add average flask uptime estimate

### DIFF
--- a/src/Classes/ItemsTab.lua
+++ b/src/Classes/ItemsTab.lua
@@ -2806,11 +2806,15 @@ function ItemsTabClass:AddItemTooltip(tooltip, item, slot, dbMode)
 				local flaskDuration = flaskData.duration * (1 + durInc / 100)
 				local per3Duration = flaskDuration - (flaskDuration % 3)
 				local per5Duration = flaskDuration - (flaskDuration % 5)
-				local averageChargesGenerated = (chargesGenerated + chargesGeneratedPerFlask) * flaskDuration
 				local minimumChargesGenerated = per3Duration * chargesGenerated + per5Duration * chargesGeneratedPerFlask
-				local percentageAvg = math.min(averageChargesGenerated / flaskChargesUsed * 100, 100)
 				local percentageMin = math.min(minimumChargesGenerated / flaskChargesUsed * 100, 100)
-				t_insert(stats, s_format("^8Flask uptime: ^7%d%%^8 average, ^7%d%%^8 minimum", percentageAvg, percentageMin))
+				if percentageMin < 100 then
+					local averageChargesGenerated = (chargesGenerated + chargesGeneratedPerFlask) * flaskDuration
+					local percentageAvg = math.min(averageChargesGenerated / flaskChargesUsed * 100, 100)
+					t_insert(stats, s_format("^8Flask uptime: ^7%d%%^8 average, ^7%d%%^8 minimum", percentageAvg, percentageMin))
+				else
+					t_insert(stats, s_format("^8Flask uptime: ^7100%%^8"))
+				end
 			end
 		end
 

--- a/src/Classes/ItemsTab.lua
+++ b/src/Classes/ItemsTab.lua
@@ -2801,15 +2801,11 @@ function ItemsTabClass:AddItemTooltip(tooltip, item, slot, dbMode)
 
 		-- flask uptime
 		if not item.base.flask.life and not item.base.flask.mana then
-			local flaskDuration = flaskData.duration * (1 + durInc / 100)
-			local per3Duration = flaskDuration - (flaskDuration % 3)
-			local per5Duration = flaskDuration - (flaskDuration % 5)
-
-			local flaskChargesUsed = m_floor(flaskData.chargesUsed * (1 + usedInc / 100))
-
+			local flaskChargesUsed = flaskData.chargesUsed * (1 + usedInc / 100)
 			if flaskChargesUsed > 0 then
-				local totalChargesGenerated = (per3Duration * chargesGenerated) + (per5Duration * chargesGeneratedPerFlask)
-				local percentageOf = math.min(totalChargesGenerated / flaskChargesUsed * 100, 100)
+				local flaskDuration = flaskData.duration * (1 + durInc / 100)
+				local averageChargesGenerated = (chargesGenerated + chargesGeneratedPerFlask) * flaskDuration
+				local percentageOf = math.min(averageChargesGenerated / flaskChargesUsed * 100, 100)
 				t_insert(stats, s_format("^8Flask uptime: ^7%d%%^8", percentageOf))
 			end
 		end

--- a/src/Classes/ItemsTab.lua
+++ b/src/Classes/ItemsTab.lua
@@ -2804,9 +2804,13 @@ function ItemsTabClass:AddItemTooltip(tooltip, item, slot, dbMode)
 			local flaskChargesUsed = flaskData.chargesUsed * (1 + usedInc / 100)
 			if flaskChargesUsed > 0 then
 				local flaskDuration = flaskData.duration * (1 + durInc / 100)
+				local per3Duration = flaskDuration - (flaskDuration % 3)
+				local per5Duration = flaskDuration - (flaskDuration % 5)
 				local averageChargesGenerated = (chargesGenerated + chargesGeneratedPerFlask) * flaskDuration
-				local percentageOf = math.min(averageChargesGenerated / flaskChargesUsed * 100, 100)
-				t_insert(stats, s_format("^8Flask uptime: ^7%d%%^8", percentageOf))
+				local minimumChargesGenerated = per3Duration * chargesGenerated + per5Duration * chargesGeneratedPerFlask
+				local percentageAvg = math.min(averageChargesGenerated / flaskChargesUsed * 100, 100)
+				local percentageMin = math.min(minimumChargesGenerated / flaskChargesUsed * 100, 100)
+				t_insert(stats, s_format("^8Flask uptime: ^7%d%%^8 average, ^7%d%%^8 minimum", percentageAvg, percentageMin))
 			end
 		end
 


### PR DESCRIPTION
### Description of the problem being solved:
Certain modulo operations were being used to calculate flask charges generated by modifiers like the Flask Mastery "Utility Flasks gain 1 Charge every 3 seconds" &mdash; creating **severe** and unrealistic breakpoints related to flask duration.

~~Removing those modulo operations and using averages instead when calculating flask uptime provides significantly more consistent results.~~

Edit: After talking with deathbeam I decided to show both the average and minimum flask uptime, as there is some merit in the minimum uptime value when combined with the "use at full charges" flask enchant. Hiding the average or minimum uptime value may be worth considering based on which flask enchant is detected.

### Link to a build that showcases this PR:
https://pastebin.com/KU3n2Agt
### Before screenshot:
![](https://puu.sh/IThtG/2787520537.png)
### After screenshot:
![](http://puu.sh/IThXt/25c4b98840.png)