### PR TITLE
Node power sorting

### DIFF
--- a/src/Classes/NotableDBControl.lua
+++ b/src/Classes/NotableDBControl.lua
@@ -9,6 +9,7 @@ local t_insert = table.insert
 local t_sort = table.sort
 local m_max = math.max
 local m_floor = math.floor
+local m_huge = math.huge
 local s_format = string.format
 
 ---@param node table
@@ -131,6 +132,7 @@ function NotableDBClass:ListBuilder()
 
 	if self.sortDetail and self.sortDetail.stat then -- stat-based
 		local cache = { }
+		local infinites = { }
 		local start = GetTime()
 		local calcFunc = self.itemsTab.build.calcsTab:GetMiscCalculator()
 		local itemType = self.itemsTab.displayItem.base.type
@@ -141,13 +143,24 @@ function NotableDBClass:ListBuilder()
 			if node.modKey ~= "" then
 				local output = calcFunc({ repSlotName = itemType, repItem = self.itemsTab:anointItem(node) }, {})
 				node.measuredPower = self:CalculatePowerStat(self.sortDetail, output, calcBase)
-				self.sortMaxPower = m_max(self.sortMaxPower, node.measuredPower)
+				if node.measuredPower == m_huge then
+					t_insert(infinites, node)
+				else
+					self.sortMaxPower = m_max(self.sortMaxPower, node.measuredPower)
+				end
 			end
 			local now = GetTime()
 			if now - start > 50 then
 				self.defaultText = "^7Sorting... ("..m_floor(nodeIndex/#list*100).."%)"
 				coroutine.yield()
 				start = now
+			end
+		end
+		
+		if #infinites > 0 then
+			self.sortMaxPower = self.sortMaxPower * 2
+			for _, node in ipairs(infinites) do
+				node.measuredPower = self.sortMaxPower
 			end
 		end
 	end

--- a/src/Modules/CalcDefence.lua
+++ b/src/Modules/CalcDefence.lua
@@ -1991,4 +1991,16 @@ function calcs.defence(env, actor)
 			 t_insert(breakdown[damageType.."MaximumHitTaken"], s_format("Maximum hit you can take: %.0f", output[damageType.."MaximumHitTaken"]))
 		end
 	end
+
+	local minimum = m_huge
+	local SecondMinimum = m_huge
+	for _, damageType in ipairs(dmgTypeList) do
+		if output[damageType.."MaximumHitTaken"] < minimum then
+			SecondMinimum = minimum
+			minimum = output[damageType.."MaximumHitTaken"]
+		elseif output[damageType.."MaximumHitTaken"] < SecondMinimum then
+			SecondMinimum = output[damageType.."MaximumHitTaken"]
+		end
+	end
+	output.SecondMinimalMaximumHitTaken = SecondMinimum
 end


### PR DESCRIPTION
Fixes node power when infinities are involved (eg ehp)
This works for both anoints and passive tree

before:
![image](https://user-images.githubusercontent.com/49933620/179721156-b767d808-e7db-4ca9-9e4d-fb2b498d7da6.png)

after:
![image](https://user-images.githubusercontent.com/49933620/179721052-e9d2721b-220c-4777-b2f3-418f4175bce5.png)

This also re-implemented max hit sorting, using SecondMinimalMaximumHitTaken 