### PR TITLE
Fix: Selected Mastery Tree Upconversion Error

### DIFF
--- a/src/Classes/PassiveSpec.lua
+++ b/src/Classes/PassiveSpec.lua
@@ -852,11 +852,16 @@ function PassiveSpecClass:BuildAllDependsAndPaths()
 	for id, node in pairs(self.nodes) do
 		if node.type == "Mastery" and self.masterySelections[id] then
 			local effect = self.tree.masteryEffects[self.masterySelections[id]]
-			node.sd = effect.sd
-			node.allMasteryOptions = false
-			node.reminderText = { "Tip: Right click to select a different effect" }
-			self.tree:ProcessStats(node)
-			self.allocatedMasteryCount = self.allocatedMasteryCount + 1
+			if effect then
+				node.sd = effect.sd
+				node.allMasteryOptions = false
+				node.reminderText = { "Tip: Right click to select a different effect" }
+				self.tree:ProcessStats(node)
+				self.allocatedMasteryCount = self.allocatedMasteryCount + 1
+			else
+				self.nodes[id].alloc = false
+				self.allocNodes[id] = nil
+			end
 		elseif node.type == "Mastery" then
 			self:AddMasteryEffectOptionsToNode(node)
 		elseif node.type == "Notable" and node.alloc then


### PR DESCRIPTION
Fixes error: When upconverting between trees, if a Mastery lost a mod from its pool that was allocated it would throw an error.

### Description of the problem being solved:
Crash on up conversion related to mastery index selections that went away but were allocated on the tree being upconverted.

### Steps taken to verify a working solution:
- Using Reggie's 3.19 Tree upconvert the build link provided below (without this PR)
- See crash
- Add this PR, see that no crash, plus that Mastery allocation (`Reservation Mastery` -> `15% increased Mana Reservation Efficiency of Skills`) is no unallocated and Passive Skill Point is refunded.

### Link to a build that showcases this PR:
https://pobb.in/SzBELuhWm4p0

### Before screenshot:
![Before](https://user-images.githubusercontent.com/1735956/184413474-d2c61bb8-777c-4003-82bf-69b32dd10f94.png)

### After screenshot:
![After](https://user-images.githubusercontent.com/1735956/184413691-a7dc1768-08f8-4ee2-8f0f-13f31b66793c.png)
