### PR TITLE
Display Phantasm DPS in Total DPS

### DIFF
--- a/src/Modules/CalcPerform.lua
+++ b/src/Modules/CalcPerform.lua
@@ -2419,6 +2419,43 @@ function calcs.perform(env, avoidCache)
 		end
 	end
 
+	local supportedByPhantasm = false
+	if env.player.mainSkill.socketGroup ~= nil and env.player.mainSkill.socketGroup.gemList ~= nil then
+		for _, gem in ipairs(env.player.mainSkill.socketGroup.gemList) do
+			if gem.nameSpec == "Summon Phantasm" then
+				supportedByPhantasm = true
+			end
+		end
+	end
+
+	if supportedByPhantasm and not env.player.mainSkill.marked then
+		local calcMode = env.mode == "CALCS" and "CALCS" or "MAIN"
+		-- First, create a copy of the main skill that is supported by phantasm
+		local newSkill, newEnv = calcs.copyActiveSkill(env, calcMode, env.player.mainSkill)
+		-- Override srcInstance with a copy to break the link with UI changes
+		newSkill.activeEffect.srcInstance = copyTable(newSkill.activeEffect.srcInstance, true)
+		-- Override selected active minion and minion skill
+		newSkill.activeEffect.srcInstance.skillMinion = "SummonedPhantasm"
+		newSkill.activeEffect.srcInstance.skillMinionSkill = 2 -- Physical Projectile
+		-- Now we need to copy it again to trigger newEnv.minion recalculation for phantasms
+		newSkill, newEnv = calcs.copyActiveSkill(env, calcMode, newSkill)
+
+		-- Assign as a main skill and perform calc
+		newEnv.player.mainSkill = newSkill
+		-- mark it so we don't recurse infinitely
+		newSkill.marked = true
+		newEnv.dontCache = true
+		calcs.perform(newEnv)
+
+		-- Store the output for later display
+		env.player.mainSkill.phantasm = { }
+		env.player.mainSkill.phantasm.count = newEnv.player.output.ActiveMinionLimit -- Correctly handles bonuses from Replica Midnight Bargain and gem level
+		env.player.mainSkill.phantasm.name = "Summoned Phantasm"
+		env.player.mainSkill.phantasm.source = env.player.mainSkill.activeEffect.grantedEffect.name -- Source skill name
+		env.player.mainSkill.phantasm.minion = {}
+		env.player.mainSkill.phantasm.minion.output = newEnv.minion.output
+	end
+
 	-- Mirage Archer Support
 	-- This creates and populates env.player.mainSkill.mirage table
 	if env.player.mainSkill.skillData.triggeredByMirageArcher and not env.player.mainSkill.skillFlags.minion and not env.player.mainSkill.marked then

--- a/src/Modules/Calcs.lua
+++ b/src/Modules/Calcs.lua
@@ -219,6 +219,36 @@ function calcs.calcFullDPS(build, mode, override, specEnv)
 					end
 				end
 
+				if activeSkill.phantasm then
+					if activeSkill.phantasm.minion.output.TotalDPS and activeSkill.phantasm.minion.output.TotalDPS > 0 then
+						t_insert(fullDPS.skills, { name = activeSkill.phantasm.name, dps = activeSkill.phantasm.minion.output.TotalDPS, count = activeSkill.phantasm.count, trigger = activeSkill.infoTrigger, skillPart = "Summoned by: "..activeSkill.phantasm.source })
+						fullDPS.combinedDPS = fullDPS.combinedDPS + activeSkill.phantasm.minion.output.TotalDPS * activeSkill.phantasm.count
+					end
+					if activeSkill.phantasm.minion.output.BleedDPS and activeSkill.phantasm.minion.output.BleedDPS > fullDPS.bleedDPS then
+						fullDPS.bleedDPS = activeSkill.phantasm.minion.output.BleedDPS
+						bleedSource = activeSkill.activeEffect.grantedEffect.name
+					end
+					if activeSkill.phantasm.minion.output.IgniteDPS and activeSkill.phantasm.minion.output.IgniteDPS > fullDPS.igniteDPS then
+						fullDPS.igniteDPS = activeSkill.phantasm.minion.output.IgniteDPS
+						igniteSource = activeSkill.activeEffect.grantedEffect.name
+					end
+					if activeSkill.phantasm.minion.output.PoisonDPS and activeSkill.phantasm.minion.output.PoisonDPS > 0 then
+						fullDPS.poisonDPS = fullDPS.poisonDPS + activeSkill.phantasm.minion.output.PoisonDPS * (activeSkill.phantasm.minion.output.TotalPoisonStacks or 1) * activeSkillCount
+					end
+					if activeSkill.phantasm.minion.output.ImpaleDPS and activeSkill.phantasm.minion.output.ImpaleDPS > 0 then
+						fullDPS.impaleDPS = fullDPS.impaleDPS + activeSkill.phantasm.minion.output.ImpaleDPS * activeSkillCount
+					end
+					if activeSkill.phantasm.minion.output.DecayDPS and activeSkill.phantasm.minion.output.DecayDPS > 0 then
+						fullDPS.decayDPS = fullDPS.decayDPS + activeSkill.phantasm.minion.output.DecayDPS
+					end
+					if activeSkill.phantasm.minion.output.TotalDot and activeSkill.phantasm.minion.output.TotalDot > 0 then
+						fullDPS.dotDPS = fullDPS.dotDPS + activeSkill.phantasm.minion.output.TotalDot
+					end
+					if activeSkill.phantasm.minion.output.CullMultiplier and activeSkill.phantasm.minion.output.CullMultiplier > 1 and activeSkill.phantasm.minion.output.CullMultiplier > fullDPS.cullingMulti then
+						fullDPS.cullingMulti = activeSkill.phantasm.minion.output.CullMultiplier
+					end
+				end
+
 				if activeSkill.mirage then
 					local mirageCount = (activeSkill.mirage.count or 1) * activeSkillCount
 					if activeSkill.mirage.output.TotalDPS and activeSkill.mirage.output.TotalDPS > 0 then


### PR DESCRIPTION
### Description of the problem being solved:
Phantasms are not being counted in the Total DPS even if the skill has this support gem inserted 
- Count is based on maximum available phantasm limit
- DPS is always calculated for the "Physical Projectile" minion's skill
- Such problem as multiple phantasm sources and global limit is out of scope

### Steps taken to verify a working solution:
1. Create a new skill group
2. Add some active skill gem
3. Add Summon Phantasm
4. Toggle "Show in Total DPS"

### Link to a build that showcases this PR:
https://pobb.in/HMjN6iKQ-EDg

### Before screenshot:
![image](https://user-images.githubusercontent.com/254369/181563811-4064bff0-f50d-480b-8413-e0939fc30417.png)

### After screenshot:
![image](https://user-images.githubusercontent.com/254369/181564367-d9c6eb99-321c-4148-9b84-1ce40c1e9a26.png)