### PR TITLE
[Kalandra] Batch of unique update. All remaining from M to O

### DIFF
--- a/src/Data/Uniques/gloves.lua
+++ b/src/Data/Uniques/gloves.lua
@@ -856,7 +856,7 @@ Variant: Current
 Requires Level 5
 {variant:1}20% increased Attack Speed when on Full Life
 {variant:2,3}30% increased Attack Speed when on Full Life
-{variant:1}Adds 1 to 13 Lightning Damage to Attacks
+{variant:1,2}Adds 1 to 13 Lightning Damage to Attacks
 {variant:3}Adds (1-4) to (30-50) Lightning Damage to Attacks
 {variant:1,2}+(50-80) to Accuracy Rating
 {variant:3}+(100-200) to Accuracy Rating

--- a/src/Data/Uniques/gloves.lua
+++ b/src/Data/Uniques/gloves.lua
@@ -113,13 +113,18 @@ Meginord's Vise
 Steel Gauntlets
 Variant: Pre 1.1.0
 Variant: Pre 2.6.0
+Variant: Pre 3.19.0
 Variant: Current
 Requires Level 35, 52 Str
-10% increased Physical Damage
-+100 to Strength
+{variant:1,2,3}10% increased Global Physical Damage
+{variant:1,2,3}+100 to Strength
+{variant:4}+50 to Strength
 {variant:1}(5-15)% reduced Attack Speed
 (40-60)% increased Armour
 {variant:3}2% of Life Regenerated per second with at least 400 Strength
