### PR TITLE
Allow certain controls not require focus to display tooltips

### DIFF
--- a/src/Classes/ButtonControl.lua
+++ b/src/Classes/ButtonControl.lua
@@ -3,12 +3,13 @@
 -- Class: Button Control
 -- Basic button control.
 --
-local ButtonClass = newClass("ButtonControl", "Control", "TooltipHost", function(self, anchor, x, y, width, height, label, onClick, onHover)
+local ButtonClass = newClass("ButtonControl", "Control", "TooltipHost", function(self, anchor, x, y, width, height, label, onClick, onHover, forceTooltip)
 	self.Control(anchor, x, y, width, height)
 	self.TooltipHost()
 	self.label = label
 	self.onClick = onClick
 	self.onHover = onHover
+	self.forceTooltip = forceTooltip
 end)
 
 function ButtonClass:Click()
@@ -88,7 +89,7 @@ function ButtonClass:Draw(viewPort, noTooltip)
 		DrawString(x + width / 2, y + 2 - overSize, "CENTER_X", height - 4 + overSize * 2, "VAR", label)
 	end
 	if mOver then
-		if not noTooltip then
+		if not noTooltip or self.forceTooltip then
 			SetDrawLayer(nil, 100)
 			self:DrawTooltip(x, y, width, height, viewPort)
 			SetDrawLayer(nil, 0)

--- a/src/Classes/DropDownControl.lua
+++ b/src/Classes/DropDownControl.lua
@@ -33,13 +33,13 @@ local DropDownClass = newClass("DropDownControl", "Control", "ControlHost", "Too
 	self:SetList(list or { })
 	self.selIndex = 1
 	self.selFunc = selFunc
-	  -- Current value of the width of the dropped component
+	-- Current value of the width of the dropped component
 	self.droppedWidth = self.width
-	  -- Set by the parent control. The maximum width of the dropped component will go to.
+	-- Set by the parent control. The maximum width of the dropped component will go to.
 	self.maxDroppedWidth = m_max(self.width, 300)
-	  -- Set by the parent control. Activates the auto width of the dropped component. 
+	-- Set by the parent control. Activates the auto width of the dropped component.
 	self.enableDroppedWidth = false
-	  -- Set by the parent control. Activates the auto width of the box component. 
+	-- Set by the parent control. Activates the auto width of the box component.
 	self.enableChangeBoxWidth = false
 	-- self.tag = "-"
 end)

--- a/src/Classes/GemSelectControl.lua
+++ b/src/Classes/GemSelectControl.lua
@@ -19,7 +19,7 @@ local altQualMap = {
 	["Alternate3"] = "Phantasmal ",
 }
 
-local GemSelectClass = newClass("GemSelectControl", "EditControl", function(self, anchor, x, y, width, height, skillsTab, index, changeFunc)
+local GemSelectClass = newClass("GemSelectControl", "EditControl", function(self, anchor, x, y, width, height, skillsTab, index, changeFunc, forceTooltip)
 	self.EditControl(anchor, x, y, width, height, nil, nil, "^ %a':-")
 	self.controls.scrollBar = new("ScrollBarControl", {"TOPRIGHT",self,"TOPRIGHT"}, -1, 0, 18, 0, (height - 4) * 4)
 	self.controls.scrollBar.y = function()
@@ -37,6 +37,7 @@ local GemSelectClass = newClass("GemSelectControl", "EditControl", function(self
 	self:PopulateGemList()
 	self.index = index
 	self.gemChangeFunc = changeFunc
+	self.forceTooltip = forceTooltip
 	self.list = { }
 	self.changeFunc = function()
 		if not self.dropped then
@@ -338,9 +339,8 @@ function GemSelectClass:IsMouseOver()
 	return mOver, mOverComp
 end
 
-function GemSelectClass:Draw(viewPort) --, noTooltip)
-	local noTooltip = false -- ignore noTooltip, as we explicitly want this control to draw tooltips even when it isn't the active control
-	self.EditControl:Draw(viewPort, noTooltip)
+function GemSelectClass:Draw(viewPort, noTooltip)
+	self.EditControl:Draw(viewPort, noTooltip or self.forceTooltip)
 	local x, y = self:GetPos()
 	local width, height = self:GetSize()
 	local enabled = self:IsEnabled()
@@ -405,7 +405,7 @@ function GemSelectClass:Draw(viewPort) --, noTooltip)
 			end
 		end
 		SetViewport()
-		self:DrawControls(viewPort, noTooltip and self)
+		self:DrawControls(viewPort, (noTooltip or self.forceTooltip) and self)
 		if self.hoverSel then
 			local calcFunc, calcBase = self.skillsTab.build.calcsTab:GetMiscCalculator(self.build)
 			if calcFunc then
@@ -466,7 +466,7 @@ function GemSelectClass:Draw(viewPort) --, noTooltip)
 			   DrawImage(nil, x, y, width, height)
 			end
 		end
-		if mOver and (not self.skillsTab.selControl or self.skillsTab.selControl._className ~= "GemSelectControl" or not self.skillsTab.selControl.dropped) and not noTooltip then
+		if mOver and (not self.skillsTab.selControl or self.skillsTab.selControl._className ~= "GemSelectControl" or not self.skillsTab.selControl.dropped) and (not noTooltip or self.forceTooltip) then
 			local gemInstance = self.skillsTab.displayGroup.gemList[self.index]
 			SetDrawLayer(nil, 10)
 			self.tooltip:Clear()

--- a/src/Classes/GemSelectControl.lua
+++ b/src/Classes/GemSelectControl.lua
@@ -340,7 +340,7 @@ function GemSelectClass:IsMouseOver()
 end
 
 function GemSelectClass:Draw(viewPort, noTooltip)
-	self.EditControl:Draw(viewPort, noTooltip or self.forceTooltip)
+	self.EditControl:Draw(viewPort, noTooltip and not self.forceTooltip)
 	local x, y = self:GetPos()
 	local width, height = self:GetSize()
 	local enabled = self:IsEnabled()
@@ -405,7 +405,7 @@ function GemSelectClass:Draw(viewPort, noTooltip)
 			end
 		end
 		SetViewport()
-		self:DrawControls(viewPort, (noTooltip or self.forceTooltip) and self)
+		self:DrawControls(viewPort, (noTooltip and not self.forceTooltip) and self)
 		if self.hoverSel then
 			local calcFunc, calcBase = self.skillsTab.build.calcsTab:GetMiscCalculator(self.build)
 			if calcFunc then

--- a/src/Classes/GemSelectControl.lua
+++ b/src/Classes/GemSelectControl.lua
@@ -338,7 +338,8 @@ function GemSelectClass:IsMouseOver()
 	return mOver, mOverComp
 end
 
-function GemSelectClass:Draw(viewPort, noTooltip)
+function GemSelectClass:Draw(viewPort) --, noTooltip)
+	local noTooltip = false -- ignore noTooltip, as we explicitly want this control to draw tooltips even when it isn't the active control
 	self.EditControl:Draw(viewPort, noTooltip)
 	local x, y = self:GetPos()
 	local width, height = self:GetSize()
@@ -476,7 +477,7 @@ function GemSelectClass:Draw(viewPort, noTooltip)
 				end
 				self:AddGemTooltip(gemInstance)
 			else
-				self.tooltip:AddLine(16, toolTipText )
+				self.tooltip:AddLine(16, toolTipText)
 			end
 			self.tooltip:Draw(x, y, width, height, viewPort)
 			SetDrawLayer(nil, 0)

--- a/src/Classes/ItemListControl.lua
+++ b/src/Classes/ItemListControl.lua
@@ -6,8 +6,8 @@
 local pairs = pairs
 local t_insert = table.insert
 
-local ItemListClass = newClass("ItemListControl", "ListControl", function(self, anchor, x, y, width, height, itemsTab)
-	self.ListControl(anchor, x, y, width, height, 16, "VERTICAL", true, itemsTab.itemOrderList)
+local ItemListClass = newClass("ItemListControl", "ListControl", function(self, anchor, x, y, width, height, itemsTab, forceTooltip)
+	self.ListControl(anchor, x, y, width, height, 16, "VERTICAL", true, itemsTab.itemOrderList, forceTooltip)
 	self.itemsTab = itemsTab
 	self.label = "^7All items:"
 	self.defaultText = "^x7F7F7FThis is the list of items that have been added to this build.\nYou can add items to this list by dragging them from\none of the other lists, or by clicking 'Add to build' when\nviewing an item."

--- a/src/Classes/ItemsTab.lua
+++ b/src/Classes/ItemsTab.lua
@@ -211,9 +211,9 @@ local ItemsTabClass = newClass("ItemsTab", "UndoHandler", "ControlHost", "Contro
 
 	-- All items list
 	if main.portraitMode then
-		self.controls.itemList = new("ItemListControl", {"TOPRIGHT",self.lastSlot,"BOTTOMRIGHT"}, 0, 0, 360, 308, self)
+		self.controls.itemList = new("ItemListControl", {"TOPRIGHT",self.lastSlot,"BOTTOMRIGHT"}, 0, 0, 360, 308, self, true)
 	else
-		self.controls.itemList = new("ItemListControl", {"TOPLEFT",self.slotAnchor,"TOPRIGHT"}, 20, -20, 360, 308, self)
+		self.controls.itemList = new("ItemListControl", {"TOPLEFT",self.slotAnchor,"TOPRIGHT"}, 20, -20, 360, 308, self, true)
 	end
 
 	-- Database selector
@@ -264,7 +264,7 @@ drag it onto the slot.  This will also add it to
 your build if it's from the unique/template list.
 If there's 2 slots an item can go in, 
 holding Shift will put it in the second.]])
-	self.controls.sharedItemList = new("SharedItemListControl", {"TOPLEFT",self.controls.craftDisplayItem, "BOTTOMLEFT"}, 0, 232, 340, 308, self)
+	self.controls.sharedItemList = new("SharedItemListControl", {"TOPLEFT",self.controls.craftDisplayItem, "BOTTOMLEFT"}, 0, 232, 340, 308, self, true)
 
 	-- Display item
 	self.displayItemTooltip = new("Tooltip")

--- a/src/Classes/ItemsTab.lua
+++ b/src/Classes/ItemsTab.lua
@@ -1849,7 +1849,7 @@ function ItemsTabClass:EditDisplayItemText()
 		self:CreateDisplayItemFromRaw(buildRaw(), not self.displayItem)
 		self.displayItem.id = id
 		main:ClosePopup()
-	end)
+	end, nil, true)
 	controls.save.enabled = function()
 		local item = new("Item", buildRaw())
 		return item.base ~= nil

