### PR TITLE
Fix saving of changed placeholdered values

### DIFF
--- a/src/Classes/ConfigTab.lua
+++ b/src/Classes/ConfigTab.lua
@@ -288,6 +288,10 @@ function ConfigTabClass:Load(xml, fileName)
 end
 
 function ConfigTabClass:GetDefaultState(var, varType)
+	if self.placeholder[var] ~= nil then
+		return self.placeholder[var]
+	end
+
 	for i = 1, #varList do
 		if varList[i].var == var then
 			if varType == "number" then


### PR DESCRIPTION
Return placeholder value when checking default state

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>

### Description of the problem being solved:
Currently code thinks that the default state is 0 when saving numbers, this means when i am changing placeholder for for example lightning pen from 5 to 0 it wont save and then dissapears on reload.

### Steps taken to verify a working solution:
- Set enemy to Guardian/Pinnacle Boss
- Set enemy lightning pen to 0
- Save build
- Close build
- Reopen build
- Enemy lightning pen is still 0