+{variant:4}100% increased Knockback Distance
+{variant:4}Melee Hits with Strike Skills Always Knockback
+{variant:4}Melee Strike Skills deal Splash Damage to surrounding targets
 ]],[[
 Veruso's Battering Rams
 Titan Gauntlets
@@ -846,14 +851,17 @@ Lose a Power Charge each second if you have not Detonated Mines Recently
 Ondar's Clasp
 Wrapped Mitts
 Variant: Pre 1.1.0
+Variant: Pre 3.19.0
 Variant: Current
 Requires Level 5
 {variant:1}20% increased Attack Speed when on Full Life
-{variant:2}30% increased Attack Speed when on Full Life
-Adds 1 to 13 Lightning Damage to Attacks
-+(50-80) to Accuracy Rating
+{variant:2,3}30% increased Attack Speed when on Full Life
+{variant:1}Adds 1 to 13 Lightning Damage to Attacks
+{variant:3}Adds (1-4) to (30-50) Lightning Damage to Attacks
+{variant:1,2}+(50-80) to Accuracy Rating
+{variant:3}+(100-200) to Accuracy Rating
 {variant:1}(10-15)% increased Movement Speed when on Low Life
-{variant:2}20% increased Movement Speed when on Low Life
+{variant:2,3}20% increased Movement Speed when on Low Life
 ]],[[
 Malachai's Mark
 Murder Mitts

--- a/src/Data/Uniques/mace.lua
+++ b/src/Data/Uniques/mace.lua
@@ -455,40 +455,47 @@ Void Sceptre
 Variant: Pre 1.2.0
 Variant: Pre 2.3.0
 Variant: Pre 2.6.0
+Variant: Pre 3.19.0
 Variant: Current
 Requires Level 68, 104 Str, 122 Int
 Implicits: 2
 {variant:1,2}15% increased Elemental Damage
-{variant:3,4}40% increased Elemental Damage
+{variant:3,4,5}40% increased Elemental Damage
 50% reduced maximum number of Raised Zombies
 {variant:1}Raised Zombies have +500 to maximum Life
 {variant:2,3}Raised Zombies have +2000 to maximum Life
-{variant:4}Raised Zombies have +5000 to maximum Life
+{variant:4,5}Raised Zombies have +5000 to maximum Life
 Raised Zombies have +(25-30)% to all Resistances
 25% increased Zombie Size
-Enemies killed by Zombies explode dealing 20% of their Maximum Life as Fire Damage
+{variant:1,2,3,4}Enemies killed by Zombies explode dealing 20% of their Maximum Life as Fire Damage
+{variant:5}Enemies killed by Zombies explode dealing 50% of their Maximum Life as Fire Damage
 {variant:1,2,3}Raised Zombies deal (80-100)% increased Physical Damage
 {variant:4}Raised Zombies deal (80-100)% more Physical Damage
+{variant:5}Raised Zombies deal (100-125)% more Physical Damage
 ]],[[
 Nycta's Lantern
 Crystal Sceptre
 Variant: Pre 2.0.0
 Variant: Pre 2.3.0
 Variant: Pre 2.6.0
+Variant: Pre 3.19.0
 Variant: Current
 Requires Level 41, 59 Str, 85 Int
 Implicits: 2
 {variant:1,2}20% increased Elemental Damage
-{variant:3,4}30% increased Elemental Damage
+{variant:3,4,5}30% increased Elemental Damage
 {variant:4}+2 to Level of Socketed Fire Gems
 {variant:1,2,3}Socketed Gems are Supported by level 10 Added Fire Damage
 {variant:1,2,3}Socketed Gems are Supported by level 10 Cold to Fire
-Socketed Gems are Supported by level 10 Fire Penetration
+{variant:1,2,3,4}Socketed Gems are Supported by level 10 Fire Penetration
 {variant:4}Socketed Gems deal 63 to 94 additional Fire Damage
-(20-30)% increased Spell Damage
-{variant:2,3,4}(150-200)% increased Physical Damage
-+(6-10) Life gained for each Enemy hit by Attacks
-25% increased Light Radius
+{variant:1,2,3,4}(20-30)% increased Spell Damage
+{variant:2,3,4,5}(150-200)% increased Physical Damage
+{variant:5}Adds (76-98) to (161-176) Fire Damage
+{variant:1,2,3,4}+(6-10) Life gained for each Enemy hit by Attacks
+{variant:1,2,3,4}25% increased Light Radius
+{variant:5}50% increased Light Radius
+{variant:5}Battlemage
 ]],[[
 Sign of the Sin Eater
 Tyrant's Sekhem

--- a/src/Data/Uniques/ring.lua
+++ b/src/Data/Uniques/ring.lua
@@ -655,6 +655,7 @@ Ming's Heart
 Amethyst Ring
 Variant: Pre 2.6.0
 Variant: Pre 3.0.0
+Variant: Pre 3.19.0
 Variant: Current
 Requires Level 69
 Implicits: 1
@@ -662,22 +663,30 @@ Implicits: 1
 {variant:1}{tags:life}15% reduced maximum Life
 {variant:2}{tags:life}10% reduced maximum Life
 {variant:3}{tags:life}(5-10)% reduced maximum Life
+{variant:4}{tags:life}25% reduced maximum Life
 {variant:1}{tags:jewellery_defense}15% reduced maximum Energy Shield
 {variant:2}{tags:jewellery_defense}10% reduced maximum Energy Shield
 {variant:3}{tags:jewellery_defense}(5-10)% reduced maximum Energy Shield
+{variant:4}{tags:jewellery_defense}25% reduced maximum Energy Shield
 {tags:chaos,jewellery_resistance}+(40-50)% to Chaos Resistance
-{tags:chaos,physical}Gain 20% of Physical Damage as Extra Chaos Damage
+{variant:1,2,3}{tags:chaos,physical}Gain 20% of Physical Damage as Extra Chaos Damage
+{variant:4}{tags:chaos,physical}Gain (40-60)% of Physical Damage as Extra Chaos Damage
 ]],[[
 Mokou's Embrace
 Ruby Ring
+Variant: Pre 3.19.0
+Variant: Current
 Requires Level 16
 Implicits: 1
 {tags:jewellery_resistance}+(20-30)% to Fire Resistance
-{tags:jewellery_elemental}(15-25)% increased Fire Damage
+{variant:1}{tags:jewellery_elemental}(15-25)% increased Fire Damage
 {tags:jewellery_resistance}+(25-40)% to Cold Resistance
-{tags:jewellery_elemental}(5-10)% chance to Ignite
-{tags:attack,speed}20% increased Attack Speed while Ignited
-{tags:caster,speed}20% increased Cast Speed while Ignited
+{variant:1}{tags:jewellery_elemental}(5-10)% chance to Ignite
+{variant:2}{tags:jewellery_elemental}All Damage Taken from Hits can Ignite you
+{variant:1}{tags:attack,speed}20% increased Attack Speed while Ignited
+{variant:2}{tags:attack,speed}(25-40)% increased Attack Speed while Ignited
+{variant:1}{tags:caster,speed}20% increased Cast Speed while Ignited
+{variant:2}{tags:caster,speed}(25-40)% increased Cast Speed while Ignited
 {tags:jewellery_elemental}+25% chance to be Ignited
 ]],[[
 Mutewind Seal

--- a/src/Data/Uniques/shield.lua
+++ b/src/Data/Uniques/shield.lua
@@ -566,16 +566,20 @@ equal to 25% of Sacrificed Mana for 4 seconds
 Matua Tupuna
 Tarnished Spirit Shield
 Variant: Pre 3.0.0
+Variant: Pre 3.19.0
 Variant: Current
 Implicits: 2
 {variant:1}5% increased Spell Damage
-{variant:2}(5-10)% increased Spell Damage
+{variant:2,3}(5-10)% increased Spell Damage
 +2 to Level of Socketed Minion Gems
 (40-80)% increased Energy Shield
 +(15-25) to maximum Mana
-10% increased effect of Non-Curse Auras from your Skills on your Minions
-Spreads Tar when you take a Critical Strike
-10% increased effect of Non-Curse Auras from your Skills
+{variant:1,2}10% increased effect of Non-Curse Auras from your Skills on your Minions
+{variant:3}20% increased effect of Non-Curse Auras from your Skills on your Minions
+{variant:1,2}Spreads Tar when you take a Critical Strike
+{variant:3}Spreads Tar when you Block
+{variant:1,2}10% increased effect of Non-Curse Auras from your Skills
+{variant:3}20% increased effect of Non-Curse Auras from your Skills
 ]],[[
 Whakatutuki o Matua
 Tarnished Spirit Shield

--- a/src/Data/Uniques/wand.lua
+++ b/src/Data/Uniques/wand.lua
@@ -158,17 +158,18 @@ Obliteration
 Demon's Horn
 Variant: Pre 2.3.0
 Variant: Pre 3.10.0
+Variant: Pre 3.19.0
 Variant: Current
 Requires Level 56, 179 Int
 Implicits: 2
 {variant:1}(15-18)% increased Spell Damage
-{variant:2,3}(31-35)% increased Spell Damage
+{variant:2,3,4}(31-35)% increased Spell Damage
 {variant:1,2}Adds (24-30) to (80-92) Physical Damage
 {variant:3}Adds (25-50) to (85-125) Physical Damage
-(26-32)% increased Critical Strike Chance
-Gain (13-15)% of Physical Damage as Extra Chaos Damage
-Enemies you Kill have a 20% chance to Explode, dealing a quarter
-of their maximum Life as Chaos Damage
+{variant:1,2,3}(26-32)% increased Critical Strike Chance
+{variant:1,2,3}Gain (13-15)% of Physical Damage as Extra Chaos Damage
+{variant:4}Gain (30-40)% of Physical Damage as Extra Chaos Damage
+Enemies you Kill have a 20% chance to Explode, dealing a quarter of their maximum Life as Chaos Damage
 ]],[[
 Piscator's Vigil
 Tornado Wand


### PR DESCRIPTION
Matua Tupuna: perfect
Meginord's Vise: unsure affix order
Ming's Heart: perfect
Mokou's Embrace: attack and cast speed two affixes or one affix? it was 2. GGG patchnote " It also now has 25-40% increased Attack and Cast Speed while Ignited (both previously 20%)" ambigous
Mon'tregul's Grasp: perfect
Nycta's Lantern: perfect
Obliteration: perfect
Ondar's Clasp: perfect