### PR TITLE
Fix Vaal Discipline not counting towards Aura count

### DIFF
--- a/src/Data/Skills/act_int.lua
+++ b/src/Data/Skills/act_int.lua
@@ -2700,8 +2700,8 @@ skills["VaalDiscipline"] = {
 	statDescriptionScope = "aura_skill_stat_descriptions",
 	castTime = 0,
 	statMap = {
-		["base_maximum_energy_shield"] = {
-			mod("EnergyShield", "BASE", nil, 0, 0, { type = "GlobalEffect", effectType = "Aura" }),
+		["energy_shield_recharge_not_delayed_by_damage"] = {
+			mod("EnergyShieldRechargeNotDelayedByDamage", "DUMMY", nil, 0, 0, { type = "GlobalEffect", effectType = "Aura" }),
 		},
 	},
 	baseFlags = {

--- a/src/Export/Skills/act_int.txt
+++ b/src/Export/Skills/act_int.txt
@@ -611,8 +611,8 @@ local skills, mod, flag, skill = ...
 #skill VaalDiscipline
 #flags spell aura area duration
 	statMap = {
-		["base_maximum_energy_shield"] = {
-			mod("EnergyShield", "BASE", nil, 0, 0, { type = "GlobalEffect", effectType = "Aura" }),
+		["energy_shield_recharge_not_delayed_by_damage"] = {
+			mod("EnergyShieldRechargeNotDelayedByDamage", "DUMMY", nil, 0, 0, { type = "GlobalEffect", effectType = "Aura" }),
 		},
 	},
 #baseMod skill("radius", 40)


### PR DESCRIPTION
When GGG changed the file format to use Constant stats they removed the previously unused stat of `base_maximum_energy_shield` so it made Vaal Discipline no longer count towards mods like `Auras from your Skills grant x`. This adds a Dummy stat to fix that issue
The stat name is `EnergyShieldRechargeNotDelayedByDamage` so when it shows up under the `Aura and Buff Skills` section, it is clear to users what the mod is