### PR TITLE
[Kalandra]Batch of uniques update. All missing starting with R

### DIFF
--- a/src/Data/Uniques/amulet.lua
+++ b/src/Data/Uniques/amulet.lua
@@ -762,24 +762,33 @@ Primordial
 ]],[[
 Rashkaldor's Patience
 Jade Amulet
-Requires Level 61
+Variant: Pre 3.19.0
+Variant: Current
+Requires Level 48
 Implicits: 1
 {tags:jewellery_attribute}+(20-30) to Dexterity
 {tags:life}+(40-80) to maximum Life
 {tags:mana}+(20-40) to maximum Mana
-{tags:jewellery_elemental}20% increased Duration of Elemental Ailments on Enemies
-Items and Gems have 10% reduced Attribute Requirements
-{tags:jewellery_elemental}5% chance to Freeze, Shock and Ignite
-Cannot gain Power Charges
+{variant:1}{tags:jewellery_elemental}20% increased Duration of Elemental Ailments on Enemies
+{variant:2}{tags:jewellery_elemental}20% reduced Duration of Elemental Ailments on Enemies
+{variant:1}Items and Gems have 10% reduced Attribute Requirements
+{variant:2}Items and Gems have 10% increased Attribute Requirements
+{variant:1}{tags:jewellery_elemental}5% chance to Freeze, Shock and Ignite
+{variant:2}Always Freeze, Shock and Ignite
+{variant:1}Cannot gain Power Charges
 ]],[[
 Retaliation Charm
 Citrine Amulet
+Variant: Pre 3.19.0
+Variant: Current
 Requires Level 30
 Implicits: 1
 {tags:jewellery_attribute}+(16-24) to Strength and Dexterity
-(25-40)% increased Damage with Hits and Ailments against Blinded Enemies
-{tags:critical}(30-50)% increased Critical Strike Chance against Blinded Enemies
-{tags:critical}(40-50)% chance to Blind Enemies on Critical Strike
+{variant:1}(25-40)% increased Damage with Hits and Ailments against Blinded Enemies
+{variant:1}{tags:critical}(30-50)% increased Critical Strike Chance against Blinded Enemies
+{variant:1}{tags:critical}(40-50)% chance to Blind Enemies on Critical Strike
+{variant:2}(10-20)% chance to gain a Frenzy Charge On Hit while Blinded
+{variant:2}(10-20)% chance to gain a Blind Enemies on Hit with Attacks
 Blind does not affect your Light Radius
 Blind you inflict is Reflected to you
 ]],[[

--- a/src/Data/Uniques/body.lua
+++ b/src/Data/Uniques/body.lua
@@ -1108,7 +1108,7 @@ Implicits: 1
 {variant:3}4% increased Movement Speed per Frenzy Charge
 {variant:1}Regenerate (15.0-20.0) Life per second per Endurance Charge
 {variant:2}Regenerate (20.0-30.0) Life per second per Endurance Charge
-{variant:3}Regenerate 75.0 Life per second per Endurance Charge
+{variant:3}Regenerate 75 Life per second per Endurance Charge
 {variant:1,2}100% increased Endurance, Frenzy and Power Charge Duration
 {variant:3}(100-200)% increased Endurance, Frenzy and Power Charge Duration
 ]],[[

--- a/src/Data/Uniques/body.lua
+++ b/src/Data/Uniques/body.lua
@@ -327,15 +327,18 @@ The Rat Cage
 Sharkskin Tunic
 League: Torment
 Variant: Pre 2.6.0
+Variant: 3.19.0
 Variant: Current
 Implicits: 0
 (100-120)% increased Evasion Rating
-+(160-200) to maximum Life
+{variant:1,2}+(160-200) to maximum Life
+{variant:3}+(200-300) to maximum Life
 {variant:1}−5% to maximum Fire Resistance
 {variant:2}-50% to Fire Resistance
 15% increased Movement Speed
-20% increased Fire Damage taken
-10% of Fire Damage from Hits taken as Physical Damage
+{variant:1,2}20% increased Fire Damage taken
+{variant:1,2}10% of Fire Damage from Hits taken as Physical Damage
+{variant:3}100% of Fire Damage from Hits taken as Physical Damage
 ]],[[
 The Snowblind Grace
 Coronal Leather
@@ -1093,17 +1096,21 @@ Unaffected by Shock
 The Restless Ward
 Carnal Armour
 Variant: Pre 2.6.0
+Variant: Pre.3.19.0
 Variant: Current
 Implicits: 1
 +(20-25) to maximum Mana
 {variant:1}(120-150)% increased Evasion and Energy Shield
-{variant:2}(220-250)% increased Evasion and Energy Shield
+{variant:2,3}(220-250)% increased Evasion and Energy Shield
 {variant:1}+(40-60) to maximum Life
-{variant:2}+(60-80) to maximum Life
-1% increased Movement Speed per Frenzy Charge
+{variant:2,3}+(60-80) to maximum Life
+{variant:1,2}1% increased Movement Speed per Frenzy Charge
+{variant:3}4% increased Movement Speed per Frenzy Charge
 {variant:1}Regenerate (15.0-20.0) Life per second per Endurance Charge
 {variant:2}Regenerate (20.0-30.0) Life per second per Endurance Charge
-100% increased Endurance, Frenzy and Power Charge Duration
+{variant:3}Regenerate 75.0 Life per second per Endurance Charge
+{variant:1,2}100% increased Endurance, Frenzy and Power Charge Duration
+{variant:3}(100-200)% increased Endurance, Frenzy and Power Charge Duration
 ]],[[
 Replica Restless Ward
 Carnal Armour

--- a/src/Data/Uniques/boots.lua
+++ b/src/Data/Uniques/boots.lua
@@ -433,17 +433,19 @@ Variant: Pre 1.0.0
 Variant: Pre 1.1.0
 Variant: Pre 2.6.0
 Variant: Pre 3.4.0
+Variant: Pre 3.19.0
 Variant: Current
 Requires Level 53, 94 Int
 {variant:1,2,3,4}(6-7)% Chance to Block Spell Damage
 {variant:5}(4-6)% Chance to Block Spell Damage
+{variant:6}(15-20)% Chance to Block Spell Damage
 {variant:1,2}+(80-100) to maximum Mana
-{variant:3,4,5}+(40-60) to maximum Mana
+{variant:3,4,5,6}+(40-60) to maximum Mana
 {variant:1,2}(150-200)% increased Energy Shield
 {variant:3,4,5}(140-180)% increased Energy Shield
-{variant:1,3,4,5}+20% to all Elemental Resistances
+{variant:1,3,4,5,6}+20% to all Elemental Resistances
 {variant:2}+8% to all Elemental Resistances
-{variant:1,2,3}20% increased Movement Speed
+{variant:1,2,3,6}20% increased Movement Speed
 {variant:4,5}25% increased Movement Speed
 ]],[[
 Shavronne's Pace
@@ -751,11 +753,15 @@ Socketed Gems are Supported by Level 25 Divine Blessing
 ]],[[
 Ralakesh's Impatience
 Riveted Boots
+Variant: Pre 3.19.0
+Variant: Current
 Requires Level 36, 35 Str, 35 Int
 +(15-25)% to Cold Resistance 
 +(15-25)% to Chaos Resistance 
-20% increased Movement Speed 
-Gain a Frenzy, Endurance, or Power Charge once per second while you are Stationary 
+{variant:1}20% increased Movement Speed 
+{variant:2}30% increased Movement Speed 
+{variant:1}Gain a Frenzy, Endurance, or Power Charge once per second while you are Stationary 
+{variant:2}Your minimum Frenzy, Endurance and Power Charges are equal to yor maximum while you are Stationary
 Lose all Frenzy, Endurance, and Power Charges when you Move
 ]],[[
 Wake of Destruction

--- a/src/Data/Uniques/boots.lua
+++ b/src/Data/Uniques/boots.lua
@@ -761,7 +761,7 @@ Requires Level 36, 35 Str, 35 Int
 {variant:1}20% increased Movement Speed 
 {variant:2}30% increased Movement Speed 
 {variant:1}Gain a Frenzy, Endurance, or Power Charge once per second while you are Stationary 
-{variant:2}Your minimum Frenzy, Endurance and Power Charges are equal to yor maximum while you are Stationary
+{variant:2}Your minimum Frenzy, Endurance and Power Charges are equal to your maximum while you are Stationary
 Lose all Frenzy, Endurance, and Power Charges when you Move
 ]],[[
 Wake of Destruction

--- a/src/Data/Uniques/bow.lua
+++ b/src/Data/Uniques/bow.lua
@@ -415,14 +415,17 @@ Requires Level 64, 212 Dex
 Roth's Reach
 Recurve Bow
 Variant: Pre 3.9.0
+Variant: Pre 3.19.0
 Variant: Current
 Requires Level 18, 71 Dex
 Implicits: 1
-{variant:2}+(15-25)% to Global Critical Strike Multiplier
+{variant:2,3}+(15-25)% to Global Critical Strike Multiplier
 (60-80)% increased Physical Damage
-(20-40)% increased Elemental Damage with Attack Skills
-(4-8)% increased Attack Speed
-Skills Chain +1 times
+{variant:1,2}(20-40)% increased Elemental Damage with Attack Skills
+{variant:3}(60-80)% increased Elemental Damage with Attack Skills
+{variant:1,2}(4-8)% increased Attack Speed
+{variant:1,2}Skills Chain +1 times
+{variant:3}Skills Chain +2 times
 30% increased Projectile Speed
 ]],[[
 Silverbranch

--- a/src/Data/Uniques/gloves.lua
+++ b/src/Data/Uniques/gloves.lua
@@ -608,10 +608,14 @@ Life Leech effects are not removed at Full Life
 ]],[[
 Repentance
 Crusader Gloves
+Variant: Pre 3.19.0
+Variant: Current
 Requires Level 66, 306 Str, 306 Int
-(0-30)% reduced Spell Damage
-(120-180)% increased Armour and Energy Shield
-+(8-16) to maximum Energy Shield
+{variant:1}(0-30)% reduced Spell Damage
+{variant:1}(120-180)% increased Armour and Energy Shield
+{variant:2}(400-500)% increased Armour and Energy Shield
+{variant:1}+(8-16) to maximum Energy Shield
+{variant:2}(6-12)% increased Strength
 500% increased Attribute Requirements
 Iron Will
 ]],[[

--- a/src/Data/Uniques/ring.lua
+++ b/src/Data/Uniques/ring.lua
@@ -850,14 +850,17 @@ Has 1 Socket
 Rigwald's Crest
 Two-Stone Ring
 League: Talisman
+Variant: Pre 3.19.0
+Variant: Current
 Source: Drops from unique{Rigwald, the Wolven King} (Level 60+)
 Requires Level 49
 Implicits: 1
 {tags:jewellery_resistance}+(12-16)% to Fire and Cold Resistances
-{tags:jewellery_elemental}(20-30)% increased Fire Damage
-{tags:jewellery_elemental}(20-30)% increased Cold Damage
+{variant:1}{tags:jewellery_elemental}(20-30)% increased Fire Damage
+{variant:1}{tags:jewellery_elemental}(20-30)% increased Cold Damage
 {tags:mana}(20-30)% increased Mana Regeneration Rate
-10% Chance to Trigger Level 10 Summon Spectral Wolf on Kill
+{variant:1}10% Chance to Trigger Level 10 Summon Spectral Wolf on Kill
+{variant:2}Trigger Level 10 Summon Spectral Wolf on Kill
 ]],[[
 Romira's Banquet
 Diamond Ring

--- a/src/Data/Uniques/shield.lua
+++ b/src/Data/Uniques/shield.lua
@@ -598,17 +598,21 @@ League: Legion
 Source: Drops from Vaal Legion
 Variant: Pre 3.4.0
 Variant: Pre 3.7.0
+Variant: 3.19.0
 Variant: Current
 Implicits: 0
 {variant:1}+(12-18)% chance to Block Spell Damage
-{variant:2,3}+(10-15)% chance to Block Spell Damage
+{variant:2,3,4}+(10-15)% chance to Block Spell Damage
 {variant:1,2}(40-60)% increased Spell Damage
 (120-160)% increased Energy Shield
 10% increased maximum Life
 {variant:1,2}+25% to Lightning Resistance
 {variant:3}Sacrifice 4% of your Life when you Use or Trigger a Spell Skill
+{variant:4}Sacrifice 10% of your Life when you Use or Trigger a Spell Skill
 {variant:3}2% increased Critical Strike Chance for Spells per 100 Player Maximum Life
+{variant:4}5% increased Critical Strike Chance for Spells per 100 Player Maximum Life
 {variant:3}2% increased Spell Damage per 100 Player Maximum Life
+{variant:4}5% increased Spell Damage per 100 Player Maximum Life
 ]],[[
 The Scales of Justice
 Chiming Spirit Shield
@@ -825,16 +829,19 @@ Rise of the Phoenix
 Mosaic Kite Shield
 Variant: Pre 1.1.0
 Variant: Pre 3.1.0
+Variant: Pre 3.19.0
 Variant: Current
 Implicits: 2
 {variant:1}+16% to all Elemental Resistances
-{variant:2,3}+8% to all Elemental Resistances
-(80-100)% increased Armour and Energy Shield
+{variant:2,3,4}+8% to all Elemental Resistances
+{variant:1,2,3}(80-100)% increased Armour and Energy Shield
+{variant:4}(240-300)% increased Armour and Energy Shield
 {variant:3}+(40-60) maximum Life
 {variant:1,2}Regenerate 6 Life per second
 {variant:3}Regenerate (15-20) Life per second
+{variant:4}Regenerate (100-200) Life per second
 {variant:1,2}+8% to maximum Fire Resistance
-{variant:3}+5% to maximum Fire Resistance
+{variant:3,4}+5% to maximum Fire Resistance
 +(20-25)% to Fire Resistance
 +25% to Fire Resistance while on Low Life
 10% increased Movement Speed when on Low Life

--- a/src/Data/Uniques/wand.lua
+++ b/src/Data/Uniques/wand.lua
@@ -200,13 +200,16 @@ Reverberation Rod
 Spiraled Wand
 Variant: Pre 2.3.0
 Variant: Pre 3.11.0
+Variant: Pre 3.19.0
 Variant: Current
 Requires Level 24, 83 Int
 Implicits: 2
 {variant:1}(10-14)% increased Spell Damage
-{variant:2,3}(15-19)% increased Spell Damage
+{variant:2,3,4}(15-19)% increased Spell Damage
 {variant:1,2}+1 to Level of Socketed Gems
-{variant:3}+2 to Level of Socketed Gems
+{variant:3,4}+2 to Level of Socketed Gems
+{variant:4}Socketed Gems are Supported by Level 10 Arcane Surge
+{variant:4}Socketed Gems are Supported by Level 10 Controlled Destruction
 Socketed Gems are Supported by Level 10 Spell Echo
 +(10-30) to Intelligence
 ]],[[

--- a/src/Modules/CalcPerform.lua
+++ b/src/Modules/CalcPerform.lua
@@ -771,11 +771,11 @@ local function doActorMisc(env, actor)
 	output.BlitzChargesMax = modDB:Sum("BASE", nil, "BlitzChargesMax")
 	output.InspirationChargesMax = modDB:Sum("BASE", nil, "InspirationChargesMax")
 	output.CrabBarriersMax = modDB:Sum("BASE", nil, "CrabBarriersMax")
-	output.BrutalChargesMin = modDB:Flag(nil, "MinimumEnduranceChargesEqualsMinimumBrutalCharges") and output.EnduranceChargesMin or 0
+	output.BrutalChargesMin = modDB:Flag(nil, "MinimumEnduranceChargesEqualsMinimumBrutalCharges") and (modDB:Flag(nil, "MinimumEnduranceChargesIsMaximumEnduranceCharges") and output.EnduranceChargesMax or output.EnduranceChargesMin) or 0 
 	output.BrutalChargesMax = modDB:Flag(nil, "MaximumEnduranceChargesEqualsMaximumBrutalCharges") and output.EnduranceChargesMax or 0
-	output.AbsorptionChargesMin = modDB:Flag(nil, "MinimumPowerChargesEqualsMinimumAbsorptionCharges") and output.PowerChargesMin or 0
+	output.AbsorptionChargesMin = modDB:Flag(nil, "MinimumPowerChargesEqualsMinimumAbsorptionCharges") and (modDB:Flag(nil, "MinimumPowerChargesIsMaximumPowerCharges") and output.PowerChargesMax or output.PowerChargesMin) or 0
 	output.AbsorptionChargesMax = modDB:Flag(nil, "MaximumPowerChargesEqualsMaximumAbsorptionCharges") and output.PowerChargesMax or 0
-	output.AfflictionChargesMin = modDB:Flag(nil, "MinimumFrenzyChargesEqualsMinimumAfflictionCharges") and output.FrenzyChargesMin or 0
+	output.AfflictionChargesMin = modDB:Flag(nil, "MinimumFrenzyChargesEqualsMinimumAfflictionCharges") and (modDB:Flag(nil, "MinimumFrenzyChargesIsMaximumFrenzyCharges") and output.FrenzyChargesMax or output.FrenzyChargesMin) or 0
 	output.AfflictionChargesMax = modDB:Flag(nil, "MaximumFrenzyChargesEqualsMaximumAfflictionCharges") and output.FrenzyChargesMax or 0
 	output.BloodChargesMax = modDB:Sum("BASE", nil, "BloodChargesMax")
 
@@ -794,6 +794,15 @@ local function doActorMisc(env, actor)
 	output.BloodCharges = 0
 
 	-- Conditionally over-write Charge values
+	if modDB:Flag(nil, "MinimumFrenzyChargesIsMaximumFrenzyCharges") then
+		output.FrenzyChargesMin = output.FrenzyChargesMax
+	end
+	if modDB:Flag(nil, "MinimumEnduranceChargesIsMaximumEnduranceCharges") then
+		output.EnduranceChargesMin = output.EnduranceChargesMax
+	end
+	if modDB:Flag(nil, "MinimumPowerChargesIsMaximumPowerCharges") then
+		output.PowerChargesMin = output.PowerChargesMax
+	end
 	if modDB:Flag(nil, "UsePowerCharges") then
 		output.PowerCharges = modDB:Override(nil, "PowerCharges") or output.PowerChargesMax
 	end

--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -1875,6 +1875,11 @@ local specialModList = {
 	["hits always ignite"] = { mod("EnemyIgniteChance", "BASE", 100) },
 	["your hits always shock"] = { mod("EnemyShockChance", "BASE", 100) },
 	["hits always shock"] = { mod("EnemyShockChance", "BASE", 100) },
+	["always freeze, shock and ignite"] = {
+		mod("EnemyFreezeChance", "BASE", 100),
+		mod("EnemyShockChance", "BASE", 100) ,
+		mod("EnemyIgniteChance", "BASE", 100),
+	},
 	["all damage with hits can ignite"] = {
 		flag("PhysicalCanIgnite"),
 		flag("ColdCanIgnite"),

--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -3212,6 +3212,11 @@ local specialModList = {
 	["added small passive skills have (%d+)%% increased effect"] = function(num) return { mod("JewelData", "LIST", { key = "clusterJewelIncEffect", value = num }) } end,
 	["this jewel's socket has (%d+)%% increased effect per allocated passive skill between it and your class' starting location"] = function(num) return { mod("JewelData", "LIST", { key = "jewelIncEffectFromClassStart", value = num }) } end,
 	-- Misc
+	["your minimum frenzy, endurance and power charges are equal to your maximum while you are stationary"] = {
+		flag("MinimumFrenzyChargesIsMaximumFrenzyCharges", {type = "Condition", var = "Stationary"}), 
+		flag("MinimumEnduranceChargesIsMaximumEnduranceCharges", {type = "Condition", var = "Stationary"}), 
+		flag("MinimumPowerChargesIsMaximumPowerCharges", {type = "Condition", var = "Stationary"}), 
+	},
 	["leftmost (%d+) magic utility flasks constantly apply their flask effects to you"] = function(num) return { mod("ActiveMagicUtilityFlasks", "BASE", num) } end,
 	["marauder: melee skills have (%d+)%% increased area of effect"] = function(num) return { mod("AreaOfEffect", "INC", num, { type = "Condition", var = "ConnectedToMarauderStart" }, { type = "SkillType", skillType = SkillType.Melee }) } end,
 	["intelligence provides no inherent bonus to energy shield"] = { flag("NoIntBonusToES") },


### PR DESCRIPTION
Ralakesh's Impatience: perfect
Rainbowstride: perfect
Rashkaldor's Patience: I think we dont support "always freeze, shock, ignite" mods
The Rat Cage: perfect
Rathpith Globe: perfect
Repentance: unsure of affix order
The Restless Ward: perfect
Retaliation Charm: do we want to support the two conditional mods? "10-20% chance to gain a Frenzy Charge on Hit while Blinded" and "10-20% chance to Blind Enemies on Hit with Attacks"
Reverberation Rod: unsure of affix order
Rigwald's Crest: spectral wolves atk will be pulled from ggpk? patchnotes states they attack faster now
Rise of the Phoenix: perfect
Roth's Reach: perfect