### PR TITLE
Skip invalid nodeIDs for Glorious Vanity

### DIFF
--- a/src/Modules/Data.lua
+++ b/src/Modules/Data.lua
@@ -685,7 +685,7 @@ data.readLUT = function(seed, nodeID, jewelType)
 				result[i] = data.timelessJewelLUTs[jewelType].data[index + 1][seedOffset + 1]:byte(i)
 			end
 			return result
-		else
+		elseif index <= data.nodeIDList["sizeNotable"] then
 			return { data.timelessJewelLUTs[jewelType].data:byte(index * seedSize + seedOffset + 1) }
 		end
 	else

--- a/src/Modules/Data.lua
+++ b/src/Modules/Data.lua
@@ -550,12 +550,21 @@ end
 -- lazy load a specific timeless jewel type
 -- valid values: "Glorious Vanity", "Lethal Pride", "Brutal Restraint", "Militant Faith", "Elegant Hubris"
 local function loadTimelessJewel(jewelType, nodeID)
-	local nodeIndex = data.nodeIDList[nodeID] and data.nodeIDList[nodeID].index or nil
-	-- if already loaded, return
-	if data.timelessJewelLUTs[jewelType] and ((jewelType == 1 and data.timelessJewelLUTs[jewelType].data[nodeIndex + 1].raw == nil) or (jewelType ~= 1 and data.timelessJewelLUTs[jewelType].data)) then return end
+	local nodeIndex = nil
+	if nodeID and data.nodeIDList[nodeID] then
+		nodeIndex = data.nodeIDList[nodeID].index
+	end
+	-- for GV, if nodeIndex is invalid, return
+	if jewelType == 1 and nodeIndex == nil then
+		return
+	end
+	-- if LUT is already loaded, and this either isn't GV, or GV has already emptied it's raw data out, return
+	if data.timelessJewelLUTs[jewelType] and data.timelessJewelLUTs[jewelType].data and (jewelType ~= 1 or data.timelessJewelLUTs[jewelType].data[nodeIndex + 1].raw == nil) then
+		return
+	end
 
 	if jewelType == 1 then
-		--if data is already loaded but table for specific node is not created, just make table and return
+		-- if data is already loaded but table for specific node is not created, just make table and return
 		if data.timelessJewelLUTs[jewelType] and data.timelessJewelLUTs[jewelType].data[nodeIndex + 1] and data.timelessJewelLUTs[jewelType].data[nodeIndex + 1].raw then
 			local jewelData = data.timelessJewelLUTs[jewelType].data[nodeIndex + 1].raw
 			local seedSize = data.timelessJewelSeedMax[1] - data.timelessJewelSeedMin[1] + 1


### PR DESCRIPTION
Fixes #4562. Node IDs need to be validated before ``loadTimelessJewel(...)`` attempts to do anything with them for Glorious Vanity.

### Description of the problem being solved:
![](https://user-images.githubusercontent.com/18443616/178766532-0970b270-e53a-4b5a-9986-776eccfd3d52.png)

### Link to a build that showcases this PR:
https://pastebin.com/ATj6THEm