### PR TITLE
Fix dps comparison not working correctly when using the saviour and using overrides

### DIFF
--- a/src/Modules/CalcActiveSkill.lua
+++ b/src/Modules/CalcActiveSkill.lua
@@ -127,7 +127,7 @@ end
 -- Copy an Active Skill
 function calcs.copyActiveSkill(env, mode, skill)
 	local newSkill = calcs.createActiveSkill(skill.activeEffect, skill.supportList, skill.actor, skill.socketGroup, skill.summonSkill)
-	local newEnv, _, _, _ = calcs.initEnv(env.build, mode)
+	local newEnv, _, _, _ = calcs.initEnv(env.build, mode, env.override)
 	calcs.buildActiveSkillModList(newEnv, newSkill)
 	newSkill.skillModList = new("ModList", newSkill.baseSkillModList)
 	if newSkill.minion then

--- a/src/Modules/CalcSetup.lua
+++ b/src/Modules/CalcSetup.lua
@@ -753,18 +753,17 @@ function calcs.initEnv(build, mode, override, specEnv)
 				end
 			end
 		end
+		if override.toggleFlask then
+			if env.flasks[override.toggleFlask] then
+				env.flasks[override.toggleFlask] = nil
+			else
+				env.flasks[override.toggleFlask] = true
+			end
+		end
 	end
 
 	-- Merge env.itemModDB with env.ModDB
 	mergeDB(env.modDB, env.itemModDB)
-
-	if override.toggleFlask then
-		if env.flasks[override.toggleFlask] then
-			env.flasks[override.toggleFlask] = nil
-		else
-			env.flasks[override.toggleFlask] = true
-		end
-	end
 
 	-- Add granted passives (e.g., amulet anoints)
 	if not accelerate.nodeAlloc then

--- a/src/Modules/Calcs.lua
+++ b/src/Modules/Calcs.lua
@@ -286,7 +286,7 @@ function calcs.calcFullDPS(build, mode, override, specEnv)
 					skills = true,
 					everything = true,
 				}
-				fullEnv, _, _, _ = calcs.initEnv(build, mode, override or {}, { cachedPlayerDB = cachedPlayerDB, cachedEnemyDB = cachedEnemyDB, cachedMinionDB = cachedMinionDB, env = fullEnv, accelerate = accelerationTbl })
+				fullEnv, _, _, _ = calcs.initEnv(build, mode, override, { cachedPlayerDB = cachedPlayerDB, cachedEnemyDB = cachedEnemyDB, cachedMinionDB = cachedMinionDB, env = fullEnv, accelerate = accelerationTbl })
 			end
 		end
 	end


### PR DESCRIPTION
Fixes #4631 .

### Description of the problem being solved:

Overrides were not propagating through the call to initEnv in copyActiveSkill which was causing issues with dps comparison. Fixing that issues caused dps comparison to only work correctly when an odd number of skills was selected for full fps due to flask toggles being applied multiple times to a single env instance because of caching in calcs.calcFullDPS. Toggling flasks only when a cached env is not present seems to resolve the issue.

### Steps taken to verify a working solution:
- Tested with and without The Saviour and got expected behavior