### PR TITLE
Add enter function for Import Edit control

### DIFF
--- a/src/Classes/ImportTab.lua
+++ b/src/Classes/ImportTab.lua
@@ -285,6 +285,11 @@ You can get this from your web browser's cookies while logged into the Path of E
 	end
 
 	self.controls.importCodeIn = new("EditControl", {"TOPLEFT",self.controls.importCodeHeader,"BOTTOMLEFT"}, 0, 4, 328, 20, "", nil, nil, nil, importCodeHandle)
+	self.controls.importCodeIn.enterFunc = function()
+		if self.importCodeValid then
+			self.controls.importCodeGo.onClick()
+		end
+	end
 	self.controls.importCodeState = new("LabelControl", {"LEFT",self.controls.importCodeIn,"RIGHT"}, 8, 0, 0, 16)
 	self.controls.importCodeState.label = function()
 		return self.importCodeDetail or ""


### PR DESCRIPTION
Fixes missing enter function for keyboard style import.

### Description of the problem being solved:
Pressing Ctrl-N, Ctrl-I, Ctrl-V, [enter] failed to complete the import.

### Steps taken to verify a working solution:
- Using https://pastebin.com/WMichBY3, use the keys listed above to prove the import works (main skill is Dark Pact)
- Using https://pastebin.com/WMichBx3, use the keys listed above to see that the normal error routine(s) are still being observed.
- Using the mouse, paste https://pastebin.com/WMichBY3 into import edit box and select 'Import' button and see import occurs without the two click process

### Link to a build that showcases this PR:
Noted in tests

### Before screenshot:
N/A
### After screenshot:
N/A
