### PR TITLE
Prevent saving nil groupCount to build XML

### DIFF
--- a/src/Classes/SkillsTab.lua
+++ b/src/Classes/SkillsTab.lua
@@ -379,7 +379,7 @@ function SkillsTabClass:Save(xml)
 			local node = { elem = "Skill", attrib = {
 				enabled = tostring(socketGroup.enabled),
 				includeInFullDPS = tostring(socketGroup.includeInFullDPS),
-				groupCount = tostring(socketGroup.groupCount),
+				groupCount = socketGroup.groupCount ~= nil and tostring(socketGroup.groupCount),
 				label = socketGroup.label,
 				slot = socketGroup.slot,
 				source = socketGroup.source,


### PR DESCRIPTION
Generally we don't want to save ``nil`` to a string in the build XML, as simply discarding it is more efficient and results in a smaller file size. It also avoids unnecessary string reparsing, as almost regardless of how you read a missing build XML variable.. if it's not there: it's ``nil``.