### PR TITLE
Add reservation scaling with stages for blood sacrament

### DIFF
--- a/src/Modules/CalcPerform.lua
+++ b/src/Modules/CalcPerform.lua
@@ -1581,6 +1581,10 @@ function calcs.perform(env, avoidCache)
 					values.reservedFlat = values.reservedFlat * activeSkill.activeMineCount
 					values.reservedPercent = values.reservedPercent * activeSkill.activeMineCount
 				end
+				if activeSkill.activeStageCount then
+					values.reservedFlat = values.reservedFlat * (activeSkill.activeStageCount + 1)
+					values.reservedPercent = values.reservedPercent * (activeSkill.activeStageCount + 1)
+				end
 				if values.reservedFlat ~= 0 then
 					activeSkill.skillData[name.."ReservedBase"] = values.reservedFlat
 					env.player["reserved_"..name.."Base"] = env.player["reserved_"..name.."Base"] + values.reservedFlat


### PR DESCRIPTION
### Description of the problem being solved:
Increasing the stages of blood sacrament doesn't increase the life reserved.

### Steps taken to verify a working solution:
- Increasing the stages increases the reservation.

### Link to a build that showcases this PR:
https://poe.ninja/pob/Bvt

### Before screenshot:
![image](https://user-images.githubusercontent.com/31533893/178642816-02fb44eb-2dbc-4a17-b533-c8bca440f305.png)

### After screenshot:
![image](https://user-images.githubusercontent.com/31533893/178642786-2d56653d-af81-4545-abd4-bc1e5ff29c13.png)
