### PR TITLE
Add keyboard shortcut for Notes section "Ctrl+6"

### DIFF
--- a/src/Modules/Build.lua
+++ b/src/Modules/Build.lua
@@ -945,6 +945,8 @@ function buildMode:OnFrame(inputEvents)
 					self.viewMode = "CALCS"
 				elseif event.key == "5" then
 					self.viewMode = "CONFIG"
+				elseif event.key == "6" then
+					self.viewMode = "NOTES"
 				end
 			end
 		end


### PR DESCRIPTION
Fixes 2531. Sort of.

### Description of the problem being solved:
No existing "Ctrl+" shortcut for 'Notes' tab. 

### Steps taken to verify a working solution:
-Open PoB in dev
-Press shortcut `CTRL+6` 
