### PR TITLE
Add zoom support by using shift + mouse

### DIFF
--- a/src/Classes/EditControl.lua
+++ b/src/Classes/EditControl.lua
@@ -173,8 +173,8 @@ function EditClass:ZoomText(zoom)
 		textHeight = self.defaultLineHeight
 	end
 
-	if textHeight < 1 then
-		textHeight = 1
+	if textHeight < 10 then
+		textHeight = 10
 	elseif textHeight > 100 then
 		textHeight = 100
 	end

--- a/src/Classes/EditControl.lua
+++ b/src/Classes/EditControl.lua
@@ -53,7 +53,7 @@ local EditClass = newClass("EditControl", "ControlHost", "Control", "UndoHandler
 	self.selCol = "^0"
 	self.selBGCol = "^xBBBBBB"
 	self.blinkStart = GetTime()
-    self.allowZoom = allowZoom
+	self.allowZoom = allowZoom
 	if self.filter == "%D" or self.filter == "^%-%d" then
 		-- Add +/- buttons for integer number edits
 		self.isNumeric = true
@@ -598,7 +598,7 @@ function EditClass:OnKeyUp(key)
 			self.selControl = nil
 		end
 	end
-    
+
 	local shift = IsKeyDown("SHIFT")
 	if key == "LEFTBUTTON" then
 		if self.drag then
@@ -607,7 +607,7 @@ function EditClass:OnKeyUp(key)
 	elseif self.isNumeric then
 		local cur = tonumber(self.buf)
 		if key == "WHEELUP" or key == "UP" then
-            if cur then
+			if cur then
 				self:SetText(tostring(cur + (self.numberInc or 1)), true)
 			else
 				self:SetText("1", true)
@@ -620,17 +620,17 @@ function EditClass:OnKeyUp(key)
 			end
 		end
 	elseif key == "WHEELUP" then
-        if shift and self.allowZoom then
-            self.lineHeight = self.lineHeight + 1
-        elseif self.controls.scrollBarV.enabled then
+		if shift and self.allowZoom then
+			self.lineHeight = self.lineHeight + 1
+		elseif self.controls.scrollBarV.enabled then
 			self.controls.scrollBarV:Scroll(-1)
 		else
 			self.controls.scrollBarH:Scroll(-1)
 		end
 	elseif key == "WHEELDOWN" then		
-        if shift and self.allowZoom then
-            self.lineHeight = self.lineHeight - 1
-        elseif self.controls.scrollBarV.enabled then
+		if shift and self.allowZoom then
+			self.lineHeight = self.lineHeight - 1
+		elseif self.controls.scrollBarV.enabled then
 			self.controls.scrollBarV:Scroll(1)
 		else
 			self.controls.scrollBarH:Scroll(1)

--- a/src/Classes/EditControl.lua
+++ b/src/Classes/EditControl.lua
@@ -34,7 +34,7 @@ local function newlineCount(str)
 	end
 end
 
-local EditClass = newClass("EditControl", "ControlHost", "Control", "UndoHandler", "TooltipHost", function(self, anchor, x, y, width, height, init, prompt, filter, limit, changeFunc, lineHeight)
+local EditClass = newClass("EditControl", "ControlHost", "Control", "UndoHandler", "TooltipHost", function(self, anchor, x, y, width, height, init, prompt, filter, limit, changeFunc, lineHeight, allowZoom)
 	self.ControlHost()
 	self.Control(anchor, x, y, width, height)
 	self.UndoHandler()
@@ -53,6 +53,7 @@ local EditClass = newClass("EditControl", "ControlHost", "Control", "UndoHandler
 	self.selCol = "^0"
 	self.selBGCol = "^xBBBBBB"
 	self.blinkStart = GetTime()
+    self.allowZoom = allowZoom
 	if self.filter == "%D" or self.filter == "^%-%d" then
 		-- Add +/- buttons for integer number edits
 		self.isNumeric = true
@@ -597,6 +598,8 @@ function EditClass:OnKeyUp(key)
 			self.selControl = nil
 		end
 	end
+    
+	local shift = IsKeyDown("SHIFT")
 	if key == "LEFTBUTTON" then
 		if self.drag then
 			self.drag = false
@@ -604,7 +607,7 @@ function EditClass:OnKeyUp(key)
 	elseif self.isNumeric then
 		local cur = tonumber(self.buf)
 		if key == "WHEELUP" or key == "UP" then
-			if cur then
+            if cur then
 				self:SetText(tostring(cur + (self.numberInc or 1)), true)
 			else
 				self:SetText("1", true)
@@ -617,13 +620,17 @@ function EditClass:OnKeyUp(key)
 			end
 		end
 	elseif key == "WHEELUP" then
-		if self.controls.scrollBarV.enabled then
+        if shift and self.allowZoom then
+            self.lineHeight = self.lineHeight + 1
+        elseif self.controls.scrollBarV.enabled then
 			self.controls.scrollBarV:Scroll(-1)
 		else
 			self.controls.scrollBarH:Scroll(-1)
 		end
-	elseif key == "WHEELDOWN" then
-		if self.controls.scrollBarV.enabled then
+	elseif key == "WHEELDOWN" then		
+        if shift and self.allowZoom then
+            self.lineHeight = self.lineHeight - 1
+        elseif self.controls.scrollBarV.enabled then
 			self.controls.scrollBarV:Scroll(1)
 		else
 			self.controls.scrollBarH:Scroll(1)

--- a/src/Classes/NotesTab.lua
+++ b/src/Classes/NotesTab.lua
@@ -14,8 +14,8 @@ local NotesTabClass = newClass("NotesTab", "ControlHost", "Control", function(se
 	self.lastContent = ""
 	self.showColorCodes = false
 
-	local colorDesc = [[^7This field supports different colors.  Using the caret symbol (^) followed by a Hex code or a number (0-9) will set the color.
-Below are some common color codes PoB uses:	]]
+	local colorDesc = [[^7This field supports different colors.  Using the caret symbol (^) followed by a Hex code or a number (0-9) will set the color. 
+You can use SHIFT + WHEEL UP/DOWN to zoom in and out. Below are some common color codes PoB uses:	]]
 	self.controls.colorDoc = new("LabelControl", {"TOPLEFT",self,"TOPLEFT"}, 8, 8, 150, 16, colorDesc)
 	self.controls.normal = new("ButtonControl", {"TOPLEFT",self.controls.colorDoc,"TOPLEFT"}, 0, 32, 100, 18, colorCodes.NORMAL.."NORMAL", function() self:SetColor(colorCodes.NORMAL) end)
 	self.controls.magic = new("ButtonControl", {"TOPLEFT",self.controls.normal,"TOPLEFT"}, 120, 0, 100, 18, colorCodes.MAGIC.."MAGIC", function() self:SetColor(colorCodes.MAGIC) end)
@@ -30,7 +30,7 @@ Below are some common color codes PoB uses:	]]
 	self.controls.intelligence = new("ButtonControl", {"TOPLEFT",self.controls.dexterity,"TOPLEFT"}, 120, 0, 100, 18, colorCodes.INTELLIGENCE.."INTELLIGENCE", function() self:SetColor(colorCodes.INTELLIGENCE) end)
 	self.controls.default = new("ButtonControl", {"TOPLEFT",self.controls.intelligence,"TOPLEFT"}, 120, 0, 100, 18, "^7DEFAULT", function() self:SetColor("^7") end)
 
-	self.controls.edit = new("EditControl", {"TOPLEFT",self.controls.fire,"TOPLEFT"}, 0, 48, 0, 0, "", nil, "^%C\t\n", nil, nil, 16)
+	self.controls.edit = new("EditControl", {"TOPLEFT",self.controls.fire,"TOPLEFT"}, 0, 48, 0, 0, "", nil, "^%C\t\n", nil, nil, 16, true)
 	self.controls.edit.width = function()
 		return self.width - 16
 	end

--- a/src/Classes/NotesTab.lua
+++ b/src/Classes/NotesTab.lua
@@ -14,10 +14,11 @@ local NotesTabClass = newClass("NotesTab", "ControlHost", "Control", function(se
 	self.lastContent = ""
 	self.showColorCodes = false
 
-	local colorDesc = [[^7This field supports different colors.  Using the caret symbol (^) followed by a Hex code or a number (0-9) will set the color. 
-You can use CTRL +/- (or CTRL Mousewheel) to zoom in and out and CTRL 0 to reset. Below are some common color codes PoB uses:	]]
-	self.controls.colorDoc = new("LabelControl", {"TOPLEFT",self,"TOPLEFT"}, 8, 8, 150, 16, colorDesc)
-	self.controls.normal = new("ButtonControl", {"TOPLEFT",self.controls.colorDoc,"TOPLEFT"}, 0, 32, 100, 18, colorCodes.NORMAL.."NORMAL", function() self:SetColor(colorCodes.NORMAL) end)
+	local notesDesc = [[^7You can use Ctrl +/- (or Ctrl+Scroll) to zoom in and out and Ctrl+0 to reset.
+This field also supports different colors.  Using the caret symbol (^) followed by a Hex code or a number (0-9) will set the color.
+Below are some common color codes PoB uses:	]]
+	self.controls.notesDesc = new("LabelControl", {"TOPLEFT",self,"TOPLEFT"}, 8, 8, 150, 16, notesDesc)
+	self.controls.normal = new("ButtonControl", {"TOPLEFT",self.controls.notesDesc,"TOPLEFT"}, 0, 48, 100, 18, colorCodes.NORMAL.."NORMAL", function() self:SetColor(colorCodes.NORMAL) end)
 	self.controls.magic = new("ButtonControl", {"TOPLEFT",self.controls.normal,"TOPLEFT"}, 120, 0, 100, 18, colorCodes.MAGIC.."MAGIC", function() self:SetColor(colorCodes.MAGIC) end)
 	self.controls.rare = new("ButtonControl", {"TOPLEFT",self.controls.magic,"TOPLEFT"}, 120, 0, 100, 18, colorCodes.RARE.."RARE", function() self:SetColor(colorCodes.RARE) end)
 	self.controls.unique = new("ButtonControl", {"TOPLEFT",self.controls.rare,"TOPLEFT"}, 120, 0, 100, 18, colorCodes.UNIQUE.."UNIQUE", function() self:SetColor(colorCodes.UNIQUE) end)

--- a/src/Classes/NotesTab.lua
+++ b/src/Classes/NotesTab.lua
@@ -15,7 +15,7 @@ local NotesTabClass = newClass("NotesTab", "ControlHost", "Control", function(se
 	self.showColorCodes = false
 
 	local colorDesc = [[^7This field supports different colors.  Using the caret symbol (^) followed by a Hex code or a number (0-9) will set the color. 
-You can use SHIFT + WHEEL UP/DOWN to zoom in and out. Below are some common color codes PoB uses:	]]
+You can use CTRL +/- (or CTRL Mousewheel) to zoom in and out and CTRL 0 to reset. Below are some common color codes PoB uses:	]]
 	self.controls.colorDoc = new("LabelControl", {"TOPLEFT",self,"TOPLEFT"}, 8, 8, 150, 16, colorDesc)
 	self.controls.normal = new("ButtonControl", {"TOPLEFT",self.controls.colorDoc,"TOPLEFT"}, 0, 32, 100, 18, colorCodes.NORMAL.."NORMAL", function() self:SetColor(colorCodes.NORMAL) end)
 	self.controls.magic = new("ButtonControl", {"TOPLEFT",self.controls.normal,"TOPLEFT"}, 120, 0, 100, 18, colorCodes.MAGIC.."MAGIC", function() self:SetColor(colorCodes.MAGIC) end)


### PR DESCRIPTION
This adds support to zoom in and out in any `EditControl`.

Main usage for this is the `Notes` section, which can be kinda hard to read on high resolutions.

Many build authors meanwhile use this area to describe detailed step-by-step leveling guides with a build and having the screen open while reading is probably an regular usecase. Beeing able to zoom in here might help alot of ppl.

For now I only enabled zooming for the notes. Not sure whether other editors (like editing details in the crafting screen) would benefit from it also.