### PR TITLE
Fix "NaN" EHP initialization error and cap enemyLevel

### DIFF
--- a/src/Classes/EditControl.lua
+++ b/src/Classes/EditControl.lua
@@ -649,7 +649,7 @@ function EditClass:OnKeyUp(key)
 				self:SetText(tostring(cur + (self.numberInc or 1)), true)
 			else
 				if self.placeholder then
-					self:SetText(tostring(self.placeholder + (self.numberInc or 1)), true)
+					self:SetText(tostring((tonumber(self.placeholder) or 0) + (self.numberInc or 1)), true)
 				else
 					self:SetText("1", true)
 				end
@@ -659,7 +659,7 @@ function EditClass:OnKeyUp(key)
 				self:SetText(tostring(cur - (self.numberInc or 1)), true)
 			else
 				if self.placeholder then
-					self:SetText(tostring(self.placeholder - (self.numberInc or 1)), true)
+					self:SetText(tostring((tonumber(self.placeholder) or 0) - (self.numberInc or 1)), true)
 				else
 					self:SetText("0", true)
 				end

--- a/src/Modules/CalcDefence.lua
+++ b/src/Modules/CalcDefence.lua
@@ -880,7 +880,7 @@ function calcs.defence(env, actor)
 				if tonumber(env.configPlaceholder["enemy"..damageType.."Damage"]) ~= nil then
 					enemyDamage = tonumber(env.configPlaceholder["enemy"..damageType.."Damage"])
 				elseif damageType == "Physical" then
-					enemyDamage = round(data.monsterDamageTable[m_min(env.enemyLevel, 83)] * 1.5)
+					enemyDamage = round(data.monsterDamageTable[83] * 1.5)
 				else
 					enemyDamage = 0
 				end

--- a/src/Modules/CalcDefence.lua
+++ b/src/Modules/CalcDefence.lua
@@ -1416,7 +1416,7 @@ function calcs.defence(env, actor)
 		end
 	end
 	
-	-- helper function that itteratively reduces pools until life hits 0 to determine the number of hits it would take with given damage to die
+	-- helper function that iteratively reduces pools until life hits 0 to determine the number of hits it would take with given damage to die
 	function numberOfHitsToDie(DamageIn)
 		local numHits = 0
 		DamageIn["cycles"] = DamageIn["cycles"] or 1

--- a/src/Modules/CalcDefence.lua
+++ b/src/Modules/CalcDefence.lua
@@ -880,7 +880,7 @@ function calcs.defence(env, actor)
 				if tonumber(env.configPlaceholder["enemy"..damageType.."Damage"]) ~= nil then
 					enemyDamage = tonumber(env.configPlaceholder["enemy"..damageType.."Damage"])
 				elseif damageType == "Physical" then
-					enemyDamage = round(data.monsterDamageTable[83] * 1.5)
+					enemyDamage = round(data.monsterDamageTable[m_min(env.build.characterLevel, 83)] * 1.5)
 				else
 					enemyDamage = 0
 				end

--- a/src/Modules/CalcDefence.lua
+++ b/src/Modules/CalcDefence.lua
@@ -880,7 +880,7 @@ function calcs.defence(env, actor)
 				if tonumber(env.configPlaceholder["enemy"..damageType.."Damage"]) ~= nil then
 					enemyDamage = tonumber(env.configPlaceholder["enemy"..damageType.."Damage"])
 				elseif damageType == "Physical" then
-					enemyDamage = round(data.monsterDamageTable[m_min(env.build.characterLevel, 83)] * 1.5)
+					enemyDamage = round(data.monsterDamageTable[m_min(env.build.characterLevel, 82)] * 1.5)
 				else
 					enemyDamage = 0
 				end

--- a/src/Modules/CalcDefence.lua
+++ b/src/Modules/CalcDefence.lua
@@ -1410,7 +1410,7 @@ function calcs.defence(env, actor)
 		end
 	end
 	
-	-- helper function that itterativly reduces pools untill life hits 0 to determine the number of hits it would take with given damage to die
+	-- helper function that itteratively reduces pools until life hits 0 to determine the number of hits it would take with given damage to die
 	function numberOfHitsToDie(DamageIn)
 		local numHits = 0
 		DamageIn["cycles"] = DamageIn["cycles"] or 1
@@ -1438,10 +1438,10 @@ function calcs.defence(env, actor)
 			restoreWard = 0
 		end
 		local frostShield = output["FrostShieldLife"] or 0
-		local aegis = {}
+		local aegis = { }
 		aegis["shared"] = output["sharedAegis"] or 0
 		aegis["sharedElemental"] = output["sharedElementalAegis"] or 0
-		local guard = {}
+		local guard = { }
 		guard["shared"] = output.sharedGuardAbsorb or 0
 		for _, damageType in ipairs(dmgTypeList) do
 			aegis[damageType] = output[damageType.."Aegis"] or 0
