### PR TITLE
Add support for chill and shock effect mod parsing

### DIFF
--- a/src/Modules/CalcPerform.lua
+++ b/src/Modules/CalcPerform.lua
@@ -3003,9 +3003,7 @@ function calcs.perform(env, avoidCache)
 		["Chill"] = {
 			condition = "Chilled",
 			mods = function(num)
-				local mods = {
-					modLib.createMod("ActionSpeed", "INC", -num, "Chill", { type = "Condition", var = "Chilled" })
-				}
+				local mods = { modLib.createMod("ActionSpeed", "INC", -num, "Chill", { type = "Condition", var = "Chilled" }) }
 				if output.HasBonechill and (hasGuaranteedBonechill or enemyDB:Sum("BASE", nil, "ChillVal") > 0) then
 					t_insert(mods, modLib.createMod("ColdDamageTaken", "INC", num, "Bonechill", { type = "Condition", var = "Chilled" }))
 				end
@@ -3015,33 +3013,25 @@ function calcs.perform(env, avoidCache)
 		["Shock"] = {
 			condition = "Shocked",
 			mods = function(num)
-				return {
-					modLib.createMod("DamageTaken", "INC", num, "Shock", { type = "Condition", var = "Shocked" })
-				}
+				return { modLib.createMod("DamageTaken", "INC", num, "Shock", { type = "Condition", var = "Shocked" }) }
 			end
 		},
 		["Scorch"] = {
 			condition = "Scorched",
 			mods = function(num)
-				return {
-					modLib.createMod("ElementalResist", "BASE", -num, "Scorch", { type = "Condition", var = "Scorched" })
-				}
+				return { modLib.createMod("ElementalResist", "BASE", -num, "Scorch", { type = "Condition", var = "Scorched" }) }
 			end
 		},
 		["Brittle"] = {
 			condition = "Brittle",
 			mods = function(num)
-				return {
-					modLib.createMod("SelfCritChance", "BASE", num, "Brittle", { type = "Condition", var = "Brittle" })
-				}
+				return { modLib.createMod("SelfCritChance", "BASE", num, "Brittle", { type = "Condition", var = "Brittle" }) }
 			end
 		},
 		["Sap"] = {
 			condition = "Sapped",
 			mods = function(num)
-				return {
-					modLib.createMod("Damage", "MORE", -num, "Sap", { type = "Condition", var = "Sapped" })
-				}
+				return { modLib.createMod("Damage", "MORE", -num, "Sap", { type = "Condition", var = "Sapped" }) }
 			end
 		},
 	}

--- a/src/Modules/CalcPerform.lua
+++ b/src/Modules/CalcPerform.lua
@@ -18,7 +18,7 @@ local bor = bit.bor
 local band = bit.band
 
 
--- Identify the trigger action skill for trigger conditions, take highest Attack Per Second 
+-- Identify the trigger action skill for trigger conditions, take highest Attack Per Second
 local function findTriggerSkill(env, skill, source, triggerRate, reqManaCost)
 	local uuid = cacheSkillUUID(skill)
 	if not GlobalCache.cachedData["CACHE"][uuid] or GlobalCache.dontUseCache then
@@ -1226,9 +1226,9 @@ function calcs.perform(env, avoidCache)
 		end
 		if (activeSkill.activeEffect.grantedEffect.name == "Vaal Lightning Trap" or activeSkill.activeEffect.grantedEffect.name == "Shock Ground") then
 			local effect = activeSkill.skillModList:Sum("BASE", nil, "ShockedGroundEffect")
-			local shockValMultiplier = enemyDB:Sum("BASE", nil, "Multiplier:ShockEffect")
-			if shockValMultiplier < effect then
-				enemyDB:NewMod("Multiplier:ShockEffect", "BASE", effect - shockValMultiplier, "Shocked Ground", { type = "ActorCondition", var = "OnShockedGround" })
+			local shockEffectMultiplier = enemyDB:Sum("BASE", nil, "Multiplier:ShockEffect")
+			if shockEffectMultiplier < effect then
+				enemyDB:NewMod("Multiplier:ShockEffect", "BASE", effect - shockEffectMultiplier, "Shocked Ground", { type = "ActorCondition", var = "OnShockedGround" })
 			end
 			modDB:NewMod("ShockOverride", "BASE", effect, "Shocked Ground", { type = "ActorCondition", actor = "enemy", var = "OnShockedGround" } )
 		end
