### PR TITLE
Update source text of unique cluster jewels

### DIFF
--- a/src/Data/Uniques/jewel.lua
+++ b/src/Data/Uniques/jewel.lua
@@ -67,7 +67,7 @@ Strength from Passives in Radius is Transformed to Intelligence
 Calamitous Visions
 Small Cluster Jewel
 League: Delirium
-Source: Drops from the Simulacrum Encounter
+Source: Drops from unique Delirium bosses in maps
 Adds Lone Messenger
 ]],[[
 Careful Planning
@@ -228,7 +228,7 @@ Implicits: 0
 The Front Line
 Small Cluster Jewel
 League: Delirium
-Source: Drops from the Simulacrum Encounter
+Source: Drops from unique Delirium bosses in maps
 Adds Veteran's Awareness
 ]],[[
 The Golden Rule
@@ -348,7 +348,7 @@ With 4 Notables Allocated in Radius, When you Kill a Rare monster, you gain 1 of
 The Interrogation
 Small Cluster Jewel
 League: Delirium
-Source: Drops from the Simulacrum Encounter
+Source: Drops from unique Delirium bosses in maps
 Adds Secrets of Suffering
 ]],[[
 Intuitive Leap
@@ -367,7 +367,7 @@ Source: Drops in The Lord's Labyrinth
 Kitava's Teachings
 Small Cluster Jewel
 League: Delirium
-Source: Drops from the Simulacrum Encounter
+Source: Drops from unique Delirium bosses in maps
 Adds Disciple of Kitava
 ]],[[
 Lioneye's Fall
@@ -443,13 +443,13 @@ Spells which have gained Intensity Recently lose 1 Intensity every 0.50 Seconds
 Natural Affinity
 Small Cluster Jewel
 League: Delirium
-Source: Drops from the Simulacrum Encounter
+Source: Drops from unique Delirium bosses in maps
 Adds Nature's Patience
 ]],[[
 One With Nothing
 Small Cluster Jewel
 League: Delirium
-Source: Drops from the Simulacrum Encounter
+Source: Drops from unique Delirium bosses in maps
 Adds Hollow Palm Technique
 ]],[[
 Primordial Eminence
@@ -577,7 +577,7 @@ also grant an equal chance to gain an Endurance Charge on Kill
 The Siege
 Small Cluster Jewel
 League: Delirium
-Source: Drops from the Simulacrum Encounter
+Source: Drops from unique Delirium bosses in maps
 Adds Kineticism
 ]],[[
 Soul's Wick


### PR DESCRIPTION
Fixes # .

### Description of the problem being solved:
The source in the tooltip text for all unique Delirium jewels indicated that they are from Simulacrums. This is incorrect - only Megalomaniac, Voices and Split Personality are from Simulacrums. The rest are from Kosis and Omniphobia encounters in maps.
These are:
[Calamitous Visions](https://www.poewiki.net/wiki/Calamitous_Visions)
[Kitava's Teachings](https://www.poewiki.net/wiki/Kitava%27s_Teachings)
[Natural Affinity](https://www.poewiki.net/wiki/Natural_Affinity)
[One With Nothing](https://www.poewiki.net/wiki/One_With_Nothing)
[The Front Line](https://www.poewiki.net/wiki/The_Front_Line)
[The Interrogation](https://www.poewiki.net/wiki/The_Interrogation)
[The Siege](https://www.poewiki.net/wiki/The_Siege)

### Steps taken to verify a working solution:
- Updated the text in `src/data/Uniques/jewel.lua`

### Link to a build that showcases this PR:

### Before screenshot:
![image](https://user-images.githubusercontent.com/43037308/178115707-c027aae9-f587-4b08-ba6d-f447e512717d.png)

### After screenshot:
![image](https://user-images.githubusercontent.com/43037308/178115698-11a4f66e-51c2-4faf-a7e1-12340214d23a.png)
