### PR TITLE
Remove invalid Lua pattern text

### DIFF
--- a/src/Classes/TreeTab.lua
+++ b/src/Classes/TreeTab.lua
@@ -1144,7 +1144,7 @@ function TreeTabClass:FindTimelessJewel()
 			timelessData.sharedResults.socket = timelessData.jewelSocket
 			timelessData.sharedResults.desiredNodes = desiredNodes
 			local function formatSearchValue(input)
-				local matchPattern = "[%.| ]0"
+				local matchPattern = "[. ]0"
 				local replacePattern = { [" 0"] = "   ", [".0"] = "   " }
 				return (" " .. s_format("%0006.1f", input)):gsub(matchPattern, replacePattern):gsub(matchPattern, replacePattern):gsub(matchPattern, replacePattern)
 			end


### PR DESCRIPTION
Extremely minor technical fix.

``[%.| ]`` to ``[. ]`` -- the period doesn't need to be escaped inside a set and the pipe character is just invalid here (I was thinking of alternation from regex and could have sworn I read it was valid syntax somewhere, but apparently this doesn't actually exist in Lua patterns).

https://gitspartv.github.io/lua-patterns/?pattern=%5B%25.%7C%20%5D

https://gitspartv.github.io/lua-patterns/?pattern=%5B.%20%5D