@@ -1238,18 +1238,18 @@ function calcs.perform(env, avoidCache)
 		if activeSkill.activeEffect.grantedEffect.name == "Summon Skitterbots" then
 			if not activeSkill.skillModList:Flag(nil, "SkitterbotsCannotShock") then
 				local effect = data.nonDamagingAilment.Shock.default * (1 + activeSkill.skillModList:Sum("INC", { source = "Skill" }, "EnemyShockEffect") / 100)
-				local shockValMultiplier = enemyDB:Sum("BASE", nil, "Multiplier:ShockEffect")
-				if shockValMultiplier < effect then
-					enemyDB:NewMod("Multiplier:ShockEffect", "BASE", effect - shockValMultiplier, activeSkill.activeEffect.grantedEffect.name)
+				local shockEffectMultiplier = enemyDB:Sum("BASE", nil, "Multiplier:ShockEffect")
+				if shockEffectMultiplier < effect then
+					enemyDB:NewMod("Multiplier:ShockEffect", "BASE", effect - shockEffectMultiplier, activeSkill.activeEffect.grantedEffect.name)
 				end
 				modDB:NewMod("ShockOverride", "BASE", effect, activeSkill.activeEffect.grantedEffect.name)
 				enemyDB:NewMod("Condition:Shocked", "FLAG", true, activeSkill.activeEffect.grantedEffect.name)
 			end
 			if not activeSkill.skillModList:Flag(nil, "SkitterbotsCannotChill") then
 				local effect = data.nonDamagingAilment.Chill.default * (1 + activeSkill.skillModList:Sum("INC", { source = "Skill" }, "EnemyChillEffect") / 100)
-				local chillValMultiplier = enemyDB:Sum("BASE", nil, "Multiplier:ChillEffect")
-				if chillValMultiplier < effect then
-					enemyDB:NewMod("Multiplier:ChillEffect", "BASE", effect - chillValMultiplier, activeSkill.activeEffect.grantedEffect.name)
+				local chillEffectMultiplier = enemyDB:Sum("BASE", nil, "Multiplier:ChillEffect")
+				if chillEffectMultiplier < effect then
+					enemyDB:NewMod("Multiplier:ChillEffect", "BASE", effect - chillEffectMultiplier, activeSkill.activeEffect.grantedEffect.name)
 				end
 				modDB:NewMod("ChillOverride", "BASE", effect, activeSkill.activeEffect.grantedEffect.name)
 				enemyDB:NewMod("Condition:Chilled", "FLAG", true, activeSkill.activeEffect.grantedEffect.name)
@@ -1259,9 +1259,9 @@ function calcs.perform(env, avoidCache)
 			end
 		elseif activeSkill.skillTypes[SkillType.ChillingArea] or (activeSkill.skillTypes[SkillType.NonHitChill] and not activeSkill.skillModList:Flag(nil, "CannotChill")) then
 			local effect = data.nonDamagingAilment.Chill.default * (1 + activeSkill.skillModList:Sum("INC", nil, "EnemyChillEffect") / 100)
-			local chillValMultiplier = enemyDB:Sum("BASE", nil, "Multiplier:ChillEffect")
-			if chillValMultiplier < effect then
-				enemyDB:NewMod("Multiplier:ChillEffect", "BASE", effect - chillValMultiplier, activeSkill.activeEffect.grantedEffect.name)
+			local chillEffectMultiplier = enemyDB:Sum("BASE", nil, "Multiplier:ChillEffect")
+			if chillEffectMultiplier < effect then
+				enemyDB:NewMod("Multiplier:ChillEffect", "BASE", effect - chillEffectMultiplier, activeSkill.activeEffect.grantedEffect.name)
 			end
 			modDB:NewMod("ChillOverride", "BASE", effect, activeSkill.activeEffect.grantedEffect.name)
 			enemyDB:NewMod("Condition:Chilled", "FLAG", true, activeSkill.activeEffect.grantedEffect.name)
