### PR TITLE
[Kalandra] No longer obtainable uniques

### DIFF
--- a/src/Data/Uniques/axe.lua
+++ b/src/Data/Uniques/axe.lua
@@ -303,7 +303,7 @@ Culling Strike
 ]],[[
 The Cauteriser
 Woodsplitter
-Source: Drops from any endgame map boss
+Source: No longer obtainable
 Variant: Pre 3.11.0
 Variant: Current
 LevelReq: 40

--- a/src/Data/Uniques/belt.lua
+++ b/src/Data/Uniques/belt.lua
@@ -454,7 +454,7 @@ Implicits: 1
 ]],[[
 The Nomad
 Studded Belt
-Source: Drops from any endgame map boss
+Source: No longer obtainable
 LevelReq: 48
 Implicits: 1
 (20-30)% increased Stun Duration on Enemies
@@ -467,7 +467,7 @@ Implicits: 1
 ]],[[
 The Tactician
 Studded Belt
-Source: Drops from any endgame map boss
+Source: No longer obtainable
 LevelReq: 48
 Implicits: 1
 (20-30)% increased Stun Duration on Enemies

--- a/src/Data/Uniques/body.lua
+++ b/src/Data/Uniques/body.lua
@@ -217,7 +217,7 @@ Implicits: 0
 ]],[[
 Wildwrap
 Strapped Leather
-Source: Drops from any endgame map boss
+Source: No longer obtainable
 LevelReq: 57
 Implicits: 0
 10% increased Attack Speed
@@ -759,7 +759,7 @@ Adds 1 to (20-30) Lightning Damage to Attacks
 ]],[[
 Viper's Scales
 Full Scale Armour
-Source: Drops in The Lord's Labyrinth
+Source: No longer obtainable
 Implicits: 0
 (80-100)% increased Armour and Evasion
 +(30-40) to maximum Life
@@ -952,6 +952,7 @@ Your Maximum Resistances are (70-72)%
 ]],[[
 Rotting Legion
 Loricated Ringmail
+Source: No longer obtainable
 League: Blight
 Implicits: 0
 Socketed Gems are Supported by Level 1 Meat Shield

--- a/src/Data/Uniques/boots.lua
+++ b/src/Data/Uniques/boots.lua
@@ -142,7 +142,7 @@ Enemies can have 1 additional Curse
 ]],[[
 Windshriek
 Reinforced Greaves
-Source: Drops from any endgame map boss
+Source: No longer obtainable
 Requires Level 60, 60 Str
 (200-250)% increased Armour
 +(10-15)% to all Elemental Resistances
@@ -605,7 +605,7 @@ Requires Level 18, 19 Str, 19 Dex
 ]],[[
 Duskblight
 Ironscale Boots
-Source: Drops from any endgame map boss
+Source: No longer obtainable
 Variant: Pre 3.11.0
 Variant: Current
 Requires Level 40, 19 Str, 19 Dex

--- a/src/Data/Uniques/bow.lua
+++ b/src/Data/Uniques/bow.lua
@@ -164,7 +164,7 @@ Adds an additional Arrow
 ]],[[
 Death's Opus
 Death Bow
-Source: Drops from any endgame map boss
+Source: No longer obtainable
 Variant: Pre 1.2.0
 Variant: Pre 2.2.0
 Variant: Pre 3.0.0
@@ -203,7 +203,7 @@ Implicits: 2
 ]],[[
 Doomfletch's Prism
 Royal Bow
-Source: Drops from any endgame map boss
+Source: No longer obtainable
 Variant: Pre 2.0.0
 Variant: Pre 2.6.0
 Variant: Pre 3.1.0
@@ -480,7 +480,7 @@ No Physical Damage
 ]],[[
 The Tempest
 Long Bow
-Source: Drops from any endgame map boss
+Source: No longer obtainable
 Requires Level 32, 38 Dex
 No Physical Damage
 100% increased Lightning Damage

--- a/src/Data/Uniques/claw.lua
+++ b/src/Data/Uniques/claw.lua
@@ -194,7 +194,7 @@ Implicits: 2
 ]],[[
 Izaro's Dilemma
 Imperial Claw
-Source: Drops in The Lord's Labyrinth
+Source: No longer obtainable
 Variant: Pre 2.6.0
 Variant: Pre 3.7.0
 Variant: Current

--- a/src/Data/Uniques/gloves.lua
+++ b/src/Data/Uniques/gloves.lua
@@ -181,7 +181,7 @@ Reflects 10 Cold Damage to Melee Attackers
 ]],[[
 Hrimburn
 Goathide Gloves
-Source: Drops from any endgame map boss
+Source: No longer obtainable
 Variant: Pre 2.6.0
 Variant: Current
 Requires Level 24, 17 Dex
@@ -328,7 +328,7 @@ Requires Level 12, 21 Int
 ]],[[
 Doedre's Malevolence
 Velvet Gloves
-Source: Drops from any endgame map boss
+Source: No longer obtainable
 Variant: Pre 3.11.0
 Variant: Current
 Requires Level 64, 21 Int
@@ -530,6 +530,7 @@ You gain Onslaught for 5 seconds on using a Vaal Skill
 ]],[[
 Worldcarver
 Dragonscale Gauntlets
+Source: No longer obtainable
 Requires Level 67, 51 Str, 51 Dex
 Trigger Level 20 Arcane Wake after Spending a total of 200 Mana
 +(200-300) to Accuracy Rating

--- a/src/Data/Uniques/helmet.lua
+++ b/src/Data/Uniques/helmet.lua
@@ -184,7 +184,7 @@ Requires Level 20, 46 Dex
 ]],[[
 Frostferno
 Leather Hood
-Source: Drops from any endgame map boss
+Source: No longer obtainable
 Requires Level 60, 46 Dex
 +2 to Level of Socketed Fire Gems
 +2 to Level of Socketed Cold Gems
@@ -258,7 +258,7 @@ Requires Level 8, 23 Int
 ]],[[
 Asenath's Chant
 Iron Circlet
-Source: Drops from any endgame map boss
+Source: No longer obtainable
 Variant: Pre 3.9.0
 Variant: Current
 Requires Level 45, 23 Int
@@ -697,6 +697,7 @@ Far Shot
 ]],[[
 The Peregrine
 Visored Sallet
+Source: No longer obtainable
 Variant: Pre 2.6.0
 Variant: Pre 3.7.0
 Variant: Current
@@ -1213,7 +1214,7 @@ Blood Magic
 ]],[[
 Malachai's Awakening
 Iron Mask
-Source: Drops from any endgame map boss
+Source: No longer obtainable
 Variant: Pre 3.7.0
 Variant: Pre 3.17.0
 Variant: Current

--- a/src/Data/Uniques/jewel.lua
+++ b/src/Data/Uniques/jewel.lua
@@ -78,11 +78,13 @@ Intelligence from Passives in Radius is Transformed to Dexterity
 ]],[[
 Cheap Construction
 Viridian Jewel
+Source: No longer obtainable
 10% reduced Trap Duration
 Can have up to 1 additional Trap placed at a time
 ]],[[
 Replica Cheap Construction
 Viridian Jewel
+Source: No longer obtainable
 League: Heist
 (100-120)% increased Critical Strike Chance with Traps
 Can have 5 fewer Traps placed at a time
@@ -358,7 +360,7 @@ Passives in Radius can be Allocated without being connected to your tree
 ]],[[
 Izaro's Turmoil
 Crimson Jewel
-Source: Drops in The Lord's Labyrinth
+Source: No longer obtainable
 (18-25)% increased Fire Damage
 (18-25)% increased Cold Damage
 2% chance to Freeze

--- a/src/Data/Uniques/mace.lua
+++ b/src/Data/Uniques/mace.lua
@@ -49,7 +49,7 @@ Adds (10-20) to (30-50) Cold Damage
 ]],[[
 Cameria's Avarice
 Gavel
-Source: No longer obtainable
+Source: Vendor Recipe
 Requires Level 60, 212 Str
 Implicits: 1
 15% reduced Enemy Stun Threshold

--- a/src/Data/Uniques/mace.lua
+++ b/src/Data/Uniques/mace.lua
@@ -49,7 +49,7 @@ Adds (10-20) to (30-50) Cold Damage
 ]],[[
 Cameria's Avarice
 Gavel
-Source: Drops from any endgame map boss
+Source: No longer obtainable
 Requires Level 60, 212 Str
 Implicits: 1
 15% reduced Enemy Stun Threshold
@@ -517,7 +517,7 @@ Nearby Enemies are Hindered, with 25% reduced Movement Speed
 ]],[[
 Spine of the First Claimant
 Iron Sceptre
-Source: Drops in The Lord's Labyrinth
+Source: No longer obtainable
 Variant: Pre 2.3.0
 Variant: Pre 3.5.0
 Variant: Current
@@ -605,7 +605,7 @@ Minions have (20-40)% increased maximum Life
 ]],[[
 Chaber Cairn
 Great Mallet
-Source: Drops from any endgame map boss
+Source: No longer obtainable
 Requires Level 60, 131 Str
 Implicits: 1
 30% increased Stun Duration on Enemies
@@ -632,7 +632,7 @@ Never deal Critical Strikes
 ]],[[
 Geofri's Devotion
 Brass Maul
-Source: Drops from any endgame map boss
+Source: No longer obtainable
 Variant: Pre 2.6.0
 Variant: Pre 3.11.0
 Variant: Current

--- a/src/Data/Uniques/quiver.lua
+++ b/src/Data/Uniques/quiver.lua
@@ -61,7 +61,7 @@ The Signal Fire
 Fire Arrow Quiver
 Variant: Pre 3.14.0
 Variant: Pre 3.17.0
-Source: Drops from any endgame map boss
+Source: No longer obtainable
 Requires Level 24
 Implicits: 1
 3 to 5 Added Fire Damage with Bow Attacks
@@ -75,7 +75,7 @@ Adds 5 to 10 Fire Damage to Attacks with Bows
 ]],[[
 The Signal Fire
 Blazing Arrow Quiver
-Source: Drops from any endgame map boss
+Source: No longer obtainable
 Requires Level 45
 Implicits: 1
 (12-15) to (24-27) Added Fire Damage with Bow Attacks
@@ -165,7 +165,7 @@ Implicits: 1
 ]],[[
 Hyrri's Demise
 Sharktooth Arrow Quiver
-Source: Drops from any endgame map boss
+Source: No longer obtainable
 Requires Level 45
 Implicits: 1
 +(6-8) Life gained for each Enemy hit by your Attacks

--- a/src/Data/Uniques/ring.lua
+++ b/src/Data/Uniques/ring.lua
@@ -530,7 +530,7 @@ Kaom's Way
 Coral Ring
 Variant: Pre 3.16.0
 Variant: Current
-Source: Drops from any endgame map boss
+Source: No longer obtainable
 Requires Level 32
 Implicits: 1
 {tags:life}+(20-30) to maximum Life

--- a/src/Data/Uniques/shield.lua
+++ b/src/Data/Uniques/shield.lua
@@ -579,7 +579,7 @@ Spreads Tar when you take a Critical Strike
 ]],[[
 Whakatutuki o Matua
 Tarnished Spirit Shield
-Source: Drops from any endgame map boss
+Source: No longer obtainable
 LevelReq: 63
 Implicits: 1
 (5-10)% increased Spell Damage
@@ -971,6 +971,7 @@ Implicits: 1
 ]],[[
 Glitterdisc
 Burnished Spiked Shield
+Source: No longer obtainable
 Variant: Pre 3.0.0
 Variant: Current
 Implicits: 2

--- a/src/Data/Uniques/staff.lua
+++ b/src/Data/Uniques/staff.lua
@@ -510,7 +510,7 @@ Adds (1-10) to (70-90) Lightning Damage
 ]],[[
 The Stormwall
 Royal Staff
-Source: Drops from any endgame map boss
+Source: No longer obtainable
 Requires Level 60, 51 Str, 51 Int
 Implicits: 1
 18% Chance to Block Attack Damage while wielding a Staff

--- a/src/Data/Uniques/sword.lua
+++ b/src/Data/Uniques/sword.lua
@@ -323,7 +323,7 @@ Adds 2 to 6 Physical Damage
 ]],[[
 Dreadbeak
 Rusted Sword
-Source: Drops from any endgame map boss
+Source: No longer obtainable
 Variant: Pre 2.6.0
 Variant: Pre 3.7.0
 Variant: Current
@@ -545,6 +545,7 @@ Implicits: 3
 ]],[[
 Chitus' Needle
 Elegant Foil
+Source: No longer obtainable
 Variant: Pre 2.2.0
 Variant: Pre 2.6.0
 Variant: Current
@@ -801,7 +802,7 @@ Implicits: 2
 ]],[[
 Queen's Escape
 Ornate Sword
-Source: Drops from any endgame map boss
+Source: No longer obtainable
 Variant: Pre 2.6.0
 Variant: Pre 3.8.0
 Variant: Current

--- a/src/Data/Uniques/wand.lua
+++ b/src/Data/Uniques/wand.lua
@@ -221,7 +221,7 @@ Your Critical Strike Chance is Lucky while on Low Life
 ]],[[
 Amplification Rod
 Spiraled Wand
-Source: Drops from any endgame map boss
+Source: No longer obtainable
 Variant: Pre 3.11.0
 Variant: Current
 Requires Level 36, 83 Int


### PR DESCRIPTION
Fated Uniques can no longer be acquired.
The following unique items can no longer drop. May they rest in peace in Standard.
The Cheap Construction
Replica Cheap Construction
Chitus' Needle
Glitterdisc
Izaro's Dilemma
Izaro's Turmoil
Rotting Legion
Spine of the First Claimant
The Peregrine
Viper's Scales
Worldcarver

Verified correct by double checking all fated unquies. 
There were some fated uniques that were renamed or put into different drop pools and so are likely not considered fated anymore including "The Iron Fortress", "Atziri's Reflection" and "Winterweave".