### PR TITLE
Remove ward regen from breakdown

### DIFF
--- a/src/Modules/CalcSections.lua
+++ b/src/Modules/CalcSections.lua
@@ -1259,10 +1259,6 @@ return {
 		{ breakdown = "WardRechargeDelay" },
 		{ modName = "WardRechargeFaster" },
 	}, },
-	{ label = "Regen", { format = "{1:output:EnergyShieldRegen} ({1:output:EnergyShieldRegenPercent}%)",
-		{ label = "Sources", modName = { "EnergyShieldRegen", "EnergyShieldRecovery", "EnergyShieldRegenPercent", "EnergyShieldDegen", "NoEnergyShieldRegen" } },
-		{ label = "Recovery modifiers", modName = "EnergyShieldRecoveryRate" },
-	}, },
 } }
 } },
 { 1, "Armour", 3, colorCodes.DEFENCE, {{ defaultCollapsed = false, label = "Armour", data = {


### PR DESCRIPTION
Fixes #3944

### Description of the problem being solved:
Ward does not regen at all, and even if it did it wouldn't use ES Regen.

### Steps taken to verify a working solution:
- Allocate Zealot's Oath with any life regen, verify that ES regen doesn't show up under ward

### Before screenshot:
![image](https://user-images.githubusercontent.com/5985728/166102477-a5852e4e-730e-4ea2-be5f-108bec11b43a.png)

### After screenshot:
![image](https://user-images.githubusercontent.com/5985728/166102481-5db888ee-4db6-46cd-88ab-2c117cb9403c.png)

