### PR TITLE
Fix Paradoxica

### DIFF
--- a/src/Data/Uniques/Special/Generated.lua
+++ b/src/Data/Uniques/Special/Generated.lua
@@ -57,9 +57,13 @@ local paradoxica = {
 }
 
 for index, mod in pairs(paradoxicaMods) do
-	if (mod.veiledName ~= "(Suffix) Double Damage Chance") then
-		table.insert(paradoxica, "Variant: "..mod.veiledName)
+	if (mod.veiledName == "(Suffix) Double Damage Chance") then
+		table.remove(paradoxicaMods, index)
 	end
+end
+
+for index, mod in pairs(paradoxicaMods) do
+	table.insert(paradoxica, "Variant: "..mod.veiledName)
 end
 
 table.insert(paradoxica, "Source: Drops from Bosses in Safehouse")
@@ -68,10 +72,8 @@ table.insert(paradoxica, "Implicits: 1")
 table.insert(paradoxica, "+25% to Global Critical Strike Multiplier")
 
 for index, mod in pairs(paradoxicaMods) do
-	if (mod.veiledName ~= "(Suffix) Double Damage Chance") then
-		for _, value in pairs(mod.veiledLines) do
-			table.insert(paradoxica, "{variant:"..index.."}"..value.."")
-		end
+	for _, value in pairs(mod.veiledLines) do
+		table.insert(paradoxica, "{variant:"..index.."}"..value.."")
 	end
 end
 


### PR DESCRIPTION
Fixes #4399.

### Description of the problem being solved:
Variant index's didn't lineup due to double damage being omitted.

### Steps taken to verify a working solution:
- Try to select fire dot multi and or minion damage and it produces the correct mod.

### Link to a build that showcases this PR:
https://poe.ninja/pob/An5

### Before screenshot:
![image](https://user-images.githubusercontent.com/31533893/175771021-be97a027-9862-4702-92e2-062503c18767.png)


### After screenshot:
![image](https://user-images.githubusercontent.com/31533893/175771009-20d66778-06d1-458e-97d8-a9624be4064d.png)
