### PR TITLE
Display effect of active gem variant when mousing over the "Variant" drop-down selector and small behaviour change to gemSelectControl

### DIFF
--- a/src/Classes/GemSelectControl.lua
+++ b/src/Classes/GemSelectControl.lua
@@ -697,7 +697,7 @@ function GemSelectClass:OnKeyDown(key, doubleClick)
 				self.selIndex = self.hoverSel
 				self:SetText(self.gems[self.list[self.selIndex]].name)
 				self:UpdateGem(false, true)
-				return self
+				return
 			end
 		elseif key == "RETURN" then
 			self.dropped = false
@@ -706,7 +706,7 @@ function GemSelectClass:OnKeyDown(key, doubleClick)
 			end
 			self.selIndex = m_max(self.selIndex, 1)
 			self:UpdateGem(true, true)
-			return self
+			return
 		elseif key == "ESCAPE" then
 			self.dropped = false
 			self:BuildList("")

--- a/src/Classes/GemSelectControl.lua
+++ b/src/Classes/GemSelectControl.lua
@@ -672,7 +672,6 @@ function GemSelectClass:OnFocusLost()
 		if self.noMatches then
 			self:SetText("")
 		end
-		self:UpdateGem(true, true)
 	end
 end
 
@@ -712,7 +711,6 @@ function GemSelectClass:OnKeyDown(key, doubleClick)
 			self:BuildList("")
 			self.buf = self.initialBuf
 			self.selIndex = self.initialIndex
-			-- self:UpdateGem(false, true)
 			return
 		elseif key == "WHEELUP" then
 			self.controls.scrollBar:Scroll(-1)

--- a/src/Classes/GemSelectControl.lua
+++ b/src/Classes/GemSelectControl.lua
@@ -712,7 +712,7 @@ function GemSelectClass:OnKeyDown(key, doubleClick)
 			self:BuildList("")
 			self.buf = self.initialBuf
 			self.selIndex = self.initialIndex
-			self:UpdateGem(false, true)
+			-- self:UpdateGem(false, true)
 			return
 		elseif key == "WHEELUP" then
 			self.controls.scrollBar:Scroll(-1)

--- a/src/Classes/SkillsTab.lua
+++ b/src/Classes/SkillsTab.lua
@@ -660,10 +660,6 @@ function SkillsTabClass:CreateGemSlot(index)
 	slot.qualityId.tooltipFunc = function(tooltip)
 		-- Reset the tooltip
 		tooltip:Clear()
-		-- Only show the tooltip if the combo box is expanded; this is to prevent multiple tooltips from appearing due to mouse being over other skills' combo boxes
-		if not slot.qualityId.dropped then
-			return
-		end
 		-- Get the gem instance from the skills
 		local gemInstance = self.displayGroup.gemList[index]
 		if not gemInstance then
@@ -671,7 +667,12 @@ function SkillsTabClass:CreateGemSlot(index)
 		end
 		local gemData = gemInstance.gemData
 		-- Get the hovered quality item
-		local hoveredQuality = alternateGemQualityList[slot.qualityId.hoverSel]
+		local hoveredQuality
+		if not slot.qualityId.dropped then
+			hoveredQuality = alternateGemQualityList[slot.qualityId.selIndex]
+		else
+			hoveredQuality = alternateGemQualityList[slot.qualityId.hoverSel]
+		end
 		-- gem data may not be initialized yet, or the quality may be nil, which happens when just floating over the dropdown
 		if not gemData or not hoveredQuality then
 			return


### PR DESCRIPTION
Fixes #4517  .

### Description of the problem being solved:
When hovering over the expanded alternate quality box there is a tooltip describing the effect of the quality when hovering with the mouse. When hovering over the "closed" box, there is no tooltip.


### Steps taken to verify a working solution:
I removed the if-statement 
Modified the tooltipFunc in the qualityID to display the selected item if the listbox is closed.

### Link to a build that showcases this PR:
https://pobb.in/ivbVY__36yk8

### Before screenshot:
<img width="400" alt="image" src="https://user-images.githubusercontent.com/1473420/180450093-8074b47e-4b3d-4713-b7f1-c8570e2cbe7e.png">

### After screenshot:
<img width="240" alt="image" src="https://user-images.githubusercontent.com/1473420/180449869-10313d49-d2ab-4ec4-9a09-1d7f9e546863.png">
