### PR TITLE
[Kalandra] Update replica bitterdream

### DIFF
--- a/src/Data/Uniques/mace.lua
+++ b/src/Data/Uniques/mace.lua
@@ -288,11 +288,11 @@ Requires Level 32, 52 Str, 62 Int
 Implicits: 1
 22% increased Elemental Damage
 Socketed Gems are Supported by Level 1 Elemental Penetration
-Socketed Gems are Supported by Level 10 Immolate
-Socketed Gems are Supported by Level 1 Unbound Ailments
-Socketed Gems are Supported by Level 10 Ice Bite
-Socketed Gems are Supported by Level 1 Inspiration
-Socketed Gems are Supported by Level 10 Innervate
+Socketed Gems are Supported by Level 15 Immolate
+Socketed Gems are Supported by Level 15 Unbound Ailments
+Socketed Gems are Supported by Level 15 Ice Bite
+Socketed Gems are Supported by Level 15 Inspiration
+Socketed Gems are Supported by Level 15 Innervate
 ]],[[
 The Black Cane
 Royal Sceptre


### PR DESCRIPTION
> The Replica Bitterdream Unique Sceptre now causes Socketed Gems to be Supported by Level 15 Immolate, Unbound Ailments, Ice Bite, Inspiration, and Innervate (previously either Level 1 or 10). This change affects existing items, though you will need to use a Divine Orb to fix the description on the item.

Old items mods no longer exist elementral peneration is likely to remain on the item at level 1 from this wording.