@@ -1454,17 +1454,17 @@ function calcs.defence(env, actor)
 		DamageIn["LifeLossBelowHalfLost"] = DamageIn["LifeLossBelowHalfLost"] or 0
 		DamageIn["WardBypass"] = DamageIn["WardBypass"] or modDB:Sum("BASE", nil, "WardBypass") or 0
 		
-		local itterationMultiplier = 1
+		local iterationMultiplier = 1
 		local maxHits = data.misc.ehpCalcMaxHitsToCalc
 		maxHits = maxHits / DamageIn["cycles"]
 		while life > 0 and numHits < maxHits do
-			numHits = numHits + itterationMultiplier
-			local Damage = {}
+			numHits = numHits + iterationMultiplier
+			local Damage = { }
 			for _, damageType in ipairs(dmgTypeList) do
-				Damage[damageType] = DamageIn[damageType] * itterationMultiplier
+				Damage[damageType] = DamageIn[damageType] * iterationMultiplier
 			end
-			if DamageIn.GainWhenHit and (itterationMultiplier > 1 or DamageIn["cycles"] > 1) then
-				local gainMult = itterationMultiplier * DamageIn["cycles"]
+			if DamageIn.GainWhenHit and (iterationMultiplier > 1 or DamageIn["cycles"] > 1) then
+				local gainMult = iterationMultiplier * DamageIn["cycles"]
 				life = m_min(life + DamageIn.LifeWhenHit * (gainMult - 1), gainMult * (output.LifeRecoverable or 0))
 				mana = m_min(mana + DamageIn.ManaWhenHit * (gainMult - 1), gainMult * (output.ManaUnreserved or 0))
 				energyShield = m_min(energyShield + DamageIn.EnergyShieldWhenHit * (gainMult - 1), gainMult * output.EnergyShieldRecoveryCap)
@@ -1472,7 +1472,7 @@ function calcs.defence(env, actor)
 			for _, damageType in ipairs(dmgTypeList) do
 				if Damage[damageType] > 0 then
 					if frostShield > 0 then
-						local tempDamage = m_min(Damage[damageType] * output["FrostShieldDamageMitigation"] / 100 / itterationMultiplier, frostShield)
+						local tempDamage = m_min(Damage[damageType] * output["FrostShieldDamageMitigation"] / 100 / iterationMultiplier, frostShield)
 						frostShield = frostShield - tempDamage
 						Damage[damageType] = Damage[damageType] - tempDamage
 					end
@@ -1492,12 +1492,12 @@ function calcs.defence(env, actor)
 						Damage[damageType] = Damage[damageType] - tempDamage
 					end
 					if guard[damageType] > 0 then
-						local tempDamage = m_min(Damage[damageType] * output[damageType.."GuardAbsorbRate"] / 100 / itterationMultiplier, guard[damageType])
+						local tempDamage = m_min(Damage[damageType] * output[damageType.."GuardAbsorbRate"] / 100 / iterationMultiplier, guard[damageType])
 						guard[damageType] = guard[damageType] - tempDamage
 						Damage[damageType] = Damage[damageType] - tempDamage
 					end
 					if guard["shared"] > 0 then
-						local tempDamage = m_min(Damage[damageType] * output["sharedGuardAbsorbRate"] / 100 / itterationMultiplier, guard["shared"])
+						local tempDamage = m_min(Damage[damageType] * output["sharedGuardAbsorbRate"] / 100 / iterationMultiplier, guard["shared"])
 						guard["shared"] = guard["shared"] - tempDamage
 						Damage[damageType] = Damage[damageType] - tempDamage
 					end
@@ -1545,18 +1545,18 @@ function calcs.defence(env, actor)
 				mana = m_min(mana + DamageIn.ManaWhenHit, output.ManaUnreserved or 0)
 				energyShield = m_min(energyShield + DamageIn.EnergyShieldWhenHit, output.EnergyShieldRecoveryCap)
 			end
-			itterationMultiplier = 1
-			--To speed it up, run recurivly but speed up
+			iterationMultiplier = 1
+			-- to speed it up, run recursively but accelerated
 			local maxDepth = data.misc.ehpCalcMaxDepth
 			local speedUp = data.misc.ehpCalcSpeedUp
 			DamageIn["cyclesRan"] = DamageIn["cyclesRan"] or false
 			if not DamageIn["cyclesRan"] and life > 0 and DamageIn["cycles"] < maxDepth then
-				Damage = {}
+				Damage = { }
 				for _, damageType in ipairs(dmgTypeList) do
 					Damage[damageType] = DamageIn[damageType] * speedUp
 				end	
 				Damage["cycles"] = DamageIn["cycles"] * speedUp
