### PR TITLE
Fix unicode sanitization issues

### DIFF
--- a/src/Classes/ItemsTab.lua
+++ b/src/Classes/ItemsTab.lua
@@ -1828,7 +1828,7 @@ function ItemsTabClass:EditDisplayItemText()
 	local controls = { }
 	local function buildRaw()
 		local editBuf = controls.edit.buf
-		if editBuf:match("^Item Class: .*\nRarity: ") then
+		if editBuf:match("^Item Class: .*\nRarity: ") or editBuf:match("^Rarity: ") then
 			return editBuf
 		else
 			return "Rarity: "..controls.rarity.list[controls.rarity.selIndex].rarity.."\n"..controls.edit.buf
@@ -1843,9 +1843,7 @@ function ItemsTabClass:EditDisplayItemText()
 		controls.rarity.selIndex = 3
 	end
 	controls.edit.font = "FIXED"
-	controls.edit.pasteFilter = function(text)
-		return text:gsub("\246","o")
-	end
+	controls.edit.pasteFilter = itemLib.sanitiseItemText
 	controls.save = new("ButtonControl", nil, -45, 470, 80, 20, self.displayItem and "Save" or "Create", function()
 		local id = self.displayItem and self.displayItem.id
 		self:CreateDisplayItemFromRaw(buildRaw(), not self.displayItem)


### PR DESCRIPTION
### Description of the problem being solved:
Pasting "Doppelgänger Guise" into the custom item creation box shows as "Doppelg?nger Guise".  This is true for many letters as the old way was only checking for ö -> o.  Also fixed a small issue when copying an item from poe.ninja that wouldn't show the item as unique

### Before screenshot:
![image](https://user-images.githubusercontent.com/1209372/172774620-589113b7-e644-459e-a7ee-6cce4d7f7890.png)

### After screenshot:
![image](https://user-images.githubusercontent.com/1209372/172774706-93fe91fb-6173-4495-8498-2de4630fe2d7.png)
