### PR TITLE
Set skillset to nil instead of removing it from table and reordering it

### DIFF
--- a/src/Classes/SkillSetListControl.lua
+++ b/src/Classes/SkillSetListControl.lua
@@ -100,7 +100,7 @@ function SkillSetListClass:OnSelDelete(index, skillSetId)
 	if #self.list > 1 then
 		main:OpenConfirmPopup("Delete Item Set", "Are you sure you want to delete '"..(skillSet.title or "Default").."'?", "Delete", function()
 			t_remove(self.list, index)
-			t_remove(self.skillsTab.skillSets, skillSetId)
+			self.skillsTab.skillSets[skillSetId] = nil
 			self.selIndex = nil
 			self.selValue = nil
 			if skillSetId == self.skillsTab.activeSkillSetId then


### PR DESCRIPTION
When removing it from table this causes crash when rebuilding skill set
dropdown.

Fixes #4771

Signed-off-by: Tomas Slusny <ts6234@intl.att.com>

### Steps taken to verify a working solution:
- Create new build
- Add socket group to default skill set
- Copy default skillset and set its name to anything you want
- Try to delete default skillset
- Pob is no longer crashing