### PR TITLE
Feat: Add support for Massive Radius

### DIFF
--- a/src/Data/Uniques/jewel.lua
+++ b/src/Data/Uniques/jewel.lua
@@ -695,12 +695,14 @@ Variant: Small Ring
 Variant: Medium Ring
 Variant: Large Ring
 Variant: Very Large Ring
+Variant: Massive Ring
 Radius: Variable
 Implicits: 0
 {variant:1}Only affects Passives in Small Ring
 {variant:2}Only affects Passives in Medium Ring
 {variant:3}Only affects Passives in Large Ring
 {variant:4}Only affects Passives in Very Large Ring
+{variant:5}Only affects Passives in Massive Ring
 Passives in Radius can be Allocated without being connected to your tree
 -(20-10)% to all Elemental Resistances
 ]],[[

--- a/src/Modules/Data.lua
+++ b/src/Modules/Data.lua
@@ -133,10 +133,8 @@ data.setJewelRadiiGlobally = function(treeVersion)
 	local major, minor = treeVersion:match("(%d+)_(%d+)")
 	if tonumber(major) <= 3 and tonumber(minor) <= 15 then
 		data.jewelRadius = data.jewelRadii["3_15"]
-	elseif tonumber(major) <= 3 and tonumber(minor) <= 17 then
-		data.jewelRadius = data.jewelRadii["3_16"]
 	else
-		data.jewelRadius = data.jewelRadii["3_18"]
+		data.jewelRadius = data.jewelRadii["3_16"]
 	end
 end
 
@@ -161,18 +159,7 @@ data.jewelRadii = {
 		{ inner = 1320, outer = 1680, col = "^x66FFCC", label = "Variable" },
 		{ inner = 1680, outer = 2040, col = "^x2222CC", label = "Variable" },
 		{ inner = 2040, outer = 2400, col = "^xC100FF", label = "Variable" },
-		{ inner = 2040, outer = 2400, col = "^xFFFF77", label = "Variable" },
-	},
-	["3_18"] = {
-		{ inner = 0, outer = 800, col = "^xBB6600", label = "Small" },
-		{ inner = 0, outer = 1200, col = "^x66FFCC", label = "Medium" },
-		{ inner = 0, outer = 1500, col = "^x2222CC", label = "Large" },
-
-		{ inner = 800, outer = 1100, col = "^xD35400", label = "Variable" },
-		{ inner = 1100, outer = 1400, col = "^x66FFCC", label = "Variable" },
-		{ inner = 1400, outer = 1700, col = "^x2222CC", label = "Variable" },
-		{ inner = 1700, outer = 2000, col = "^xC100FF", label = "Variable" },
-		{ inner = 2000, outer = 2400, col = "^xFFFF77", label = "Variable" },
+		{ inner = 2400, outer = 2760, col = "^x0B9300", label = "Variable" },
 	}
 }
 

--- a/src/Modules/Data.lua
+++ b/src/Modules/Data.lua
@@ -133,8 +133,10 @@ data.setJewelRadiiGlobally = function(treeVersion)
 	local major, minor = treeVersion:match("(%d+)_(%d+)")
 	if tonumber(major) <= 3 and tonumber(minor) <= 15 then
 		data.jewelRadius = data.jewelRadii["3_15"]
-	else
+	elseif tonumber(major) <= 3 and tonumber(minor) <= 17 then
 		data.jewelRadius = data.jewelRadii["3_16"]
+	else
+		data.jewelRadius = data.jewelRadii["3_18"]
 	end
 end
 
@@ -148,6 +150,7 @@ data.jewelRadii = {
 		{ inner = 1150, outer = 1400, col = "^x66FFCC", label = "Variable" },
 		{ inner = 1450, outer = 1700, col = "^x2222CC", label = "Variable" },
 		{ inner = 1750, outer = 2000, col = "^xC100FF", label = "Variable" },
+		{ inner = 1750, outer = 2000, col = "^xC100FF", label = "Variable" },
 	},
 	["3_16"] = {
 		{ inner = 0, outer = 960, col = "^xBB6600", label = "Small" },
@@ -158,6 +161,18 @@ data.jewelRadii = {
 		{ inner = 1320, outer = 1680, col = "^x66FFCC", label = "Variable" },
 		{ inner = 1680, outer = 2040, col = "^x2222CC", label = "Variable" },
 		{ inner = 2040, outer = 2400, col = "^xC100FF", label = "Variable" },
+		{ inner = 2040, outer = 2400, col = "^xFFFF77", label = "Variable" },
+	},
+	["3_18"] = {
+		{ inner = 0, outer = 800, col = "^xBB6600", label = "Small" },
+		{ inner = 0, outer = 1200, col = "^x66FFCC", label = "Medium" },
+		{ inner = 0, outer = 1500, col = "^x2222CC", label = "Large" },
+
+		{ inner = 800, outer = 1100, col = "^xD35400", label = "Variable" },
+		{ inner = 1100, outer = 1400, col = "^x66FFCC", label = "Variable" },
+		{ inner = 1400, outer = 1700, col = "^x2222CC", label = "Variable" },
+		{ inner = 1700, outer = 2000, col = "^xC100FF", label = "Variable" },
+		{ inner = 2000, outer = 2400, col = "^xFFFF77", label = "Variable" },
 	}
 }
 

--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -3009,10 +3009,12 @@ local specialModList = {
 	["affects passives in medium ring"] = { mod("JewelData", "LIST", { key = "radiusIndex", value = 5 }) },
 	["affects passives in large ring"] = { mod("JewelData", "LIST", { key = "radiusIndex", value = 6 }) },
 	["affects passives in very large ring"] = { mod("JewelData", "LIST", { key = "radiusIndex", value = 7 }) },
+	["affects passives in massive ring"] = { mod("JewelData", "LIST", { key = "radiusIndex", value = 8 }) },
 	["only affects passives in small ring"] = { mod("JewelData", "LIST", { key = "radiusIndex", value = 4 }) },
 	["only affects passives in medium ring"] = { mod("JewelData", "LIST", { key = "radiusIndex", value = 5 }) },
 	["only affects passives in large ring"] = { mod("JewelData", "LIST", { key = "radiusIndex", value = 6 }) },
 	["only affects passives in very large ring"] = { mod("JewelData", "LIST", { key = "radiusIndex", value = 7 }) },
+	["only affects passives in massive ring"] = { mod("JewelData", "LIST", { key = "radiusIndex", value = 8 }) },
 	["(%d+)%% increased elemental damage per grand spectrum"] = function(num) return {
 		mod("ElementalDamage", "INC", num, { type = "Multiplier", var = "GrandSpectrum" }),
 		mod("Multiplier:GrandSpectrum", "BASE", 1),


### PR DESCRIPTION
According to my dialog with OpenArl we should have been using the PassiveJewelRadii.DAT values for jewel rings. This PR correct the values to those using the data.jewelRadii approach (in order to preserve backward compatibility) and adds support for the new ring size `Massive` which is to be 2000 to 2400 (although can change prior to 3.18 release)