### PR TITLE
[Kalandra]Batch of uniques update. All missing starting with T

### DIFF
--- a/src/Data/Uniques/amulet.lua
+++ b/src/Data/Uniques/amulet.lua
@@ -919,28 +919,35 @@ Tavukai
 Coral Amulet
 League: Legion
 Source: Drops from Karui Legion
+Variant: Pre 3.19.0
+Variant: Current
 Requires Level 54
 Implicits: 1
 {tags:life}(2.0-4.0) Life regenerated per second
 {tags:jewellery_attribute}+(30-40) to Intelligence
 {tags:chaos,jewellery_resistance}Minions have (-17-17)% to Chaos Resistance
 Summon Raging Spirit has (20-30)% increased Duration
-Summoned Raging Spirits deal (60-80)% increased Damage
-{tags:life}Summoned Raging Spirits have (80-100)% increased maximum Life
+{variant:1}Summoned Raging Spirits deal (60-80)% increased Damage
+{variant:2}Summoned Raging Spirits deal (25-40)% increased Damage
+{variant:1}{tags:life}Summoned Raging Spirits have (80-100)% increased maximum Life
+{variant:2}{tags:life}Summoned Raging Spirits have (25-40)% increased maximum Life
 {tags:chaos}Summoned Raging Spirits take 20% of their Maximum Life per second as Chaos Damage
 ]],[[
 Tear of Purity
 Lapis Amulet
 Variant: Pre 3.16.0
+Variant: Pre 3.19.0
 Variant: Current
-Requires Level 20
+Requires Level 5
 Implicits: 1
 {tags:jewellery_attribute}+(20-30) to Intelligence
 Grants level 10 Purity of Elements Skill
-{tags:jewellery_attribute}+(5-10) to all Attributes
+{variant:1,2}{tags:jewellery_attribute}+(5-10) to all Attributes
+{variant:3}{tags:jewellery_attribute}+(10-20) to all Attributes
 {tags:life}+(20-40) to maximum Life
 {variant:1}5% chance to avoid Elemental Ailments
 {variant:2}+5% to all Elemental Resistances
+{variant:3}+(5-10)% to all Elemental Resistances
 ]],[[
 Ungil's Harmony
 Turquoise Amulet
@@ -1030,18 +1037,23 @@ Gain an Endurance Charge when a Power Charge expires or is consumed
 Warped Timepiece
 Turquoise Amulet
 Variant: Pre 3.11.0
+Variant: Pre 3.19.0
 Variant: Current
 Requires Level 50
 Implicits: 1
 {tags:jewellery_attribute}+(16-24) to Dexterity and Intelligence
 {variant:1}{tags:attack,speed}(8-12)% increased Attack Speed
 {variant:2}{tags:attack,speed}(10-15)% increased Attack Speed
+{variant:3}{tags:attack,speed}(10-25)% increased Attack Speed
 {variant:1}{tags:caster,speed}(8-12)% increased Cast Speed
 {variant:2}{tags:caster,speed}(10-15)% increased Cast Speed
+{variant:3}{tags:caster,speed}(10-25)% increased Cast Speed
 {tags:speed}12% increased Movement Speed
 {variant:1}(8-12)% reduced Skill Effect Duration
 {variant:2}(10-15)% reduced Skill Effect Duration
-30% increased total Recovery per second from Life, Mana, or Energy Shield Leech
+{variant:3}(10-20)% reduced Skill Effect Duration
+{variant:1,2}30% increased total Recovery per second from Life, Mana, or Energy Shield Leech
+{variant:3}Debuffs on you Expire 100% Faster
 ]],[[
 Willowgift
 Jade Amulet

--- a/src/Data/Uniques/body.lua
+++ b/src/Data/Uniques/body.lua
@@ -615,19 +615,30 @@ Sockets: W-W-W-W-W-W
 Thousand Ribbons
 Simple Robe
 Variant: Pre 3.0.0
+Variant: Pre 3.19.0
 Variant: Current
 Socketed Gems are Supported by Level 5 Elemental Proliferation
-Adds 2 to 3 Fire Damage to Spells and Attacks
-Adds 2 to 3 Cold Damage to Spells and Attacks
-Adds 1 to 4 Lightning Damage to Spells and Attacks
+{variant:1,2}Adds 2 to 3 Fire Damage to Spells and Attacks
+{variant:3}Adds (2-4) to (5-9) Fire Damage to Spells and Attacks
+{variant:1,2}Adds 2 to 3 Cold Damage to Spells and Attacks
+{variant:3}Adds (2-4) to (5-9) Cold Damage to Spells and Attacks
+{variant:1,2}Adds 1 to 4 Lightning Damage to Spells and Attacks
+{variant:3}Adds 1 to (4-12) Lightning Damage to Spells and Attacks
 {variant:1}10% reduced Cast Speed
-+(10-20) to Evasion Rating
-+(10-20) to maximum Energy Shield
-+6 to maximum Life
-+6 to maximum Mana
-+(5-10)% to Fire Resistance
-+(5-10)% to Cold Resistance
-+(5-10)% to Lightning Resistance
+{variant:1,2}+(10-20) to Evasion Rating
+{variant:3}+(30-60) to Evasion Rating
+{variant:1,2}+(10-20) to maximum Energy Shield
+{variant:3}+(30-60) to maximum Energy Shield
+{variant:1,2}+6 to maximum Life
+{variant:3}+(25-50) to maximum Life
+{variant:1,2}+6 to maximum Mana
+{variant:3}+(25-50) to maximum Mana
+{variant:1,2}+(5-10)% to Fire Resistance
+{variant:3}+(15-30)% to Fire Resistance
+{variant:1,2}+(5-10)% to Cold Resistance
+{variant:3}+(15-30)% to Cold Resistance
+{variant:1,2}+(5-10)% to Lightning Resistance
+{variant:3}+(15-30)% to Lightning Resistance
 ]],[[
 Vis Mortis
 Necromancer Silks

--- a/src/Data/Uniques/boots.lua
+++ b/src/Data/Uniques/boots.lua
@@ -130,14 +130,17 @@ Requires Level 37, 67 Str
 Windscream
 Reinforced Greaves
 Variant: Pre 2.6.0
+Variant: Pre 3.19.0
 Variant: Current
 Requires Level 33, 60 Str
 (50-80)% increased Armour
 +(10-15)% to all Elemental Resistances
 {variant:1}10% increased Movement Speed
 {variant:2}15% increased Movement Speed
+{variant:3}20% increased Movement Speed
 {variant:1}10% increased Elemental Damage
 {variant:2}(10-20)% increased Elemental Damage
+{variant:3}50% increased Area of Effect of Hex Skills
 Enemies can have 1 additional Curse
 ]],[[
 Windshriek
@@ -336,15 +339,19 @@ Requires Level 55, 97 Dex
 Victario's Flight
 Goathide Boots
 Variant: Pre 2.6.0
+Variant: Pre 3.19.0
 Variant: Current
 Requires Level 12, 26 Dex
 +15 to Dexterity
 +15 to Intelligence
 (100-150)% increased Evasion Rating
 {variant:1}30% increased Movement Speed when on Low Life
+{variant:3}(10-20)% increased Movement Speed when on Low Life
+{variant:3}Quicksilver Flasks you Use also apply to nearby Allies
 {variant:2}15% increased Movement Speed
+{variant:3}(10-20)% increased Movement Speed
 {variant:2}You and nearby allies have 10% increased Movement Speed
-(5-10)% of Damage taken Recouped as Mana
+{variant:1,2}(5-10)% of Damage taken Recouped as Mana
 ]],
 -- Boots: Energy Shield
 [[
@@ -515,15 +522,21 @@ Cannot be Frozen
 Wondertrap
 Velvet Slippers
 Variant: Pre 1.0.0
+Variant: Pre 3.19.0
 Variant: Current
 Requires Level 9, 21 Int
-+(5-10) to Strength
-+(5-10) to Dexterity
-+(5-10) to Intelligence
-+(10-16) to maximum Energy Shield
+{variant:1,2}+(5-10) to Strength
+{variant:3}+(5-30) to Strength
+{variant:1,2}+(5-10) to Dexterity
+{variant:3}+(5-30) to Dexterity
+{variant:1,2}+(5-10) to Intelligence
+{variant:3}+(5-30) to Intelligence
+{variant:1,2}+(10-16) to maximum Energy Shield
+{variant:3}+(5-30) to maximum Energy Shield
 100% increased Rarity of Items found when on Low Life
 {variant:1}15% increased Movement Speed
 {variant:2}10% increased Movement Speed
+{variant:3}(10-25)% increased Movement Speed
 ]],[[
 Greedtrap
 Velvet Slippers

--- a/src/Data/Uniques/bow.lua
+++ b/src/Data/Uniques/bow.lua
@@ -497,8 +497,8 @@ Adds 1 to (275-325) Lightning Damage
 60% of Lightning Damage Converted to Chaos Damage
 10% Chance to Shock
 Your Chaos Damage can Shock
-{variant:2}Shock Enemies as though dealing 300% more Damage
-{variant:2}Your Shocks can increase Damage taken by up to a maximum of 100%
+{variant:2}Hits with this Weapon Shock Enemies as though dealing 300% more Damage
+{variant:2}+40% to maximum Effect of Shock
 ]],[[
 Windripper
 Imperial Bow

--- a/src/Data/Uniques/gloves.lua
+++ b/src/Data/Uniques/gloves.lua
@@ -518,15 +518,19 @@ Vaal Caress
 Bronzescale Gauntlets
 League: Ambush, Invasion
 Variant: Pre 2.6.0
+Variant: Pre 3.19.0
 Variant: Current
 Requires Level 27, 22 Str, 22 Dex
-+2 to Level of Socketed Vaal Gems
+{variant:1,2}+2 to Level of Socketed Vaal Gems
+{variant:3}-5 to Level of Socketed Non-Vaal Gems
+{variant:3}+5 to Level of Socketed Vaal Gems
 (120-140)% increased Armour and Evasion
 {variant:1}+(30-40) to maximum Life
-{variant:2}+(50-70) to maximum Life
+{variant:2,3}+(50-70) to maximum Life
 {variant:1}+30% to Cold Resistance
-{variant:2}+40% to Cold Resistance
-You gain Onslaught for 5 seconds on using a Vaal Skill
+{variant:2,3}+40% to Cold Resistance
+{variant:1,2}You gain Onslaught for 5 seconds on using a Vaal Skill
+{variant:3}You gain Onslaught for 20 seconds on using a Vaal Skill
 ]],[[
 Worldcarver
 Dragonscale Gauntlets
@@ -911,15 +915,19 @@ Thunderfist
 Murder Mitts
 Variant: Pre 1.0.0
 Variant: Pre 2.6.0
+Variant: Pre 3.19.0
 Variant: Current
 Requires Level 67, 51 Dex, 51 Int
-Socketed Gems are Supported by level 18 Added Lightning Damage
+{variant:1,2,3}Socketed Gems are Supported by level 18 Added Lightning Damage
+{variant:4}Socketed Gems are Supported by level 30 Added Lightning Damage
 {variant:1,3}Adds 1 to 100 Lightning Damage to Attacks
 {variant:2}Adds 1 to 40 Lightning Damage to Attacks
 10% increased Attack Speed
-+(25-30) to maximum Energy Shield
-10% increased Stun Duration on Enemies
-100% increased Duration of Lightning Ailments
+{variant:1,2,3}+(25-30) to maximum Energy Shield
+{variant:4}(150-200)% increased Evasion and Energy Shield
+{variant:1,2,3}10% increased Stun Duration on Enemies
+{variant:1,2,3}100% increased Duration of Lightning Ailments
+{variant:4}100% increased effect of Lightning Ailments
 ]],
 -- Gloves: Ward
 [[

--- a/src/Data/Uniques/ring.lua
+++ b/src/Data/Uniques/ring.lua
@@ -1028,26 +1028,29 @@ Prismatic Ring
 Variant: Pre 1.0.0
 Variant: Pre 1.1.0
 Variant: Pre 2.6.0
+Variant: Pre 3.19.0
 Variant: Current
 Requires Level 30
 Implicits: 2
 {variant:1}{tags:jewellery_resistance}+(8-12) to all Elemental Resistances
-{variant:2,3,4}{tags:jewellery_resistance}+(8-10)% to all Elemental Resistances
+{variant:2,3,4,5}{tags:jewellery_resistance}+(8-10)% to all Elemental Resistances
 {variant:1,2}(15-25)% increased Quantity of Items found
-{variant:3,4}(10-16)% increased Quantity of Items found
+{variant:3,4,5}(10-16)% increased Quantity of Items found
 Can't use other Rings
 {variant:1,2,3}{tags:jewellery_resistance}+(8-12)% to all Elemental Resistances
 {variant:4}{tags:jewellery_resistance}+(16-24)% to all Elemental Resistances
+{variant:5}{tags:jewellery_resistance}+(25-40)% to all Elemental Resistances
 {tags:caster}50% reduced Effect of Curses on You
 {variant:1,2,3}{tags:attack,life}+(20-30) Life gained for each Enemy hit by your Attacks
-{variant:4}{tags:attack,life}+(40-60) Life gained for each Enemy hit by your Attacks
+{variant:4,5}{tags:attack,life}+(40-60) Life gained for each Enemy hit by your Attacks
 {variant:1,2,3}{tags:attack,mana}+15 Mana gained for each Enemy hit by your Attacks
-{variant:4}{tags:attack,mana}+30 Mana gained for each Enemy hit by your Attacks
+{variant:4,5}{tags:attack,mana}+30 Mana gained for each Enemy hit by your Attacks
 ]],[[
 Timeclasp
 Moonstone Ring
 Variant: Pre 2.6.0
 Variant: Pre 3.17.0
+Variant: Pre 3.19.0
 Variant: Current
 Requires Level 22
 Implicits: 1
@@ -1055,15 +1058,19 @@ Implicits: 1
 {tags:attack,speed}(10-15)% increased Attack Speed
 {variant:1}{tags:caster,speed}(5-8)% increased Cast Speed
 {variant:2,3}{tags:caster,speed}(5-10)% increased Cast Speed
+{variant:4}{tags:caster,speed}(10-15)% increased Cast Speed
 {variant:1}{tags:mana}15% reduced Mana Regeneration Rate
 {variant:2,3}{tags:mana}15% increased Mana Regeneration Rate
+{variant:4}{tags:ressource,life}(6-12)% of Damage Taken Recouped as Life
+{variant:4}{tags:ressource,mana}(6-12)% of Damage Taken Recouped as Mana
 {variant:1}{tags:jewellery_defense}+(10-25) to maximum Energy Shield
 {variant:2}{tags:jewellery_defense}+(15-25) to maximum Energy Shield
 {variant:3}{tags:jewellery_defense}+(40-45) to maximum Energy Shield
 {variant:1}{tags:caster}Temporal Chains has 30% reduced Effect on You
 {variant:2}{tags:caster}Temporal Chains has 50% reduced Effect on You
 {variant:3}(-10-10)% increased Skill Effect Duration
-{variant:3}Unaffected by Temporal Chains
+{variant:4}(-20-20)% increased Skill Effect Duration
+{variant:3,4}Unaffected by Temporal Chains
 ]],[[
 Timetwist
 Moonstone Ring

--- a/src/Data/Uniques/shield.lua
+++ b/src/Data/Uniques/shield.lua
@@ -366,14 +366,17 @@ Thousand Teeth Temu
 Vaal Buckler
 Variant: Pre 2.6.0
 Variant: Pre 3.0.0
+Variant: Pre 3.19.0
 Variant: Current
 Implicits: 1
-{variant:3}3% increased Movement Speed
+{variant:3,4}3% increased Movement Speed
 (100-120)% increased Evasion Rating
 +(70-90) to maximum Life
 0.4% of Physical Attack Damage Leeched as Life
-+5% Chance to Block
-Reflects 1 to 1000 Physical Damage to Attackers on Block
+{variant:1,2,3}+5% Chance to Block
+{variant:4}+10% Chance to Block
+{variant:1,2,3}Reflects 1 to 1000 Physical Damage to Attackers on Block
+{variant:4}Reflects 1000 to 10000 Physical Damage to Attackers on Block
 {variant:2,3}10% of Damage you Reflect to Enemies when Hit is gained as Life
 ]],
 -- Shield: Energy Shield
