### PR TITLE
Fix default level for pinnacles

### DIFF
--- a/src/Modules/CalcSetup.lua
+++ b/src/Modules/CalcSetup.lua
@@ -293,7 +293,7 @@ function calcs.initEnv(build, mode, override, specEnv)
 		if env.configInput.enemyLevel then
 			env.enemyLevel = m_min(data.misc.MaxEnemyLevel, env.configInput.enemyLevel)
 		elseif env.configPlaceholder["enemyLevel"] then
-			if env.configInput.enemyIsBoss == "None" or env.configInput.enemyIsBoss == "Standard Boss" then
+			if env.configInput.enemyIsBoss == "None" or env.configInput.enemyIsBoss == "Boss" then
 				env.enemyLevel = m_min(data.misc.MaxEnemyLevel, env.build.characterLevel, env.configPlaceholder["enemyLevel"])
 			else
 				env.enemyLevel = m_min(data.misc.MaxEnemyLevel, env.configPlaceholder["enemyLevel"])

--- a/src/Modules/ConfigOptions.lua
+++ b/src/Modules/ConfigOptions.lua
@@ -1471,7 +1471,7 @@ Uber Pinnacle Boss adds the following modifiers:
 			local defaultLevel = 84
 			build.configTab.varControls['enemyLevel']:SetPlaceholder(defaultLevel, true)
 			if build.calcsTab.mainEnv then
-				defaultLevel = build.calcsTab.mainEnv.enemyLevel
+				defaultLevel = m_max(build.calcsTab.mainEnv.enemyLevel, defaultLevel)
 			end
 
 			local defaultDamage = round(data.monsterDamageTable[defaultLevel] * 1.5  * data.misc.pinnacleBossDPSMult)
@@ -1502,7 +1502,7 @@ Uber Pinnacle Boss adds the following modifiers:
 			local defaultLevel = 85
 			build.configTab.varControls['enemyLevel']:SetPlaceholder(defaultLevel, true)
 			if build.calcsTab.mainEnv then
-				defaultLevel = build.calcsTab.mainEnv.enemyLevel
+				defaultLevel = m_max(build.calcsTab.mainEnv.enemyLevel, defaultLevel)
 			end
 
 			local defaultDamage = round(data.monsterDamageTable[defaultLevel] * 1.5  * data.misc.uberBossDPSMult)


### PR DESCRIPTION
### Description of the problem being solved:
1) The check for if an enemy was a standard boss for setting an enemy level cap was using the label, not the value, and thus wasn't working.
2) The level cap was being calculated after configoptions took effect, leading to a situation where changing what boss you were targeting used the previous boss' level cap. 

### Steps to reproduce
- Set boss to "No"
- Set boss to either pinnacle option
- Boss damage is set to whatever is the cap for a monster of the same level as your character (18 for uber pinnacle on a level 1 character)

### Steps taken to verify a working solution:
- Set boss to "No"
- Set boss to either pinnacle option
- Boss damage is set to the default level of the boss, or whatever you set it to if what you set it to is higher.
