### PR TITLE
Update Skyforth, Victario's Flight, Mindspiral, Mutewind Seal

### DIFF
--- a/src/Data/Uniques/boots.lua
+++ b/src/Data/Uniques/boots.lua
@@ -344,7 +344,7 @@ Requires Level 12, 26 Dex
 {variant:1}30% increased Movement Speed when on Low Life
 {variant:2}15% increased Movement Speed
 {variant:2}You and nearby allies have 10% increased Movement Speed
-(5-10)% of Damage taken Gained as Mana over 4 seconds when Hit
+(5-10)% of Damage taken Recouped as Mana
 ]],
 -- Boots: Energy Shield
 [[
@@ -481,14 +481,11 @@ Requires Level 32, 54 Int
 Skyforth
 Sorcerer Boots
 Energy Shield: 64
-Variant: Pre 3.16.0
-Variant: Current
 Requires Level 67, 123 Int
 +(60-120) to maximum Mana
 30% increased Movement Speed
 25% chance to gain a Power Charge on Critical Strike
-{variant:1}12% increased Mana Reservation Efficiency
-{variant:2}12% increased Reservation Efficiency
+12% increased Reservation Efficiency of Skills
 You have no Life Regeneration
 Stun Threshold is based on 500% of your Mana instead of Life
 ]],[[

--- a/src/Data/Uniques/helmet.lua
+++ b/src/Data/Uniques/helmet.lua
@@ -995,7 +995,7 @@ Requires Level 37, 42 Str, 42 Int
 {variant:2}+(100-120) to maximum Mana
 {variant:2}Gain (5-10)% of Maximum Mana as Extra Maximum Energy Shield
 Enemies Cannot Leech Mana From You
-(5-10)% of Damage taken Gained as Mana over 4 seconds when Hit
+(5-10)% of Damage taken Recouped as Mana
 Cannot Leech Mana
 ]],[[
 Speaker's Wreath

--- a/src/Data/Uniques/ring.lua
+++ b/src/Data/Uniques/ring.lua
@@ -695,8 +695,8 @@ Has 1 Socket
 {variant:2,3}{tags:attack,caster,speed}Socketed Golem Skills have 20% increased Attack and Cast Speed
 {tags:attack,physical}Adds (5-10) to (11-15) Physical Damage to Attacks
 {tags:attack,speed}(5-10)% increased Attack Speed
-{variant:1}(1-2)% chance to Dodge Attack Hits
-{variant:2}(3-5)% chance to Dodge Attack Hits
+{variant:1}(1-2)% increased Movement Speed
+{variant:2}(3-5)% increased Movement Speed
 {variant:1}Socketed Gems are Supported by Level 16 Increased Minion Speed
 {variant:2,3}Gain Onslaught for 10 seconds when you Cast Socketed Golem Skill
 ]],[[


### PR DESCRIPTION
Fixes #4511.

Skyforth's reservation wording did not match in-game. Skyforth also had legacy variants when none exist in-game. Both of these issues were fixed.

Victario's Flight and Mindspiral were updated to use the Recoup keyword (added in 3.12) that replaced "Mana gained over 4 seconds when hit" globally.

Attack dodge no longer exists anywhere in PoE (as of 3.16) and was replaced with movement speed on Mutewind Seal specifically.