### PR TITLE
Add support for Ryslatha life flask charge generation

### DIFF
--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -3437,6 +3437,10 @@ local specialModList = {
 	["while stationary, gain (%d+)%% additional physical damage reduction every second, up to a maximum of (%d+)%%"] = function(num, _, limit) return {
 		mod("PhysicalDamageReduction", "BASE", num, { type = "Multiplier", var = "StationarySeconds", limit = tonumber(limit), limitTotal = true }, { type = "Condition", var = "Stationary" }),
 	} end,
+	-- Pantheon: Soul of Ryslatha support
+	["life flasks gain (%d+) charges? every (%d+) seconds if you haven't used a life flask recently"] = function(num, _, div) return {
+		mod("LifeFlaskChargesGenerated", "BASE", num / div, { type = "Condition", var = "UsingLifeFlask", neg = true })
+	} end,
 	-- Skill-specific enchantment modifiers
 	["(%d+)%% increased decoy totem life"] = function(num) return { mod("TotemLife", "INC", num, { type = "SkillName", skillName = "Decoy Totem" }) } end,
 	["(%d+)%% increased ice spear critical strike chance in second form"] = function(num) return { mod("CritChance", "INC", num, { type = "SkillName", skillName = "Ice Spear" }, { type = "SkillPart", skillPart = 2 }) } end,


### PR DESCRIPTION
It assumes that the pantheon is active when life flask is not active as simplified condition.

![image](https://user-images.githubusercontent.com/5115805/183696527-8602f65d-a188-4f8f-b1b9-441777bf9682.png)

![image](https://user-images.githubusercontent.com/5115805/183696595-da0faf6d-09bf-46e2-bf3c-2c016f4faea8.png)

### Example POB

https://pobb.in/mc1bE8B0gDzM