@@ -3060,6 +3060,16 @@ function calcs.perform(env, avoidCache)
 			end
 			enemyDB:NewMod("Condition:Already"..val.condition, "FLAG", true, { type = "Condition", var = val.condition } ) -- Prevents ailment from applying doubly for minions
 		end
+	end
+
+	-- Cap chill and shock multipliers
+	local chillValMultiplier = enemyDB:Sum("BASE", nil, "Multiplier:ChillEffect")
+	if chillValMultiplier > output["MaximumChill"] then
+		enemyDB:NewMod("Multiplier:ChillEffect", "BASE", output["MaximumChill"] - chillValMultiplier, "Maximum Chill")
+	end
+	local shockValMultiplier = enemyDB:Sum("BASE", nil, "Multiplier:ShockEffect")
+	if shockValMultiplier > output["MaximumShock"] then
+		enemyDB:NewMod("Multiplier:ShockEffect", "BASE", output["MaximumShock"] - shockValMultiplier, "Maximum Shock")
 	end
 
 	-- Check for extra auras

--- a/src/Modules/CalcPerform.lua
+++ b/src/Modules/CalcPerform.lua
@@ -1226,9 +1226,9 @@ function calcs.perform(env, avoidCache)
 		end
 		if (activeSkill.activeEffect.grantedEffect.name == "Vaal Lightning Trap" or activeSkill.activeEffect.grantedEffect.name == "Shock Ground") then
 			local effect = activeSkill.skillModList:Sum("BASE", nil, "ShockedGroundEffect")
-			local shockValMultiplier = enemyDB:Sum("BASE", nil, "Multiplier:ShockVal")
+			local shockValMultiplier = enemyDB:Sum("BASE", nil, "Multiplier:ShockEffect")
 			if shockValMultiplier < effect then
-				enemyDB:NewMod("Multiplier:ShockVal", "BASE", effect - shockValMultiplier, "Shocked Ground", { type = "ActorCondition", var = "OnShockedGround" })
+				enemyDB:NewMod("Multiplier:ShockEffect", "BASE", effect - shockValMultiplier, "Shocked Ground", { type = "ActorCondition", var = "OnShockedGround" })
 			end
 			modDB:NewMod("ShockOverride", "BASE", effect, "Shocked Ground", { type = "ActorCondition", actor = "enemy", var = "OnShockedGround" } )
 		end
@@ -1238,18 +1238,18 @@ function calcs.perform(env, avoidCache)
 		if activeSkill.activeEffect.grantedEffect.name == "Summon Skitterbots" then
 			if not activeSkill.skillModList:Flag(nil, "SkitterbotsCannotShock") then
 				local effect = data.nonDamagingAilment.Shock.default * (1 + activeSkill.skillModList:Sum("INC", { source = "Skill" }, "EnemyShockEffect") / 100)
-				local shockValMultiplier = enemyDB:Sum("BASE", nil, "Multiplier:ShockVal")
+				local shockValMultiplier = enemyDB:Sum("BASE", nil, "Multiplier:ShockEffect")
 				if shockValMultiplier < effect then
-					enemyDB:NewMod("Multiplier:ShockVal", "BASE", effect - shockValMultiplier, activeSkill.activeEffect.grantedEffect.name)
+					enemyDB:NewMod("Multiplier:ShockEffect", "BASE", effect - shockValMultiplier, activeSkill.activeEffect.grantedEffect.name)
 				end
 				modDB:NewMod("ShockOverride", "BASE", effect, activeSkill.activeEffect.grantedEffect.name)
 				enemyDB:NewMod("Condition:Shocked", "FLAG", true, activeSkill.activeEffect.grantedEffect.name)
 			end
 			if not activeSkill.skillModList:Flag(nil, "SkitterbotsCannotChill") then
 				local effect = data.nonDamagingAilment.Chill.default * (1 + activeSkill.skillModList:Sum("INC", { source = "Skill" }, "EnemyChillEffect") / 100)
