### PR TITLE
[Kalandra] Update Ngamahu's Sign

### DIFF
--- a/src/Data/Uniques/ring.lua
+++ b/src/Data/Uniques/ring.lua
@@ -704,6 +704,7 @@ Ngamahu's Sign
 Ruby Ring
 League: Bloodlines
 Variant: Pre 2.6.0
+Variant: Pre 3.19.0
 Variant: Current
 Requires Level 29
 Implicits: 1
@@ -711,11 +712,12 @@ Implicits: 1
 {tags:jewellery_attribute}+(15-25) to Strength
 {variant:1}{tags:jewellery_elemental,attack}Adds (8-10) to (12-14) Fire Damage to Attacks
 {variant:2}{tags:jewellery_elemental,attack,caster}Adds (8-10) to (12-14) Fire Damage to Spells and Attacks
-{variant:1}{tags:life}+(4-5) Life gained for each Ignited Enemy hit by your Attacks
-{variant:2}{tags:life}Recover (20-30) Life when you Ignite an Enemy
-15% increased Ignite Duration on Enemies
+{variant:3}{tags:jewellery_elemental,attack,caster}Adds (20-25) to (30-35) Fire Damage to Spells and Attacks
+{variant:1,2,3}15% increased Ignite Duration on Enemies
 {variant:1}{tags:jewellery_elemental}5% chance to Ignite
-{variant:2}{tags:jewellery_elemental}10% chance to Ignite
+{variant:2,3}{tags:jewellery_elemental}10% chance to Ignite
+{variant:1}{tags:life}+(4-5) Life gained for each Ignited Enemy hit by your Attacks
+{variant:2,3}{tags:life}Recover (20-30) Life when you Ignite an Enemy
 ]],[[
 The Pariah
 Unset Ring

--- a/src/Data/Uniques/ring.lua
+++ b/src/Data/Uniques/ring.lua
@@ -713,7 +713,7 @@ Implicits: 1
 {variant:1}{tags:jewellery_elemental,attack}Adds (8-10) to (12-14) Fire Damage to Attacks
 {variant:2}{tags:jewellery_elemental,attack,caster}Adds (8-10) to (12-14) Fire Damage to Spells and Attacks
 {variant:3}{tags:jewellery_elemental,attack,caster}Adds (20-25) to (30-35) Fire Damage to Spells and Attacks
-{variant:1,2,3}15% increased Ignite Duration on Enemies
+15% increased Ignite Duration on Enemies
 {variant:1}{tags:jewellery_elemental}5% chance to Ignite
 {variant:2,3}{tags:jewellery_elemental}10% chance to Ignite
 {variant:1}{tags:life}+(4-5) Life gained for each Ignited Enemy hit by your Attacks


### PR DESCRIPTION
Ngamahu's Sign - Perfect - now adds 20-25 to 30-35 Fire Damage to Spells and Attacks (previously 8-10 to 12-14).
