### PR TITLE
Fix alternate quality dropdown options not changing on gem deletion

### DIFF
--- a/src/Classes/SkillsTab.lua
+++ b/src/Classes/SkillsTab.lua
@@ -471,6 +471,7 @@ function SkillsTabClass:CreateGemSlot(index)
 			self.gemSlots[index2].nameSpec:SetText(gemInstance.nameSpec)
 			self.gemSlots[index2].level:SetText(gemInstance.level)
 			self.gemSlots[index2].quality:SetText(gemInstance.quality)
+			self.gemSlots[index2].qualityId.list = self:getGemAltQualityList(gemInstance.gemData)
 			self.gemSlots[index2].qualityId:SelByValue(gemInstance.qualityId, "type")
 			self.gemSlots[index2].enabled.state = gemInstance.enabled
 			self.gemSlots[index2].count:SetText(gemInstance.count or 1)


### PR DESCRIPTION
Fixes #2810 .

### Description of the problem being solved:
See issue
### Steps taken to verify a working solution:
- Create a gem
- Support it with alt quality gem
- Support it with Awakened gem
- Support it with alt quality gem
- Delete first alt quality gem
- Verify the only alt quality option for the awakened gem is "Default"
- Verify the other alt quality gem has their normal alt quality options
