### PR TITLE
[Kalandra] Update batch 1 of uniques.

### DIFF
--- a/src/Data/Uniques/amulet.lua
+++ b/src/Data/Uniques/amulet.lua
@@ -7,33 +7,40 @@ The Anvil
 Amber Amulet
 Variant: Pre 1.3.0
 Variant: Pre 2.6.0
+Variant: Pre 3.19.0
 Variant: Current
 Requires Level 45
 Implicits: 1
 {tags:jewellery_attribute}+(20-30) to Strength
+{variant:1}10% Chance to Block Attack Damage
+{variant:2,3}8% Chance to Block Attack Damage
+{variant:4}(10-15)% Chance to Block Attack Damage
 {tags:attack,speed}10% reduced Attack Speed
 {tags:caster,speed}10% reduced Cast Speed
 {tags:jewellery_defense}+(400-500) to Armour
 {variant:1}{tags:life}+(30-40) Life gained when you Block
-{variant:2,3}{tags:life}+(34-48) Life gained when you Block
+{variant:2,3,4}{tags:life}+(34-48) Life gained when you Block
 {variant:1}{tags:mana}+(10-20) Mana gained when you Block
-{variant:2,3}{tags:mana}+(10-24) Mana gained when you Block
+{variant:2,3,4}{tags:mana}+(10-24) Mana gained when you Block
 {variant:1}{tags:speed}20% reduced Movement Speed
 {variant:2}{tags:speed}10% reduced Movement Speed
-+3% to maximum Block Chance
-{variant:1}10% Chance to Block
-{variant:2,3}8% Chance to Block
++3% to maximum Chance to Block Attack Damage
 {tags:physical}{variant:1}Reflects 200 to 250 Physical Damage to Attackers on Block
