### PR TITLE
Fix "save" on generate #4619

### DIFF
--- a/src/Classes/CalcsTab.lua
+++ b/src/Classes/CalcsTab.lua
@@ -211,7 +211,6 @@ function CalcsTabClass:Save(xml)
 			} })
 		end
 	end
-	self.modFlag = false
 end
 
 function CalcsTabClass:Draw(viewPort, inputEvents)

--- a/src/Classes/ConfigTab.lua
+++ b/src/Classes/ConfigTab.lua
@@ -335,7 +335,6 @@ function ConfigTabClass:Save(xml)
 		end
 		t_insert(xml, child)
 	end
-	self.modFlag = false
 end
 
 function ConfigTabClass:UpdateControls()

--- a/src/Classes/ItemsTab.lua
+++ b/src/Classes/ItemsTab.lua
@@ -978,7 +978,6 @@ function ItemsTabClass:Save(xml)
 		end
 		t_insert(xml, child)
 	end
-	self.modFlag = false
 end
 
 function ItemsTabClass:Draw(viewPort, inputEvents)

--- a/src/Classes/PassiveSpec.lua
+++ b/src/Classes/PassiveSpec.lua
@@ -158,7 +158,6 @@ function PassiveSpecClass:Save(xml)
 	end
 	t_insert(xml, sockets)
 
-	self.modFlag = false
 end
 
 function PassiveSpecClass:PostLoad()

--- a/src/Classes/SkillsTab.lua
+++ b/src/Classes/SkillsTab.lua
@@ -415,7 +415,6 @@ function SkillsTabClass:Save(xml)
 			t_insert(child, node)
 		end
 	end
-	self.modFlag = false
 end
 
 function SkillsTabClass:Draw(viewPort, inputEvents)

--- a/src/Classes/TreeTab.lua
+++ b/src/Classes/TreeTab.lua
@@ -322,7 +322,6 @@ function TreeTabClass:Save(xml)
 		spec:Save(child)
 		t_insert(xml, child)
 	end
-	self.modFlag = false
 end
 
 function TreeTabClass:SetActiveSpec(specId)

--- a/src/Modules/Build.lua
+++ b/src/Modules/Build.lua
@@ -1560,9 +1560,8 @@ function buildMode:SaveDBFile()
 	local action = self.actionOnSave
 	self.actionOnSave = nil
 
-	-- Reset modflag for each saver to show that the build is saved
+	-- Reset all modFlags
 	self:ResetModFlags()
-
 
 	if action == "LIST" then
 		self:CloseBuild()

--- a/src/Modules/Build.lua
+++ b/src/Modules/Build.lua
@@ -877,7 +877,17 @@ function buildMode:Save(xml)
 		}
 	}
 	t_insert(xml, timelessData)
+end
+
+function buildMode:ResetModFlags()
 	self.modFlag = false
+	self.notesTab.modFlag = false
+	self.configTab.modFlag = false
+	self.treeTab.modFlag = false
+	self.spec.modFlag = false
+	self.skillsTab.modFlag = false
+	self.itemsTab.modFlag = false
+	self.calcsTab.modFlag = false
 end
 
 function buildMode:OnFrame(inputEvents)
@@ -1530,6 +1540,7 @@ function buildMode:SaveDB(fileName)
 	end
 end
 
+
 function buildMode:SaveDBFile()
 	if not self.dbFileName then
 		self:OpenSaveAsPopup()
@@ -1548,6 +1559,11 @@ function buildMode:SaveDBFile()
 	file:close()
 	local action = self.actionOnSave
 	self.actionOnSave = nil
+
+	-- Reset modflag for each saver to show that the build is saved
+	self:ResetModFlags()
+
+
 	if action == "LIST" then
 		self:CloseBuild()
 	elseif action == "EXIT" then


### PR DESCRIPTION
Fixes #4619  and #2271

The Generate button in "Import/Export Build" ran buildMode:SaveDB, which runsdifferent Saver functions to generate the build XML . However it did not run the function that saves the file.

The problem is that the modFlags that are used to see if the build is unsaved is reset already in the Save functions. This causes the save button to be disabled, looking like the build is saved, but not really saving.

I created a new function to do the reset-logic and moved that to when buildMode:SaveDBFile is run (since that is when the file is actually saved).

I defined all the modFlags separately to reset in the reset function (i was initially thinking about creating a reset-function in each "saver"-class and iterating over them, however it does not cover all the cases and the actual check against the modFlags are hardcoded in the statement verifying them i.e:

`self.unsaved = self.modFlag or self.notesTab.modFlag or self.configTab.modFlag or self.treeTab.modFlag or self.spec.modFlag or self.skillsTab.modFlag or self.itemsTab.modFlag or self.calcsTab.modFlag`

This also solved the issue with the save-button having strange behaviour for notes as described in #2271.
