### PR TITLE
Remove tooltip if covering dropdown is opened

### DIFF
--- a/src/Modules/Build.lua
+++ b/src/Modules/Build.lua
@@ -554,6 +554,10 @@ function buildMode:Init(dbFileName, buildName, buildXML, convertBuild)
 	end)
 	self.controls.mainSocketGroup.maxDroppedWidth = 500
 	self.controls.mainSocketGroup.tooltipFunc = function(tooltip, mode, index, value)
+		if self.controls.pantheonMinorGod.dropped then
+			tooltip:Clear()
+			return
+		end
 		local socketGroup = self.skillsTab.socketGroupList[index]
 		if socketGroup and tooltip:CheckForUpdate(socketGroup, self.outputRevision) then
 			self.skillsTab:AddSocketGroupTooltip(tooltip, socketGroup)

--- a/src/Modules/Build.lua
+++ b/src/Modules/Build.lua
@@ -554,7 +554,7 @@ function buildMode:Init(dbFileName, buildName, buildXML, convertBuild)
 	end)
 	self.controls.mainSocketGroup.maxDroppedWidth = 500
 	self.controls.mainSocketGroup.tooltipFunc = function(tooltip, mode, index, value)
-		if self.controls.pantheonMinorGod.dropped then
+		if self.controls.pantheonMinorGod.dropped or self.controls.pantheonMajorGod.dropped then
 			tooltip:Clear()
 			return
 		end

--- a/src/Modules/Build.lua
+++ b/src/Modules/Build.lua
@@ -537,13 +537,25 @@ function buildMode:Init(dbFileName, buildName, buildXML, convertBuild)
 		self.modFlag = true
 		self.buildFlag = true
 	end)
-	self.controls.pantheonMajorGod.tooltipFunc = applyPantheonDescription
+	self.controls.pantheonMajorGod.tooltipFunc = function(tooltip, mode, index, value)
+		if self.controls.pantheonMinorGod.dropped then
+			tooltip:Clear()
+			return
+		end
+		applyPantheonDescription(tooltip, mode, index, value)
+	end
 	self.controls.pantheonMinorGod = new("DropDownControl", {"TOPLEFT",self.anchorSideBar,"TOPLEFT"}, 0, 130, 300, 16, PantheonMinorGodDropList, function(index, value)
 		self.pantheonMinorGod = value.id
 		self.modFlag = true
 		self.buildFlag = true
 	end)
-	self.controls.pantheonMinorGod.tooltipFunc = applyPantheonDescription
+	self.controls.pantheonMinorGod.tooltipFunc = function(tooltip, mode, index, value)
+		if self.controls.pantheonMajorGod.dropped then
+			tooltip:Clear()
+			return
+		end
+		applyPantheonDescription(tooltip, mode, index, value)
+	end
 	self.controls.pantheonLabel = new("LabelControl", {"BOTTOMLEFT",self.controls.pantheonMajorGod,"TOPLEFT"}, 0, 0, 0, 14, "^7The Pantheon:")
 	-- Skills
 	self.controls.mainSkillLabel = new("LabelControl", {"TOPLEFT",self.anchorSideBar,"TOPLEFT"}, 0, 155, 300, 16, "^7Main Skill:")

--- a/src/Modules/Build.lua
+++ b/src/Modules/Build.lua
@@ -549,13 +549,7 @@ function buildMode:Init(dbFileName, buildName, buildXML, convertBuild)
 		self.modFlag = true
 		self.buildFlag = true
 	end)
-	self.controls.pantheonMinorGod.tooltipFunc = function(tooltip, mode, index, value)
-		if self.controls.pantheonMajorGod.dropped then
-			tooltip:Clear()
-			return
-		end
-		applyPantheonDescription(tooltip, mode, index, value)
-	end
+	self.controls.pantheonMinorGod.tooltipFunc = applyPantheonDescription
 	self.controls.pantheonLabel = new("LabelControl", {"BOTTOMLEFT",self.controls.pantheonMajorGod,"TOPLEFT"}, 0, 0, 0, 14, "^7The Pantheon:")
 	-- Skills
 	self.controls.mainSkillLabel = new("LabelControl", {"TOPLEFT",self.anchorSideBar,"TOPLEFT"}, 0, 155, 300, 16, "^7Main Skill:")


### PR DESCRIPTION
Fixes #2366 .

This is done on a case-by-case basis instead of globally because there are only a few dropdowns that have this issue, and the ability to view tooltips with a dropdown open is still a desirable feature.