-{tags:physical}{variant:2,3}Reflects 240 to 300 Physical Damage to Attackers on Block
+{tags:physical}{variant:2,3,4}Reflects 240 to 300 Physical Damage to Attackers on Block
 ]],[[
 Araku Tiki
 Coral Amulet
+Variant: Pre 3.19.0
+Variant: Current
 Implicits: 1
 {tags:life}(2-4) Life Regenerated per second
-{tags:jewellery_defense,life}You gain 100 Evasion Rating when on Low Life
+{variant:1}{tags:jewellery_defense,life}You gain 100 Evasion Rating when on Low Life
+{variant:2}{tags:jewellery_defense,life}You gain (150-250) Evasion Rating when on Low Life
 {tags:life}+(30-50) to maximum Life
 {tags:jewellery_resistance}+(20-30)% to Fire Resistance
-{tags:life}1% of Life Regenerated per Second while on Low Life
+{variant:1}{tags:life}1% of Life Regenerated per Second while on Low Life
+{variant:2}Gain Elusive on reaching Low Life
+{variant:2}Phasing while on Low Life
 ]],[[
 Ngamahu Tiki
 Coral Amulet

--- a/src/Data/Uniques/body.lua
+++ b/src/Data/Uniques/body.lua
@@ -190,6 +190,7 @@ Chaos Damage taken does not bypass Energy Shield
 Ashrend
 Buckskin Tunic
 Variant: Pre 2.6.0
+Variant: Pre 3.19.0
 Variant: Current
 Implicits: 0
 {variant:2}Socketed Gems are Supported by Level 10 Added Fire Damage
@@ -197,8 +198,10 @@ Implicits: 0
 {variant:2}+(30-50) to maximum Life
 +(40-50)% to Fire Resistance
 Cannot be Ignited
-(10-15)% increased Physical Damage with Ranged Weapons
-−(5-7) Physical Damage taken from Attack Hits
+{variant:1,2}(10-15)% increased Physical Damage with Ranged Weapons
+{variant:3}(75-150)% increased Physical Damage with Ranged Weapons
+{variant:1,2}−(5-7) Physical Damage taken from Attack Hits
+{variant:3}−(30-60)Physical Damage taken from Attack Hits
 ]],[[
 Briskwrap
 Strapped Leather
@@ -417,15 +420,19 @@ Projectile Attack Skills have (40-60)% increased Critical Strike Chance
 The Beast Fur Shawl
 Vaal Regalia
 Variant: Pre 3.0.0
+Variant: Pre 3.19.0
 Variant: Current
 Implicits: 0
 40% increased Spell Damage
 {variant:1}+(50-65) to maximum Energy Shield
 {variant:2}+(15-25) to maximum Energy Shield
-(110-130)% increased Energy Shield
+{variant:1,2}(110-130)% increased Energy Shield
+{variant:3}(120-160)% increased Energy Shield
+{variant:1,2}(30-40)% increased Energy Shield Recovery Rate
+{variant:3}(50-100)% increased Energy Shield Recovery rate
 10% increased Area of Effect
-5% increased Damage taken
-(30-40)% increased Energy Shield Recovery Rate
+{variant:1,2}5% increased Damage taken
+{variant:3}10% increased Damage taken
 ]],[[
 Cloak of Flame
 Scholar's Robe
@@ -775,17 +782,20 @@ Crusader Chainmail
 Variant: Pre 1.0.0
 Variant: Pre 2.0.0
 Variant: Pre 2.6.0
+Variant: Pre 3.19.0
 Variant: Current
 Implicits: 0
 {variant:1}(80-100)% increased Armour and Energy Shield
 {variant:2}(140-180)% increased Armour and Energy Shield
-{variant:3,4}(180-220)% increased Armour and Energy Shield
-{variant:4}+(60-80) to maximum Life
+{variant:3,4,5}(180-220)% increased Armour and Energy Shield
+{variant:4,5}+(60-80) to maximum Life
 {variant:1,2}+10% to all Elemental Resistances
-{variant:3,4}+15% to all Elemental Resistances
-Gain an Endurance Charge when you take a Critical Strike
+{variant:3,4,5}+15% to all Elemental Resistances
+{variant:1,2,3,4}Gain an Endurance Charge when you take a Critical Strike
+{variant:5}Gain up to Maximum Endurance Charge when you take a Critical Strike
 {variant:1,2,3}Regenerate 2% of Life per Second while on Low Life
 Share Endurance Charges with nearby party members
+{variant:5}Your nearby party members' maximum Endurance Charges are equal to yours.
 {variant:4}Regenerate 2% of Life per second if you have been Hit Recently
 ]],[[
 Replica Ambu's Charge

--- a/src/Data/Uniques/boots.lua
+++ b/src/Data/Uniques/boots.lua
@@ -702,7 +702,7 @@ Adds 1 to 80 Chaos Damage to Attacks
 {variant:1}20% increased Movement Speed
 {variant:2}25% increased Movement Speed
 {variant:1}+1 to Maximum number of Skeletons
-{variant:2}Skeleton Warriors are Permanent Minions
+{variant:2}Skeleton Warriors are Permanent Minions and Follow you
 (15-18)% increased Strength
 ]],[[
 Replica Alberon's Warpath

--- a/src/Data/Uniques/boots.lua
+++ b/src/Data/Uniques/boots.lua
@@ -692,12 +692,17 @@ Grants Level 20 Aspect of the Avian Skill
 [[
 Alberon's Warpath
 Soldier Boots
+Variant: Pre 3.19.0
+Variant: Current
 Requires Level 49, 47 Str, 47 Int
 Adds 1 to 80 Chaos Damage to Attacks
 +(180-220) to Armour
-+(9-12)% to Chaos Resistance
-20% increased Movement Speed
-+1 to Maximum number of Skeletons
+{variant:1}+(9-12)% to Chaos Resistance
+{variant:2}+(13-19)% to Chaos Resistance
+{variant:1}20% increased Movement Speed
+{variant:2}25% increased Movement Speed
+{variant:1}+1 to Maximum number of Skeletons
+{variant:2}Skeleton Warriors are Permanent Minions
 (15-18)% increased Strength
 ]],[[
 Replica Alberon's Warpath

--- a/src/Data/Uniques/gloves.lua
+++ b/src/Data/Uniques/gloves.lua
@@ -250,10 +250,13 @@ Inflict non-Damaging Ailments as though dealing (100-200)% more Damage
 -- Gloves: Energy Shield
 [[
 Allelopathy
-Sorcerer Gloves
+{variant:1}Sorcerer Gloves
+{variant:2}Satin Gloves
+Variant: Pre 3.19.0
+Variant: Current
 Requires Level 69, 97 Int
 Grants level 22 Blight Skill
-(20-30)% increased Damage over Time
+{variant:1}(20-30)% increased Damage over Time
 (100-120)% increased Energy Shield
 10% increased Area of Effect of Area Skills
 Blight has (20-30)% increased Hinder Duration

--- a/src/Data/Uniques/helmet.lua
+++ b/src/Data/Uniques/helmet.lua
@@ -246,15 +246,18 @@ Requires Level 60, 138 Dex
 Asenath's Mark
 Iron Circlet
 Variant: Pre 2.6.0
+Variant: Pre 3.19.0
 Variant: Current
 Requires Level 8, 23 Int
+{variant:3}Trigger a Socketed Spell when you Attack with a Bow, with a 0.3 second Cooldown
+{variant:3}(30-60)% increased Spell Damage
 (10-15)% increased Attack Speed
-(10-15)% increased Cast Speed
-30% increased Mana Regeneration Rate
+{variant:1,2}(10-15)% increased Cast Speed
 {variant:1}50% increased Energy Shield
 {variant:2}+(30-50) to maximum Energy Shield
-5% increased Movement Speed
-(10-15)% increased Stun Recovery
+30% increased Mana Regeneration Rate
+{variant:1,2}5% increased Movement Speed
+{variant:1,2}(10-15)% increased Stun Recovery
 ]],[[
 Asenath's Chant
 Iron Circlet
@@ -262,14 +265,14 @@ Source: Drops from any endgame map boss
 Variant: Pre 3.9.0
 Variant: Current
 Requires Level 45, 23 Int
-{variant:1}25% chance to Trigger a Socketed Spell when you Attack with a Bow
+{variant:1}25% chance to Trigger a Socketed Spell when you Attack with a Bow, with a 0.3 second Cooldown
 {variant:2}Trigger a Socketed Spell when you Attack with a Bow, with a 0.3 second Cooldown
 (10-15)% increased Attack Speed
 (10-15)% increased Cast Speed
 +(100-120) to maximum Energy Shield
-(30-40)% increased Stun and Block Recovery
 30% increased Mana Regeneration Rate
 5% increased Movement Speed
+(30-40)% increased Stun and Block Recovery
 ]],[[
 Cowl of the Ceraunophile
 Solaris Circlet

--- a/src/Data/Uniques/wand.lua
+++ b/src/Data/Uniques/wand.lua
@@ -22,33 +22,40 @@ Opal Wand
 Variant: Pre 2.3.0
 Variant: Pre 3.7.0
 Variant: Pre 3.11.0
+Variant: Pre 3.19.0
 Variant: Current
 Requires Level 62, 212 Int
 Implicits: 2
 {variant:1}(17-20)% increased Spell Damage
-{variant:2,3,4}(38-42)% increased Spell Damage
+{variant:2,3,4,5}(38-42)% increased Spell Damage
 {variant:1,2}Adds (50-65) to (90-105) Chaos Damage to Spells
-{variant:3,4}Adds (90-130) to (140-190) Chaos Damage to Spells
+{variant:3,4,5}Adds (90-130) to (140-190) Chaos Damage to Spells
 (25-30)% increased Cast Speed
 +(5-10)% to Chaos Resistance
 {variant:1,2,3}40% increased Mana Cost of Skills
-{variant:4}Lose 40 Mana when you use a Skill
 {variant:3,4}Poisons you inflict deal Damage 20% faster
+{variant:5}Poisons you inflict deal Damage (30-50)% faster
+{variant:4,5}Lose 40 Mana when you use a Skill
 ]],[[
 Ashcaller
 Quartz Wand
 Variant: Pre 3.8.0
+Variant: Pre 3.19.0
 Variant: Current
 Requires Level 18, 65 Int
 Implicits: 1
 (18-22)% increased Spell Damage
-10% chance to Trigger Level 8 Summon Raging Spirit on Kill
+{variant:3}10% chance to Cover Enemies in Ash on Hit
+{variant:1,2}10% chance to Trigger Level 8 Summon Raging Spirit on Kill
+{variant:3}25% chance to Trigger Level 10 Summon Raging Spirit on Kill
 {variant:1}Adds (10-14) to (18-22) Fire Damage
+{variant:3}Adds (20-24) to (38-46) Fire Damage
 {variant:2}+(15-25)% to Fire Damage over Time Multiplier
-Adds (4-6) to (7-9) Fire Damage to Spells
+{variant:1,2}Adds (4-6) to (7-9) Fire Damage to Spells
+{variant:3}Adds (20-24) to (36-46) Fire Damage to Spells
 {variant:1}(40-50)% increased Burning Damage
 {variant:2}(20-30)% increased Burning Damage
-(16-22)% chance to Ignite
+{variant:1,2}(16-22)% chance to Ignite
 ]],[[
 Eclipse Solaris
 Crystal Wand

--- a/src/Modules/CalcOffence.lua
+++ b/src/Modules/CalcOffence.lua
@@ -1116,7 +1116,7 @@ function calcs.offence(env, actor, activeSkill)
 			end
 		end
 		local durationBase = (skillData.duration or 0) + skillModList:Sum("BASE", skillCfg, "Duration", "PrimaryDuration")
-		if durationBase > 0 then
+		if durationBase > 0 and not (activeSkill.minion and skillModList:Flag(skillCfg, activeSkill.minion.type.."PermanentDuration")) then
 			output.Duration = durationBase * output.DurationMod
 			if skillData.debuff then
 				output.Duration = output.Duration * debuffDurationMult

--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -1203,6 +1203,7 @@ local modTagList = {
 	["if you have (%d+) primordial items socketed or equipped"] = function(num) return { tag = { type = "MultiplierThreshold", var = "PrimordialItem", threshold = num } } end,
 	-- Player status conditions
 	["wh[ie][ln]e? on low life"] = { tag = { type = "Condition", var = "LowLife" } },
+	["on reaching low life"] = { tag = { type = "Condition", var = "LowLife" } },
 	["wh[ie][ln]e? not on low life"] = { tag = { type = "Condition", var = "LowLife", neg = true } },
 	["wh[ie][ln]e? on low mana"] = { tag = { type = "Condition", var = "LowMana" } },
 	["wh[ie][ln]e? not on low mana"] = { tag = { type = "Condition", var = "LowMana", neg = true } },
@@ -2719,6 +2720,7 @@ local specialModList = {
 		mod("ShrineBuff", "LIST", { mod = mod("AreaOfEffect", "INC", 20) }) 
 	},
 	["(%d+)%% increased effect of shrine buffs on you"] = function(num) return { mod("ShrineBuffEffect", "INC", num)} end,
+	["(%d+)%% chance to cover enemies in ash on hit"] = { mod("CoveredInAshEffect", "BASE", 20) },
 	["left ring slot: cover enemies in ash for 5 seconds when you ignite them"] = { mod("CoveredInAshEffect", "BASE", 20, { type = "SlotNumber", num = 1 }, { type = "ActorCondition", actor = "enemy", var = "Ignited" }) },
 	["right ring slot: cover enemies in frost for 5 seconds when you freeze them"] = { mod("CoveredInFrostEffect", "BASE", 20, { type = "SlotNumber", num = 2 }, { type = "ActorCondition", actor = "enemy", var = "Frozen" }) },
 	["([%a%s]+) has (%d+)%% increased effect"] = function(_, skill, num) return { mod("BuffEffect", "INC", num, { type = "SkillId", skillId = gemIdLookup[skill]}) } end,

--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -95,7 +95,6 @@ local formList = {
 	["^are "] = "FLAG",
 	["^gain "] = "FLAG",
 	["^you gain "] = "FLAG",
-	[""] = "FLAG",
 }
 
 -- Map of modifier names

--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -2835,6 +2835,7 @@ local specialModList = {
 		mod("MinionModifier", "LIST", { mod = mod("EnemyShockChance", "BASE", num) }, { type = "SkillName", skillName = "Summon Arbalists" }),
 		mod("MinionModifier", "LIST", { mod = mod("EnemyIgniteChance", "BASE", num) }, { type = "SkillName", skillName = "Summon Arbalists" }),
 	} end,
+	["skeleton warriors are permanent minions and follow you"] = { flag("RaisedSkeletonPermanentDuration", { type = "SkillName", skillName = "Summon Skeleton" }) },
 	-- Projectiles
 	["skills chain %+(%d) times"] = function(num) return { mod("ChainCountMax", "BASE", num) } end,
 	["skills chain an additional time while at maximum frenzy charges"] = { mod("ChainCountMax", "BASE", 1, { type = "StatThreshold", stat = "FrenzyCharges", thresholdStat = "FrenzyChargesMax" }) },
@@ -3066,6 +3067,7 @@ local specialModList = {
 		mod("EnergyShield", "INC", num, { type = "Global" }),
 		mod("LightningResist", "INC", -num),
 	} end,
+	["phasing while on low life"] = { flag("Condition:Phasing", { type = "Condition", var = "LowLife" })},
 	["cannot be ignited while on low life"] = { mod("AvoidIgnite", "BASE", 100, { type = "Condition", var = "LowLife" }) },
 	["ward does not break during flask effect"] = { flag("WardNotBreak", { type = "Condition", var = "UsingFlask" }) },
 	-- Knockback

--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -2729,7 +2729,6 @@ local specialModList = {
 		mod("ShrineBuff", "LIST", { mod = mod("AreaOfEffect", "INC", 20) }) 
 	},
 	["(%d+)%% increased effect of shrine buffs on you"] = function(num) return { mod("ShrineBuffEffect", "INC", num)} end,
-	["(%d+)%% chance to cover enemies in ash on hit"] = { mod("CoveredInAshEffect", "BASE", 20) },
 	["left ring slot: cover enemies in ash for 5 seconds when you ignite them"] = { mod("CoveredInAshEffect", "BASE", 20, { type = "SlotNumber", num = 1 }, { type = "ActorCondition", actor = "enemy", var = "Ignited" }) },
 	["right ring slot: cover enemies in frost for 5 seconds when you freeze them"] = { mod("CoveredInFrostEffect", "BASE", 20, { type = "SlotNumber", num = 2 }, { type = "ActorCondition", actor = "enemy", var = "Frozen" }) },
 	["([%a%s]+) has (%d+)%% increased effect"] = function(_, skill, num) return { mod("BuffEffect", "INC", num, { type = "SkillId", skillId = gemIdLookup[skill]}) } end,

--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -52,6 +52,7 @@ local formList = {
 	["^you gain ([%d%.]+)"] = "BASE",
 	["^gains? ([%d%.]+)%% of"] = "BASE",
 	["^([%+%-]?%d+)%% chance"] = "CHANCE",
+	["^([%+%-]?%d+)%% chance to gain "] = "FLAG",
 	["^([%+%-]?%d+)%% additional chance"] = "CHANCE",
 	["penetrates? (%d+)%%"] = "PEN",
 	["penetrates (%d+)%% of"] = "PEN",
@@ -92,6 +93,9 @@ local formList = {
 	["^you have "] = "FLAG",
 	["^you are "] = "FLAG",
 	["^are "] = "FLAG",
+	["^gain "] = "FLAG",
+	["^you gain "] = "FLAG",
+	[""] = "FLAG",
 }
 
 -- Map of modifier names
@@ -654,6 +658,11 @@ local modNameList = {
 	["flask charges gained"] = "FlaskChargesGained",
 	["charge recovery"] = "FlaskChargeRecovery",
 	["impales you inflict last"] = "ImpaleStacksMax",
+	-- Buffs
+	["phasing"] = "Condition:Phasing",
+	["onslaught"] = "Condition:Onslaught",
+	["unholy might"] = "Condition:UnholyMight",
+	["elusive"] = "Condition:CanBeElusive",
 }
 
 -- List of modifier flags
@@ -2532,6 +2541,7 @@ local specialModList = {
 	["phasing"] = { flag("Condition:Phasing") },
 	["onslaught"] = { flag("Condition:Onslaught") },
 	["unholy might"] = { flag("Condition:UnholyMight") },
+	["elusive"] = { flag("Condition:CanBeElusive") },
 	["your aura buffs do not affect allies"] = { flag("SelfAurasCannotAffectAllies") },
 	["auras from your skills can only affect you"] = { flag("SelfAurasOnlyAffectYou") },
 	["aura buffs from skills have (%d+)%% increased effect on you for each herald affecting you"] = function(num) return { mod("SkillAuraEffectOnSelf", "INC", num, { type = "Multiplier", var = "Herald"}) } end,
@@ -3628,6 +3638,7 @@ local regenTypes = {
 local flagTypes = {
 	["phasing"] = "Condition:Phasing",
 	["onslaught"] = "Condition:Onslaught",
+	["elusive"] = "Condition:CanBeElusive",
 	["fortify"] = "Condition:Fortified",
 	["fortified"] = "Condition:Fortified",
 	["unholy might"] = "Condition:UnholyMight",


### PR DESCRIPTION
Alberon's Warpath - Not 100% sure on mod wording or order for skeleton warriors permenant.
Allelopathy - Has item level bug due to multi base variant.
Ambu's Charge - Not 100% sure on mod ordering or wording.
The Anvil - 100% accurate
Apep's Rage - 100% accurate
Araku Tiki - Wording could be slighly different but all should be passed 
"on reaching Low Life" is treated as "while on low life" which isn't 100% accurate.
Asenath's Mark - 100% accurate
Ashcaller - Cover enemies in ash on hit could be in different spot but other sources seem to be at top of item.
Ashrend - 100% accurate
The Beast Fur Shawl - 100% accurate

Uses some mod passer changes from https://github.com/PathOfBuildingCommunity/PathOfBuilding/pull/4541