-				itterationMultiplier = m_max((numberOfHitsToDie(Damage) - 1) * speedUp - 1, 1)
+				iterationMultiplier = m_max((numberOfHitsToDie(Damage) - 1) * speedUp - 1, 1)
 				DamageIn["cyclesRan"] = true 
 			end
 		end
@@ -1566,9 +1566,9 @@ function calcs.defence(env, actor)
 		return numHits
 	end
 	
-	--number of damaging hits needed to be taken to die
+	-- number of damaging hits needed to be taken to die
 	do
-		local DamageIn = {}
+		local DamageIn = { }
 		for _, damageType in ipairs(dmgTypeList) do
 			DamageIn[damageType] = output[damageType.."TakenHit"]
 		end
@@ -1577,7 +1577,7 @@ function calcs.defence(env, actor)
 
 	
 	do
-		local DamageIn = {}
+		local DamageIn = { }
 		local BlockChance = 0
 		local blockEffect = 1
 		local suppressChance = 0
@@ -1585,13 +1585,13 @@ function calcs.defence(env, actor)
 		local ExtraAvoidChance = 0
 		local averageAvoidChance = 0
 		local worstOf = env.configInput.EHPUnluckyWorstOf or 1
-		--block effect
+		-- block effect
 		if damageCategoryConfig == "Melee" then
 			BlockChance = output.BlockChance / 100
 		else
 			BlockChance = output[damageCategoryConfig.."BlockChance"] / 100
 		end
-		--unlucky config to lower the value of block, dodge, evade etc for ehp
+		-- unlucky config to lower the value of block, dodge, evade etc for ehp
 		if worstOf > 1 then
 			BlockChance = BlockChance * BlockChance
 			if worstOf == 4 then
@@ -1609,11 +1609,11 @@ function calcs.defence(env, actor)
 				DamageIn.EnergyShieldWhenHit = DamageIn.EnergyShieldWhenHit + output.EnergyShieldOnSpellBlock / 2 * BlockChance
 			end
 		end
-		--supression
+		-- supression
 		if damageCategoryConfig == "Spell" or damageCategoryConfig == "SpellProjectile" or damageCategoryConfig == "Average" then
 			suppressChance = output.SpellSuppressionChance / 100
 		end
-		--unlucky config to lower the value of block, dodge, evade etc for ehp
+		-- unlucky config to lower the value of block, dodge, evade etc for ehp
 		if worstOf > 1 then
 			suppressChance = suppressChance * suppressChance
 			if worstOf == 4 then
@@ -1624,13 +1624,13 @@ function calcs.defence(env, actor)
 			suppressChance = suppressChance / 2
 		end
 		suppressionEffect = 1 - suppressChance * output.SpellSuppressionEffect / 100
-		--extra avoid chance
+		-- extra avoid chance
 		if damageCategoryConfig == "Projectile" or damageCategoryConfig == "SpellProjectile" then
 			ExtraAvoidChance = ExtraAvoidChance + output.AvoidProjectilesChance
 		elseif damageCategoryConfig == "Average" then
 			ExtraAvoidChance = ExtraAvoidChance + output.AvoidProjectilesChance / 2
 		end
-		--gain when hit (currently just gain on block)
+		-- gain when hit (currently just gain on block)
 		if not env.configInput.DisableEHPGainOnBlock then
 			if DamageIn.LifeWhenHit ~= 0 or DamageIn.ManaWhenHit ~= 0 or DamageIn.EnergyShieldWhenHit ~= 0 then
 				DamageIn.GainWhenHit = true
@@ -1642,7 +1642,7 @@ function calcs.defence(env, actor)
 				DamageIn[damageType.."EnergyShieldBypass"] = output[damageType.."EnergyShieldBypass"] * (1 - BlockChance) 
 			end
 			local AvoidChance = m_min(output["Avoid"..damageType.."DamageChance"] + ExtraAvoidChance, data.misc.AvoidChanceCap)
-			--unlucky config to lower the value of block, dodge, evade etc for ehp
+			-- unlucky config to lower the value of block, dodge, evade etc for ehp
 			if worstOf > 1 then
 				AvoidChance = AvoidChance / 100 * AvoidChance
 				if worstOf == 4 then
@@ -1652,7 +1652,7 @@ function calcs.defence(env, actor)
 			averageAvoidChance = averageAvoidChance + AvoidChance
 			DamageIn[damageType] = output[damageType.."TakenHit"] * (blockEffect * suppressionEffect * (1 - AvoidChance / 100))
 		end
-		--petrified blood degen initialisation
+		-- petrified blood degen initialisation
 		if output["preventedLifeLoss"] > 0 then
 			output["LifeLossBelowHalfLost"] = 0
 			DamageIn["LifeLossBelowHalfLost"] = modDB:Sum("BASE", nil, "LifeLossBelowHalfLost") / 100
@@ -1677,7 +1677,7 @@ function calcs.defence(env, actor)
 		end
 	end
 	
