### PR TITLE
Longshot affects all projectiles that hit

### DIFF
--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -1676,7 +1676,7 @@ local specialModList = {
 	-- Ascendant
 	["grants (%d+) passive skill points?"] = function(num) return { mod("ExtraPoints", "BASE", num) } end,
 	["can allocate passives from the %a+'s starting point"] = { },
-	["projectiles gain damage as they travel farther, dealing up to (%d+)%% increased damage with hits to targets"] = function(num) return { mod("Damage", "INC", num, nil, bor(ModFlag.Attack, ModFlag.Projectile), { type = "DistanceRamp", ramp = {{35,0},{70,1}} }) } end,
+	["projectiles gain damage as they travel farther, dealing up to (%d+)%% increased damage with hits to targets"] = function(num) return { mod("Damage", "INC", num, nil, bor(ModFlag.Hit, ModFlag.Projectile), { type = "DistanceRamp", ramp = {{35,0},{70,1}} }) } end,
 	["(%d+)%% chance to gain elusive on kill"] = {
 		flag("Condition:CanBeElusive"),
 	},


### PR DESCRIPTION
Fixes #4269

### Description of the problem being solved:
An issue was previously raised about Longshot not affecting spells. Based on the wording, it should. It looks like the rejection of the issue was based on outdated information from the fandom wiki, which I'm guessing originated from Far shot (which came before Longshot) indeed specifying that it only affects attacks.

### Link to a build that showcases this PR: https://pobb.in/L74GW_7aOVRJ