### PR TITLE
Correctly handle 100% reduced reservation efficiency and greater.

### DIFF
--- a/src/Modules/CalcOffence.lua
+++ b/src/Modules/CalcOffence.lua
@@ -841,7 +841,10 @@ function calcs.offence(env, actor, activeSkill)
 	end
 	if activeSkill.skillTypes[SkillType.HasReservation] and not activeSkill.skillTypes[SkillType.ReservationBecomesCost] then
 		for _, pool in ipairs({"Life", "Mana"}) do
-			output[pool .. "ReservedMod"] = calcLib.mod(skillModList, skillCfg, pool .. "Reserved", "Reserved") * calcLib.mod(skillModList, skillCfg, "SupportManaMultiplier") / calcLib.mod(skillModList, skillCfg, pool .. "ReservationEfficiency", "ReservationEfficiency")
+			output[pool .. "ReservedMod"] = 0
+			if calcLib.mod(skillModList, skillCfg, "SupportManaMultiplier") > 0 and calcLib.mod(skillModList, skillCfg, pool .. "Reserved", "Reserved") > 0 then
+				output[pool .. "ReservedMod"] = calcLib.mod(skillModList, skillCfg, pool .. "Reserved", "Reserved") * calcLib.mod(skillModList, skillCfg, "SupportManaMultiplier") / m_max(0, calcLib.mod(skillModList, skillCfg, pool .. "ReservationEfficiency", "ReservationEfficiency"))
+			end
 			if breakdown then
 				local inc = skillModList:Sum("INC", skillCfg, pool .. "Reserved", "Reserved", "SupportManaMultiplier")
 				local more = skillModList:More(skillCfg, pool .. "Reserved", "Reserved", "SupportManaMultiplier")

--- a/src/Modules/CalcPerform.lua
+++ b/src/Modules/CalcPerform.lua
@@ -1556,7 +1556,7 @@ function calcs.perform(env, avoidCache)
 			for name, values in pairs(pool) do
 				values.more = skillModList:More(skillCfg, name.."Reserved", "Reserved")
 				values.inc = skillModList:Sum("INC", skillCfg, name.."Reserved", "Reserved")
-				values.efficiency = skillModList:Sum("INC", skillCfg, name.."ReservationEfficiency", "ReservationEfficiency")
+				values.efficiency = m_max(skillModList:Sum("INC", skillCfg, name.."ReservationEfficiency", "ReservationEfficiency"), -100)
 				-- used for Arcane Cloak calculations in ModStore.GetStat
 				env.player[name.."Efficiency"] = values.efficiency
 				if activeSkill.skillData[name.."ReservationFlatForced"] then
@@ -1564,7 +1564,7 @@ function calcs.perform(env, avoidCache)
 				else
 					local baseFlatVal = m_floor(values.baseFlat * mult)
 					values.reservedFlat = 0
-					if values.more > 0 and values.inc > -100 then
+					if values.more > 0 and values.inc > -100 and baseFlatVal ~= 0 then
 						values.reservedFlat = m_max(round(baseFlatVal * (100 + values.inc) / 100 * values.more / (1 + values.efficiency / 100), 0), 0)
 					end
 				end
@@ -1573,7 +1573,7 @@ function calcs.perform(env, avoidCache)
 				else
 					local basePercentVal = values.basePercent * mult
 					values.reservedPercent = 0
-					if values.more > 0 and values.inc > -100 then
+					if values.more > 0 and values.inc > -100 and basePercentVal ~= 0 then
 						values.reservedPercent = m_max(round(basePercentVal * (100 + values.inc) / 100 * values.more / (1 + values.efficiency / 100), 2), 0)
 					end
 				end

--- a/src/Modules/CalcPerform.lua
+++ b/src/Modules/CalcPerform.lua
@@ -1564,7 +1564,7 @@ function calcs.perform(env, avoidCache)
 				else
 					local baseFlatVal = m_floor(values.baseFlat * mult)
 					values.reservedFlat = 0
-					if values.more <= 0 and values.inc <= -100 then
+					if values.more > 0 and values.inc > -100 then
 						values.reservedFlat = m_max(round(baseFlatVal * (100 + values.inc) / 100 * values.more / (1 + values.efficiency / 100), 0), 0)
 					end
 				end
@@ -1573,7 +1573,7 @@ function calcs.perform(env, avoidCache)
 				else
 					local basePercentVal = values.basePercent * mult
 					values.reservedPercent = 0
-					if values.more <= 0 and values.inc <= -100 then
+					if values.more > 0 and values.inc > -100 then
 						values.reservedPercent = m_max(round(basePercentVal * (100 + values.inc) / 100 * values.more / (1 + values.efficiency / 100), 2), 0)
 					end
 				end

