### PR TITLE
Makes pobbin matching less restrictive

### DIFF
--- a/src/Modules/BuildSiteTools.lua
+++ b/src/Modules/BuildSiteTools.lua
@@ -19,7 +19,7 @@ buildSites.websiteList = {
 		codeOut = "", postUrl = "https://poe.ninja/pob/api/api_post.php", postFields = "api_paste_code="
 	},
 	{
-		label = "pobb.in", id = "POBBin", matchURL = "pobb%.in/[%w-_]+", regexURL = "pobb%.in/([%w-_]+)%s*$", downloadURL = "pobb.in/pob/%1",
+		label = "pobb.in", id = "POBBin", matchURL = "pobb%.in/.+", regexURL = "pobb%.in/(.+)%s*$", downloadURL = "pobb.in/pob/%1",
 		codeOut = "https://pobb.in/", postUrl = "https://pobb.in/pob/", postFields = ""
 	},
 }


### PR DESCRIPTION
### Description of the problem being solved:

This is a preparation for a future feature of pobbin to support importing codes from different URLs (e.g. user scoped): `https://pobb.in/u/example/cool_build`

This also allows the wesbite to restructure (or introduce new) URLs without breaking PoB in the future

### Steps taken to verify a working solution:
- Testing the Import Tab with verification on stdout
- Testing the protocol import (first commandline argument)

### Before Screenshot:

Missing `/pob/` segment:
![image](https://user-images.githubusercontent.com/255721/180492595-929e813f-d95a-4a84-9361-8aa687129528.png)


### After Screenshot:

![image](https://user-images.githubusercontent.com/255721/180491432-7fea2b32-bc84-4469-a651-d68154ce17aa.png)

Fetching the build (not implemented on pobbin so the 404 is expected):
![image](https://user-images.githubusercontent.com/255721/180491485-96d0e390-8239-4531-800a-5a9c60499ec6.png)


