### PR TITLE
Add support for more Ailment effect

### DIFF
--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -2386,6 +2386,14 @@ local specialModList = {
 		mod("BrittleAsThoughDealing", "MORE", num),
 		mod("SapAsThoughDealing", "MORE", num),
 	} end,
+	["non%-damaging elemental ailments you inflict have (%d+)%% more effect"] = function(num) return {
+		mod("EnemyShockEffect", "MORE", num),
+		mod("EnemyChillEffect", "MORE", num),
+		mod("EnemyFreezeEffect", "MORE", num),
+		mod("EnemyScorchEffect", "MORE", num),
+		mod("EnemyBrittleEffect", "MORE", num),
+		mod("EnemySapEffect", "MORE", num),
+	} end,
 	["immune to elemental ailments while on consecrated ground if you have at least (%d+) devotion"] = function(num)
 		local mods = { }
 		for i, ailment in ipairs(data.elementalAilmentTypeList) do


### PR DESCRIPTION
This correctly increases ailment effect, the only source of this is Fury of Nature which is a ranger special forbidden node

A bug I encountered was that Affliction charges do not seem to apply to base shock/chill from elementalist, as they are added after its calculated ([added here](https://github.com/PathOfBuildingCommunity/PathOfBuilding/blob/ad39bdc61b752eca2d86ff3a28a97a35a1120b7a/src/Modules/CalcOffence.lua#L440-L450))