### PR TITLE
Add mouse shortcuts to skills tab

### DIFF
--- a/src/Classes/ListControl.lua
+++ b/src/Classes/ListControl.lua
@@ -431,12 +431,21 @@ function ListClass:OnKeyUp(key)
 	return self
 end
 
-function ListClass:GetHoverValue(key)
+function ListClass:GetHoverIndex()
 	local x, y = self:GetPos()
 	local cursorX, cursorY = GetCursorPos()
 	local rowRegion = self:GetRowRegion()
 	if cursorX >= x + rowRegion.x and cursorY >= y + rowRegion.y and cursorX < x + rowRegion.x + rowRegion.width and cursorY < y + rowRegion.y + rowRegion.height then
 		local index = math.floor((cursorY - y - rowRegion.y + self.controls.scrollBarV.offset) / self.rowHeight) + 1
+		if self.list[index] then
+			return index
+		end
+	end
+end
+
+function ListClass:GetHoverValue(key)
+	local index = self:GetHoverIndex()
+	if index then
 		local value = self.list[index]
 		if value then
 			return value

--- a/src/Classes/SkillListControl.lua
+++ b/src/Classes/SkillListControl.lua
@@ -52,6 +52,9 @@ function SkillListClass:GetRowValue(column, index, socketGroup)
 		if not socketGroup.enabled or not socketGroup.slotEnabled then
 			label = "^x7F7F7F" .. label .. " (Disabled)"
 		end
+		if self.skillsTab.build.mainSocketGroup == index then 
+			label = label .. colorCodes.RELIC .. " [Active]"
+		end
 		if socketGroup.includeInFullDPS then 
 			label = label .. colorCodes.CUSTOM .. " [FullDPS]"
 		end
@@ -127,6 +130,14 @@ function SkillListClass:OnHoverKeyUp(key)
 			item.enabled = not item.enabled
 			self.skillsTab:AddUndoState()
 			self.skillsTab.build.buildFlag = true
+		end
+	elseif key == 'LEFTBUTTON' and IsKeyDown('ALT') then
+		local index = self.ListControl:GetHoverIndex()
+		if index then
+			-- mirrors Build.lua:548
+			self.skillsTab.build.mainSocketGroup = index
+			self.skillsTab.build.buildFlag = true
+			self.skillsTab.build.modFlag = true
 		end
 	end
 end

--- a/src/Classes/SkillListControl.lua
+++ b/src/Classes/SkillListControl.lua
@@ -52,6 +52,9 @@ function SkillListClass:GetRowValue(column, index, socketGroup)
 		if not socketGroup.enabled or not socketGroup.slotEnabled then
 			label = "^x7F7F7F" .. label .. " (Disabled)"
 		end
+		if socketGroup.includeInFullDPS then 
+			label = label .. colorCodes.CUSTOM .. " [FullDPS]"
+		end
 		return label
 	end
 end
@@ -116,8 +119,14 @@ function SkillListClass:OnHoverKeyUp(key)
 			end
 		end
 	elseif key == 'RIGHTBUTTON' then
-		item.enabled = not item.enabled
-		self.skillsTab:AddUndoState()
-		self.skillsTab.build.buildFlag = true
+		if IsKeyDown("ALT") then
+			item.includeInFullDPS = not item.includeInFullDPS
+			self.skillsTab:AddUndoState()
+			self.skillsTab.build.buildFlag = true
+		else 
+			item.enabled = not item.enabled
+			self.skillsTab:AddUndoState()
+			self.skillsTab.build.buildFlag = true
+		end
 	end
 end

--- a/src/Classes/SkillListControl.lua
+++ b/src/Classes/SkillListControl.lua
@@ -53,10 +53,10 @@ function SkillListClass:GetRowValue(column, index, socketGroup)
 			label = "^x7F7F7F" .. label .. " (Disabled)"
 		end
 		if self.skillsTab.build.mainSocketGroup == index then 
