### PR TITLE
Fix undo resetting active display group

### DIFF
--- a/src/Classes/SkillsTab.lua
+++ b/src/Classes/SkillsTab.lua
@@ -1168,7 +1168,7 @@ function SkillsTabClass:CreateUndoState()
 	local state = { }
 	state.activeSkillSetId = self.activeSkillSetId
 	state.skillSets = {}
-	for _, skillSet in ipairs(self.skillSets) do
+	for skillSetIndex, skillSet in pairs(self.skillSets) do
 		local newSkillSet = copyTable(skillSet, true)
 		newSkillSet.socketGroupList = { }
 		for socketGroupIndex, socketGroup in pairs(skillSet.socketGroupList) do
@@ -1177,15 +1177,16 @@ function SkillsTabClass:CreateUndoState()
 			for gemIndex, gem in pairs(socketGroup.gemList) do
 				newGroup.gemList[gemIndex] = copyTable(gem, true)
 			end
-			t_insert(newSkillSet.socketGroupList, newGroup)
+			newSkillSet.socketGroupList[socketGroupIndex] = newGroup
 		end
-		t_insert(state.skillSets, newSkillSet)
+		state.skillSets[skillSetIndex] = newSkillSet
 	end
 	state.skillSetOrderList = copyTable(self.skillSetOrderList)
 	return state
 end
 
 function SkillsTabClass:RestoreUndoState(state)
+	local displayId = isValueInArray(self.socketGroupList, self.displayGroup)
 	wipeTable(self.skillSets)
 	for k, v in pairs(state.skillSets) do
 		self.skillSets[k] = v
@@ -1195,7 +1196,6 @@ function SkillsTabClass:RestoreUndoState(state)
 		self.skillSetOrderList[k] = v
 	end
 	self:SetActiveSkillSet(state.activeSkillSetId)
-	local displayId = isValueInArray(self.socketGroupList, self.displayGroup)
 	self:SetDisplayGroup(displayId and self.socketGroupList[displayId])
 	if self.controls.groupList.selValue then
 		self.controls.groupList.selValue = self.socketGroupList[self.controls.groupList.selIndex]


### PR DESCRIPTION
- Properly create undo state while 100% preserving same indices
  (probably unnecessary but I noticed that I was relying on ordered
  index)
- Move getting displayId from displayGroup at start of restore undo
  method (like before) so it can get the position before the values are
  replaced and instance comparison is no longer possible. Without this
  change display group always resets on undo

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>

### Steps to reproduce

- Add random gem to new socket group
- Add another random gem
- Undo
- Display group is reset

This PR fixes the last part.