### PR TITLE
Fix: wording of blood of karui

### DIFF
--- a/src/Data/Uniques/flask.lua
+++ b/src/Data/Uniques/flask.lua
@@ -14,8 +14,8 @@ Requires Level 50
 {variant:1,2,3}(5-20)% increased Recovery Speed
 {variant:4}(35-50)% reduced Recovery Speed
 {variant:1}No Life Recovery Applies during Flask effect
-{variant:2}100% increased Amount Recovered
-{variant:3}50% increased Amount Recovered
+{variant:2}100% increased Life Recovered
+{variant:3}50% increased Life Recovered
 Recover Full Life at the end of the Flask effect
 ]],
 -- Flask: Mana


### PR DESCRIPTION
Fixes #3728 .

### Description of the problem being solved:
The ticket was already mostly solved. The only exception is the wording change from "increased Amount recovered " to "increased Life recovered". No functionality is changed

### Before screenshot:
![karui_before](https://user-images.githubusercontent.com/100538010/183890021-82d61bfa-4e14-4c50-bcb5-a1e5334046e8.png)

### After screenshot:
![karui_after](https://user-images.githubusercontent.com/100538010/183890062-ed880de8-0325-494e-ab4f-1540e1911d0a.png)