-				local chillValMultiplier = enemyDB:Sum("BASE", nil, "Multiplier:ChillVal")
+				local chillValMultiplier = enemyDB:Sum("BASE", nil, "Multiplier:ChillEffect")
 				if chillValMultiplier < effect then
-					enemyDB:NewMod("Multiplier:ChillVal", "BASE", effect - chillValMultiplier, activeSkill.activeEffect.grantedEffect.name)
+					enemyDB:NewMod("Multiplier:ChillEffect", "BASE", effect - chillValMultiplier, activeSkill.activeEffect.grantedEffect.name)
 				end
 				modDB:NewMod("ChillOverride", "BASE", effect, activeSkill.activeEffect.grantedEffect.name)
 				enemyDB:NewMod("Condition:Chilled", "FLAG", true, activeSkill.activeEffect.grantedEffect.name)
@@ -1259,9 +1259,9 @@ function calcs.perform(env, avoidCache)
 			end
 		elseif activeSkill.skillTypes[SkillType.ChillingArea] or (activeSkill.skillTypes[SkillType.NonHitChill] and not activeSkill.skillModList:Flag(nil, "CannotChill")) then
 			local effect = data.nonDamagingAilment.Chill.default * (1 + activeSkill.skillModList:Sum("INC", nil, "EnemyChillEffect") / 100)
-			local chillValMultiplier = enemyDB:Sum("BASE", nil, "Multiplier:ChillVal")
+			local chillValMultiplier = enemyDB:Sum("BASE", nil, "Multiplier:ChillEffect")
 			if chillValMultiplier < effect then
-				enemyDB:NewMod("Multiplier:ChillVal", "BASE", effect - chillValMultiplier)
+				enemyDB:NewMod("Multiplier:ChillEffect", "BASE", effect - chillValMultiplier, activeSkill.activeEffect.grantedEffect.name)
 			end
 			modDB:NewMod("ChillOverride", "BASE", effect, activeSkill.activeEffect.grantedEffect.name)
 			enemyDB:NewMod("Condition:Chilled", "FLAG", true, activeSkill.activeEffect.grantedEffect.name)

--- a/src/Modules/CalcPerform.lua
+++ b/src/Modules/CalcPerform.lua
@@ -1225,7 +1225,12 @@ function calcs.perform(env, avoidCache)
 			modDB.multipliers["HexDoom"] =  m_min(m_max(hexDoom, modDB.multipliers["HexDoom"] or 0), output.HexDoomLimit)
 		end
 		if (activeSkill.activeEffect.grantedEffect.name == "Vaal Lightning Trap" or activeSkill.activeEffect.grantedEffect.name == "Shock Ground") then
-			modDB:NewMod("ShockOverride", "BASE", activeSkill.skillModList:Sum("BASE", nil, "ShockedGroundEffect"), "Shocked Ground", { type = "ActorCondition", actor = "enemy", var = "OnShockedGround" } )
+			local effect = activeSkill.skillModList:Sum("BASE", nil, "ShockedGroundEffect")
+			local shockValMultiplier = enemyDB:Sum("BASE", nil, "Multiplier:ShockVal")
+			if shockValMultiplier < effect then
+				enemyDB:NewMod("Multiplier:ShockVal", "BASE", effect - shockValMultiplier, "Shocked Ground", { type = "ActorCondition", var = "OnShockedGround" })
+			end
+			modDB:NewMod("ShockOverride", "BASE", effect, "Shocked Ground", { type = "ActorCondition", actor = "enemy", var = "OnShockedGround" } )
 		end
 		if activeSkill.skillData.supportBonechill and (activeSkill.skillTypes[SkillType.ChillingArea] or activeSkill.skillTypes[SkillType.NonHitChill] or not activeSkill.skillModList:Flag(nil, "CannotChill")) then
 			output.HasBonechill = true
