### PR TITLE
Fix placeholder physical damage applying to bosses

### DIFF
--- a/src/Modules/CalcDefence.lua
+++ b/src/Modules/CalcDefence.lua
@@ -879,7 +879,7 @@ function calcs.defence(env, actor)
 			if enemyDamage == nil then
 				if tonumber(env.configPlaceholder["enemy"..damageType.."Damage"]) ~= nil then
 					enemyDamage = tonumber(env.configPlaceholder["enemy"..damageType.."Damage"])
-				elseif damageType == "Physical" and (env.configInput.enemyIsBoss == nil or env.configInput.enemyIsBoss == "None") then
+				elseif damageType == "Physical" and (env.configInput.enemyIsBoss == nil or env.configInput.enemyIsBoss == "None") and (env.configInput.presetBossSkills == nil or env.configInput.presetBossSkills == "None") then
 					enemyDamage = round(data.monsterDamageTable[m_min(env.build.characterLevel, 83)] * 1.5)
 				else
 					enemyDamage = 0

--- a/src/Modules/CalcDefence.lua
+++ b/src/Modules/CalcDefence.lua
@@ -879,7 +879,7 @@ function calcs.defence(env, actor)
 			if enemyDamage == nil then
 				if tonumber(env.configPlaceholder["enemy"..damageType.."Damage"]) ~= nil then
 					enemyDamage = tonumber(env.configPlaceholder["enemy"..damageType.."Damage"])
-				elseif damageType == "Physical" then
+				elseif damageType == "Physical" and (env.configInput.enemyIsBoss == nil or env.configInput.enemyIsBoss == "None") then
 					enemyDamage = round(data.monsterDamageTable[m_min(env.build.characterLevel, 83)] * 1.5)
 				else
 					enemyDamage = 0


### PR DESCRIPTION
The placeholder physical damage value ``enemyDamage = round(data.monsterDamageTable[m_min(env.build.characterLevel, 83)] * 1.5)`` in ``CalcDefense.lua`` was incorrectly applying to bosses and boss skill presets, when it was only meant to serve as a fallback value for normal enemies when the the enemy stats configuration section is uninitialized.

This leads to things like the Shaper Ball skill preset inexplicably dealing physical damage (which is fixed by this PR).

Long term we should handle uninitialized configuration settings in a different way, as having placeholder values duplicated like this is far from ideal. @Regisle said he would look into a proper fix for this at some point.