### PR TITLE
Improve skill gem state persistence

### DIFF
--- a/src/Classes/SkillsTab.lua
+++ b/src/Classes/SkillsTab.lua
@@ -473,6 +473,8 @@ function SkillsTabClass:CreateGemSlot(index)
 			self.gemSlots[index2].quality:SetText(gemInstance.quality)
 			self.gemSlots[index2].qualityId:SelByValue(gemInstance.qualityId, "type")
 			self.gemSlots[index2].enabled.state = gemInstance.enabled
+			self.gemSlots[index2].enableGlobal1.state = gemInstance.enableGlobal1
+			self.gemSlots[index2].enableGlobal2.state = gemInstance.enableGlobal2
 			self.gemSlots[index2].count:SetText(gemInstance.count or 1)
 		end
 		self:AddUndoState()
@@ -701,8 +703,13 @@ function SkillsTabClass:CreateGemSlot(index)
 			slot.quality:SetText(gemInstance.quality)
 			slot.qualityId.list = self:getGemAltQualityList(gemInstance.gemData)
 			slot.qualityId:SelByValue(gemInstance.qualityId, "type")
-			slot.enableGlobal1.state = true
-			slot.count:SetText(getmInstance.count)
+			slot.count:SetText(gemInstance.count)
+		end
+		if not gemInstance.gemData.vaalGem then
+			slot.enableGlobal1.state = state
+			gemInstance.enableGlobal1 = state
+			slot.enableGlobal2.state = state
+			gemInstance.enableGlobal2 = state
 		end
 		gemInstance.enabled = state
 		self:ProcessSocketGroup(self.displayGroup)
@@ -817,8 +824,6 @@ function SkillsTabClass:CreateGemSlot(index)
 	end
 	self.controls["gemSlot"..index.."EnableGlobal2"] = slot.enableGlobal2
 end
-
-
 
 function SkillsTabClass:getGemAltQualityList(gemData)
 	local altQualList = { }


### PR DESCRIPTION
Video demonstration of the two bugs this PR addresses: https://www.youtube.com/watch?v=_kFGidpU7cQ

### Description of the problem being solved:

Vaal skill gems grant both a vaal skill, and the matching non-vaal equivalent. PoB controls whether or not these skill-parts are enabled via checkboxes &mdash; enableGlobal1 and enableGlobal2 respectively. 

----

Bug no. 1:
If you have two vaal skill gems with different toggle states and delete whichever one is above the other, the toggle states from the deleted gem will persist in that gem slot, overriding the expected toggle states from the gem that was not deleted. This is bizarre and counterintuitive, as everything else about the deleted gem is removed/replaced.

I fixed this by adding enableGlobal1 and enableGlobal2 to the list of gem slot variables that are updated whenever a gem is deleted.

----

Bug no. 2:
If you have a vaal skill gem and toggle both enableGlobal1 and enableGlobal2 off, renaming the gem in that slot to any non-vaal skill gem leads to those toggle states persisting. This prevents most skills from functioning and has no immediately obvious cause or solution.

To fix this I simply force enableGlobal1 and enableGlobal2 to match the primary gem enable state whenever that value updates, as long as the skill gem is a non-vaal gem (meaning the checkboxes for enableGlobal1 and enableGlobal 2 are not visible).

This solution isn't perfect as it doesn't *immediately* repair a skill gem stuck in an invalid state (it requires you to click the enable checkbox at least once) but it's still a significant improvement.

----

### Link to a build that showcases this PR:
https://pobb.in/d-xDMqPYTQom