-	--chance to not be hit
+	-- chance to not be hit
 	do
 		local worstOf = env.configInput.EHPUnluckyWorstOf or 1
 		output.MeleeNotHitChance = 100 - (1 - output.MeleeEvadeChance / 100) * (1 - output.AttackDodgeChance / 100) * 100
@@ -1686,7 +1686,7 @@ function calcs.defence(env, actor)
 		output.SpellProjectileNotHitChance = output.SpellNotHitChance
 		output.AverageNotHitChance = (output.MeleeNotHitChance + output.ProjectileNotHitChance + output.SpellNotHitChance + output.SpellProjectileNotHitChance) / 4
 		output.ConfiguredNotHitChance = output[damageCategoryConfig.."NotHitChance"]
-		--unlucky config to lower the value of block, dodge, evade etc for ehp
+		-- unlucky config to lower the value of block, dodge, evade etc for ehp
 		if worstOf > 1 then
 			output.ConfiguredNotHitChance = output.ConfiguredNotHitChance / 100 * output.ConfiguredNotHitChance
 			if worstOf == 4 then
@@ -1717,7 +1717,7 @@ function calcs.defence(env, actor)
 		end
 	end
 	
-	--effective hit pool
+	-- effective hit pool
 	output["TotalEHP"] = output["TotalNumberOfHits"] * output["totalEnemyDamageIn"]
 	if breakdown then
 		breakdown["TotalEHP"] = {
@@ -1727,7 +1727,7 @@ function calcs.defence(env, actor)
 		}
 	end
 	
-	--survival time
+	-- survival time
 	do
 		local enemySkillTime = env.configInput.enemySpeed or env.configPlaceholder.enemySpeed or 700
 		local enemyActionSpeed = calcs.actionSpeedMod(actor.enemy)
@@ -1742,7 +1742,7 @@ function calcs.defence(env, actor)
 		end
 	end
 	
-	--petrified blood "degen"
+	-- petrified blood "degen"
 	if output.preventedLifeLoss > 0 then
 		local LifeLossBelowHalfLost = modDB:Sum("BASE", nil, "LifeLossBelowHalfLost") / 100
 		output["LifeLossBelowHalfLostMax"] = output["LifeLossBelowHalfLost"] * LifeLossBelowHalfLost / 4
@@ -1764,7 +1764,7 @@ function calcs.defence(env, actor)
 		
 	end
 
-	--effective health pool vs dots
+	-- effective health pool vs dots
 	for _, damageType in ipairs(dmgTypeList) do
 		output[damageType.."DotEHP"] = output[damageType.."TotalPool"] / output[damageType.."TakenDotMult"]
 		if breakdown then
@@ -1776,7 +1776,7 @@ function calcs.defence(env, actor)
 		end
 	end
 	
-	-- Degens
+	-- degens
 	for _, damageType in ipairs(dmgTypeList) do
 		local baseVal = modDB:Sum("BASE", nil, damageType.."Degen")
 		if baseVal > 0 then
@@ -1912,15 +1912,15 @@ function calcs.defence(env, actor)
 	end
 	
 	
-	--maximum hit taken
+	-- maximum hit taken
 	-- this is not done yet, using old max hit taken
-	--fix total pools, as they arnt used anymore
+	-- fix total pools, as they aren't used anymore
 	for _, damageType in ipairs(dmgTypeList) do
-		--base + petrified blood
+		-- base + petrified blood
 		if output["preventedLifeLoss"] > 0 then
 			output[damageType.."TotalPool"] =  output[damageType.."TotalPool"] / (1 - output["preventedLifeLoss"] / 100)
 		end
-		--ward
+		-- ward
 		local wardBypass = modDB:Sum("BASE", nil, "WardBypass") or 0
 		if wardBypass > 0 then
 			local poolProtected = output.Ward / (1 - wardBypass / 100) * (wardBypass / 100)
@@ -1930,9 +1930,9 @@ function calcs.defence(env, actor)
 		else
 			output[damageType.."TotalPool"] = output[damageType.."TotalPool"] + output.Ward or 0
 		end
-		--aegis
+		-- aegis
 		output[damageType.."TotalHitPool"] = output[damageType.."TotalPool"] + output[damageType.."Aegis"] or 0 + output[damageType.."sharedAegis"] or 0 + isElemental[damageType] and output[damageType.."sharedElementalAegis"] or 0
-		--guardskill
+		-- guard skill
 		local GuardAbsorbRate = output["sharedGuardAbsorbRate"] or 0 + output[damageType.."GuardAbsorbRate"] or 0
 		if GuardAbsorbRate > 0 then
 			local GuardAbsorb = output["sharedGuardAbsorb"] or 0 + output[damageType.."GuardAbsorb"] or 0
