### PR TITLE
Fix config tab being 1 change behind enemy level

### DIFF
--- a/src/Classes/ConfigTab.lua
+++ b/src/Classes/ConfigTab.lua
@@ -20,6 +20,8 @@ local ConfigTabClass = newClass("ConfigTab", "UndoHandler", "ControlHost", "Cont
 
 	self.input = { }
 	self.placeholder = { }
+	
+	self.enemyLevel = 1
 
 	self.sectionList = { }
 	self.varControls = { }
@@ -439,6 +441,14 @@ function ConfigTabClass:BuildModList()
 	self.enemyModList = enemyModList
 	local input = self.input
 	local placeholder = self.placeholder
+	--enemy level handeled here becouse its needed to correctly set boss stats
+	if input.enemyLevel and input.enemyLevel ~= 0 then
+		self.enemyLevel = m_min(data.misc.MaxEnemyLevel, input.enemyLevel)
+	elseif placeholder.enemyLevel and placeholder.enemyLevel ~= 0 then
+		self.enemyLevel = m_min(data.misc.MaxEnemyLevel, placeholder.enemyLevel)
+	else
+		self.enemyLevel = m_min(data.misc.MaxEnemyLevel, self.build.characterLevel)
+	end
 	for _, varData in ipairs(varList) do
 		if varData.apply then
 			if varData.type == "check" then

--- a/src/Classes/ConfigTab.lua
+++ b/src/Classes/ConfigTab.lua
@@ -442,9 +442,9 @@ function ConfigTabClass:BuildModList()
 	local input = self.input
 	local placeholder = self.placeholder
 	--enemy level handled here because it's needed to correctly set boss stats
-	if input.enemyLevel and input.enemyLevel ~= 0 then
+	if input.enemyLevel and input.enemyLevel > 0 then
 		self.enemyLevel = m_min(data.misc.MaxEnemyLevel, input.enemyLevel)
-	elseif placeholder.enemyLevel and placeholder.enemyLevel ~= 0 then
+	elseif placeholder.enemyLevel and placeholder.enemyLevel > 0 then
 		self.enemyLevel = m_min(data.misc.MaxEnemyLevel, placeholder.enemyLevel)
 	else
 		self.enemyLevel = m_min(data.misc.MaxEnemyLevel, self.build.characterLevel)

--- a/src/Classes/ConfigTab.lua
+++ b/src/Classes/ConfigTab.lua
@@ -441,7 +441,7 @@ function ConfigTabClass:BuildModList()
 	self.enemyModList = enemyModList
 	local input = self.input
 	local placeholder = self.placeholder
-	--enemy level handeled here becouse its needed to correctly set boss stats
+	--enemy level handled here because it's needed to correctly set boss stats
 	if input.enemyLevel and input.enemyLevel ~= 0 then
 		self.enemyLevel = m_min(data.misc.MaxEnemyLevel, input.enemyLevel)
 	elseif placeholder.enemyLevel and placeholder.enemyLevel ~= 0 then

--- a/src/Modules/Build.lua
+++ b/src/Modules/Build.lua
@@ -205,6 +205,7 @@ function buildMode:Init(dbFileName, buildName, buildXML, convertBuild)
 	end
 	self.controls.characterLevel = new("EditControl", {"LEFT",self.controls.pointDisplay,"RIGHT"}, 12, 0, 106, 20, "", "Level", "%D", 3, function(buf)
 		self.characterLevel = m_min(m_max(tonumber(buf) or 1, 1), 100)
+		self.configTab:BuildModList()
 		self.modFlag = true
 		self.buildFlag = true
 	end)

--- a/src/Modules/CalcSetup.lua
+++ b/src/Modules/CalcSetup.lua
@@ -290,17 +290,7 @@ function calcs.initEnv(build, mode, override, specEnv)
 		env.enemyDB = enemyDB
 		env.itemModDB = new("ModDB")
 
-		if env.configInput.enemyLevel then
-			env.enemyLevel = m_min(data.misc.MaxEnemyLevel, env.configInput.enemyLevel)
-		elseif env.configPlaceholder["enemyLevel"] then
-			if env.configInput.enemyIsBoss == "None" or env.configInput.enemyIsBoss == "Boss" then
-				env.enemyLevel = m_min(data.misc.MaxEnemyLevel, env.build.characterLevel, env.configPlaceholder["enemyLevel"])
-			else
-				env.enemyLevel = m_min(data.misc.MaxEnemyLevel, env.configPlaceholder["enemyLevel"])
-			end
-		else
-			env.enemyLevel = m_min(data.misc.MaxEnemyLevel, env.build.characterLevel)
-		end
+		env.enemyLevel = build.configTab.enemyLevel or m_min(data.misc.MaxEnemyLevel, build.characterLevel)
 
 		-- Create player/enemy actors
 		env.player = {

--- a/src/Modules/ConfigOptions.lua
+++ b/src/Modules/ConfigOptions.lua
@@ -1409,9 +1409,9 @@ Uber Pinnacle Boss adds the following modifiers:
 			build.configTab.varControls['enemyChaosResist']:SetPlaceholder(defaultResist, true)
 
 			local defaultLevel = 83
-			build.configTab.varControls['enemyLevel']:SetPlaceholder(defaultLevel, true)
-			if build.calcsTab.mainEnv then
-				defaultLevel = build.calcsTab.mainEnv.enemyLevel
+			build.configTab.varControls['enemyLevel']:SetPlaceholder("", true)
+			if build.configTab.enemyLevel then
+				defaultLevel = build.configTab.enemyLevel
 			end
 
 			local defaultDamage = round(data.monsterDamageTable[defaultLevel] * 1.5)
@@ -1438,9 +1438,9 @@ Uber Pinnacle Boss adds the following modifiers:
 			build.configTab.varControls['enemyChaosResist']:SetPlaceholder(25, true)
 
 			local defaultLevel = 83
-			build.configTab.varControls['enemyLevel']:SetPlaceholder(defaultLevel, true)
-			if build.calcsTab.mainEnv then
-				defaultLevel = build.calcsTab.mainEnv.enemyLevel
+			build.configTab.varControls['enemyLevel']:SetPlaceholder("", true)
+			if build.configTab.enemyLevel then
+				defaultLevel = build.configTab.enemyLevel
 			end
 
 			local defaultDamage = round(data.monsterDamageTable[defaultLevel] * 1.5  * data.misc.stdBossDPSMult)
@@ -1470,8 +1470,8 @@ Uber Pinnacle Boss adds the following modifiers:
 
 			local defaultLevel = 84
 			build.configTab.varControls['enemyLevel']:SetPlaceholder(defaultLevel, true)
-			if build.calcsTab.mainEnv then
-				defaultLevel = m_max(build.calcsTab.mainEnv.enemyLevel, defaultLevel)
+			if build.configTab.enemyLevel then
+				defaultLevel = m_max(build.configTab.enemyLevel, defaultLevel)
 			end
 
 			local defaultDamage = round(data.monsterDamageTable[defaultLevel] * 1.5  * data.misc.pinnacleBossDPSMult)
@@ -1501,8 +1501,8 @@ Uber Pinnacle Boss adds the following modifiers:
 
 			local defaultLevel = 85
 			build.configTab.varControls['enemyLevel']:SetPlaceholder(defaultLevel, true)
-			if build.calcsTab.mainEnv then
-				defaultLevel = m_max(build.calcsTab.mainEnv.enemyLevel, defaultLevel)
+			if build.configTab.enemyLevel then
+				defaultLevel = m_max(build.configTab.enemyLevel, defaultLevel)
 			end
 
 			local defaultDamage = round(data.monsterDamageTable[defaultLevel] * 1.5  * data.misc.uberBossDPSMult)
@@ -1583,7 +1583,8 @@ Maven Memory Game: Is three separate hits, and has a large DoT effect.  Neither 
 		end
 
 		if val == "Uber Atziri Flameblast" then
-			if build.calcsTab.mainEnv then
+			if build.configTab.enemyLevel then
+				build.configTab.varControls['enemyFireDamage']:SetPlaceholder(round(data.monsterDamageTable[build.configTab.enemyLevel] * 3.48 * 10.9), true)
 				build.configTab.varControls['enemyFireDamage']:SetPlaceholder(round(data.monsterDamageTable[build.calcsTab.mainEnv.enemyLevel] * data.bossSkills["Uber Atziri Flameblast"].damageMult), true)
 				build.configTab.varControls['enemyDamageType']:SelByValue("Spell", "val")
 				build.configTab.varControls['enemyDamageType'].enabled = false
@@ -1594,7 +1595,8 @@ Maven Memory Game: Is three separate hits, and has a large DoT effect.  Neither 
 			build.configTab.varControls['enemySpeed']:SetPlaceholder(data.bossSkills["Uber Atziri Flameblast"].speed, true)
 			build.configTab.varControls['enemyCritChance']:SetPlaceholder(0, true)
 		elseif val == "Shaper Ball" then
-			if build.calcsTab.mainEnv then
+			if build.configTab.enemyLevel then
+				build.configTab.varControls['enemyColdDamage']:SetPlaceholder(round(data.monsterDamageTable[build.configTab.enemyLevel] * 9.17), true)
 				build.configTab.varControls['enemyColdDamage']:SetPlaceholder(round(data.monsterDamageTable[build.calcsTab.mainEnv.enemyLevel] * data.bossSkills["Shaper Ball"].damageMult), true)
 			end
 
@@ -1604,7 +1606,8 @@ Maven Memory Game: Is three separate hits, and has a large DoT effect.  Neither 
 			build.configTab.varControls['enemyDamageType']:SelByValue("SpellProjectile", "val")
 			build.configTab.input['enemyDamageType'] = "SpellProjectile"
 		elseif val == "Shaper Slam" then
-			if build.calcsTab.mainEnv then
+			if build.configTab.enemyLevel then
+				build.configTab.varControls['enemyPhysicalDamage']:SetPlaceholder(round(data.monsterDamageTable[build.configTab.enemyLevel] * 15.2), true)
 				build.configTab.varControls['enemyPhysicalDamage']:SetPlaceholder(round(data.monsterDamageTable[build.calcsTab.mainEnv.enemyLevel] * data.bossSkills["Shaper Slam"].damageMult), true)
 			end
 			build.configTab.varControls['enemyDamageType'].enabled = false
@@ -1613,7 +1616,8 @@ Maven Memory Game: Is three separate hits, and has a large DoT effect.  Neither 
 
 			build.configTab.varControls['enemySpeed']:SetPlaceholder(data.bossSkills["Shaper Slam"].speed, true)
 		elseif val == "Maven Memory Game" then
-			if build.calcsTab.mainEnv then
+			if build.configTab.enemyLevel then
+				local defaultEleDamage = round(data.monsterDamageTable[build.configTab.enemyLevel] * 24.69)
 				local defaultEleDamage = round(data.monsterDamageTable[build.calcsTab.mainEnv.enemyLevel] * data.bossSkills["Maven Memory Game"].damageMult)
 				build.configTab.varControls['enemyLightningDamage']:SetPlaceholder(defaultEleDamage, true)
 				build.configTab.varControls['enemyColdDamage']:SetPlaceholder(defaultEleDamage, true)

--- a/src/Modules/ConfigOptions.lua
+++ b/src/Modules/ConfigOptions.lua
@@ -1584,8 +1584,7 @@ Maven Memory Game: Is three separate hits, and has a large DoT effect.  Neither 
 
 		if val == "Uber Atziri Flameblast" then
 			if build.configTab.enemyLevel then
-				build.configTab.varControls['enemyFireDamage']:SetPlaceholder(round(data.monsterDamageTable[build.configTab.enemyLevel] * 3.48 * 10.9), true)
-				build.configTab.varControls['enemyFireDamage']:SetPlaceholder(round(data.monsterDamageTable[build.calcsTab.mainEnv.enemyLevel] * data.bossSkills["Uber Atziri Flameblast"].damageMult), true)
+				build.configTab.varControls['enemyFireDamage']:SetPlaceholder(round(data.monsterDamageTable[build.configTab.enemyLevel] * data.bossSkills["Uber Atziri Flameblast"].damageMult), true)
 				build.configTab.varControls['enemyDamageType']:SelByValue("Spell", "val")
 				build.configTab.varControls['enemyDamageType'].enabled = false
 				build.configTab.input['enemyDamageType'] = "Spell"
@@ -1596,8 +1595,7 @@ Maven Memory Game: Is three separate hits, and has a large DoT effect.  Neither 
 			build.configTab.varControls['enemyCritChance']:SetPlaceholder(0, true)
 		elseif val == "Shaper Ball" then
 			if build.configTab.enemyLevel then
-				build.configTab.varControls['enemyColdDamage']:SetPlaceholder(round(data.monsterDamageTable[build.configTab.enemyLevel] * 9.17), true)
-				build.configTab.varControls['enemyColdDamage']:SetPlaceholder(round(data.monsterDamageTable[build.calcsTab.mainEnv.enemyLevel] * data.bossSkills["Shaper Ball"].damageMult), true)
+				build.configTab.varControls['enemyColdDamage']:SetPlaceholder(round(data.monsterDamageTable[build.configTab.enemyLevel] * data.bossSkills["Shaper Ball"].damageMult), true)
 			end
 
 			build.configTab.varControls['enemyColdPen']:SetPlaceholder(25, true)
@@ -1607,8 +1605,7 @@ Maven Memory Game: Is three separate hits, and has a large DoT effect.  Neither 
 			build.configTab.input['enemyDamageType'] = "SpellProjectile"
 		elseif val == "Shaper Slam" then
 			if build.configTab.enemyLevel then
-				build.configTab.varControls['enemyPhysicalDamage']:SetPlaceholder(round(data.monsterDamageTable[build.configTab.enemyLevel] * 15.2), true)
-				build.configTab.varControls['enemyPhysicalDamage']:SetPlaceholder(round(data.monsterDamageTable[build.calcsTab.mainEnv.enemyLevel] * data.bossSkills["Shaper Slam"].damageMult), true)
+				build.configTab.varControls['enemyPhysicalDamage']:SetPlaceholder(round(data.monsterDamageTable[build.configTab.enemyLevel] * data.bossSkills["Shaper Slam"].damageMult), true)
 			end
 			build.configTab.varControls['enemyDamageType'].enabled = false
 			build.configTab.varControls['enemyDamageType']:SelByValue("Melee", "val")
@@ -1617,8 +1614,7 @@ Maven Memory Game: Is three separate hits, and has a large DoT effect.  Neither 
 			build.configTab.varControls['enemySpeed']:SetPlaceholder(data.bossSkills["Shaper Slam"].speed, true)
 		elseif val == "Maven Memory Game" then
 			if build.configTab.enemyLevel then
-				local defaultEleDamage = round(data.monsterDamageTable[build.configTab.enemyLevel] * 24.69)
-				local defaultEleDamage = round(data.monsterDamageTable[build.calcsTab.mainEnv.enemyLevel] * data.bossSkills["Maven Memory Game"].damageMult)
+				local defaultEleDamage = round(data.monsterDamageTable[build.configTab.enemyLevel] * data.bossSkills["Maven Memory Game"].damageMult)
 				build.configTab.varControls['enemyLightningDamage']:SetPlaceholder(defaultEleDamage, true)
 				build.configTab.varControls['enemyColdDamage']:SetPlaceholder(defaultEleDamage, true)
 				build.configTab.varControls['enemyFireDamage']:SetPlaceholder(defaultEleDamage, true)


### PR DESCRIPTION
Fixes the issue where when changing the enemy level in the config tab (or by changing boss preset) it would use the old value, this is because enemy level was calculated after config tab had "rebuilt"

This still needs to rebuild configTab whenever the player level is changed to be fully correct, but is progress