### PR TITLE
Fix multi number mods scaling the wrong number with catalysts

### DIFF
--- a/src/Classes/Item.lua
+++ b/src/Classes/Item.lua
@@ -431,7 +431,7 @@ function ItemClass:ParseRaw(raw)
 				if line:match("%(%d+%-%d+ to %d+%-%d+%)") or line:match("%(%-?[%d%.]+ to %-?[%d%.]+%)") or line:match("%(%-?[%d%.]+%-[%d%.]+%)") then
 					rangedLine = itemLib.applyRange(line, 1, catalystScalar)
 				elseif catalystScalar ~= 1 then
-					rangedLine = itemLib.applyValueScalar(line, catalystScalar)
+					rangedLine = itemLib.applyValueScalar(line, catalystScalar, 1)
 				end
 				local modList, extra = modLib.parseMod(rangedLine or line)
 				if (not modList or extra) and self.rawLines[l+1] then
@@ -441,7 +441,7 @@ function ItemClass:ParseRaw(raw)
 					if combLine:match("%(%d+%-%d+ to %d+%-%d+%)") or combLine:match("%(%-?[%d%.]+ to %-?[%d%.]+%)") or combLine:match("%(%-?[%d%.]+%-[%d%.]+%)") then
 						rangedLine = itemLib.applyRange(combLine, 1, catalystScalar)
 					elseif catalystScalar ~= 1 then
-						rangedLine = itemLib.applyValueScalar(combLine, catalystScalar)
+						rangedLine = itemLib.applyValueScalar(combLine, catalystScalar, 1)
 					end
 					modList, extra = modLib.parseMod(rangedLine or combLine, true)
 					if modList and not extra then

--- a/src/Modules/ItemTools.lua
+++ b/src/Modules/ItemTools.lua
@@ -21,19 +21,19 @@ itemLib.influenceInfo = {
 	{ key="eyrie", display="Redeemer", color=colorCodes.EYRIE },
 }
 
--- Apply a value scalar to any numbers present
-function itemLib.applyValueScalar(line, valueScalar)
+-- Apply a value scalar to the first n of any numbers present
+function itemLib.applyValueScalar(line, valueScalar, numbers)
 	if valueScalar and type(valueScalar) == "number" and valueScalar ~= 1 then
 		if line:match("(%d+%.%d*)") then
 			return line:gsub("(%d+%.%d*)", function(num)
 				local numVal = (m_floor(tonumber(num) * valueScalar * 100 + 0.001) / 100)
 				return tostring(numVal)
-			end)
+			end, numbers)
 		else
 			return line:gsub("(%d+)([^%.])", function(num, suffix)
 				local numVal = m_floor(num * valueScalar + 0.001)
 				return tostring(numVal)..suffix
-			end)
+			end, numbers)
 		end
 	end
 	return line
@@ -64,10 +64,12 @@ end
 
 -- Apply range value (0 to 1) to a modifier that has a range: (x to x) or (x-x to x-x)
 function itemLib.applyRange(line, range, valueScalar)
+	numbers = 0
 	line = line:gsub("%((%d+)%-(%d+) to (%d+)%-(%d+)%)", "(%1-%2) to (%3-%4)")
 		:gsub("(%+?)%((%-?%d+) to (%d+)%)", "%1(%2-%3)")
 		:gsub("(%+?)%((%-?%d+)%-(%d+)%)",
 		function(plus, min, max)
+			numbers = numbers + 1
 			local numVal = m_floor(tonumber(min) + range * (tonumber(max) - tonumber(min)) + 0.5)
 			if numVal < 0 then
 				if plus == "+" then
@@ -78,11 +80,12 @@ function itemLib.applyRange(line, range, valueScalar)
 		end)
 		:gsub("%((%d+%.?%d*)%-(%d+%.?%d*)%)",
 		function(min, max)
+			numbers = numbers + 1
 			local numVal = m_floor((tonumber(min) + range * (tonumber(max) - tonumber(min))) * 10 + 0.5) / 10
 			return tostring(numVal)
 		end)
 		:gsub("%-(%d+%%) increased", function(num) return num.." reduced" end)
-	return itemLib.applyValueScalar(line, valueScalar)
+	return itemLib.applyValueScalar(line, valueScalar, numbers)
 end
 
 --- Clean item text by removing or replacing unsupported or redundant characters or sequences


### PR DESCRIPTION
Fixes #4345.

### Description of the problem being solved:
Conditions get scaled by catalysts when they shouldn't.
This solves catalyst scaling issues on Bear's Girdle, The Magnate and other similar items.

I have very limited lua programming experience so please feel free to make sure it works properly and this change won't break other stuff.

I think this might partially fix #4466 and the reason it stop scaling at all is due to a passing issue that the mods aren't scaling anymore.

### Steps taken to verify a working solution:
### Before
![image](https://user-images.githubusercontent.com/31533893/175317021-1f57ede6-f73d-49e0-8caf-509461916141.png)
![image](https://user-images.githubusercontent.com/31533893/175316106-b7bff73f-8460-4528-977d-f9ce3f61e1e1.png)

### After
![image](https://user-images.githubusercontent.com/31533893/175316888-33be8c31-1cd1-43ab-aac0-93ce34becec5.png)
![image](https://user-images.githubusercontent.com/31533893/175315974-b99d377d-ae32-455a-95d0-27090c1156c6.png)

### Actual
![image](https://user-images.githubusercontent.com/31533893/175315900-c59011bd-12f9-4cb0-8df2-59af6a251895.png)
![image](https://user-images.githubusercontent.com/31533893/175316013-4c96a6e8-b8e4-4a84-b764-07347666a53f.png)


### Link to a build that showcases this PR:
https://pastebin.com/6Rc64wEM
