### PR TITLE
Fix total more multipliers not being round to nearest percent as done ingame.

### DIFF
--- a/src/Classes/ModDB.lua
+++ b/src/Classes/ModDB.lua
@@ -124,18 +124,20 @@ function ModDBClass:MoreInternal(context, cfg, flags, keywordFlags, source, ...)
 	local result = 1
 	for i = 1, select('#', ...) do
 		local modList = self.mods[select(i, ...)]
+		local modResult = 1 --The more multiplers for each mod are computed to the nearest percent then applied.
 		if modList then
 			for i = 1, #modList do
 				local mod = modList[i]
 				if mod.type == "MORE" and band(flags, mod.flags) == mod.flags and MatchKeywordFlags(keywordFlags, mod.keywordFlags) and (not source or mod.source:match("[^:]+") == source) then
 					if mod[1] then
-						result = result * (1 + (context:EvalMod(mod, cfg) or 0) / 100)
+						modResult = modResult * (1 + (context:EvalMod(mod, cfg) or 0) / 100)
 					else
-						result = result * (1 + mod.value / 100)
+						modResult = modResult * (1 + mod.value / 100)
 					end
 				end
 			end
 		end
+		result = result * round(modResult,2)
 	end
 	if self.parent then
 		result = result * self.parent:MoreInternal(context, cfg, flags, keywordFlags, source, ...)

--- a/src/Classes/ModStore.lua
+++ b/src/Classes/ModStore.lua
@@ -129,7 +129,7 @@ function ModStoreClass:More(cfg, ...)
 		keywordFlags = cfg.keywordFlags or 0
 		source = cfg.source
 	end
-	return self:MoreInternal(self, cfg, flags, keywordFlags, source, ...)
+	return round(self:MoreInternal(self, cfg, flags, keywordFlags, source, ...), 2)
 end
 
 function ModStoreClass:Flag(cfg, ...)

--- a/src/Classes/ModStore.lua
+++ b/src/Classes/ModStore.lua
@@ -129,7 +129,7 @@ function ModStoreClass:More(cfg, ...)
 		keywordFlags = cfg.keywordFlags or 0
 		source = cfg.source
 	end
-	return round(self:MoreInternal(self, cfg, flags, keywordFlags, source, ...), 2)
+	return self:MoreInternal(self, cfg, flags, keywordFlags, source, ...)
 end
 
 function ModStoreClass:Flag(cfg, ...)


### PR DESCRIPTION
### Description of the problem being solved:
Ingame when applying a more multiplier it truncates all of the partial more multipliers then multiplies and rounds to the nearest percent.

### Link to a build that showcases this PR:
https://pobb.in/9I_Oedp2IMk5

### Ingame First is just basalt 2nd is basalt with 64% effect.
![image](https://user-images.githubusercontent.com/31533893/180640608-95cf6871-666b-4116-8acb-e7eefcae026e.png)
![image](https://user-images.githubusercontent.com/31533893/180640592-acdc3b5c-44b8-433b-b501-aa608ec5e107.png)

### Before screenshot:
![image](https://user-images.githubusercontent.com/31533893/180640618-4ee507da-fc1d-493d-94c0-0fc2f04d9015.png)
![image](https://user-images.githubusercontent.com/31533893/180640625-2a406db5-cced-4235-83ec-1115ef9bea9e.png)

### After screenshot:
![image](https://user-images.githubusercontent.com/31533893/180640655-1c4d2a35-9554-4ab3-8496-09f05b51ff3e.png)
![image](https://user-images.githubusercontent.com/31533893/180640649-d32b29c6-11b1-4dcf-82b0-f8a5676b0ca1.png)