--- a/src/Classes/ListControl.lua
+++ b/src/Classes/ListControl.lua
@@ -27,13 +27,14 @@ local m_min = math.min
 local m_max = math.max
 local m_floor = math.floor
 
-local ListClass = newClass("ListControl", "Control", "ControlHost", function(self, anchor, x, y, width, height, rowHeight, scroll, isMutable, list)
+local ListClass = newClass("ListControl", "Control", "ControlHost", function(self, anchor, x, y, width, height, rowHeight, scroll, isMutable, list, forceTooltip)
 	self.Control(anchor, x, y, width, height)
 	self.ControlHost()
 	self.rowHeight = rowHeight
 	self.scroll = scroll
 	self.isMutable = isMutable
 	self.list = list or { }
+	self.forceTooltip = forceTooltip
 	self.colList = { { } }
 	self.tooltip = new("Tooltip")
 	self.font = "VAR"
@@ -181,7 +182,7 @@ function ListClass:Draw(viewPort, noTooltip)
 		SetDrawColor(0, 0, 0)
 	end
 	DrawImage(nil, x + 1, y + 1, width - 2, height - 2)
-	self:DrawControls(viewPort, noTooltip and self)
+	self:DrawControls(viewPort, (noTooltip and not self.forceTooltip) and self)
 
 	SetViewport(x + 2, y + 2,  self.scroll and width - 20 or width, height - 4 - (self.scroll and self.scrollH and 16 or 0))
 	local textOffsetY = self.showRowSeparators and 2 or 0
@@ -292,7 +293,7 @@ function ListClass:Draw(viewPort, noTooltip)
 
 	self.hoverIndex = ttIndex
 	self.hoverValue = ttValue
-	if ttIndex and self.AddValueTooltip and not noTooltip then
+	if ttIndex and self.AddValueTooltip and (not noTooltip or self.forceTooltip) then
 		SetDrawLayer(nil, 100)
 		self:AddValueTooltip(self.tooltip, ttIndex, ttValue)
 		self.tooltip:Draw(ttX, ttY, ttWidth, rowHeight, viewPort)

--- a/src/Classes/SharedItemListControl.lua
+++ b/src/Classes/SharedItemListControl.lua
@@ -7,8 +7,8 @@ local pairs = pairs
 local t_insert = table.insert
 local t_remove = table.remove
 
-local SharedItemListClass = newClass("SharedItemListControl", "ListControl", function(self, anchor, x, y, width, height, itemsTab)
-	self.ListControl(anchor, x, y, width, height, 16, "VERTICAL", true, main.sharedItemList)
+local SharedItemListClass = newClass("SharedItemListControl", "ListControl", function(self, anchor, x, y, width, height, itemsTab, forceTooltip)
+	self.ListControl(anchor, x, y, width, height, 16, "VERTICAL", true, main.sharedItemList, forceTooltip)
 	self.itemsTab = itemsTab
 	self.label = "^7Shared items:"
 	self.defaultText = "^x7F7F7FThis is a list of items that will be shared between all of\nyour builds.\nYou can add items to this list by dragging them from\none of the other lists."

--- a/src/Classes/SkillsTab.lua
+++ b/src/Classes/SkillsTab.lua
@@ -57,7 +57,7 @@ local SkillsTabClass = newClass("SkillsTab", "UndoHandler", "ControlHost", "Cont
 
 	self.build = build
 
-	self.socketGroupList = {}
+	self.socketGroupList = { }
 
 	self.sortGemsByDPS = true
 	self.sortGemsByDPSField = "CombinedDPS"
@@ -337,7 +337,7 @@ function SkillsTabClass:Load(xml, fileName)
 	self.sortGemsByDPSField = self.controls.sortGemsByDPSFieldControl:GetSelValue("type")
 	for _, node in ipairs(xml) do
 		if node.elem == "Skill" then
-			-- Old format, nitialize skill sets if needed
+			-- Old format, initialize skill sets if needed
 			if #self.skillSetOrderList == 0 or #self.skillSets == 0 then
 				self.skillSetOrderList = { 1 }
 				self:NewSkillSet(1)
@@ -1167,7 +1167,7 @@ end
 function SkillsTabClass:CreateUndoState()
 	local state = { }
 	state.activeSkillSetId = self.activeSkillSetId
-	state.skillSets = {}
+	state.skillSets = { }
 	for skillSetIndex, skillSet in pairs(self.skillSets) do
 		local newSkillSet = copyTable(skillSet, true)
 		newSkillSet.socketGroupList = { }

--- a/src/Classes/SkillsTab.lua
+++ b/src/Classes/SkillsTab.lua
@@ -611,7 +611,7 @@ function SkillsTabClass:CreateGemSlot(index)
 			self:AddUndoState()
 		end
 		self.build.buildFlag = true
-	end)
+	end, true)
 	slot.nameSpec:AddToTabGroup(self.controls.groupLabel)
 	self.controls["gemSlot"..index.."Name"] = slot.nameSpec
 


### PR DESCRIPTION
#4441 was preventing item list tooltips under the items tab, the "save" button when editing item text, and gem select controls from displaying tooltips when they were not the currently focused control element.

This restores that behavior, as the ``noTooltip`` functionality (as far as I can tell, anyway) is not necessary to prevent overlapping tooltips for those specific controls.

There are a few other cases where similar changes might also be beneficial (such as the equipped items list), but I wasn't able to get those elements working with a ``forceTooltip`` option.