### PR TITLE
Fix: Blood of the Karui Life recovered and wording 

### DIFF
--- a/src/Data/Uniques/flask.lua
+++ b/src/Data/Uniques/flask.lua
@@ -15,7 +15,7 @@ Requires Level 50
 {variant:4}(35-50)% reduced Recovery Speed
 {variant:1}No Life Recovery Applies during Flask effect
 {variant:2}100% increased Life Recovered
-{variant:3}50% increased Life Recovered
+{variant:3,4}50% increased Life Recovered
 Recover Full Life at the end of the Flask effect
 ]],
 -- Flask: Mana

--- a/src/Data/Uniques/flask.lua
+++ b/src/Data/Uniques/flask.lua
@@ -12,13 +12,13 @@ Variant: Pre 3.15.0
 Variant: Pre 3.16.0
 Variant: Current
 Requires Level 50
-{variant:1}(20-30)% reduced Recovery Rate
-{variant:2,3,4}(5-20)% increased Recovery Rate
-{variant:5}(35-50)% reduced Recovery Rate
-{variant:1,2}Cannot Gain Life During Flask Effect
 {variant:3}100% increased Life Recovered
 {variant:4,5}50% increased Life Recovered
+{variant:1}(20-30)% reduced Recovery rate
+{variant:2,3,4}(5-20)% increased Recovery rate
+{variant:5}(35-50)% reduced Recovery rate
 Recover Full Life at the end of the Flask effect
+{variant:1,2}Cannot gain Life during effect
 ]],
 -- Flask: Mana
 [[
@@ -48,7 +48,7 @@ Sanctified Mana Flask
 League: Domination, Nemesis
 Requires Level 50
 (30-50)% increased Amount Recovered
-100% increased Recovery Rate
+100% increased Recovery rate
 Your Skills have no Mana Cost during Flask effect
 ]],[[
 Replica Lavianga's Spirit

--- a/src/Data/Uniques/flask.lua
+++ b/src/Data/Uniques/flask.lua
@@ -14,8 +14,8 @@ Requires Level 50
 {variant:1,2,3}(5-20)% increased Recovery Speed
 {variant:4}(35-50)% reduced Recovery Speed
 {variant:1}No Life Recovery Applies during Flask effect
-{variant:2}100% increased Amount Recovered
-{variant:3}50% increased Amount Recovered
+{variant:2}100% increased Life Recovered
+{variant:3}50% increased Life Recovered
 Recover Full Life at the end of the Flask effect
 ]],
 -- Flask: Mana

--- a/src/Data/Uniques/flask.lua
+++ b/src/Data/Uniques/flask.lua
@@ -6,16 +6,18 @@ return {
 Blood of the Karui
 Sanctified Life Flask
 League: Domination, Nemesis
+Variant: Pre 1.3.0
 Variant: Pre 2.6.0
 Variant: Pre 3.15.0
 Variant: Pre 3.16.0
 Variant: Current
 Requires Level 50
-{variant:1,2,3}(5-20)% increased Recovery Speed
-{variant:4}(35-50)% reduced Recovery Speed
-{variant:1}No Life Recovery Applies during Flask effect
-{variant:2}100% increased Life Recovered
-{variant:3,4}50% increased Life Recovered
+{variant:1}(20-30)% reduced Recovery Rate
+{variant:2,3,4}(5-20)% increased Recovery Rate
+{variant:5}(35-50)% reduced Recovery Rate
+{variant:1,2}Cannot Gain Life During Flask Effect
+{variant:3}100% increased Life Recovered
+{variant:4,5}50% increased Life Recovered
 Recover Full Life at the end of the Flask effect
 ]],
 -- Flask: Mana
@@ -46,7 +48,7 @@ Sanctified Mana Flask
 League: Domination, Nemesis
 Requires Level 50
 (30-50)% increased Amount Recovered
-100% increased Recovery Speed
+100% increased Recovery Rate
 Your Skills have no Mana Cost during Flask effect
 ]],[[
 Replica Lavianga's Spirit

--- a/src/Data/Uniques/flask.lua
+++ b/src/Data/Uniques/flask.lua
@@ -17,7 +17,7 @@ Requires Level 50
 {variant:1}(20-30)% reduced Recovery rate
 {variant:2,3,4}(5-20)% increased Recovery rate
 {variant:5}(35-50)% reduced Recovery rate
-Recover Full Life at the end of the Flask effect
+Recover Full Life at the end of the Flask Effect
 {variant:1,2}Cannot gain Life during effect
 ]],
 -- Flask: Mana


### PR DESCRIPTION
Fixes #3728 .

### Description of the problem being solved:
1. The current version doesn't have the "50% increased Life Recovered" affix.
2. Wording fix from "increased Amount recovered" to "increased Life recovered

### Before screenshot:
1. 
![karui_current_before](https://user-images.githubusercontent.com/100538010/183893890-aba2ef12-24db-44eb-98f2-52ccf477c092.png)
2.
![karui_before](https://user-images.githubusercontent.com/100538010/183893913-dc207ec7-92ab-4cc0-a296-1c93bf68c420.png)

### After screenshot:
1.
![karui_current_after](https://user-images.githubusercontent.com/100538010/183893947-eb7cc803-9bbf-4e76-b084-d9e58c5fede7.png)
2.
![karui_after](https://user-images.githubusercontent.com/100538010/183893987-c224da91-610d-4745-887a-ae01b45c9084.png)



