### PR TITLE
FIX: Add an emtpy stat to remove confusing red text on incinerate

### DIFF
--- a/src/Data/Skills/act_int.lua
+++ b/src/Data/Skills/act_int.lua
@@ -5993,6 +5993,12 @@ skills["ExpandingFireCone"] = {
 		["expanding_fire_cone_maximum_number_of_stages"] = {
 			mod("Multiplier:IncinerateMaxStages", "BASE", nil),
 		},
+		["quality_display_incinerate_is_gem_hit"] = {
+			--Display Only
+		},
+		["quality_display_incinerate_is_gem_ingite"] = {
+			--Display Only
+		},
 	},
 	baseFlags = {
 		spell = true,

--- a/src/Export/Skills/act_int.txt
+++ b/src/Export/Skills/act_int.txt
@@ -1327,6 +1327,12 @@ local skills, mod, flag, skill = ...
 		["expanding_fire_cone_maximum_number_of_stages"] = {
 			mod("Multiplier:IncinerateMaxStages", "BASE", nil),
 		},
+		["quality_display_incinerate_is_gem_hit"] = {
+			--Display Only
+		},
+		["quality_display_incinerate_is_gem_ingite"] = {
+			--Display Only
+		},
 	},
 #baseMod skill("showAverage", true, { type = "SkillPart", skillPart = 2 })
 #baseMod skill("radius", 25)


### PR DESCRIPTION
Fixes #4678 .

### Description of the problem being solved:
Some mods on the incinerate gem had their text displayed in red even though they were being handled correctly.

### Before screenshot:
![before](https://user-images.githubusercontent.com/91493239/182905909-79c0a344-5687-48a9-b84a-50203e755084.jpg)

### After screenshot:
![after](https://user-images.githubusercontent.com/91493239/182905917-571b787c-dea6-4013-af2f-7a9bbfeddf97.jpg)