--- a/src/Modules/CalcPerform.lua
+++ b/src/Modules/CalcPerform.lua
@@ -1564,7 +1564,7 @@ function calcs.perform(env, avoidCache)
 				else
 					local baseFlatVal = m_floor(values.baseFlat * mult)
 					values.reservedFlat = 0
-					if values.more ~= 0 and values.inc ~= -100 then
+					if values.more <= 0 and values.inc <= -100 then
 						values.reservedFlat = m_max(round(baseFlatVal * (100 + values.inc) / 100 * values.more / (1 + values.efficiency / 100), 0), 0)
 					end
 				end
@@ -1573,7 +1573,7 @@ function calcs.perform(env, avoidCache)
 				else
 					local basePercentVal = values.basePercent * mult
 					values.reservedPercent = 0
-					if values.more ~= 0  and values.inc ~= -100 then
+					if values.more <= 0 and values.inc <= -100 then
 						values.reservedPercent = m_max(round(basePercentVal * (100 + values.inc) / 100 * values.more / (1 + values.efficiency / 100), 2), 0)
 					end
 				end

--- a/src/Modules/CalcPerform.lua
+++ b/src/Modules/CalcPerform.lua
@@ -1563,13 +1563,19 @@ function calcs.perform(env, avoidCache)
 					values.reservedFlat = activeSkill.skillData[name.."ReservationFlatForced"]
 				else
 					local baseFlatVal = m_floor(values.baseFlat * mult)
-					values.reservedFlat = m_max(round(baseFlatVal * (100 + values.inc) / 100 * values.more / (1 + values.efficiency / 100), 0), 0)
+					values.reservedFlat = 0
+					if values.more ~= 0 and values.inc ~= -100 then
+						values.reservedFlat = m_max(round(baseFlatVal * (100 + values.inc) / 100 * values.more / (1 + values.efficiency / 100), 0), 0)
+					end
 				end
 				if activeSkill.skillData[name.."ReservationPercentForced"] then
 					values.reservedPercent = activeSkill.skillData[name.."ReservationPercentForced"]
 				else
 					local basePercentVal = values.basePercent * mult
-					values.reservedPercent = m_max(round(basePercentVal * (100 + values.inc) / 100 * values.more / (1 + values.efficiency / 100), 2), 0)
+					values.reservedPercent = 0
+					if values.more ~= 0  and values.inc ~= -100 then
+						values.reservedPercent = m_max(round(basePercentVal * (100 + values.inc) / 100 * values.more / (1 + values.efficiency / 100), 2), 0)
+					end
 				end
 				if activeSkill.activeMineCount then
 					values.reservedFlat = values.reservedFlat * activeSkill.activeMineCount


### PR DESCRIPTION
Fixes #4332.

### Description of the problem being solved:
This fixes sources that reduce mana reserved to zero not applying globally on infinite mana reservations such as 100 reduced mana efficiency. This primarily is for essence worm.

### Steps taken to verify a working solution:
- Mana & life reserved is now correctly at 0 when looking in the panel.
- 100% reduced efficiency and greater now correctly display inf this coincides with ingame.
-  Greater than 100% reduced acts as 100% reduced (infinite reservation)
![image](https://user-images.githubusercontent.com/31533893/177062378-e86146f6-88b5-463e-9e7f-70c1a5086065.png)


### Link to a build that showcases this PR:
https://poe.ninja/pob/BMq

### Screenshots
Essence worm + memory vault (socketed in essence worm)
#### Before
![image](https://user-images.githubusercontent.com/31533893/177030103-cd5b8293-fcba-4e66-94a3-44399fc5154f.png)
#### After
![image](https://user-images.githubusercontent.com/31533893/177030085-ff0e1fb8-ac23-4290-bef2-cae73b325c2a.png)

2 Essence worms not socketed (160% reduced efficiency)
#### Before
![image](https://user-images.githubusercontent.com/31533893/177062289-01ea91a2-eca9-4b6c-a25c-137a3a9444f4.png)
![image](https://user-images.githubusercontent.com/31533893/177460258-3195b8cc-cc4d-4cde-bd6e-eaec6e1cfae5.png)
#### After
![image](https://user-images.githubusercontent.com/31533893/177062309-a9e53bfa-e81b-4434-9234-42e093f3204f.png)
![image](https://user-images.githubusercontent.com/31533893/177460232-7dd13d75-84af-448a-a1aa-afa3d7fa708d.png)


2 Essence worms socketed
#### Before
![image](https://user-images.githubusercontent.com/31533893/177460119-2f6f9092-6b18-48aa-ba7b-d777c09f4c3f.png)

#### After
![image](https://user-images.githubusercontent.com/31533893/177460013-8ebf5be3-46fb-4982-95a8-43745959c9b3.png)
