### PR TITLE
Fix socket group copy/paste

### DIFF
--- a/src/Classes/SkillsTab.lua
+++ b/src/Classes/SkillsTab.lua
@@ -444,7 +444,16 @@ function SkillsTabClass:PasteSocketGroup(testInput)
 			newGroup.slot = slot
 		end
 		for nameSpec, level, quality, qualityId, state, count in skillText:gmatch("([ %a']+) (%d+)/(%d+) (%a+%d?) ?(%a*) (%d+)") do
-			t_insert(newGroup.gemList, { nameSpec = nameSpec, level = tonumber(level) or 20, quality = tonumber(quality) or 0, qualityId = qualityId, enabled = state ~= "DISABLED", count = tonumber(count) or 1 })
+			t_insert(newGroup.gemList, {
+				nameSpec = nameSpec,
+				level = tonumber(level) or 20,
+				quality = tonumber(quality) or 0,
+				qualityId = qualityId,
+				enabled = state ~= "DISABLED",
+				count = tonumber(count) or 1,
+				enableGlobal1 = true,
+				enableGlobal2 = true
+			})
 		end
 		if #newGroup.gemList > 0 then
 			t_insert(self.socketGroupList, newGroup)


### PR DESCRIPTION
Currently when you copy/paste socket group with auras etc there is no
way to actually enable them because enableGlobal1/2 is not set.

Fixes #3609

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>

### Steps to reproduce
- Create new socket group with random aura reserved
- Copy and paste this socket group
- Notice that the new socket group is not reserving any mana even though it has aura active

This also applies to buffs and blessings.