### PR TITLE
force rebuild to initialise boss presets and remove phys fallback

### DIFF
--- a/src/Classes/ConfigTab.lua
+++ b/src/Classes/ConfigTab.lua
@@ -237,6 +237,10 @@ local ConfigTabClass = newClass("ConfigTab", "UndoHandler", "ControlHost", "Cont
 				self.varControls[varData.var] = control
 				self.placeholder[varData.var] = varData.defaultPlaceholderState
 				control.placeholder = varData.defaultPlaceholderState
+				if varData.defaultIndex then
+					self.input[varData.var] = varData.list[varData.defaultIndex].val
+					control.selIndex = varData.defaultIndex
+				end
 			end
 			t_insert(self.controls, control)
 			t_insert(lastSection.varControlList, control)
@@ -257,7 +261,7 @@ function ConfigTabClass:Load(xml, fileName)
 			elseif node.attrib.string then
 				if node.attrib.name == "enemyIsBoss" then
 					self.input[node.attrib.name] = node.attrib.string:lower():gsub("(%l)(%w*)", function(a,b) return s_upper(a)..b end)
-					:gsub("Uber Atziri", "Boss"):gsub("Shaper", "Pinnacle"):gsub("Sirus", "Uber")
+					:gsub("Uber Atziri", "Boss"):gsub("Shaper", "Pinnacle"):gsub("Sirus", "Pinnacle")
 				else
 					self.input[node.attrib.name] = node.attrib.string
 				end

--- a/src/Modules/Build.lua
+++ b/src/Modules/Build.lua
@@ -633,6 +633,9 @@ function buildMode:Init(dbFileName, buildName, buildXML, convertBuild)
 	self.legacyLoaders = { -- Special loaders for legacy sections
 		["Spec"] = self.treeTab,
 	}
+	
+	--special rebuild to properly initialise boss placeholders
+	self.configTab:BuildModList()
 
 	-- Initialise class dropdown
 	for classId, class in pairs(self.latestTree.classes) do

--- a/src/Modules/CalcDefence.lua
+++ b/src/Modules/CalcDefence.lua
@@ -873,13 +873,7 @@ function calcs.defence(env, actor)
 			local sourceStr = enemyDamage == nil and "Default" or "Config"
 
 			if enemyDamage == nil then
-				if tonumber(env.configPlaceholder["enemy"..damageType.."Damage"]) ~= nil then
-					enemyDamage = tonumber(env.configPlaceholder["enemy"..damageType.."Damage"])
-				elseif damageType == "Physical" and (env.configInput.enemyIsBoss == nil or env.configInput.enemyIsBoss == "None") and (env.configInput.presetBossSkills == nil or env.configInput.presetBossSkills == "None") then
-					enemyDamage = round(data.monsterDamageTable[m_min(env.build.characterLevel, 83)] * 1.5)
-				else
-					enemyDamage = 0
-				end
+				enemyDamage = tonumber(env.configPlaceholder["enemy"..damageType.."Damage"]) or 0
 			end
 			if enemyPen == nil then
 				enemyPen = tonumber(env.configPlaceholder["enemy"..damageType.."Pen"]) or 0

--- a/src/Modules/ConfigOptions.lua
+++ b/src/Modules/ConfigOptions.lua
@@ -1370,7 +1370,7 @@ return {
 	{ var = "conditionEnemyRareOrUnique", type = "check", label = "Is the enemy Rare or Unique?", ifEnemyCond = "EnemyRareOrUnique", tooltip = "The enemy will automatically be considered to be Unique if they are a Boss,\nbut you can use this option to force it if necessary.", apply = function(val, modList, enemyModList)
 		enemyModList:NewMod("Condition:RareOrUnique", "FLAG", true, "Config", { type = "Condition", var = "Effective" })
 	end },
-	{ var = "enemyIsBoss", type = "list", label = "Is the enemy a Boss?", tooltip = [[
+	{ var = "enemyIsBoss", type = "list", label = "Is the enemy a Boss?", defaultIndex = 1, tooltip = [[
 Bosses' damage is monster damage scaled to an average damage of their attacks
 This is divided by 4.25 to represent 4 damage types + some ^xD02090chaos
 ^7Fill in the exact damage numbers if more precision is needed
@@ -1409,7 +1409,7 @@ Uber Pinnacle Boss adds the following modifiers:
 			build.configTab.varControls['enemyChaosResist']:SetPlaceholder(defaultResist, true)
 
 			local defaultLevel = 83
-			build.configTab.varControls['enemyLevel']:SetPlaceholder(defaultLevel, true)
+			build.configTab.varControls['enemyLevel']:SetPlaceholder("", true)
 			if build.calcsTab.mainEnv then
 				defaultLevel = build.calcsTab.mainEnv.enemyLevel
 			end
@@ -1438,7 +1438,7 @@ Uber Pinnacle Boss adds the following modifiers:
 			build.configTab.varControls['enemyChaosResist']:SetPlaceholder(25, true)
 
 			local defaultLevel = 83
-			build.configTab.varControls['enemyLevel']:SetPlaceholder(defaultLevel, true)
+			build.configTab.varControls['enemyLevel']:SetPlaceholder("", true)
 			if build.calcsTab.mainEnv then
 				defaultLevel = build.calcsTab.mainEnv.enemyLevel
 			end

--- a/src/Modules/ConfigOptions.lua
+++ b/src/Modules/ConfigOptions.lua
@@ -1409,7 +1409,7 @@ Uber Pinnacle Boss adds the following modifiers:
 			build.configTab.varControls['enemyChaosResist']:SetPlaceholder(defaultResist, true)
 
 			local defaultLevel = 83
-			build.configTab.varControls['enemyLevel']:SetPlaceholder("", true)
+			build.configTab.varControls['enemyLevel']:SetPlaceholder(defaultLevel, true)
 			if build.calcsTab.mainEnv then
 				defaultLevel = build.calcsTab.mainEnv.enemyLevel
 			end
@@ -1438,7 +1438,7 @@ Uber Pinnacle Boss adds the following modifiers:
 			build.configTab.varControls['enemyChaosResist']:SetPlaceholder(25, true)
 
 			local defaultLevel = 83
-			build.configTab.varControls['enemyLevel']:SetPlaceholder("", true)
+			build.configTab.varControls['enemyLevel']:SetPlaceholder(defaultLevel, true)
 			if build.calcsTab.mainEnv then
 				defaultLevel = build.calcsTab.mainEnv.enemyLevel
 			end


### PR DESCRIPTION
Force rebuild to initialise boss presets and remove phys fallback in calcDefences
supersedes #4612

> The placeholder physical damage value enemyDamage = round(data.monsterDamageTable[m_min(env.build.characterLevel, 83)] * 1.5) in CalcDefense.lua was incorrectly applying to bosses and boss skill presets, when it was only meant to serve as a fallback value for normal enemies when the the enemy stats configuration section is uninitialized.
> 
> This leads to things like the Shaper Ball skill preset inexplicably dealing physical damage (which is fixed by this PR).

This also makes old builds load as pinnacle boss not uber, and no longer sets enemy level for none/boss (instead letting it be based off character level again, it will still be 83 for most builds)

### Steps taken to verify a working solution:
open a new build (or load an old xml) and see that it correctly fills out boss preset damage