### PR TITLE
Add eldritch implicits

### DIFF
--- a/src/Classes/Item.lua
+++ b/src/Classes/Item.lua
@@ -469,13 +469,13 @@ function ItemClass:ParseRaw(raw)
 					foundImplicit = true
 					gameModeStage = "IMPLICIT"
 				end
-				line = line:gsub("%b{}", ""):gsub(" %(fractured%)",""):gsub(" %(crafted%)",""):gsub(" %(implicit%)",""):gsub(" %(enchant%)",""):gsub(" %(scourge%)","")
+				line = line:gsub("%b{}", ""):gsub(" %(fractured%)",""):gsub(" %(crafted%)",""):gsub(" %(implicit%)",""):gsub(" %(enchant%)",""):gsub(" %(scourge%)",""):gsub(" %(exarch%)",""):gsub(" %(eater%)",""):gsub(" %(synthesis%)","")
 				local catalystScalar = getCatalystScalar(self.catalyst, modTags, self.catalystQuality)
 				local rangedLine = itemLib.applyRange(line, 1, catalystScalar)
 				local modList, extra = modLib.parseMod(rangedLine or line)
 				if (not modList or extra) and self.rawLines[l+1] then
 					-- Try to combine it with the next line
-					local nextLine = self.rawLines[l+1]:gsub("%b{}", ""):gsub(" ?%(fractured%)",""):gsub(" ?%(crafted%)",""):gsub(" ?%(implicit%)",""):gsub(" ?%(enchant%)",""):gsub(" ?%(scourge%)","")
+					local nextLine = self.rawLines[l+1]:gsub("%b{}", ""):gsub(" ?%(fractured%)",""):gsub(" ?%(crafted%)",""):gsub(" ?%(implicit%)",""):gsub(" ?%(enchant%)",""):gsub(" ?%(scourge%)",""):gsub(" %(exarch%)",""):gsub(" %(eater%)",""):gsub(" %(synthesis%)","")
 					local combLine = line.." "..nextLine
 					rangedLine = itemLib.applyRange(combLine, 1, catalystScalar)
 					modList, extra = modLib.parseMod(rangedLine or combLine, true)
@@ -521,7 +521,7 @@ function ItemClass:ParseRaw(raw)
 					modLines = self.explicitModLines
 				end
 				if modList then
-					t_insert(modLines, { line = line, extra = extra, modList = modList, modTags = modTags, variantList = variantList, scourge = scourge, crafted = crafted, custom = custom, fractured = fractured, implicit = implicit, range = rangedLine and (tonumber(rangeSpec) or main.defaultItemAffixQuality), valueScalar = catalystScalar })
+					t_insert(modLines, { line = line, extra = extra, modList = modList, modTags = modTags, variantList = variantList, scourge = scourge, crafted = crafted, custom = custom, fractured = fractured, exarch = exarch, eater = eater, synthesis = synthesis, implicit = implicit, range = rangedLine and (tonumber(rangeSpec) or main.defaultItemAffixQuality), valueScalar = catalystScalar })
 					if mode == "GAME" then
 						if gameModeStage == "FINDIMPLICIT" then
 							gameModeStage = "IMPLICIT"
@@ -536,12 +536,12 @@ function ItemClass:ParseRaw(raw)
 					end
 				elseif mode == "GAME" then
 					if gameModeStage == "IMPLICIT" or gameModeStage == "EXPLICIT" or (gameModeStage == "FINDIMPLICIT" and (not data.itemBases[line]) and not (self.name == line) and not line:find("Two%-Toned")) then
-						t_insert(modLines, { line = line, extra = line, modList = { }, modTags = { }, variantList = variantList, scourge = scourge, crafted = crafted, custom = custom, fractured = fractured, implicit = implicit })
+						t_insert(modLines, { line = line, extra = line, modList = { }, modTags = { }, variantList = variantList, scourge = scourge, crafted = crafted, custom = custom, fractured = fractured, exarch = exarch, eater = eater, synthesis = synthesis, implicit = implicit })
 					elseif gameModeStage == "FINDEXPLICIT" then
 						gameModeStage = "DONE"
 					end
 				elseif foundExplicit then
