### PR TITLE
[3.18] Show small ring on keystones for Impossible Escape planning

### DIFF
--- a/src/Classes/PassiveTreeView.lua
+++ b/src/Classes/PassiveTreeView.lua
@@ -658,6 +658,13 @@ function PassiveTreeViewClass:Draw(build, viewPort, inputEvents)
 								end
 							end
 						end
+					elseif hoverNode.type == "Keystone" and hoverNode.nodesInRadius then
+						-- Highlight nodes in small ring for Impossible Escape
+						local smallRadiusIndex = 1
+						local data = build.data.jewelRadius[smallRadiusIndex]						
+						if hoverNode.nodesInRadius[smallRadiusIndex][node.id] then
+							SetDrawColor(data.col)
+						end
 					end
 				end
 			end
@@ -744,6 +751,14 @@ function PassiveTreeViewClass:Draw(build, viewPort, inputEvents)
 				end
 			end
 		end
+	end
+	if hoverNode and hoverNode.type == "Keystone" then
+		-- Draw small ring overlay for Impossible Escape
+		local hackScrX, hackScrY = treeToScreen(hoverNode.x, hoverNode.y)
+		local smallRadData = build.data.jewelRadius[1]
+		local outerSize = smallRadData.outer * scale
+		SetDrawColor(smallRadData.col)
+		DrawImage(self.ring, hackScrX - outerSize, hackScrY - outerSize, outerSize * 2, outerSize * 2)
 	end
 end
 


### PR DESCRIPTION
### Description of the problem being solved:

This doesn't implement Impossible Escape, but it does set up Keystones to show a Small ring on hover for the purposes of planning with it.

This PR unilaterally enables the small ring on hover, with no check for whether Impossible Escape is actually present in the build. Probably we want to add that before merging, but I wanted to send this out as a draft in case someone wants to build on it.

### Steps taken to verify a working solution:
- Verified that the small ring shows on hovering any keystone
- Verified that the existing hover behavior for sockets still works
- Verified that it doesn't break with cluster or timeless keystones
- Verified all of the above in a 3.10 and 3.17 build.

### Link to a build that showcases this PR:
n/a

### Before screenshot:
![screenshot with no ring on keystone](https://user-images.githubusercontent.com/376284/167045863-a69c0629-d500-4e63-a100-03a71e6d1509.png)

### After screenshot:
![screenshot demonstrating new ring on keystones](https://user-images.githubusercontent.com/376284/167045444-e23e9462-d651-495d-85d8-05b9b5dcdae6.png)
