### PR TITLE
Add support for "% increased cast speed if a minion has been killed recently"

### DIFF
--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -1399,6 +1399,7 @@ local modTagList = {
 	["if you have a summoned golem"] = { tag = { type = "Condition", varList = { "HavePhysicalGolem", "HaveLightningGolem", "HaveColdGolem", "HaveFireGolem", "HaveChaosGolem", "HaveCarrionGolem" } } },
 	["while you have a summoned golem"] = { tag = { type = "Condition", varList = { "HavePhysicalGolem", "HaveLightningGolem", "HaveColdGolem", "HaveFireGolem", "HaveChaosGolem", "HaveCarrionGolem" } } },
 	["if a minion has died recently"] = { tag = { type = "Condition", var = "MinionsDiedRecently" } },
+	["if a minion has been killed recently"] = { tag = { type = "Condition", var = "MinionsDiedRecently" } },
 	["while you have sacrificial zeal"] = { tag = { type = "Condition", var = "SacrificialZeal" } },
 	["while sane"] = { tag = { type = "Condition", var = "Insane", neg = true } },
 	["while insane"] = { tag = { type = "Condition", var = "Insane" } },


### PR DESCRIPTION
Fixes #4455 .

Description of the problem being solved:

Ghastly Eye Jewel can have a mod that reads "d% increased cast speed if a minion has been killed recently". From in-game testing this seems to proc under exactly the same conditions as "if a minion died recently".

However, the mod does not get parsed by POB because we only look for the string "if a minion died recently". It is inconvenient because any build that relies on this jewels needs manually modify them each time they are imported to calculate their cast speed properly.

### Steps taken to verify a working solution:
- Create a new build
- Path to a jewel socket
- Create a custom item with the following stats 
Enthralling Leer
Ghastly Eye Jewel
Unique ID: 437aad3ec28997fc919c9d100102fb765eb5ca2a27b28d2bafa334010211790a
Item Level: 74
LevelReq: 28
Implicits: 0
+30 to maximum Life
Minions have 12% increased maximum Life
7% increased Cast Speed if a Minion has been Killed Recently
- Socket it into the Jewel socket.
- Below configuration, tick "has a minion died recently ?".
- Add any spell skill to the build (in my case SRS)
- Check that the cast speed is modified when allocating and deallocating the jewel.

### Link to a build that showcases this PR:

https://pastebin.com/V7jw0HJH

### Before screenshot:

![image](https://user-images.githubusercontent.com/58695361/173525520-c1dc99e5-6997-4a74-9bb7-e2aa05d48d67.png)

### After screenshot:

![image](https://user-images.githubusercontent.com/58695361/174160882-47b076f2-838c-4e2e-ba1b-a6d2832a42c0.png)
