### PR TITLE
Fix Massive Thread of Hope outer radius

### DIFF
--- a/src/Modules/Data.lua
+++ b/src/Modules/Data.lua
@@ -159,7 +159,7 @@ data.jewelRadii = {
 		{ inner = 1320, outer = 1680, col = "^x66FFCC", label = "Variable" },
 		{ inner = 1680, outer = 2040, col = "^x2222CC", label = "Variable" },
 		{ inner = 2040, outer = 2400, col = "^xC100FF", label = "Variable" },
-		{ inner = 2400, outer = 2760, col = "^x0B9300", label = "Variable" },
+		{ inner = 2400, outer = 2880, col = "^x0B9300", label = "Variable" },
 	}
 }
 


### PR DESCRIPTION
Outer ring has a radius of 480 more than the inner instead of the usual 360
Verified by looking at game files
Fixes #4403