### PR TITLE
Fix effect mods that are granted while affected by a buff sometimes not applying.

### DIFF
--- a/src/Modules/CalcPerform.lua
+++ b/src/Modules/CalcPerform.lua
@@ -1758,7 +1758,7 @@ function calcs.perform(env, avoidCache)
 		end
 	end
 
-	--Compute barebones no stat calculations for condtional effects.
+	--Compute barebones no stat calculations for conditional effects.
 	local affectedByAura = { }
 	for _, activeSkill in ipairs(env.player.activeSkillList) do
 		local skillModList = activeSkill.skillModList

--- a/src/Modules/CalcPerform.lua
+++ b/src/Modules/CalcPerform.lua
@@ -1779,9 +1779,6 @@ function calcs.perform(env, avoidCache)
 				 	if not buff.applyNotPlayer then
 						activeSkill.buffSkill = true
 						modDB.conditions["AffectedBy"..buff.name:gsub(" ","")] = true
-						if activeSkill.skillData.thisIsNotABuff then
-							buffs[buff.name].notBuff = true
-						end
 					end
 					if env.minion and (buff.applyMinions or buff.applyAllies) then
 						activeSkill.minionBuffSkill = true
@@ -1888,6 +1885,9 @@ function calcs.perform(env, avoidCache)
 						srcList:ScaleAddList(buff.modList, (1 + inc / 100) * more)
 						mergeBuff(srcList, buffs, buff.name)
 						mergeBuff(buff.unscalableModList, buffs, buff.name)
+						if activeSkill.skillData.thisIsNotABuff then
+							buffs[buff.name].notBuff = true
+						end
 					end
 					if env.minion and (buff.applyMinions or buff.applyAllies) then
 						local srcList = new("ModList")

--- a/src/Modules/CalcPerform.lua
+++ b/src/Modules/CalcPerform.lua
@@ -1757,7 +1757,112 @@ function calcs.perform(env, avoidCache)
 			end
 		end
 	end
+
+	--Compute barebones no stat calculations for condtional effects.
 	local affectedByAura = { }
