### PR TITLE
Add support for ailment immunity mod on timeless jewels

### DIFF
--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -2382,10 +2382,10 @@ local specialModList = {
 		mod("BrittleAsThoughDealing", "MORE", num),
 		mod("SapAsThoughDealing", "MORE", num),
 	} end,
-	["immune to elemental ailments while on consecrated ground if you have at least 150 devotion"] = function()
+	["immune to elemental ailments while on consecrated ground if you have at least (%d+) devotion"] = function(num)
 		local mods = { }
 		for i, ailment in ipairs(data.elementalAilmentTypeList) do
-			mods[i] = mod("Avoid"..ailment, "BASE", 100, { type = "Condition", var = "OnConsecratedGround" })
+			mods[i] = mod("Avoid"..ailment, "BASE", 100, { type = "Condition", var = "OnConsecratedGround" }, { type = "StatThreshold", stat = "Devotion", threshold = num })
 		end
 		return mods
 	end,

--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -2382,6 +2382,13 @@ local specialModList = {
 		mod("BrittleAsThoughDealing", "MORE", num),
 		mod("SapAsThoughDealing", "MORE", num),
 	} end,
+	["immune to elemental ailments while on consecrated ground if you have at least 150 devotion"] = function()
+		local mods = { }
+		for i, ailment in ipairs(data.elementalAilmentTypeList) do
+			mods[i] = mod("Avoid"..ailment, "BASE", 100, { type = "Condition", var = "OnConsecratedGround" })
+		end
+		return mods
+	end,
 	["freeze chilled enemies as though dealing (%d+)%% more damage"] = function(num) return { mod("FreezeAsThoughDealing", "MORE", num, { type = "ActorCondition", actor = "enemy", var = "Chilled" } ) } end,
 	["(%d+)%% chance to shock attackers for (%d+) seconds on block"] = { mod("ShockBase", "BASE", data.nonDamagingAilment["Shock"].default) },
 	["shock attackers for (%d+) seconds on block"]  = {


### PR DESCRIPTION
### Description of the problem being solved:
Ailment immunity after getting the devotion threshold wasn't supported
### Steps taken to verify a working solution:
- Added a timeless jewel with that node to the build
- Noted that the mod wasn't supported

### Link to a build that showcases this PR:
```bash
eNqtW-tz2kgS_xz-iimutuq2Ftt6I7z2bmGMH2vsOICT27q6co3FAEpGM4o0skOu_L9fjx4gMI9BvnwgQupfd09Pv6ZlTv78EVD0TKLY5-y0rh9qdUSYx0c-m5zWH4YXB279zz9qJ_dYTD-OzxKfyid_1D6cpNeIkmdCAVdHAkcTIj4XnMxH4BRiJqaEs1v8lUeXfHRav-OM1NETZiNfFN88iuP4DgfktD7wAFxHOPYIG3UW9zPCAPtswL1vRFxGPAlTsc8-ebnlI6C5vr3_2B-WhPqsLBR0_nByT_GMRAOBBYrh47TehqXjCTnHAXwCN0wTYGUf2k3DcO2mbsnP-tF68CAkZDQH6YfGJsL7iHTHY-IJ_5l0Il90pph5C3HaJty-tLcJFX5IfRKVtLI3Ia7eMG-1NtEOucD0_H4wJ3UOHddpWrmRduC42K3_F19MzygYtIIUib2eMF-QiuB77secvWN9ZejmLUoohehRo-XBk88qWeMWM9zhsYLNe_6YqFF2B2p0fQgjNUqp5T2JINCFurJ7AXIJA-JxSCb7yNgHUlpHNWEVkN1BFUAFQQOxyCTWxkRyTn7MqYyNvK6ZUKA6J89cpEWgSGBNbWvwda_u57QMs40peDqLfQ_TW_zDD5IAct8QfyMlMZa7ZaMmU8EgcjeBW86hrpluy8k-N_G58CPyThYdTkfvZTHFPN7Iw9hcL6S_lu21pSx6x5L4mnkL-q1sH1hEYhI9l8vpZgES0QcvlrX7iRJVyEJIHgwLoKZtlzUpmcg9dLeK6RHiTS-hVeljQdTyxyLDW1uNKmnLRjXcbVzXGHUz_2XAHgaSwGUD6fahuY16TwN9wdFIIcMxEk1mg6lP6J7UuSfNOjhUSIhyG8ro8nYoiivbSgmyp8G6zzheyqDO9tVk5EoLuSXQoQFgRFTb0vuIf5WNL90P1o4Cnixqj719QzJqpRUUdSDr-PtklHhL5aa1EXlG4eihqj-oReleiLYQ2Pt2zkcTspeQ_RGDJAwh0OWmq-Jk5eqT2C_1DAe2tZv6IwSWUlzJuqYuYEGtLGBew9WlrEDU1yIL7KoYR4VcWcT8NHkLqSuATJ0eReEcvAj6jZsDhxClE8g9fwFtpvJYH-9HDc3FHLCxElxEhP2cKfNfIlcS0GWjJJLurSxjFbFOzNAPIAfG8TkWGH0lL4QOZyHp4Sc5Brn1qS8wE-gCw6Gynj3PJhY5xT_QdcQZ-uJTeowcw9SWiK5HUKJXb96QWSw4kxOOAlpfSM7mI4IEIcXRCrMf6YQkJjjypj1wrzndI4POGTqnRzgJxMSLoKyMHicRT9joEftUOlTcQBH5nkAkjxooHQsB7feERDwqLficRzPMfPTPDo-iJAQ2aMAT-usKtVyXXlJafs_C7uQonSPJq-sg5JFIb3Yw9eLU3NcsTARi6SIDP_Yen5LxWM57YF0iSodU3YuLbmd4_bmb71AZEn8Daz2yJHiSI5Hs_0VsDEia-0FXSnEYE9CK-WBcHy4GEjmArfaEAjX00fkIaTct9DNe5IM_7iaVgxMFVdMx1G46OSFSIIN9wJSomkhupwyhWM1KecHZTZuOghTossmNyrLS-ZCK0YmHZwp0865MgbZLSTuPKwXqW3D0LMOrUEPjEPlPiVDyqPQMp6CBPJQoLKvcdCt5vgpZ3vspiM8b3d2UeTVWcTvInYpbdE7GBJxZKZDT5JAdtbO0V6S4kzSKYhRD7rskQXw2g-J8IQ26MgMMsAB3I0FPTtyHXJYo7AkS9bIJ_BjTWCbFMhvI91ECN0dkjBMq739KMFSomayBpbs5i1TbeMpfZIOY8ZHRHcOO9HrZkzYVOQsppJCarmgYEYJw2pTInlxm2cws8KU80Je5X5PLiUH5We7mp3XIzpDVYzlmMvVmw7JdzWzoTrNpN2y7pTkNw2laWkM3mprRcMxW0wEax9Uahus23Yasmg295WithiGnowAym2bDbpkSqrfg2rQMDRg3Td2Aa7ulNyynpWtwLWksR9f1hmlazVZDd00bPs2mC6JszbQapqtZbsN2XROU0qyWBvxdx4FPy7VBNRAMcg2zCU8B3DCNlqY39CboXEcCLFN6L6K7-SuPzBLSSB9OHvq99OLDVIgwPj46enl5OQyxmPIx-QGHp0OPB0chgMC8B2lVO5Bsj9rw72zSbl9H3Ys4EWfTVujjq08_2DPjMTt7-Tmdfhn-Rb95YnpnO-Fn_e8v4-Suc3XV9A6mkxvtyupd9Zuerj9bN_SmzQ8Ed4yeHj5c3ny-oR_b04eHGxBxmip5VGh5knUYcaZy_i3dwEUHA8k2yOr-UYY5KoHgC7hFGgjSb-TFHYcMJp_Jm8WX1Ks---Ql72IGIpKu8pPz4O_TumEfupaVeeYVweIWh7kXS4Lcq53cp6FGnfvgbVEas0VoSMJ_wa60DsEtMke-BsXj3JPl9YCItHtJYpKNTr8QHHKW3pbCsqYDCKFVjHzo_rL3Utk1BEw6-0qzwNJtA76b2e734aaYHaOHu-tPD93acheJ_g3uaf2OzN8XreN_akUbiv6SPVWtR_AkIceoRybgZbXPmZRj1Jbyknhx45wHPivfgB53hWTI5VqyjLW4ewaN8ejNXVnOGUnfarx51o4IfnMTCqGsgphueZIla9knlLTKEgXiY3AzdpCCpdCiqq7jkz9D59DUiyWzFHcku04SxWVBtz6TT7LjOJKL7kCqQmmTtUoVo7bnAS9vhvrAkE3KdmUYpbOexb001SM5eV_cu4PVpCqgNjDKl1nSNK8xaBzxAGWVtpa1pdBrz8n0VYe4wqAbFQsK6e4L4NIj3V4lR8MXvgWSPdbNWhpiffL9GBlarY9H4Efgg_LsVOv5gS9hQlLWoKekvucLeKzV_psHwbH-2sFy2ghEaEJ55I9nSDo7YhDwY-n844TKkwQciyWvpxm6gjM5GmanmLl3zxka72RYRMecoflOhvPomnO0Xq1fkM88CA5oEZaCDYUkQrqGilcgC5C9DCrH4maQ81qOzrzNGBEIjCVmu9g0l2WXonozxl3GrAb9ZmDr9TfjF2lsDIGyNiNsxuraq7kkdXvGQBDk0L8G_laeulxJJKeES-tYTS2S2YwnWxgZZUZv889uBuarXl7dtjS1hYv1WmSuKX4m6DdHk9ZeyWJb8PZrmtOIHBkg7dDJ8pykz2rjFqgjF1BYQCZBufrcLTejmsvLJvNNXU6c21i4y36xnFK73xM_DOXcIs2tb9jcZz1XDAxQlGY4hCMC-qfjjSzkxZQUER_XrsBTIVF4aZcj24J5fwAdw8YmIu8P8u6K8mKAkZEhffCCQ9R-msUxeF_eb9mLJksrmqw10FWYoQbbTnXGOYRQNYXWrWWHUmcEqs9-kAtosb8hU0klY51KZjXzqhnB-D_BrGpKOtWkOdWtWcWfduzAFYEkLPYVtMaTnCpydrjfJeXPcua8P2OzehTpVeRZ1XxBr-Z51u7tUTHsvmzXuVfFhSvlHbuCPhVyoLlLzGiGsnHantu33sqV_MuuAlIKSZWNqLROu7JZjQr77lSLJLOa-5r7e5lVPe1X8Gm9svFNFYewVIgqqP2O5kdxJ6vvglPBK6tvwzvcRTUlS6xi1KiTVrBcX56WjCopxqhs3orpQn0_qyzHVLCTXn0brMrWsqusRiVeqjv5DpXaQULX1LbsMAkHxnRqng6p01flnI39yZsX36s_gli8Lk9_DPH2Tbk8k_ryxPuRdRZ_FHCZ_k1AHT1xTglm-dT8aLO4_IceO8VlvwBZS3ZPsUemnI7gJJ4RE0aCWf5ji-IdfrP8F4nr6OXb7uJnHQXIVMAUfxJVYOzihV1u6JOj1d_C_A9sNUIp
```
### Before screenshot:
![image](https://user-images.githubusercontent.com/1209372/178223613-8dc2745e-daf3-4ad8-9d22-2f5c32caa0d4.png)

### After screenshot:
![image](https://user-images.githubusercontent.com/1209372/178224133-7858fc75-a035-4e3f-a509-64f0a14e3f3a.png)