@@ -726,13 +729,16 @@ Cannot be Frozen
 Wheel of the Stormsail
 Rotted Round Shield
 Variant: Pre 3.16.0
+Variant: Pre 3.19.0
 Variant: Current
 Implicits: 1
 60% increased Block Recovery
-+(5-10) to Armour
+{variant:1,2}+(5-10) to Armour
+{variant:3}+(20-40) to Evasion Rating
 (30-40)% increased Rarity of Items found
 100% increased Duration of Curses on you
-+5% Chance to Block
+{variant:1,2}+5% Chance to Block
+{variant:3}(50-75)% to Lightning Resistance
 {variant:1}Curse Skills have 25% increased Skill Effect Duration
 {variant:2}Curse Skills have 100% increased Skill Effect Duration
 ]],


### PR DESCRIPTION
Tear of Purity: perfect
Thief's Torment: perfect
Thousand Ribbons: perfect
Thousand Teeth Temu: perfect
Thunderfist :unsure of affix position
Timeclasp: unsure of affix position
Vaal Caress: perfect
Victario's Flight: do we want to support "Quicksilver Flasks you Use also apply to nearby Allies"?
Warped Timepiece: unsure of affix position
Wheel of the Stormsail: unsure of affix position
Windscream: perfect
Wondertrap: perfect
Voltaxic Rift: should be perfect: Hits with this Weapon Shock Enemies as though dealing 300% more Damage already implemented, max effect of shock is implemented in https://github.com/PathOfBuildingCommunity/PathOfBuilding/pull/4750
Tavukai: perfect