### PR TITLE
Add support for right-click reset for config tab options

### DIFF
--- a/src/Classes/CheckBoxControl.lua
+++ b/src/Classes/CheckBoxControl.lua
@@ -9,6 +9,7 @@ local CheckBoxClass = newClass("CheckBoxControl", "Control", "TooltipHost", func
 	self.label = label
 	self.changeFunc = changeFunc
 	self.state = initialState
+	self.initialState = initialState
 end)
 
 function CheckBoxClass:IsMouseOver()
@@ -101,4 +102,11 @@ function CheckBoxClass:OnKeyUp(key)
 		end
 	end
 	self.clicked = false
+end
+
+function CheckBoxClass:Reset()
+	self.state = self.initialState
+	if self.changeFunc then
+		self.changeFunc(self.state)
+	end
 end

--- a/src/Classes/ControlHost.lua
+++ b/src/Classes/ControlHost.lua
@@ -60,7 +60,7 @@ function ControlHostClass:ProcessControlsInput(inputEvents, viewPort)
 			local mOverControl = self:GetMouseOverControl(viewPort)
 
 			-- Avoid calculating isMouseInRegion as much as possible as it's expensive
-			if mOverControl and (not selControl or mOverControl.OnHoverKeyUp) then
+			if mOverControl and (not selControl or mOverControl.OnHoverKeyUp or mOverControl.Reset) then
 				if isMouseInRegion(viewPort) then
 					if not selControl and mOverControl.OnKeyUp and mOverControl:OnKeyUp(event.key) then
 						inputEvents[id] = nil
@@ -68,6 +68,10 @@ function ControlHostClass:ProcessControlsInput(inputEvents, viewPort)
 	
 					if mOverControl.OnHoverKeyUp then
 						mOverControl:OnHoverKeyUp(event.key)
+					end
+
+					if mOverControl.Reset and event.key == "RIGHTBUTTON" then
+						mOverControl:Reset()
 					end
 				end
 			end

--- a/src/Classes/DropDownControl.lua
+++ b/src/Classes/DropDownControl.lua
@@ -383,7 +383,7 @@ function DropDownClass:OnKeyDown(key)
 	else
 		self.selControl = nil
 	end
-	if key == "LEFTBUTTON" or key == "RIGHTBUTTON" then
+	if key == "LEFTBUTTON" then
 		local mOver, mOverComp = self:IsMouseOver()
 		if not mOver or (self.dropped and mOverComp == "BODY") then
 			self.dropped = false
@@ -412,7 +412,7 @@ function DropDownClass:OnKeyUp(key)
 		end
 		return self
 	end
-	if key == "LEFTBUTTON" or key == "RIGHTBUTTON" then
+	if key == "LEFTBUTTON" then
 		local mOver, mOverComp = self:IsMouseOver()
 		if not mOver then
 			self.dropped = false
@@ -500,4 +500,9 @@ function DropDownClass:CheckDroppedWidth(enable)
 		self.droppedWidth = self.width
 		self.controls.scrollBar.x = -1
 	end
+end
+
+function DropDownClass:Reset()
+	self:SetSel(1)
+	self:ScrollSelIntoView()
 end

--- a/src/Classes/EditControl.lua
+++ b/src/Classes/EditControl.lua
@@ -102,6 +102,10 @@ function EditClass:SetPlaceholder(text, notify)
 	end
 end
 
+function EditClass:Reset()
+	self:SetText("", true)
+end
+
 function EditClass:IsMouseOver()
 	if not self:IsShown() then
 		return false
@@ -473,7 +477,7 @@ function EditClass:OnKeyDown(key, doubleClick)
 				self:ReplaceSel("")
 			end
 		end
-	elseif key == "v" and ctrl or key == "RIGHTBUTTON" and self.Object:IsMouseOver() then
+	elseif key == "v" and ctrl then
 		local text = Paste()
 		if text then
 			if self.pasteFilter then


### PR DESCRIPTION
Right click resets config option to default state if possible.
This is related to #4716 but I figured its useful as separate change.

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>