### PR TITLE
Extend default gem level functionality

### DIFF
--- a/src/Classes/GemSelectControl.lua
+++ b/src/Classes/GemSelectControl.lua
@@ -62,16 +62,21 @@ function GemSelectClass:PopulateGemList()
 	local showAll = self.skillsTab.showSupportGemTypes == "ALL"
 	local showAwakened = self.skillsTab.showSupportGemTypes == "AWAKENED"
 	local showNormal = self.skillsTab.showSupportGemTypes == "NORMAL"
+	local matchLevel = self.skillsTab.defaultGemLevel == "characterLevel"
+	local characterLevel = self.skillsTab.build and self.skillsTab.build.characterLevel or 1
 	for gemId, gemData in pairs(self.skillsTab.build.data.gems) do
-		if (showAwakened or showAll) and gemData.grantedEffect.plusVersionOf then
-			self.gems["Default:" .. gemId] = gemData
-		elseif showNormal or showAll then
-			if self.skillsTab.showAltQualityGems and self.skillsTab.defaultGemQuality or 0 > 0 then
-				for _, altQual in ipairs(self.skillsTab:getGemAltQualityList(gemData)) do
-					self.gems[altQual.type .. ":" .. gemId] = gemData
-				end
-			else
+		local levelRequirement = gemData.grantedEffect.levels[1].levelRequirement or 1
+		if characterLevel >= levelRequirement or not matchLevel then
+			if (showAwakened or showAll) and gemData.grantedEffect.plusVersionOf then
 				self.gems["Default:" .. gemId] = gemData
+			elseif showNormal or showAll then
+				if self.skillsTab.showAltQualityGems and (self.skillsTab.defaultGemQuality or 0) > 0 then
+					for _, altQual in ipairs(self.skillsTab:getGemAltQualityList(gemData)) do
+						self.gems[altQual.type .. ":" .. gemId] = gemData
+					end
+				else
+					self.gems["Default:" .. gemId] = gemData
+				end
 			end
 		end
 	end
@@ -199,7 +204,7 @@ function GemSelectClass:UpdateSortCache()
 	end
 
 	if sortCache and (sortCache.considerAlternates ~= self.skillsTab.showAltQualityGems or sortCache.considerGemType ~= self.skillsTab.showSupportGemTypes 
-		or sortCache.defaultQuality ~= self.skillsTab.defaultGemQuality) then
+		or sortCache.defaultQuality ~= self.skillsTab.defaultGemQuality or sortCache.characterLevel ~= self.skillsTab.build.characterLevel) then
 		self:PopulateGemList()
 	end
 
@@ -212,6 +217,7 @@ function GemSelectClass:UpdateSortCache()
 		outputRevision = self.skillsTab.build.outputRevision,
 		defaultLevel = self.skillsTab.defaultGemLevel,
 		defaultQuality = self.skillsTab.defaultGemQuality,
+		characterLevel = self.skillsTab.build and self.skillsTab.build.characterLevel or 1,
 		canSupport = { },
 		dps = { },
 		dpsColor = { },

--- a/src/Classes/GemSelectControl.lua
+++ b/src/Classes/GemSelectControl.lua
@@ -246,7 +246,14 @@ function GemSelectClass:UpdateSortCache()
 			if gemList[self.index] then
 				oldGem = copyTable(gemList[self.index], true)
 			else
-				gemList[self.index] = { level = self.skillsTab.defaultGemLevel or gemData.defaultLevel, qualityId = self:GetQualityType(gemId), quality = self.skillsTab.defaultGemQuality or 0, enabled = true, enableGlobal1 = true }
+				gemList[self.index] = {
+					level = self.skillsTab:ProcessGemLevel(gemData),
+					qualityId = self:GetQualityType(gemId),
+					quality = self.skillsTab.defaultGemQuality or 0,
+					enabled = true,
+					enableGlobal1 = true,
+					enableGlobal2 = true
+				}
 			end
 			local gemInstance = gemList[self.index]
 			if gemInstance.gemData and gemInstance.gemData.defaultLevel ~= gemData.defaultLevel then
@@ -417,12 +424,19 @@ function GemSelectClass:Draw(viewPort, noTooltip)
 				if gemList[self.index] then
 					oldGem = copyTable(gemList[self.index], true)
 				else
-					gemList[self.index] = { level = self.skillsTab:MatchGemLevelToCharacterLevel(gemData, m_min(self.skillsTab.defaultGemLevel or gemData.defaultLevel, gemData.defaultLevel + 1)), qualityId = self:GetQualityType(self.list[self.hoverSel]), quality = self.skillsTab.defaultGemQuality or 0, enabled = true, enableGlobal1 = true }
+					gemList[self.index] = {
+						level = self.skillsTab:ProcessGemLevel(gemData),
+						qualityId = self:GetQualityType(self.list[self.hoverSel]),
+						quality = self.skillsTab.defaultGemQuality or 0,
+						enabled = true,
+						enableGlobal1 = true,
+						enableGlobal2 = true
+					}
 				end
 				-- Create gemInstance to represent the hovered gem
 				local gemInstance = gemList[self.index]
 				if gemInstance.gemData and gemInstance.gemData.defaultLevel ~= gemData.defaultLevel then
-					gemInstance.level = self.skillsTab:MatchGemLevelToCharacterLevel(gemData, m_min(self.skillsTab.defaultGemLevel or gemData.defaultLevel, gemData.defaultLevel + 1))
+					gemInstance.level = self.skillsTab:ProcessGemLevel(gemData)
 				end
 				gemInstance.gemData = gemData
 				-- Clear the displayEffect so it only displays the temporary gem instance

--- a/src/Classes/GemSelectControl.lua
+++ b/src/Classes/GemSelectControl.lua
@@ -191,15 +191,15 @@ function GemSelectClass:UpdateSortCache()
 	--local start = GetTime()
 	local sortCache = self.sortCache
 	--Don't update the cache if no settings have changed that would impact the ordering
-	if sortCache and sortCache.socketGroup == self.skillsTab.displayGroup and sortCache.gemInstance == self.skillsTab.displayGroup.gemList[self.index] and 
-	  sortCache.outputRevision == self.skillsTab.build.outputRevision and sortCache.defaultLevel == self.skillsTab.defaultGemLevel 
-	  and sortCache.defaultQuality == self.skillsTab.defaultGemQuality and sortCache.sortType == self.skillsTab.sortGemsByDPSField 
-	  and sortCache.considerAlternates == self.skillsTab.showAltQualityGems and sortCache.considerAwakened == self.skillsTab.showSupportGemTypes then
+	if sortCache and sortCache.socketGroup == self.skillsTab.displayGroup and sortCache.gemInstance == self.skillsTab.displayGroup.gemList[self.index] and
+		sortCache.outputRevision == self.skillsTab.build.outputRevision and sortCache.defaultLevel == self.skillsTab.defaultGemLevel
+		and sortCache.defaultQuality == self.skillsTab.defaultGemQuality and sortCache.sortType == self.skillsTab.sortGemsByDPSField
+		and sortCache.considerAlternates == self.skillsTab.showAltQualityGems and sortCache.considerAwakened == self.skillsTab.showSupportGemTypes then
 		return
 	end
 
 	if sortCache and (sortCache.considerAlternates ~= self.skillsTab.showAltQualityGems or sortCache.considerGemType ~= self.skillsTab.showSupportGemTypes 
-	  or sortCache.defaultQuality ~= self.skillsTab.defaultGemQuality) then
+		or sortCache.defaultQuality ~= self.skillsTab.defaultGemQuality) then
 		self:PopulateGemList()
 	end
 
@@ -239,7 +239,7 @@ function GemSelectClass:UpdateSortCache()
 
 	for gemId, gemData in pairs(self.gems) do
 		sortCache.dps[gemId] = baseDPS
-		--Ignore gems that don't support the active skill
+		-- Ignore gems that don't support the active skill
 		if sortCache.canSupport[gemId] or gemData.grantedEffect.hasGlobalEffect then
 			local gemList = self.skillsTab.displayGroup.gemList
 			local oldGem
@@ -247,7 +247,7 @@ function GemSelectClass:UpdateSortCache()
 				oldGem = copyTable(gemList[self.index], true)
 			else
 				gemList[self.index] = {
-					level = self.skillsTab:ProcessGemLevel(gemData),
+					level = gemData.defaultLevel,
 					qualityId = self:GetQualityType(gemId),
 					quality = self.skillsTab.defaultGemQuality or 0,
 					enabled = true,
@@ -255,16 +255,12 @@ function GemSelectClass:UpdateSortCache()
 					enableGlobal2 = true
 				}
 			end
+			-- Create gemInstance to represent the hovered gem
 			local gemInstance = gemList[self.index]
-			if gemInstance.gemData and gemInstance.gemData.defaultLevel ~= gemData.defaultLevel then
-				gemInstance.level = self.skillsTab.defaultGemLevel or gemData.defaultLevel
-			end
+			gemInstance.level = self.skillsTab:ProcessGemLevel(gemData)
 			gemInstance.gemData = gemData
-			if (gemData.grantedEffect.plusVersionOf and gemInstance.level > gemData.defaultLevel) or not gemData.grantedEffect.levels[gemInstance.level] then
-				gemInstance.level = gemData.defaultLevel
-			end
-			--Calculate the impact of using this gem
-			local output = calcFunc({}, { allocNodes = true, requirementsItems = true })
+			-- Calculate the impact of using this gem
+			local output = calcFunc({ }, { allocNodes = true, requirementsItems = true })
 			if oldGem then
 				gemInstance.gemData = oldGem.gemData
 				gemInstance.level = oldGem.level
