### PR TITLE
Add support for ReservationBecomesCost modifier (Divine Blessing/Totems)

### DIFF
--- a/src/Data/SkillStatMap.lua
+++ b/src/Data/SkillStatMap.lua
@@ -327,6 +327,9 @@ return {
 	mod("ManaCost", "INC", nil),
 	mult = -1,
 },
+["base_mana_cost_+"] = {
+	mod("ManaCostNoMult", "BASE", nil),
+},
 ["no_mana_cost"] = {
 	mod("ManaCost", "MORE", nil),
 	value = -100,

--- a/src/Data/Skills/sup_str.lua
+++ b/src/Data/Skills/sup_str.lua
@@ -1341,7 +1341,7 @@ skills["SupportAuraDuration"] = {
 			div = 1000,
 		},
 		["base_mana_cost_+"] = {
-			mod("ManaCost", "BASE", nil),
+			mod("ManaCostNoMult", "BASE", nil),
 		},
 	},
 	baseMods = {

--- a/src/Data/Skills/sup_str.lua
+++ b/src/Data/Skills/sup_str.lua
@@ -1340,9 +1340,6 @@ skills["SupportAuraDuration"] = {
 			skill("auraDuration", nil),
 			div = 1000,
 		},
-		["base_mana_cost_+"] = {
-			mod("ManaCostNoMult", "BASE", nil),
-		},
 	},
 	baseMods = {
 	},

--- a/src/Export/Skills/sup_str.txt
+++ b/src/Export/Skills/sup_str.txt
@@ -153,7 +153,7 @@ local skills, mod, flag, skill = ...
 			div = 1000,
 		},
 		["base_mana_cost_+"] = {
-			mod("ManaCost", "BASE", nil),
+			mod("ManaCostNoMult", "BASE", nil),
 		},
 	},
 #mods

--- a/src/Export/Skills/sup_str.txt
+++ b/src/Export/Skills/sup_str.txt
@@ -152,9 +152,6 @@ local skills, mod, flag, skill = ...
 			skill("auraDuration", nil),
 			div = 1000,
 		},
-		["base_mana_cost_+"] = {
-			mod("ManaCostNoMult", "BASE", nil),
-		},
 	},
 #mods
 

--- a/src/Modules/CalcOffence.lua
+++ b/src/Modules/CalcOffence.lua
@@ -837,7 +837,7 @@ function calcs.offence(env, actor, activeSkill)
 			breakdown.AuraEffectMod = breakdown.mod(skillModList, skillCfg, "AuraEffect")
 		end
 	end
-	if activeSkill.skillTypes[SkillType.HasReservation] then
+	if activeSkill.skillTypes[SkillType.HasReservation] and not activeSkill.skillTypes[SkillType.ReservationBecomesCost] then
 		for _, pool in ipairs({"Life", "Mana"}) do
 			output[pool .. "ReservedMod"] = calcLib.mod(skillModList, skillCfg, pool .. "Reserved", "Reserved") * calcLib.mod(skillModList, skillCfg, "SupportManaMultiplier") / calcLib.mod(skillModList, skillCfg, pool .. "ReservationEfficiency", "ReservationEfficiency")
 			if breakdown then
@@ -1215,7 +1215,7 @@ function calcs.offence(env, actor, activeSkill)
 		-- Extra cost (e.g. Petrified Blood) calculations happen after cost conversion (e.g. Blood Magic)
 		if val.type == "Mana" and skillModList:Sum("BASE", skillCfg, "ManaCostAsLifeCost") then
 			local target = resource:gsub("Mana", "Life")
-			costs[target].baseCost = costs[target].baseCost + baseCost * skillModList:Sum("BASE", skillCfg, "ManaCostAsLifeCost") / 100
+			costs[target].baseCost = costs[target].baseCost + (baseCost + baseCostNoMult) * skillModList:Sum("BASE", skillCfg, "ManaCostAsLifeCost") / 100
 		end
 		val.baseCost = val.baseCost + baseCost
 		val.totalCost = val.totalCost + totalCost
@@ -1237,6 +1237,9 @@ function calcs.offence(env, actor, activeSkill)
 			}
 			if mult ~= 1 then
 				t_insert(breakdown[costName], s_format("x %.2f ^8(cost multiplier)", mult))
+			end
+			if val.baseCostNoMult ~= 0 then
+				t_insert(breakdown[costName], s_format("+ %d ^8(additional "..val.text.." cost)", val.baseCostNoMult))
 			end
 			if inc ~= 0 then
 				t_insert(breakdown[costName], s_format("x %.2f ^8(increased/reduced "..val.text.." cost)", 1 + inc/100))

--- a/src/Modules/CalcPerform.lua
+++ b/src/Modules/CalcPerform.lua
@@ -1526,7 +1526,7 @@ function calcs.perform(env, avoidCache)
 		breakdown.ManaReserved = { reservations = { } }
 	end
 	for _, activeSkill in ipairs(env.player.activeSkillList) do
