### PR TITLE
Fix Energy Shield Recharge mastery

### DIFF
--- a/src/Modules/CalcDefence.lua
+++ b/src/Modules/CalcDefence.lua
@@ -179,7 +179,7 @@ function calcs.defence(env, actor)
 	if modDB:Flag(nil, "ArmourAppliesToEnergyShieldRecharge") then
 		-- Armour to ES Recharge conversion from Armour and Energy Shield Mastery
 		local multiplier = (modDB:Max(nil, "ImprovedArmourAppliesToEnergyShieldRecharge") or 100) / 100
-		for _, value in ipairs(modDB:Tabulate("INC", nil, "Armour")) do
+		for _, value in ipairs(modDB:Tabulate("INC", nil, "Armour", "ArmourAndEvasion", "Defences")) do
 			local mod = value.mod
 			local modifiers = calcLib.getConvertedModTags(mod, multiplier)
 			modDB:NewMod("EnergyShieldRecharge", "INC", m_floor(mod.value * multiplier), mod.source, mod.flags, mod.keywordFlags, unpack(modifiers))


### PR DESCRIPTION
### Description of the problem being solved:
The "Increases and Reductions to Armour also apply to Energy Shield Recharge rate at 20% of their value" mastery does not currently scale with % Evasion and Armour, or % Global Defences modifiers.

In-game testing indicates that this is incorrect. All modifiers to % Armour are meant to apply to Energy Shield Recharge rate with this mastery allocated, not just pure % Armour and hybrid % Armour / % Energy Shield modifiers.

### Link to a build that showcases this PR:
https://pobb.in/OIzAQlu7GjUW

### Before screenshot:
![](https://user-images.githubusercontent.com/18443616/176315575-91222b97-9e9d-4d23-b6c9-5b8cc372465a.png)

### After screenshot:
![](https://user-images.githubusercontent.com/18443616/176315621-10a586df-03ff-48e5-b495-f870f12b5af8.png)
