### PR TITLE
Automate installer upload

### DIFF
--- a/.github/workflows/installer.yml
+++ b/.github/workflows/installer.yml
@@ -1,0 +1,18 @@
+name: Create new installer
+on:
+  release:
+    types: [published]
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+            - name: Checkout
+              uses: actions/checkout@v3
+              with:
+                repository: 'https://github.com/PathOfBuildingCommunity/PathOfBuilding-Installer'
+                ref: 'master'
+            - name: Create installer
+              run: 'python3 make_release.py'
+            - name: Upload artifact
+              run: 'gh release upload ${{ github.event.release.tag_name }} Dist/* --clobber'
+

--- a/.github/workflows/installer.yml
+++ b/.github/workflows/installer.yml
@@ -4,15 +4,18 @@ on:
     types: [published]
 jobs:
   release:
-    runs-on: ubuntu-latest
+    runs-on: windows-latest
     steps:
             - name: Checkout
               uses: actions/checkout@v3
               with:
-                repository: 'https://github.com/PathOfBuildingCommunity/PathOfBuilding-Installer'
+                repository: 'PathOfBuildingCommunity/PathOfBuilding-Installer'
                 ref: 'master'
+                ssh-key: '${{ secrets.POB_INSTALLER_KEY }}'
             - name: Create installer
               run: 'python3 make_release.py'
             - name: Upload artifact
-              run: 'gh release upload ${{ github.event.release.tag_name }} Dist/* --clobber'
+              run: >
+              echo "${{ secrets.GITHUB_TOKEN }}" | gh auth login --with-token;
+              gh release upload ${{ github.event.release.tag_name }} (Get-ChildItem Dist -File).FullName --clobber -R ${{ github.repository }};
 


### PR DESCRIPTION
Fixes #4456 .

### Description of the problem being solved:
The PoB standalone file and installer have to be manually created and uploaded to each release by a maintainer.  This isn't always consistent because it's a manual action.  This PR does all that through GitHub Actions
### Steps taken to verify a working solution:
- Ran a successful build on my personal repo: https://github.com/Wires77/PathOfBuilding/runs/7293463450?check_suite_focus=true
- Validated that the files appeared as expected here: https://github.com/Wires77/PathOfBuilding/releases/tag/powershell