-			label = label .. colorCodes.RELIC .. " [Active]"
+			label = label .. colorCodes.RELIC .. " (Active)"
 		end
 		if socketGroup.includeInFullDPS then 
-			label = label .. colorCodes.CUSTOM .. " [FullDPS]"
+			label = label .. colorCodes.CUSTOM .. " (FullDPS)"
 		end
 		return label
 	end
@@ -113,31 +113,31 @@ end
 
 function SkillListClass:OnHoverKeyUp(key)
 	local item = self.ListControl:GetHoverValue()
-	if itemLib.wiki.matchesKey(key) then
-		if item then
+	if item then
+		if itemLib.wiki.matchesKey(key) then
 			-- Get the first gem in the group
 			local gem = item.gemList[1]
 			if gem then
 				itemLib.wiki.openGem(gem.gemData)
 			end
-		end
-	elseif key == 'RIGHTBUTTON' then
-		if IsKeyDown("ALT") then
-			item.includeInFullDPS = not item.includeInFullDPS
-			self.skillsTab:AddUndoState()
-			self.skillsTab.build.buildFlag = true
-		else 
+		elseif key == "RIGHTBUTTON" then
+			if IsKeyDown("CTRL") then
+				item.includeInFullDPS = not item.includeInFullDPS
+				self.skillsTab:AddUndoState()
+				self.skillsTab.build.buildFlag = true
+			else
+				local index = self.ListControl:GetHoverIndex()
+				if index then
+					-- mirrors Build.lua:548
+					self.skillsTab.build.mainSocketGroup = index
+					self.skillsTab.build.buildFlag = true
+					self.skillsTab.build.modFlag = true
+				end
+			end
+		elseif key == "LEFTBUTTON" and IsKeyDown("CTRL") then
 			item.enabled = not item.enabled
 			self.skillsTab:AddUndoState()
 			self.skillsTab.build.buildFlag = true
-		end
-	elseif key == 'LEFTBUTTON' and IsKeyDown('ALT') then
-		local index = self.ListControl:GetHoverIndex()
-		if index then
-			-- mirrors Build.lua:548
-			self.skillsTab.build.mainSocketGroup = index
-			self.skillsTab.build.buildFlag = true
-			self.skillsTab.build.modFlag = true
 		end
 	end
 end

--- a/src/Classes/SkillListControl.lua
+++ b/src/Classes/SkillListControl.lua
@@ -106,8 +106,8 @@ function SkillListClass:OnSelDelete(index, socketGroup)
 end
 
 function SkillListClass:OnHoverKeyUp(key)
+	local item = self.ListControl:GetHoverValue()
 	if itemLib.wiki.matchesKey(key) then
-		local item = self.ListControl:GetHoverValue()
 		if item then
 			-- Get the first gem in the group
 			local gem = item.gemList[1]
@@ -115,5 +115,9 @@ function SkillListClass:OnHoverKeyUp(key)
 				itemLib.wiki.openGem(gem.gemData)
 			end
 		end
+	elseif key == 'RIGHTBUTTON' then
+		item.enabled = not item.enabled
+		self.skillsTab:AddUndoState()
+		self.skillsTab.build.buildFlag = true
 	end
 end

