### PR TITLE
Remove leftover skillSet field on Skill when saving to XML

### DIFF
--- a/src/Classes/SkillsTab.lua
+++ b/src/Classes/SkillsTab.lua
@@ -385,7 +385,6 @@ function SkillsTabClass:Save(xml)
 				source = socketGroup.source,
 				mainActiveSkill = tostring(socketGroup.mainActiveSkill),
 				mainActiveSkillCalcs = tostring(socketGroup.mainActiveSkillCalcs),
-				skillSet = tostring(socketGroup.skillSet)
 			} }
 			for _, gemInstance in ipairs(socketGroup.gemList) do
 				t_insert(node, { elem = "Gem", attrib = {


### PR DESCRIPTION
This is leftover from the original format where skillSet was saved on
Skill instead of being wrapped in SkillSet

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>