### PR TITLE
[Kalandra] Batch of uniques update. All missingfrom D to L

### DIFF
--- a/src/Data/Uniques/amulet.lua
+++ b/src/Data/Uniques/amulet.lua
@@ -517,17 +517,21 @@ Jade Amulet
 League: Synthesis
 Requires Level 64
 Variant: Pre 3.16.0
+Variant: Pre 3.19.0
 Variant: Current
 Implicits: 1
 {tags:jewellery_attribute}+(20-30) to Dexterity
 Grants Level 22 Precision Skill
-{tags:jewellery_attribute}+(25-35) to Dexterity
-{tags:attack,physical}Adds (12-15) to (24-28) Physical Damage to Attacks
-{tags:jewellery_elemental,attack}Adds (11-15) to (23-28) Cold Damage to Attacks
-+(23-28)% to Global Critical Strike Multiplier
-{tags:attack,life,physical}(0.8-1)% of Physical Attack Damage Leeched as Life
+{variant:1,2}{tags:jewellery_attribute}+(25-35) to Dexterity
+{variant:3}{tags:jewellery_attribute}+(40-80) to Dexterity
+{variant:1,2}{tags:attack,physical}Adds (12-15) to (24-28) Physical Damage to Attacks
+{variant:1,2}{tags:jewellery_elemental,attack}Adds (11-15) to (23-28) Cold Damage to Attacks
+{variant:3}Bow Attacks have Culling Strike
+{variant:1,2}{tags:critical}+(23-28)% to Global Critical Strike Multiplier
+{variant:3}{tags:critical}+(25-50)% to Global Critical Strike Multiplier
+{variant:1,2}{tags:attack,life,physical}(0.8-1)% of Physical Attack Damage Leeched as Life
 {variant:1}Precision has 50% less Reservation
