### PR TITLE
Update wording on Maw of Conquest, Thousand Teeth Temu

### DIFF
--- a/src/Data/Uniques/helmet.lua
+++ b/src/Data/Uniques/helmet.lua
@@ -510,7 +510,7 @@ Requires Level 48, 101 Int
 (200-250)% increased Energy Shield
 +(50-70) to maximum Life
 Unaffected by Poison
-(10-20)% of Damage taken gained as Life over 4 seconds when Hit
+(10-20)% of Damage taken Recouped as Life
 ]],[[
 Plume of Pursuit
 Bone Circlet

--- a/src/Data/Uniques/shield.lua
+++ b/src/Data/Uniques/shield.lua
@@ -404,7 +404,7 @@ Implicits: 1
 0.4% of Physical Attack Damage Leeched as Life
 +5% Chance to Block
 Reflects 1 to 1000 Physical Damage to Attackers on Block
-{variant:2,3}10% of Damage Reflected Gained as Life
+{variant:2,3}10% of Damage you Reflect to Enemies when Hit is gained as Life
 ]],
 -- Shield: Energy Shield
 [[


### PR DESCRIPTION
Updated Maw of Conquest to use the Recoup keyword added in 3.12.

Updated Thousand Teeth Temu to use the correct reflect recovery wording. This new wording was added somewhere between April 2017 and April 2021, it doesn't appear to be documented anywhere though.