+	for _, activeSkill in ipairs(env.player.activeSkillList) do
+		local skillModList = activeSkill.skillModList
+		local skillCfg = activeSkill.skillCfg
+		for _, buff in ipairs(activeSkill.buffList) do
+			--Skip adding buff if reservation exceeds maximum
+			for _, value in ipairs({"Mana", "Life"}) do
+				if activeSkill.skillData[value.."ReservedBase"] and activeSkill.skillData[value.."ReservedBase"] > env.player.output[value] then
+					goto disableAuraAffected
+				end
+			end
+			if buff.cond and not skillModList:GetCondition(buff.cond, skillCfg) then
+				-- Nothing!
+			elseif buff.enemyCond and not enemyDB:GetCondition(buff.enemyCond) then
+				-- Also nothing :/
+			elseif buff.type == "Buff" then
+				if env.mode_buffs and (not activeSkill.skillFlags.totem or buff.allowTotemBuff) then
+				 	if not buff.applyNotPlayer then
+						activeSkill.buffSkill = true
+						modDB.conditions["AffectedBy"..buff.name:gsub(" ","")] = true
+						if activeSkill.skillData.thisIsNotABuff then
+							buffs[buff.name].notBuff = true
+						end
+					end
+					if env.minion and (buff.applyMinions or buff.applyAllies) then
+						activeSkill.minionBuffSkill = true
+						env.minion.modDB.conditions["AffectedBy"..buff.name:gsub(" ","")] = true
+					end
+				end
+			elseif buff.type == "Guard" then
+				if env.mode_buffs and (not activeSkill.skillFlags.totem or buff.allowTotemBuff) then
+				 	if not buff.applyNotPlayer then
+						activeSkill.buffSkill = true
+					end
+				end
+			elseif buff.type == "Aura" then
+				if env.mode_buffs then
+					if not activeSkill.skillData.auraCannotAffectSelf then
+						activeSkill.buffSkill = true
+						affectedByAura[env.player] = true
+						if buff.name:sub(1,4) == "Vaal" then
+							modDB.conditions["AffectedBy"..buff.name:sub(6):gsub(" ","")] = true
+						end
+						modDB.conditions["AffectedBy"..buff.name:gsub(" ","")] = true
+					end
+					if env.minion and not (modDB:Flag(nil, "SelfAurasCannotAffectAllies") or modDB:Flag(nil, "SelfAurasOnlyAffectYou") or modDB:Flag(nil, "SelfAuraSkillsCannotAffectAllies")) then
+						activeSkill.minionBuffSkill = true
+						affectedByAura[env.minion] = true
+						env.minion.modDB.conditions["AffectedBy"..buff.name:gsub(" ","")] = true
+					end
+				end
+			elseif buff.type == "Debuff" or buff.type == "AuraDebuff" then
+				if buff.stackVar then
+					buff.stackCount = skillModList:Sum("BASE", skillCfg, "Multiplier:"..buff.stackVar)
+					if buff.stackLimit then
+						buff.stackCount = m_min(buff.stackCount, buff.stackLimit)
+					elseif buff.stackLimitVar then
+						buff.stackCount = m_min(buff.stackCount, skillModList:Sum("BASE", skillCfg, "Multiplier:"..buff.stackLimitVar))
+					end
+				else
+					buff.stackCount = activeSkill.skillData.stackCount or 1
+				end
+				if env.mode_effective and buff.stackCount > 0 then
+					activeSkill.debuffSkill = true
+					modDB.conditions["AffectedBy"..buff.name:gsub(" ","")] = true
+				end
+			end
+			::disableAuraAffected::
+		end
+		if activeSkill.minion and activeSkill.minion.activeSkillList then
+			local castingMinion = activeSkill.minion
+			for _, activeSkill in ipairs(activeSkill.minion.activeSkillList) do
+				local skillCfg = activeSkill.skillCfg
+				for _, buff in ipairs(activeSkill.buffList) do
+					if buff.type == "Buff" then
+						if env.mode_buffs and activeSkill.skillData.enable then
+							if buff.applyAllies then
+								modDB.conditions["AffectedBy"..buff.name:gsub(" ","")] = true
+							end
+							if env.minion and (env.minion == castingMinion or buff.applyAllies) then
+				 				env.minion.modDB.conditions["AffectedBy"..buff.name:gsub(" ","")] = true
+							end
+						end
+					elseif buff.type == "Debuff" then
+						if buff.stackVar then
+							buff.stackCount = modDB:Sum("BASE", skillCfg, "Multiplier:"..buff.stackVar)
+							if buff.stackLimit then
+								buff.stackCount = m_min(buff.stackCount, buff.stackLimit)
+							elseif buff.stackLimitVar then
+								buff.stackCount = m_min(buff.stackCount, modDB:Sum("BASE", skillCfg, "Multiplier:"..buff.stackLimitVar))
+							end
+						else
+							buff.stackCount = activeSkill.skillData.stackCount or 1
+						end
+						if env.mode_effective and buff.stackCount > 0 then
+							activeSkill.debuffSkill = true
+						end
+					end
+				end
+			end
+		end
+	end
+
+	--Compute buff, curse, aura and debuff effects.
 	for _, activeSkill in ipairs(env.player.activeSkillList) do
 		local skillModList = activeSkill.skillModList
 		local skillCfg = activeSkill.skillCfg
@@ -1777,21 +1882,14 @@ function calcs.perform(env, avoidCache)
 					local skillCfg = buff.activeSkillBuff and skillCfg
 					local modStore = buff.activeSkillBuff and skillModList or modDB
 				 	if not buff.applyNotPlayer then
-						activeSkill.buffSkill = true
-						modDB.conditions["AffectedBy"..buff.name:gsub(" ","")] = true
 						local srcList = new("ModList")
 						local inc = modStore:Sum("INC", skillCfg, "BuffEffect", "BuffEffectOnSelf", "BuffEffectOnPlayer") + skillModList:Sum("INC", skillCfg, buff.name:gsub(" ", "").."Effect")
 						local more = modStore:More(skillCfg, "BuffEffect", "BuffEffectOnSelf")
 						srcList:ScaleAddList(buff.modList, (1 + inc / 100) * more)
 						mergeBuff(srcList, buffs, buff.name)
 						mergeBuff(buff.unscalableModList, buffs, buff.name)
-						if activeSkill.skillData.thisIsNotABuff then
-							buffs[buff.name].notBuff = true
-						end
 					end
 					if env.minion and (buff.applyMinions or buff.applyAllies) then