@@ -1943,7 +1943,7 @@ function calcs.defence(env, actor)
 				output[damageType.."TotalHitPool"] = m_max(output[damageType.."TotalHitPool"] - poolProtected, 0) + m_min(output[damageType.."TotalHitPool"], poolProtected) / (1 - GuardAbsorbRate / 100)
 			end
 		end
-		--frost shield
+		-- frost shield
 		if output["FrostShieldLife"] > 0 then
 			local poolProtected = output["FrostShieldLife"] / (output["FrostShieldDamageMitigation"] / 100) * (1 - output["FrostShieldDamageMitigation"] / 100)
 			output[damageType.."TotalHitPool"] = m_max(output[damageType.."TotalHitPool"] - poolProtected, 0) + m_min(output[damageType.."TotalHitPool"], poolProtected) / (1 - output["FrostShieldDamageMitigation"] / 100)

--- a/src/Modules/CalcDefence.lua
+++ b/src/Modules/CalcDefence.lua
@@ -871,19 +871,25 @@ function calcs.defence(env, actor)
 		local enemyCritDamage = env.configInput["enemyCritDamage"] or env.configPlaceholder["enemyCritDamage"] or 0
 		output["EnemyCritEffect"] = 1 + enemyCritChance / 100 * (enemyCritDamage / 100) * (1 - output.CritExtraDamageReduction / 100)
 		for _, damageType in ipairs(dmgTypeList) do
-			local enemyDamageMult = calcLib.mod(enemyDB, nil, "Damage", damageType.."Damage", isElemental[damageType] and "ElementalDamage" or nil) --missing taunt from allies
-			local enemyDamage = env.configInput["enemy"..damageType.."Damage"]
-			local enemyPen = env.configInput["enemy"..damageType.."Pen"]
+			local enemyDamageMult = calcLib.mod(enemyDB, nil, "Damage", damageType.."Damage", isElemental[damageType] and "ElementalDamage" or nil) -- missing taunt from allies
+			local enemyDamage = tonumber(env.configInput["enemy"..damageType.."Damage"])
+			local enemyPen = tonumber(env.configInput["enemy"..damageType.."Pen"])
 			local sourceStr = enemyDamage == nil and "Default" or "Config"
-			
-			if enemyDamage == nil and env.configPlaceholder["enemy"..damageType.."Damage"] then
-				enemyDamage = env.configPlaceholder["enemy"..damageType.."Damage"]
+
+			if enemyDamage == nil then
+				if tonumber(env.configPlaceholder["enemy"..damageType.."Damage"]) ~= nil then
+					enemyDamage = tonumber(env.configPlaceholder["enemy"..damageType.."Damage"])
+				elseif damageType == "Physical" then
+					enemyDamage = round(data.monsterDamageTable[m_min(env.enemyLevel, 83)] * 1.5)
+				else
+					enemyDamage = 0
+				end
 			end
-			if enemyPen == nil and env.configPlaceholder["enemy"..damageType.."Pen"] then
-				enemyPen = env.configPlaceholder["enemy"..damageType.."Pen"]
+			if enemyPen == nil then
+				enemyPen = tonumber(env.configPlaceholder["enemy"..damageType.."Pen"]) or 0
 			end
-			enemyDamage = enemyDamage or 0
-			output[damageType.."EnemyPen"] = enemyPen or 0
+
+			output[damageType.."EnemyPen"] = enemyPen
 			output["totalEnemyDamageIn"] = output["totalEnemyDamageIn"] + enemyDamage
 			output[damageType.."EnemyDamage"] = enemyDamage * enemyDamageMult * output["EnemyCritEffect"]
 			output["totalEnemyDamage"] = output["totalEnemyDamage"] + output[damageType.."EnemyDamage"]

--- a/src/Modules/CalcDefence.lua
+++ b/src/Modules/CalcDefence.lua
@@ -880,7 +880,7 @@ function calcs.defence(env, actor)
 				if tonumber(env.configPlaceholder["enemy"..damageType.."Damage"]) ~= nil then
 					enemyDamage = tonumber(env.configPlaceholder["enemy"..damageType.."Damage"])
 				elseif damageType == "Physical" then
-					enemyDamage = round(data.monsterDamageTable[m_min(env.build.characterLevel, 82)] * 1.5)
+					enemyDamage = round(data.monsterDamageTable[m_min(env.build.characterLevel, 83)] * 1.5)
 				else
 					enemyDamage = 0
 				end

--- a/src/Modules/CalcSetup.lua
+++ b/src/Modules/CalcSetup.lua
@@ -293,7 +293,7 @@ function calcs.initEnv(build, mode, override, specEnv)
 		if env.configInput.enemyLevel then
 			env.enemyLevel = m_min(data.misc.MaxEnemyLevel, env.configInput.enemyLevel)
 		elseif env.configPlaceholder["enemyLevel"] then
