### PR TITLE
Skip writing uncompressedFile if denied access, and skip reading changelog.txt if it doesn't exist

### DIFF
--- a/src/Modules/Data.lua
+++ b/src/Modules/Data.lua
@@ -541,8 +541,10 @@ local function loadJewelFile(jewelTypeName)
 		ConPrintf("Failed to load either file: " .. jewelTypeName .. ".zip, " .. jewelTypeName .. ".bin")
 	else
 		local uncompressedFile = io.open(scriptPath .. jewelTypeName .. ".bin", "wb+")
-		uncompressedFile:write(jewelData)
-		uncompressedFile:close()
+		if uncompressedFile then
+			uncompressedFile:write(jewelData)
+			uncompressedFile:close()
+		end
 	end
 	return jewelData
 end

--- a/src/Modules/Data.lua
+++ b/src/Modules/Data.lua
@@ -521,7 +521,7 @@ local function loadJewelFile(jewelTypeName)
 		local uncompressedFile = io.open(scriptPath .. jewelTypeName .. ".bin", "rb")
 		if uncompressedFile then
 			jewelData = uncompressedFile:read("*a")
-			uncompressedFile.close()
+			uncompressedFile:close()
 		end
 		if jewelData then
 			return jewelData

--- a/src/Modules/Main.lua
+++ b/src/Modules/Main.lua
@@ -818,18 +818,22 @@ end
 function main:OpenUpdatePopup()
 	local changeList = { }
 	local changelogName = launch.devMode and "../changelog.txt" or "changelog.txt"
-	for line in io.lines(changelogName) do
-		local ver, date = line:match("^VERSION%[(.+)%]%[(.+)%]$")
-		if ver then
-			if ver == launch.versionNumber then
-				break
+	local changelogFile = io.open(changelogName, "r")
+	if changelogFile then
+		changelogFile:close()
+		for line in io.lines(changelogName) do
+			local ver, date = line:match("^VERSION%[(.+)%]%[(.+)%]$")
+			if ver then
+				if ver == launch.versionNumber then
+					break
+				end
+				if #changeList > 0 then
+					t_insert(changeList, { height = 12 })
+				end
+				t_insert(changeList, { height = 20, "^7Version "..ver.." ("..date..")" })
+			else
+				t_insert(changeList, { height = 14, "^7"..line })
 			end
-			if #changeList > 0 then
-				t_insert(changeList, { height = 12 })
-			end
-			t_insert(changeList, { height = 20, "^7Version "..ver.." ("..date..")" })
-		else
-			t_insert(changeList, { height = 14, "^7"..line })
 		end
 	end
 	local controls = { }
@@ -850,24 +854,28 @@ end
 function main:OpenAboutPopup()
 	local changeList = { }
 	local changelogName = launch.devMode and "../changelog.txt" or "changelog.txt"
-	for line in io.lines(changelogName) do
-		local ver, date = line:match("^VERSION%[(.+)%]%[(.+)%]$")
-		if ver then
-			if #changeList > 0 then
-				t_insert(changeList, { height = 10 })
+	local changelogFile = io.open(changelogName, "r")
+	if changelogFile then
+		changelogFile:close()
+		for line in io.lines(changelogName) do
+			local ver, date = line:match("^VERSION%[(.+)%]%[(.+)%]$")
+			if ver then
+				if #changeList > 0 then
+					t_insert(changeList, { height = 10 })
+				end
+				t_insert(changeList, { height = 18, "^7Version "..ver.." ("..date..")" })
+			else
+				t_insert(changeList, { height = 12, "^7"..line })
 			end
-			t_insert(changeList, { height = 18, "^7Version "..ver.." ("..date..")" })
-		else
-			t_insert(changeList, { height = 12, "^7"..line })
 		end
 	end
 	local controls = { }
 	controls.close = new("ButtonControl", {"TOPRIGHT",nil,"TOPRIGHT"}, -10, 10, 50, 20, "Close", function()
 		self:ClosePopup()
 	end)
-	controls.version = new("LabelControl", nil, 0, 18, 0, 18, "Path of Building Community Fork v"..launch.versionNumber)
-	controls.forum = new("LabelControl", nil, 0, 36, 0, 18, "Based on Openarl's Path of Building")
-	controls.github = new("ButtonControl", nil, 0, 62, 438, 18, "GitHub page: ^x4040FFhttps://github.com/PathOfBuildingCommunity/PathOfBuilding", function(control)
+	controls.version = new("LabelControl", nil, 0, 18, 0, 18, "^7Path of Building Community Fork v"..launch.versionNumber)
+	controls.forum = new("LabelControl", nil, 0, 36, 0, 18, "^7Based on Openarl's Path of Building")
+	controls.github = new("ButtonControl", nil, 0, 62, 438, 18, "^7GitHub page: ^x4040FFhttps://github.com/PathOfBuildingCommunity/PathOfBuilding", function(control)
 		OpenURL("https://github.com/PathOfBuildingCommunity/PathOfBuilding")
 	end)
 	controls.verLabel = new("LabelControl", { "TOPLEFT", nil, "TOPLEFT" }, 10, 82, 0, 18, "^7Version history:")


### PR DESCRIPTION
Under certain conditions PoB is denied write access to ``GetScriptPath()``. This generally means the user updates PoB using something other than our built-in updater. In this scenario we cannot write the ``*.bin`` TimelessJewelData files to disk, and if we try to do so it breaks quite horribly. Luckily we don't actually need to write those files to disk, so we can just skip it.

See: https://aur.archlinux.org/packages/path-of-building-community-git#comment-873655

Additionally ``changelog.txt`` sometimes does not exist. If we attempt to read from it with ``io.lines`` before verifying the file actually exists, an error is thrown.

See: https://aur.archlinux.org/packages/path-of-building-community-git#comment-868605