### PR TITLE
Fix overlapping tooltips, move bandit and pantheon options into the Config tab

### DIFF
--- a/src/Classes/ButtonControl.lua
+++ b/src/Classes/ButtonControl.lua
@@ -33,7 +33,7 @@ function ButtonClass:IsMouseOver()
 	return self:IsMouseInBounds()
 end
 
-function ButtonClass:Draw(viewPort)
+function ButtonClass:Draw(viewPort, noTooltip)
 	local x, y = self:GetPos()
 	local width, height = self:GetSize()
 	local enabled = self:IsEnabled()
@@ -85,12 +85,14 @@ function ButtonClass:Draw(viewPort)
 		DrawImageQuad(nil, x + width * 0.7, y + height * 0.2, x + width * 0.8, y + height * 0.3, x + width * 0.3, y + height * 0.8, x + width * 0.2, y + height * 0.7)
 	else
 		local overSize = self.overSizeText or 0
-		DrawString(x + width / 2, y + 2 - overSize, "CENTER_X", height - 4 + overSize * 2, "VAR",label )
+		DrawString(x + width / 2, y + 2 - overSize, "CENTER_X", height - 4 + overSize * 2, "VAR", label)
 	end
 	if mOver then
-		SetDrawLayer(nil, 100)
-		self:DrawTooltip(x, y, width, height, viewPort)
-		SetDrawLayer(nil, 0)
+		if not noTooltip then
+			SetDrawLayer(nil, 100)
+			self:DrawTooltip(x, y, width, height, viewPort)
+			SetDrawLayer(nil, 0)
+		end
 		if self.onHover ~= nil then
 			return self.onHover()
 		end

--- a/src/Classes/CalcSectionControl.lua
+++ b/src/Classes/CalcSectionControl.lua
@@ -210,7 +210,7 @@ function CalcSectionClass:FormatStr(str, actor, colData)
 	return str
 end
 
-function CalcSectionClass:Draw(viewPort)
+function CalcSectionClass:Draw(viewPort, noTooltip)
 	local x, y = self:GetPos()
 	local width, height = self:GetSize()
 	local cursorX, cursorY = GetCursorPos()
@@ -244,7 +244,7 @@ function CalcSectionClass:Draw(viewPort)
 		DrawImage(nil, x + 2, lineY + 20, width - 4, 2)
 		-- Draw controls
 		SetDrawLayer(nil, 0)
-		self:DrawControls(viewPort)
+		self:DrawControls(viewPort, noTooltip and self.calcsTab.selControl)
 		if subSec.collapsed or not self.enabled then
 			if primary then
 				return

--- a/src/Classes/CalcsTab.lua
+++ b/src/Classes/CalcsTab.lua
@@ -325,7 +325,7 @@ function CalcsTabClass:Draw(viewPort, inputEvents)
 		self.displayData = nil
 	end
 
-	self:DrawControls(viewPort)
+	self:DrawControls(viewPort, self.selControl)
 
 	if self.displayData then
 		if self.displayPinned and not self.selControl then

--- a/src/Classes/CheckBoxControl.lua
+++ b/src/Classes/CheckBoxControl.lua
@@ -29,7 +29,7 @@ function CheckBoxClass:IsMouseOver()
 	return cursorX >= x and cursorY >= y and cursorX < x + width and cursorY < y + height
 end
 
-function CheckBoxClass:Draw(viewPort)
+function CheckBoxClass:Draw(viewPort, noTooltip)
 	local x, y = self:GetPos()
 	local size = self.width
 	local enabled = self:IsEnabled()
@@ -71,7 +71,7 @@ function CheckBoxClass:Draw(viewPort)
 	if label then
 		DrawString(x - 5, y + 2, "RIGHT_X", size - 4, "VAR", label)
 	end
-	if mOver then
+	if mOver and not noTooltip then
 		SetDrawLayer(nil, 100)
 		self:DrawTooltip(x, y, size, size, viewPort, self.state)
 		SetDrawLayer(nil, 0)

