### PR TITLE
Fix a bug where if affected by a vaal aura you weren't considered affected by the regular aura

### DIFF
--- a/src/Modules/CalcPerform.lua
+++ b/src/Modules/CalcPerform.lua
@@ -1817,6 +1817,9 @@ function calcs.perform(env, avoidCache)
 					if not activeSkill.skillData.auraCannotAffectSelf then
 						activeSkill.buffSkill = true
 						affectedByAura[env.player] = true
+						if buff.name:sub(1,4) == "Vaal" then
+							modDB.conditions["AffectedBy"..buff.name:sub(6):gsub(" ","")] = true
+						end
 						modDB.conditions["AffectedBy"..buff.name:gsub(" ","")] = true
 						local srcList = new("ModList")
 						local inc = skillModList:Sum("INC", skillCfg, "AuraEffect", "BuffEffect", "BuffEffectOnSelf", "AuraEffectOnSelf", "AuraBuffEffect", "SkillAuraEffectOnSelf")


### PR DESCRIPTION
Fixes #2229.

### Description of the problem being solved:
when using x aura or similar modifier doesn't consider you using the base aura of the vaal aura.

### Steps taken to verify a working solution:
- Add spell suppression haste watchers
- Enable Vaal Haste
- See spell suppression chance go up.

### Link to a build that showcases this PR:
https://poe.ninja/pob/Am6

### Before screenshot:
![image](https://user-images.githubusercontent.com/31533893/175757128-9b2b17c5-7791-4648-9e66-c440da34b37f.png)

### After screenshot:
![image](https://user-images.githubusercontent.com/31533893/175757071-8889409b-3f8c-4ef3-9d60-523b04c7d171.png)
