### PR TITLE
Fix: Double Counting Dual Wield Poison Stacks

### DIFF
--- a/src/Data/Skills/act_dex.lua
+++ b/src/Data/Skills/act_dex.lua
@@ -8681,7 +8681,6 @@ skills["ViperStrike"] = {
 	},
 	baseMods = {
 		skill("poisonIsSkillEffect", true),
-		skill("stackMultiplier", 2, { type = "Condition", var = "DualWielding" }),
 	},
 	qualityStats = {
 		Default = {

--- a/src/Export/Skills/act_dex.txt
+++ b/src/Export/Skills/act_dex.txt
@@ -1484,7 +1484,6 @@ local skills, mod, flag, skill = ...
 		},
 	},
 #baseMod skill("poisonIsSkillEffect", true)
-#baseMod skill("stackMultiplier", 2, { type = "Condition", var = "DualWielding" })
 #mods
 
 #skill VolatileDead


### PR DESCRIPTION
Fixes #4356.

### Description of the problem being solved:
Viper Strike was corrected in two separate ways for counting poison stacks back in January, 2022. 
1) I added coded for tracking `stackMultiplier` so you can set number of "hit" instances a skill provided for things that stack (e.g., Poisons, Impales, etc.). 
2) I corrected code for how `stats` were combined for skills that had the `skillData.doubleHitsWhenDualWielding` set to not average (i.e., "divide by 2") but rather combine the two hits.

Implementing both fixes resulted now in Viper Strike applying 4x the amount of stacks it was doing, rather than just 2x.

### Steps taken to verify a working solution:
- Loaded build code: https://pastebin.com/RyQx3EUp
- Compared "before" and "after" Calcs Tab for `Max Poisons Stacks` breakdown
-

### Link to a build that showcases this PR:
https://pastebin.com/RyQx3EUp

### Before screenshot:
![Before](https://user-images.githubusercontent.com/1735956/171172353-510fdfd9-a785-4c0a-b785-de0240d4772e.png)

### After screenshot:
![After](https://user-images.githubusercontent.com/1735956/171172176-f99bd922-d89b-492f-aa62-87748a6d6a44.png)

