### PR TITLE
Do not hide config options that are configured without source

### DIFF
--- a/src/Classes/ConfigTab.lua
+++ b/src/Classes/ConfigTab.lua
@@ -250,6 +250,39 @@ local ConfigTabClass = newClass("ConfigTab", "UndoHandler", "ControlHost", "Cont
 					control.selIndex = varData.defaultIndex
 				end
 			end
+
+			local innerShown = control.shown
+			control.shown = function()
+				local shown = type(innerShown) == "boolean" and innerShown or innerShown()
+				return not shown and control.state ~= self:GetDefaultState(varData.var, type(control.state)) or shown
+			end
+			local innerLabel = control.label
+			control.label = function()
+				local shown = type(innerShown) == "boolean" and innerShown or innerShown()
+				if not shown and control.state ~= self:GetDefaultState(varData.var, type(control.state)) then
+					return "^1"..innerLabel
+				end
+				return innerLabel
+			end
+			local innerTooltipFunc = control.tooltipFunc
+			control.tooltipFunc = function (tooltip, ...)
+				tooltip:Clear()
+
+				if innerTooltipFunc then
+					innerTooltipFunc(tooltip, ...)
+				else
+					local tooltipText = control:GetProperty("tooltipText")
+					if tooltipText then
+						tooltip:AddLine(14, tooltipText)
+					end
+				end
+
+				local shown = type(innerShown) == "boolean" and innerShown or innerShown()
+				if not shown and control.state ~= self:GetDefaultState(varData.var, type(control.state)) then
+					tooltip:AddLine(14, "^1This config option is conditional with missing source and is invalid.")
+				end
+			end
+
 			t_insert(self.controls, control)
 			t_insert(lastSection.varControlList, control)
 		end


### PR DESCRIPTION
Instead highlight them in red to let user know its an error.

Closes https://github.com/PathOfBuildingCommunity/PathOfBuilding/issues/4407
Closes https://github.com/PathOfBuildingCommunity/PathOfBuilding/issues/4468
Closes https://github.com/PathOfBuildingCommunity/PathOfBuilding/issues/1945
Closes #4841 

### Link to a build that showcases this PR:

https://pobb.in/jJf-KmAMp90k

### Screenshot

![image](https://user-images.githubusercontent.com/5115805/183647242-df2c510f-c642-48d5-9bf3-29461e2e14c5.png)