@@ -274,7 +270,7 @@ function GemSelectClass:UpdateSortCache()
 			-- Check for nil because some fields may not be populated, default to 0
 			sortCache.dps[gemId] = (dpsField == "FullDPS" and output[dpsField] ~= nil and output[dpsField]) or (output.Minion and output.Minion.CombinedDPS) or (output[dpsField] ~= nil and output[dpsField]) or 0
 		end
-		--Color based on the dps
+		-- Color based on the DPS
 		if sortCache.dps[gemId] > baseDPS then
 			sortCache.dpsColor[gemId] = "^x228866"
 		elseif sortCache.dps[gemId] < baseDPS then
@@ -425,7 +421,7 @@ function GemSelectClass:Draw(viewPort, noTooltip)
 					oldGem = copyTable(gemList[self.index], true)
 				else
 					gemList[self.index] = {
-						level = self.skillsTab:ProcessGemLevel(gemData),
+						level = gemData.defaultLevel,
 						qualityId = self:GetQualityType(self.list[self.hoverSel]),
 						quality = self.skillsTab.defaultGemQuality or 0,
 						enabled = true,
@@ -435,9 +431,7 @@ function GemSelectClass:Draw(viewPort, noTooltip)
 				end
 				-- Create gemInstance to represent the hovered gem
 				local gemInstance = gemList[self.index]
-				if gemInstance.gemData and gemInstance.gemData.defaultLevel ~= gemData.defaultLevel then
-					gemInstance.level = self.skillsTab:ProcessGemLevel(gemData)
-				end
+				gemInstance.level = self.skillsTab:ProcessGemLevel(gemData)
 				gemInstance.gemData = gemData
 				-- Clear the displayEffect so it only displays the temporary gem instance
 				gemInstance.displayEffect = nil

--- a/src/Classes/GemSelectControl.lua
+++ b/src/Classes/GemSelectControl.lua
@@ -21,7 +21,7 @@ local altQualMap = {
 
 local GemSelectClass = newClass("GemSelectControl", "EditControl", function(self, anchor, x, y, width, height, skillsTab, index, changeFunc, forceTooltip)
 	self.EditControl(anchor, x, y, width, height, nil, nil, "^ %a':-")
-	self.controls.scrollBar = new("ScrollBarControl", {"TOPRIGHT",self,"TOPRIGHT"}, -1, 0, 18, 0, (height - 4) * 4)
+	self.controls.scrollBar = new("ScrollBarControl", { "TOPRIGHT", self, "TOPRIGHT" }, -1, 0, 18, 0, (height - 4) * 4)
 	self.controls.scrollBar.y = function()
 		local width, height = self:GetSize()
 		return height + 1
@@ -107,15 +107,15 @@ function GemSelectClass:BuildList(buf)
 
 		-- split the buffer using :
 		-- Remove the first entry as the name search term (can be blank)
-		tagsList = self.searchStr:split(':')
+		tagsList = self.searchStr:split(":")
 		searchTerm = tagsList[1]
-		t_remove(tagsList,1)
+		t_remove(tagsList, 1)
 
 		-- Search for gem name using increasingly broad search patterns
 		local patternList = {
-			"^ "..searchTerm:lower().."$", -- Exact match
-			"^"..searchTerm:lower():gsub("%a", " %0%%l+").."$", -- Simple abbreviation ("CtF" -> "Cold to Fire")
-			"^ "..searchTerm:lower(), -- Starts with
+			"^ " .. searchTerm:lower().."$", -- Exact match
+			"^" .. searchTerm:lower():gsub("%a", " %0%%l+") .. "$", -- Simple abbreviation ("CtF" -> "Cold to Fire")
+			"^ " .. searchTerm:lower(), -- Starts with
 			searchTerm:lower(), -- Contains
 		}
 		for i, pattern in ipairs(patternList) do
@@ -126,7 +126,7 @@ function GemSelectClass:BuildList(buf)
 					if #tagsList > 0 then
 						for _, tag in ipairs(tagsList) do
 							local tagName = tag:gsub("%s+", ""):lower()
-							local negateTag = tagName:sub(1, 1) == '-'
+							local negateTag = tagName:sub(1, 1) == "-"
 							if negateTag then tagName = tagName:sub(2) end
 							if tagName == "active" then
 								tagName = "active_skill"
@@ -139,7 +139,7 @@ function GemSelectClass:BuildList(buf)
 							end
 							-- for :melee we want to exclude gems that DON'T have this tag
 							-- for :-melee we want to exclude gems that DO have this tag
-							  -- EG: :active:fire:-aura		<-- No Anger (Calming ?)
+							-- EG: :active:fire:-aura		<-- No Anger (Calming ?)
 							if negateTag then
 								if gemData.tags[tagName] and gemData.tags[tagName] == true then addThisGem = false end
 							else
@@ -176,7 +176,7 @@ function GemSelectClass:BuildList(buf)
 			end
 		end
 	else
-		--nothing in buffer
+		-- nothing in buffer
 		for gemId, gemData in pairs(self.gems) do
 			if self:FilterSupport(gemId, gemData) then
 				t_insert(self.list, gemId)
@@ -198,9 +198,9 @@ function GemSelectClass:UpdateSortCache()
 	-- Don't update the cache if no settings have changed that would impact the ordering
 	if sortCache and sortCache.socketGroup == self.skillsTab.displayGroup and sortCache.gemInstance == self.skillsTab.displayGroup.gemList[self.index]
 		and sortCache.outputRevision == self.skillsTab.build.outputRevision and sortCache.defaultLevel == self.skillsTab.defaultGemLevel
-		and (sortCache.characterLevel == self.skillsTab.build.characterLevel or self.skillsTab.defaultGemLevel ~= "characterLevel")
-		and sortCache.defaultQuality == self.skillsTab.defaultGemQuality and sortCache.sortType == self.skillsTab.sortGemsByDPSField
-		and sortCache.considerAlternates == self.skillsTab.showAltQualityGems and sortCache.considerAwakened == self.skillsTab.showSupportGemTypes then
+		and sortCache.characterLevel == self.skillsTab.build.characterLevel and sortCache.defaultQuality == self.skillsTab.defaultGemQuality
+		and sortCache.sortType == self.skillsTab.sortGemsByDPSField and sortCache.considerAlternates == self.skillsTab.showAltQualityGems
+		and sortCache.considerAwakened == self.skillsTab.showSupportGemTypes then
 		return
 	end
 
@@ -515,19 +515,19 @@ function GemSelectClass:AddGemTooltip(gemInstance)
 	if secondary and (not secondary.support or gemInstance.gemData.secondaryEffectName) then
 		local grantedEffect = gemInstance.gemData.VaalGem and secondary or primary
 		local grantedEffectSecondary = gemInstance.gemData.VaalGem and primary or secondary
-		self.tooltip:AddLine(20, colorCodes.GEM..altQualMap[gemInstance.qualityId]..grantedEffect.name)
+		self.tooltip:AddLine(20, colorCodes.GEM .. altQualMap[gemInstance.qualityId]..grantedEffect.name)
 		self.tooltip:AddSeparator(10)
-		self.tooltip:AddLine(16, "^x7F7F7F"..gemInstance.gemData.tagString)
+		self.tooltip:AddLine(16, "^x7F7F7F" .. gemInstance.gemData.tagString)
 		self:AddCommonGemInfo(gemInstance, grantedEffect, true)
 		self.tooltip:AddSeparator(10)
-		self.tooltip:AddLine(20, colorCodes.GEM..(gemInstance.gemData.secondaryEffectName or grantedEffectSecondary.name))
+		self.tooltip:AddLine(20, colorCodes.GEM .. (gemInstance.gemData.secondaryEffectName or grantedEffectSecondary.name))
 		self.tooltip:AddSeparator(10)
 		self:AddCommonGemInfo(gemInstance, grantedEffectSecondary)
 	else
 		local grantedEffect = gemInstance.gemData.grantedEffect
-		self.tooltip:AddLine(20, colorCodes.GEM..altQualMap[gemInstance.qualityId]..grantedEffect.name)
+		self.tooltip:AddLine(20, colorCodes.GEM .. altQualMap[gemInstance.qualityId]..grantedEffect.name)
 		self.tooltip:AddSeparator(10)
-		self.tooltip:AddLine(16, "^x7F7F7F"..gemInstance.gemData.tagString)
+		self.tooltip:AddLine(16, "^x7F7F7F" .. gemInstance.gemData.tagString)
 		self:AddCommonGemInfo(gemInstance, grantedEffect, true, secondary and secondary.support and secondary)
 	end
 end
@@ -538,7 +538,7 @@ function GemSelectClass:AddCommonGemInfo(gemInstance, grantedEffect, addReq, mer
 	if addReq then
 		self.tooltip:AddLine(16, string.format("^x7F7F7FLevel: ^7%d%s%s",
 			gemInstance.level, 
-			((displayInstance.level > gemInstance.level) and " ("..colorCodes.MAGIC.."+"..(displayInstance.level - gemInstance.level).."^7)") or ((displayInstance.level < gemInstance.level) and " ("..colorCodes.WARNING.."-"..(gemInstance.level - displayInstance.level).."^7)") or "",
+			((displayInstance.level > gemInstance.level) and " (" .. colorCodes.MAGIC .. "+" .. (displayInstance.level - gemInstance.level) .. "^7)") or ((displayInstance.level < gemInstance.level) and " (" .. colorCodes.WARNING .. "-" .. (gemInstance.level - displayInstance.level) .. "^7)") or "",
 			(gemInstance.level >= gemInstance.gemData.defaultLevel) and " (Max)" or ""
 		))
 	end
@@ -549,7 +549,7 @@ function GemSelectClass:AddCommonGemInfo(gemInstance, grantedEffect, addReq, mer
 		local reservation
 		for name, res in pairs(self.reservationMap) do
 			if grantedEffectLevel[name] then
-				reservation = (reservation and (reservation..", ") or "")..self.costs[isValueInArrayPred(self.costs, function(v) return v.Resource == res end)].ResourceString:gsub("{0}", string.format("%d", grantedEffectLevel[name]))
+				reservation = (reservation and (reservation .. ", ") or "") .. self.costs[isValueInArrayPred(self.costs, function(v) return v.Resource == res end)].ResourceString:gsub("{0}", string.format("%d", grantedEffectLevel[name]))
 			end
 		end
 		if reservation then
@@ -562,16 +562,16 @@ function GemSelectClass:AddCommonGemInfo(gemInstance, grantedEffect, addReq, mer
 		local reservation
 		for name, res in pairs(self.reservationMap) do
 			if grantedEffectLevel[name] then
-				reservation = (reservation and (reservation..", ") or "")..self.costs[isValueInArrayPred(self.costs, function(v) return v.Resource == res end)].ResourceString:gsub("{0}", string.format("%d", grantedEffectLevel[name]))
+				reservation = (reservation and (reservation..", ") or "") .. self.costs[isValueInArrayPred(self.costs, function(v) return v.Resource == res end)].ResourceString:gsub("{0}", string.format("%d", grantedEffectLevel[name]))
 			end
 		end
 		if reservation then
-			self.tooltip:AddLine(16, "^x7F7F7FReservation: ^7"..reservation)
+			self.tooltip:AddLine(16, "^x7F7F7FReservation: ^7" .. reservation)
 		end
 		local cost
 		for _, res in ipairs(self.costs) do
 			if grantedEffectLevel.cost and grantedEffectLevel.cost[res.Resource] then
-				cost = (cost and (cost..", ") or "")..res.ResourceString:gsub("{0}", string.format("%g", round(grantedEffectLevel.cost[res.Resource] / res.Divisor, 2)))
+				cost = (cost and (cost..", ") or "") .. res.ResourceString:gsub("{0}", string.format("%g", round(grantedEffectLevel.cost[res.Resource] / res.Divisor, 2)))
 			end
 		end
 		if cost then
@@ -655,12 +655,12 @@ function GemSelectClass:AddCommonGemInfo(gemInstance, grantedEffect, addReq, mer
 					end
 					line = line .. " ^2" .. devText
 				end
-				self.tooltip:AddLine(16, colorCodes.MAGIC..line)
+				self.tooltip:AddLine(16, colorCodes.MAGIC .. line)
 			else
 				if launch.devModeAlt then
 					line = line .. " ^1" .. lineMap[line]
 				end
-				self.tooltip:AddLine(16, colorCodes.UNSUPPORTED..line)
+				self.tooltip:AddLine(16, colorCodes.UNSUPPORTED .. line)
 			end
 		end
 	end

--- a/src/Classes/GemSelectControl.lua
+++ b/src/Classes/GemSelectControl.lua
@@ -195,9 +195,10 @@ end
 function GemSelectClass:UpdateSortCache()
 	--local start = GetTime()
 	local sortCache = self.sortCache
-	--Don't update the cache if no settings have changed that would impact the ordering
-	if sortCache and sortCache.socketGroup == self.skillsTab.displayGroup and sortCache.gemInstance == self.skillsTab.displayGroup.gemList[self.index] and
-		sortCache.outputRevision == self.skillsTab.build.outputRevision and sortCache.defaultLevel == self.skillsTab.defaultGemLevel
+	-- Don't update the cache if no settings have changed that would impact the ordering
+	if sortCache and sortCache.socketGroup == self.skillsTab.displayGroup and sortCache.gemInstance == self.skillsTab.displayGroup.gemList[self.index]
+		and sortCache.outputRevision == self.skillsTab.build.outputRevision and sortCache.defaultLevel == self.skillsTab.defaultGemLevel
+		and (sortCache.characterLevel == self.skillsTab.build.characterLevel or self.skillsTab.defaultGemLevel ~= "characterLevel")
 		and sortCache.defaultQuality == self.skillsTab.defaultGemQuality and sortCache.sortType == self.skillsTab.sortGemsByDPSField
 		and sortCache.considerAlternates == self.skillsTab.showAltQualityGems and sortCache.considerAwakened == self.skillsTab.showSupportGemTypes then
 		return
@@ -210,7 +211,7 @@ function GemSelectClass:UpdateSortCache()
 		self:PopulateGemList()
 	end
 
-	--Initialize a new sort cache
+	-- Initialize a new sort cache
 	sortCache = {
 		considerGemType = self.skillsTab.showSupportGemTypes,
 		considerAlternates = self.skillsTab.showAltQualityGems,
@@ -226,7 +227,7 @@ function GemSelectClass:UpdateSortCache()
 		sortType = self.skillsTab.sortGemsByDPSField
 	}
 	self.sortCache = sortCache
-	--Determine supports that affect the active skill
+	-- Determine supports that affect the active skill
 	if self.skillsTab.displayGroup.displaySkillList and self.skillsTab.displayGroup.displaySkillList[1] then
 		for gemId, gemData in pairs(self.gems) do
 			if gemData.grantedEffect.support then

--- a/src/Classes/GemSelectControl.lua
+++ b/src/Classes/GemSelectControl.lua
@@ -198,9 +198,9 @@ function GemSelectClass:UpdateSortCache()
 	-- Don't update the cache if no settings have changed that would impact the ordering
 	if sortCache and sortCache.socketGroup == self.skillsTab.displayGroup and sortCache.gemInstance == self.skillsTab.displayGroup.gemList[self.index]
 		and sortCache.outputRevision == self.skillsTab.build.outputRevision and sortCache.defaultLevel == self.skillsTab.defaultGemLevel
-		and sortCache.characterLevel == self.skillsTab.build.characterLevel and sortCache.defaultQuality == self.skillsTab.defaultGemQuality
-		and sortCache.sortType == self.skillsTab.sortGemsByDPSField and sortCache.considerAlternates == self.skillsTab.showAltQualityGems
-		and sortCache.considerAwakened == self.skillsTab.showSupportGemTypes then
+		and (sortCache.characterLevel == self.skillsTab.build.characterLevel or self.skillsTab.defaultGemLevel ~= "characterLevel")
+		and sortCache.defaultQuality == self.skillsTab.defaultGemQuality and sortCache.sortType == self.skillsTab.sortGemsByDPSField
+		and sortCache.considerAlternates == self.skillsTab.showAltQualityGems and sortCache.considerAwakened == self.skillsTab.showSupportGemTypes then
 		return
 	end
 

--- a/src/Classes/GemSelectControl.lua
+++ b/src/Classes/GemSelectControl.lua
@@ -204,7 +204,9 @@ function GemSelectClass:UpdateSortCache()
 	end
 
 	if sortCache and (sortCache.considerAlternates ~= self.skillsTab.showAltQualityGems or sortCache.considerGemType ~= self.skillsTab.showSupportGemTypes 
-		or sortCache.defaultQuality ~= self.skillsTab.defaultGemQuality or sortCache.characterLevel ~= self.skillsTab.build.characterLevel) then
+		or sortCache.defaultQuality ~= self.skillsTab.defaultGemQuality
+		or sortCache.defaultLevel ~= self.skillsTab.defaultGemLevel
+		or (sortCache.characterLevel ~= self.skillsTab.build.characterLevel and self.skillsTab.defaultGemLevel == "characterLevel")) then
 		self:PopulateGemList()
 	end
 

--- a/src/Classes/GemSelectControl.lua
+++ b/src/Classes/GemSelectControl.lua
@@ -204,7 +204,7 @@ function GemSelectClass:UpdateSortCache()
 		return
 	end
 
-	if sortCache and (sortCache.considerAlternates ~= self.skillsTab.showAltQualityGems or sortCache.considerGemType ~= self.skillsTab.showSupportGemTypes 
+	if not sortCache or (sortCache.considerAlternates ~= self.skillsTab.showAltQualityGems or sortCache.considerGemType ~= self.skillsTab.showSupportGemTypes 
 		or sortCache.defaultQuality ~= self.skillsTab.defaultGemQuality
 		or sortCache.defaultLevel ~= self.skillsTab.defaultGemLevel
 		or (sortCache.characterLevel ~= self.skillsTab.build.characterLevel and self.skillsTab.defaultGemLevel == "characterLevel")) then

--- a/src/Classes/SkillsTab.lua
+++ b/src/Classes/SkillsTab.lua
@@ -343,7 +343,14 @@ function SkillsTabClass:Load(xml, fileName)
 	self.activeSkillSetId = 0
 	self.skillSets = { }
 	self.skillSetOrderList = { }
-	self.controls.defaultLevel:SelByValue(xml.attrib.defaultGemLevel or "normalMaximum", "gemLevel")
+	-- Handle legacy configuration settings when loading `defaultGemLevel`
+	if xml.attrib.matchGemLevelToCharacterLevel == "true" then
+		self.controls.defaultLevel:SelByValue("characterLevel", "gemLevel")
+	elseif type(xml.attrib.defaultGemLevel) == "string" and tonumber(xml.attrib.defaultGemLevel) == nil then
+		self.controls.defaultLevel:SelByValue(xml.attrib.defaultGemLevel, "gemLevel")
+	else
+		self.controls.defaultLevel:SelByValue("normalMaximum", "gemLevel")
+	end
 	self.defaultGemLevel = self.controls.defaultLevel:GetSelValue("gemLevel")
 	self.defaultGemQuality = m_max(m_min(tonumber(xml.attrib.defaultGemQuality) or 0, 23), 0)
 	self.controls.defaultQuality:SetText(self.defaultGemQuality or "")

--- a/src/Classes/SkillsTab.lua
+++ b/src/Classes/SkillsTab.lua
@@ -507,10 +507,10 @@ end
 function SkillsTabClass:CopySocketGroup(socketGroup)
 	local skillText = ""
 	if socketGroup.label and socketGroup.label:match("%S") then
-		skillText = skillText .. "Label: "..socketGroup.label.."\r\n"
+		skillText = skillText .. "Label: " .. socketGroup.label .. "\r\n"
 	end
 	if socketGroup.slot then
-		skillText = skillText .. "Slot: "..socketGroup.slot.."\r\n"
+		skillText = skillText .. "Slot: " .. socketGroup.slot .. "\r\n"
 	end
 	for _, gemInstance in ipairs(socketGroup.gemList) do
 		skillText = skillText .. string.format("%s %d/%d %s %s %d\r\n", gemInstance.nameSpec, gemInstance.level, gemInstance.quality, gemInstance.qualityId, gemInstance.enabled and "" or "DISABLED", gemInstance.count or 1)
@@ -595,7 +595,7 @@ function SkillsTabClass:CreateGemSlot(index)
 	self.controls["gemSlot"..index.."Delete"] = slot.delete
 
 	-- Gem name specification
-	slot.nameSpec = new("GemSelectControl", {"LEFT",slot.delete,"RIGHT"}, 2, 0, 300, 20, self, index, function(gemId, qualityId, addUndo)
+	slot.nameSpec = new("GemSelectControl", { "LEFT", slot.delete, "RIGHT" }, 2, 0, 300, 20, self, index, function(gemId, qualityId, addUndo)
 		if not self.displayGroup then
 			return
 		end
@@ -646,7 +646,7 @@ function SkillsTabClass:CreateGemSlot(index)
 	self.controls["gemSlot"..index.."Name"] = slot.nameSpec
 
 	-- Gem level
-	slot.level = new("EditControl", {"LEFT",slot.nameSpec,"RIGHT"}, 2, 0, 60, 20, nil, nil, "%D", 2, function(buf)
+	slot.level = new("EditControl", { "LEFT", slot.nameSpec, "RIGHT" }, 2, 0, 60, 20, nil, nil, "%D", 2, function(buf)
 		local gemInstance = self.displayGroup.gemList[index]
 		if not gemInstance then
 			gemInstance = { nameSpec = "", level = self.defaultGemLevel or 20, quality = self.defaultGemQuality or 0, qualityId = "Default", enabled = true, enableGlobal1 = true, enableGlobal2 = true, count = 1, new = true }

--- a/src/Classes/SkillsTab.lua
+++ b/src/Classes/SkillsTab.lua
@@ -26,28 +26,34 @@ local groupSlotDropList = {
 	{ label = "Belt", slotName = "Belt" },
 }
 
+local defaultGemLevelList = {
+	{ label = "Match Character Level", gemLevel = "characterLevel" },
+	{ label = "Natural Maximum", gemLevel = "naturalMaximum" },
+	{ label = "Corrupted Maximum", gemLevel = "corruptMaximum" },
+}
+
 local showSupportGemTypeList = {
 	{ label = "All", show = "ALL" },
 	{ label = "Non-Awakened", show = "NORMAL" },
 	{ label = "Awakened", show = "AWAKENED" },
 }
 
-local sortGemTypeList ={
-	{label = "Full DPS", type = "FullDPS"},
-	{label = "Combined DPS", type = "CombinedDPS"},
-	{label = "Total DPS", type = "TotalDPS"},
-	{label = "Average Hit", type = "AverageDamage"},
-	{label = "DoT DPS", type = "TotalDot"},
-	{label = "Bleed DPS", type = "BleedDPS"},
-	{label = "Ignite DPS", type = "IgniteDPS"},
-	{label = "Poison DPS", type = "TotalPoisonDPS"},
+local sortGemTypeList = {
+	{ label = "Full DPS", type = "FullDPS" },
+	{ label = "Combined DPS", type = "CombinedDPS" },
+	{ label = "Total DPS", type = "TotalDPS" },
+	{ label = "Average Hit", type = "AverageDamage" },
+	{ label = "DoT DPS", type = "TotalDot" },
+	{ label = "Bleed DPS", type = "BleedDPS" },
+	{ label = "Ignite DPS", type = "IgniteDPS" },
+	{ label = "Poison DPS", type = "TotalPoisonDPS" },
 }
 
 local alternateGemQualityList ={
-	{label = "Default", type = "Default"},
-	{label = "Anomalous", type = "Alternate1"},
-	{label = "Divergent", type = "Alternate2"},
-	{label = "Phantasmal", type = "Alternate3"},
+	{ label = "Default", type = "Default" },
+	{ label = "Anomalous", type = "Alternate1" },
+	{ label = "Divergent", type = "Alternate2" },
+	{ label = "Phantasmal", type = "Alternate3" },
 }
 
 local SkillsTabClass = newClass("SkillsTab", "UndoHandler", "ControlHost", "Control", function(self, build)
@@ -67,7 +73,7 @@ local SkillsTabClass = newClass("SkillsTab", "UndoHandler", "ControlHost", "Cont
 	self.defaultGemQuality = main.defaultGemQuality
 
 	-- Set selector
-	self.controls.setSelect = new("DropDownControl", {"TOPLEFT",self,"TOPLEFT"}, 76, 8, 210, 20, nil, function(index, value)
+	self.controls.setSelect = new("DropDownControl", { "TOPLEFT", self, "TOPLEFT" }, 76, 8, 210, 20, nil, function(index, value)
 		self:SetActiveSkillSet(self.skillSetOrderList[index])
 		self:SetDisplayGroup(self.socketGroupList[1])
 		self:AddUndoState()
@@ -76,14 +82,14 @@ local SkillsTabClass = newClass("SkillsTab", "UndoHandler", "ControlHost", "Cont
 	self.controls.setSelect.enabled = function()
 		return #self.skillSetOrderList > 1
 	end
-	self.controls.setLabel = new("LabelControl", {"RIGHT",self.controls.setSelect,"LEFT"}, -2, 0, 0, 16, "^7Skill set:")
-	self.controls.setManage = new("ButtonControl", {"LEFT",self.controls.setSelect,"RIGHT"}, 4, 0, 90, 20, "Manage...", function()
+	self.controls.setLabel = new("LabelControl", { "RIGHT", self.controls.setSelect, "LEFT" }, -2, 0, 0, 16, "^7Skill set:")
+	self.controls.setManage = new("ButtonControl", { "LEFT", self.controls.setSelect, "RIGHT" }, 4, 0, 90, 20, "Manage...", function()
 		self:OpenSkillSetManagePopup()
 	end)
 
 	-- Socket group list
-	self.controls.groupList = new("SkillListControl", {"TOPLEFT",self,"TOPLEFT"}, 20, 54, 360, 300, self)
-	self.controls.groupTip = new("LabelControl", {"TOPLEFT",self.controls.groupList,"BOTTOMLEFT"}, 0, 8, 0, 14, 
+	self.controls.groupList = new("SkillListControl", { "TOPLEFT", self, "TOPLEFT" }, 20, 54, 360, 300, self)
+	self.controls.groupTip = new("LabelControl", { "TOPLEFT", self.controls.groupList, "BOTTOMLEFT" }, 0, 8, 0, 14, 
 [[
 ^7Usage Tips:
 - You can copy/paste socket groups using Ctrl+C and Ctrl+V.
@@ -94,51 +100,48 @@ local SkillsTabClass = newClass("SkillsTab", "UndoHandler", "ControlHost", "Cont
 	)
 
 	-- Gem options
-	local optionInputsX = 211
+	local optionInputsX = 170
 	local optionInputsY = 45
-	self.controls.optionSection = new("SectionControl", {"TOPLEFT",self.controls.groupList,"BOTTOMLEFT"}, 0, optionInputsY+50, 375, 180, "Gem Options")
-	self.controls.sortGemsByDPS = new("CheckBoxControl", {"TOPLEFT",self.controls.groupList,"BOTTOMLEFT"}, optionInputsX, optionInputsY+70, 20, "Sort gems by DPS:", function(state)
+	self.controls.optionSection = new("SectionControl", { "TOPLEFT", self.controls.groupList, "BOTTOMLEFT" }, 0, optionInputsY + 50, 360, 156, "Gem Options")
+	self.controls.sortGemsByDPS = new("CheckBoxControl", { "TOPLEFT", self.controls.groupList, "BOTTOMLEFT" }, optionInputsX, optionInputsY + 70, 20, "Sort gems by DPS:", function(state)
 		self.sortGemsByDPS = state
 	end, nil, true)
-	self.controls.sortGemsByDPSFieldControl = new("DropDownControl", {"LEFT", self.controls.sortGemsByDPS, "RIGHT"}, 10, 0, 120, 20, sortGemTypeList, function(index, value)
+	self.controls.sortGemsByDPSFieldControl = new("DropDownControl", { "LEFT", self.controls.sortGemsByDPS, "RIGHT" }, 10, 0, 140, 20, sortGemTypeList, function(index, value)
 		self.sortGemsByDPSField = value.type
 	end)
-	self.controls.matchGemLevelToCharacterLevel = new("CheckBoxControl", {"TOPLEFT",self.controls.groupList,"BOTTOMLEFT"}, optionInputsX, optionInputsY+94, 20, "^7Match gems to character level:", function(state)
-		self.matchGemLevelToCharacterLevel = state
+	self.controls.defaultLevel = new("DropDownControl", { "TOPLEFT", self.controls.groupList, "BOTTOMLEFT" }, optionInputsX, optionInputsY + 94, 170, 20, defaultGemLevelList, function(index, value)
+		self.defaultGemLevel = value.gemLevel
 	end)
-	self.controls.defaultLevel = new("EditControl", {"TOPLEFT",self.controls.groupList,"BOTTOMLEFT"}, optionInputsX, optionInputsY+118, 60, 20, nil, nil, "%D", 2, function(buf)
-		self.defaultGemLevel = m_max(m_min(tonumber(buf) or 20, 21), 1)
-	end)
-	self.controls.defaultLevelLabel = new("LabelControl", {"RIGHT",self.controls.defaultLevel,"LEFT"}, -4, 0, 0, 16, "^7Default gem level:")
-	self.controls.defaultQuality = new("EditControl", {"TOPLEFT",self.controls.groupList,"BOTTOMLEFT"}, optionInputsX, optionInputsY+142, 60, 20, nil, nil, "%D", 2, function(buf)
+	self.controls.defaultLevelLabel = new("LabelControl", { "RIGHT", self.controls.defaultLevel, "LEFT" }, -4, 0, 0, 16, "^7Default gem level:")
+	self.controls.defaultQuality = new("EditControl", { "TOPLEFT", self.controls.groupList, "BOTTOMLEFT" }, optionInputsX, optionInputsY + 118, 60, 20, nil, nil, "%D", 2, function(buf)
 		self.defaultGemQuality = m_min(tonumber(buf) or 0, 23)
 	end)
-	self.controls.defaultQualityLabel = new("LabelControl", {"RIGHT",self.controls.defaultQuality,"LEFT"}, -4, 0, 0, 16, "^7Default gem quality:")
-	self.controls.showSupportGemTypes = new("DropDownControl", {"TOPLEFT",self.controls.groupList,"BOTTOMLEFT"}, optionInputsX, optionInputsY+166, 120, 20, showSupportGemTypeList, function(index, value)
+	self.controls.defaultQualityLabel = new("LabelControl", { "RIGHT", self.controls.defaultQuality, "LEFT" }, -4, 0, 0, 16, "^7Default gem quality:")
+	self.controls.showSupportGemTypes = new("DropDownControl", { "TOPLEFT", self.controls.groupList, "BOTTOMLEFT" }, optionInputsX, optionInputsY + 142, 170, 20, showSupportGemTypeList, function(index, value)
 		self.showSupportGemTypes = value.show
 	end)
-	self.controls.showSupportGemTypesLabel = new("LabelControl", {"RIGHT",self.controls.showSupportGemTypes,"LEFT"}, -4, 0, 0, 16, "^7Show support gems:")
-	self.controls.showAltQualityGems = new("CheckBoxControl", {"TOPLEFT",self.controls.groupList,"BOTTOMLEFT"}, optionInputsX, optionInputsY+190, 20, "^7Show gem quality variants:", function(state)
+	self.controls.showSupportGemTypesLabel = new("LabelControl", { "RIGHT", self.controls.showSupportGemTypes, "LEFT" }, -4, 0, 0, 16, "^7Show support gems:")
+	self.controls.showAltQualityGems = new("CheckBoxControl", { "TOPLEFT", self.controls.groupList, "BOTTOMLEFT" }, optionInputsX, optionInputsY + 166, 20, "^7Show quality variants:", function(state)
 		self.showAltQualityGems = state
 	end)
 
 	-- Socket group details
 	if main.portraitMode then
-		self.anchorGroupDetail = new("Control", {"TOPLEFT",self.controls.optionSection,"BOTTOMLEFT"}, 0, 20, 0, 0)
+		self.anchorGroupDetail = new("Control", { "TOPLEFT", self.controls.optionSection, "BOTTOMLEFT" }, 0, 20, 0, 0)
 	else
-		self.anchorGroupDetail = new("Control", {"TOPLEFT",self.controls.groupList,"TOPRIGHT"}, 20, 0, 0, 0)
+		self.anchorGroupDetail = new("Control", { "TOPLEFT", self.controls.groupList, "TOPRIGHT" }, 20, 0, 0, 0)
 	end
 	self.anchorGroupDetail.shown = function()
 		return self.displayGroup ~= nil
 	end
-	self.controls.groupLabel = new("EditControl", {"TOPLEFT",self.anchorGroupDetail,"TOPLEFT"}, 0, 0, 380, 20, nil, "Label", "%c", 50, function(buf)
+	self.controls.groupLabel = new("EditControl", { "TOPLEFT", self.anchorGroupDetail, "TOPLEFT" }, 0, 0, 380, 20, nil, "Label", "%c", 50, function(buf)
 		self.displayGroup.label = buf
 		self:ProcessSocketGroup(self.displayGroup)
 		self:AddUndoState()
 		self.build.buildFlag = true
 	end)
-	self.controls.groupSlotLabel = new("LabelControl", {"TOPLEFT",self.anchorGroupDetail,"TOPLEFT"}, 0, 30, 0, 16, "^7Socketed in:")
-	self.controls.groupSlot = new("DropDownControl", {"TOPLEFT",self.anchorGroupDetail,"TOPLEFT"}, 85, 28, 130, 20, groupSlotDropList, function(index, value)
+	self.controls.groupSlotLabel = new("LabelControl", { "TOPLEFT", self.anchorGroupDetail, "TOPLEFT" }, 0, 30, 0, 16, "^7Socketed in:")
+	self.controls.groupSlot = new("DropDownControl", { "TOPLEFT", self.anchorGroupDetail, "TOPLEFT" }, 85, 28, 130, 20, groupSlotDropList, function(index, value)
 		self.displayGroup.slot = value.slotName
 		self:AddUndoState()
 		self.build.buildFlag = true
@@ -161,21 +164,21 @@ local SkillsTabClass = newClass("SkillsTab", "UndoHandler", "ControlHost", "Cont
 	self.controls.groupSlot.enabled = function()
 		return self.displayGroup.source == nil
 	end
-	self.controls.groupEnabled = new("CheckBoxControl", {"LEFT",self.controls.groupSlot,"RIGHT"}, 70, 0, 20, "Enabled:", function(state)
+	self.controls.groupEnabled = new("CheckBoxControl", { "LEFT", self.controls.groupSlot, "RIGHT" }, 70, 0, 20, "Enabled:", function(state)
 		self.displayGroup.enabled = state
 		self:AddUndoState()
 		self.build.buildFlag = true
 	end)
-	self.controls.includeInFullDPS = new("CheckBoxControl", {"LEFT",self.controls.groupEnabled,"RIGHT"}, 145, 0, 20, "Include in Full DPS:", function(state)
+	self.controls.includeInFullDPS = new("CheckBoxControl", { "LEFT", self.controls.groupEnabled, "RIGHT" }, 145, 0, 20, "Include in Full DPS:", function(state)
 		self.displayGroup.includeInFullDPS = state
 		self:AddUndoState()
 		self.build.buildFlag = true
 	end)
-	self.controls.groupCountLabel = new("LabelControl", {"LEFT",self.controls.includeInFullDPS,"RIGHT"}, 16, 0, 0, 16, "Count:")
+	self.controls.groupCountLabel = new("LabelControl", { "LEFT", self.controls.includeInFullDPS, "RIGHT" }, 16, 0, 0, 16, "Count:")
 	self.controls.groupCountLabel.shown = function()
 		return self.displayGroup.source ~= nil
 	end
-	self.controls.groupCount = new("EditControl", {"LEFT",self.controls.groupCountLabel,"RIGHT"}, 4, 0, 60, 20, nil, nil, "%D", 2, function(buf)
+	self.controls.groupCount = new("EditControl", { "LEFT", self.controls.groupCountLabel, "RIGHT" }, 4, 0, 60, 20, nil, nil, "%D", 2, function(buf)
 		self.displayGroup.groupCount = tonumber(buf) or 1
 		self:AddUndoState()
 		self.build.buildFlag = true
@@ -183,20 +186,20 @@ local SkillsTabClass = newClass("SkillsTab", "UndoHandler", "ControlHost", "Cont
 	self.controls.groupCount.shown = function()
 		return self.displayGroup.source ~= nil
 	end
-	self.controls.sourceNote = new("LabelControl", {"TOPLEFT",self.controls.groupSlotLabel,"TOPLEFT"}, 0, 30, 0, 16)
+	self.controls.sourceNote = new("LabelControl", { "TOPLEFT", self.controls.groupSlotLabel, "TOPLEFT" }, 0, 30, 0, 16)
 	self.controls.sourceNote.shown = function()
 		return self.displayGroup.source ~= nil
 	end
 	self.controls.sourceNote.label = function()
 		local source = self.displayGroup.sourceItem or (self.displayGroup.sourceNode and { rarity = "NORMAL", name = self.displayGroup.sourceNode.name }) or { rarity = "NORMAL", name = "?" }
-		local sourceName = colorCodes[source.rarity]..source.name.."^7"
+		local sourceName = colorCodes[source.rarity] .. source.name .. "^7"
 		local activeGem = self.displayGroup.gemList[1]
-		local label = [[^7This is a special group created for the ']]..activeGem.color..(activeGem.grantedEffect and activeGem.grantedEffect.name or activeGem.nameSpec)..[[^7' skill,
-which is being provided by ']]..sourceName..[['.
-You cannot delete this group, but it will disappear if you ]]..(self.displayGroup.sourceNode and [[un-allocate the node.]] or [[un-equip the item.]])
+		local label = [[^7This is a special group created for the ']] .. activeGem.color .. (activeGem.grantedEffect and activeGem.grantedEffect.name or activeGem.nameSpec) .. [[^7' skill,
+which is being provided by ']] .. sourceName .. [['.
+You cannot delete this group, but it will disappear if you ]] .. (self.displayGroup.sourceNode and [[un-allocate the node.]] or [[un-equip the item.]])
 		if not self.displayGroup.noSupports then
 			label = label .. "\n\n" .. [[You cannot add support gems to this group, but support gems in
-any other group socketed into ']]..sourceName..[['
+any other group socketed into ']] .. sourceName .. [['
 will automatically apply to the skill.]]
 		end
 		return label
@@ -215,18 +218,18 @@ will automatically apply to the skill.]]
 	self.anchorGemSlots = new("Control", {"TOPLEFT",self.anchorGroupDetail,"TOPLEFT"}, 0, 28 + 28 + 16, 0, 0)
 	self.gemSlots = { }
 	self:CreateGemSlot(1)
-	self.controls.gemNameHeader = new("LabelControl", {"BOTTOMLEFT",self.gemSlots[1].nameSpec,"TOPLEFT"}, 0, -2, 0, 16, "^7Gem name:")
-	self.controls.gemLevelHeader = new("LabelControl", {"BOTTOMLEFT",self.gemSlots[1].level,"TOPLEFT"}, 0, -2, 0, 16, "^7Level:")
-	self.controls.gemQualityIdHeader = new("LabelControl", {"BOTTOMLEFT",self.gemSlots[1].qualityId,"TOPLEFT"}, 0, -2, 0, 16, "^7Variant:")
-	self.controls.gemQualityHeader = new("LabelControl", {"BOTTOMLEFT",self.gemSlots[1].quality,"TOPLEFT"}, 0, -2, 0, 16, "^7Quality:")
-	self.controls.gemEnableHeader = new("LabelControl", {"BOTTOMLEFT",self.gemSlots[1].enabled,"TOPLEFT"}, -16, -2, 0, 16, "^7Enabled:")
-	self.controls.gemCountHeader = new("LabelControl", {"BOTTOMLEFT",self.gemSlots[1].count,"TOPLEFT"}, 8, -2, 0, 16, "^7Count:")
+	self.controls.gemNameHeader = new("LabelControl", { "BOTTOMLEFT", self.gemSlots[1].nameSpec, "TOPLEFT" }, 0, -2, 0, 16, "^7Gem name:")
+	self.controls.gemLevelHeader = new("LabelControl", { "BOTTOMLEFT", self.gemSlots[1].level, "TOPLEFT" }, 0, -2, 0, 16, "^7Level:")
+	self.controls.gemQualityIdHeader = new("LabelControl", { "BOTTOMLEFT", self.gemSlots[1].qualityId, "TOPLEFT" }, 0, -2, 0, 16, "^7Variant:")
+	self.controls.gemQualityHeader = new("LabelControl", { "BOTTOMLEFT", self.gemSlots[1].quality, "TOPLEFT" }, 0, -2, 0, 16, "^7Quality:")
+	self.controls.gemEnableHeader = new("LabelControl", { "BOTTOMLEFT", self.gemSlots[1].enabled, "TOPLEFT" }, -16, -2, 0, 16, "^7Enabled:")
+	self.controls.gemCountHeader = new("LabelControl", { "BOTTOMLEFT", self.gemSlots[1].count, "TOPLEFT" }, 8, -2, 0, 16, "^7Count:")
 end)
 
 -- parse real gem name and quality by omitting the first word if alt qual is set
 function SkillsTabClass:GetBaseNameAndQuality(gemTypeLine, quality)
 	-- if quality is default or nil check the gem type line if we have alt qual by comparing to the existing list
-	if gemTypeLine and (quality == nil or quality == '' or quality == 'Default') then
+	if gemTypeLine and (quality == nil or quality == "" or quality == "Default") then
 		local firstword, otherwords = gemTypeLine:match("(%w+)%s(.+)")
 		if firstword and otherwords then
 			for _, entry in ipairs(alternateGemQualityList) do
@@ -241,7 +244,7 @@ function SkillsTabClass:GetBaseNameAndQuality(gemTypeLine, quality)
 		end
 	end
 	-- no alt qual found, return gemTypeLine as is and either existing quality or Default if none is set
-	return gemTypeLine, quality or 'Default'
+	return gemTypeLine, quality or "Default"
 end
 
 function SkillsTabClass:LoadSkill(node, skillSetId)
@@ -315,9 +318,9 @@ function SkillsTabClass:Load(xml, fileName)
 	self.activeSkillSetId = 0
 	self.skillSets = { }
 	self.skillSetOrderList = { }
-	self.defaultGemLevel = m_max(m_min(tonumber(xml.attrib.defaultGemLevel) or 20, 21), 1)
+	self.controls.defaultLevel:SelByValue(xml.attrib.defaultGemLevel or "characterLevel", "gemLevel")
+	self.defaultGemLevel = self.controls.defaultLevel:GetSelValue("gemLevel")
 	self.defaultGemQuality = m_max(m_min(tonumber(xml.attrib.defaultGemQuality) or 0, 23), 0)
-	self.controls.defaultLevel:SetText(self.defaultGemLevel or "")
 	self.controls.defaultQuality:SetText(self.defaultGemQuality or "")
 	if xml.attrib.sortGemsByDPS then
 		self.sortGemsByDPS = xml.attrib.sortGemsByDPS == "true"
@@ -327,10 +330,6 @@ function SkillsTabClass:Load(xml, fileName)
 		self.showAltQualityGems = xml.attrib.showAltQualityGems == "true"
 	end
 	self.controls.showAltQualityGems.state = self.showAltQualityGems
-	if xml.attrib.matchGemLevelToCharacterLevel then
-		self.matchGemLevelToCharacterLevel = xml.attrib.matchGemLevelToCharacterLevel == "true"
-	end
-	self.controls.matchGemLevelToCharacterLevel.state = self.matchGemLevelToCharacterLevel
 	self.controls.showSupportGemTypes:SelByValue(xml.attrib.showSupportGemTypes or "ALL", "show")
 	self.controls.sortGemsByDPSFieldControl:SelByValue(xml.attrib.sortGemsByDPSField or "CombinedDPS", "type") 
 	self.showSupportGemTypes = self.controls.showSupportGemTypes:GetSelValue("show")
@@ -362,13 +361,12 @@ end
 function SkillsTabClass:Save(xml)
 	xml.attrib = {
 		activeSkillSet = tostring(self.activeSkillSetId),
-		defaultGemLevel = tostring(self.defaultGemLevel),
+		defaultGemLevel = self.defaultGemLevel,
 		defaultGemQuality = tostring(self.defaultGemQuality),
 		sortGemsByDPS = tostring(self.sortGemsByDPS),
 		showSupportGemTypes = self.showSupportGemTypes,
 		sortGemsByDPSField = self.sortGemsByDPSField,
-		showAltQualityGems = tostring(self.showAltQualityGems),
-		matchGemLevelToCharacterLevel = tostring(self.matchGemLevelToCharacterLevel)
+		showAltQualityGems = tostring(self.showAltQualityGems)
 	}
 	for _, skillSetId in ipairs(self.skillSetOrderList) do
 		local skillSet = self.skillSets[skillSetId]
@@ -581,7 +579,17 @@ function SkillsTabClass:CreateGemSlot(index)
 			if not gemId then
 				return
 			end
-			gemInstance = { nameSpec = "", level = self.defaultGemLevel or 20, quality = self.defaultGemQuality or 0, qualityId = "Default", enabled = true, enableGlobal1 = true, enableGlobal2 = true, count = 1, new = true }
+			gemInstance = {
+				nameSpec = "",
+				level = 1,
+				quality = self.defaultGemQuality or 0,
+				qualityId = "Default",
+				enabled = true,
+				enableGlobal1 = true,
+				enableGlobal2 = true,
+				count = 1,
+				new = true
+			}
 			self.displayGroup.gemList[index] = gemInstance
 			slot.level:SetText(gemInstance.level)
 			slot.quality:SetText(gemInstance.quality)
@@ -596,10 +604,13 @@ function SkillsTabClass:CreateGemSlot(index)
 		gemInstance.skillId = nil
 		self:ProcessSocketGroup(self.displayGroup)
 		-- New gems need to be constrained by matchGemLevelToCharacterLevel if enabled
-		if self.matchGemLevelToCharacterLevel and gemInstance.gemData then
+		--[[if self.matchGemLevelToCharacterLevel and gemInstance.gemData then
 			gemInstance.level = self:MatchGemLevelToCharacterLevel(gemInstance.gemData)
 			gemInstance.defaultLevel = gemInstance.level
-		end
+		end]]
+		-- WIP
+		gemInstance.level = self:ProcessGemLevel(gemInstance.gemData)
+		gemInstance.defaultLevel = gemInstance.level
 		-- Gem changed, update the list and default the quality id
 		slot.qualityId.list = self:getGemAltQualityList(gemInstance.gemData)
 		slot.qualityId:SelByValue(qualityId or "Default", "type")
@@ -949,7 +960,7 @@ function SkillsTabClass:FindSkillGem(nameSpec)
 		for gemId, gemData in pairs(self.build.data.gems) do
 			if (" "..gemData.name):match(pattern) then
 				if foundGemData then
-					return "Ambiguous gem name '"..nameSpec.."': matches '"..foundGemData.name.."', '"..gemData.name.."'"
+					return "Ambiguous gem name '" .. nameSpec .. "': matches '" .. foundGemData.name .. "', '" .. gemData.name .. "'"
 				end
 				foundGemData = gemData
 			end
@@ -958,23 +969,29 @@ function SkillsTabClass:FindSkillGem(nameSpec)
 			return nil, foundGemData
 		end
 	end
-	return "Unrecognised gem name '"..nameSpec.."'"
+	return "Unrecognised gem name '" .. nameSpec .. "'"
 end
 
-function SkillsTabClass:MatchGemLevelToCharacterLevel(gemData, fallbackGemLevel)
-	if self.matchGemLevelToCharacterLevel then
-		local maxGemLevel = m_min(self.defaultGemLevel or gemData.defaultLevel, gemData.defaultLevel + 1)
-		if not gemData.grantedEffect.levels[maxGemLevel] then
-			maxGemLevel = #gemData.grantedEffect.levels
+function SkillsTabClass:ProcessGemLevel(gemData)
+	local grantedEffect = gemData.grantedEffect
+	local defaultLevel = grantedEffect.defaultLevel or gemData.defaultLevel or 1
+	if self.defaultGemLevel == "corruptMaximum" then
+		return defaultLevel + 1
+	elseif self.defaultGemLevel == "naturalMaximum" then
+		return defaultLevel
+	else
+		local maxGemLevel = defaultLevel
+		if not grantedEffect.levels[maxGemLevel] then
+			maxGemLevel = #grantedEffect.levels
 		end
+		local characterLevel = self.build and self.build.characterLevel or 1
 		for gemLevel = maxGemLevel, 1, -1 do
-			if gemData.grantedEffect.levels[gemLevel].levelRequirement <= self.build.characterLevel then
+			if grantedEffect.levels[gemLevel].levelRequirement <= characterLevel then
 				return gemLevel
 			end
 		end
 		return 1
 	end
-	return fallbackGemLevel or 1
 end
 
 -- Processes the given socket group, filling in information that will be used for display or calculations
@@ -984,7 +1001,7 @@ function SkillsTabClass:ProcessSocketGroup(socketGroup)
 	for _, gemInstance in ipairs(socketGroup.gemList) do
 		gemInstance.color = "^8"
 		gemInstance.nameSpec = gemInstance.nameSpec or ""
-		local prevDefaultLevel = gemInstance.gemData and gemInstance.gemData.defaultLevel or (gemInstance.new and (self.defaultGemLevel or 20))
+		local prevDefaultLevel = gemInstance.gemData and gemInstance.gemData.defaultLevel or (gemInstance.new and 20)
 		gemInstance.gemData, gemInstance.grantedEffect = nil
 		if gemInstance.gemId then
 			-- Specified by gem ID
@@ -1024,7 +1041,7 @@ function SkillsTabClass:ProcessSocketGroup(socketGroup)
 			gemInstance.errMsg, gemInstance.gemData, gemInstance.skillId = nil
 		end
 		if gemInstance.gemData and gemInstance.gemData.grantedEffect.unsupported then
-			gemInstance.errMsg = gemInstance.nameSpec.." is not supported yet"
+			gemInstance.errMsg = gemInstance.nameSpec .. " is not supported yet"
 			gemInstance.gemData = nil
 		end
 		if gemInstance.gemData or gemInstance.grantedEffect then
@@ -1040,7 +1057,7 @@ function SkillsTabClass:ProcessSocketGroup(socketGroup)
 				gemInstance.color = colorCodes.NORMAL
 			end
 			if prevDefaultLevel and gemInstance.gemData and gemInstance.gemData.defaultLevel ~= prevDefaultLevel then
-				gemInstance.level = m_min(self.defaultGemLevel or gemInstance.gemData.defaultLevel, gemInstance.gemData.defaultLevel + 1)
+				gemInstance.level = gemInstance.gemData.defaultLevel
 				gemInstance.defaultLevel = gemInstance.level
 			end
 			calcLib.validateGemLevel(gemInstance)
@@ -1089,7 +1106,7 @@ function SkillsTabClass:AddSocketGroupTooltip(tooltip, socketGroup)
 	end
 	local source = socketGroup.sourceItem or socketGroup.sourceNode
 	if source then
-		tooltip:AddLine(18, "^7Source: "..colorCodes[source.rarity or "NORMAL"]..source.name)
+		tooltip:AddLine(18, "^7Source: " .. colorCodes[source.rarity or "NORMAL"] .. source.name)
 		tooltip:AddSeparator(10)
 	end
 	local gemShown = { }
@@ -1113,15 +1130,15 @@ function SkillsTabClass:AddSocketGroupTooltip(tooltip, socketGroup)
 		end
 		if activeSkill.minion then
 			tooltip:AddSeparator(10)
-			tooltip:AddLine(16, "^7Active Skill #"..index.."'s Main Minion Skill:")
+			tooltip:AddLine(16, "^7Active Skill #" .. index .. "'s Main Minion Skill:")
 			local activeEffect = activeSkill.minion.mainSkill.effectList[1]
 			tooltip:AddLine(20, string.format("%s%s ^7%d%s/%d%s",
 				data.skillColorMap[activeEffect.grantedEffect.color],
 				activeEffect.grantedEffect.name,
 				activeEffect.level,
-				(activeEffect.srcInstance and activeEffect.level > activeEffect.srcInstance.level) and colorCodes.MAGIC.."+"..(activeEffect.level - activeEffect.srcInstance.level).."^7" or "",
+				(activeEffect.srcInstance and activeEffect.level > activeEffect.srcInstance.level) and colorCodes.MAGIC .. "+" .. (activeEffect.level - activeEffect.srcInstance.level) .. "^7" or "",
 				activeEffect.quality,
-				(activeEffect.srcInstance and activeEffect.quality > activeEffect.srcInstance.quality) and colorCodes.MAGIC.."+"..(activeEffect.quality - activeEffect.srcInstance.quality).."^7" or ""
+				(activeEffect.srcInstance and activeEffect.quality > activeEffect.srcInstance.quality) and colorCodes.MAGIC .. "+" .. (activeEffect.quality - activeEffect.srcInstance.quality) .. "^7" or ""
 			))
 			if activeEffect.srcInstance then
 				gemShown[activeEffect.srcInstance] = true
@@ -1155,9 +1172,9 @@ function SkillsTabClass:AddSocketGroupTooltip(tooltip, socketGroup)
 				gemInstance.color,
 				(gemInstance.grantedEffect and gemInstance.grantedEffect.name) or (gemInstance.gemData and gemInstance.gemData.name) or gemInstance.nameSpec,
 				displayEffect.level,
-				displayEffect.level > gemInstance.level and colorCodes.MAGIC.."+"..(displayEffect.level - gemInstance.level).."^7" or "",
+				displayEffect.level > gemInstance.level and colorCodes.MAGIC .. "+" .. (displayEffect.level - gemInstance.level) .. "^7" or "",
 				displayEffect.quality,
-				displayEffect.quality > gemInstance.quality and colorCodes.MAGIC.."+"..(displayEffect.quality - gemInstance.quality).."^7" or "",
+				displayEffect.quality > gemInstance.quality and colorCodes.MAGIC .. "+" .. (displayEffect.quality - gemInstance.quality) .. "^7" or "",
 				reason
 			))
 		end

--- a/src/Classes/SkillsTab.lua
+++ b/src/Classes/SkillsTab.lua
@@ -28,8 +28,9 @@ local groupSlotDropList = {
 
 local defaultGemLevelList = {
 	{ label = "Match Character Level", gemLevel = "characterLevel" },
-	{ label = "Natural Maximum", gemLevel = "naturalMaximum" },
-	{ label = "Corrupted Maximum", gemLevel = "corruptMaximum" },
+	{ label = "Normal Maximum", gemLevel = "normalMaximum" },
+	{ label = "Corrupted Maximum", gemLevel = "corruptedMaximum" },
+	{ label = "Awakened Maximum", gemLevel = "awakenedMaximum" },
 }
 
 local showSupportGemTypeList = {
@@ -975,9 +976,15 @@ end
 function SkillsTabClass:ProcessGemLevel(gemData)
 	local grantedEffect = gemData.grantedEffect
 	local defaultLevel = grantedEffect.defaultLevel or gemData.defaultLevel or 1
-	if self.defaultGemLevel == "corruptMaximum" then
+	if self.defaultGemLevel == "awakenedMaximum" then
 		return defaultLevel + 1
-	elseif self.defaultGemLevel == "naturalMaximum" then
+	elseif self.defaultGemLevel == "corruptedMaximum" then
+		if grantedEffect.plusVersionOf then
+			return defaultLevel
+		else
+			return defaultLevel + 1
+		end
+	elseif self.defaultGemLevel == "normalMaximum" then
 		return defaultLevel
 	else
 		local maxGemLevel = defaultLevel

--- a/src/Classes/SkillsTab.lua
+++ b/src/Classes/SkillsTab.lua
@@ -28,24 +28,26 @@ local groupSlotDropList = {
 
 local defaultGemLevelList = {
 	{
-		label = "Match Character Level",
-		description = "All gems default to their highest valid non-corrupted gem level that your character meets the level requirement for.",
-		gemLevel = "characterLevel",
-	},
-	{
 		label = "Normal Maximum",
 		description = "All gems default to their highest valid non-corrupted gem level.",
 		gemLevel = "normalMaximum",
 	},
 	{
 		label = "Corrupted Maximum",
-		description = "Normal gems default to their highest valid corrupted gem level.\nAwakened gems default to their highest valid non-corrupted gem level.",
+		description = [[Normal gems default to their highest valid corrupted gem level.
+Awakened gems default to their highest valid non-corrupted gem level.]],
 		gemLevel = "corruptedMaximum",
 	},
 	{
 		label = "Awakened Maximum",
 		description = "All gems default to their highest valid corrupted gem level.",
 		gemLevel = "awakenedMaximum",
+	},
+	{
+		label = "Match Character Level",
+		description = [[All gems default to their highest valid non-corrupted gem level that your character meets the level requirement for.
+This hides gems with a minimum level requirement above your character level, preventing them from showing up in the dropdown list.]],
+		gemLevel = "characterLevel",
 	},
 }
 
@@ -340,7 +342,7 @@ function SkillsTabClass:Load(xml, fileName)
 	self.activeSkillSetId = 0
 	self.skillSets = { }
 	self.skillSetOrderList = { }
-	self.controls.defaultLevel:SelByValue(xml.attrib.defaultGemLevel or "characterLevel", "gemLevel")
+	self.controls.defaultLevel:SelByValue(xml.attrib.defaultGemLevel or "normalMaximum", "gemLevel")
 	self.defaultGemLevel = self.controls.defaultLevel:GetSelValue("gemLevel")
 	self.defaultGemQuality = m_max(m_min(tonumber(xml.attrib.defaultGemQuality) or 0, 23), 0)
 	self.controls.defaultQuality:SetText(self.defaultGemQuality or "")

--- a/src/Classes/SkillsTab.lua
+++ b/src/Classes/SkillsTab.lua
@@ -30,22 +30,22 @@ local defaultGemLevelList = {
 	{
 		label = "Match Character Level",
 		description = "All gems default to their highest valid non-corrupted gem level that your character meets the level requirement for.",
-		gemLevel = "CharacterLevel",
+		gemLevel = "characterLevel",
 	},
 	{
 		label = "Normal Maximum",
 		description = "All gems default to their highest valid non-corrupted gem level.",
-		gemLevel = "NormalMaximum",
+		gemLevel = "normalMaximum",
 	},
 	{
 		label = "Corrupted Maximum",
 		description = "Normal gems default to their highest valid corrupted gem level.\nAwakened gems default to their highest valid non-corrupted gem level.",
-		gemLevel = "CorruptedMaximum",
+		gemLevel = "corruptedMaximum",
 	},
 	{
 		label = "Awakened Maximum",
 		description = "All gems default to their highest valid corrupted gem level.",
-		gemLevel = "AwakenedMaximum",
+		gemLevel = "awakenedMaximum",
 	},
 }
 
@@ -86,7 +86,6 @@ local SkillsTabClass = newClass("SkillsTab", "UndoHandler", "ControlHost", "Cont
 	self.sortGemsByDPSField = "CombinedDPS"
 	self.showSupportGemTypes = "ALL"
 	self.showAltQualityGems = false
-	self.matchGemLevelToCharacterLevel = false
 	self.defaultGemQuality = main.defaultGemQuality
 
 	-- Set selector
@@ -993,17 +992,17 @@ end
 function SkillsTabClass:ProcessGemLevel(gemData)
 	local grantedEffect = gemData.grantedEffect
 	local defaultLevel = grantedEffect.defaultLevel or gemData.defaultLevel or 1
-	if self.defaultGemLevel == "AwakenedMaximum" then
+	if self.defaultGemLevel == "awakenedMaximum" then
 		return defaultLevel + 1
-	elseif self.defaultGemLevel == "CorruptedMaximum" then
+	elseif self.defaultGemLevel == "corruptedMaximum" then
 		if grantedEffect.plusVersionOf then
 			return defaultLevel
 		else
 			return defaultLevel + 1
 		end
-	elseif self.defaultGemLevel == "NormalMaximum" then
+	elseif self.defaultGemLevel == "normalMaximum" then
 		return defaultLevel
-	else -- self.defaultGemLevel == "CharacterLevel"
+	else -- self.defaultGemLevel == "characterLevel"
 		local maxGemLevel = defaultLevel
 		if not grantedEffect.levels[maxGemLevel] then
 			maxGemLevel = #grantedEffect.levels

--- a/src/Classes/SkillsTab.lua
+++ b/src/Classes/SkillsTab.lua
@@ -27,10 +27,26 @@ local groupSlotDropList = {
 }
 
 local defaultGemLevelList = {
-	{ label = "Match Character Level", gemLevel = "characterLevel" },
-	{ label = "Normal Maximum", gemLevel = "normalMaximum" },
-	{ label = "Corrupted Maximum", gemLevel = "corruptedMaximum" },
-	{ label = "Awakened Maximum", gemLevel = "awakenedMaximum" },
+	{
+		label = "Match Character Level",
+		description = "All gems default to their highest valid non-corrupted gem level that your character meets the level requirement for.",
+		gemLevel = "CharacterLevel",
+	},
+	{
+		label = "Normal Maximum",
+		description = "All gems default to their highest valid non-corrupted gem level.",
+		gemLevel = "NormalMaximum",
+	},
+	{
+		label = "Corrupted Maximum",
+		description = "Normal gems default to their highest valid corrupted gem level.\nAwakened gems default to their highest valid non-corrupted gem level.",
+		gemLevel = "CorruptedMaximum",
+	},
+	{
+		label = "Awakened Maximum",
+		description = "All gems default to their highest valid corrupted gem level.",
+		gemLevel = "AwakenedMaximum",
+	},
 }
 
 local showSupportGemTypeList = {
@@ -113,6 +129,12 @@ local SkillsTabClass = newClass("SkillsTab", "UndoHandler", "ControlHost", "Cont
 	self.controls.defaultLevel = new("DropDownControl", { "TOPLEFT", self.controls.groupList, "BOTTOMLEFT" }, optionInputsX, optionInputsY + 94, 170, 20, defaultGemLevelList, function(index, value)
 		self.defaultGemLevel = value.gemLevel
 	end)
+	self.controls.defaultLevel.tooltipFunc = function(tooltip, mode, index, value)
+		tooltip:Clear()
+		if mode ~= "OUT" and value.description then
+			tooltip:AddLine(16, "^7" .. value.description)
+		end
+	end
 	self.controls.defaultLevelLabel = new("LabelControl", { "RIGHT", self.controls.defaultLevel, "LEFT" }, -4, 0, 0, 16, "^7Default gem level:")
 	self.controls.defaultQuality = new("EditControl", { "TOPLEFT", self.controls.groupList, "BOTTOMLEFT" }, optionInputsX, optionInputsY + 118, 60, 20, nil, nil, "%D", 2, function(buf)
 		self.defaultGemQuality = m_min(tonumber(buf) or 0, 23)
@@ -976,17 +998,17 @@ end
 function SkillsTabClass:ProcessGemLevel(gemData)
 	local grantedEffect = gemData.grantedEffect
 	local defaultLevel = grantedEffect.defaultLevel or gemData.defaultLevel or 1
-	if self.defaultGemLevel == "awakenedMaximum" then
+	if self.defaultGemLevel == "AwakenedMaximum" then
 		return defaultLevel + 1
-	elseif self.defaultGemLevel == "corruptedMaximum" then
+	elseif self.defaultGemLevel == "CorruptedMaximum" then
 		if grantedEffect.plusVersionOf then
 			return defaultLevel
 		else
 			return defaultLevel + 1
 		end
-	elseif self.defaultGemLevel == "normalMaximum" then
+	elseif self.defaultGemLevel == "NormalMaximum" then
 		return defaultLevel
-	else
+	else -- self.defaultGemLevel == "CharacterLevel"
 		local maxGemLevel = defaultLevel
 		if not grantedEffect.levels[maxGemLevel] then
 			maxGemLevel = #grantedEffect.levels

--- a/src/Classes/SkillsTab.lua
+++ b/src/Classes/SkillsTab.lua
@@ -88,6 +88,7 @@ local SkillsTabClass = newClass("SkillsTab", "UndoHandler", "ControlHost", "Cont
 	self.sortGemsByDPSField = "CombinedDPS"
 	self.showSupportGemTypes = "ALL"
 	self.showAltQualityGems = false
+	self.defaultGemLevel = "normalMaximum"
 	self.defaultGemQuality = main.defaultGemQuality
 
 	-- Set selector

--- a/src/Classes/SkillsTab.lua
+++ b/src/Classes/SkillsTab.lua
@@ -626,12 +626,7 @@ function SkillsTabClass:CreateGemSlot(index)
 		gemInstance.gemId = gemId
 		gemInstance.skillId = nil
 		self:ProcessSocketGroup(self.displayGroup)
-		-- New gems need to be constrained by matchGemLevelToCharacterLevel if enabled
-		--[[if self.matchGemLevelToCharacterLevel and gemInstance.gemData then
-			gemInstance.level = self:MatchGemLevelToCharacterLevel(gemInstance.gemData)
-			gemInstance.defaultLevel = gemInstance.level
-		end]]
-		-- WIP
+		-- New gems need to be constrained by ProcessGemLevel
 		gemInstance.level = self:ProcessGemLevel(gemInstance.gemData)
 		gemInstance.defaultLevel = gemInstance.level
 		-- Gem changed, update the list and default the quality id


### PR DESCRIPTION
Fixes #4630.

This replaces the old gem level selection and "match gem level to character" level options with a dropdown selection that has four options:
- Normal Maximum: All gems default to their highest valid non-corrupted gem level.
- Corrupted Maximum: Normal gems default to their highest valid corrupted gem level. Awakened gems default to their highest valid non-corrupted gem level.
- Awakened Maximum: All gems default to their highest valid corrupted gem level.
- Match Character Level: All gems default to their highest valid non-corrupted gem level that your character meets the level requirement for. This hides gems with a minimum level requirement above your character level, preventing them from showing up in the dropdown list.

### Before screenshot:
![](https://user-images.githubusercontent.com/18443616/183775327-7dbda316-7eb8-45cd-9557-a1e35315aa3e.png)

### After screenshot:
![](https://user-images.githubusercontent.com/18443616/183780960-f3f2b0d5-9a9d-466c-a0d2-f48b6203c826.png)