### PR TITLE
Save anointed notables to legion jewel editedNode data

### DIFF
--- a/src/Classes/PassiveSpec.lua
+++ b/src/Classes/PassiveSpec.lua
@@ -183,10 +183,14 @@ function PassiveSpecClass:Save(xml)
 				end
 				-- Do not save current editedNode data unless the current node is conquered
 				if self.nodes[nodeId] and self.nodes[nodeId].conqueredBy then
-					-- Do not save current editedNode data unless the current node is allocated
-					for allocNodeId in pairs(self.allocNodes) do
-						if nodeId == allocNodeId then
-							t_insert(editedNodes, editedNode)
+					-- Do not save current editedNode data unless the current node is anointed or allocated
+					if self.build.calcsTab.mainEnv.grantedPassives[nodeId] then
+						t_insert(editedNodes, editedNode)
+					else
+						for allocNodeId in pairs(self.allocNodes) do
+							if nodeId == allocNodeId then
+								t_insert(editedNodes, editedNode)
+							end
 						end
 					end
 				end


### PR DESCRIPTION
Fixes #3839.

### Description of the problem being solved:
Anointed notables were not being saved to editedNode data (as they are not actually allocated on the passive tree, and were being excluded from the editedNode saving process as a result) preventing changes made to conquered anointed notables from saving to build XML.

### Steps taken to verify a working solution:
- Load showcase build.
- Right click the anointed Robust notable and assign it any conquered modifier.
- Save the build and restart Path of Building.
- Load the build you just saved and verify whether or not the anointed notable is still conquered.

### Link to a build that showcases this PR:
https://pastebin.com/7SuQUibq