### PR TITLE
Rename old dodge chance mods on watcher's eye

### DIFF
--- a/src/Data/Uniques/Special/Generated.lua
+++ b/src/Data/Uniques/Special/Generated.lua
@@ -462,6 +462,9 @@ table.insert(data.uniques.generated, table.concat(impossibleEscape, "\n"))
 		-- Has only a version when it changed
 	- Mod changed/removed, but isn't legacy
 		-- Has empty table to exclude it from the list
+
+	4th scenario: Mod was changed (not legacy), but the mod ID (aka Variant name) no longer reflects the mod
+		-- Has 'rename' field to customize the name
 ]]
 local watchersEyeLegacyMods = {
 	["ClarityManaAddedAsEnergyShield"] = {
@@ -504,6 +507,12 @@ local watchersEyeLegacyMods = {
 	},
 	["WrathLightningDamageManaLeech"] = {
 		["version"] = "3.8.0",
+	},
+	["GraceChanceToDodge"] = {
+		["rename"] = "Haste: Chance to Suppress Spells",
+	},
+	["HasteChanceToDodgeSpells"] = {
+		["rename"] = "Haste: Chance to Suppress Spells",
 	},
 	["PurityOfFireReducedReflectedFireDamage"] = { },
 	["PurityOfIceReducedReflectedColdDamage"] = { },
@@ -554,6 +563,9 @@ for _, mod in ipairs(data.uniqueMods["Watcher's Eye"]) do
 			if watchersEyeLegacyMods[mod.Id].legacyMod then
 				table.insert(watchersEye, "Variant:" .. variantName)
 			end
+			if watchersEyeLegacyMods[mod.Id].rename then
+				table.insert(watchersEye, "Variant: " .. watchersEyeLegacyMods[mod.Id].rename)
+			end
 		else
 			table.insert(watchersEye, "Variant:" .. variantName)
 		end
@@ -578,7 +590,7 @@ for _, mod in ipairs(data.uniqueMods["Watcher's Eye"]) do
 				table.insert(watchersEye, "{variant:" .. indexWatchersEye .. "}" .. watchersEyeLegacyMods[mod.Id].legacyMod(mod.mod[1]))
 				indexWatchersEye = indexWatchersEye + 1
 			end
-			if watchersEyeLegacyMods[mod.Id].version then
+			if watchersEyeLegacyMods[mod.Id].version or watchersEyeLegacyMods[mod.Id].rename then
 				table.insert(watchersEye, "{variant:" .. indexWatchersEye .. "}" .. mod.mod[1])
 				indexWatchersEye = indexWatchersEye + 1
 			end

--- a/src/Data/Uniques/Special/Generated.lua
+++ b/src/Data/Uniques/Special/Generated.lua
@@ -509,7 +509,7 @@ local watchersEyeLegacyMods = {
 		["version"] = "3.8.0",
 	},
 	["GraceChanceToDodge"] = {
-		["rename"] = "Haste: Chance to Suppress Spells",
+		["rename"] = "Grace: Chance to Suppress Spells",
 	},
 	["HasteChanceToDodgeSpells"] = {
 		["rename"] = "Haste: Chance to Suppress Spells",


### PR DESCRIPTION
### Description of the problem being solved:
Watcher's Eye still read the grace and haste dodge mods as the variant name, when they instead give a chance to suppress spells, now
### Link to a build that showcases this PR:
Just search for watcher's eye
### Before screenshot:
![image](https://user-images.githubusercontent.com/1209372/174868800-6b5e43a7-c150-4e5c-9d3c-bf15e649919d.png)

### After screenshot:
![image](https://user-images.githubusercontent.com/1209372/174869067-cb54c820-880f-4987-86fb-dcb7d6619c4b.png)
