### PR TITLE
General improvements to "Damaging Hits" section and armour breakdown.

### DIFF
--- a/src/Modules/CalcDefence.lua
+++ b/src/Modules/CalcDefence.lua
@@ -1114,20 +1114,20 @@ function calcs.defence(env, actor)
 			end
 		end
 		local takenMult = output[damageType.."TakenHitMult"]
-		local spellSupressMult = 1
+		local spellSuppressMult = 1
 		if damageCategoryConfig == "Melee" or damageCategoryConfig == "Projectile" then
 			takenMult = output[damageType.."AttackTakenHitMult"]
 		elseif damageCategoryConfig == "Spell" or damageCategoryConfig == "SpellProjectile" then
 			takenMult = output[damageType.."SpellTakenHitMult"]
-			spellSupressMult = output.SpellSuppressionChance == 100 and (1 - output.SpellSuppressionEffect / 100) or 1
+			spellSuppressMult = output.SpellSuppressionChance == 100 and (1 - output.SpellSuppressionEffect / 100) or 1
 		elseif damageCategoryConfig == "Average" then
 			takenMult = (output[damageType.."SpellTakenHitMult"] + output[damageType.."AttackTakenHitMult"]) / 2
-			spellSupressMult = output.SpellSuppressionChance == 100 and (1 - output.SpellSuppressionEffect / 100 / 2) or 1
+			spellSuppressMult = output.SpellSuppressionChance == 100 and (1 - output.SpellSuppressionEffect / 100 / 2) or 1
 		end
-		output[damageType.."BaseTakenHitMult"] = baseMult * takenMult * spellSupressMult
+		output[damageType.."BaseTakenHitMult"] = baseMult * takenMult * spellSuppressMult
 		local takenMultReflect = output[damageType.."TakenReflect"]
 		local finalReflect = baseMult * takenMultReflect
-		output[damageType.."TakenHit"] = m_max(damage * baseMult + takenFlat, 0) * takenMult * spellSupressMult
+		output[damageType.."TakenHit"] = m_max(damage * baseMult + takenFlat, 0) * takenMult * spellSuppressMult
 		output[damageType.."TakenHitMult"] = (damage > 0) and (output[damageType.."TakenHit"] / damage) or 0
 		output["totalTakenHit"] = output["totalTakenHit"] + output[damageType.."TakenHit"]
 		if output.AnyTakenReflect then
@@ -1160,10 +1160,10 @@ function calcs.defence(env, actor)
 			if takenMult ~= 1 then
 				t_insert(breakdown[damageType.."TakenHitMult"], s_format("x Taken: %.3f", takenMult))
 			end
-			if spellSupressMult ~= 1 then
-				t_insert(breakdown[damageType.."TakenHitMult"], s_format("x Spell Supression: %.3f", spellSupressMult))
+			if spellSuppressMult ~= 1 then
+				t_insert(breakdown[damageType.."TakenHitMult"], s_format("x Spell Suppression: %.3f", spellSuppressMult))
 			end
