### PR TITLE
Add option to overwrite all enemy defaults if any config

### DIFF
--- a/src/Modules/CalcDefence.lua
+++ b/src/Modules/CalcDefence.lua
@@ -857,42 +857,52 @@ function calcs.defence(env, actor)
 		local enemyCritChance = env.configInput["enemyCritChance"] or 5
 		local enemyCritDamage = env.configInput["enemyCritDamage"] or 30
 		output["EnemyCritEffect"] = 1 + enemyCritChance / 100 * (enemyCritDamage / 100) * (1 - output.CritExtraDamageReduction / 100)
+		local sourceVal = "Default"
+		for _, damageType in ipairs(dmgTypeList) do
+			if env.configInput["enemy"..damageType.."Damage"] or env.configInput["enemy"..damageType.."Pen"] then
+				sourceVal = "Config"
+			end
+		end
 		for _, damageType in ipairs(dmgTypeList) do
 			local enemyDamageMult = calcLib.mod(enemyDB, nil, "Damage", damageType.."Damage", isElemental[damageType] and "ElementalDamage" or nil) --missing taunt from allies
 			local enemyDamage = env.configInput["enemy"..damageType.."Damage"]
 			local enemyPen = env.configInput["enemy"..damageType.."Pen"]
-			local sourceStr = enemyDamage == nil and "Default" or "Config"
+			local sourceStr = sourceVal
+			
+			if sourceVal == "Default" or main.doNotOverwriteEnemyDefaultsWithConfig then
+				sourceStr = enemyDamage == nil and "Default" or "Config"
 
-			if env.configInput["enemyIsBoss"] == "Uber Atziri" then -- random boss (not specificaly uber ziri)
-				if enemyDamage == nil then
-					enemyDamage = env.data.monsterDamageTable[env.enemyLevel] * 1.5  * data.misc.stdBossDPSMult
-					if damageType == "Chaos" then
-						enemyDamage = enemyDamage / 4
+				if env.configInput["enemyIsBoss"] == "Uber Atziri" then -- random boss (not specificaly uber ziri)
+					if enemyDamage == nil then
+						enemyDamage = env.data.monsterDamageTable[env.enemyLevel] * 1.5  * data.misc.stdBossDPSMult
+						if damageType == "Chaos" then
+							enemyDamage = enemyDamage / 4
+						end
 					end
-				end
-			elseif env.configInput["enemyIsBoss"] == "Shaper" then
-				if enemyDamage == nil then
-					enemyDamage = env.data.monsterDamageTable[env.enemyLevel] * 1.5  * data.misc.shaperDPSMult
-					if damageType == "Chaos" then
-						enemyDamage = enemyDamage / 4
+				elseif env.configInput["enemyIsBoss"] == "Shaper" then
+					if enemyDamage == nil then
+						enemyDamage = env.data.monsterDamageTable[env.enemyLevel] * 1.5  * data.misc.shaperDPSMult
+						if damageType == "Chaos" then
+							enemyDamage = enemyDamage / 4
+						end
 					end
-				end
-				if enemyPen == nil and isElemental[damageType] then
-					enemyPen = data.misc.shaperPen
-				end
-			elseif env.configInput["enemyIsBoss"] == "Sirus" then
-				if enemyDamage == nil then
-					enemyDamage = env.data.monsterDamageTable[env.enemyLevel] * 1.5  * data.misc.sirusDPSMult
-					if damageType == "Chaos" then
-						enemyDamage = enemyDamage / 4
+					if enemyPen == nil and isElemental[damageType] then
+						enemyPen = data.misc.shaperPen
 					end
-				end
-				if enemyPen == nil and isElemental[damageType] then
-					output[damageType.."EnemyPen"] = data.misc.sirusPen
-				end
-			else
-				if enemyDamage == nil and damageType == "Physical" then
-					enemyDamage = env.data.monsterDamageTable[env.enemyLevel] * 1.5
+				elseif env.configInput["enemyIsBoss"] == "Sirus" then
+					if enemyDamage == nil then
+						enemyDamage = env.data.monsterDamageTable[env.enemyLevel] * 1.5  * data.misc.sirusDPSMult
+						if damageType == "Chaos" then
+							enemyDamage = enemyDamage / 4
+						end
+					end
+					if enemyPen == nil and isElemental[damageType] then
+						enemyPen = data.misc.sirusPen
+					end
+				else
+					if enemyDamage == nil and damageType == "Physical" then
+						enemyDamage = env.data.monsterDamageTable[env.enemyLevel] * 1.5
+					end
 				end
 			end
 

