### PR TITLE
Cap enemyLevel to level 85 properly

### DIFF
--- a/src/Modules/CalcSetup.lua
+++ b/src/Modules/CalcSetup.lua
@@ -290,7 +290,7 @@ function calcs.initEnv(build, mode, override, specEnv)
 		env.enemyDB = enemyDB
 		env.itemModDB = new("ModDB")
 
-		env.enemyLevel = m_max(1, m_min(100, env.configInput.enemyLevel and env.configInput.enemyLevel or env.configPlaceholder["enemyLevel"] or m_min(env.build.characterLevel, data.misc.MaxEnemyLevel)))
+		env.enemyLevel = m_max(1, m_min(data.misc.MaxEnemyLevel, env.configInput.enemyLevel and env.configInput.enemyLevel or env.configPlaceholder["enemyLevel"] or env.build.characterLevel))
 
 		-- Create player/enemy actors
 		env.player = {


### PR DESCRIPTION
When calculating ailment thresholds, enemy level was going out of
constraints of the table and that caused issues. The tables only go to
level 90 but over level 85 is unreasonable anyway so lets just reuse
same cap as for character level -> enemy level.

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>

### Steps taken to verify a working solution:
- Set enemy level to above 90
- Do not see any exceptions anymore

![image](https://user-images.githubusercontent.com/5115805/178693051-6218183d-2e63-4594-baed-fc15b3ccb2a2.png)