--- a/src/Classes/ConfigTab.lua
+++ b/src/Classes/ConfigTab.lua
@@ -216,6 +216,9 @@ local ConfigTabClass = newClass("ConfigTab", "UndoHandler", "ControlHost", "Cont
 			else
 				control.tooltipText = varData.tooltip
 			end
+			if varData.tooltipFunc then
+				control.tooltipFunc = varData.tooltipFunc
+			end
 			if varData.label and varData.type ~= "check" then
 				t_insert(self.controls, new("LabelControl", {"RIGHT",control,"LEFT"}, -4, 0, 0, DrawStringWidth(14, "VAR", varData.label) > 228 and 12 or 14, "^7"..varData.label))
 			end

--- a/src/Classes/ControlHost.lua
+++ b/src/Classes/ControlHost.lua
@@ -82,10 +82,10 @@ function ControlHostClass:ProcessControlsInput(inputEvents, viewPort)
 	end	
 end
 
-function ControlHostClass:DrawControls(viewPort)
+function ControlHostClass:DrawControls(viewPort, selControl)
 	for _, control in pairs(self.controls) do
 		if control:IsShown() and control.Draw then
-			control:Draw(viewPort)
+			control:Draw(viewPort, (self.selControl and self.selControl.hasFocus and self.selControl ~= control) or (selControl and selControl.hasFocus and selControl ~= control))
 		end
 	end
 end

--- a/src/Classes/DropDownControl.lua
+++ b/src/Classes/DropDownControl.lua
@@ -191,7 +191,7 @@ function DropDownClass:IsMouseOver()
 	return mOver, mOverComp
 end
 
-function DropDownClass:Draw(viewPort)
+function DropDownClass:Draw(viewPort, noTooltip)
 	local x, y = self:GetPos()
 	local width, height = self:GetSize()
 	local enabled = self:IsEnabled()
@@ -275,7 +275,7 @@ function DropDownClass:Draw(viewPort)
 
 	-- draw dropdown bar
 	if enabled then
-		if (mOver or self.dropped) and mOverComp ~= "DROP" then
+		if (mOver or self.dropped) and mOverComp ~= "DROP" and not noTooltip then
 			SetDrawLayer(nil, 100)
 			self:DrawTooltip(
 				x, y - (self.dropped and self.dropUp and dropExtra or 0), 
@@ -315,7 +315,7 @@ function DropDownClass:Draw(viewPort)
 		if self.hoverSel and not self.list[self.hoverSel] then
 			self.hoverSel = nil
 		end
-		if self.hoverSel then
+		if self.hoverSel and not noTooltip then
 			SetDrawLayer(nil, 100)
 			self:DrawTooltip(
 				x, dropY + 2 + (self.hoverSelDrop - 1) * lineHeight - scrollBar.offset,

--- a/src/Classes/EditControl.lua
+++ b/src/Classes/EditControl.lua
@@ -216,7 +216,7 @@ function EditClass:MoveCaretVertically(offset)
 	self.blinkStart = GetTime()
 end
 
-function EditClass:Draw(viewPort)
+function EditClass:Draw(viewPort, noTooltip)
 	local x, y = self:GetPos()
 	local width, height = self:GetSize()
 	local enabled = self:IsEnabled()
@@ -255,7 +255,7 @@ function EditClass:Draw(viewPort)
 	if not enabled then
 		return
 	end
-	if mOver then
+	if mOver and not noTooltip then
 		SetDrawLayer(nil, 100)
 		self:DrawTooltip(x, y, width, height, viewPort)
 		SetDrawLayer(nil, 0)
@@ -269,7 +269,7 @@ function EditClass:Draw(viewPort)
 		SetDrawColor(self.inactiveCol)
 		DrawString(-self.controls.scrollBarH.offset, -self.controls.scrollBarV.offset, "LEFT", textHeight, self.font, self.buf)
 		SetViewport()
-		self:DrawControls(viewPort)
+		self:DrawControls(viewPort, noTooltip and self)
 		return
 	end
 	if not IsKeyDown("LEFTBUTTON") then
@@ -363,7 +363,7 @@ function EditClass:Draw(viewPort)
 		end
 	end
 	SetViewport()
-	self:DrawControls(viewPort)
+	self:DrawControls(viewPort, noTooltip and self)
 end
 
 function EditClass:OnFocusGained()

--- a/src/Classes/GemSelectControl.lua
+++ b/src/Classes/GemSelectControl.lua
@@ -338,8 +338,8 @@ function GemSelectClass:IsMouseOver()
 	return mOver, mOverComp
 end
 
-function GemSelectClass:Draw(viewPort)
-	self.EditControl:Draw(viewPort)
+function GemSelectClass:Draw(viewPort, noTooltip)
+	self.EditControl:Draw(viewPort, noTooltip)
 	local x, y = self:GetPos()
 	local width, height = self:GetSize()
 	local enabled = self:IsEnabled()
@@ -404,7 +404,7 @@ function GemSelectClass:Draw(viewPort)
 			end
 		end
 		SetViewport()
-		self:DrawControls(viewPort)
+		self:DrawControls(viewPort, noTooltip and self)
 		if self.hoverSel then
 			local calcFunc, calcBase = self.skillsTab.build.calcsTab:GetMiscCalculator(self.build)
 			if calcFunc then
@@ -465,7 +465,7 @@ function GemSelectClass:Draw(viewPort)
 			   DrawImage(nil, x, y, width, height)
 			end
 		end
-		if mOver and (not self.skillsTab.selControl or self.skillsTab.selControl._className ~= "GemSelectControl" or not self.skillsTab.selControl.dropped) then
+		if mOver and (not self.skillsTab.selControl or self.skillsTab.selControl._className ~= "GemSelectControl" or not self.skillsTab.selControl.dropped) and not noTooltip then
 			local gemInstance = self.skillsTab.displayGroup.gemList[self.index]
 			SetDrawLayer(nil, 10)
 			self.tooltip:Clear()

--- a/src/Classes/ListControl.lua
+++ b/src/Classes/ListControl.lua
@@ -108,7 +108,7 @@ function ListClass:GetRowRegion()
 	}
 end
 
-function ListClass:Draw(viewPort)
+function ListClass:Draw(viewPort, noTooltip)
 	local x, y = self:GetPos()
 	local width, height = self:GetSize()
 	local rowHeight = self.rowHeight
@@ -181,7 +181,7 @@ function ListClass:Draw(viewPort)
 		SetDrawColor(0, 0, 0)
 	end
 	DrawImage(nil, x + 1, y + 1, width - 2, height - 2)
-	self:DrawControls(viewPort)
+	self:DrawControls(viewPort, noTooltip and self)
 
 	SetViewport(x + 2, y + 2,  self.scroll and width - 20 or width, height - 4 - (self.scroll and self.scrollH and 16 or 0))
 	local textOffsetY = self.showRowSeparators and 2 or 0
@@ -292,7 +292,7 @@ function ListClass:Draw(viewPort)
 
 	self.hoverIndex = ttIndex
 	self.hoverValue = ttValue
-	if ttIndex and self.AddValueTooltip then
+	if ttIndex and self.AddValueTooltip and not noTooltip then
 		SetDrawLayer(nil, 100)
 		self:AddValueTooltip(self.tooltip, ttIndex, ttValue)
 		self.tooltip:Draw(ttX, ttY, ttWidth, rowHeight, viewPort)

--- a/src/Modules/Build.lua
+++ b/src/Modules/Build.lua
@@ -12,33 +12,6 @@ local m_floor = math.floor
 local m_abs = math.abs
 local s_format = string.format
 
-local banditDropList = {
-	{ label = "2 Passive Points", id = "None" },
-	{ label = "Oak (Life Regen, Phys.Dmg. Reduction, Phys.Dmg)", id = "Oak" },
-	{ label = "Kraityn (Attack/Cast Speed, Avoid Elemental Ailments, Move Speed)", id = "Kraityn" },
-	{ label = "Alira (Mana Regen, Crit Multiplier, Resists)", id = "Alira" },
-}
-
-local PantheonMajorGodDropList = {
-	{ label = "Nothing", id = "None" },
-	{ label = "Soul of the Brine King", id = "TheBrineKing" },
-	{ label = "Soul of Lunaris", id = "Lunaris" },
-	{ label = "Soul of Solaris", id = "Solaris" },
-	{ label = "Soul of Arakaali", id = "Arakaali" },
-}
-
-local PantheonMinorGodDropList = {
-	{ label = "Nothing", id = "None" },
-	{ label = "Soul of Gruthkul", id = "Gruthkul" },
-	{ label = "Soul of Yugul", id = "Yugul" },
-	{ label = "Soul of Abberath", id = "Abberath" },
-	{ label = "Soul of Tukohama", id = "Tukohama" },
-	{ label = "Soul of Garukhan", id = "Garukhan" },
-	{ label = "Soul of Ralakesh", id = "Ralakesh" },
-	{ label = "Soul of Ryslatha", id = "Ryslatha" },
-	{ label = "Soul of Shakari", id = "Shakari" },
-}
-
 local buildMode = new("ControlHost")
 
 local function InsertIfNew(t, val)
@@ -509,79 +482,27 @@ function buildMode:Init(dbFileName, buildName, buildXML, convertBuild)
 		self.viewMode = "CALCS"
 	end)
 	self.controls.modeCalcs.locked = function() return self.viewMode == "CALCS" end
-	self.controls.bandit = new("DropDownControl", {"TOPLEFT",self.anchorSideBar,"TOPLEFT"}, 0, 70, 300, 16, banditDropList, function(index, value)
-		self.bandit = value.id
-		self.modFlag = true
-		self.buildFlag = true
-	end)
-	self.controls.bandit.maxDroppedWidth = 500
-	self.controls.bandit:CheckDroppedWidth(true)
-	self.controls.banditLabel = new("LabelControl", {"BOTTOMLEFT",self.controls.bandit,"TOPLEFT"}, 0, 0, 0, 14, "^7Bandit:")
-	-- The Pantheon
-	local function applyPantheonDescription(tooltip, mode, index, value)
-		tooltip:Clear()
-		if value.id == "None" then
-			return
-		end
-		local applyModes = { BODY = true, HOVER = true }
-		if applyModes[mode] then
-			local god = self.data.pantheons[value.id]
-			for _, soul in ipairs(god.souls) do
-				local name = soul.name
-				local lines = { }
-				for _, mod in ipairs(soul.mods) do
-					t_insert(lines, mod.line)
-				end
-				tooltip:AddLine(20, '^8'..name)
-				tooltip:AddLine(14, '^6'..table.concat(lines, '\n'))
-				tooltip:AddSeparator(10)
-			end
-		end
-	end
-	self.controls.pantheonMajorGod = new("DropDownControl", {"TOPLEFT",self.anchorSideBar,"TOPLEFT"}, 0, 110, 300, 16, PantheonMajorGodDropList, function(index, value)
-		self.pantheonMajorGod = value.id
-		self.modFlag = true
-		self.buildFlag = true
-	end)
-	self.controls.pantheonMajorGod.tooltipFunc = function(tooltip, mode, index, value)
-		if self.controls.pantheonMinorGod.dropped then
-			tooltip:Clear()
-			return
-		end
-		applyPantheonDescription(tooltip, mode, index, value)
-	end
-	self.controls.pantheonMinorGod = new("DropDownControl", {"TOPLEFT",self.anchorSideBar,"TOPLEFT"}, 0, 130, 300, 16, PantheonMinorGodDropList, function(index, value)
-		self.pantheonMinorGod = value.id
-		self.modFlag = true
-		self.buildFlag = true
-	end)
-	self.controls.pantheonMinorGod.tooltipFunc = applyPantheonDescription
-	self.controls.pantheonLabel = new("LabelControl", {"BOTTOMLEFT",self.controls.pantheonMajorGod,"TOPLEFT"}, 0, 0, 0, 14, "^7The Pantheon:")
 	-- Skills
-	self.controls.mainSkillLabel = new("LabelControl", {"TOPLEFT",self.anchorSideBar,"TOPLEFT"}, 0, 155, 300, 16, "^7Main Skill:")
-	self.controls.mainSocketGroup = new("DropDownControl", {"TOPLEFT",self.controls.mainSkillLabel,"BOTTOMLEFT"}, 0, 2, 300, 16, nil, function(index, value)
+	self.controls.mainSkillLabel = new("LabelControl", {"TOPLEFT",self.anchorSideBar,"TOPLEFT"}, 0, 54, 300, 16, "^7Main Skill:")
+	self.controls.mainSocketGroup = new("DropDownControl", {"TOPLEFT",self.controls.mainSkillLabel,"BOTTOMLEFT"}, 0, 2, 300, 18, nil, function(index, value)
 		self.mainSocketGroup = index
 		self.modFlag = true
 		self.buildFlag = true
 	end)
 	self.controls.mainSocketGroup.maxDroppedWidth = 500
 	self.controls.mainSocketGroup.tooltipFunc = function(tooltip, mode, index, value)
-		if self.controls.pantheonMinorGod.dropped or self.controls.pantheonMajorGod.dropped then
-			tooltip:Clear()
-			return
-		end
 		local socketGroup = self.skillsTab.socketGroupList[index]
 		if socketGroup and tooltip:CheckForUpdate(socketGroup, self.outputRevision) then
 			self.skillsTab:AddSocketGroupTooltip(tooltip, socketGroup)
 		end
 	end
-	self.controls.mainSkill = new("DropDownControl", {"TOPLEFT",self.controls.mainSocketGroup,"BOTTOMLEFT"}, 0, 2, 300, 16, nil, function(index, value)
+	self.controls.mainSkill = new("DropDownControl", {"TOPLEFT",self.controls.mainSocketGroup,"BOTTOMLEFT"}, 0, 2, 300, 18, nil, function(index, value)
 		local mainSocketGroup = self.skillsTab.socketGroupList[self.mainSocketGroup]
 		mainSocketGroup.mainActiveSkill = index
 		self.modFlag = true
 		self.buildFlag = true
 	end)
-	self.controls.mainSkillPart = new("DropDownControl", {"TOPLEFT",self.controls.mainSkill,"BOTTOMLEFT",true}, 0, 2, 200, 18, nil, function(index, value)
+	self.controls.mainSkillPart = new("DropDownControl", {"TOPLEFT",self.controls.mainSkill,"BOTTOMLEFT",true}, 0, 2, 300, 18, nil, function(index, value)
 		local mainSocketGroup = self.skillsTab.socketGroupList[self.mainSocketGroup]
 		local srcInstance = mainSocketGroup.displaySkillList[mainSocketGroup.mainActiveSkill].activeEffect.srcInstance
 		srcInstance.skillPart = index
@@ -729,6 +650,11 @@ function buildMode:Init(dbFileName, buildName, buildXML, convertBuild)
 	end
 	table.sort(self.controls.classDrop.list, function(a, b) return a.label < b.label end)
 
+	-- Load legacy bandit and pantheon choices from build section
+	for _, control in ipairs({ "bandit", "pantheonMajorGod", "pantheonMinorGod" }) do
+		self.configTab.input[control] = self[control]
+	end
+
 	-- so we ran into problems with converted trees, trying to check passive tree routes and also consider thread jewels
 	-- but we cant check jewel info because items have not been loaded yet, and they come after passives in the xml.
 	-- the simplest solution seems to be making sure passive trees (which contain jewel sockets) are loaded last.
@@ -861,9 +787,9 @@ function buildMode:Save(xml)
 		level = tostring(self.characterLevel),
 		className = self.spec.curClassName,
 		ascendClassName = self.spec.curAscendClassName,
-		bandit = self.bandit,
-		pantheonMajorGod = self.pantheonMajorGod,
-		pantheonMinorGod = self.pantheonMinorGod,
+		bandit = self.configTab.input.bandit,
+		pantheonMajorGod = self.configTab.input.pantheonMajorGod,
+		pantheonMinorGod = self.configTab.input.pantheonMinorGod,
 		mainSocketGroup = tostring(self.mainSocketGroup),
 	}
 	for _, id in ipairs(self.spectreList) do
@@ -969,12 +895,6 @@ function buildMode:OnFrame(inputEvents)
 	self.controls.classDrop:SelByValue(self.spec.curClassId, "classId")
 	self.controls.ascendDrop.list = self.controls.classDrop:GetSelValue("ascendencies")
 	self.controls.ascendDrop:SelByValue(self.spec.curAscendClassId, "ascendClassId")
-
-	for _, diff in pairs({ "bandit", "pantheonMajorGod", "pantheonMinorGod" }) do
-		if self.controls[diff] then
-			self.controls[diff]:SelByValue(self[diff], "id")
-		end
-	end
 
 	local checkFabricatedGroups = self.buildFlag
 	if self.buildFlag then

--- a/src/Modules/CalcSetup.lua
+++ b/src/Modules/CalcSetup.lua
@@ -412,18 +412,18 @@ function calcs.initEnv(build, mode, override, specEnv)
 		modDB:NewMod("Multiplier:AllocatedMastery", "BASE", env.spec.allocatedMasteryCount, "")
 
 		-- Add bandit mods
-		if build.bandit == "Alira" then
+		if env.configInput.bandit == "Alira" then
 			modDB:NewMod("ManaRegen", "BASE", 5, "Bandit")
 			modDB:NewMod("CritMultiplier", "BASE", 20, "Bandit")
 			modDB:NewMod("ElementalResist", "BASE", 15, "Bandit")
-		elseif build.bandit == "Kraityn" then
+		elseif env.configInput.bandit == "Kraityn" then
 			modDB:NewMod("Speed", "INC", 6, "Bandit")
 			modDB:NewMod("AvoidShock", "BASE", 10, "Bandit")
 			modDB:NewMod("AvoidFreeze", "BASE", 10, "Bandit")
 			modDB:NewMod("AvoidChill", "BASE", 10, "Bandit")
 			modDB:NewMod("AvoidIgnite", "BASE", 10, "Bandit")
 			modDB:NewMod("MovementSpeed", "INC", 6, "Bandit")
-		elseif build.bandit == "Oak" then
+		elseif env.configInput.bandit == "Oak" then
 			modDB:NewMod("LifeRegenPercent", "BASE", 1, "Bandit")
 			modDB:NewMod("PhysicalDamageReduction", "BASE", 2, "Bandit")
 			modDB:NewMod("PhysicalDamage", "INC", 20, "Bandit")
@@ -434,13 +434,13 @@ function calcs.initEnv(build, mode, override, specEnv)
 		-- Add Pantheon mods
 		local parser = modLib.parseMod
 		-- Major Gods
-		if build.pantheonMajorGod ~= "None" then
-			local majorGod = env.data.pantheons[build.pantheonMajorGod]
+		if env.configInput.pantheonMajorGod ~= "None" then
+			local majorGod = env.data.pantheons[env.configInput.pantheonMajorGod]
 			pantheon.applySoulMod(modDB, parser, majorGod)
 		end
 		-- Minor Gods
-		if build.pantheonMinorGod ~= "None" then
-			local minorGod = env.data.pantheons[build.pantheonMinorGod]
+		if env.configInput.pantheonMinorGod ~= "None" then
+			local minorGod = env.data.pantheons[env.configInput.pantheonMinorGod]
 			pantheon.applySoulMod(modDB, parser, minorGod)
 		end
 

--- a/src/Modules/ConfigOptions.lua
+++ b/src/Modules/ConfigOptions.lua
@@ -7,10 +7,64 @@
 local m_min = math.min
 local m_max = math.max
 
+local function applyPantheonDescription(tooltip, mode, index, value)
+	tooltip:Clear()
+	if value.val == "None" then
+		return
+	end
+	local applyModes = { BODY = true, HOVER = true }
+	if applyModes[mode] then
+		local god = data.pantheons[value.val]
+		for _, soul in ipairs(god.souls) do
+			local name = soul.name
+			local lines = { }
+			for _, mod in ipairs(soul.mods) do
+				table.insert(lines, mod.line)
+			end
+			tooltip:AddLine(20, '^8'..name)
+			tooltip:AddLine(14, '^6'..table.concat(lines, '\n'))
+			tooltip:AddSeparator(10)
+		end
+	end
+end
+
+local function banditTooltip(tooltip, mode, index, value)
+	local banditBenefits = {
+		["None"] = "Grants 2 Passive Skill Points",
+		["Oak"] = "Regenerate 1% of Life per second\n2% additional Physical Damage Reduction\n20% icreased Physical Damage",
+		["Kraityn"] = "6% increased Attack and Cast Speed\n10% chance to Avoid Elemental Ailments\n6% increased Movement Speed",
+		["Alira"] = "Regenerate 5 Mana per second\n+20% to Critical Strike Multiplier\n+15% to all Elemental Resistances",
+	}
+	local applyModes = { BODY = true, HOVER = true }
+	tooltip:Clear()
+	if applyModes[mode] then
+		tooltip:AddLine(14, '^8'..banditBenefits[value.val])
+	end
+end
+
 return {
 	-- Section: General options
 	{ section = "General", col = 1 },
 	{ var = "resistancePenalty", type = "list", label = "Resistance penalty:", list = {{val=0,label="None"},{val=-30,label="Act 5 (-30%)"},{val=nil,label="Act 10 (-60%)"}} },
+	{ var = "bandit", type = "list", label = "Bandit quest:", tooltipFunc = banditTooltip, list = {{val="None",label="Kill all"},{val="Oak",label="Help Oak"},{val="Kraityn",label="Help Kraityn"},{val="Alira",label="Help Alira"}} },
+	{ var = "pantheonMajorGod", type = "list", label = "Major God:", tooltipFunc = applyPantheonDescription, list = {
+		{ label = "Nothing", val = "None" },
+		{ label = "Soul of the Brine King", val = "TheBrineKing" },
+		{ label = "Soul of Lunaris", val = "Lunaris" },
+		{ label = "Soul of Solaris", val = "Solaris" },
+		{ label = "Soul of Arakaali", val = "Arakaali" },
+	} },
+	{ var = "pantheonMinorGod", type = "list", label = "Minor God:", tooltipFunc = applyPantheonDescription, list = {
+		{ label = "Nothing", val = "None" },
+		{ label = "Soul of Gruthkul", val = "Gruthkul" },
+		{ label = "Soul of Yugul", val = "Yugul" },
+		{ label = "Soul of Abberath", val = "Abberath" },
+		{ label = "Soul of Tukohama", val = "Tukohama" },
+		{ label = "Soul of Garukhan", val = "Garukhan" },
+		{ label = "Soul of Ralakesh", val = "Ralakesh" },
+		{ label = "Soul of Ryslatha", val = "Ryslatha" },
+		{ label = "Soul of Shakari", val = "Shakari" },
+	} },
 	{ var = "detonateDeadCorpseLife", type = "count", label = "Enemy Corpse ^xE05030Life:", tooltip = "Sets the maximum ^xE05030life ^7of the target corpse for Detonate Dead and similar skills.\nFor reference, a level 70 monster has "..data.monsterLifeTable[70].." base ^xE05030life^7, and a level 80 monster has "..data.monsterLifeTable[80]..".", apply = function(val, modList, enemyModList)
 		modList:NewMod("SkillData", "LIST", { key = "corpseLife", value = val }, "Config")
 	end },


### PR DESCRIPTION
### Description of the problem being solved:
#### Fix multiple tooltips displayed over each other, specifically when hovering over a dropdown control.
`ControlHost` remembers the currently active control in `selControl` and can inform it's controls via additional parameter `noTooltip` passed to `Draw` methods whether they should draw tooltips. Additional parameter in `DrawControls` allows to pass the active control to lower levels in cases of nested controls (e.g. `CalcSectionControl`)

#### Move bandit and pantheon dropdowns to the configuration tab.
This frees some space in the side panel. Loading old build should work correctly and the attributes are saved in the `Build` node as well for backwards compatibility.

### Before screenshot:
![image](https://user-images.githubusercontent.com/18018499/172952670-929f2ede-6352-4483-a291-0009a2f82c8d.png)

### After screenshot:
![image](https://user-images.githubusercontent.com/18018499/172950670-75a1a6d3-7f92-4b32-8829-a92a6ac984b3.png)
