### PR TITLE
Remove Phase Acrobatics from Impossible Escape

### DIFF
--- a/src/Data/Uniques/Special/Generated.lua
+++ b/src/Data/Uniques/Special/Generated.lua
@@ -42,7 +42,7 @@ local getVeiledMods = function (baseType, specificType, canHaveCatarinaMod)
 			end
 		end
 	end
-    table.sort(veiledMods, function (m1, m2) return m1.veiledName < m2.veiledName end )
+	table.sort(veiledMods, function (m1, m2) return m1.veiledName < m2.veiledName end )
 	return veiledMods
 end
 
@@ -401,8 +401,10 @@ local excludedItemKeystones = {
 	"Immortal Ambition", -- exclusive to specific unique
 	"Secrets of Suffering", -- exclusive to specific items
 	"Inner Conviction", -- exclusive to specific items
+	"Phase Acrobatics", -- removed from game
 	"Mortal Conviction", -- removed from game
-}local excludedPassiveKeystones = {
+}
+local excludedPassiveKeystones = {
 	"Chaos Inoculation", -- to prevent infinite loop
 	"Necromantic Aegis", -- to prevent infinite loop
 }
@@ -433,20 +435,20 @@ for _, name in ipairs(data.keystones) do
 	end
 end
 local impossibleEscape = {
-    "Impossible Escape",
-    "Viridian Jewel",
-    "League: Sentinel",
-    "Limited to: 1",
-    "Source: Drops from Uber unique{Maven}",
-    "Radius: Small"
+	"Impossible Escape",
+	"Viridian Jewel",
+	"League: Sentinel",
+	"Limited to: 1",
+	"Source: Drops from Uber unique{Maven}",
+	"Radius: Small"
 }
 for _, name in ipairs(impossibleEscapeKeystones) do
-    table.insert(impossibleEscape, "Variant: "..name)
+	table.insert(impossibleEscape, "Variant: "..name)
 end
 table.insert(impossibleEscape, "Variant: Everything (QoL Test Variant)")
 local variantCount = 1
 for index, name in ipairs(impossibleEscapeKeystones) do
-    table.insert(impossibleEscape, "{variant:"..index.."}Passives in radius of "..name.." can be allocated without being connected to your tree")
+	table.insert(impossibleEscape, "{variant:"..index.."}Passives in radius of "..name.." can be allocated without being connected to your tree")
 	variantCount = variantCount + 1
 end
 for _, name in ipairs(impossibleEscapeKeystones) do


### PR DESCRIPTION
Phase Acrobatics was removed from the game in 3.16.

Impossible Escape was introduced in 3.18, meaning there's no situation where Impossible Escape should ever roll Phase Acrobatics.

I added Phase Acrobatics to ``excludedItemKeystones`` (similar to Mortal Conviction, which was already present) to fix this.

This also removes Phase Acrobatics keystone option from Skin of the Lords. This does not affect builds that already contain uniques with Phase Acrobatics. In 3.16 GGG swapped Phase Acrobatics for Acrobatics on existing items.

Minor formatting errors in ``\src\Data\Uniques\Special\Generated.lua`` were also fixed (mostly mixed tabs and space indentation, converting 4 spaces to tabs).

### Before Screenshot:
![](http://puu.sh/J7gR9/b3cecb6b22.png)

### After Screenshot:
![](http://puu.sh/J7gRV/4144ab27db.png)