### PR TITLE
Prevent invalid character level values

### DIFF
--- a/src/Modules/Build.lua
+++ b/src/Modules/Build.lua
@@ -40,7 +40,7 @@ function buildMode:Init(dbFileName, buildName, buildXML, convertBuild)
 	self.spectreList = { }
 	self.timelessData = { jewelType = { }, conquerorType = { }, jewelSocket = { }, searchList = "", searchResults = { }, sharedResults = { } }
 	self.viewMode = "TREE"
-	self.characterLevel = main.defaultCharLevel or 1
+	self.characterLevel = m_min(m_max(main.defaultCharLevel or 1, 1), 100)
 	self.targetVersion = liveTargetVersion
 	self.bandit = "None"
 	self.pantheonMajorGod = "None"
@@ -204,7 +204,7 @@ function buildMode:Init(dbFileName, buildName, buildXML, convertBuild)
 		end
 	end
 	self.controls.characterLevel = new("EditControl", {"LEFT",self.controls.pointDisplay,"RIGHT"}, 12, 0, 106, 20, "", "Level", "%D", 3, function(buf)
-		self.characterLevel = m_min(tonumber(buf) or 1, 100)
+		self.characterLevel = m_min(m_max(tonumber(buf) or 1, 1), 100)
 		self.modFlag = true
 		self.buildFlag = true
 	end)

--- a/src/Modules/Main.lua
+++ b/src/Modules/Main.lua
@@ -517,7 +517,7 @@ function main:LoadSettings(ignoreBuild)
 					self.defaultGemQuality = m_min(tonumber(node.attrib.defaultGemQuality) or 0, 23)
 				end
 				if node.attrib.defaultCharLevel then
-					self.defaultCharLevel = m_min(tonumber(node.attrib.defaultCharLevel) or 1, 100)
+					self.defaultCharLevel = m_min(m_max(tonumber(node.attrib.defaultCharLevel) or 1, 1), 100)
 				end
 				if node.attrib.defaultItemAffixQuality then
 					self.defaultItemAffixQuality = m_min(tonumber(node.attrib.defaultItemAffixQuality) or 0.5, 1)
@@ -708,7 +708,7 @@ function main:OpenOptionsPopup()
 
 	nextRow()
 	controls.defaultCharLevel = new("EditControl", { "TOPLEFT", nil, "TOPLEFT" }, defaultLabelPlacementX, currentY, 80, 20, self.defaultCharLevel, nil, "%D", 3, function(charLevel)
-		self.defaultCharLevel = m_min(tonumber(charLevel) or 1, 100)
+		self.defaultCharLevel = m_min(m_max(tonumber(charLevel) or 1, 1), 100)
 	end)
 	controls.defaultCharLevel.tooltipText = "Set the default character level that can be overwritten by build-related level settings."
 	controls.defaultCharLevelLabel = new("LabelControl", { "RIGHT", controls.defaultCharLevel, "LEFT" }, defaultLabelSpacingPx, 0, 0, 16, "^7Default character level:")


### PR DESCRIPTION
Fixes #4605.

### Description of the problem being solved:
Character levels were not restricted to a valid range (1-100) leading to various crashes in ``ModDB.lua``.

This PR prevents invalid default character levels from being saved under options and forces character levels to fit within the valid range (1-100) when loading build files.