### PR TITLE
Fix auras disabling due to multiple iterations of reservation calculations

### DIFF
--- a/src/Modules/CalcPerform.lua
+++ b/src/Modules/CalcPerform.lua
@@ -1598,7 +1598,7 @@ function calcs.perform(env, avoidCache)
 				end
 				if values.reservedPercent ~= 0 then
 					activeSkill.skillData[name.."ReservedPercent"] = values.reservedPercent
-					activeSkill.skillData[name.."ReservedBase"] = (activeSkill.skillData[name.."ReservedBase"] or 0) + m_ceil(output[name] * values.reservedPercent / 100)
+					activeSkill.skillData[name.."ReservedBase"] = (values.reservedFlat or 0) + m_ceil(output[name] * values.reservedPercent / 100)
 					env.player["reserved_"..name.."Percent"] = env.player["reserved_"..name.."Percent"] + values.reservedPercent
 					if breakdown then
 						t_insert(breakdown[name.."Reserved"].reservations, {


### PR DESCRIPTION
### Description of the problem being solved:
Auras disable sometimes due to multiple iterations of reservation calculations
As reserve base is calculated with reference to the previous reserve base calculation it grows until the aura gets disabled. This changes it to use the currently calculated flat resource to reserve.
### Steps taken to verify a working solution:
- Toggling supreme ego now correctly shows dps increase not decrease.
-  Looking at variables they do not grow on iterations.

### Link to a build that showcases this PR:
https://pobb.in/yyfVaqMYkCpz
### Before screenshot:
![image](https://user-images.githubusercontent.com/31533893/178630122-e00fa463-e155-463e-81fb-5f7d67216663.png)

### After screenshot:
![image](https://user-images.githubusercontent.com/31533893/178630143-38d04b35-a889-463c-9e20-3182a7d3052c.png)