--- a/src/Modules/Main.lua
+++ b/src/Modules/Main.lua
@@ -205,6 +205,7 @@ the "Releases" section of the GitHub page.]])
 	self.showTitlebarName = true
 	self.showWarnings = true
 	self.slotOnlyTooltips = true
+	self.doNotOverwriteEnemyDefaultsWithConfig = true
 
 	local ignoreBuild
 	if arg[1] then
@@ -528,6 +529,9 @@ function main:LoadSettings(ignoreBuild)
 				if node.attrib.slotOnlyTooltips then
 					self.slotOnlyTooltips = node.attrib.slotOnlyTooltips == "true"
 				end
+				if node.attrib.doNotOverwriteEnemyDefaultsWithConfig then
+					self.doNotOverwriteEnemyDefaultsWithConfig = node.attrib.doNotOverwriteEnemyDefaultsWithConfig == "true"
+				end
 			end
 		end
 	end
@@ -581,6 +585,7 @@ function main:SaveSettings()
 		lastExportWebsite = self.lastExportWebsite,
 		showWarnings = tostring(self.showWarnings),
 		slotOnlyTooltips = tostring(self.slotOnlyTooltips),
+		doNotOverwriteEnemyDefaultsWithConfig = tostring(self.doNotOverwriteEnemyDefaultsWithConfig),
 	} })
 	local res, errMsg = common.xml.SaveXMLFile(setXML, self.userPath.."Settings.xml")
 	if not res then
@@ -717,11 +722,16 @@ function main:OpenOptionsPopup()
 	controls.slotOnlyTooltips = new("CheckBoxControl", {"TOPLEFT",nil,"TOPLEFT"}, defaultLabelPlacementX, currentY, 20, "^7Show tooltips only for affected slots:", function(state)
 		self.slotOnlyTooltips = state
 	end)
+	nextRow()
+	controls.doNotOverwriteEnemyDefaultsWithConfig = new("CheckBoxControl", {"TOPLEFT",nil,"TOPLEFT"}, defaultLabelPlacementX, currentY, 20, "^7EHP, dont overwrite enemy defaults:", function(state)
+		self.doNotOverwriteEnemyDefaultsWithConfig = state
+	end)
 
 	controls.betaTest.state = self.betaTest
 	controls.titlebarName.state = self.showTitlebarName
 	controls.showWarnings.state = self.showWarnings
 	controls.slotOnlyTooltips.state = self.slotOnlyTooltips
+	controls.doNotOverwriteEnemyDefaultsWithConfig.state = self.doNotOverwriteEnemyDefaultsWithConfig
 	local initialNodePowerTheme = self.nodePowerTheme
 	local initialThousandsSeparatorDisplay = self.showThousandsSeparators
 	local initialTitlebarName = self.showTitlebarName
@@ -732,6 +742,7 @@ function main:OpenOptionsPopup()
 	local initialDefaultCharLevel = self.defaultCharLevel or 1
 	local initialshowWarnings = self.showWarnings
 	local initialSlotOnlyTooltips = self.slotOnlyTooltips
+	local initialDoNotOverwriteEnemyDefaultsWithConfig = self.doNotOverwriteEnemyDefaultsWithConfig
 
 	-- last line with buttons has more spacing
 	nextRow(1.5)
@@ -771,6 +782,7 @@ function main:OpenOptionsPopup()
 		self.defaultCharLevel = initialDefaultCharLevel
 		self.showWarnings = initialshowWarnings
 		self.slotOnlyTooltips = initialSlotOnlyTooltips
+		self.doNotOverwriteEnemyDefaultsWithConfig = initialDoNotOverwriteEnemyDefaultsWithConfig
 		main:ClosePopup()
 	end)
 	nextRow(1.5)


### PR DESCRIPTION
This adds back the option (removed in  #4327, must be toggled to change functionality) to overwrite all enemy defaults if you enter a number in any, rather than having to 0 all the ones you do not care about
![image](https://user-images.githubusercontent.com/49933620/171799853-25639753-2f07-4ed6-930e-cce2a7dfefcd.png)

it also fixes a bug where default pen on sirus config was ignored (introduced in the same PR)