-			if env.configInput.enemyIsBoss == "None" then
+			if env.configInput.enemyIsBoss == "None" or env.configInput.enemyIsBoss == "Standard Boss" then
 				env.enemyLevel = m_min(data.misc.MaxEnemyLevel, env.build.characterLevel, env.configPlaceholder["enemyLevel"])
 			else
 				env.enemyLevel = m_min(data.misc.MaxEnemyLevel, env.configPlaceholder["enemyLevel"])

--- a/src/Modules/CalcSetup.lua
+++ b/src/Modules/CalcSetup.lua
@@ -290,7 +290,13 @@ function calcs.initEnv(build, mode, override, specEnv)
 		env.enemyDB = enemyDB
 		env.itemModDB = new("ModDB")
 
-		env.enemyLevel = m_max(1, m_min(100, env.configInput.enemyLevel and env.configInput.enemyLevel or env.configPlaceholder["enemyLevel"] or m_min(env.build.characterLevel, data.misc.MaxEnemyLevel)))
+		if env.configInput.enemyLevel then
+			env.enemyLevel = m_min(data.misc.MaxEnemyLevel, env.configInput.enemyLevel)
+		elseif env.configPlaceholder["enemyLevel"] then
+			env.enemyLevel = m_min(data.misc.MaxEnemyLevel, env.build.characterLevel, env.configPlaceholder["enemyLevel"])
+		else
+			env.enemyLevel = m_min(data.misc.MaxEnemyLevel, env.build.characterLevel)
+		end
 
 		-- Create player/enemy actors
 		env.player = {

--- a/src/Modules/CalcSetup.lua
+++ b/src/Modules/CalcSetup.lua
@@ -293,7 +293,11 @@ function calcs.initEnv(build, mode, override, specEnv)
 		if env.configInput.enemyLevel then
 			env.enemyLevel = m_min(data.misc.MaxEnemyLevel, env.configInput.enemyLevel)
 		elseif env.configPlaceholder["enemyLevel"] then
-			env.enemyLevel = m_min(data.misc.MaxEnemyLevel, env.build.characterLevel, env.configPlaceholder["enemyLevel"])
+			if env.configPlaceholder["enemyLevel"] == 82 then
+				env.enemyLevel = m_min(data.misc.MaxEnemyLevel, env.build.characterLevel, env.configPlaceholder["enemyLevel"])
+			else
+				env.enemyLevel = m_min(data.misc.MaxEnemyLevel, env.configPlaceholder["enemyLevel"])
+			end
 		else
 			env.enemyLevel = m_min(data.misc.MaxEnemyLevel, env.build.characterLevel)
 		end

--- a/src/Modules/CalcSetup.lua
+++ b/src/Modules/CalcSetup.lua
@@ -293,7 +293,7 @@ function calcs.initEnv(build, mode, override, specEnv)
 		if env.configInput.enemyLevel then
 			env.enemyLevel = m_min(data.misc.MaxEnemyLevel, env.configInput.enemyLevel)
 		elseif env.configPlaceholder["enemyLevel"] then
-			if env.configPlaceholder["enemyLevel"] == 82 then
+			if env.configInput.enemyIsBoss == "None" then
 				env.enemyLevel = m_min(data.misc.MaxEnemyLevel, env.build.characterLevel, env.configPlaceholder["enemyLevel"])
 			else
 				env.enemyLevel = m_min(data.misc.MaxEnemyLevel, env.configPlaceholder["enemyLevel"])

--- a/src/Modules/ConfigOptions.lua
+++ b/src/Modules/ConfigOptions.lua
@@ -1366,7 +1366,7 @@ return {
 	{ var = "EEIgnoreHitDamage", type = "check", label = "Ignore Skill Hit Damage?", ifFlag = "ElementalEquilibrium", tooltip = "This option prevents EE from being reset by the hit damage of your main skill." },
 	-- Section: Enemy Stats
 	{ section = "Enemy Stats", col = 3 },
-	{ var = "enemyLevel", type = "count", label = "Enemy Level:", tooltip = "This overrides the default enemy level used to estimate your hit and ^x33FF77evade ^7chance.\nThe default level for normal monsters is 83, capped by your character level.\nThe default level for bosses is 83, scaling up to 85, and is not capped by your character level." },
+	{ var = "enemyLevel", type = "count", label = "Enemy Level:", tooltip = "This overrides the default enemy level used to estimate your hit and ^x33FF77evade ^7chance.\n\nThe default level for normal enemies and standard bosses is 83.\nTheir default level is capped by your character level.\n\nThe default level for pinnacle bosses is 84, and the default level for uber pinnacle bosses is 85.\nTheir default level is not capped by your character level." },
 	{ var = "conditionEnemyRareOrUnique", type = "check", label = "Is the enemy Rare or Unique?", ifEnemyCond = "EnemyRareOrUnique", tooltip = "The enemy will automatically be considered to be Unique if they are a Boss,\nbut you can use this option to force it if necessary.", apply = function(val, modList, enemyModList)
 		enemyModList:NewMod("Condition:RareOrUnique", "FLAG", true, "Config", { type = "Condition", var = "Effective" })
 	end },

--- a/src/Modules/ConfigOptions.lua
+++ b/src/Modules/ConfigOptions.lua
@@ -1396,8 +1396,7 @@ Uber Pinnacle Boss adds the following modifiers:
 	^7+100% to enemy Armour
 	70% less to enemy Damage taken
 	235% of monster damage
-	8% penetration
-	]], list = {{val="None",label="No"},{val="Boss",label="Standard Boss"},{val="Pinnacle",label="Guardian/Pinnacle Boss"},{val="Uber",label="Uber Pinnacle Boss"}}, apply = function(val, modList, enemyModList, build)
+	8% penetration]], list = {{val="None",label="No"},{val="Boss",label="Standard Boss"},{val="Pinnacle",label="Guardian/Pinnacle Boss"},{val="Uber",label="Uber Pinnacle Boss"}}, apply = function(val, modList, enemyModList, build)
 		--these defaults are here so that the placeholder gets reset correctly
 		build.configTab.varControls['enemySpeed']:SetPlaceholder(700, true)
 		build.configTab.varControls['enemyCritChance']:SetPlaceholder(5, true)
