### PR TITLE
Change sidebar to show red numbers for unreserved life of 0

### DIFF
--- a/src/Modules/Build.lua
+++ b/src/Modules/Build.lua
@@ -346,7 +346,7 @@ function buildMode:Init(dbFileName, buildName, buildXML, convertBuild)
 		{ },
 		{ stat = "Life", label = "Total Life", fmt = "d", color = colorCodes.LIFE, compPercent = true },
 		{ stat = "Spec:LifeInc", label = "%Inc Life from Tree", fmt = "d%%", color = colorCodes.LIFE, condFunc = function(v,o) return v > 0 and o.Life > 1 end },
-		{ stat = "LifeUnreserved", label = "Unreserved Life", fmt = "d", color = colorCodes.LIFE, condFunc = function(v,o) return v < o.Life end, compPercent = true, warnFunc = function(v) return v < 0 and "Your unreserved Life is negative" end },
+		{ stat = "LifeUnreserved", label = "Unreserved Life", fmt = "d", color = colorCodes.LIFE, condFunc = function(v,o) return v < o.Life end, compPercent = true, warnFunc = function(v) return v <= 0 and "Your unreserved Life is below 1" end },
 		{ stat = "LifeRecoverable", label = "Life Recoverable", fmt = "d", color = colorCodes.LIFE, condFunc = function(v,o) return v < o.LifeUnreserved end, },
 		{ stat = "LifeUnreservedPercent", label = "Unreserved Life", fmt = "d%%", color = colorCodes.LIFE, condFunc = function(v,o) return v < 100 end },
 		{ stat = "LifeRegen", label = "Life Regen", fmt = ".1f", color = colorCodes.LIFE },
@@ -1252,6 +1252,9 @@ function buildMode:FormatStat(statData, statVal, overCapStatVal)
 	if type(statVal) == "table" then return "" end
 	local val = statVal * ((statData.pc or statData.mod) and 100 or 1) - (statData.mod and 100 or 0)
 	local color = (statVal >= 0 and "^7" or statData.chaosInoc and "^8" or colorCodes.NEGATIVE)
+	if statData.label == "Unreserved Life" and statVal == 0 then
+		color = colorCodes.NEGATIVE
+	end
 	local valStr = s_format("%"..statData.fmt, val)
 	valStr:gsub("%.", main.decimalSeparator)
 	valStr = color .. formatNumSep(valStr)


### PR DESCRIPTION
Fixes #1649  .

### Description of the problem being solved:

Solution for issue: Unreserved life: 0 does not turn red in POB #1649

### Steps taken to verify a working solution:
The function buildMode:FormatStat is set to only highlight values when they are below 0. In:

`local color = (statVal > 0 and "^7" or statData.chaosInoc and "^8" or colorCodes.NEGATIVE`

I added an if-condition to after the color assignment to check if it was for the label Unreserved Life, and value 0 and then also set it to colorCodes.NEGATIVE. 
This also made it logical to also update the warningtext/function in displayStats to "Your unreserved Life is less than 1" and make the warning show at 0 aswell.

More general solutions could be to have a flag/evaluation function in the stats-definition which is being read/called in FormatStat, but it might be overkill if it's only needed for Unreserved Life


### Link to a build that showcases this PR:
<details>
  <summary>
    Example Build
  </summary>
