### PR TITLE
Fix Herald of Purity minions missing a duration

### DIFF
--- a/src/Data/Skills/act_str.lua
+++ b/src/Data/Skills/act_str.lua
@@ -3798,6 +3798,7 @@ skills["HeraldOfPurity"] = {
 	baseFlags = {
 		spell = true,
 		minion = true,
+		duration = true,
 	},
 	qualityStats = {
 		Default = {

--- a/src/Export/Skills/act_str.txt
+++ b/src/Export/Skills/act_str.txt
@@ -639,7 +639,7 @@ local skills, mod, flag, skill = ...
 #mods
 
 #skill HeraldOfPurity
-#flags spell minion
+#flags spell minion duration
 	minionList = {
 		"AxisEliteSoldierHeraldOfLight",
 	},


### PR DESCRIPTION
Fixes #4508 .

### Description of the problem being solved:
Herald of Purity minions were missing a duration tag

### After screenshot:
![image](https://user-images.githubusercontent.com/1209372/178140050-d1ad926d-12e2-465f-92ac-3d816e7242ba.png)
