### PR TITLE
Fix catalysts visually not scaling certain mods.

### DIFF
--- a/src/Classes/Item.lua
+++ b/src/Classes/Item.lua
@@ -468,22 +468,13 @@ function ItemClass:ParseRaw(raw)
 				end
 				line = line:gsub("%b{}", ""):gsub(" %(fractured%)",""):gsub(" %(crafted%)",""):gsub(" %(implicit%)",""):gsub(" %(enchant%)",""):gsub(" %(scourge%)","")
 				local catalystScalar = getCatalystScalar(self.catalyst, modTags, self.catalystQuality)
-				local rangedLine
-				if line:match("%(%d+%-%d+ to %d+%-%d+%)") or line:match("%(%-?[%d%.]+ to %-?[%d%.]+%)") or line:match("%(%-?[%d%.]+%-[%d%.]+%)") then
-					rangedLine = itemLib.applyRange(line, 1, catalystScalar)
-				elseif catalystScalar ~= 1 then
-					rangedLine = itemLib.applyValueScalar(line, catalystScalar, 1)
-				end
+				local rangedLine = itemLib.applyRange(line, 1, catalystScalar)
 				local modList, extra = modLib.parseMod(rangedLine or line)
 				if (not modList or extra) and self.rawLines[l+1] then
 					-- Try to combine it with the next line
 					local nextLine = self.rawLines[l+1]:gsub("%b{}", ""):gsub(" ?%(fractured%)",""):gsub(" ?%(crafted%)",""):gsub(" ?%(implicit%)",""):gsub(" ?%(enchant%)",""):gsub(" ?%(scourge%)","")
 					local combLine = line.." "..nextLine
-					if combLine:match("%(%d+%-%d+ to %d+%-%d+%)") or combLine:match("%(%-?[%d%.]+ to %-?[%d%.]+%)") or combLine:match("%(%-?[%d%.]+%-[%d%.]+%)") then
-						rangedLine = itemLib.applyRange(combLine, 1, catalystScalar)
-					elseif catalystScalar ~= 1 then
-						rangedLine = itemLib.applyValueScalar(combLine, catalystScalar, 1)
-					end
+					rangedLine = itemLib.applyRange(combLine, 1, catalystScalar)
 					modList, extra = modLib.parseMod(rangedLine or combLine, true)
 					if modList and not extra then
 						line = line.."\n"..nextLine

--- a/src/Modules/ItemTools.lua
+++ b/src/Modules/ItemTools.lua
@@ -66,7 +66,7 @@ end
 
 -- Apply range value (0 to 1) to a modifier that has a range: (x to x) or (x-x to x-x)
 function itemLib.applyRange(line, range, valueScalar)
-	numbers = 0
+	local numbers = 0
 	line = line:gsub("%((%d+)%-(%d+) to (%d+)%-(%d+)%)", "(%1-%2) to (%3-%4)")
 		:gsub("(%+?)%((%-?%d+) to (%d+)%)", "%1(%2-%3)")
 		:gsub("(%+?)%((%-?%d+)%-(%d+)%)",
@@ -87,6 +87,10 @@ function itemLib.applyRange(line, range, valueScalar)
 			return tostring(numVal)
 		end)
 		:gsub("%-(%d+%%) increased", function(num) return num.." reduced" end)
+		:gsub("%-(%d+%%) more", function(num) return num.." less" end)
+		if numbers == 0 and line:match("(%d+)%%? ") then --If a mod contains x or x% and is not already a ranged value, then only the first number will be scalable as any following numbers will always be conditions or unscalable values.
+			numbers = 1
+		end
 	return itemLib.applyValueScalar(line, valueScalar, numbers)
 end
 


### PR DESCRIPTION
### Description of the problem being solved:
Introduced in https://github.com/PathOfBuildingCommunity/PathOfBuilding/pull/4484.
Due to applyRange() being called to scale mods visually and actual mod scaling being done by applying applyRange() on ranges and applyValueScalar() on everything else. This meant some mods weren't being scaled. This updates applyRange() to support singular mods and remove direct usage of applyValueScalar()

### Steps taken to verify a working solution:
- Applying crit catalyst now scales Marylene's Fallacy less critical strike chance visually.

### Link to a build that showcases this PR:
https://pobb.in/pNGoft1qYVy9

### Before screenshot:
![image](https://user-images.githubusercontent.com/31533893/179353662-0d1a6d1f-cd9e-4836-aa71-353074bb05cf.png)

### After screenshot:
![image](https://user-images.githubusercontent.com/31533893/179353668-d4d83155-6573-454d-88b3-7ce46001b242.png)