-{variant:2}Precision has 100% increased Mana Reservation Efficiency
+{variant:2,3}Precision has 100% increased Mana Reservation Efficiency
 ]],[[
 Replica Hyrri's Truth
 Jade Amulet
@@ -548,14 +552,19 @@ Grants Level 22 Hatred Skill
 ]],[[
 The Ignomon
 Gold Amulet
+Variant: Pre 3.19.0
+Variant: Current
 Requires Level 8
 Implicits: 1
 (12-20)% increased Rarity of Items found
-{tags:jewellery_attribute}+10 to Dexterity
-{tags:jewellery_elemental,attack}Adds 12 to 24 Fire Damage to Attacks
+{variant:1}{tags:jewellery_attribute}+10 to Dexterity
+{variant:1}{tags:jewellery_elemental,attack}Adds 12 to 24 Fire Damage to Attacks
+{variant:2}{tags:jewellery_elemental,attack}Adds (18-24) to (32-40) Fire Damage to Attacks
 {tags:attack}+(100-150) to Accuracy Rating
 {tags:jewellery_defense}+(100-150) to Evasion Rating
 {tags:jewellery_resistance}+20% to Fire Resistance
+{variant:2}20% to Light Radius
+{variant:2}Nearby Enemies are Blinded
 ]],[[
 The Effigon
 Gold Amulet

--- a/src/Data/Uniques/body.lua
+++ b/src/Data/Uniques/body.lua
@@ -257,14 +257,18 @@ Your Hexes can affect Hexproof Enemies
 Foxshade
 Wild Leather
 Variant: Pre 2.6.0
+Variant: Pre 3.19.0
 Variant: Current
 Implicits: 0
 +(20-30) to Dexterity
-Adds 5 to 12 Physical Damage to Attacks
+{variant:1,2}Adds 5 to 12 Physical Damage to Attacks
 {variant:1}You gain 150 Evasion Rating when on Full Life
-{variant:2}You gain 500 Evasion Rating when on Full Life
+{variant:2}+500 to Evasion Rating while on Full Life
+{variant:3}+1000 to Evasion Rating while on Full Life
 (50-70)% increased Evasion Rating
-10% increased Movement Speed
+{variant:1,2}10% increased Movement Speed
+{variant:3}30% increased Movement Speed while on Full Life
+{variant:3}Damage of Enemies hitting you is Unlucky while you are on Full Life
 ]],[[
 Fox's Fortune
 Wild Leather
@@ -301,12 +305,17 @@ Implicits: 0
 ]],[[
 Kintsugi
 Exquisite Leather
+Variant: Pre 3.19.0
+Variant: Current
 Implicits: 0
-(100-120)% increased Evasion Rating
-+(60-80) to maximum Life
+{variant:1}(100-120)% increased Evasion Rating
+{variant:2}(120-160)% increased Evasion Rating
+{variant:1}+(60-80) to maximum Life
 +30% to Fire Resistance
-20% less Damage taken if you have not been Hit Recently
-50% increased Evasion if you have been Hit Recently
+{variant:1}20% less Damage taken if you have not been Hit Recently
+{variant:2}35% less Damage taken if you have not been Hit Recently
+{variant:1}50% increased Evasion if you have been Hit Recently
+{variant:2}100% increased Evasion if you have been Hit Recently
 ]],[[
 Queen of the Forest
 Destiny Leather
@@ -541,15 +550,17 @@ Infernal Mantle
 Widowsilk Robe
 Variant: Pre 3.0.0
 Variant: Pre 3.14.0
+Variant: Pre 3.19.0
 Variant: Current
 Implicits: 0
-+1 to Level of Socketed Fire Gems
-(25-35)% increased Fire Damage
+{variant:1,2,3}+1 to Level of Socketed Fire Gems
+{variant:4}+3 to Level of Socketed Fire Gems
+{variant:1,2,3}(25-35)% increased Fire Damage
 100% increased Global Critical Strike Chance
 {variant:1}(190-230)% increased Energy Shield
-{variant:2,3}(120-160)% increased Energy Shield
+{variant:2,3,4}(120-160)% increased Energy Shield
 15% of Fire Damage Converted to Chaos Damage
-{variant:1}100% increased Spell Damage taken when on Low Mana
+{variant:1,4}100% increased Spell Damage taken when on Low Mana
 {variant:2}25% increased Spell Damage taken when on Low Mana
 {variant:3}15% increased Spell Damage taken when on Low Mana
 ]],[[
@@ -732,15 +743,19 @@ You have Onslaught while you have Cat's Agility
 Gruthkul's Pelt
 Wyrmscale Doublet
 Variant: Pre 3.5.0
+Variant: Pre 3.19.0
 Variant: Current
 Implicits: 0
 {variant:1}(60-100)% increased Global Physical Damage
-{variant:2}100% increased Global Physical Damage
+{variant:2,3}100% increased Global Physical Damage
+{variant:3}(300-400)% increased Armour and Evasion Rating
 {variant:1}+(130-160) to maximum Life
 {variant:2}+(200-240) to maximum Life
-+(20-40)% to Cold Resistance
+{variant:3}+(240-300) to maximum Life
+{variant:1,2}+(20-40)% to Cold Resistance
 {variant:1}2% of Life Regenerated per second
 {variant:2}5% of Life Regenerated per second
+{variant:3}10% of Life Regenerated per second
 15% increased Character Size
 Spell Skills deal no Damage
 Your Spells are disabled
@@ -748,6 +763,7 @@ Your Spells are disabled
 Lightning Coil
 Desert Brigandine
 Variant: Pre 1.3.0
+Variant: Pre 3.19.0
 Variant: Current
 Implicits: 0
 Adds 1 to (20-30) Lightning Damage to Attacks
@@ -756,6 +772,7 @@ Adds 1 to (20-30) Lightning Damage to Attacks
 −60% to Lightning Resistance
 {variant:1}40% of Physical Damage from Hits taken as Lightning Damage
 {variant:2}30% of Physical Damage from Hits taken as Lightning Damage
+{variant:3}50% of Physical Damage from Hits taken as Lightning Damage
 ]],[[
 Viper's Scales
 Full Scale Armour
@@ -840,16 +857,18 @@ Zealot's Oath
 Icetomb
 Latticed Ringmail
 Variant: Pre 2.0.0
+Variant: Pre 3.19.0
 Variant: Current
 Implicits: 0
 {variant:1}+15 to Strength
-{variant:2}+(30-40) to Strength
+{variant:2,3}+(30-40) to Strength
 {variant:1}+15 to Intelligence
-{variant:2}+(30-40) to Intelligence
+{variant:2,3}+(30-40) to Intelligence
 (140-160)% increased Armour and Energy Shield
 +(50-75)% to Cold Resistance
 Cannot be Chilled
-150% increased Chill Duration on Enemies
+{variant:1,2}150% increased Chill Duration on Enemies
+{variant:3}20% chance to Freeze Enemies for 1 second when Hit
 ]],[[
 Crystal Vault
 Latticed Ringmail

--- a/src/Data/Uniques/boots.lua
+++ b/src/Data/Uniques/boots.lua
@@ -579,16 +579,20 @@ Requires Level 65, 62 Str, 62 Dex
 Dusktoe
 Ironscale Boots
 Variant: Pre 2.6.0
+Variant: Pre 3.19.0
 Variant: Current
 Requires Level 18, 19 Str, 19 Dex
-(40-60)% increased Armour and Evasion
+{variant:1,2}(40-60)% increased Armour and Evasion
+{variant:3}(60-100)% increased Armour and Evasion
 {variant:1}+(10-20) to maximum Life
 {variant:2}+(20-30) to maximum Life
 {variant:1}+(10-20) to maximum Mana
-15% increased Movement Speed
-50% increased Stun Recovery
+{variant:1,2}15% increased Movement Speed
+{variant:3}20% increased Movement Speed
+{variant:1,2}50% increased Stun and Block Recovery
 20% reduced Light Radius
 {variant:2}Adds (15-20) to (25-30) Chaos Damage to Spells and Attacks while using a Flask
+{variant:3}Adds (30-40) to (50-60) Chaos Damage to Spells and Attacks while using a Flask
 +50% to Chaos Resistance while using a Flask
 ]],[[
 Dusktoe

--- a/src/Data/Uniques/bow.lua
+++ b/src/Data/Uniques/bow.lua
@@ -188,18 +188,20 @@ Royal Bow
 Variant: Pre 2.0.0
 Variant: Pre 2.6.0
 Variant: Pre 3.1.0
+Variant: Pre 3.19.0
 Variant: Current
 Requires Level 28, 95 Dex
 Implicits: 2
 {variant:2}(6-12)% increased Elemental Damage with Attack Skills
-{variant:3,4}(20-24)% increased Elemental Damage with Attack Skills
+{variant:3,4,5}(20-24)% increased Elemental Damage with Attack Skills
 {variant:2,3}Adds (8-12) to (16-20) Physical Damage
-{variant:4}Adds (12-16) to (20-24) Physical Damage
+{variant:4,5}Adds (12-16) to (20-24) Physical Damage
 (10-14)% increased Attack Speed
 {variant:1,2,3}(30-40)% increased Critical Strike Chance
 60% increased Mana Regeneration Rate
 {variant:1,2,3}Gain 110% of Bow Physical Damage as Extra Damage of an Element
 {variant:4}Gain 100% of Bow Physical Damage as Extra Damage of an Element
+{variant:5}Gain 100% of Bow Physical Damage as Extra Damage of each Element
 ]],[[
 Doomfletch's Prism
 Royal Bow

--- a/src/Data/Uniques/gloves.lua
+++ b/src/Data/Uniques/gloves.lua
@@ -91,15 +91,21 @@ Socketed Gems are Supported by level 10 Knockback
 ]],[[
 Giantsbane
 Bronze Gauntlets
+Variant: Pre 3.19.0
+Variant: Current
 Requires Level: 23, 36 Str
-Adds (3-6) to (10-12) Physical Damage to Attacks
 +(30-40) to Strength
+{variant:1}Adds (3-6) to (10-12) Physical Damage to Attacks
+{variant:2}Adds (5-8) to (12-16) Physical Damage to Attacks
 (80-100)% increased Armour
+{variant:2}10% reduced Attack Speed
+{variant:2}Arrows Pierce 2 additional Targets
 Iron Grip
 ]],[[
 Lochtonial Caress
 Iron Gauntlets
 Variant: Pre 2.6.0
+Variant: Pre 3.19.0
 Variant: Current
 (10-15)% increased Attack Speed
 {variant:1}+(10-20) to Armour
@@ -107,6 +113,7 @@ Variant: Current
 (10-15)% reduced maximum Mana
 (10-15)% increased Cast Speed
 {variant:2}10% chance to gain a Frenzy, Power or Endurance Charge on Kill
+{variant:3}(10-15)% chance to gain a Frenzy, Power or Endurance Charge on Kill
 Conduit
 ]],[[
 Meginord's Vise
@@ -167,17 +174,20 @@ Adds (8-12) to (15-20) Physical Damage to Attacks
 Hrimsorrow
 Goathide Gloves
 Variant: Pre 2.6.0
+Variant: Pre 3.19.0
 Variant: Current
 Requires Level 9, 17 Dex
 +(20-30) to Strength
 {variant:1}50% increased Evasion Rating
-{variant:2}+(40-50) to Evasion Rating
+{variant:2,3}+(40-50) to Evasion Rating
 {variant:1}+(10-20)% to Cold Resistance
-{variant:2}+(20-30)% to Cold Resistance
+{variant:2,3}+(20-30)% to Cold Resistance
 {variant:2}Adds (5-7) to (13-15) Cold Damage to Spells and Attacks
 {variant:1}25% of Physical Damage Converted to Cold Damage
 {variant:2}50% of Physical Damage Converted to Cold Damage
-Reflects 10 Cold Damage to Melee Attackers
+{variant:3}100% of Physical Damage Converted to Cold Damage
+{variant:1,2}Reflects 10 Cold Damage to Melee Attackers
+{variant:3}Reflects 100 Cold Damage to Melee Attackers
 ]],[[
 Hrimburn
 Goathide Gloves
@@ -315,14 +325,18 @@ Sacrifice 5% of Life to gain that much Energy Shield when you Cast a Spell
 Doedre's Tenure
 Velvet Gloves
 Variant: Pre 2.6.0
+Variant: Pre 3.19.0
 Variant: Current
 Requires Level 12, 21 Int
 {variant:1}(40-50)% increased Spell Damage
 {variant:2}(50-60)% increased Spell Damage
+{variant:3}100% increased Spell Damage
 {variant:1}+10 to Intelligence
 {variant:2}+20 to Intelligence
+{variant:3}+(20-50) to Intelligence
 {variant:1}20% reduced Cast Speed
 {variant:2}15% reduced Cast Speed
+{variant:3}(15-25)% reduced Cast Speed
 {variant:1}+16 to maximum Energy Shield
 {variant:2}+32 to maximum Energy Shield
 ]],[[

--- a/src/Data/Uniques/ring.lua
+++ b/src/Data/Uniques/ring.lua
@@ -484,13 +484,18 @@ Minions have 10% increased Area of Effect of Area Skills
 The Highwayman
 Gold Ring
 League: Heist
+Variant: Pre 3.19.0
+Variant: Current
 Requires Level 44
 Implicits: 1
 (6-15)% increased Rarity of Items found
 (15-25)% increased Rarity of Items found
-{tags:speed}5% increased Movement Speed
-25% chance to Steal Power, Frenzy, and Endurance Charges on Hit
-0.5% of Damage Leeched as Life while you have at least 5 total Endurance, Frenzy and Power Charges
+{variant:1}{tags:speed}5% increased Movement Speed
+{variant:2}{tags:speed}(5-10)% increased Movement Speed
+{variant:1}25% chance to Steal Power, Frenzy, and Endurance Charges on Hit
+{variant:2}100% chance to Steal Power, Frenzy, and Endurance Charges on Hit
+{variant:1}0.5% of Damage Leeched as Life while you have at least 5 total Endurance, Frenzy and Power Charges
+{variant:2}{tags:life}1% of Damage leeched as Life
 Total Recovery per second from Life Leech is Doubled
 ]],[[
 The Hungry Loop
@@ -518,12 +523,14 @@ Poisoned Enemies you Kill with Hits Shatter
 Kaom's Sign
 Coral Ring
 Variant: Pre 2.0.0
+Variant: Pre 3.19.0
 Variant: Current
 Implicits: 1
 {tags:life}+(20-30) to maximum Life
 {tags:jewellery_attribute}+(10-20) to Strength
 {variant:1}{tags:attack,life,physical}0.4% of Physical Attack Damage Leeched as Life
 {variant:2}{tags:attack,life}+(2-4) Life gained for each Enemy hit by your Attacks
+{variant:3}Grants Level 10 Enduring Cry
 +1 Maximum Endurance Charge
 ]],[[
 Kaom's Way
@@ -545,6 +552,7 @@ Kikazaru
 Topaz Ring
 Variant: Pre 2.6.0
 Variant: Pre 3.16.0
+Variant: Pre 3.19.0
 Variant: Current
 Requires Level 20
 Implicits: 1
@@ -552,10 +560,11 @@ Implicits: 1
 {tags:jewellery_attribute}+(10-15) to all Attributes
 {variant:1}{tags:life}(13-17) Life Regenerated per second
 {variant:2,3}{tags:life}1 Life Regenerated per second per Level
+{variant:4}{tags:life}3 Life Regenerated per second per Level
 {tags:mana}(20-40)% increased Mana Regeneration Rate
 {variant:1}{tags:caster}20% reduced Effect of Curses on You
 {variant:2}{tags:caster}40% reduced Effect of Curses on You
-{variant:3}{tags:caster}60% reduced Effect of Curses on You
+{variant:3,4}{tags:caster}60% reduced Effect of Curses on You
 ]],[[
 Le Heup of All
 Iron Ring

--- a/src/Data/Uniques/shield.lua
+++ b/src/Data/Uniques/shield.lua
@@ -775,11 +775,14 @@ Create Profane Ground instead of Consecrated Ground
 Emperor's Vigilance
 Steel Kite Shield
 League: Harvest
+Variant: Pre 3.19.0
+Variant: Current
 Implicits: 0
 (16-22)% Chance to Block Spell Damage
-(300-400)% increased Armour and Energy Shield
-(10-15)% increased maximum Life
-Cannot Block while you have no Energy Shield
+{variant:1}(300-400)% increased Armour and Energy Shield
+{variant:2}1000% increased Armour and Energy Shield
+{variant:1}(10-15)% increased maximum Life
+{variant:1}Cannot Block while you have no Energy Shield
 Damage taken from Blocked Hits cannot bypass Energy Shield
 Damage taken from Unblocked hits always bypasses Energy Shield
 Glancing Blows

--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -2632,6 +2632,7 @@ local specialModList = {
 		mod("ExtraAura", "LIST", { mod = mod("Speed", "INC", num) }, { type = "Condition", var = "UsedWarcryRecently" }),
 		mod("ExtraAura", "LIST", { mod = mod("MovementSpeed", "INC", num) }, { type = "Condition", var = "UsedWarcryRecently" }),
 	} end,
+	["(%d+)%% increased movement speed while on full life"] = function(num) return { mod("MovementSpeed", "INC", num, { type = "Condition", var = "FullLife" }) } end,
 	["when you warcry, you and nearby allies gain onslaught for 4 seconds"] = { mod("ExtraAura", "LIST", { mod = flag("Onslaught") }, { type = "Condition", var = "UsedWarcryRecently" }) },
 	["enemies in your chilling areas take (%d+)%% increased lightning damage"] = function(num) return { mod("EnemyModifier", "LIST", { mod = mod("LightningDamageTaken", "INC", num) }, { type = "ActorCondition", actor = "enemy", var = "InChillingArea" }) } end,
 	["(%d+)%% chance to sap enemies in chilling areas"] = function(num) return { mod("EnemySapChance", "BASE", num, { type = "ActorCondition", actor = "enemy", var = "InChillingArea" } ) } end,
@@ -2855,6 +2856,7 @@ local specialModList = {
 	["projectiles pierce (%d+) additional targets while you have phasing"] = function(num) return { mod("PierceCount", "BASE", num, { type = "Condition", var = "Phasing" }) } end,
 	["projectiles pierce all targets while you have phasing"] = { flag("PierceAllTargets", { type = "Condition", var = "Phasing" }) },
 	["arrows pierce an additional target"] = { mod("PierceCount", "BASE", 1, nil, ModFlag.Attack) },
+	["arrows pierce (%d+) additional targets"] = function(num) return { mod("PierceCount", "BASE", num, nil, ModFlag.Attack) } end,
 	["arrows pierce one target"] = { mod("PierceCount", "BASE", 1, nil, ModFlag.Attack) },
 	["arrows pierce (%d+) targets?"] = function(num) return { mod("PierceCount", "BASE", num, nil, ModFlag.Attack) } end,
 	["always pierce with arrows"] = { flag("PierceAllTargets", nil, ModFlag.Attack) },
@@ -3083,6 +3085,7 @@ local specialModList = {
 	["critical strikes have culling strike"] = { mod("CriticalCullPercent", "MAX", 10) },
 	["your critical strikes have culling strike"] = { mod("CriticalCullPercent", "MAX", 10) },
 	["your spells have culling strike"] = { mod("CullPercent", "MAX", 10, nil, ModFlag.Spell) },
+	["bow attacks have culling strike"] = { mod("CullPercent", "MAX", 10, nil, bor(ModFlag.Attack, ModFlag.Bow)) },
 	["culling strike against burning enemies"] = { mod("CullPercent", "MAX", 10, { type = "ActorCondition", actor = "enemy", var = "Burning" }) },
 	["culling strike against marked enemy"] = { mod("CullPercent", "MAX", 10, { type = "ActorCondition", actor = "enemy", var = "Marked" }) },
 	-- Intimidate


### PR DESCRIPTION
Doedre's Tenure: perfect
Doomfletch: perfect
Dusktoe: perfect
Emperor's Vigilance: perfect
Foxshade: perfect. implemented "increased Movement Speed while on Full Life"
Giantsbane: implemented arrow pierce 2 additional targets; unsure affix order
Gruthkul's Pelt: perfect
The Highwayman: perfect
Hrimsorrow: perfect
Hyrri's Truth: unsure about affix order; bow attacks have culling strike implemented
Icetomb: perfect. I assume we won't support chance to Freeze Enemies for 1 second when Hit
The Ignomon: unsure about affix order
Infernal Mantle: perfect
Kaom's Sign: unsure about affix order
Kikazaru: perfect
Kintsugi: perect
Lightning Coil: perfect
Lochtonial Caress: perfect