-					t_insert(modLines, { line = line, extra = line, modList = { }, modTags = { }, variantList = variantList, scourge = scourge, crafted = crafted, custom = custom, fractured = fractured, implicit = implicit })
+					t_insert(modLines, { line = line, extra = line, modList = { }, modTags = { }, variantList = variantList, scourge = scourge, crafted = crafted, custom = custom, fractured = fractured, exarch = exarch, eater = eater, synthesis = synthesis, implicit = implicit })
 				end
 			end
 		end

--- a/src/Classes/Item.lua
+++ b/src/Classes/Item.lua
@@ -448,6 +448,9 @@ function ItemClass:ParseRaw(raw)
 						end
 					end
 				end
+				local eater = line:match("{eater}")
+				local exarch = line:match("{exarch}")
+				local synthesis = line:match("{synthesis}")
 				local fractured = line:match("{fractured}") or line:match(" %(fractured%)")
 				local rangeSpec = line:match("{range:([%d.]+)}")
 				local enchant = line:match(" %(enchant%)")
@@ -751,6 +754,15 @@ function ItemClass:BuildRaw()
 		end
 		if modLine.fractured then
 			line = "{fractured}" .. line
+		end
+		if modLine.exarch then
+			line = "{exarch}" .. line
+		end
+		if modLine.eater then
+			line = "{eater}" .. line
+		end
+		if modLine.synthesis then
+			line = "{synthesis}" .. line
 		end
 		if modLine.variantList then
 			local varSpec

--- a/src/Classes/ItemsTab.lua
+++ b/src/Classes/ItemsTab.lua
@@ -2532,8 +2532,22 @@ function ItemsTabClass:AddImplicitToDisplayItem()
 		elseif sourceId == "DelveImplicit" then
 			for i, mod in pairs(self.displayItem.affixes) do
 				if self.displayItem:GetModSpawnWeight(mod) > 0 and sourceId:lower() == mod.type:lower() then
