### PR TITLE
Fix Determination aura alt quality mod

### DIFF
--- a/src/Data/Skills/act_str.lua
+++ b/src/Data/Skills/act_str.lua
@@ -2066,6 +2066,9 @@ skills["Determination"] = {
 		["base_physical_damage_reduction_rating"] = {
 			mod("Armour", "BASE", nil, 0, 0, { type = "GlobalEffect", effectType = "Aura" }),
 		},
+		["base_avoid_stun_%"] = {
+			mod("AvoidStun", "BASE", nil, 0, 0, { type = "GlobalEffect", effectType = "Aura" }),
+		},
 		["evasion_rating_%_to_add_as_armour"] = {
 			mod("EvasionGainAsArmour", "BASE", nil, 0, 0, { type = "GlobalEffect", effectType = "Aura" }),
 		},

--- a/src/Export/Skills/act_str.txt
+++ b/src/Export/Skills/act_str.txt
@@ -358,6 +358,9 @@ local skills, mod, flag, skill = ...
 		["base_physical_damage_reduction_rating"] = {
 			mod("Armour", "BASE", nil, 0, 0, { type = "GlobalEffect", effectType = "Aura" }),
 		},
+		["base_avoid_stun_%"] = {
+			mod("AvoidStun", "BASE", nil, 0, 0, { type = "GlobalEffect", effectType = "Aura" }),
+		},
 		["evasion_rating_%_to_add_as_armour"] = {
 			mod("EvasionGainAsArmour", "BASE", nil, 0, 0, { type = "GlobalEffect", effectType = "Aura" }),
 		},


### PR DESCRIPTION
Fixes #4501

Determination skill is missing proper stat for alt quality stun avoidance mod. This PR adds it.

## BEFORE
![image](https://user-images.githubusercontent.com/5316261/175949203-0527cbb2-57fc-4731-9353-4f8db92a6991.png)
![image](https://user-images.githubusercontent.com/5316261/175949676-41e41c15-7f5c-448a-8444-9808c5226238.png)

## AFTER
![image](https://user-images.githubusercontent.com/5316261/175949302-b871a401-4f13-4099-95b3-fe17a29aaf49.png)
![image](https://user-images.githubusercontent.com/5316261/175949562-994e2e1d-d630-4a43-a855-c475fa1aa9ec.png)