-						activeSkill.minionBuffSkill = true
-						env.minion.modDB.conditions["AffectedBy"..buff.name:gsub(" ","")] = true
 						local srcList = new("ModList")
 						local inc = modStore:Sum("INC", skillCfg, "BuffEffect", "BuffEffectOnMinion") + env.minion.modDB:Sum("INC", nil, "BuffEffectOnSelf")
 						local more = modStore:More(skillCfg, "BuffEffect", "BuffEffectOnMinion") * env.minion.modDB:More(nil, "BuffEffectOnSelf")
@@ -1805,7 +1903,6 @@ function calcs.perform(env, avoidCache)
 					local skillCfg = buff.activeSkillBuff and skillCfg
 					local modStore = buff.activeSkillBuff and skillModList or modDB
 				 	if not buff.applyNotPlayer then
-						activeSkill.buffSkill = true
 						local srcList = new("ModList")
 						local inc = modStore:Sum("INC", skillCfg, "BuffEffect", "BuffEffectOnSelf", "BuffEffectOnPlayer")
 						local more = modStore:More(skillCfg, "BuffEffect", "BuffEffectOnSelf")
@@ -1832,12 +1929,6 @@ function calcs.perform(env, avoidCache)
 						end
 					end
 					if not activeSkill.skillData.auraCannotAffectSelf then
-						activeSkill.buffSkill = true
-						affectedByAura[env.player] = true
-						if buff.name:sub(1,4) == "Vaal" then
-							modDB.conditions["AffectedBy"..buff.name:sub(6):gsub(" ","")] = true
-						end
-						modDB.conditions["AffectedBy"..buff.name:gsub(" ","")] = true
 						local srcList = new("ModList")
 						local inc = skillModList:Sum("INC", skillCfg, "AuraEffect", "BuffEffect", "BuffEffectOnSelf", "AuraEffectOnSelf", "AuraBuffEffect", "SkillAuraEffectOnSelf")
 						local more = skillModList:More(skillCfg, "AuraEffect", "BuffEffect", "BuffEffectOnSelf", "AuraEffectOnSelf", "AuraBuffEffect", "SkillAuraEffectOnSelf")
@@ -1847,9 +1938,6 @@ function calcs.perform(env, avoidCache)
 						mergeBuff(srcList, buffs, buff.name)
 					end
 					if env.minion and not (modDB:Flag(nil, "SelfAurasCannotAffectAllies") or modDB:Flag(nil, "SelfAurasOnlyAffectYou") or modDB:Flag(nil, "SelfAuraSkillsCannotAffectAllies")) then
-						activeSkill.minionBuffSkill = true
-						affectedByAura[env.minion] = true
-						env.minion.modDB.conditions["AffectedBy"..buff.name:gsub(" ","")] = true
 						local srcList = new("ModList")
 						local inc = skillModList:Sum("INC", skillCfg, "AuraEffect", "BuffEffect") + env.minion.modDB:Sum("INC", nil, "BuffEffectOnSelf", "AuraEffectOnSelf")
 						local more = skillModList:More(skillCfg, "AuraEffect", "BuffEffect") * env.minion.modDB:More(nil, "BuffEffectOnSelf", "AuraEffectOnSelf")
@@ -1860,20 +1948,7 @@ function calcs.perform(env, avoidCache)
 					end
 				end
 			elseif buff.type == "Debuff" or buff.type == "AuraDebuff" then
-				local stackCount
-				if buff.stackVar then
-					stackCount = skillModList:Sum("BASE", skillCfg, "Multiplier:"..buff.stackVar)
-					if buff.stackLimit then
-						stackCount = m_min(stackCount, buff.stackLimit)
-					elseif buff.stackLimitVar then
-						stackCount = m_min(stackCount, skillModList:Sum("BASE", skillCfg, "Multiplier:"..buff.stackLimitVar))
-					end
-				else
-					stackCount = activeSkill.skillData.stackCount or 1
-				end
-				if env.mode_effective and stackCount > 0 then
-					activeSkill.debuffSkill = true
-					modDB.conditions["AffectedBy"..buff.name:gsub(" ","")] = true
+				if env.mode_effective and buff.stackCount > 0 then
 					local srcList = new("ModList")
 					local mult = 1
 					if buff.type == "AuraDebuff" then