@@ -1233,11 +1238,19 @@ function calcs.perform(env, avoidCache)
 		if activeSkill.activeEffect.grantedEffect.name == "Summon Skitterbots" then
 			if not activeSkill.skillModList:Flag(nil, "SkitterbotsCannotShock") then
 				local effect = data.nonDamagingAilment.Shock.default * (1 + activeSkill.skillModList:Sum("INC", { source = "Skill" }, "EnemyShockEffect") / 100)
+				local shockValMultiplier = enemyDB:Sum("BASE", nil, "Multiplier:ShockVal")
+				if shockValMultiplier < effect then
+					enemyDB:NewMod("Multiplier:ShockVal", "BASE", effect - shockValMultiplier, activeSkill.activeEffect.grantedEffect.name)
+				end
 				modDB:NewMod("ShockOverride", "BASE", effect, activeSkill.activeEffect.grantedEffect.name)
 				enemyDB:NewMod("Condition:Shocked", "FLAG", true, activeSkill.activeEffect.grantedEffect.name)
 			end
 			if not activeSkill.skillModList:Flag(nil, "SkitterbotsCannotChill") then
 				local effect = data.nonDamagingAilment.Chill.default * (1 + activeSkill.skillModList:Sum("INC", { source = "Skill" }, "EnemyChillEffect") / 100)
+				local chillValMultiplier = enemyDB:Sum("BASE", nil, "Multiplier:ChillVal")
+				if chillValMultiplier < effect then
+					enemyDB:NewMod("Multiplier:ChillVal", "BASE", effect - chillValMultiplier, activeSkill.activeEffect.grantedEffect.name)
+				end
 				modDB:NewMod("ChillOverride", "BASE", effect, activeSkill.activeEffect.grantedEffect.name)
 				enemyDB:NewMod("Condition:Chilled", "FLAG", true, activeSkill.activeEffect.grantedEffect.name)
 				if activeSkill.skillData.supportBonechill then
@@ -1246,6 +1259,10 @@ function calcs.perform(env, avoidCache)
 			end
 		elseif activeSkill.skillTypes[SkillType.ChillingArea] or (activeSkill.skillTypes[SkillType.NonHitChill] and not activeSkill.skillModList:Flag(nil, "CannotChill")) then
 			local effect = data.nonDamagingAilment.Chill.default * (1 + activeSkill.skillModList:Sum("INC", nil, "EnemyChillEffect") / 100)
+			local chillValMultiplier = enemyDB:Sum("BASE", nil, "Multiplier:ChillVal")
+			if chillValMultiplier < effect then
+				enemyDB:NewMod("Multiplier:ChillVal", "BASE", effect - chillValMultiplier)
+			end
 			modDB:NewMod("ChillOverride", "BASE", effect, activeSkill.activeEffect.grantedEffect.name)
 			enemyDB:NewMod("Condition:Chilled", "FLAG", true, activeSkill.activeEffect.grantedEffect.name)
 			if activeSkill.skillData.supportBonechill then
