### PR TITLE
Fixed smite area hit being classed as melee

### DIFF
--- a/src/Data/Skills/act_str.lua
+++ b/src/Data/Skills/act_str.lua
@@ -6252,6 +6252,7 @@ skills["Smite"] = {
 		{
 			name = "Area Hit",
 			area = true,
+			melee = false,
 		},
 	},
 	statMap = {

--- a/src/Export/Skills/act_str.txt
+++ b/src/Export/Skills/act_str.txt
@@ -1081,6 +1081,7 @@ local skills, mod, flag, skill = ...
 		{
 			name = "Area Hit",
 			area = true,
+			melee = false,
 		},
 	},
 	statMap = {


### PR DESCRIPTION
Fixes #4347.

### Description of the problem being solved:
Smite's area hit is not a melee attack.
This is further supported by the wiki saying this as well. https://www.poewiki.net/wiki/Smite

### Steps taken to verify a working solution:
- Applying melee modifers no longer effects the area hit.

### Link to a build that showcases this PR:
https://poe.ninja/pob/BMs

### Before screenshot:
![image](https://user-images.githubusercontent.com/31533893/177030249-313029e7-97f0-40a7-b863-919e01d24ec4.png)

### After screenshot:
![image](https://user-images.githubusercontent.com/31533893/177030237-fd853445-d966-479b-95e7-1547e4a3fdb5.png)
