### PR TITLE
[Kalandra] Add new chainbreaker wording and displays Rage Regeneration

### DIFF
--- a/src/Data/LegionPassives.lua
+++ b/src/Data/LegionPassives.lua
@@ -3634,8 +3634,8 @@ return {
 			}, 
 			["not"] = false, 
 			["sd"] = {
-				[1] = "Regenerate 3 Rage per second", 
-				[2] = "Increases and Reductions to Mana Regeneration Rate instead apply to Rage Regeneration Rate", 
+				[1] = "1 Rage regenerated for every 25 Mana Regeneration per second",
+				[2] = "Mana Recovery from Regeneration is not applied", 
 				[3] = "Skills Cost +3 Rage", 
 			}, 
 			["isMultipleChoiceOption"] = false, 

--- a/src/Modules/Build.lua
+++ b/src/Modules/Build.lua
@@ -362,6 +362,7 @@ function buildMode:Init(dbFileName, buildName, buildXML, convertBuild)
 		{ stat = "ManaUnreserved", label = "Unreserved Mana", fmt = "d", color = colorCodes.MANA, condFunc = function(v,o) return v < o.Mana end, compPercent = true, warnFunc = function(v) return v < 0 and "Your unreserved Mana is negative" end },
 		{ stat = "ManaUnreservedPercent", label = "Unreserved Mana", fmt = "d%%", color = colorCodes.MANA, condFunc = function(v,o) return v < 100 end },
 		{ stat = "ManaRegen", label = "Mana Regen", fmt = ".1f", color = colorCodes.MANA },
+		{ stat = "RageRegen", label = "Rage Regen", fmt = "d", color = colorCodes.RAGE, compPercent = true, condFunc = function(v,o) return v > 0 end },
 		{ stat = "ManaLeechGainRate", label = "Mana Leech/On Hit Rate", fmt = ".1f", color = colorCodes.MANA, compPercent = true },
 		{ stat = "ManaLeechGainPerHit", label = "Mana Leech/Gain per Hit", fmt = ".1f", color = colorCodes.MANA, compPercent = true },
 		{ },

--- a/src/Modules/CalcDefence.lua
+++ b/src/Modules/CalcDefence.lua
@@ -683,7 +683,7 @@ function calcs.defence(env, actor)
 	end
 	output.EnergyShieldRegen = output.EnergyShieldRegen + modDB:Sum("BASE", nil, "EnergyShieldRecovery") * output.EnergyShieldRecoveryRateMod
 	output.EnergyShieldRegenPercent = round(output.EnergyShieldRegen / output.EnergyShield * 100, 1)
-	if modDB:Flag(nil, "NoManaRegenAppliedToYou") then  --Chainbreaker Flag
+	if modDB:Flag(nil, "UnaffectedByManaRegen") then  --Chainbreaker Flag
 		output.WouldBeManaRegen = output.ManaRegen
 		output.ManaRegen = 0
     end

--- a/src/Modules/CalcDefence.lua
+++ b/src/Modules/CalcDefence.lua
@@ -683,6 +683,10 @@ function calcs.defence(env, actor)
 	end
 	output.EnergyShieldRegen = output.EnergyShieldRegen + modDB:Sum("BASE", nil, "EnergyShieldRecovery") * output.EnergyShieldRecoveryRateMod
 	output.EnergyShieldRegenPercent = round(output.EnergyShieldRegen / output.EnergyShield * 100, 1)
+	if modDB:Flag(nil, "NoManaRegenAppliedToYou") then  --Chainbreaker Flag
+		output.WouldBeManaRegen = output.ManaRegen
+		output.ManaRegen = 0
+    end
 	if modDB:Sum("BASE", nil, "RageRegen") > 0 then
 		modDB:NewMod("Condition:CanGainRage", "FLAG", true, "RageRegen")
 		local base = modDB:Sum("BASE", nil, "RageRegen")

--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -1516,7 +1516,7 @@ end
 local specialModList = {
 	-- Keystones
 	["(%d+) rage regenerated for every (%d+) mana regeneration per second"] = function(num, _, div) return { mod("RageRegen", "BASE", num, {type = "PerStat", stat = "WouldBeManaRegen", div = tonumber(div) }) } end,
-	["mana recovery from regeneration is not applied"] = { flag("NoManaRegenAppliedToYou") },
+	["mana recovery from regeneration is not applied"] = { flag("UnaffectedByManaRegen") },
 	["(%d+)%% less damage taken for every (%d+)%% life recovery per second from leech"] = function(num, _, div)
 		return {  mod("DamageTaken", "MORE", -num, { type = "PerStat", stat = "MaxLifeLeechRatePercent", div = tonumber(div) }) }
 	end,

--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -1515,6 +1515,8 @@ end
 -- List of special modifiers
 local specialModList = {
 	-- Keystones
+	["(%d+) rage regenerated for every (%d+) mana regeneration per second"] = function(num, _, div) return { mod("RageRegen", "BASE", num, {type = "PerStat", stat = "WouldBeManaRegen", div = tonumber(div) }) } end,
+	["mana recovery from regeneration is not applied"] = { flag("NoManaRegenAppliedToYou") },
 	["(%d+)%% less damage taken for every (%d+)%% life recovery per second from leech"] = function(num, _, div)
 		return {  mod("DamageTaken", "MORE", -num, { type = "PerStat", stat = "MaxLifeLeechRatePercent", div = tonumber(div) }) }
 	end,


### PR DESCRIPTION
Adds "1 Rage regenerated for every 25 Mana Regeneration per second" and "Mana Recovery from regeneration is not applied" wording
Displays Rage Regen beneath Mana Regen

### Steps taken to verify a working solution:
- 2 Test Images with and without clarity to showcase the rage generation depends on total mana regen instead of the mana regeneration increase modifiers from now old chainbreaker 
![chainbreaker_with_clarity](https://user-images.githubusercontent.com/100538010/184501705-b1bb60a3-08e0-4235-9f9f-0d6295dc761e.png)

![chainbreaker_without_clarity](https://user-images.githubusercontent.com/100538010/184501711-64069e39-d547-4cc8-beef-fb54f3b92b85.png)

### Link to a build that showcases this PR:
https://pastebin.com/nNhMWJ2t