### PR TITLE
Fix Decay breakdown

### DIFF
--- a/src/Modules/CalcOffence.lua
+++ b/src/Modules/CalcOffence.lua
@@ -3693,19 +3693,14 @@ function calcs.offence(env, actor, activeSkill)
 		local more = round(skillModList:More(dotCfg, "Damage", "ChaosDamage"), 2)
 		local mult = skillModList:Sum("BASE", dotTypeCfg, "DotMultiplier", "ChaosDotMultiplier")
 		output.DecayDPS = skillData.decay * (1 + inc/100) * more * (1 + mult/100) * effMult
-		local durationMod = calcLib.mod(skillModList, dotCfg, "Duration", "SkillAndDamagingAilmentDuration")
-		output.DecayDuration = 10 * durationMod * debuffDurationMult
+		output.DecayDuration = 8 * debuffDurationMult
 		if breakdown then
 			breakdown.DecayDPS = { }
-			t_insert(breakdown.DecayDPS, "Decay DPS:")
 			breakdown.dot(breakdown.DecayDPS, skillData.decay, inc, more, mult, nil, nil, effMult, output.DecayDPS)
-			if output.DecayDuration ~= 2 then
+			if output.DecayDuration ~= 8 then
 				breakdown.DecayDuration = {
-					s_format("%.2fs ^8(base duration)", 10)
+					s_format("%.2fs ^8(base duration)", 8)
 				}
-				if durationMod ~= 1 then
-					t_insert(breakdown.DecayDuration, s_format("x %.2f ^8(duration modifier)", durationMod))
-				end
 				if debuffDurationMult ~= 1 then
 					t_insert(breakdown.DecayDuration, s_format("/ %.2f ^8(debuff expires slower/faster)", 1 / debuffDurationMult))
 				end

--- a/src/Modules/CalcSections.lua
+++ b/src/Modules/CalcSections.lua
@@ -855,7 +855,6 @@ return {
 	}, },
 	{ label = "Decay Duration", { format = "{2:output:DecayDuration}s", 
 		{ breakdown = "DecayDuration" },
-		{ modName = { "Duration", "SkillAndDamagingAilmentDuration" }, cfg = "decay" },
 	}, },
 } }
 } },


### PR DESCRIPTION
### Description of the problem being solved:
Decay hasn't been updated since pre-3.0.0. It has the wrong base duration (10 seconds instead of 8 seconds), and scales with skill duration in PoB when the duration only scales with debuff expiry rate modifiers (such as Temporal Chains) in-game.

See also: https://old.reddit.com/r/pathofexile/comments/u33tmx/decay_not_lasting_as_long_as_pob_says_it_should/

### Link to a build that showcases this PR:
https://pobb.in/68HafczBnlPu
### Before screenshot:
![](http://puu.sh/IUBqe/8926157b11.png)
### After screenshot:
![](http://puu.sh/IUBqp/0d327288f0.png)