### PR TITLE
Fix: Thrusting should be a base subType

### DIFF
--- a/src/Data/Bases/sword.lua
+++ b/src/Data/Bases/sword.lua
@@ -276,232 +276,6 @@ itemBases["Energy Blade One Handed"] = {
 	req = { },
 }
 
-itemBases["Rusted Spike"] = {
-	type = "Thrusting One Handed Sword",
-	socketLimit = 3,
-	tags = { onehand = true, rapier = true, weapon = true, sword = true, one_hand_weapon = true, default = true, },
-	implicit = "+25% to Global Critical Strike Multiplier",
-	implicitModTypes = { { "damage", "critical" }, },
-	weapon = { PhysicalMin = 5, PhysicalMax = 11, CritChanceBase = 5.5, AttackRateBase = 1.55, Range = 14, },
-	req = { dex = 20, },
-}
-itemBases["Whalebone Rapier"] = {
-	type = "Thrusting One Handed Sword",
-	socketLimit = 3,
-	tags = { onehand = true, rapier = true, weapon = true, sword = true, one_hand_weapon = true, default = true, },
-	implicit = "+25% to Global Critical Strike Multiplier",
-	implicitModTypes = { { "damage", "critical" }, },
-	weapon = { PhysicalMin = 4, PhysicalMax = 17, CritChanceBase = 5.5, AttackRateBase = 1.6, Range = 14, },
-	req = { level = 7, dex = 32, },
-}
-itemBases["Battered Foil"] = {
-	type = "Thrusting One Handed Sword",
-	socketLimit = 3,
-	tags = { onehand = true, rapier = true, weapon = true, sword = true, one_hand_weapon = true, default = true, },
-	implicit = "+25% to Global Critical Strike Multiplier",
-	implicitModTypes = { { "damage", "critical" }, },
-	weapon = { PhysicalMin = 11, PhysicalMax = 20, CritChanceBase = 6, AttackRateBase = 1.5, Range = 14, },
-	req = { level = 12, dex = 47, },
-}
-itemBases["Basket Rapier"] = {
-	type = "Thrusting One Handed Sword",
-	socketLimit = 3,
-	tags = { onehand = true, rapier = true, weapon = true, sword = true, one_hand_weapon = true, default = true, },
-	implicit = "+25% to Global Critical Strike Multiplier",
-	implicitModTypes = { { "damage", "critical" }, },
-	weapon = { PhysicalMin = 11, PhysicalMax = 25, CritChanceBase = 5.5, AttackRateBase = 1.55, Range = 14, },
-	req = { level = 17, dex = 62, },
-}
-itemBases["Jagged Foil"] = {
-	type = "Thrusting One Handed Sword",
-	socketLimit = 3,
-	tags = { onehand = true, rapier = true, weapon = true, sword = true, one_hand_weapon = true, default = true, },
-	implicit = "+25% to Global Critical Strike Multiplier",
-	implicitModTypes = { { "damage", "critical" }, },
-	weapon = { PhysicalMin = 12, PhysicalMax = 29, CritChanceBase = 5.5, AttackRateBase = 1.6, Range = 14, },
-	req = { level = 22, dex = 77, },
-}
-itemBases["Antique Rapier"] = {
-	type = "Thrusting One Handed Sword",
-	socketLimit = 3,
-	tags = { onehand = true, rapier = true, weapon = true, sword = true, one_hand_weapon = true, default = true, },
-	implicit = "+25% to Global Critical Strike Multiplier",
-	implicitModTypes = { { "damage", "critical" }, },
-	weapon = { PhysicalMin = 12, PhysicalMax = 46, CritChanceBase = 6.5, AttackRateBase = 1.3, Range = 14, },
-	req = { level = 26, dex = 89, },
-}
-itemBases["Elegant Foil"] = {
-	type = "Thrusting One Handed Sword",
-	socketLimit = 3,
-	tags = { onehand = true, rapier = true, weapon = true, sword = true, one_hand_weapon = true, default = true, },
-	implicit = "+25% to Global Critical Strike Multiplier",
-	implicitModTypes = { { "damage", "critical" }, },
-	weapon = { PhysicalMin = 18, PhysicalMax = 33, CritChanceBase = 5.5, AttackRateBase = 1.6, Range = 14, },
-	req = { level = 30, dex = 101, },
-}
-itemBases["Thorn Rapier"] = {
-	type = "Thrusting One Handed Sword",
-	socketLimit = 3,
-	tags = { onehand = true, rapier = true, weapon = true, sword = true, one_hand_weapon = true, default = true, },
-	implicit = "+35% to Global Critical Strike Multiplier",
-	implicitModTypes = { { "damage", "critical" }, },
-	weapon = { PhysicalMin = 19, PhysicalMax = 44, CritChanceBase = 5.7, AttackRateBase = 1.4, Range = 14, },
-	req = { level = 34, dex = 113, },
-}
-itemBases["Smallsword"] = {
-	type = "Thrusting One Handed Sword",
-	socketLimit = 3,
-	tags = { maraketh = true, rapier = true, onehand = true, not_for_sale = true, weapon = true, sword = true, one_hand_weapon = true, default = true, },
-	implicit = "15% chance to cause Bleeding on Hit",
-	implicitModTypes = { { "bleed", "physical", "attack", "ailment" }, },
-	weapon = { PhysicalMin = 19, PhysicalMax = 40, CritChanceBase = 6, AttackRateBase = 1.55, Range = 14, },
-	req = { level = 36, dex = 124, },
-}
-itemBases["Wyrmbone Rapier"] = {
-	type = "Thrusting One Handed Sword",
-	socketLimit = 3,
-	tags = { onehand = true, rapier = true, weapon = true, sword = true, one_hand_weapon = true, default = true, },
-	implicit = "+25% to Global Critical Strike Multiplier",
-	implicitModTypes = { { "damage", "critical" }, },
-	weapon = { PhysicalMin = 13, PhysicalMax = 51, CritChanceBase = 5.5, AttackRateBase = 1.5, Range = 14, },
-	req = { level = 37, dex = 122, },
-}
-itemBases["Burnished Foil"] = {
-	type = "Thrusting One Handed Sword",
-	socketLimit = 3,
-	tags = { onehand = true, rapier = true, weapon = true, sword = true, one_hand_weapon = true, default = true, },
-	implicit = "+25% to Global Critical Strike Multiplier",
-	implicitModTypes = { { "damage", "critical" }, },
-	weapon = { PhysicalMin = 25, PhysicalMax = 46, CritChanceBase = 6, AttackRateBase = 1.4, Range = 14, },
-	req = { level = 40, dex = 131, },
-}
-itemBases["Estoc"] = {
-	type = "Thrusting One Handed Sword",
-	socketLimit = 3,
-	tags = { onehand = true, rapier = true, weapon = true, sword = true, one_hand_weapon = true, default = true, },
-	implicit = "+25% to Global Critical Strike Multiplier",
-	implicitModTypes = { { "damage", "critical" }, },
-	weapon = { PhysicalMin = 21, PhysicalMax = 50, CritChanceBase = 5.5, AttackRateBase = 1.5, Range = 14, },
-	req = { level = 43, dex = 140, },
-}
-itemBases["Serrated Foil"] = {
-	type = "Thrusting One Handed Sword",
-	socketLimit = 3,
-	tags = { onehand = true, rapier = true, weapon = true, sword = true, one_hand_weapon = true, default = true, },
-	implicit = "+25% to Global Critical Strike Multiplier",
-	implicitModTypes = { { "damage", "critical" }, },
-	weapon = { PhysicalMin = 21, PhysicalMax = 49, CritChanceBase = 5.5, AttackRateBase = 1.6, Range = 14, },
-	req = { level = 46, dex = 149, },
-}
-itemBases["Primeval Rapier"] = {
-	type = "Thrusting One Handed Sword",
-	socketLimit = 3,
-	tags = { onehand = true, rapier = true, weapon = true, sword = true, one_hand_weapon = true, default = true, },
-	implicit = "+25% to Global Critical Strike Multiplier",
-	implicitModTypes = { { "damage", "critical" }, },
-	weapon = { PhysicalMin = 18, PhysicalMax = 73, CritChanceBase = 6.5, AttackRateBase = 1.3, Range = 14, },
-	req = { level = 49, dex = 158, },
-}
-itemBases["Fancy Foil"] = {
-	type = "Thrusting One Handed Sword",
-	socketLimit = 3,
-	tags = { onehand = true, rapier = true, weapon = true, sword = true, one_hand_weapon = true, default = true, },
-	implicit = "+25% to Global Critical Strike Multiplier",
-	implicitModTypes = { { "damage", "critical" }, },
-	weapon = { PhysicalMin = 28, PhysicalMax = 51, CritChanceBase = 5.5, AttackRateBase = 1.6, Range = 14, },
-	req = { level = 52, dex = 167, },
-}
-itemBases["Apex Rapier"] = {
-	type = "Thrusting One Handed Sword",
-	socketLimit = 3,
-	tags = { onehand = true, rapier = true, weapon = true, sword = true, one_hand_weapon = true, default = true, },
-	implicit = "+35% to Global Critical Strike Multiplier",
-	implicitModTypes = { { "damage", "critical" }, },
-	weapon = { PhysicalMin = 29, PhysicalMax = 67, CritChanceBase = 5.7, AttackRateBase = 1.4, Range = 14, },
-	req = { level = 55, dex = 176, },
-}
-itemBases["Courtesan Sword"] = {
-	type = "Thrusting One Handed Sword",
-	socketLimit = 3,
-	tags = { maraketh = true, rapier = true, onehand = true, not_for_sale = true, weapon = true, sword = true, one_hand_weapon = true, default = true, },
-	implicit = "15% chance to cause Bleeding on Hit",
-	implicitModTypes = { { "bleed", "physical", "attack", "ailment" }, },
-	weapon = { PhysicalMin = 29, PhysicalMax = 60, CritChanceBase = 6, AttackRateBase = 1.55, Range = 14, },
-	req = { level = 57, dex = 190, },
-}
-itemBases["Dragonbone Rapier"] = {
-	type = "Thrusting One Handed Sword",
-	socketLimit = 3,
-	tags = { onehand = true, rapier = true, weapon = true, sword = true, one_hand_weapon = true, default = true, },
-	implicit = "+25% to Global Critical Strike Multiplier",
-	implicitModTypes = { { "damage", "critical" }, },
-	weapon = { PhysicalMin = 19, PhysicalMax = 75, CritChanceBase = 5.5, AttackRateBase = 1.5, Range = 14, },
-	req = { level = 58, dex = 185, },
-}
-itemBases["Tempered Foil"] = {
-	type = "Thrusting One Handed Sword",
-	socketLimit = 3,
-	tags = { onehand = true, rapier = true, weapon = true, sword = true, one_hand_weapon = true, default = true, },
-	implicit = "+25% to Global Critical Strike Multiplier",
-	implicitModTypes = { { "damage", "critical" }, },
-	weapon = { PhysicalMin = 35, PhysicalMax = 65, CritChanceBase = 6, AttackRateBase = 1.4, Range = 14, },
-	req = { level = 60, dex = 212, },
-}
-itemBases["Pecoraro"] = {
-	type = "Thrusting One Handed Sword",
-	socketLimit = 3,
-	tags = { onehand = true, rapier = true, weapon = true, sword = true, one_hand_weapon = true, default = true, },
-	implicit = "+25% to Global Critical Strike Multiplier",
-	implicitModTypes = { { "damage", "critical" }, },
-	weapon = { PhysicalMin = 29, PhysicalMax = 69, CritChanceBase = 5.5, AttackRateBase = 1.5, Range = 14, },
-	req = { level = 62, dex = 212, },
-}
-itemBases["Spiraled Foil"] = {
-	type = "Thrusting One Handed Sword",
-	socketLimit = 3,
-	tags = { onehand = true, rapier = true, weapon = true, sword = true, one_hand_weapon = true, default = true, },
-	implicit = "+25% to Global Critical Strike Multiplier",
-	implicitModTypes = { { "damage", "critical" }, },
-	weapon = { PhysicalMin = 27, PhysicalMax = 64, CritChanceBase = 5.5, AttackRateBase = 1.6, Range = 14, },
-	req = { level = 64, dex = 212, },
-}
-itemBases["Vaal Rapier"] = {
-	type = "Thrusting One Handed Sword",
-	socketLimit = 3,
-	tags = { onehand = true, rapier = true, weapon = true, sword = true, one_hand_weapon = true, default = true, },
-	implicit = "+25% to Global Critical Strike Multiplier",
-	implicitModTypes = { { "damage", "critical" }, },
-	weapon = { PhysicalMin = 22, PhysicalMax = 87, CritChanceBase = 6.5, AttackRateBase = 1.3, Range = 14, },
-	req = { level = 66, dex = 212, },
-}
-itemBases["Jewelled Foil"] = {
-	type = "Thrusting One Handed Sword",
-	socketLimit = 3,
-	tags = { onehand = true, rapier = true, weapon = true, sword = true, one_hand_weapon = true, default = true, },
-	implicit = "+25% to Global Critical Strike Multiplier",
-	implicitModTypes = { { "damage", "critical" }, },
-	weapon = { PhysicalMin = 32, PhysicalMax = 60, CritChanceBase = 5.5, AttackRateBase = 1.6, Range = 14, },
-	req = { level = 68, dex = 212, },
-}
-itemBases["Harpy Rapier"] = {
-	type = "Thrusting One Handed Sword",
-	socketLimit = 3,
-	tags = { onehand = true, rapier = true, weapon = true, sword = true, one_hand_weapon = true, default = true, },
-	implicit = "+35% to Global Critical Strike Multiplier",
-	implicitModTypes = { { "damage", "critical" }, },
-	weapon = { PhysicalMin = 31, PhysicalMax = 72, CritChanceBase = 5.7, AttackRateBase = 1.4, Range = 14, },
-	req = { level = 70, dex = 212, },
-}
-itemBases["Dragoon Sword"] = {
-	type = "Thrusting One Handed Sword",
-	socketLimit = 3,
-	tags = { maraketh = true, rapier = true, onehand = true, not_for_sale = true, weapon = true, sword = true, one_hand_weapon = true, default = true, },
-	implicit = "20% chance to cause Bleeding on Hit",
-	implicitModTypes = { { "bleed", "physical", "attack", "ailment" }, },
-	weapon = { PhysicalMin = 32, PhysicalMax = 66, CritChanceBase = 6, AttackRateBase = 1.5, Range = 14, },
-	req = { level = 72, dex = 220, },
-}
-
 itemBases["Keyblade"] = {
 	type = "Two Handed Sword",
 	hidden = true,
@@ -745,4 +519,255 @@ itemBases["Energy Blade Two Handed"] = {
 	implicitModTypes = { },
 	weapon = { PhysicalMin = 0, PhysicalMax = 0, CritChanceBase = 7, AttackRateBase = 1.6, Range = 13, },
 	req = { },
+}
+
+itemBases["Rusted Spike"] = {
+	type = "One Handed Sword",
+	subType = "Thrusting",
+	socketLimit = 3,
+	tags = { onehand = true, rapier = true, weapon = true, sword = true, one_hand_weapon = true, default = true, },
+	implicit = "+25% to Global Critical Strike Multiplier",
+	implicitModTypes = { { "damage", "critical" }, },
+	weapon = { PhysicalMin = 5, PhysicalMax = 11, CritChanceBase = 5.5, AttackRateBase = 1.55, Range = 14, },
+	req = { dex = 20, },
+}
+itemBases["Whalebone Rapier"] = {
+	type = "One Handed Sword",
+	subType = "Thrusting",
+	socketLimit = 3,
+	tags = { onehand = true, rapier = true, weapon = true, sword = true, one_hand_weapon = true, default = true, },
+	implicit = "+25% to Global Critical Strike Multiplier",
+	implicitModTypes = { { "damage", "critical" }, },
+	weapon = { PhysicalMin = 4, PhysicalMax = 17, CritChanceBase = 5.5, AttackRateBase = 1.6, Range = 14, },
+	req = { level = 7, dex = 32, },
+}
+itemBases["Battered Foil"] = {
+	type = "One Handed Sword",
+	subType = "Thrusting",
+	socketLimit = 3,
+	tags = { onehand = true, rapier = true, weapon = true, sword = true, one_hand_weapon = true, default = true, },
+	implicit = "+25% to Global Critical Strike Multiplier",
+	implicitModTypes = { { "damage", "critical" }, },
+	weapon = { PhysicalMin = 11, PhysicalMax = 20, CritChanceBase = 6, AttackRateBase = 1.5, Range = 14, },
+	req = { level = 12, dex = 47, },
+}
+itemBases["Basket Rapier"] = {
+	type = "One Handed Sword",
+	subType = "Thrusting",
+	socketLimit = 3,
+	tags = { onehand = true, rapier = true, weapon = true, sword = true, one_hand_weapon = true, default = true, },
+	implicit = "+25% to Global Critical Strike Multiplier",
+	implicitModTypes = { { "damage", "critical" }, },
+	weapon = { PhysicalMin = 11, PhysicalMax = 25, CritChanceBase = 5.5, AttackRateBase = 1.55, Range = 14, },
+	req = { level = 17, dex = 62, },
+}
+itemBases["Jagged Foil"] = {
+	type = "One Handed Sword",
+	subType = "Thrusting",
+	socketLimit = 3,
+	tags = { onehand = true, rapier = true, weapon = true, sword = true, one_hand_weapon = true, default = true, },
+	implicit = "+25% to Global Critical Strike Multiplier",
+	implicitModTypes = { { "damage", "critical" }, },
+	weapon = { PhysicalMin = 12, PhysicalMax = 29, CritChanceBase = 5.5, AttackRateBase = 1.6, Range = 14, },
+	req = { level = 22, dex = 77, },
+}
+itemBases["Antique Rapier"] = {
+	type = "One Handed Sword",
+	subType = "Thrusting",
+	socketLimit = 3,
+	tags = { onehand = true, rapier = true, weapon = true, sword = true, one_hand_weapon = true, default = true, },
+	implicit = "+25% to Global Critical Strike Multiplier",
+	implicitModTypes = { { "damage", "critical" }, },
+	weapon = { PhysicalMin = 12, PhysicalMax = 46, CritChanceBase = 6.5, AttackRateBase = 1.3, Range = 14, },
+	req = { level = 26, dex = 89, },
+}
+itemBases["Elegant Foil"] = {
+	type = "One Handed Sword",
+	subType = "Thrusting",
+	socketLimit = 3,
+	tags = { onehand = true, rapier = true, weapon = true, sword = true, one_hand_weapon = true, default = true, },
+	implicit = "+25% to Global Critical Strike Multiplier",
+	implicitModTypes = { { "damage", "critical" }, },
+	weapon = { PhysicalMin = 18, PhysicalMax = 33, CritChanceBase = 5.5, AttackRateBase = 1.6, Range = 14, },
+	req = { level = 30, dex = 101, },
+}
+itemBases["Thorn Rapier"] = {
+	type = "One Handed Sword",
+	subType = "Thrusting",
+	socketLimit = 3,
+	tags = { onehand = true, rapier = true, weapon = true, sword = true, one_hand_weapon = true, default = true, },
+	implicit = "+35% to Global Critical Strike Multiplier",
+	implicitModTypes = { { "damage", "critical" }, },
+	weapon = { PhysicalMin = 19, PhysicalMax = 44, CritChanceBase = 5.7, AttackRateBase = 1.4, Range = 14, },
+	req = { level = 34, dex = 113, },
+}
+itemBases["Smallsword"] = {
+	type = "One Handed Sword",
+	subType = "Thrusting",
+	socketLimit = 3,
+	tags = { maraketh = true, rapier = true, onehand = true, not_for_sale = true, weapon = true, sword = true, one_hand_weapon = true, default = true, },
+	implicit = "15% chance to cause Bleeding on Hit",
+	implicitModTypes = { { "bleed", "physical", "attack", "ailment" }, },
+	weapon = { PhysicalMin = 19, PhysicalMax = 40, CritChanceBase = 6, AttackRateBase = 1.55, Range = 14, },
+	req = { level = 36, dex = 124, },
+}
+itemBases["Wyrmbone Rapier"] = {
+	type = "One Handed Sword",
+	subType = "Thrusting",
+	socketLimit = 3,
+	tags = { onehand = true, rapier = true, weapon = true, sword = true, one_hand_weapon = true, default = true, },
+	implicit = "+25% to Global Critical Strike Multiplier",
+	implicitModTypes = { { "damage", "critical" }, },
+	weapon = { PhysicalMin = 13, PhysicalMax = 51, CritChanceBase = 5.5, AttackRateBase = 1.5, Range = 14, },
+	req = { level = 37, dex = 122, },
+}
+itemBases["Burnished Foil"] = {
+	type = "One Handed Sword",
+	subType = "Thrusting",
+	socketLimit = 3,
+	tags = { onehand = true, rapier = true, weapon = true, sword = true, one_hand_weapon = true, default = true, },
+	implicit = "+25% to Global Critical Strike Multiplier",
+	implicitModTypes = { { "damage", "critical" }, },
+	weapon = { PhysicalMin = 25, PhysicalMax = 46, CritChanceBase = 6, AttackRateBase = 1.4, Range = 14, },
+	req = { level = 40, dex = 131, },
+}
+itemBases["Estoc"] = {
+	type = "One Handed Sword",
+	subType = "Thrusting",
+	socketLimit = 3,
+	tags = { onehand = true, rapier = true, weapon = true, sword = true, one_hand_weapon = true, default = true, },
+	implicit = "+25% to Global Critical Strike Multiplier",
+	implicitModTypes = { { "damage", "critical" }, },
+	weapon = { PhysicalMin = 21, PhysicalMax = 50, CritChanceBase = 5.5, AttackRateBase = 1.5, Range = 14, },
+	req = { level = 43, dex = 140, },
+}
+itemBases["Serrated Foil"] = {
+	type = "One Handed Sword",
+	subType = "Thrusting",
+	socketLimit = 3,
+	tags = { onehand = true, rapier = true, weapon = true, sword = true, one_hand_weapon = true, default = true, },
+	implicit = "+25% to Global Critical Strike Multiplier",
+	implicitModTypes = { { "damage", "critical" }, },
+	weapon = { PhysicalMin = 21, PhysicalMax = 49, CritChanceBase = 5.5, AttackRateBase = 1.6, Range = 14, },
+	req = { level = 46, dex = 149, },
+}
+itemBases["Primeval Rapier"] = {
+	type = "One Handed Sword",
+	subType = "Thrusting",
+	socketLimit = 3,
+	tags = { onehand = true, rapier = true, weapon = true, sword = true, one_hand_weapon = true, default = true, },
+	implicit = "+25% to Global Critical Strike Multiplier",
+	implicitModTypes = { { "damage", "critical" }, },
+	weapon = { PhysicalMin = 18, PhysicalMax = 73, CritChanceBase = 6.5, AttackRateBase = 1.3, Range = 14, },
+	req = { level = 49, dex = 158, },
+}
+itemBases["Fancy Foil"] = {
+	type = "One Handed Sword",
+	subType = "Thrusting",
+	socketLimit = 3,
+	tags = { onehand = true, rapier = true, weapon = true, sword = true, one_hand_weapon = true, default = true, },
+	implicit = "+25% to Global Critical Strike Multiplier",
+	implicitModTypes = { { "damage", "critical" }, },
+	weapon = { PhysicalMin = 28, PhysicalMax = 51, CritChanceBase = 5.5, AttackRateBase = 1.6, Range = 14, },
+	req = { level = 52, dex = 167, },
+}
+itemBases["Apex Rapier"] = {
+	type = "One Handed Sword",
+	subType = "Thrusting",
+	socketLimit = 3,
+	tags = { onehand = true, rapier = true, weapon = true, sword = true, one_hand_weapon = true, default = true, },
+	implicit = "+35% to Global Critical Strike Multiplier",
+	implicitModTypes = { { "damage", "critical" }, },
+	weapon = { PhysicalMin = 29, PhysicalMax = 67, CritChanceBase = 5.7, AttackRateBase = 1.4, Range = 14, },
+	req = { level = 55, dex = 176, },
+}
+itemBases["Courtesan Sword"] = {
+	type = "One Handed Sword",
+	subType = "Thrusting",
+	socketLimit = 3,
+	tags = { maraketh = true, rapier = true, onehand = true, not_for_sale = true, weapon = true, sword = true, one_hand_weapon = true, default = true, },
+	implicit = "15% chance to cause Bleeding on Hit",
+	implicitModTypes = { { "bleed", "physical", "attack", "ailment" }, },
+	weapon = { PhysicalMin = 29, PhysicalMax = 60, CritChanceBase = 6, AttackRateBase = 1.55, Range = 14, },
+	req = { level = 57, dex = 190, },
+}
+itemBases["Dragonbone Rapier"] = {
+	type = "One Handed Sword",
+	subType = "Thrusting",
+	socketLimit = 3,
+	tags = { onehand = true, rapier = true, weapon = true, sword = true, one_hand_weapon = true, default = true, },
+	implicit = "+25% to Global Critical Strike Multiplier",
+	implicitModTypes = { { "damage", "critical" }, },
+	weapon = { PhysicalMin = 19, PhysicalMax = 75, CritChanceBase = 5.5, AttackRateBase = 1.5, Range = 14, },
+	req = { level = 58, dex = 185, },
+}
+itemBases["Tempered Foil"] = {
+	type = "One Handed Sword",
+	subType = "Thrusting",
+	socketLimit = 3,
+	tags = { onehand = true, rapier = true, weapon = true, sword = true, one_hand_weapon = true, default = true, },
+	implicit = "+25% to Global Critical Strike Multiplier",
+	implicitModTypes = { { "damage", "critical" }, },
+	weapon = { PhysicalMin = 35, PhysicalMax = 65, CritChanceBase = 6, AttackRateBase = 1.4, Range = 14, },
+	req = { level = 60, dex = 212, },
+}
+itemBases["Pecoraro"] = {
+	type = "One Handed Sword",
+	subType = "Thrusting",
+	socketLimit = 3,
+	tags = { onehand = true, rapier = true, weapon = true, sword = true, one_hand_weapon = true, default = true, },
+	implicit = "+25% to Global Critical Strike Multiplier",
+	implicitModTypes = { { "damage", "critical" }, },
+	weapon = { PhysicalMin = 29, PhysicalMax = 69, CritChanceBase = 5.5, AttackRateBase = 1.5, Range = 14, },
+	req = { level = 62, dex = 212, },
+}
+itemBases["Spiraled Foil"] = {
+	type = "One Handed Sword",
+	subType = "Thrusting",
+	socketLimit = 3,
+	tags = { onehand = true, rapier = true, weapon = true, sword = true, one_hand_weapon = true, default = true, },
+	implicit = "+25% to Global Critical Strike Multiplier",
+	implicitModTypes = { { "damage", "critical" }, },
+	weapon = { PhysicalMin = 27, PhysicalMax = 64, CritChanceBase = 5.5, AttackRateBase = 1.6, Range = 14, },
+	req = { level = 64, dex = 212, },
+}
+itemBases["Vaal Rapier"] = {
+	type = "One Handed Sword",
+	subType = "Thrusting",
+	socketLimit = 3,
+	tags = { onehand = true, rapier = true, weapon = true, sword = true, one_hand_weapon = true, default = true, },
+	implicit = "+25% to Global Critical Strike Multiplier",
+	implicitModTypes = { { "damage", "critical" }, },
+	weapon = { PhysicalMin = 22, PhysicalMax = 87, CritChanceBase = 6.5, AttackRateBase = 1.3, Range = 14, },
+	req = { level = 66, dex = 212, },
+}
+itemBases["Jewelled Foil"] = {
+	type = "One Handed Sword",
+	subType = "Thrusting",
+	socketLimit = 3,
+	tags = { onehand = true, rapier = true, weapon = true, sword = true, one_hand_weapon = true, default = true, },
+	implicit = "+25% to Global Critical Strike Multiplier",
+	implicitModTypes = { { "damage", "critical" }, },
+	weapon = { PhysicalMin = 32, PhysicalMax = 60, CritChanceBase = 5.5, AttackRateBase = 1.6, Range = 14, },
+	req = { level = 68, dex = 212, },
+}
+itemBases["Harpy Rapier"] = {
+	type = "One Handed Sword",
+	subType = "Thrusting",
+	socketLimit = 3,
+	tags = { onehand = true, rapier = true, weapon = true, sword = true, one_hand_weapon = true, default = true, },
+	implicit = "+35% to Global Critical Strike Multiplier",
+	implicitModTypes = { { "damage", "critical" }, },
+	weapon = { PhysicalMin = 31, PhysicalMax = 72, CritChanceBase = 5.7, AttackRateBase = 1.4, Range = 14, },
+	req = { level = 70, dex = 212, },
+}
+itemBases["Dragoon Sword"] = {
+	type = "One Handed Sword",
+	subType = "Thrusting",
+	socketLimit = 3,
+	tags = { maraketh = true, rapier = true, onehand = true, not_for_sale = true, weapon = true, sword = true, one_hand_weapon = true, default = true, },
+	implicit = "20% chance to cause Bleeding on Hit",
+	implicitModTypes = { { "bleed", "physical", "attack", "ailment" }, },
+	weapon = { PhysicalMin = 32, PhysicalMax = 66, CritChanceBase = 6, AttackRateBase = 1.5, Range = 14, },
+	req = { level = 72, dex = 220, },
 }

--- a/src/Data/Bases/sword.lua
+++ b/src/Data/Bases/sword.lua
@@ -276,251 +276,6 @@ itemBases["Energy Blade One Handed"] = {
 	req = { },
 }
 
-itemBases["Keyblade"] = {
-	type = "Two Handed Sword",
-	hidden = true,
-	socketLimit = 6,
-	tags = { two_hand_weapon = true, not_for_sale = true, weapon = true, sword = true, twohand = true, default = true, },
-	implicitModTypes = { },
-	weapon = { PhysicalMin = 1, PhysicalMax = 1, CritChanceBase = 5, AttackRateBase = 1.2, Range = 13, },
-	req = { str = 8, dex = 8, },
-}
-itemBases["Corroded Blade"] = {
-	type = "Two Handed Sword",
-	socketLimit = 6,
-	tags = { two_hand_weapon = true, weapon = true, sword = true, twohand = true, default = true, },
-	implicit = "40% increased Global Accuracy Rating",
-	implicitModTypes = { { "attack" }, },
-	weapon = { PhysicalMin = 8, PhysicalMax = 16, CritChanceBase = 5, AttackRateBase = 1.45, Range = 13, },
-	req = { str = 11, dex = 11, },
-}
-itemBases["Longsword"] = {
-	type = "Two Handed Sword",
-	socketLimit = 6,
-	tags = { two_hand_weapon = true, weapon = true, sword = true, twohand = true, default = true, },
-	implicit = "+60 to Accuracy Rating",
-	implicitModTypes = { { "attack" }, },
-	weapon = { PhysicalMin = 11, PhysicalMax = 26, CritChanceBase = 5, AttackRateBase = 1.4, Range = 13, },
-	req = { level = 8, str = 20, dex = 17, },
-}
-itemBases["Bastard Sword"] = {
-	type = "Two Handed Sword",
-	socketLimit = 6,
-	tags = { two_hand_weapon = true, weapon = true, sword = true, twohand = true, default = true, },
-	implicit = "60% increased Global Accuracy Rating",
-	implicitModTypes = { { "attack" }, },
-	weapon = { PhysicalMin = 17, PhysicalMax = 29, CritChanceBase = 5, AttackRateBase = 1.45, Range = 13, },
-	req = { level = 12, str = 21, dex = 30, },
-}
-itemBases["Two-Handed Sword"] = {
-	type = "Two Handed Sword",
-	socketLimit = 6,
-	tags = { two_hand_weapon = true, weapon = true, sword = true, twohand = true, default = true, },
-	implicit = "+120 to Accuracy Rating",
-	implicitModTypes = { { "attack" }, },
-	weapon = { PhysicalMin = 20, PhysicalMax = 38, CritChanceBase = 5, AttackRateBase = 1.4, Range = 13, },
-	req = { level = 17, str = 33, dex = 33, },
-}
-itemBases["Etched Greatsword"] = {
-	type = "Two Handed Sword",
-	socketLimit = 6,
-	tags = { two_hand_weapon = true, weapon = true, sword = true, twohand = true, default = true, },
-	implicit = "60% increased Global Accuracy Rating",
-	implicitModTypes = { { "attack" }, },
-	weapon = { PhysicalMin = 23, PhysicalMax = 48, CritChanceBase = 5, AttackRateBase = 1.4, Range = 13, },
-	req = { level = 22, str = 45, dex = 38, },
-}
-itemBases["Ornate Sword"] = {
-	type = "Two Handed Sword",
-	socketLimit = 6,
-	tags = { two_hand_weapon = true, weapon = true, sword = true, twohand = true, default = true, },
-	implicit = "+185 to Accuracy Rating",
-	implicitModTypes = { { "attack" }, },
-	weapon = { PhysicalMin = 30, PhysicalMax = 50, CritChanceBase = 5, AttackRateBase = 1.4, Range = 13, },
-	req = { level = 27, str = 45, dex = 54, },
-}
-itemBases["Spectral Sword"] = {
-	type = "Two Handed Sword",
-	socketLimit = 6,
-	tags = { two_hand_weapon = true, weapon = true, sword = true, twohand = true, default = true, },
-	implicit = "45% increased Global Accuracy Rating",
-	implicitModTypes = { { "attack" }, },
-	weapon = { PhysicalMin = 31, PhysicalMax = 65, CritChanceBase = 5, AttackRateBase = 1.35, Range = 13, },
-	req = { level = 32, str = 57, dex = 57, },
-}
-itemBases["Curved Blade"] = {
-	type = "Two Handed Sword",
-	socketLimit = 6,
-	tags = { two_hand_weapon = true, maraketh = true, not_for_sale = true, weapon = true, sword = true, twohand = true, default = true, },
-	implicit = "+40% to Global Critical Strike Multiplier",
-	implicitModTypes = { { "damage", "critical" }, },
-	weapon = { PhysicalMin = 41, PhysicalMax = 68, CritChanceBase = 6, AttackRateBase = 1.35, Range = 13, },
-	req = { level = 35, str = 62, dex = 73, },
-}
-itemBases["Butcher Sword"] = {
-	type = "Two Handed Sword",
-	socketLimit = 6,
-	tags = { two_hand_weapon = true, weapon = true, sword = true, twohand = true, default = true, },
-	implicit = "+250 to Accuracy Rating",
-	implicitModTypes = { { "attack" }, },
-	weapon = { PhysicalMin = 34, PhysicalMax = 79, CritChanceBase = 5, AttackRateBase = 1.3, Range = 13, },
-	req = { level = 36, str = 69, dex = 58, },
-}
-itemBases["Footman Sword"] = {
-	type = "Two Handed Sword",
-	socketLimit = 6,
-	tags = { two_hand_weapon = true, weapon = true, sword = true, twohand = true, default = true, },
-	implicit = "60% increased Global Accuracy Rating",
-	implicitModTypes = { { "attack" }, },
-	weapon = { PhysicalMin = 39, PhysicalMax = 65, CritChanceBase = 5, AttackRateBase = 1.45, Range = 13, },
-	req = { level = 40, str = 57, dex = 83, },
-}
-itemBases["Highland Blade"] = {
-	type = "Two Handed Sword",
-	socketLimit = 6,
-	tags = { two_hand_weapon = true, weapon = true, sword = true, twohand = true, default = true, },
-	implicit = "+305 to Accuracy Rating",
-	implicitModTypes = { { "attack" }, },
-	weapon = { PhysicalMin = 45, PhysicalMax = 84, CritChanceBase = 5, AttackRateBase = 1.35, Range = 13, },
-	req = { level = 44, str = 77, dex = 77, },
-}
-itemBases["Engraved Greatsword"] = {
-	type = "Two Handed Sword",
-	socketLimit = 6,
-	tags = { two_hand_weapon = true, weapon = true, sword = true, twohand = true, default = true, },
-	implicit = "60% increased Global Accuracy Rating",
-	implicitModTypes = { { "attack" }, },
-	weapon = { PhysicalMin = 49, PhysicalMax = 102, CritChanceBase = 5, AttackRateBase = 1.3, Range = 13, },
-	req = { level = 48, str = 91, dex = 76, },
-}
-itemBases["Tiger Sword"] = {
-	type = "Two Handed Sword",
-	socketLimit = 6,
-	tags = { two_hand_weapon = true, weapon = true, sword = true, twohand = true, default = true, },
-	implicit = "+360 to Accuracy Rating",
-	implicitModTypes = { { "attack" }, },
-	weapon = { PhysicalMin = 54, PhysicalMax = 89, CritChanceBase = 5, AttackRateBase = 1.4, Range = 13, },
-	req = { level = 51, str = 80, dex = 96, },
-}
-itemBases["Wraith Sword"] = {
-	type = "Two Handed Sword",
-	socketLimit = 6,
-	tags = { two_hand_weapon = true, weapon = true, sword = true, twohand = true, default = true, },
-	implicit = "45% increased Global Accuracy Rating",
-	implicitModTypes = { { "attack" }, },
-	weapon = { PhysicalMin = 52, PhysicalMax = 109, CritChanceBase = 5, AttackRateBase = 1.35, Range = 13, },
-	req = { level = 54, str = 93, dex = 93, },
-}
-itemBases["Lithe Blade"] = {
-	type = "Two Handed Sword",
-	socketLimit = 6,
-	tags = { two_hand_weapon = true, maraketh = true, not_for_sale = true, weapon = true, sword = true, twohand = true, default = true, },
-	implicit = "+40% to Global Critical Strike Multiplier",
-	implicitModTypes = { { "damage", "critical" }, },
-	weapon = { PhysicalMin = 63, PhysicalMax = 104, CritChanceBase = 6, AttackRateBase = 1.35, Range = 13, },
-	req = { level = 56, str = 96, dex = 113, },
-}
-itemBases["Headman's Sword"] = {
-	type = "Two Handed Sword",
-	socketLimit = 6,
-	tags = { two_hand_weapon = true, weapon = true, sword = true, twohand = true, default = true, },
-	implicit = "+400 to Accuracy Rating",
-	implicitModTypes = { { "attack" }, },
-	weapon = { PhysicalMin = 55, PhysicalMax = 128, CritChanceBase = 5, AttackRateBase = 1.3, Range = 13, },
-	req = { level = 57, str = 106, dex = 89, },
-}
-itemBases["Reaver Sword"] = {
-	type = "Two Handed Sword",
-	socketLimit = 6,
-	tags = { two_hand_weapon = true, weapon = true, sword = true, twohand = true, default = true, },
-	implicit = "60% increased Global Accuracy Rating",
-	implicitModTypes = { { "attack" }, },
-	weapon = { PhysicalMin = 62, PhysicalMax = 104, CritChanceBase = 5, AttackRateBase = 1.5, Range = 13, },
-	req = { level = 59, str = 82, dex = 119, },
-}
-itemBases["Ezomyte Blade"] = {
-	type = "Two Handed Sword",
-	socketLimit = 6,
-	tags = { two_hand_weapon = true, weapon = true, sword = true, twohand = true, default = true, },
-	implicit = "+25% to Global Critical Strike Multiplier",
-	implicitModTypes = { { "damage", "critical" }, },
-	weapon = { PhysicalMin = 62, PhysicalMax = 115, CritChanceBase = 6.5, AttackRateBase = 1.4, Range = 13, },
-	req = { level = 61, str = 113, dex = 113, },
-}
-itemBases["Vaal Greatsword"] = {
-	type = "Two Handed Sword",
-	socketLimit = 6,
-	tags = { two_hand_weapon = true, weapon = true, sword = true, twohand = true, default = true, },
-	implicit = "+470 to Accuracy Rating",
-	implicitModTypes = { { "attack" }, },
-	weapon = { PhysicalMin = 68, PhysicalMax = 142, CritChanceBase = 5, AttackRateBase = 1.3, Range = 13, },
-	req = { level = 63, str = 122, dex = 104, },
-}
-itemBases["Lion Sword"] = {
-	type = "Two Handed Sword",
-	socketLimit = 6,
-	tags = { two_hand_weapon = true, weapon = true, sword = true, twohand = true, default = true, },
-	implicit = "+50 to Strength and Dexterity",
-	implicitModTypes = { { "attribute" }, },
-	weapon = { PhysicalMin = 69, PhysicalMax = 115, CritChanceBase = 5, AttackRateBase = 1.45, Range = 13, },
-	req = { level = 65, str = 104, dex = 122, },
-}
-itemBases["Infernal Sword"] = {
-	type = "Two Handed Sword",
-	socketLimit = 6,
-	tags = { two_hand_weapon = true, weapon = true, sword = true, twohand = true, default = true, },
-	implicit = "30% increased Elemental Damage with Attack Skills",
-	implicitModTypes = { { "elemental_damage", "damage", "elemental", "attack" }, },
-	weapon = { PhysicalMin = 62, PhysicalMax = 129, CritChanceBase = 5, AttackRateBase = 1.35, Range = 13, },
-	req = { level = 67, str = 113, dex = 113, },
-}
-itemBases["Exquisite Blade"] = {
-	type = "Two Handed Sword",
-	socketLimit = 6,
-	tags = { two_hand_weapon = true, maraketh = true, not_for_sale = true, weapon = true, sword = true, twohand = true, default = true, },
-	implicit = "+50% to Global Critical Strike Multiplier",
-	implicitModTypes = { { "damage", "critical" }, },
-	weapon = { PhysicalMin = 67, PhysicalMax = 112, CritChanceBase = 5.7, AttackRateBase = 1.35, Range = 13, },
-	req = { level = 70, str = 119, dex = 131, },
-}
-itemBases["Rebuking Blade"] = {
-	type = "Two Handed Sword",
-	socketLimit = 6,
-	tags = { two_hand_weapon = true, not_for_sale = true, weapon = true, sword = true, twohand = true, default = true, },
-	implicit = "Attack Critical Strikes ignore Enemy Monster Elemental Resistances",
-	implicitModTypes = { {  }, },
-	weapon = { PhysicalMin = 34, PhysicalMax = 63, CritChanceBase = 6, AttackRateBase = 1.3, Range = 13, },
-	req = { level = 30, str = 54, dex = 54, },
-}
-itemBases["Blasting Blade"] = {
-	type = "Two Handed Sword",
-	socketLimit = 6,
-	tags = { two_hand_weapon = true, not_for_sale = true, weapon = true, sword = true, twohand = true, default = true, },
-	implicit = "Attack Critical Strikes ignore Enemy Monster Elemental Resistances",
-	implicitModTypes = { {  }, },
-	weapon = { PhysicalMin = 52, PhysicalMax = 97, CritChanceBase = 6, AttackRateBase = 1.3, Range = 13, },
-	req = { level = 50, str = 86, dex = 86, },
-}
-itemBases["Banishing Blade"] = {
-	type = "Two Handed Sword",
-	socketLimit = 6,
-	tags = { two_hand_weapon = true, not_for_sale = true, weapon = true, sword = true, twohand = true, default = true, },
-	implicit = "Attack Critical Strikes ignore Enemy Monster Elemental Resistances",
-	implicitModTypes = { {  }, },
-	weapon = { PhysicalMin = 61, PhysicalMax = 114, CritChanceBase = 6, AttackRateBase = 1.3, Range = 13, },
-	req = { level = 70, str = 130, dex = 130, },
-}
-
-itemBases["Energy Blade Two Handed"] = {
-	type = "Two Handed Sword",
-	hidden = true,
-	socketLimit = 6,
-	tags = { two_hand_weapon = true, not_for_sale = true, weapon = true, sword = true, twohand = true, default = true, },
-	implicitModTypes = { },
-	weapon = { PhysicalMin = 0, PhysicalMax = 0, CritChanceBase = 7, AttackRateBase = 1.6, Range = 13, },
-	req = { },
-}
-
 itemBases["Rusted Spike"] = {
 	type = "One Handed Sword",
 	subType = "Thrusting",
@@ -770,4 +525,249 @@ itemBases["Dragoon Sword"] = {
 	implicitModTypes = { { "bleed", "physical", "attack", "ailment" }, },
 	weapon = { PhysicalMin = 32, PhysicalMax = 66, CritChanceBase = 6, AttackRateBase = 1.5, Range = 14, },
 	req = { level = 72, dex = 220, },
+}
+
+itemBases["Keyblade"] = {
+	type = "Two Handed Sword",
+	hidden = true,
+	socketLimit = 6,
+	tags = { two_hand_weapon = true, not_for_sale = true, weapon = true, sword = true, twohand = true, default = true, },
+	implicitModTypes = { },
+	weapon = { PhysicalMin = 1, PhysicalMax = 1, CritChanceBase = 5, AttackRateBase = 1.2, Range = 13, },
+	req = { str = 8, dex = 8, },
+}
+itemBases["Corroded Blade"] = {
+	type = "Two Handed Sword",
+	socketLimit = 6,
+	tags = { two_hand_weapon = true, weapon = true, sword = true, twohand = true, default = true, },
+	implicit = "40% increased Global Accuracy Rating",
+	implicitModTypes = { { "attack" }, },
+	weapon = { PhysicalMin = 8, PhysicalMax = 16, CritChanceBase = 5, AttackRateBase = 1.45, Range = 13, },
+	req = { str = 11, dex = 11, },
+}
+itemBases["Longsword"] = {
+	type = "Two Handed Sword",
+	socketLimit = 6,
+	tags = { two_hand_weapon = true, weapon = true, sword = true, twohand = true, default = true, },
+	implicit = "+60 to Accuracy Rating",
+	implicitModTypes = { { "attack" }, },
+	weapon = { PhysicalMin = 11, PhysicalMax = 26, CritChanceBase = 5, AttackRateBase = 1.4, Range = 13, },
+	req = { level = 8, str = 20, dex = 17, },
+}
+itemBases["Bastard Sword"] = {
+	type = "Two Handed Sword",
+	socketLimit = 6,
+	tags = { two_hand_weapon = true, weapon = true, sword = true, twohand = true, default = true, },
+	implicit = "60% increased Global Accuracy Rating",
+	implicitModTypes = { { "attack" }, },
+	weapon = { PhysicalMin = 17, PhysicalMax = 29, CritChanceBase = 5, AttackRateBase = 1.45, Range = 13, },
+	req = { level = 12, str = 21, dex = 30, },
+}
+itemBases["Two-Handed Sword"] = {
+	type = "Two Handed Sword",
+	socketLimit = 6,
+	tags = { two_hand_weapon = true, weapon = true, sword = true, twohand = true, default = true, },
+	implicit = "+120 to Accuracy Rating",
+	implicitModTypes = { { "attack" }, },
+	weapon = { PhysicalMin = 20, PhysicalMax = 38, CritChanceBase = 5, AttackRateBase = 1.4, Range = 13, },
+	req = { level = 17, str = 33, dex = 33, },
+}
+itemBases["Etched Greatsword"] = {
+	type = "Two Handed Sword",
+	socketLimit = 6,
+	tags = { two_hand_weapon = true, weapon = true, sword = true, twohand = true, default = true, },
+	implicit = "60% increased Global Accuracy Rating",
+	implicitModTypes = { { "attack" }, },
+	weapon = { PhysicalMin = 23, PhysicalMax = 48, CritChanceBase = 5, AttackRateBase = 1.4, Range = 13, },
+	req = { level = 22, str = 45, dex = 38, },
+}
+itemBases["Ornate Sword"] = {
+	type = "Two Handed Sword",
+	socketLimit = 6,
+	tags = { two_hand_weapon = true, weapon = true, sword = true, twohand = true, default = true, },
+	implicit = "+185 to Accuracy Rating",
+	implicitModTypes = { { "attack" }, },
+	weapon = { PhysicalMin = 30, PhysicalMax = 50, CritChanceBase = 5, AttackRateBase = 1.4, Range = 13, },
+	req = { level = 27, str = 45, dex = 54, },
+}
+itemBases["Spectral Sword"] = {
+	type = "Two Handed Sword",
+	socketLimit = 6,
+	tags = { two_hand_weapon = true, weapon = true, sword = true, twohand = true, default = true, },
+	implicit = "45% increased Global Accuracy Rating",
+	implicitModTypes = { { "attack" }, },
+	weapon = { PhysicalMin = 31, PhysicalMax = 65, CritChanceBase = 5, AttackRateBase = 1.35, Range = 13, },
+	req = { level = 32, str = 57, dex = 57, },
+}
+itemBases["Curved Blade"] = {
+	type = "Two Handed Sword",
+	socketLimit = 6,
+	tags = { two_hand_weapon = true, maraketh = true, not_for_sale = true, weapon = true, sword = true, twohand = true, default = true, },
+	implicit = "+40% to Global Critical Strike Multiplier",
+	implicitModTypes = { { "damage", "critical" }, },
+	weapon = { PhysicalMin = 41, PhysicalMax = 68, CritChanceBase = 6, AttackRateBase = 1.35, Range = 13, },
+	req = { level = 35, str = 62, dex = 73, },
+}
+itemBases["Butcher Sword"] = {
+	type = "Two Handed Sword",
+	socketLimit = 6,
+	tags = { two_hand_weapon = true, weapon = true, sword = true, twohand = true, default = true, },
+	implicit = "+250 to Accuracy Rating",
+	implicitModTypes = { { "attack" }, },
+	weapon = { PhysicalMin = 34, PhysicalMax = 79, CritChanceBase = 5, AttackRateBase = 1.3, Range = 13, },
+	req = { level = 36, str = 69, dex = 58, },
+}
+itemBases["Footman Sword"] = {
+	type = "Two Handed Sword",
+	socketLimit = 6,
+	tags = { two_hand_weapon = true, weapon = true, sword = true, twohand = true, default = true, },
+	implicit = "60% increased Global Accuracy Rating",
+	implicitModTypes = { { "attack" }, },
+	weapon = { PhysicalMin = 39, PhysicalMax = 65, CritChanceBase = 5, AttackRateBase = 1.45, Range = 13, },
+	req = { level = 40, str = 57, dex = 83, },
+}
+itemBases["Highland Blade"] = {
+	type = "Two Handed Sword",
+	socketLimit = 6,
+	tags = { two_hand_weapon = true, weapon = true, sword = true, twohand = true, default = true, },
+	implicit = "+305 to Accuracy Rating",
+	implicitModTypes = { { "attack" }, },
+	weapon = { PhysicalMin = 45, PhysicalMax = 84, CritChanceBase = 5, AttackRateBase = 1.35, Range = 13, },
+	req = { level = 44, str = 77, dex = 77, },
+}
+itemBases["Engraved Greatsword"] = {
+	type = "Two Handed Sword",
+	socketLimit = 6,
+	tags = { two_hand_weapon = true, weapon = true, sword = true, twohand = true, default = true, },
+	implicit = "60% increased Global Accuracy Rating",
+	implicitModTypes = { { "attack" }, },
+	weapon = { PhysicalMin = 49, PhysicalMax = 102, CritChanceBase = 5, AttackRateBase = 1.3, Range = 13, },
+	req = { level = 48, str = 91, dex = 76, },
+}
+itemBases["Tiger Sword"] = {
+	type = "Two Handed Sword",
+	socketLimit = 6,
+	tags = { two_hand_weapon = true, weapon = true, sword = true, twohand = true, default = true, },
+	implicit = "+360 to Accuracy Rating",
+	implicitModTypes = { { "attack" }, },
+	weapon = { PhysicalMin = 54, PhysicalMax = 89, CritChanceBase = 5, AttackRateBase = 1.4, Range = 13, },
+	req = { level = 51, str = 80, dex = 96, },
+}
+itemBases["Wraith Sword"] = {
+	type = "Two Handed Sword",
+	socketLimit = 6,
+	tags = { two_hand_weapon = true, weapon = true, sword = true, twohand = true, default = true, },
+	implicit = "45% increased Global Accuracy Rating",
+	implicitModTypes = { { "attack" }, },
+	weapon = { PhysicalMin = 52, PhysicalMax = 109, CritChanceBase = 5, AttackRateBase = 1.35, Range = 13, },
+	req = { level = 54, str = 93, dex = 93, },
+}
+itemBases["Lithe Blade"] = {
+	type = "Two Handed Sword",
+	socketLimit = 6,
+	tags = { two_hand_weapon = true, maraketh = true, not_for_sale = true, weapon = true, sword = true, twohand = true, default = true, },
+	implicit = "+40% to Global Critical Strike Multiplier",
+	implicitModTypes = { { "damage", "critical" }, },
+	weapon = { PhysicalMin = 63, PhysicalMax = 104, CritChanceBase = 6, AttackRateBase = 1.35, Range = 13, },
+	req = { level = 56, str = 96, dex = 113, },
+}
+itemBases["Headman's Sword"] = {
+	type = "Two Handed Sword",
+	socketLimit = 6,
+	tags = { two_hand_weapon = true, weapon = true, sword = true, twohand = true, default = true, },
+	implicit = "+400 to Accuracy Rating",
+	implicitModTypes = { { "attack" }, },
+	weapon = { PhysicalMin = 55, PhysicalMax = 128, CritChanceBase = 5, AttackRateBase = 1.3, Range = 13, },
+	req = { level = 57, str = 106, dex = 89, },
+}
+itemBases["Reaver Sword"] = {
+	type = "Two Handed Sword",
+	socketLimit = 6,
+	tags = { two_hand_weapon = true, weapon = true, sword = true, twohand = true, default = true, },
+	implicit = "60% increased Global Accuracy Rating",
+	implicitModTypes = { { "attack" }, },
+	weapon = { PhysicalMin = 62, PhysicalMax = 104, CritChanceBase = 5, AttackRateBase = 1.5, Range = 13, },
+	req = { level = 59, str = 82, dex = 119, },
+}
+itemBases["Ezomyte Blade"] = {
+	type = "Two Handed Sword",
+	socketLimit = 6,
+	tags = { two_hand_weapon = true, weapon = true, sword = true, twohand = true, default = true, },
+	implicit = "+25% to Global Critical Strike Multiplier",
+	implicitModTypes = { { "damage", "critical" }, },
+	weapon = { PhysicalMin = 62, PhysicalMax = 115, CritChanceBase = 6.5, AttackRateBase = 1.4, Range = 13, },
+	req = { level = 61, str = 113, dex = 113, },
+}
+itemBases["Vaal Greatsword"] = {
+	type = "Two Handed Sword",
+	socketLimit = 6,
+	tags = { two_hand_weapon = true, weapon = true, sword = true, twohand = true, default = true, },
+	implicit = "+470 to Accuracy Rating",
+	implicitModTypes = { { "attack" }, },
+	weapon = { PhysicalMin = 68, PhysicalMax = 142, CritChanceBase = 5, AttackRateBase = 1.3, Range = 13, },
+	req = { level = 63, str = 122, dex = 104, },
+}
+itemBases["Lion Sword"] = {
+	type = "Two Handed Sword",
+	socketLimit = 6,
+	tags = { two_hand_weapon = true, weapon = true, sword = true, twohand = true, default = true, },
+	implicit = "+50 to Strength and Dexterity",
+	implicitModTypes = { { "attribute" }, },
+	weapon = { PhysicalMin = 69, PhysicalMax = 115, CritChanceBase = 5, AttackRateBase = 1.45, Range = 13, },
+	req = { level = 65, str = 104, dex = 122, },
+}
+itemBases["Infernal Sword"] = {
+	type = "Two Handed Sword",
+	socketLimit = 6,
+	tags = { two_hand_weapon = true, weapon = true, sword = true, twohand = true, default = true, },
+	implicit = "30% increased Elemental Damage with Attack Skills",
+	implicitModTypes = { { "elemental_damage", "damage", "elemental", "attack" }, },
+	weapon = { PhysicalMin = 62, PhysicalMax = 129, CritChanceBase = 5, AttackRateBase = 1.35, Range = 13, },
+	req = { level = 67, str = 113, dex = 113, },
+}
+itemBases["Exquisite Blade"] = {
+	type = "Two Handed Sword",
+	socketLimit = 6,
+	tags = { two_hand_weapon = true, maraketh = true, not_for_sale = true, weapon = true, sword = true, twohand = true, default = true, },
+	implicit = "+50% to Global Critical Strike Multiplier",
+	implicitModTypes = { { "damage", "critical" }, },
+	weapon = { PhysicalMin = 67, PhysicalMax = 112, CritChanceBase = 5.7, AttackRateBase = 1.35, Range = 13, },
+	req = { level = 70, str = 119, dex = 131, },
+}
+itemBases["Rebuking Blade"] = {
+	type = "Two Handed Sword",
+	socketLimit = 6,
+	tags = { two_hand_weapon = true, not_for_sale = true, weapon = true, sword = true, twohand = true, default = true, },
+	implicit = "Attack Critical Strikes ignore Enemy Monster Elemental Resistances",
+	implicitModTypes = { {  }, },
+	weapon = { PhysicalMin = 34, PhysicalMax = 63, CritChanceBase = 6, AttackRateBase = 1.3, Range = 13, },
+	req = { level = 30, str = 54, dex = 54, },
+}
+itemBases["Blasting Blade"] = {
+	type = "Two Handed Sword",
+	socketLimit = 6,
+	tags = { two_hand_weapon = true, not_for_sale = true, weapon = true, sword = true, twohand = true, default = true, },
+	implicit = "Attack Critical Strikes ignore Enemy Monster Elemental Resistances",
+	implicitModTypes = { {  }, },
+	weapon = { PhysicalMin = 52, PhysicalMax = 97, CritChanceBase = 6, AttackRateBase = 1.3, Range = 13, },
+	req = { level = 50, str = 86, dex = 86, },
+}
+itemBases["Banishing Blade"] = {
+	type = "Two Handed Sword",
+	socketLimit = 6,
+	tags = { two_hand_weapon = true, not_for_sale = true, weapon = true, sword = true, twohand = true, default = true, },
+	implicit = "Attack Critical Strikes ignore Enemy Monster Elemental Resistances",
+	implicitModTypes = { {  }, },
+	weapon = { PhysicalMin = 61, PhysicalMax = 114, CritChanceBase = 6, AttackRateBase = 1.3, Range = 13, },
+	req = { level = 70, str = 130, dex = 130, },
+}
+
+itemBases["Energy Blade Two Handed"] = {
+	type = "Two Handed Sword",
+	hidden = true,
+	socketLimit = 6,
+	tags = { two_hand_weapon = true, not_for_sale = true, weapon = true, sword = true, twohand = true, default = true, },
+	implicitModTypes = { },
+	weapon = { PhysicalMin = 0, PhysicalMax = 0, CritChanceBase = 7, AttackRateBase = 1.6, Range = 13, },
+	req = { },
 }

--- a/src/Export/Bases/sword.txt
+++ b/src/Export/Bases/sword.txt
@@ -13,9 +13,6 @@ local itemBases = ...
 #base Metadata/Items/Weapons/OneHandWeapons/OneHandSwords/StormBladeOneHand
 #forceHide false
 
-#type Thrusting One Handed Sword
-#baseMatch Metadata/Items/Weapons/OneHandWeapons/OneHandThrustingSwords/Rapier
-
 #type Two Handed Sword
 #socketLimit 6
 #baseTags weapon twohand sword two_hand_weapon
@@ -24,3 +21,9 @@ local itemBases = ...
 #forceHide true
 #base Metadata/Items/Weapons/TwoHandWeapons/TwoHandSwords/StormBladeTwoHand
 #forceHide false
+
+#type One Handed Sword
+#subType Thrusting
+#socketLimit 3
+#baseTags weapon onehand sword one_hand_weapon
+#baseMatch Metadata/Items/Weapons/OneHandWeapons/OneHandThrustingSwords/Rapier

--- a/src/Export/Bases/sword.txt
+++ b/src/Export/Bases/sword.txt
@@ -13,7 +13,12 @@ local itemBases = ...
 #base Metadata/Items/Weapons/OneHandWeapons/OneHandSwords/StormBladeOneHand
 #forceHide false
 
+#type One Handed Sword
+#subType Thrusting
+#baseMatch Metadata/Items/Weapons/OneHandWeapons/OneHandThrustingSwords/Rapier
+
 #type Two Handed Sword
+#subType
 #socketLimit 6
 #baseTags weapon twohand sword two_hand_weapon
 #baseMatch Metadata/Items/Weapons/TwoHandWeapons/TwoHandSwords/TwoHandSword
@@ -21,9 +26,3 @@ local itemBases = ...
 #forceHide true
 #base Metadata/Items/Weapons/TwoHandWeapons/TwoHandSwords/StormBladeTwoHand
 #forceHide false
-
-#type One Handed Sword
-#subType Thrusting
-#socketLimit 3
-#baseTags weapon onehand sword one_hand_weapon
-#baseMatch Metadata/Items/Weapons/OneHandWeapons/OneHandThrustingSwords/Rapier


### PR DESCRIPTION
This makes PoB compliant with raw text item representation as provided on Path of Exile trade and for item imports. Thrusting swords got the same treatment as how we handle Rune Daggers.

This is also necessary for proper parameter scraping in the PoBTrader PR when comparing items pulled from the trade site and how we parse the raw item text.