### PR TITLE
Fix bottom bar wrapping in the tree tab

### DIFF
--- a/src/Classes/TreeTab.lua
+++ b/src/Classes/TreeTab.lua
@@ -127,6 +127,7 @@ local TreeTabClass = newClass("TreeTab", "ControlHost", function(self, build)
 	self.controls.treeHeatMapStatSelect = new("DropDownControl", { "LEFT", self.controls.treeHeatMap, "RIGHT" }, 8, 0, 150, 20, nil, function(index, value)
 		self:SetPowerCalc(value)
 	end)
+	self.controls.treeHeatMapStatSelect.shown = false
 	self.controls.treeHeatMap.tooltipText = function()
 		local offCol, defCol = main.nodePowerTheme:match("(%a+)/(%a+)")
 		return "When enabled, an estimate of the offensive and defensive strength of\neach unallocated passive is calculated and displayed visually.\nOffensive power shows as "..offCol:lower()..", defensive power as "..defCol:lower().."."

--- a/src/Classes/TreeTab.lua
+++ b/src/Classes/TreeTab.lua
@@ -198,15 +198,7 @@ function TreeTabClass:Draw(viewPort, inputEvents)
 
 	-- Determine positions if one line of controls doesn't fit in the screen width
 	local twoLineHeight = 24
-	-- Calculate offset caused by compare and/or "Show Node Power" is selected
-	local offset = 0
-	if self.isComparing then
-		offset = offset + 198
-	end
-	if self.viewer.showHeatMap then
-		offset = offset + 316
-	end
-	if viewPort.width >= 1168 + offset then
+	if viewPort.width >= 1168 + (self.isComparing and 198 or 0) + (self.viewer.showHeatMap and 316 or 0) then
 		twoLineHeight = 0
 		self.controls.findTimelessJewel:SetAnchor("LEFT", self.controls.treeSearch, "RIGHT", 8, 0)
 		if self.controls.powerReportList then

--- a/src/Classes/TreeTab.lua
+++ b/src/Classes/TreeTab.lua
@@ -199,7 +199,15 @@ function TreeTabClass:Draw(viewPort, inputEvents)
 
 	-- Determine positions if one line of controls doesn't fit in the screen width
 	local twoLineHeight = 24
-	if viewPort.width >= 1484 or (viewPort.width >= 1168 and not self.viewer.showHeatMap) then
+	-- Calculate offset caused by compare and/or "Show Node Power" is selected
+	local offset = 0
+	if self.isComparing then
+		offset = offset + 198
+	end
+	if self.viewer.showHeatMap then
+		offset = offset + 316
+	end
+	if viewPort.width >= 1168 + offset then
 		twoLineHeight = 0
 		self.controls.findTimelessJewel:SetAnchor("LEFT", self.controls.treeSearch, "RIGHT", 8, 0)
 		if self.controls.powerReportList then

--- a/src/Classes/TreeTab.lua
+++ b/src/Classes/TreeTab.lua
@@ -127,7 +127,6 @@ local TreeTabClass = newClass("TreeTab", "ControlHost", function(self, build)
 	self.controls.treeHeatMapStatSelect = new("DropDownControl", { "LEFT", self.controls.treeHeatMap, "RIGHT" }, 8, 0, 150, 20, nil, function(index, value)
 		self:SetPowerCalc(value)
 	end)
-	self.controls.treeHeatMapStatSelect.shown = false
 	self.controls.treeHeatMap.tooltipText = function()
 		local offCol, defCol = main.nodePowerTheme:match("(%a+)/(%a+)")
 		return "When enabled, an estimate of the offensive and defensive strength of\neach unallocated passive is calculated and displayed visually.\nOffensive power shows as "..offCol:lower()..", defensive power as "..defCol:lower().."."
@@ -254,6 +253,7 @@ function TreeTabClass:Draw(viewPort, inputEvents)
 	end
 
 	self.controls.treeHeatMap.state = self.viewer.showHeatMap
+	self.controls.treeHeatMapStatSelect.shown = self.viewer.showHeatMap
 	self.controls.treeHeatMapStatSelect.list = self.powerStatList
 	self.controls.treeHeatMapStatSelect.selIndex = 1
 	self.controls.treeHeatMapStatSelect:CheckDroppedWidth(true)


### PR DESCRIPTION
Fixes #4691 and #1265 .

### Description of the problem being solved:
The bottom toolbar in the Tree tab does not always wrap to two lines at the right time.
Problem in #4691 was caused by the fact that the node power selector/button could be shown even if "Show node power" was not selected: 
<img width="445" alt="image" src="https://user-images.githubusercontent.com/1473420/183285242-d286ecd1-966c-4f9d-9f58-05e87d1db3cb.png">

but in the logic for wrapping, it was assumed that these two items where hidden.
This was caused by the fact that during initial load, the two items does not check if show node power is selected (this check is only when the box is clicked).

I added logic in the draw-function to make sure that the visibility was set correctly. I also changed the if-statement for wrapping since it did take into account "Node Power", but not take into account if "Compare" is clicked or not.


### Steps taken to verify a working solution:
Load PoB both with or without "Show Node Power" selected in the build.
With node power preselected:
<img width="366" alt="image" src="https://user-images.githubusercontent.com/1473420/183285358-93faf81e-b1fe-48eb-9a6b-1cae1d4e93bf.png">

Without node power preselected
<img width="290" alt="image" src="https://user-images.githubusercontent.com/1473420/183285362-639c9a81-9140-43c5-bc05-6be1f7df9f35.png">

Tried the wrapping with the different combinations of node power and Compare to see that it now wraps in the same spot.