-			if takenMult ~= 1 or takenFlat ~= 0 or spellSupressMult ~= 1 then
+			if takenMult ~= 1 or takenFlat ~= 0 or spellSuppressMult ~= 1 then
 				t_insert(breakdown[damageType.."TakenHitMult"], s_format("= %.3f", output[damageType.."TakenHitMult"]))
 			end
 			breakdown[damageType.."TakenHit"] = {
@@ -1639,7 +1639,7 @@ function calcs.defence(env, actor)
 				DamageIn.EnergyShieldWhenHit = DamageIn.EnergyShieldWhenHit + output.EnergyShieldOnSpellBlock / 2 * BlockChance
 			end
 		end
-		-- supression
+		-- suppression
 		if damageCategoryConfig == "Spell" or damageCategoryConfig == "SpellProjectile" or damageCategoryConfig == "Average" then
 			suppressChance = output.SpellSuppressionChance / 100
 		end

--- a/src/Modules/CalcDefence.lua
+++ b/src/Modules/CalcDefence.lua
@@ -1043,20 +1043,15 @@ function calcs.defence(env, actor)
 			local reduction = modDB:Flag(nil, "SelfIgnore"..damageType.."DamageReduction") and 0 or output[damageType.."DamageReduction"]
 			output[damageType.."TakenDotMult"] = (1 - resist / 100) * (1 - reduction / 100) * (1 + takenInc / 100) * takenMore
 			if breakdown then
-				breakdown[damageType.."TakenDotMult"] = { s_format("DoT Multiplier:"), }
-				if resist ~= 0 then
-					t_insert(breakdown[damageType.."TakenDotMult"], s_format("%.2f ^8(resistance)", (1 - resist / 100)))
-				end
-				if reduction ~= 0 then
-					t_insert(breakdown[damageType.."TakenDotMult"], s_format("%.2f ^8(%s damage reduction)", (1 - reduction / 100), damageType:lower()))
-				end
-				if takenInc ~= 0 then
-					t_insert(breakdown[damageType.."TakenDotMult"], s_format("%.2f ^8(increased/reduced damage taken)", (1 + takenInc / 100)))
-				end
-				if takenMore ~= 1 then
-					t_insert(breakdown[damageType.."TakenDotMult"], s_format("%.2f ^8(more/less damage taken)", takenMore))
-				end
-				t_insert(breakdown[damageType.."TakenDotMult"], s_format("= %.2f", output[damageType.."TakenDotMult"]))
+				breakdown[damageType.."TakenDotMult"] = { }
+				breakdown.multiChain(breakdown[damageType.."TakenDotMult"], {
+					label = "DoT Multiplier:",
+					{ "%.2f ^8(resistance)", (1 - resist / 100) },
+					{ "%.2f ^8(%s damage reduction)", (1 - reduction / 100), damageType:lower() },
+					{ "%.2f ^8(increased/reduced damage taken)", (1 + takenInc / 100) },
+					{ "%.2f ^8(more/less damage taken)", takenMore },
+					total = s_format("= %.2f", output[damageType.."TakenDotMult"]),
+				})
 			end
 		end
 	end

--- a/src/Modules/CalcDefence.lua
+++ b/src/Modules/CalcDefence.lua
@@ -1092,22 +1092,20 @@ function calcs.defence(env, actor)
 		end
 		reductMult = (1 - m_max(m_min(output.DamageReductionMax, armourReduct + reduction - enemyOverwhelm), 0) / 100)
 		output[damageType.."DamageReduction"] = 100 - reductMult * 100
-		if reductMult ~= 1 then
-			if breakdown and reductMult ~= 1 then
-				breakdown[damageType.."DamageReduction"] = { }
-				if armourReduct ~= 0 then
-					if resMult ~= 1 then
-						t_insert(breakdown[damageType.."DamageReduction"], s_format("Enemy Hit Damage After Resistance: %d ^8(total incoming damage)", damage * resMult))
-					else
-						t_insert(breakdown[damageType.."DamageReduction"], s_format("Enemy Hit Damage: %d ^8(total incoming damage)", damage))
-					end
-					t_insert(breakdown[damageType.."DamageReduction"], s_format("Reduction from Armour: %d%%", armourReduct))
+		if breakdown and reductMult ~= 1 then
+			breakdown[damageType.."DamageReduction"] = { }
+			if armourReduct ~= 0 then
+				if resMult ~= 1 then
+					t_insert(breakdown[damageType.."DamageReduction"], s_format("Enemy Hit Damage After Resistance: %d ^8(total incoming damage)", damage * resMult))
+				else
+					t_insert(breakdown[damageType.."DamageReduction"], s_format("Enemy Hit Damage: %d ^8(total incoming damage)", damage))
 				end
-				if reduction ~= 0 then
-					t_insert(breakdown[damageType.."DamageReduction"], s_format("Base %s Damage Reduction: %d%%", damageType, reduction))
-					if armourReduct ~= 0 then
-						t_insert(breakdown[damageType.."DamageReduction"], s_format("Total %s Damage Reduction: %d%%", damageType, 100 - reductMult * 100))
-					end
+				t_insert(breakdown[damageType.."DamageReduction"], s_format("Reduction from Armour: %d%%", armourReduct))
+			end
+			if reduction ~= 0 then
+				t_insert(breakdown[damageType.."DamageReduction"], s_format("Base %s Damage Reduction: %d%%", damageType, reduction))
+				if armourReduct ~= 0 then
+					t_insert(breakdown[damageType.."DamageReduction"], s_format("Total %s Damage Reduction: %d%%", damageType, 100 - reductMult * 100))
 				end
 			end
 		end
@@ -1708,7 +1706,7 @@ function calcs.defence(env, actor)
 			if output.ShowBlockEffect then
 				t_insert(breakdown["ConfiguredDamageChance"], s_format("x %.2f ^8(block effect)", output.BlockEffect / 100))
 			end
-			if suppressionEffect < 1 then
+			if suppressionEffect ~= 1 then
 				t_insert(breakdown["ConfiguredDamageChance"], s_format("x %.3f ^8(suppression effect)", suppressionEffect))
 			end
 			if averageAvoidChance > 0 then

--- a/src/Modules/CalcDefence.lua
+++ b/src/Modules/CalcDefence.lua
@@ -33,7 +33,7 @@ function calcs.hitChance(evasion, accuracy)
 	return m_max(m_min(round(rawChance), 100), 5)	
 end
 
--- Calculate physical damage reduction from armour, float
+-- Calculate damage reduction from armour, float
 function calcs.armourReductionF(armour, raw)
 	if armour == 0 and raw == 0 then
 		return 0
@@ -41,7 +41,7 @@ function calcs.armourReductionF(armour, raw)
 	return (armour / (armour + raw * 5) * 100)
 end
 
--- Calculate physical damage reduction from armour, int
+-- Calculate damage reduction from armour, int
 function calcs.armourReduction(armour, raw)
 	return round(calcs.armourReductionF(armour, raw))
 end

--- a/src/Modules/CalcDefence.lua
+++ b/src/Modules/CalcDefence.lua
@@ -1161,7 +1161,7 @@ function calcs.defence(env, actor)
 				else
 					t_insert(breakdown[damageType.."TakenHitMult"], s_format("Enemy Hit Damage: %d ^8(total incoming damage)", damage))
 				end
-				t_insert(breakdown[damageType.."TakenHitMult"], s_format("- Reduction from Armour: %.2f", 1 - armourReduct / 100))
+				t_insert(breakdown[damageType.."TakenHitMult"], s_format("Reduction from Armour: %.2f", 1 - armourReduct / 100))
 			end
 			if enemyOverwhelm ~= 0 then
 				t_insert(breakdown[damageType.."TakenHitMult"], s_format("+ Enemy Overwhelm %s Damage: %.2f", damageType, enemyOverwhelm / 100))

--- a/src/Modules/CalcDefence.lua
+++ b/src/Modules/CalcDefence.lua
@@ -1643,17 +1643,19 @@ function calcs.defence(env, actor)
 		if damageCategoryConfig == "Spell" or damageCategoryConfig == "SpellProjectile" or damageCategoryConfig == "Average" then
 			suppressChance = output.SpellSuppressionChance / 100
 		end
-		-- unlucky config to lower the value of block, dodge, evade etc for ehp
-		if worstOf > 1 then
-			suppressChance = suppressChance * suppressChance
-			if worstOf == 4 then
+		if suppressChance < 1 then -- We include suppresion in damage reduction if it is 100% otherwise we handle it here.
+			-- unlucky config to lower the value of block, dodge, evade etc for ehp
+			if worstOf > 1 then
 				suppressChance = suppressChance * suppressChance
+				if worstOf == 4 then
+					suppressChance = suppressChance * suppressChance
+				end
 			end
+			if damageCategoryConfig == "Average" then
+				suppressChance = suppressChance / 2
+			end
+			suppressionEffect = 1 - suppressChance * output.SpellSuppressionEffect / 100
 		end
-		if damageCategoryConfig == "Average" then
-			suppressChance = suppressChance / 2
-		end
-		suppressionEffect = 1 - suppressChance * output.SpellSuppressionEffect / 100
 		-- extra avoid chance
 		if damageCategoryConfig == "Projectile" or damageCategoryConfig == "SpellProjectile" then
 			ExtraAvoidChance = ExtraAvoidChance + output.AvoidProjectilesChance
@@ -1697,7 +1699,7 @@ function calcs.defence(env, actor)
 			if output.ShowBlockEffect then
 				t_insert(breakdown["ConfiguredDamageChance"], s_format("x %.2f ^8(block effect)", output.BlockEffect / 100))
 			end
-			if suppressionEffect > 0 then
+			if suppressionEffect < 1 then
 				t_insert(breakdown["ConfiguredDamageChance"], s_format("x %.3f ^8(suppression effect)", suppressionEffect))
 			end
 			if averageAvoidChance > 0 then

--- a/src/Modules/CalcDefence.lua
+++ b/src/Modules/CalcDefence.lua
@@ -1048,7 +1048,7 @@ function calcs.defence(env, actor)
 					t_insert(breakdown[damageType.."TakenDotMult"], s_format("%.2f ^8(resistance)", (1 - resist / 100)))
 				end
 				if reduction ~= 0 then
-					t_insert(breakdown[damageType.."TakenDotMult"], s_format("%.2f ^8(%s damage reduction)", (1 - reduction / 100), damageType))
+					t_insert(breakdown[damageType.."TakenDotMult"], s_format("%.2f ^8(%s damage reduction)", (1 - reduction / 100), damageType:lower()))
 				end
 				if takenInc ~= 0 then
 					t_insert(breakdown[damageType.."TakenDotMult"], s_format("%.2f ^8(increased/reduced damage taken)", (1 + takenInc / 100)))

--- a/src/Modules/CalcDefence.lua
+++ b/src/Modules/CalcDefence.lua
@@ -1134,7 +1134,7 @@ function calcs.defence(env, actor)
 			output[damageType.."TakenReflectMult"] = finalReflect
 		end
 		if breakdown then
-			breakdown[damageType.."TakenHitMult"] = { }	
+			breakdown[damageType.."TakenHitMult"] = { }
 			if resist ~= 0 then
 				t_insert(breakdown[damageType.."TakenHitMult"], s_format(s_format("Resistance: %.2f", 1 - resist / 100)))
 			end

--- a/src/Modules/CalcDefence.lua
+++ b/src/Modules/CalcDefence.lua
@@ -1041,9 +1041,6 @@ function calcs.defence(env, actor)
 			end
 			local resist = modDB:Flag(nil, "SelfIgnore"..damageType.."Resistance") and 0 or output[damageType.."Resist"]
 			local reduction = modDB:Flag(nil, "SelfIgnore"..damageType.."DamageReduction") and 0 or output[damageType.."DamageReduction"]
-			if reduction then
-				reduction = m_max(reduction, 0)
-			end
 			output[damageType.."TakenDotMult"] = (1 - resist / 100) * (1 - reduction / 100) * (1 + takenInc / 100) * takenMore
 			if breakdown then
 				breakdown[damageType.."TakenDotMult"] = { s_format("DoT Multiplier:"), }

--- a/src/Modules/CalcDefence.lua
+++ b/src/Modules/CalcDefence.lua
@@ -1080,8 +1080,7 @@ function calcs.defence(env, actor)
 		local damage = output[damageType.."TakenDamage"]
 		local armourReduct = 0
 		local resMult = 1 - (resist - enemyPen) / 100
-		local reductMult = (1 - m_max(m_min(output.DamageReductionMax, reduction - enemyOverwhelm), 0) / 100)
-		local baseMult = resMult * reductMult
+		local reductMult = 1
 		if damageCategoryConfig == "Melee" or damageCategoryConfig == "Projectile" then
 			takenFlat = takenFlat + modDB:Sum("BASE", nil, "DamageTakenFromAttacks", damageType.."DamageTakenFromAttacks")
 		elseif damageCategoryConfig == "Average" then
@@ -1090,9 +1089,8 @@ function calcs.defence(env, actor)
 		if (modDB:Flag(nil, "ArmourAppliesTo"..damageType.."DamageTaken")) and not modDB:Flag(nil, "ArmourDoesNotApplyTo"..damageType.."DamageTaken") then
 			armourReduct = calcs.armourReduction(output.Armour * (1 + output.ArmourDefense), damage * resMult)
 			armourReduct = m_min(output.DamageReductionMax, armourReduct)
-			reductMult = (1 - m_max(m_min(output.DamageReductionMax, armourReduct + reduction - enemyOverwhelm), 0) / 100)
-			baseMult = reductMult * resMult
 		end
+		reductMult = (1 - m_max(m_min(output.DamageReductionMax, armourReduct + reduction - enemyOverwhelm), 0) / 100)
 		output[damageType.."DamageReduction"] = 100 - reductMult * 100
 		if reductMult ~= 1 then
 			if breakdown and reductMult ~= 1 then
@@ -1113,6 +1111,7 @@ function calcs.defence(env, actor)
 				end
 			end
 		end
+		local baseMult = resMult * reductMult
 		local takenMult = output[damageType.."TakenHitMult"]
 		local spellSuppressMult = 1
 		if damageCategoryConfig == "Melee" or damageCategoryConfig == "Projectile" then


### PR DESCRIPTION
Fixes #4240.

### Description of the problem being solved:
The calculations for armour mitigations are very vague/confusing and have minimal breakdowns.
Spell suppression isn't included if it is guaranteed against spells.
Certain breakdown sections don't hide when irrelevant.
Generalised and separate resistances and base damage reduction. This makes it much easier to handle large changes to this in the future and allowed explicit references to damage types to be removed.

### Before Transcendence Armour Stacker
![image](https://user-images.githubusercontent.com/31533893/180598482-0c2cad92-3f6c-4dc0-b4f2-7ea43dffe5f5.png)
![image](https://user-images.githubusercontent.com/31533893/180598478-9f12f521-c06c-47a3-86dc-2b9bdcaeb2eb.png)
![image](https://user-images.githubusercontent.com/31533893/180598450-7d7a3ac9-a133-4011-8ad8-9a8a1baab217.png)
![image](https://user-images.githubusercontent.com/31533893/180598686-5b036969-45a6-42e9-aaaa-823b59ee2f3b.png)
![image](https://user-images.githubusercontent.com/31533893/180598762-35a30a09-02e1-471f-89f2-3e9bbdebbcae.png)
### After 
![image](https://user-images.githubusercontent.com/31533893/180598492-740d8227-af2d-4ac1-b5f1-2abc2c4ce35b.png)
![image](https://user-images.githubusercontent.com/31533893/180598502-e7425fdc-6355-4cf1-8ce7-62e8f286ef66.png)
![image](https://user-images.githubusercontent.com/31533893/180598464-baf1b854-5734-424e-8375-463b48bedbe0.png)
![image](https://user-images.githubusercontent.com/31533893/183271857-8e255928-1611-451e-89ac-48f5c3b3b7ee.png)
![image](https://user-images.githubusercontent.com/31533893/183271858-cb6d5565-5061-4b0c-807e-b010461dea9c.png)

### Before Regular Build
![image](https://user-images.githubusercontent.com/31533893/180599598-d364a369-71f8-49eb-a3a9-e658d862e62b.png)
![image](https://user-images.githubusercontent.com/31533893/183271707-bfa63a93-19e0-4f31-886b-af22de13327b.png)
### After 
![image](https://user-images.githubusercontent.com/31533893/183271674-26ac3dd4-e80d-4a0e-949e-90d50030dd6b.png)
![image](https://user-images.githubusercontent.com/31533893/183271871-4889554f-f46e-4138-87d9-b79b2d58c4b2.png)

### Before Enduring Cry Transcendence Without
![image](https://user-images.githubusercontent.com/31533893/180599346-9d73906d-2981-4730-ae06-4c73f75c7e8a.png)
![image](https://user-images.githubusercontent.com/31533893/183273269-a4e24d57-f022-4e5d-a6f4-22a3139f0d23.png)
### After
![image](https://user-images.githubusercontent.com/31533893/180599365-3ecc3aa5-40c8-4960-87a9-1628b0660d6b.png)
![image](https://user-images.githubusercontent.com/31533893/183273253-e43617ce-ed13-4eb2-81e2-f6d60bb77f3e.png)

### Before Enduring Cry Transcendence With
![image](https://user-images.githubusercontent.com/31533893/180599403-a14eae61-1d04-4148-968d-a5c42bac0792.png)
### After
![image](https://user-images.githubusercontent.com/31533893/180599436-f25c8884-6383-4cb5-9f94-5bf09eeaba71.png)

With 100% chance spell suppresion will appear in breakdown and get removed from other eHP calculations.
### Spell Suppression "Spell"
![image](https://user-images.githubusercontent.com/31533893/183271912-b8b76c6d-6fa8-4bba-afcf-c06c0b063034.png)

### Spell Suppression "Average"
![image](https://user-images.githubusercontent.com/31533893/183271905-526144ec-2c34-41e6-b4c6-6c3ac30c78b4.png)

### Link to a build that showcases this PR:
Transcendence Armour Stacker + Phys to ele https://pobb.in/S8lGNPQF8Af8
Regular Build https://pobb.in/3XXONK_WLL2U
Enduring cry transcendence https://pobb.in/h5VqofF3ymJH
