### PR TITLE
Fix Out of Memory crash in Items Tab

### DIFF
--- a/src/Classes/ItemsTab.lua
+++ b/src/Classes/ItemsTab.lua
@@ -2902,7 +2902,10 @@ end
 function ItemsTabClass:CreateUndoState()
 	local state = { }
 	state.activeItemSetId = self.activeItemSetId
-	state.items = copyTableSafe(self.items, false, true)
+	state.items = { }
+	for k, v in pairs(self.items) do
+		state.items[k] = copyTableSafe(self.items[k], true, true)
+	end
 	state.itemOrderList = copyTable(self.itemOrderList)
 	state.slotSelItemId = { }
 	for slotName, slot in pairs(self.slots) do


### PR DESCRIPTION
``self.items`` in ``ItemsTab.lua`` was being copied recursively whenever an UndoState was created, storing way too much information and eventually crashing PoB entirely due to Out of Memory errors.

Limiting that recursion to a certain depth fixes the problem, and doesn't seem to break anything (fingers crossed).

Fixes #3733, #4311.

Demo video: https://www.youtube.com/watch?v=F5ejSSiNgwA