-					t_insert(modList, {
-						label = table.concat(mod, "/"),
+					local modLabel = table.concat(mod, "/")
+					if not groupIndexs[mod.group] then
+						t_insert(modList, {})
+						t_insert(modGroups, {
+							label = modLabel,
+							mod = mod,
+							modListIndex = #modList,
+							defaultOrder = i,
+						})
+						groupIndexs[mod.group] = #modGroups
+					--elseif mod[1].len() < modGroups[groupIndexs[mod.group] ].mod[1].len() then
+					--	modGroups[groupIndexs[mod.group]].label = modLabel
+					--	modGroups[groupIndexs[mod.group]].mod = mod
+					end
+					t_insert(modList[groupIndexs[mod.group]], {
+						label = modLabel,
 						mod = mod,
 						affixType = mod.type,
 						type = "custom",
@@ -2598,10 +2612,15 @@ function ItemsTabClass:AddImplicitToDisplayItem()
 	end
 	controls.sourceLabel = new("LabelControl", {"TOPRIGHT",nil,"TOPLEFT"}, 95, 20, 0, 16, "^7Source:")
 	controls.source = new("DropDownControl", {"TOPLEFT",nil,"TOPLEFT"}, 100, 20, 150, 18, sourceList, function(index, value)
-		buildMods(value.sourceId)
-		controls.modGroupSelect:SetSel(1)
-		controls.modSelect.list = modList[modGroups[1].modListIndex]
-		controls.modSelect:SetSel(1)
+		if value.sourceId ~= "CUSTOM" then
+			controls.modSelectLabel.y = 70
+			buildMods(value.sourceId)
+			controls.modGroupSelect:SetSel(1)
+			controls.modSelect.list = modList[modGroups[1].modListIndex]
+			controls.modSelect:SetSel(1)
+		else
+			controls.modSelectLabel.y = 45
+		end
 	end)
 	controls.source.enabled = #sourceList > 1
 	controls.modGroupSelectLabel = new("LabelControl", {"TOPRIGHT",nil,"TOPLEFT"}, 95, 45, 0, 16, "^7Type:")
@@ -2609,6 +2628,9 @@ function ItemsTabClass:AddImplicitToDisplayItem()
 		controls.modSelect.list = modList[value.modListIndex]
 		controls.modSelect:SetSel(1)
 	end)
+	controls.modGroupSelectLabel.shown = function()
+		return sourceList[controls.source.selIndex].sourceId ~= "CUSTOM"
+	end
 	controls.modGroupSelect.shown = function()
 		return sourceList[controls.source.selIndex].sourceId ~= "CUSTOM"
 	end

--- a/src/Classes/ItemsTab.lua
+++ b/src/Classes/ItemsTab.lua
@@ -2459,7 +2459,7 @@ function ItemsTabClass:AddImplicitToDisplayItem()
 			for i, mod in pairs(self.displayItem.affixes) do
 				if self.displayItem:GetModSpawnWeight(mod) > 0 and sourceId:lower() == mod.type:lower() then
 					t_insert(modList, {
-						label = table.concat(mod, "/") .. " (" .. mod.type .. ")",
+						label = table.concat(mod, "/"),
 						mod = mod,
 						affixType = mod.type,
 						type = "custom",
@@ -2481,11 +2481,11 @@ function ItemsTabClass:AddImplicitToDisplayItem()
 				end
 				return modA.level > modB.level
 			end)
-		elseif sourceId == "Synthesis" then
+		elseif sourceId == "SYNTHESIS" then
 			for i, mod in pairs(self.displayItem.affixes) do
 				if sourceId:lower() == mod.type:lower() then -- weights are missing and so are 0, how do I determine what goes on what item?, also arnt these supposed to work on jewels?
 					t_insert(modList, {
-						label = table.concat(mod, "/") .. " (" .. mod.type .. ")",
+						label = table.concat(mod, "/"),
 						mod = mod,
 						affixType = mod.type,
 						type = "custom",
@@ -2500,7 +2500,7 @@ function ItemsTabClass:AddImplicitToDisplayItem()
 			for i, mod in pairs(self.displayItem.affixes) do
 				if self.displayItem:GetModSpawnWeight(mod) > 0 and sourceId:lower() == mod.type:lower() then
 					t_insert(modList, {
-						label = table.concat(mod, "/") .. " (" .. mod.type .. ")",
+						label = table.concat(mod, "/"),
 						mod = mod,
 						affixType = mod.type,
 						type = "custom",
@@ -2518,7 +2518,7 @@ function ItemsTabClass:AddImplicitToDisplayItem()
 		t_insert(sourceList, { label = "Eater of Worlds", sourceId = "EATER" })
 	end
 	if self.displayItem.type ~= "Flask" and self.displayItem.type ~= "Jewel" then
-		t_insert(sourceList, { label = "Synth", sourceId = "Synthesis" })
+		t_insert(sourceList, { label = "Synth", sourceId = "SYNTHESIS" })
 		t_insert(sourceList, { label = "Delve", sourceId = "DelveImplicit" })
 	end
 	t_insert(sourceList, { label = "Custom", sourceId = "CUSTOM" })
@@ -2527,24 +2527,47 @@ function ItemsTabClass:AddImplicitToDisplayItem()
 		local item = new("Item", self.displayItem:BuildRaw())
 		item.id = self.displayItem.id
 		local sourceId = sourceList[controls.source.selIndex].sourceId
-		local newImplicit = { }
-		local newType = false
 		if sourceId == "CUSTOM" then
 			if controls.custom.buf:match("%S") then
-				t_insert(newImplicit, { line = controls.custom.buf, custom = true })
+				t_insert(item.implicitModLines, { line = controls.custom.buf, custom = true })
+			end
+		elseif sourceId == "SYNTHESIS" then
+			local listMod = modList[controls.modSelect.selIndex]
+			for _, line in ipairs(listMod.mod) do
+				t_insert(item.implicitModLines, { line = line, modTags = listMod.mod.modTags, [listMod.type] = true })
+			end
+		elseif sourceId == "EXARCH" or sourceId == "EATER" then
+			local listMod = modList[controls.modSelect.selIndex]
+			local index = nil
+			for i, implictMod in ipairs(item.implicitModLines) do
+				for _, mod in ipairs(modList) do
+					for _, modLine in ipairs(mod.mod) do
+						if modLine == implictMod.line then
+							index = i
+							break
+						end
+					end
+					if index then
+						break
+					end
+				end
+				if index then
+					break
+				end
+			end
+			if index then
+				for _, line in ipairs(listMod.mod) do
+					item.implicitModLines[index] = { line = line, modTags = listMod.mod.modTags, [listMod.type] = true }
+				end
+			else
+				for _, line in ipairs(listMod.mod) do
+					t_insert(item.implicitModLines, { line = line, modTags = listMod.mod.modTags, [listMod.type] = true })
+				end
 			end
 		else
 			local listMod = modList[controls.modSelect.selIndex]
 			for _, line in ipairs(listMod.mod) do
-				t_insert(newImplicit, { line = line, modTags = listMod.mod.modTags, [listMod.type] = true })
-			end
-		end
-		if #newImplicit > 0 then
-			if newType then
-				wipeTable(item.implicitModLines)
-			end
-			for i, implicit in ipairs(newImplicit) do
-				t_insert(item.implicitModLines, i, implicit)
+				t_insert(item.implicitModLines, { line = line, modTags = listMod.mod.modTags, [listMod.type] = true })
 			end
 		end
 		item:BuildAndParseRaw()

--- a/src/Classes/ItemsTab.lua
+++ b/src/Classes/ItemsTab.lua
@@ -2462,7 +2462,7 @@ function ItemsTabClass:AddImplicitToDisplayItem()
 						label = table.concat(mod, "/"),
 						mod = mod,
 						affixType = mod.type,
-						type = "custom",
+						type = sourceId:lower(),
 						defaultOrder = i,
 					})
 				end
@@ -2488,7 +2488,7 @@ function ItemsTabClass:AddImplicitToDisplayItem()
 						label = table.concat(mod, "/"),
 						mod = mod,
 						affixType = mod.type,
-						type = "custom",
+						type = "synthesis",
 						defaultOrder = i,
 					})
 				end

--- a/src/Classes/ItemsTab.lua
+++ b/src/Classes/ItemsTab.lua
@@ -2481,16 +2481,46 @@ function ItemsTabClass:AddImplicitToDisplayItem()
 				end
 				return modA.level > modB.level
 			end)
+		elseif sourceId == "Synthesis" then
+			for i, mod in pairs(self.displayItem.affixes) do
+				if sourceId:lower() == mod.type:lower() then -- weights are missing and so are 0, how do I determine what goes on what item?
+					t_insert(modList, {
+						label = table.concat(mod, "/") .. " (" .. mod.type .. ")",
+						mod = mod,
+						affixType = mod.type,
+						type = "custom",
+						defaultOrder = i,
+					})
+				end
+			end
+			table.sort(modList, function(a, b)
+				return a.defaultOrder < b.defaultOrder
+			end)
+		elseif sourceId == "DelveImplicit" then
+			for i, mod in pairs(self.displayItem.affixes) do
+				if self.displayItem:GetModSpawnWeight(mod) > 0 and sourceId:lower() == mod.type:lower() then
+					t_insert(modList, {
+						label = table.concat(mod, "/") .. " (" .. mod.type .. ")",
+						mod = mod,
+						affixType = mod.type,
+						type = "custom",
+						defaultOrder = i,
+					})
+				end
+			end
+			table.sort(modList, function(a, b)
+				return a.defaultOrder < b.defaultOrder
+			end)
 		end
 	end
 	if (self.displayItem.rarity ~= "UNIQUE" and self.displayItem.rarity ~= "RELIC") and (self.displayItem.type == "Helmet" or self.displayItem.type == "Body Armour" or self.displayItem.type == "Gloves" or self.displayItem.type == "Boots") then
 		t_insert(sourceList, { label = "Searing Exarch", sourceId = "EXARCH" })
 		t_insert(sourceList, { label = "Eater of Worlds", sourceId = "EATER" })
 	end
-	--if self.displayItem.type ~= "Flask" then
-	--	t_insert(sourceList, { label = "Synth", sourceId = "SYNTH" })
-	--	t_insert(sourceList, { label = "Delve", sourceId = "DelveImplicit" })
-	--end
+	if self.displayItem.type ~= "Flask" then
+		t_insert(sourceList, { label = "Synth", sourceId = "Synthesis" })
+		t_insert(sourceList, { label = "Delve", sourceId = "DelveImplicit" })
+	end
 	t_insert(sourceList, { label = "Custom", sourceId = "CUSTOM" })
 	buildMods(sourceList[1].sourceId)
 	local function addModifier()

--- a/src/Classes/ItemsTab.lua
+++ b/src/Classes/ItemsTab.lua
@@ -2483,10 +2483,14 @@ function ItemsTabClass:AddImplicitToDisplayItem()
 			end)
 		end
 	end
-	t_insert(sourceList, { label = "Searing Exarch", sourceId = "EXARCH" })
-	t_insert(sourceList, { label = "Eater of Worlds", sourceId = "EATER" })
-	--t_insert(sourceList, { label = "Synth", sourceId = "EXARCH" })
-	--t_insert(sourceList, { label = "Delve", sourceId = "EXARCH" })
+	if (self.displayItem.rarity ~= "UNIQUE" and self.displayItem.rarity ~= "RELIC") and (self.displayItem.type == "Helmet" or self.displayItem.type == "Body Armour" or self.displayItem.type == "Gloves" or self.displayItem.type == "Boots") then
+		t_insert(sourceList, { label = "Searing Exarch", sourceId = "EXARCH" })
+		t_insert(sourceList, { label = "Eater of Worlds", sourceId = "EATER" })
+	end
+	--if self.displayItem.type ~= "Flask" then
+	--	t_insert(sourceList, { label = "Synth", sourceId = "SYNTH" })
+	--	t_insert(sourceList, { label = "Delve", sourceId = "DelveImplicit" })
+	--end
 	t_insert(sourceList, { label = "Custom", sourceId = "CUSTOM" })
 	buildMods(sourceList[1].sourceId)
 	local function addModifier()

--- a/src/Classes/ItemsTab.lua
+++ b/src/Classes/ItemsTab.lua
@@ -2244,7 +2244,7 @@ function ItemsTabClass:AddCustomModifierToDisplayItem()
 			end
 			table.sort(modList, function(a, b)
 				if a.essence.type ~= b.essence.type then
-					return a.essence.type > b.essence.type 
+					return a.essence.type > b.essence.type
 				else
 					return a.essence.tier > b.essence.tier
 				end
@@ -2259,7 +2259,7 @@ function ItemsTabClass:AddCustomModifierToDisplayItem()
 					})
 				end
 			end
-			table.sort(modList, function(a, b) 
+			table.sort(modList, function(a, b)
 				local modA = a.mod
 				local modB = b.mod
 				for i = 1, m_max(#modA, #modB) do
@@ -2277,7 +2277,7 @@ function ItemsTabClass:AddCustomModifierToDisplayItem()
 			for i, mod in pairs(self.build.data.veiledMods) do
 				if self.displayItem:GetModSpawnWeight(mod) > 0 then
 					t_insert(modList, {
-						label =  table.concat(mod, "/") .. " (" .. mod.type .. ")",
+						label = table.concat(mod, "/") .. " (" .. mod.type .. ")",
 						mod = mod,
 						affixType = mod.type,
 						type = "custom",
@@ -2296,7 +2296,7 @@ function ItemsTabClass:AddCustomModifierToDisplayItem()
 			for i, mod in pairs(self.displayItem.affixes) do
 				if self.displayItem:CheckIfModIsDelve(mod) and self.displayItem:GetModSpawnWeight(mod) > 0 then
 					t_insert(modList, {
-						label =  table.concat(mod, "/") .. " (" .. mod.type .. ")",
+						label = table.concat(mod, "/") .. " (" .. mod.type .. ")",
 						mod = mod,
 						affixType = mod.type,
 						type = "custom",
@@ -2310,6 +2310,32 @@ function ItemsTabClass:AddCustomModifierToDisplayItem()
 				else
 					return a.defaultOrder < b.defaultOrder
 				end
+			end)
+		elseif sourceId == "EXARCH" or sourceId == "EATER" then
+			for i, mod in pairs(self.displayItem.affixes) do
+				if self.displayItem:GetModSpawnWeight(mod) > 0 and sourceId:lower() == mod.type:lower() then
+					t_insert(modList, {
+						label = table.concat(mod, "/") .. " (" .. mod.type .. ")",
+						mod = mod,
+						affixType = mod.type,
+						type = "custom",
+						defaultOrder = i,
+					})
+				end
+			end
+			table.sort(modList, function(a, b)
+				local modA = a.mod
+				local modB = b.mod
+				for i = 1, m_max(#modA, #modB) do
+					if not modA[i] then
+						return true
+					elseif not modB[i] then
+						return false
+					elseif modA.statOrder[i] ~= modB.statOrder[i] then
+						return modA.statOrder[i] < modB.statOrder[i]
+					end
+				end
+				return modA.level > modB.level
 			end)
 		end
 	end
@@ -2330,6 +2356,8 @@ function ItemsTabClass:AddCustomModifierToDisplayItem()
 		t_insert(sourceList, { label = "Suffix", sourceId = "SUFFIX" })
 	end
 	t_insert(sourceList, { label = "Custom", sourceId = "CUSTOM" })
+	t_insert(sourceList, { label = "Searing Exarch", sourceId = "EXARCH" })
+	t_insert(sourceList, { label = "Eater of Worlds", sourceId = "EATER" })
 	buildMods(sourceList[1].sourceId)
 	local function addModifier()
 		local item = new("Item", self.displayItem:BuildRaw())

--- a/src/Classes/ItemsTab.lua
+++ b/src/Classes/ItemsTab.lua
@@ -2561,8 +2561,12 @@ function ItemsTabClass:AddImplicitToDisplayItem()
 		end
 	end
 	if (self.displayItem.rarity ~= "UNIQUE" and self.displayItem.rarity ~= "RELIC") and (self.displayItem.type == "Helmet" or self.displayItem.type == "Body Armour" or self.displayItem.type == "Gloves" or self.displayItem.type == "Boots") then
-		t_insert(sourceList, { label = "Searing Exarch", sourceId = "EXARCH" })
-		t_insert(sourceList, { label = "Eater of Worlds", sourceId = "EATER" })
+		if self.displayItem.cleansing then
+			t_insert(sourceList, { label = "Searing Exarch", sourceId = "EXARCH" })
+		end
+		if self.displayItem.tangle then
+			t_insert(sourceList, { label = "Eater of Worlds", sourceId = "EATER" })
+		end
 	end
 	if self.displayItem.type ~= "Flask" and self.displayItem.type ~= "Jewel" then
 		--t_insert(sourceList, { label = "Synth", sourceId = "SYNTHESIS" }) -- synth removed untill we get proper support for where the mods go
@@ -2602,7 +2606,7 @@ function ItemsTabClass:AddImplicitToDisplayItem()
 				end
 			end
 		else
-			local listMod = modList[controls.modSelect.selIndex]
+			local listMod = modList[modGroups[controls.modGroupSelect.selIndex].modListIndex][controls.modSelect.selIndex]
 			for _, line in ipairs(listMod.mod) do
 				t_insert(item.implicitModLines, { line = line, modTags = listMod.mod.modTags, [listMod.type] = true })
 			end

--- a/src/Classes/ItemsTab.lua
+++ b/src/Classes/ItemsTab.lua
@@ -2555,9 +2555,11 @@ function ItemsTabClass:AddImplicitToDisplayItem()
 					})
 				end
 			end
-			table.sort(modList, function(a, b)
-				return a.defaultOrder < b.defaultOrder
-			end)
+			for i, _ in pairs(modList) do
+				table.sort(modList[i], function(a, b)
+					return a.defaultOrder < b.defaultOrder
+				end)
+			end
 		end
 	end
 	if (self.displayItem.rarity ~= "UNIQUE" and self.displayItem.rarity ~= "RELIC") and (self.displayItem.type == "Helmet" or self.displayItem.type == "Body Armour" or self.displayItem.type == "Gloves" or self.displayItem.type == "Boots") then

--- a/src/Classes/ItemsTab.lua
+++ b/src/Classes/ItemsTab.lua
@@ -2483,7 +2483,7 @@ function ItemsTabClass:AddImplicitToDisplayItem()
 			end)
 		elseif sourceId == "Synthesis" then
 			for i, mod in pairs(self.displayItem.affixes) do
-				if sourceId:lower() == mod.type:lower() then -- weights are missing and so are 0, how do I determine what goes on what item?
+				if sourceId:lower() == mod.type:lower() then -- weights are missing and so are 0, how do I determine what goes on what item?, also arnt these supposed to work on jewels?
 					t_insert(modList, {
 						label = table.concat(mod, "/") .. " (" .. mod.type .. ")",
 						mod = mod,
@@ -2517,7 +2517,7 @@ function ItemsTabClass:AddImplicitToDisplayItem()
 		t_insert(sourceList, { label = "Searing Exarch", sourceId = "EXARCH" })
 		t_insert(sourceList, { label = "Eater of Worlds", sourceId = "EATER" })
 	end
-	if self.displayItem.type ~= "Flask" then
+	if self.displayItem.type ~= "Flask" and self.displayItem.type ~= "Jewel" then
 		t_insert(sourceList, { label = "Synth", sourceId = "Synthesis" })
 		t_insert(sourceList, { label = "Delve", sourceId = "DelveImplicit" })
 	end

--- a/src/Export/Scripts/mods.lua
+++ b/src/Export/Scripts/mods.lua
@@ -33,6 +33,8 @@ local function writeMods(outName, condFunc)
 					print("[Jewel]: Skipping '" .. mod.Id .. "'")
 					goto continue
 				end
+			elseif mod.GenerationType == 3 and not (mod.Domain == 16 or (mod.Domain == 1 and mod.Id:match("^Synthesis"))) then
+				goto continue
 			end
 			local stats, orders = describeMod(mod)
 			if #orders > 0 then
@@ -41,8 +43,12 @@ local function writeMods(outName, condFunc)
 					out:write('type = "Prefix", ')
 				elseif mod.GenerationType == 2 then
 					out:write('type = "Suffix", ')
-				--elseif mod.GenerationType == 3 then
-				--	out:write('type = "Synthesis", ')
+				elseif mod.GenerationType == 3 then
+					if mod.Domain == 1 and mod.Id:match("^Synthesis") then
+						out:write('type = "Synthesis", ')
+					elseif mod.Domain == 16 then
+						out:write('type = "DelveImplicit", ')
+					end
 				elseif mod.GenerationType == 5 then
 					out:write('type = "Corrupted", ')
 				elseif mod.GenerationType == 24 then
@@ -109,8 +115,8 @@ end
 
 writeMods("../Data/ModItem.lua", function(mod)
 	return (mod.Domain == 1 or mod.Domain == 16)
-			and (mod.GenerationType == 1 or mod.GenerationType == 2 or mod.GenerationType == 5 or mod.GenerationType == 25 or mod.GenerationType == 24
-			or mod.GenerationType == 28 or mod.GenerationType == 29) -- Eldritch Implicits
+			and (mod.GenerationType == 1 or mod.GenerationType == 2 or mod.GenerationType == 3 or mod.GenerationType == 5
+			 or mod.GenerationType == 25 or mod.GenerationType == 24 or mod.GenerationType == 28 or mod.GenerationType == 29)
 			and not mod.Id:match("^Hellscape[UpDown]+sideMap") -- Exclude Scourge map mods
 			and #mod.AuraFlags == 0
 end)

--- a/src/Export/Scripts/mods.lua
+++ b/src/Export/Scripts/mods.lua
@@ -62,6 +62,16 @@ local function writeMods(outName, condFunc)
 						break
 					end
  				end
+				if string.find(mod.Id, "EldritchImplicitUniquePresence") and #stats > 0 and #orders > 0 then
+					for i, stat in ipairs(stats) do
+						stats[i] = 	"While a Unique Enemy is in your Presence, ".. stat
+					end
+				end
+				if string.find(mod.Id, "EldritchImplicitPinnaclePresence") and #stats > 0 and #orders > 0 then
+					for i, stat in ipairs(stats) do
+						stats[i] = "While a Pinnacle Atlas Boss is in your Presence, ".. stat
+					end
+				end
 				out:write('"', table.concat(stats, '", "'), '", ')
 				out:write('statOrderKey = "', table.concat(orders, ','), '", ')
 				out:write('statOrder = { ', table.concat(orders, ', '), ' }, ')
@@ -100,7 +110,7 @@ end
 writeMods("../Data/ModItem.lua", function(mod)
 	return (mod.Domain == 1 or mod.Domain == 16)
 			and (mod.GenerationType == 1 or mod.GenerationType == 2 or mod.GenerationType == 5 or mod.GenerationType == 25 or mod.GenerationType == 24
-			or mod.GenerationType == 29 or mod.GenerationType == 30) -- Eldritch Implicits
+			or mod.GenerationType == 28 or mod.GenerationType == 29) -- Eldritch Implicits
 			and not mod.Id:match("^Hellscape[UpDown]+sideMap") -- Exclude Scourge map mods
 			and #mod.AuraFlags == 0
 end)

--- a/src/Export/Scripts/mods.lua
+++ b/src/Export/Scripts/mods.lua
@@ -70,7 +70,7 @@ local function writeMods(outName, condFunc)
  				end
 				if string.find(mod.Id, "EldritchImplicitUniquePresence") and #stats > 0 and #orders > 0 then
 					for i, stat in ipairs(stats) do
-						stats[i] = 	"While a Unique Enemy is in your Presence, ".. stat
+						stats[i] = "While a Unique Enemy is in your Presence, ".. stat
 					end
 				end
 				if string.find(mod.Id, "EldritchImplicitPinnaclePresence") and #stats > 0 and #orders > 0 then

--- a/src/Export/Scripts/mods.lua
+++ b/src/Export/Scripts/mods.lua
@@ -41,13 +41,17 @@ local function writeMods(outName, condFunc)
 					out:write('type = "Prefix", ')
 				elseif mod.GenerationType == 2 then
 					out:write('type = "Suffix", ')
+				--elseif mod.GenerationType == 3 then
+				--	out:write('type = "Synthesis", ')
 				elseif mod.GenerationType == 5 then
 					out:write('type = "Corrupted", ')
-				elseif mod.GenerationType == 25 or mod.GenerationType == 24 then
-					out:write('type = "Scourge", ')
-				elseif mod.GenerationType == 29 then
+				elseif mod.GenerationType == 24 then
+					out:write('type = "ScourgeUpside", ')
+				elseif mod.GenerationType == 25 then
+					out:write('type = "ScourgeDownside", ')
+				elseif mod.GenerationType == 28 then
 					out:write('type = "Exarch", ')
-				elseif mod.GenerationType == 30 then
+				elseif mod.GenerationType == 29 then
 					out:write('type = "Eater", ')
 				end
 				out:write('affix = "', mod.Name, '", ')

--- a/src/Export/Scripts/mods.lua
+++ b/src/Export/Scripts/mods.lua
@@ -45,6 +45,10 @@ local function writeMods(outName, condFunc)
 					out:write('type = "Corrupted", ')
 				elseif mod.GenerationType == 25 or mod.GenerationType == 24 then
 					out:write('type = "Scourge", ')
+				elseif mod.GenerationType == 29 then
+					out:write('type = "Exarch", ')
+				elseif mod.GenerationType == 30 then
+					out:write('type = "Eater", ')
 				end
 				out:write('affix = "', mod.Name, '", ')
 				for index, value in pairs(mod.Family) do
@@ -91,8 +95,9 @@ end
 
 writeMods("../Data/ModItem.lua", function(mod)
 	return (mod.Domain == 1 or mod.Domain == 16)
-			and (mod.GenerationType == 1 or mod.GenerationType == 2 or mod.GenerationType == 5 or mod.GenerationType == 25 or mod.GenerationType == 24)
-			and not mod.Id:match("^Hellscape[UpDown]+sideMap")
+			and (mod.GenerationType == 1 or mod.GenerationType == 2 or mod.GenerationType == 5 or mod.GenerationType == 25 or mod.GenerationType == 24
+			or mod.GenerationType == 29 or mod.GenerationType == 30) -- Eldritch Implicits
+			and not mod.Id:match("^Hellscape[UpDown]+sideMap") -- Exclude Scourge map mods
 			and #mod.AuraFlags == 0
 end)
 writeMods("../Data/ModFlask.lua", function(mod)


### PR DESCRIPTION
needs feedback and testing

thoughts on changes
currently I have exarch/eater show up based on base type of the item, do I want to swap this to checking for influence instead?

I also have exarch/eater check if a mod of their type already exists in the list and replace that instead, do I want to add logic for clearing implicits to it/synth if wrong type? (eg if none of the implicts are exarch/eater wipe the list and add the mod
same with synth, if none are synth replace the whole list?) if so do I want this to be default logic, or add a button, or add a toggle?

how do I sort exarch/eater mods, they are a mess atm, it would help if I could combine groups similar to how affixes work but I am not sure its possible for this kinda addition, I could add slots for implicit on crafted items that would let me do that though

and then lastly, how do I determine which items what synth mod belongs to, they have no weights