-		if activeSkill.skillTypes[SkillType.HasReservation] and not activeSkill.skillFlags.totem then
+		if activeSkill.skillTypes[SkillType.HasReservation] and not activeSkill.skillTypes[SkillType.ReservationBecomesCost] then
 			local skillModList = activeSkill.skillModList
 			local skillCfg = activeSkill.skillCfg
 			local mult = skillModList:More(skillCfg, "SupportManaMultiplier")

--- a/src/Modules/CalcSections.lua
+++ b/src/Modules/CalcSections.lua
@@ -309,18 +309,6 @@ return {
 	}, },
 	{ label = "Skill DPS", flag = "notAverage", notFlag = "triggered", { format = "{1:output:TotalDPS}", { breakdown = "TotalDPS" }, }, },
 	{ label = "Skill DPS", flag = "triggered", { format = "{1:output:TotalDPS}", { breakdown = "TotalDPS" }, }, },
-	{ label = "Mana Cost", color = colorCodes.MANA, haveOutput = "ManaCost", { format = "{0:output:ManaCost}", { breakdown = "ManaCost" }, { modName = { "ManaCost", "Cost" }, cfg = "skill" }, }, },
-	{ label = "Life Cost", color = colorCodes.LIFE, haveOutput = "LifeCost", { format = "{0:output:LifeCost}", { breakdown = "LifeCost" }, { modName = { "LifeCost", "Cost" }, cfg = "skill" }, }, },
-	{ label = "ES Cost", color = colorCodes.ES, haveOutput = "ESCost", { format = "{0:output:ESCost}", { breakdown = "ESCost" }, { modName = { "ESCost", "Cost" }, cfg = "skill" }, }, },
-	{ label = "Rage Cost", color = colorCodes.RAGE, haveOutput = "RageCost", { format = "{0:output:RageCost}", { breakdown = "RageCost" }, { modName = { "RageCost", "Cost" }, cfg = "skill" }, }, },
-	{ label = "Mana % Cost", color = colorCodes.MANA, haveOutput = "ManaPercentCost", { format = "{0:output:ManaPercentCost}", { breakdown = "ManaPercentCost" }, { modName = { "ManaCost", "Cost" }, cfg = "skill" }, }, },
-	{ label = "Life % Cost", color = colorCodes.LIFE, haveOutput = "LifePercentCost", { format = "{0:output:LifePercentCost}", { breakdown = "LifePercentCost" }, { modName = { "LifeCost", "Cost" }, cfg = "skill" }, }, },
-	{ label = "Mana Cost", color = colorCodes.MANA, haveOutput = "ManaPerSecondCost", { format = "{2:output:ManaPerSecondCost}/s", { breakdown = "ManaPerSecondCost" }, { modName = { "ManaCost", "Cost" }, cfg = "skill" }, }, },
-	{ label = "Life Cost", color = colorCodes.LIFE, haveOutput = "LifePerSecondCost", { format = "{2:output:LifePerSecondCost}/s", { breakdown = "LifePerSecondCost" }, { modName = { "LifeCost", "Cost" }, cfg = "skill" }, }, },
-	{ label = "Mana % Cost", color = colorCodes.MANA, haveOutput = "ManaPercentPerSecondCost", { format = "{2:output:ManaPercentPerSecondCost}/s", { breakdown = "ManaPercentPerSecondCost" }, { modName = { "ManaCost", "Cost" }, cfg = "skill" }, }, },
-	{ label = "Life % Cost", color = colorCodes.LIFE, haveOutput = "LifePercentPerSecondCost", { format = "{2:output:LifePercentPerSecondCost}/s", { breakdown = "LifePercentPerSecondCost" }, { modName = { "LifeCost", "Cost" }, cfg = "skill" }, }, },
-	{ label = "ES Cost", color = colorCodes.ES, haveOutput = "ESPerSecondCost", { format = "{2:output:ESPerSecondCost}/s", { breakdown = "ESPerSecondCost" }, { modName = { "ESCost", "Cost" }, cfg = "skill" }, }, },
-	{ label = "ES % Cost", color = colorCodes.ES, haveOutput = "ESPercentPerSecondCost", { format = "{2:output:ESPercentPerSecondCost}/s", { breakdown = "ESPercentPerSecondCost" }, { modName = { "ESCost", "Cost" }, cfg = "skill" }, }, },
 } }
 } },
 { 3, "Warcries", 1, colorCodes.OFFENCE, {{ defaultCollapsed = false, label = "Exerting Warcries", data = {
@@ -446,7 +434,6 @@ return {
 		{ format = "{1:output:ChaosDot}", { breakdown = "ChaosDot" }, },
 	},
 	{ label = "Skill DoT DPS", { format = "{1:output:TotalDot}", { breakdown = "TotalDot" }, }, },
-	{ label = "Mana Cost", { format = "{0:output:ManaCost}", { breakdown = "ManaCost" }, { modName = "ManaCost", cfg = "skill" }, }, },
 } }
 } },
 { 1, "Speed", 1, colorCodes.OFFENCE, {{ defaultCollapsed = false, label = "Attack/Cast Rate", data = {
@@ -565,6 +552,18 @@ return {
 } }
 } },
 { 1, "SkillTypeStats", 1, colorCodes.OFFENCE, {{ defaultCollapsed = false, label = "Skill type-specific Stats", data = {
+	{ label = "Mana Cost", color = colorCodes.MANA, haveOutput = "ManaCost", { format = "{0:output:ManaCost}", { breakdown = "ManaCost" }, { modName = { "ManaCost", "Cost" }, cfg = "skill" }, }, },
+	{ label = "Life Cost", color = colorCodes.LIFE, haveOutput = "LifeCost", { format = "{0:output:LifeCost}", { breakdown = "LifeCost" }, { modName = { "LifeCost", "Cost" }, cfg = "skill" }, }, },
+	{ label = "ES Cost", color = colorCodes.ES, haveOutput = "ESCost", { format = "{0:output:ESCost}", { breakdown = "ESCost" }, { modName = { "ESCost", "Cost" }, cfg = "skill" }, }, },
+	{ label = "Rage Cost", color = colorCodes.RAGE, haveOutput = "RageCost", { format = "{0:output:RageCost}", { breakdown = "RageCost" }, { modName = { "RageCost", "Cost" }, cfg = "skill" }, }, },
+	{ label = "Mana % Cost", color = colorCodes.MANA, haveOutput = "ManaPercentCost", { format = "{0:output:ManaPercentCost}", { breakdown = "ManaPercentCost" }, { modName = { "ManaCost", "Cost" }, cfg = "skill" }, }, },
+	{ label = "Life % Cost", color = colorCodes.LIFE, haveOutput = "LifePercentCost", { format = "{0:output:LifePercentCost}", { breakdown = "LifePercentCost" }, { modName = { "LifeCost", "Cost" }, cfg = "skill" }, }, },
+	{ label = "Mana Cost", color = colorCodes.MANA, haveOutput = "ManaPerSecondCost", { format = "{2:output:ManaPerSecondCost}/s", { breakdown = "ManaPerSecondCost" }, { modName = { "ManaCost", "Cost" }, cfg = "skill" }, }, },
+	{ label = "Life Cost", color = colorCodes.LIFE, haveOutput = "LifePerSecondCost", { format = "{2:output:LifePerSecondCost}/s", { breakdown = "LifePerSecondCost" }, { modName = { "LifeCost", "Cost" }, cfg = "skill" }, }, },
+	{ label = "Mana % Cost", color = colorCodes.MANA, haveOutput = "ManaPercentPerSecondCost", { format = "{2:output:ManaPercentPerSecondCost}/s", { breakdown = "ManaPercentPerSecondCost" }, { modName = { "ManaCost", "Cost" }, cfg = "skill" }, }, },
+	{ label = "Life % Cost", color = colorCodes.LIFE, haveOutput = "LifePercentPerSecondCost", { format = "{2:output:LifePercentPerSecondCost}/s", { breakdown = "LifePercentPerSecondCost" }, { modName = { "LifeCost", "Cost" }, cfg = "skill" }, }, },
+	{ label = "ES Cost", color = colorCodes.ES, haveOutput = "ESPerSecondCost", { format = "{2:output:ESPerSecondCost}/s", { breakdown = "ESPerSecondCost" }, { modName = { "ESCost", "Cost" }, cfg = "skill" }, }, },
+	{ label = "ES % Cost", color = colorCodes.ES, haveOutput = "ESPercentPerSecondCost", { format = "{2:output:ESPercentPerSecondCost}/s", { breakdown = "ESPercentPerSecondCost" }, { modName = { "ESCost", "Cost" }, cfg = "skill" }, }, },
 	{ label = "Active Minion Limit", haveOutput = "ActiveMinionLimit", { format = "{0:output:ActiveMinionLimit}" } },
 	{ label = "Quantity Multiplier", haveOutput = "QuantityMultiplier", { format = "{0:output:QuantityMultiplier}",
 	    { breakdown = "QuantityMultiplier" },


### PR DESCRIPTION
This adds support for ReservationBecomesCost skill modifier what makes
Divine Blessing and Spell Totem mana cost work correctly.

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>

Fixes #4078 

Example pob:

https://pastebin.com/mSyAeaki

Verification in game:

![image](https://user-images.githubusercontent.com/5115805/163599523-1928aaa3-b127-467b-9ba0-2b521ce0c072.png)