@@ -1558,7 +1557,7 @@ Uber Pinnacle Boss adds the following modifiers:
 	{ var = "presetBossSkills", type = "list", label = "Boss Skill Preset", tooltip = [[
 Used to fill in defaults for specific boss skills if the boss config is not set
 
-Bosses' damage is assumed at a 2/3 roll, with no Atlas passives, at the normal monster level for your character level (capped at 84)
+Bosses' damage is assumed at a 2/3 roll, with no Atlas passives, at the normal monster level for your character level (capped at 85)
 Fill in the exact damage numbers if more precision is needed
 
 Caveats for certain skills are below

--- a/src/Modules/ConfigOptions.lua
+++ b/src/Modules/ConfigOptions.lua
@@ -1366,7 +1366,7 @@ return {
 	{ var = "EEIgnoreHitDamage", type = "check", label = "Ignore Skill Hit Damage?", ifFlag = "ElementalEquilibrium", tooltip = "This option prevents EE from being reset by the hit damage of your main skill." },
 	-- Section: Enemy Stats
 	{ section = "Enemy Stats", col = 3 },
-	{ var = "enemyLevel", type = "count", label = "Enemy Level:", tooltip = "This overrides the default enemy level used to estimate your hit and ^x33FF77evade ^7chances.\nThe default level for normal monsters is 83, capped by your character level.\nThe default level for bosses is 83, scaling up to 85, and is not capped by your character level." },
+	{ var = "enemyLevel", type = "count", label = "Enemy Level:", tooltip = "This overrides the default enemy level used to estimate your hit and ^x33FF77evade ^7chance.\nThe default level for normal monsters is 83, capped by your character level.\nThe default level for bosses is 83, scaling up to 85, and is not capped by your character level." },
 	{ var = "conditionEnemyRareOrUnique", type = "check", label = "Is the enemy Rare or Unique?", ifEnemyCond = "EnemyRareOrUnique", tooltip = "The enemy will automatically be considered to be Unique if they are a Boss,\nbut you can use this option to force it if necessary.", apply = function(val, modList, enemyModList)
 		enemyModList:NewMod("Condition:RareOrUnique", "FLAG", true, "Config", { type = "Condition", var = "Effective" })
 	end },

--- a/src/Modules/ConfigOptions.lua
+++ b/src/Modules/ConfigOptions.lua
@@ -1366,7 +1366,7 @@ return {
 	{ var = "EEIgnoreHitDamage", type = "check", label = "Ignore Skill Hit Damage?", ifFlag = "ElementalEquilibrium", tooltip = "This option prevents EE from being reset by the hit damage of your main skill." },
 	-- Section: Enemy Stats
 	{ section = "Enemy Stats", col = 3 },
-	{ var = "enemyLevel", type = "count", label = "Enemy Level:", tooltip = "This overrides the default enemy level used to estimate your hit and ^x33FF77evade ^7chances.\nThe default level for normal monsters is 82, capped by your character level.\nThe default level for bosses is 83, scaling up to 85, and is not capped by your character level." },
+	{ var = "enemyLevel", type = "count", label = "Enemy Level:", tooltip = "This overrides the default enemy level used to estimate your hit and ^x33FF77evade ^7chances.\nThe default level for normal monsters is 83, capped by your character level.\nThe default level for bosses is 83, scaling up to 85, and is not capped by your character level." },
 	{ var = "conditionEnemyRareOrUnique", type = "check", label = "Is the enemy Rare or Unique?", ifEnemyCond = "EnemyRareOrUnique", tooltip = "The enemy will automatically be considered to be Unique if they are a Boss,\nbut you can use this option to force it if necessary.", apply = function(val, modList, enemyModList)
 		enemyModList:NewMod("Condition:RareOrUnique", "FLAG", true, "Config", { type = "Condition", var = "Effective" })
 	end },
@@ -1408,7 +1408,7 @@ Uber Pinnacle Boss adds the following modifiers:
 			build.configTab.varControls['enemyFireResist']:SetPlaceholder(defaultResist, true)
 			build.configTab.varControls['enemyChaosResist']:SetPlaceholder(defaultResist, true)
 
-			local defaultLevel = 82
+			local defaultLevel = 83
 			build.configTab.varControls['enemyLevel']:SetPlaceholder(defaultLevel, true)
 			if build.calcsTab.mainEnv then
 				defaultLevel = build.calcsTab.mainEnv.enemyLevel

--- a/src/Modules/ConfigOptions.lua
+++ b/src/Modules/ConfigOptions.lua
@@ -1409,7 +1409,8 @@ Uber Pinnacle Boss adds the following modifiers:
 			build.configTab.varControls['enemyFireResist']:SetPlaceholder(defaultResist, true)
 			build.configTab.varControls['enemyChaosResist']:SetPlaceholder(defaultResist, true)
 
-			local defaultLevel = 66
+			local defaultLevel = 83
+			build.configTab.varControls['enemyLevel']:SetPlaceholder(defaultLevel, true)
 			if build.calcsTab.mainEnv then
 				defaultLevel = build.calcsTab.mainEnv.enemyLevel
 			end

--- a/src/Modules/ConfigOptions.lua
+++ b/src/Modules/ConfigOptions.lua
@@ -1366,7 +1366,7 @@ return {
 	{ var = "EEIgnoreHitDamage", type = "check", label = "Ignore Skill Hit Damage?", ifFlag = "ElementalEquilibrium", tooltip = "This option prevents EE from being reset by the hit damage of your main skill." },
 	-- Section: Enemy Stats
 	{ section = "Enemy Stats", col = 3 },
-	{ var = "enemyLevel", type = "count", label = "Enemy Level:", tooltip = "This overrides the default enemy level used to estimate your hit and ^x33FF77evade ^7chances.\nThe default level is your character level, capped at 85, which is the same value\nused in-game to calculate the stats on the character sheet." },
+	{ var = "enemyLevel", type = "count", label = "Enemy Level:", tooltip = "This overrides the default enemy level used to estimate your hit and ^x33FF77evade ^7chances.\nThe default level for normal monsters is 82, capped by your character level.\nThe default level for bosses is 83, scaling up to 85, and is not capped by your character level." },
 	{ var = "conditionEnemyRareOrUnique", type = "check", label = "Is the enemy Rare or Unique?", ifEnemyCond = "EnemyRareOrUnique", tooltip = "The enemy will automatically be considered to be Unique if they are a Boss,\nbut you can use this option to force it if necessary.", apply = function(val, modList, enemyModList)
 		enemyModList:NewMod("Condition:RareOrUnique", "FLAG", true, "Config", { type = "Condition", var = "Effective" })
 	end },
@@ -1408,7 +1408,7 @@ Uber Pinnacle Boss adds the following modifiers:
 			build.configTab.varControls['enemyFireResist']:SetPlaceholder(defaultResist, true)
 			build.configTab.varControls['enemyChaosResist']:SetPlaceholder(defaultResist, true)
 
-			local defaultLevel = 83
+			local defaultLevel = 82
 			build.configTab.varControls['enemyLevel']:SetPlaceholder(defaultLevel, true)
 			if build.calcsTab.mainEnv then
 				defaultLevel = build.calcsTab.mainEnv.enemyLevel


### PR DESCRIPTION
Fixes #4571. Supersedes #4585.

### Description of the problem being solved:
Character EHP was ``nan`` for all new builds, as various different configuration options were not initialized correctly until after you poke some settings in the configuration tab.

This also caps enemyLevel to characterLevel for normal enemies when left at their default placeholder level. This does not affect boss enemies, as capping their level doesn't really make sense.

### Before screenshots:
![](https://user-images.githubusercontent.com/18443616/178810706-9bf8974c-58b0-4294-bf6d-7c3faf91d8ae.png)
![](https://user-images.githubusercontent.com/18443616/178810748-bcf95d7d-ac77-4781-a524-8f62c7bbfacf.png)

### After screenshots:
![](https://user-images.githubusercontent.com/18443616/178810926-846953c6-c306-4d12-94d2-7e56c8234dbc.png)
![](https://user-images.githubusercontent.com/18443616/178810978-f5b30d95-7af7-430c-9715-762d2f120feb.png)