@@ -2983,27 +3000,50 @@ function calcs.perform(env, avoidCache)
 	-- Calculate maximum and apply the strongest non-damaging ailments
 	local ailmentData = data.nonDamagingAilment
 	local ailments = {
-		["Chill"] = { condition = "Chilled", mods = function(num)
-			local mods = {
-				modLib.createMod("ActionSpeed", "INC", -num, "Chill", { type = "Condition", var = "Chilled" })
-			}
-			if output.HasBonechill and (hasGuaranteedBonechill or enemyDB:Sum("BASE", nil, "ChillVal") > 0) then
-				t_insert(mods, modLib.createMod("ColdDamageTaken", "INC", num, "Bonechill", { type = "Condition", var = "Chilled" }))
+		["Chill"] = {
+			condition = "Chilled",
+			mods = function(num)
+				local mods = {
+					modLib.createMod("ActionSpeed", "INC", -num, "Chill", { type = "Condition", var = "Chilled" })
+				}
+				if output.HasBonechill and (hasGuaranteedBonechill or enemyDB:Sum("BASE", nil, "ChillVal") > 0) then
+					t_insert(mods, modLib.createMod("ColdDamageTaken", "INC", num, "Bonechill", { type = "Condition", var = "Chilled" }))
+				end
+				return mods
 			end
-			return mods
-		end },
-		["Shock"] = { condition = "Shocked", mods = function(num) return {
-			modLib.createMod("DamageTaken", "INC", num, "Shock", { type = "Condition", var = "Shocked" })
-		} end },
-		["Scorch"] = { condition = "Scorched", mods = function(num) return {
-			modLib.createMod("ElementalResist", "BASE", -num, "Scorch", { type = "Condition", var = "Scorched" })
-		} end },
-		["Brittle"] = { condition = "Brittle", mods = function(num) return {
-			modLib.createMod("SelfCritChance", "BASE", num, "Brittle", { type = "Condition", var = "Brittle" })
-		} end },
-		["Sap"] = { condition = "Sapped", mods = function(num) return {
-			modLib.createMod("Damage", "MORE", -num, "Sap", { type = "Condition", var = "Sapped" })
-		} end },
+		},
+		["Shock"] = {
+			condition = "Shocked",
+			mods = function(num)
+				return {
+					modLib.createMod("DamageTaken", "INC", num, "Shock", { type = "Condition", var = "Shocked" })
+				}
+			end
+		},
+		["Scorch"] = {
+			condition = "Scorched",
+			mods = function(num)
+				return {
+					modLib.createMod("ElementalResist", "BASE", -num, "Scorch", { type = "Condition", var = "Scorched" })
+				}
+			end
+		},
+		["Brittle"] = {
+			condition = "Brittle",
+			mods = function(num)
+				return {
+					modLib.createMod("SelfCritChance", "BASE", num, "Brittle", { type = "Condition", var = "Brittle" })
+				}
+			end
+		},
+		["Sap"] = {
+			condition = "Sapped",
+			mods = function(num)
+				return {
+					modLib.createMod("Damage", "MORE", -num, "Sap", { type = "Condition", var = "Sapped" })
+				}
+			end
+		},
 	}
 
 	for ailment, val in pairs(ailments) do

--- a/src/Modules/ConfigOptions.lua
+++ b/src/Modules/ConfigOptions.lua
@@ -1262,7 +1262,7 @@ return {
 		enemyModList:NewMod("Condition:ChilledConfig", "FLAG", true, "Config", { type = "Condition", var = "Effective" })
 	end },
 	{ var = "conditionEnemyChilledEffect", type = "count", label = "Effect of ^x3F6DB3Chill:", ifOption = "conditionEnemyChilled", apply = function(val, modList, enemyModList)
-		enemyModList:NewMod("Multiplier:ChillVal", "BASE", val, "Config", { type = "Condition", var = "ChilledConfig" })
+		enemyModList:NewMod("Multiplier:ChillEffect", "BASE", val, "Config", { type = "Condition", var = "ChilledConfig" })
 		enemyModList:NewMod("ChillVal", "BASE", val, "Chill", { type = "Condition", var = "ChilledConfig" })
 		enemyModList:NewMod("DesiredChillVal", "BASE", val, "Chill", { type = "Condition", var = "ChilledConfig", neg = true })
 	end },
@@ -1290,7 +1290,7 @@ return {
 		enemyModList:NewMod("Condition:ShockedConfig", "FLAG", true, "Config", { type = "Condition", var = "Effective" })
 	end },
 	{ var = "conditionShockEffect", type = "count", label = "Effect of ^xADAA47Shock:", tooltip = "If you have a guaranteed source of ^xADAA47Shock^7,\nthe strongest one will apply instead unless this option would apply a stronger ^xADAA47Shock.", apply = function(val, modList, enemyModList)
-		enemyModList:NewMod("Multiplier:ShockVal", "BASE", val, "Config", { type = "Condition", var = "ShockedConfig" })
+		enemyModList:NewMod("Multiplier:ShockEffect", "BASE", val, "Config", { type = "Condition", var = "ShockedConfig" })
 		enemyModList:NewMod("ShockVal", "BASE", val, "Shock", { type = "Condition", var = "ShockedConfig" })
 		enemyModList:NewMod("DesiredShockVal", "BASE", val, "Shock", { type = "Condition", var = "ShockedConfig", neg = true })
 	end },

