### PR TITLE
Fix broken mastery import state

### DIFF
--- a/src/Classes/PassiveSpec.lua
+++ b/src/Classes/PassiveSpec.lua
@@ -211,7 +211,6 @@ end
 
 function PassiveSpecClass:AllocateMasteryEffects(masteryEffects)
 	for i = 1, #masteryEffects - 1, 4 do
-
 		local effectId = masteryEffects:byte(i) * 256 + masteryEffects:byte(i + 1)
 		local id  = masteryEffects:byte(i + 2) * 256 + masteryEffects:byte(i + 3)
 

--- a/src/Classes/PassiveSpec.lua
+++ b/src/Classes/PassiveSpec.lua
@@ -215,11 +215,12 @@ function PassiveSpecClass:AllocateMasteryEffects(masteryEffects)
 		local effectId = masteryEffects:byte(i) * 256 + masteryEffects:byte(i + 1)
 		local id  = masteryEffects:byte(i + 2) * 256 + masteryEffects:byte(i + 3)
 
-		self.masterySelections[id] = effectId
 		local effect = self.tree.masteryEffects[effectId]
 		self.allocNodes[id].sd = effect.sd
+		self.allocNodes[id].allMasteryOptions = false
 		self.allocNodes[id].reminderText = { "Tip: Right click to select a different effect" }
 		self.tree:ProcessStats(self.allocNodes[id])
+		self.masterySelections[id] = effectId
 		self.allocatedMasteryCount = self.allocatedMasteryCount + 1
 	end
 end

--- a/src/Classes/PassiveTreeView.lua
+++ b/src/Classes/PassiveTreeView.lua
@@ -916,8 +916,8 @@ function PassiveTreeViewClass:AddNodeTooltip(tooltip, node, build)
 	end
 
 	local function addModInfoToTooltip(node, i, line)
-		if node.mods[i].list then
-			if launch.devModeAlt then
+		if node.mods[i] then
+			if launch.devModeAlt and node.mods[i].list then
 				-- Modifier debugging info
 				local modStr
 				for _, mod in pairs(node.mods[i].list) do
@@ -930,8 +930,8 @@ function PassiveTreeViewClass:AddNodeTooltip(tooltip, node, build)
 					line = line .. "  " .. modStr
 				end
 			end
+			tooltip:AddLine(16, ((node.mods[i].extra or not node.mods[i].list) and colorCodes.UNSUPPORTED or colorCodes.MAGIC)..line)
 		end
-		tooltip:AddLine(16, ((node.mods[i].extra or not node.mods[i].list) and colorCodes.UNSUPPORTED or colorCodes.MAGIC)..line)
 	end
 
 	-- If node is a Mastery node, check if compare tree is on


### PR DESCRIPTION
Fixes #3762.

Masteries were not initialized correctly upon import.

``self.allocNodes[id].allMasteryOptions = false`` was not set by ``PassiveSpecClass:AllocateMasteryEffects(...)``, breaking the mastery dropdown list tooltip (as it attempts to index multiple ``node.mods[i]`` when only one is valid).