### PR TITLE
Fixes labels having an incorrect font size and alignment for checkmark boxes.

### DIFF
--- a/src/Classes/CheckBoxControl.lua
+++ b/src/Classes/CheckBoxControl.lua
@@ -22,9 +22,9 @@ function CheckBoxClass:IsMouseOver()
 	-- move x left by label width, increase width by label width
 	local label = self:GetProperty("label")
 	if label then
-		local labelWidth = DrawStringWidth(height, "VAR", label) - width
-		x = x - labelWidth
-		width = width + labelWidth
+		local labelWidth = DrawStringWidth(height - 4, "VAR", label)
+		x = x - labelWidth - 5
+		width = width + labelWidth + 5
 	end
 	return cursorX >= x and cursorY >= y and cursorX < x + width and cursorY < y + height
 end

--- a/src/Classes/CheckBoxControl.lua
+++ b/src/Classes/CheckBoxControl.lua
@@ -22,9 +22,9 @@ function CheckBoxClass:IsMouseOver()
 	-- move x left by label width, increase width by label width
 	local label = self:GetProperty("label")
 	if label then
-		local labelWidth = DrawStringWidth(height - 4, "VAR", label)
-		x = x - labelWidth - 5
-		width = width + labelWidth + 5
+		local labelWidth = DrawStringWidth(height - 4, "VAR", label) + 5
+		x = x - labelWidth
+		width = width + labelWidth
 	end
 	return cursorX >= x and cursorY >= y and cursorX < x + width and cursorY < y + height
 end


### PR DESCRIPTION
Fixes #4418 #3811.

### Description of the problem being solved:
Incorrectly aligned clicking on text for associated check box.

### Steps taken to verify a working solution:
- Clicking on the boxes and text now properly lines up.

### Link to a build that showcases this PR:
https://pastebin.com/aX9t1W7r

### Before screenshot:
![Vaal Gem bug](https://user-images.githubusercontent.com/31533893/171978719-19827f26-9815-4c8c-91c9-f7f801214eaf.png)

### After screen
![Vaal Gem Fixed](https://user-images.githubusercontent.com/31533893/175527278-3f65786d-1d40-4611-9af0-b52cdfcba61b.png)