### PR TITLE
Imported items were getting incorrect variable percentages because of default quality coming in as 20

### DIFF
--- a/src/Classes/Item.lua
+++ b/src/Classes/Item.lua
@@ -627,7 +627,7 @@ end
 function ItemClass:NormaliseQuality()
 	if self.base and (self.base.armour or self.base.weapon or self.base.flask) then
 		if not self.quality then
-			self.quality = self.corrupted and 0 or 20 
+			self.quality = 0
 		elseif not self.uniqueID and not self.corrupted and self.quality < 20 then
 			self.quality = 20
 		end


### PR DESCRIPTION
### Description of the problem being solved:
Previously, PoB would automatically assign an armour's quality to 20% when importing it from the game, but that causes issues with the calculation of the base percentage value (since it calculates it as if the armour already had 20% quality).  This was only an issue with armours that had 0% quality.

### Steps taken to verify a working solution:
- Copied a myriad of different armours from the trade site, comparing their values
### Before screenshot:
![image](https://user-images.githubusercontent.com/1209372/184038502-733dc5f1-f749-407b-ae77-6026daff8e3e.png)
```
Item Class: Body Armours
Rarity: Rare
Spirit Suit
Exquisite Leather
--------
Evasion Rating: 945 (augmented)
--------
Requirements:
Level: 67
Dex: 170
--------
Sockets: G 
--------
Item Level: 86
--------
+43 to Evasion Rating
14% increased Evasion Rating
+40% to Fire Resistance
+47% to Cold Resistance
8% increased Stun and Block Recovery
Attacks have +1.5% to Critical Strike Chance
+75 to maximum Life (crafted)
--------
Elder Item
--------
Note: ~price 4 exalted
```

### After screenshot:
![image](https://user-images.githubusercontent.com/1209372/184038583-12a342de-a09d-4be7-9744-d8622895ea35.png)

