### PR TITLE
Show Boss 'less curse effect' in resistance breakdown

### DIFF
--- a/src/Modules/CalcSections.lua
+++ b/src/Modules/CalcSections.lua
@@ -6,19 +6,19 @@
 
 -- Commonly used modifier lists
 local physicalHitTaken = {
-	"DamageTaken", "PhysicalDamageTaken"
+	"DamageTaken", "PhysicalDamageTaken", "CurseEffectOnSelf"
 }
 local lightningHitTaken = {
-	"DamageTaken", "LightningDamageTaken", "ElementalDamageTaken", "LightningResist", "ElementalResist"
+	"DamageTaken", "LightningDamageTaken", "ElementalDamageTaken", "LightningResist", "ElementalResist", "CurseEffectOnSelf"
 }
 local coldHitTaken = {
-	"DamageTaken", "ColdDamageTaken", "ElementalDamageTaken", "ColdResist", "ElementalResist"
+	"DamageTaken", "ColdDamageTaken", "ElementalDamageTaken", "ColdResist", "ElementalResist", "CurseEffectOnSelf"
 }
 local fireHitTaken = {
-	"DamageTaken", "FireDamageTaken", "ElementalDamageTaken", "FireResist", "ElementalResist"
+	"DamageTaken", "FireDamageTaken", "ElementalDamageTaken", "FireResist", "ElementalResist", "CurseEffectOnSelf"
 }
 local chaosHitTaken = {
-	"DamageTaken", "ChaosDamageTaken", "ChaosResist"
+	"DamageTaken", "ChaosDamageTaken", "ChaosResist", "CurseEffectOnSelf"
 }
 local physicalConvert = { 
 	"SkillPhysicalDamageConvertToLightning", "SkillPhysicalDamageConvertToCold", "SkillPhysicalDamageConvertToFire", "SkillPhysicalDamageConvertToChaos", 


### PR DESCRIPTION
### Description of the problem being solved:
Some new users to PoB would not understand why their curse effect was not being applied at full effect to bosses. This PR adds the bosses 'less curse effect' stat to the breakdown so its clearer to see why it is the case

### Link to a build that showcases this PR:
https://pobb.in/F97WIYdi-nGm

### Before screenshot:
![image](https://user-images.githubusercontent.com/31035929/169453037-db83659b-67c6-4339-a015-419067f05077.png)


### After screenshot:
![image](https://user-images.githubusercontent.com/31035929/169452920-284aa350-d9f2-4191-b235-5d149c4bce7b.png)
