### PR TITLE
Fix saving of section/subsection collapsing in calcs

### DIFF
--- a/src/Classes/CalcSectionControl.lua
+++ b/src/Classes/CalcSectionControl.lua
@@ -17,8 +17,10 @@ local CalcSectionClass = newClass("CalcSectionControl", "Control", "ControlHost"
 	self.flag = subSection[1].data.flag
 	self.notFlag = subSection[1].data.notFlag
 	self.updateFunc = updateFunc
-	
+
 	for i, subSec in ipairs(self.subSection) do
+		subSec.id = subSec.label:gsub("%W", "")
+
 		for _, data in ipairs(subSec.data) do
 			for _, colData in ipairs(data) do
 				if colData.control then
@@ -134,7 +136,7 @@ function CalcSectionClass:UpdateSize()
 end
 
 function CalcSectionClass:UpdatePos()
-	if self.subSection[1].collapsed or not self.enabled then
+	if not self.enabled then
 		return
 	end
 	local x, y = self:GetPos()

--- a/src/Classes/CalcsTab.lua
+++ b/src/Classes/CalcsTab.lua
@@ -174,8 +174,13 @@ function CalcsTabClass:Load(xml, dbFileName)
 					return true
 				end
 				for _, section in ipairs(self.sectionList) do
-					if section.id == node.attrib.id then
-						section.collapsed = (node.attrib.collapsed == "true")
+					if section.id == node.attrib.id and node.attrib.subsection then
+						for _, subsection in ipairs(section.subSection) do
+							if subsection.id == node.attrib.subsection then
+								subsection.collapsed = node.attrib.collapsed == "true"
+								break
+							end
+						end
 						break
 					end
 				end
@@ -198,10 +203,13 @@ function CalcsTabClass:Save(xml)
 		t_insert(xml, child)
 	end
 	for _, section in ipairs(self.sectionList) do
-		t_insert(xml, { elem = "Section", attrib = {
-			id = section.id,
-			collapsed = tostring(section.collapsed),
-		} })
+		for _, subSection in ipairs(section.subSection) do
+			t_insert(xml, { elem = "Section", attrib = {
+				id = section.id,
+				subsection = subSection.id,
+				collapsed = tostring(subSection.collapsed),
+			} })
+		end
 	end
 	self.modFlag = false
 end


### PR DESCRIPTION
This fixes loading and saving of collapse state for sections/subsections
in calcs. I assume at some point collapsing for subsections was added
but the loading/saving code was never adjusted.

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>

### Before screenshot:

![image](https://user-images.githubusercontent.com/5115805/178360946-d5a4ba51-7070-4485-899e-702ed53bb753.png)


### After screenshot:

![image](https://user-images.githubusercontent.com/5115805/178373500-4a7ebbd7-9be9-47f7-a211-15572287171b.png)

### Example pob

https://pastebin.com/Mb2wy4hX

### Subsection storage format

```xml
  <Calcs>
    <Input number="2" name="skill_number"/>
    <Input string="EFFECTIVE" name="misc_buffMode"/>
    <Section id="SkillSelect" subsection="ViewSkillDetails" collapsed="false"/>
    <Section id="HitDamage" subsection="SkillHitDamage" collapsed="true"/>
    <Section id="Warcries" subsection="ExertingWarcries" collapsed="false"/>
    <Section id="Dot" subsection="SkillDamageoverTime" collapsed="false"/>
    <Section id="Speed" subsection="AttackCastRate" collapsed="false"/>
    <Section id="Crit" subsection="Crits" collapsed="true"/>
    <Section id="Impale" subsection="Impale" collapsed="false"/>
    <Section id="SkillTypeStats" subsection="SkilltypespecificStats" collapsed="false"/>
    <Section id="HitChance" subsection="Accuracy" collapsed="false"/>
    <Section id="Bleed" subsection="Bleed" collapsed="false"/>
    <Section id="Poison" subsection="Poison" collapsed="false"/>
    <Section id="Ignite" subsection="Ignite" collapsed="false"/>
    <Section id="Decay" subsection="Decay" collapsed="false"/>
    <Section id="LeechGain" subsection="LeechGainonHit" collapsed="false"/>
    <Section id="EleAilments" subsection="NonDamagingAilments" collapsed="true"/>
    <Section id="MiscEffects" subsection="OtherEffects" collapsed="true"/>
    <Section id="Attributes" subsection="Attributes" collapsed="false"/>
    <Section id="Life" subsection="Life" collapsed="false"/>
    <Section id="Mana" subsection="Mana" collapsed="true"/>
    <Section id="EnergyShield" subsection="EnergyShield" collapsed="true"/>
    <Section id="Ward" subsection="Ward" collapsed="true"/>
    <Section id="Armour" subsection="Armour" collapsed="true"/>
    <Section id="Evasion" subsection="Evasion" collapsed="true"/>
    <Section id="Resist" subsection="Resists" collapsed="false"/>
    <Section id="Block" subsection="Block" collapsed="true"/>
    <Section id="Block" subsection="GainonBlock" collapsed="true"/>
    <Section id="MiscDefences" subsection="OtherDefences" collapsed="false"/>
    <Section id="MiscDefences" subsection="DamageAvoidance" collapsed="true"/>
    <Section id="MiscDefences" subsection="OtherAvoidance" collapsed="true"/>
    <Section id="MiscDefences" subsection="OtherAilmentDefences" collapsed="true"/>
    <Section id="MiscDefences" subsection="Dodge" collapsed="true"/>
    <Section id="MiscDefences" subsection="SpellSuppression" collapsed="false"/>
    <Section id="DamageTaken" subsection="DamageTaken" collapsed="false"/>
    <Section id="DamageTaken" subsection="DamagingHits" collapsed="false"/>
    <Section id="DamageTaken" subsection="EffectiveHealthPool" collapsed="true"/>
    <Section id="DamageTaken" subsection="MaximumHitTaken" collapsed="false"/>
    <Section id="DamageTaken" subsection="DotsandDegens" collapsed="true"/>
  </Calcs>
```