### PR TITLE
Fix enable skill tooltip visibility for non-vaal active skill gems

### DIFF
--- a/src/Classes/SkillsTab.lua
+++ b/src/Classes/SkillsTab.lua
@@ -581,7 +581,7 @@ function SkillsTabClass:CreateGemSlot(index)
 			if not gemId then
 				return
 			end
-			gemInstance = { nameSpec = "", level = self.defaultGemLevel or 20, quality = self.defaultGemQuality or 0, qualityId = "Default", enabled = true, enableGlobal1 = true, count = 1, new = true }
+			gemInstance = { nameSpec = "", level = self.defaultGemLevel or 20, quality = self.defaultGemQuality or 0, qualityId = "Default", enabled = true, enableGlobal1 = true, enableGlobal2 = true, count = 1, new = true }
 			self.displayGroup.gemList[index] = gemInstance
 			slot.level:SetText(gemInstance.level)
 			slot.quality:SetText(gemInstance.quality)
@@ -618,7 +618,7 @@ function SkillsTabClass:CreateGemSlot(index)
 	slot.level = new("EditControl", {"LEFT",slot.nameSpec,"RIGHT"}, 2, 0, 60, 20, nil, nil, "%D", 2, function(buf)
 		local gemInstance = self.displayGroup.gemList[index]
 		if not gemInstance then
-			gemInstance = { nameSpec = "", level = self.defaultGemLevel or 20, quality = self.defaultGemQuality or 0, qualityId = "Default", enabled = true, enableGlobal1 = true, count = 1, new = true }
+			gemInstance = { nameSpec = "", level = self.defaultGemLevel or 20, quality = self.defaultGemQuality or 0, qualityId = "Default", enabled = true, enableGlobal1 = true, enableGlobal2 = true, count = 1, new = true }
 			self.displayGroup.gemList[index] = gemInstance
 			slot.qualityId.list = self:getGemAltQualityList(gemInstance.gemData)
 			slot.quality:SetText(gemInstance.quality)
@@ -642,7 +642,7 @@ function SkillsTabClass:CreateGemSlot(index)
 	slot.qualityId = new("DropDownControl",  {"LEFT",slot.level,"RIGHT"}, 2, 0, 90, 20, alternateGemQualityList, function(dropDownIndex, value)
 		local gemInstance = self.displayGroup.gemList[index]
 		if not gemInstance then
-			gemInstance = { nameSpec = "", level = self.defaultGemLevel or 20, quality = self.defaultGemQuality or 0, qualityId = "Default", enabled = true, enableGlobal1 = true, count = 1, new = true }
+			gemInstance = { nameSpec = "", level = self.defaultGemLevel or 20, quality = self.defaultGemQuality or 0, qualityId = "Default", enabled = true, enableGlobal1 = true, enableGlobal2 = true, count = 1, new = true }
 			self.displayGroup.gemList[index] = gemInstance
 			slot.level:SetText(gemInstance.level)
 			slot.enabled.state = true
@@ -732,7 +732,7 @@ function SkillsTabClass:CreateGemSlot(index)
 	slot.quality = new("EditControl", {"LEFT",slot.qualityId,"RIGHT"}, 2, 0, 60, 20, nil, nil, "%D", 2, function(buf)
 		local gemInstance = self.displayGroup.gemList[index]
 		if not gemInstance then
-			gemInstance = { nameSpec = "", level = self.defaultGemLevel or 20, quality = self.defaultGemQuality or 0, qualityId = "Default", enabled = true, enableGlobal1 = true, count = 1, new = true }
+			gemInstance = { nameSpec = "", level = self.defaultGemLevel or 20, quality = self.defaultGemQuality or 0, qualityId = "Default", enabled = true, enableGlobal1 = true, enableGlobal2 = true, count = 1, new = true }
 			self.displayGroup.gemList[index] = gemInstance
 			slot.level:SetText(gemInstance.level)
 			slot.enabled.state = true
@@ -771,7 +771,7 @@ function SkillsTabClass:CreateGemSlot(index)
 	slot.enabled = new("CheckBoxControl", {"LEFT",slot.quality,"RIGHT"}, 18, 0, 20, nil, function(state)
 		local gemInstance = self.displayGroup.gemList[index]
 		if not gemInstance then
-			gemInstance = { nameSpec = "", level = self.defaultGemLevel or 20, quality = self.defaultGemQuality or 0, qualityId = "Default", enabled = true, enableGlobal1 = true, count = 1, new = true }
+			gemInstance = { nameSpec = "", level = self.defaultGemLevel or 20, quality = self.defaultGemQuality or 0, qualityId = "Default", enabled = true, enableGlobal1 = true, enableGlobal2 = true, count = 1, new = true }
 			self.displayGroup.gemList[index] = gemInstance
 			slot.level:SetText(gemInstance.level)
 			slot.quality:SetText(gemInstance.quality)
@@ -780,10 +780,10 @@ function SkillsTabClass:CreateGemSlot(index)
 			slot.count:SetText(gemInstance.count)
 		end
 		if not gemInstance.gemData.vaalGem then
-			slot.enableGlobal1.state = state
-			gemInstance.enableGlobal1 = state
-			slot.enableGlobal2.state = state
-			gemInstance.enableGlobal2 = state
+			slot.enableGlobal1.state = true
+			gemInstance.enableGlobal1 = true
+			slot.enableGlobal2.state = true
+			gemInstance.enableGlobal2 = true
 		end
 		gemInstance.enabled = state
 		self:ProcessSocketGroup(self.displayGroup)


### PR DESCRIPTION
Fixes a bug introduced by #4493 where the toggle state of ``enableGlobal1`` and ``enableGlobal2`` were linked to the overall skill enable state for non-vaal skill gems, causing the ``Enabling this gem will give you`` tooltip text to never be visible.

Note that you will need to toggle the skills enable state if loading an old build where these variables were previously linked, as it doesn't go out of its way to correct existing data (as it technically doesn't cause any issues with the actual build, it only affects this one tooltip).

### Link to a build that showcases this PR:
https://pobb.in/28v14DODnY7L

### Before screenshot:
![](https://user-images.githubusercontent.com/18443616/179375682-ff23273c-a91b-4a7b-add7-19608b93d0fa.png)

### After screenshot:
![](https://user-images.githubusercontent.com/18443616/179375671-f7150fa1-01d2-47c6-88c4-d240bb357f39.png)
