### PR TITLE
Stop support gems from using minionTypes to determine compatibility with minion attack skills

### DIFF
--- a/src/Modules/CalcTools.lua
+++ b/src/Modules/CalcTools.lua
@@ -89,9 +89,6 @@ function calcLib.canGrantedEffectSupportActiveSkill(grantedEffect, activeSkill)
 	if grantedEffect.supportGemsOnly and not activeSkill.activeEffect.gemData then
 		return false
 	end
-	if activeSkill.summonSkill then
-		return calcLib.canGrantedEffectSupportActiveSkill(grantedEffect, activeSkill.summonSkill)
-	end
 	if grantedEffect.excludeSkillTypes[1] and calcLib.doesTypeExpressionMatch(grantedEffect.excludeSkillTypes, activeSkill.skillTypes) then
 		return false
 	end


### PR DESCRIPTION
Fixes #4497 .

### Description of the problem being solved:

Minion skills such as ChaosElementalCascadeSummoned and MinionInstability would use minionSkillTypes from the summoning gem to determine compatibility instead of the skillTypes from the minion skill it self. 

### Steps taken to verify a working solution:
- Test minion instability and minions skills of SRS and Chaos Golem
- Check other minion gems and combinations of supports

### Link to a build that showcases this PR:

`https://pobb.in/v2X-xHNx3_ja`

### Before screenshot:
![before](https://user-images.githubusercontent.com/91493239/180108708-53bbd074-9d3c-49d4-8c2f-f032121ca525.jpg)

### After screenshot:
![after](https://user-images.githubusercontent.com/91493239/180108713-a0a16d52-c472-44f7-9afc-6db8059f2cfa.jpg)