@@ -1889,9 +1964,9 @@ function calcs.perform(env, avoidCache)
 						local more = skillModList:More(skillCfg, "DebuffEffect")
 						mult = (1 + inc / 100) * more
 					end
-					srcList:ScaleAddList(buff.modList, mult * stackCount)
+					srcList:ScaleAddList(buff.modList, mult * buff.stackCount)
 					if activeSkill.skillData.stackCount or buff.stackVar then
-						srcList:NewMod("Multiplier:"..buff.name.."Stack", "BASE", stackCount, buff.name)
+						srcList:NewMod("Multiplier:"..buff.name.."Stack", "BASE", buff.stackCount, buff.name)
 					end
 					mergeBuff(srcList, debuffs, buff.name)
 				end
@@ -1953,7 +2028,6 @@ function calcs.perform(env, avoidCache)
 							local skillCfg = buff.activeSkillBuff and skillCfg
 							local modStore = buff.activeSkillBuff and skillModList or castingMinion.modDB
 							if buff.applyAllies then
-								modDB.conditions["AffectedBy"..buff.name:gsub(" ","")] = true
 								local srcList = new("ModList")
 								local inc = modStore:Sum("INC", skillCfg, "BuffEffect") + modDB:Sum("INC", nil, "BuffEffectOnSelf")
 								local more = modStore:More(skillCfg, "BuffEffect") * modDB:More(nil, "BuffEffectOnSelf")
@@ -1962,7 +2036,6 @@ function calcs.perform(env, avoidCache)
 								mergeBuff(buff.unscalableModList, buffs, buff.name)
 							end
 							if env.minion and (env.minion == castingMinion or buff.applyAllies) then
-				 				env.minion.modDB.conditions["AffectedBy"..buff.name:gsub(" ","")] = true
 								local srcList = new("ModList")
 								local inc = modStore:Sum("INC", skillCfg, "BuffEffect", "BuffEffectOnSelf")
 								local more = modStore:More(skillCfg, "BuffEffect", "BuffEffectOnSelf")
@@ -2001,21 +2074,9 @@ function calcs.perform(env, avoidCache)
 							t_insert(minionCurses, curse)
 						end
 					elseif buff.type == "Debuff" then
-						local stackCount
-						if buff.stackVar then
-							stackCount = modDB:Sum("BASE", skillCfg, "Multiplier:"..buff.stackVar)
-							if buff.stackLimit then
-								stackCount = m_min(stackCount, buff.stackLimit)
-							elseif buff.stackLimitVar then
-								stackCount = m_min(stackCount, modDB:Sum("BASE", skillCfg, "Multiplier:"..buff.stackLimitVar))
-							end
-						else
-							stackCount = activeSkill.skillData.stackCount or 1
-						end
-						if env.mode_effective and stackCount > 0 then
-							activeSkill.debuffSkill = true
+						if env.mode_effective and buff.stackCount > 0 then
 							local srcList = new("ModList")
-							srcList:ScaleAddList(buff.modList, stackCount)
+							srcList:ScaleAddList(buff.modList, buff.stackCount)
 							if activeSkill.skillData.stackCount then
 								srcList:NewMod("Multiplier:"..buff.name.."Stack", "BASE", activeSkill.skillData.stackCount, buff.name)
 							end


### PR DESCRIPTION
Fixes #4388.

Sorry for the second pull request I couldn't figure out how to fix the other one.

### Description of the problem being solved:
When calculating effect to apply to buffs we add affected by tags at the same time this means if a mod gives effect while under affect it is likely it will be missed.

This was solved by splitting it into two parses first we apply all the tags then we apply the effect and add the buffs.
### Steps taken to verify a working solution:
- Hovering over the total more now correctly shows 36% more spell damage.

### Link to a build that showcases this PR:
https://poe.ninja/pob/Bkm

Problematic Mod
![image](https://user-images.githubusercontent.com/31533893/178091371-86f87c0a-adb7-45bf-b8f2-a79e37558e06.png)

### Before screenshot:
![image](https://user-images.githubusercontent.com/31533893/178091206-4308bccd-e595-4b53-a389-3e533c508e54.png)

### After screenshot:
![image](https://user-images.githubusercontent.com/31533893/178091156-78d643e2-63a3-46c9-9a50-6205e2b915b1.png)