### PR TITLE
Fix Absolution spell hit counted multiple times in the Total DPS

### DIFF
--- a/src/Modules/Calcs.lua
+++ b/src/Modules/Calcs.lua
@@ -220,6 +220,7 @@ function calcs.calcFullDPS(build, mode, override, specEnv)
 					-- This is a fix to prevent Absolution spell hit from being counted multiple times when increasing minions count
                     if activeSkill.activeEffect.grantedEffect.name == "Absolution" then
                         activeSkillCount = 1
+						activeSkill.infoMessage2 = "Skill Damage"
                     end
 				end
 

--- a/src/Modules/Calcs.lua
+++ b/src/Modules/Calcs.lua
@@ -217,6 +217,10 @@ function calcs.calcFullDPS(build, mode, override, specEnv)
 					if usedEnv.minion.output.CullMultiplier and usedEnv.minion.output.CullMultiplier > 1 and usedEnv.minion.output.CullMultiplier > fullDPS.cullingMulti then
 						fullDPS.cullingMulti = usedEnv.minion.output.CullMultiplier
 					end
+					-- This is a fix to prevent Absolution spell hit from being counted multiple times when increasing minions count
+                    if activeSkill.activeEffect.grantedEffect.name == "Absolution" then
+                        activeSkillCount = 1
+                    end
 				end
 
 				if activeSkill.mirage then

--- a/src/Modules/Calcs.lua
+++ b/src/Modules/Calcs.lua
@@ -218,7 +218,7 @@ function calcs.calcFullDPS(build, mode, override, specEnv)
 						fullDPS.cullingMulti = usedEnv.minion.output.CullMultiplier
 					end
 					-- This is a fix to prevent Absolution spell hit from being counted multiple times when increasing minions count
-					if activeSkill.activeEffect.grantedEffect.name == "Absolution" then
+					if activeSkill.activeEffect.grantedEffect.name == "Absolution" and fullEnv.modDB:Flag(false, "Condition:AbsolutionSkillDamageCountedOnce") then
 						activeSkillCount = 1
 						activeSkill.infoMessage2 = "Skill Damage"
 					end

--- a/src/Modules/Calcs.lua
+++ b/src/Modules/Calcs.lua
@@ -220,7 +220,7 @@ function calcs.calcFullDPS(build, mode, override, specEnv)
 					-- This is a fix to prevent Absolution spell hit from being counted multiple times when increasing minions count
                     if activeSkill.activeEffect.grantedEffect.name == "Absolution" then
                         activeSkillCount = 1
-					    activeSkill.infoMessage2 = "Skill Damage"
+                        activeSkill.infoMessage2 = "Skill Damage"
                     end
 				end
 

--- a/src/Modules/Calcs.lua
+++ b/src/Modules/Calcs.lua
@@ -218,10 +218,10 @@ function calcs.calcFullDPS(build, mode, override, specEnv)
 						fullDPS.cullingMulti = usedEnv.minion.output.CullMultiplier
 					end
 					-- This is a fix to prevent Absolution spell hit from being counted multiple times when increasing minions count
-                    if activeSkill.activeEffect.grantedEffect.name == "Absolution" then
-                        activeSkillCount = 1
-                        activeSkill.infoMessage2 = "Skill Damage"
-                    end
+					if activeSkill.activeEffect.grantedEffect.name == "Absolution" then
+						activeSkillCount = 1
+						activeSkill.infoMessage2 = "Skill Damage"
+					end
 				end
 
 				if activeSkill.mirage then

--- a/src/Modules/Calcs.lua
+++ b/src/Modules/Calcs.lua
@@ -220,7 +220,7 @@ function calcs.calcFullDPS(build, mode, override, specEnv)
 					-- This is a fix to prevent Absolution spell hit from being counted multiple times when increasing minions count
                     if activeSkill.activeEffect.grantedEffect.name == "Absolution" then
                         activeSkillCount = 1
-						activeSkill.infoMessage2 = "Skill Damage"
+					    activeSkill.infoMessage2 = "Skill Damage"
                     end
 				end
 

--- a/src/Modules/ConfigOptions.lua
+++ b/src/Modules/ConfigOptions.lua
@@ -437,6 +437,9 @@ return {
 			modList:NewMod("Condition:WaveOfConvictionLightningExposureActive", "FLAG", true, "Config")
 		end
 	end },
+	{ var = "absolutionSkillDamageCountedOnce", type = "check", label = "Absolution: Count skill damage once", ifSkill = "Absolution", tooltip = "Your Absolution Skill Damage will not be scaled with Count setting.\nBy default it multiplies both minion count and skill hit count which leads to incorrect\nTotal DPS calculation since Absolution cannot inherently shotgun.\nDo not enable if you use Spell Totem support, Spell Cascade support or similar supports", apply = function(val, modList, enemyModList)
+		modList:NewMod("Condition:AbsolutionSkillDamageCountedOnce", "FLAG", true, "Config", { type = "Condition", var = "Combat" })
+	end },
 	{ label = "Molten Shell:", ifSkill = "Molten Shell" },
 	{ var = "MoltenShellDamageMitigated", type = "count", label = "Damage mitigated:", tooltip = "Molten Shell reflects damage to the enemy,\nbased on the amount of damage it has mitigated.", ifSkill = "Molten Shell", apply = function(val, modList, enemyModList)
 		modList:NewMod("SkillData", "LIST", { key = "MoltenShellDamageMitigated", value = val }, "Config", { type = "SkillName", skillName = "Molten Shell" })


### PR DESCRIPTION
### Description of the problem being solved:

While calculating Full DPS for `Absolution` the `Count` increases not only the number of minions (which is correct) but also multiplies the dps of the spell itself (which is incorrect)

### Steps taken to verify a working solution:
1. Add `Absolution` active skill
2. Increase count
3. Check `Include in Full DPS`

### Link to a build that showcases this PR:
[https://pobb.in/-aL0wEIoqGe_](https://pobb.in/-aL0wEIoqGe_)

### Before screenshot:
![image](https://user-images.githubusercontent.com/254369/181277281-1b95c0ca-d35e-4922-a1f5-430707fee6d6.png)

### After screenshot:
![image](https://user-images.githubusercontent.com/254369/181277300-54aa4f36-63a9-4a43-869e-7ad9d3c34694.png)

![image](https://user-images.githubusercontent.com/254369/181505812-c72a7e7c-5d14-40dc-8066-414bfb6d837c.png)