eNqtW-1z2jga_9z8FR5mbuZu9hLe0xxDdocASbgJLQtpe_epI-wH0Fa2qC0nYXf6v-8jyQZDkJGd5kML6Pe8v-iRDN3fXnzmPEEYUR5cV-oXtYoDgcs9GiyvK58eb8-vKr_9etadELH6uLiJKZMrv56966rXDoMnYEhXcQQJlyA-p5yaX5HTmgRiBTwYkz94eMe968oHHkDFmZPAoyJ95zISRR-ID9eVmYvEFYdELgRef_e5BvqEBjPufgNxF_J4rcQ-UXgecw8xo_Hk4_QxI5QGWaGo87vuhJENhDNBhBPhP9eVHppOlnBPBbIiLEY-tUr1OHa2BvBOwyYhDBcLcAV9gn5IRX9FAhdO0xXFjmMm6JpRCLf4-kXbRPHIBWGDyew0b43kFg75QsXqhqFTrPhK9GgZUAHW8AmnEQ8KaW0F7seMYRrbYbk_p4GljX3Omcefg0xEGo26Cd0LgXxc6GSZEo_G0Zau1TIRjUlA-jyyCM8DXYAdcjizw02xVOyQUssJhFjGwl7ZQgSJhBm4HFtFERlFSDJ2lBNWgnI4K0NQQtBMZFpH0xx1-L6HrBsTegAvW9j7dg6_LLB1aQKOgp0RjZpZ6BMXatuw6hHD-4lFD19tIuoSNiYv1I993B4eyTcIbKK-XIkAe0thylsaQmGiPrab4kQrwqMSli0gkwNXObuk25HgUeDacf0UhBBB-GSzuUr8FFNcbttzBkUFJHViK2dp65gHAHd1h-PJlAiw6ypbVLud60qJtXKlBB5xpZn9PsGha-q1XEn7zskZPCS4oHu-kNAiFYYBhMvNbEWBFUQnCbTpk7XV1Od2stRWwdgXZ5VHWZKCDhs-kSjbAevv863RcLusAhzwkMAD29l0EvI_5PTLipH1Qp_HoWU8NNjKgLSVD4iP08sUvNi12y1uGB41bLVHrRgrRNETgrjfBtxbQiEhxSlm8XqNVS5DbksnN6MpRDQzRZxfWqA_YllZVZXcuOwF7NDWArYbsb2UAxJ7W-R-WsCYHdxaxPZAOcbG5WObVmdRPPfuSt4YHDzrWJ1dJvwZtVnJY3xUDI2zxJagadQjhODPjTX_PbiVgGHgxaFMb2sZhxTHxDxSHztgFA2IIE4EJHRXDxi564pa71bVNYh8NfLXPBTqwz5hbqSoR8E6Fk6g7jB8Grlf5_FiIa8rKqhCqO5Yhre3w_7j6PMwEZglib5Rxr4GsT-Xh3z9_y7UM1CdzInieaRfXlc-U3ieSaoBCEIZOsHljJF1BN51ZUFYhJIpvlSYGVrmihxuCoUjou6dJl47gJnT8AVCgfbi1u6GFIx6bddPKKUFyl1cBsjETd5imBnpDtwnkdC7rMFT6tbHzEVexRjNkYs5tJgzhBklJ6snPCE2a4hwT6QL6srczg_5I6I1Kscvrotl4W5y4p3sI2Ye6lrIxEAvmon1tY-JOlnN8aq6ZDJ6Va-ayQfgEqPtetFMvB3ceKDuFI9z2aJyOH3ggUpyLJoeZbLnGyM7ZLCFmBl-FCsI9UZi5DTGHpVCcgsnpPNYmMs4g8jxlTpRGjwk18yk-gBlsEGu5XSivWODwaFZjJmVPqcYG1keaTrtGtynV3OMSAd-g_7JspmBnj-M8Uummbz6xlHXXN9y0Uys6-M1CxHGlhxULg9gAdiFcpN5i8mpd7WV9J449fRw_CZuSrPjzHbmFeKlK_uosYU5qsPDGy08PFP8FPcnl1CGppuBnGCE3fI-Zz-247Sdtu-BMPkUgrO3MXx12fYmO7mISOAN5K2CtaHdajqUdtUcEDkRTqt34Ec3Gzwd3MpOd_CswycCNynwH-QjvkcuZ2TiCggf9CO_RBhRjkrGSaEeye1xTpPUgwWJmfz895gwKjZyLs98mnBt4IfRij_L_NJs5MQSYUt8eNArPSYSDlJGqof2VqKF8kBdfZZ8qB4d9naqKmcoZWngstiDUZCck7aGMTKXCsnHofKmcVttB5y2gt51UZ8EfMf4nLBGSqLG-DENMHwH0jMryYe9ecRZLCP9CP6akfC_sSpZtvNPVkZ9T8ZIjnnac9hBuTfGgnBfy1eiv2snjtRQo6JQcZbgy_djPDt4eN6pjgS6uCr9XN0FJMv5eyaWB35yeRzofJBnGXlrI_e1kC91X8zoZDS6esqxiVPap3ySTrS9wFPjeg_fFfeA5IavJiEO27rxFTR_R6kt62qeKnerafKqYtU1Kl8-hgBpkSkm9STX8U32ObnUuiazM8IS3SQznEzfAE-b-KJ9ddVsVhyB7DLP6OtXyeN3Ta61-jR90I5fCbGOOtXq8_PzxZqIFV_AC2Vw4XK_ukYi1Olc-fhcsq328O9m2VN_2ryUU1c_tY-qiamouzJTGidffOA4Kco1-WH6Rpkuz7PJsXsmQmnPn5z7_1e2ym6AHVqMyXpbtXI1aSXNpJPgaWdA0R-h2onS-Ejg_9K7ga4Kc-Jm-TptZXEE-oHaFyBrrB75cabhSGi22UwJZtem40x70-HZB9RcAs5uWAzOBG1gTs-PGYizfkgWAryOI3U5w7RY0JeO81dIgiV0ahf19tWPUeCGQLCty0m4tsXIrzLsv5nFiyx1_Qf6CYKlWP3n9dIAXjA7UMXdmuKRNNSOUztTzpvC947z_v0ZnkAZdbFgOk797C9BllEHN30cTV34t49j9o-tyu0f_2xdnbcv__UP2VG15o6cxB11-w0hUfuYPGifZYh-abcdwZ1U5SNLW5X31ppyyde7qiM9pLJszL2pxDgKicG9aFeS8CQFZ0Q0TiKaJxHpI3vVNPbzo5GXH30IMSsIegenF0NuvI570STYw5mjflUrFvWr83ptL-hpVGTw80L9cwKWcfaM8fTeTDrSkZu70O08BWcguhJ3kPRSLan-nMrfny52HDXQqc-eydrpzTdRRJijG5_T3gmqpaYdIT0ka9iR5aNuOA6MJRU6ZssJpW6AiYIkt7gDfXOaVio1jqnULOdeOyc0fhJZq5ySl-WkXZb3Zpl8OhGBe8BDrCgq6EgmXZaRcyL9cGp8kgfr4oyb5auoXkZeq1wu1MtlXut0eGwcW5TtsfQqabhV32mX0KdED2yeEuNtHH3vVzB8x71cKr_aZYisStImEKXsbJd2a6NE3C_LVVKzXPo2i2dZq3zbL5HT9dLOb9okRMsGVELtNww_lpEsH4XLEllZPgxvSBfblixpLavGHlrCc-pM0CjTYhql3VuyXdjHs4w5TQs_vT47WYehVdpb7TLW2NRL-SQ_oZLpEFlNTpHqkkvdLamvhfBgQZevvuRx-HuV3VdD1O9WqmaC5Fc1Jwn0z22OwiaMuLDizIMwAUMA_ib5qUv6jZP32e-CHsPLW9X0SyIpUdOCJv0-WkrTTh9WJK7qVg9_ePQ3GzzX4A==
</details>

### Before screenshot:

![image](https://user-images.githubusercontent.com/1473420/179760316-871b1e58-7614-4207-9f7d-b7c62e459327.png)

### After screenshot:

![image](https://user-images.githubusercontent.com/1473420/179760421-2855cc63-9418-4685-9ab1-3c90ff0ad317.png)
![image](https://user-images.githubusercontent.com/1473420/179760439-1ad8e60f-2424-459e-8a74-331cafc22357.png)