--- a/src/Classes/SkillsTab.lua
+++ b/src/Classes/SkillsTab.lua
@@ -68,33 +68,42 @@ local SkillsTabClass = newClass("SkillsTab", "UndoHandler", "ControlHost", "Cont
 
 	-- Socket group list
 	self.controls.groupList = new("SkillListControl", {"TOPLEFT",self,"TOPLEFT"}, 20, 24, 360, 300, self)
-	self.controls.groupTip = new("LabelControl", {"TOPLEFT",self.controls.groupList,"BOTTOMLEFT"}, 0, 8, 0, 14, "^7Tip: You can copy/paste socket groups using Ctrl+C and Ctrl+V.")
+	self.controls.groupTip = new("LabelControl", {"TOPLEFT",self.controls.groupList,"BOTTOMLEFT"}, 0, 8, 0, 14, 
+[[
+^7Usage Tips:
+- You can copy/paste socket groups using Ctrl+C and Ctrl+V.
+- Right click to enable/disable socket groups.
+- Alt + Right click to include/exclude in FullDPS calculations.
+- Alt + Left click to set as Main skill group.
+]]
+	)
 
 	-- Gem options
 	local optionInputsX = 211
-	self.controls.optionSection = new("SectionControl", {"TOPLEFT",self.controls.groupList,"BOTTOMLEFT"}, 0, 50, 375, 180, "Gem Options")
-	self.controls.sortGemsByDPS = new("CheckBoxControl", {"TOPLEFT",self.controls.groupList,"BOTTOMLEFT"}, optionInputsX, 70, 20, "Sort gems by DPS:", function(state)
+	local optionInputsY = 45
+	self.controls.optionSection = new("SectionControl", {"TOPLEFT",self.controls.groupList,"BOTTOMLEFT"}, 0, optionInputsY+50, 375, 180, "Gem Options")
+	self.controls.sortGemsByDPS = new("CheckBoxControl", {"TOPLEFT",self.controls.groupList,"BOTTOMLEFT"}, optionInputsX, optionInputsY+70, 20, "Sort gems by DPS:", function(state)
 		self.sortGemsByDPS = state
 	end, nil, true)
 	self.controls.sortGemsByDPSFieldControl = new("DropDownControl", {"LEFT", self.controls.sortGemsByDPS, "RIGHT"}, 10, 0, 120, 20, sortGemTypeList, function(index, value)
 		self.sortGemsByDPSField = value.type
 	end)
-	self.controls.matchGemLevelToCharacterLevel = new("CheckBoxControl", {"TOPLEFT",self.controls.groupList,"BOTTOMLEFT"}, optionInputsX, 94, 20, "^7Match gems to character level:", function(state)
+	self.controls.matchGemLevelToCharacterLevel = new("CheckBoxControl", {"TOPLEFT",self.controls.groupList,"BOTTOMLEFT"}, optionInputsX, optionInputsY+94, 20, "^7Match gems to character level:", function(state)
 		self.matchGemLevelToCharacterLevel = state
 	end)
-	self.controls.defaultLevel = new("EditControl", {"TOPLEFT",self.controls.groupList,"BOTTOMLEFT"}, optionInputsX, 118, 60, 20, nil, nil, "%D", 2, function(buf)
+	self.controls.defaultLevel = new("EditControl", {"TOPLEFT",self.controls.groupList,"BOTTOMLEFT"}, optionInputsX, optionInputsY+118, 60, 20, nil, nil, "%D", 2, function(buf)
 		self.defaultGemLevel = m_max(m_min(tonumber(buf) or 20, 21), 1)
 	end)
 	self.controls.defaultLevelLabel = new("LabelControl", {"RIGHT",self.controls.defaultLevel,"LEFT"}, -4, 0, 0, 16, "^7Default gem level:")
-	self.controls.defaultQuality = new("EditControl", {"TOPLEFT",self.controls.groupList,"BOTTOMLEFT"}, optionInputsX, 142, 60, 20, nil, nil, "%D", 2, function(buf)
+	self.controls.defaultQuality = new("EditControl", {"TOPLEFT",self.controls.groupList,"BOTTOMLEFT"}, optionInputsX, optionInputsY+142, 60, 20, nil, nil, "%D", 2, function(buf)
 		self.defaultGemQuality = m_min(tonumber(buf) or 0, 23)
 	end)
 	self.controls.defaultQualityLabel = new("LabelControl", {"RIGHT",self.controls.defaultQuality,"LEFT"}, -4, 0, 0, 16, "^7Default gem quality:")
-	self.controls.showSupportGemTypes = new("DropDownControl", {"TOPLEFT",self.controls.groupList,"BOTTOMLEFT"}, optionInputsX, 166, 120, 20, showSupportGemTypeList, function(index, value)
+	self.controls.showSupportGemTypes = new("DropDownControl", {"TOPLEFT",self.controls.groupList,"BOTTOMLEFT"}, optionInputsX, optionInputsY+166, 120, 20, showSupportGemTypeList, function(index, value)
 		self.showSupportGemTypes = value.show
 	end)
 	self.controls.showSupportGemTypesLabel = new("LabelControl", {"RIGHT",self.controls.showSupportGemTypes,"LEFT"}, -4, 0, 0, 16, "^7Show support gems:")
-	self.controls.showAltQualityGems = new("CheckBoxControl", {"TOPLEFT",self.controls.groupList,"BOTTOMLEFT"}, optionInputsX, 190, 20, "^7Show gem quality variants:", function(state)
+	self.controls.showAltQualityGems = new("CheckBoxControl", {"TOPLEFT",self.controls.groupList,"BOTTOMLEFT"}, optionInputsX, optionInputsY+190, 20, "^7Show gem quality variants:", function(state)
 		self.showAltQualityGems = state
 	end)
 

--- a/src/Classes/SkillsTab.lua
+++ b/src/Classes/SkillsTab.lua
@@ -72,9 +72,9 @@ local SkillsTabClass = newClass("SkillsTab", "UndoHandler", "ControlHost", "Cont
 [[
 ^7Usage Tips:
 - You can copy/paste socket groups using Ctrl+C and Ctrl+V.
-- Right click to enable/disable socket groups.
-- Alt + Right click to include/exclude in FullDPS calculations.
-- Alt + Left click to set as Main skill group.
+- Ctrl + Click to enable/disable socket groups.
+- Ctrl + Right click to include/exclude in FullDPS calculations.
+- Right click to set as the Main skill group.
 ]]
 	)
 


### PR DESCRIPTION
I wanted to ease the tedium of enabling/disabling multiple skill groups typically found in build guide pobs and went a little further in the process.

This PR adds the following shortcuts to the skill list in Skills Tab:
- `Right Click`: enable/disable skill group
- `ALT + Right Click`: include/exclude skill group in FullDPS calculation
- `ALT + Left Click`: select skill group as the main skill

also `[FullDPS]` and `[Active]` tags are added to skill group labels to indicate their configurations

## Current behavior

This is the current process when you want to switch between different skill sets, it requires a lot of clicks:

https://user-images.githubusercontent.com/5316261/168825159-9e81d81e-dfa0-4443-9493-336b5141016d.mp4

Also, you have to hunt for enabled FullDPS boxes if you have multiple sets of the same skill since the left column display doesn't include any info other than the active skill name:

https://user-images.githubusercontent.com/5316261/168826463-318b8ba0-1361-4d89-824d-200b1d55324f.mp4


## Proposed functionality


https://user-images.githubusercontent.com/5316261/168840252-88812679-82f5-4537-ac77-b5c5015f38d7.mp4

I was going to split this PR into two parts, one for enable/disable shortcut and another one for other functionality which comes with new tags but didn't want to clutter the repo with similar requests.

Toggling enable/disable already has an indicator (`(Disabled)` tag) so it is a visually non-invasive addition compared to the other two.

Added tags look fine to me but I can see an argument being made for potential visual clutter. I considered adding background color to rows instead of tags but throwing around colors doesn't feel better.
Between two tags, `FullDPS` one feels mandatory with hotkey since there is no indicator for toggling this flag like enable/disable tag `(Disabled)`.
`Active` tag is a helpful indicator in no label scenarios like [this](https://user-images.githubusercontent.com/5316261/168853036-a9290121-f3c3-44ad-aad1-b63b89bb797b.png) and provides instant feedback when main skill is changed via proposed alt+click shortcut but one can argue that it's not mandatory for shortcut function since main skill update on left panel is also visible.

Overall, I think these features feel great whether you navigate a content creator's PoB with a skill section for every act or check numbers on the different combinations of curse-aura-skill setups.

All the styling and hotkey selection are done arbitrarily, let me know if you have any suggestions.
