### PR TITLE
Fix Flask Duration to match in game values

### DIFF
--- a/src/Classes/Item.lua
+++ b/src/Classes/Item.lua
@@ -1142,7 +1142,7 @@ function ItemClass:BuildModListForSlotNum(baseList, slotNum)
 			flaskData.instantPerc = calcLocal(modList, "FlaskInstantRecovery", "BASE", 0)
 			local recoveryMod = 1 + calcLocal(modList, "FlaskRecovery", "INC", 0) / 100
 			local rateMod = 1 + calcLocal(modList, "FlaskRecoveryRate", "INC", 0) / 100
-			flaskData.duration = self.base.flask.duration * (1 + durationInc / 100) / rateMod * durationMore
+			flaskData.duration = round(self.base.flask.duration * (1 + durationInc / 100) / rateMod * durationMore, 1)
 			if self.base.flask.life then
 				flaskData.lifeBase = self.base.flask.life * (1 + self.quality / 100) * recoveryMod
 				flaskData.lifeInstant = flaskData.lifeBase * flaskData.instantPerc / 100
@@ -1158,7 +1158,7 @@ function ItemClass:BuildModListForSlotNum(baseList, slotNum)
 			end
 		else
 			-- Utility flask
-			flaskData.duration = self.base.flask.duration * (1 + (durationInc + self.quality) / 100) * durationMore
+			flaskData.duration = round(self.base.flask.duration * (1 + (durationInc + self.quality) / 100) * durationMore, 1)
 		end
 		flaskData.chargesMax = self.base.flask.chargesMax + calcLocal(modList, "FlaskCharges", "BASE", 0)
 		flaskData.chargesUsed = m_floor(self.base.flask.chargesUsed * (1 + calcLocal(modList, "FlaskChargesUsed", "INC", 0) / 100))


### PR DESCRIPTION
Fixes #4223.

### Description of the problem being solved:
Flask duration is round to 1 decimal place ingame

### Steps taken to verify a working solution:
- Flask duration are now correct to what is seen ingame display 2 dp but round to 1.

### Link to a build that showcases this PR:
https://pastebin.com/tQKeZPGz

### Before screenshot:
![image](https://user-images.githubusercontent.com/31533893/177533373-5a232b49-6cd1-471b-ae88-7a48c34bef0e.png)

### After screenshot:
![image](https://user-images.githubusercontent.com/31533893/177533327-dba993b3-9869-4234-b8f7-92ae6540c1f6.png)