--- a/src/Modules/ConfigOptions.lua
+++ b/src/Modules/ConfigOptions.lua
@@ -1259,10 +1259,12 @@ return {
 	end },
 	{ var = "conditionEnemyChilled", type = "check", label = "Is the enemy ^x3F6DB3Chilled?", apply = function(val, modList, enemyModList)
 		enemyModList:NewMod("Condition:Chilled", "FLAG", true, "Config", { type = "Condition", var = "Effective" })
+		enemyModList:NewMod("Condition:ChilledConfig", "FLAG", true, "Config", { type = "Condition", var = "Effective" })
 	end },
 	{ var = "conditionEnemyChilledEffect", type = "count", label = "Effect of ^x3F6DB3Chill:", ifOption = "conditionEnemyChilled", apply = function(val, modList, enemyModList)
-		enemyModList:NewMod("ChillVal", "BASE", val, "Chill", { type = "Condition", var = "Chilled" })
-		enemyModList:NewMod("DesiredChillVal", "BASE", val, "Chill", { type = "Condition", var = "Chilled", neg = true })
+		enemyModList:NewMod("Multiplier:ChillVal", "BASE", val, "Config", { type = "Condition", var = "ChilledConfig" })
+		enemyModList:NewMod("ChillVal", "BASE", val, "Chill", { type = "Condition", var = "ChilledConfig" })
+		enemyModList:NewMod("DesiredChillVal", "BASE", val, "Chill", { type = "Condition", var = "ChilledConfig", neg = true })
 	end },
 	{ var = "conditionEnemyChilledByYourHits", type = "check", ifEnemyCond = "ChilledByYourHits", label = "Is the enemy ^x3F6DB3Chilled ^7by your Hits?", apply = function(val, modList, enemyModList)
 		enemyModList:NewMod("Condition:Chilled", "FLAG", true, "Config", { type = "Condition", var = "Effective" })
@@ -1288,6 +1290,7 @@ return {
 		enemyModList:NewMod("Condition:ShockedConfig", "FLAG", true, "Config", { type = "Condition", var = "Effective" })
 	end },
 	{ var = "conditionShockEffect", type = "count", label = "Effect of ^xADAA47Shock:", tooltip = "If you have a guaranteed source of ^xADAA47Shock^7,\nthe strongest one will apply instead unless this option would apply a stronger ^xADAA47Shock.", apply = function(val, modList, enemyModList)
+		enemyModList:NewMod("Multiplier:ShockVal", "BASE", val, "Config", { type = "Condition", var = "ShockedConfig" })
 		enemyModList:NewMod("ShockVal", "BASE", val, "Shock", { type = "Condition", var = "ShockedConfig" })
 		enemyModList:NewMod("DesiredShockVal", "BASE", val, "Shock", { type = "Condition", var = "ShockedConfig", neg = true })
 	end },

--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -1009,6 +1009,7 @@ local modTagList = {
 	["per level"] = { tag = { type = "Multiplier", var = "Level" } },
 	["per (%d+) player levels"] = function(num) return { tag = { type = "Multiplier", var = "Level", div = num } } end,
 	["per defiance"] = { tag = { type = "Multiplier", var = "Defiance" } },
+	["per (%d+)%% (%a+) effect on enemy"] = function(num, _, effectName) return { tag = { type = "Multiplier", var = firstToUpper(effectName) .. "Effect", div = num, actor = "enemy" } } end,
 	["for each equipped normal item"] = { tag = { type = "Multiplier", var = "NormalItem" } },
 	["for each normal item equipped"] = { tag = { type = "Multiplier", var = "NormalItem" } },
 	["for each normal item you have equipped"] = { tag = { type = "Multiplier", var = "NormalItem" } },


### PR DESCRIPTION
This adds support for ``{ type = "Multiplier", actor = "enemy", var = "ChillEffect" }`` and ``{ type = "Multiplier", actor = "enemy", var = "ShockEffect" }`` in ``ModParser.lua``, and is intended to enable parsing for various modifiers that scale based off of the effective shock and/or chill value on enemies.