### PR TITLE
reverted changes to escape/onfocuslost in gemselectcontrol

### DIFF
--- a/src/Classes/GemSelectControl.lua
+++ b/src/Classes/GemSelectControl.lua
@@ -672,6 +672,7 @@ function GemSelectClass:OnFocusLost()
 		if self.noMatches then
 			self:SetText("")
 		end
+		self:UpdateGem(true,true)
 	end
 end
 
@@ -711,6 +712,7 @@ function GemSelectClass:OnKeyDown(key, doubleClick)
 			self:BuildList("")
 			self.buf = self.initialBuf
 			self.selIndex = self.initialIndex
+			self:UpdateGem(false,true)
 			return
 		elseif key == "WHEELUP" then
 			self.controls.scrollBar:Scroll(-1)


### PR DESCRIPTION
I reverted two of the commits from Pull Request #4633

The solution to #4517 is still intact

But #863 is still not solved
The changes was meant to give a consistent behavior when clicking outside of a expanded selection box, or when pressing escape. 

There was still issues when the selected skill is filtered out (as described in #863) and it added some other issues (such as partial searches not updating to the full name in some occasions).

