### PR TITLE
Separated boxes related to taken damage in Calcs

### DIFF
--- a/src/Modules/CalcSections.lua
+++ b/src/Modules/CalcSections.lua
@@ -1502,9 +1502,10 @@ return {
 		{ format = "{2:output:ChaosTakenDamage}",
 			{ breakdown = "ChaosTakenDamage" }, 
 			{ modName = { "PhysicalDamageTakenAsChaos", "LightningDamageTakenAsChaos", "ColdDamageTakenAsChaos", "FireDamageTakenAsChaos", "ElementalDamageTakenAsChaos", "ChaosDamageTakenAsPhysical", "ChaosDamageTakenAsLightning", "ChaosDamageTakenAsCold", "ChaosDamageTakenAsFire" } }
-		},
-	},
-} }, { defaultCollapsed = false, label = "Damaging Hits", data = {
+		}, },
+} }
+} },
+{ 3, "DamagingHits", 1, colorCodes.DEFENCE, {{defaultCollapsed = false, label = "Damaging Hits", data = {
 	colWidth = 95,
 	{ label = "Hit taken Mult.",
 		{ format = "" },
@@ -1707,7 +1708,9 @@ return {
 	},
 	{ label = "Hits before death",{ format = "{output:NumberOfDamagingHits}", },
 	}
-}, }, { defaultCollapsed = false, label = "Effective \"Health\" Pool", data = {
+} }
+} },
+{ 3, "EffectiveHealthPool", 1, colorCodes.DEFENCE, {{ defaultCollapsed = false, label = "Effective \"Health\" Pool", data = {
 	extra = "{0:output:TotalEHP}",
 	{ label = "Unmitigated %", { format = "{0:output:ConfiguredDamageChance}%", { breakdown = "ConfiguredDamageChance" }, }, },
 	{ label = "Mitigated hits", { format = "{2:output:NumberOfMitigatedDamagingHits}", }, },
@@ -1717,8 +1720,10 @@ return {
 	{ label = "Time before death",{ format = "{2:output:EHPsurvivalTime}s", 
 		{ breakdown = "EHPsurvivalTime" }, 
 		{ label = "Enemy modifiers", modName = { "TemporalChainsActionSpeed", "ActionSpeed" }, enemy = true },
-	},}
-}, }, { defaultCollapsed = false, label = "Maximum Hit Taken", data = {
+	}, }
+} }
+} },
+{ 3, "MaximumHitTaken", 1, colorCodes.DEFENCE, {{ defaultCollapsed = false, label = "Maximum Hit Taken", data = {
 	colWidth = 114,
 	{
 		{ format = colorCodes.PHYS.."Physical:" },
@@ -1744,7 +1749,9 @@ return {
 			{ breakdown = "ChaosMaximumHitTaken" }, 
 		},
 	}
-} }, { defaultCollapsed = false, label = "Dots and Degens", data = {
+} }
+} },
+{ 3, "DotsAndDegens", 1, colorCodes.DEFENCE, {{ defaultCollapsed = false, label = "Dots and Degens", data = {
 	colWidth = 114,
 	{
 		{ format = colorCodes.PHYS.."Physical:" },
@@ -1852,5 +1859,5 @@ return {
 		},
 	},
 } }
-} },
+} }
 }


### PR DESCRIPTION
Fixes #3772 .

### Description of the problem being solved:
In the Calcs-tab all boxes are separated, and separately minimizeable, except for the boxes under Damage Taken.
If minimizing the box "Damage Taken" the following boxes also gets minimized: 

Damaging Hits
Effective "Health" Pool
Maximum Hit Taken
Dots and Degens

### Steps taken to verify a working solution:
Separate out the boxes in CalcSections.lua

### Link to a build that showcases this PR:
N/A

### Before screenshot:
<img width="539" alt="image" src="https://user-images.githubusercontent.com/1473420/181545144-5011a81e-4a1d-42bf-832a-42223eded5c6.png">

### After screenshot:
<img width="535" alt="image" src="https://user-images.githubusercontent.com/1473420/181545415-4b354d2f-103a-4ae3-864d-bf29b61efa36.png">
