### PR TITLE
Add button to open random build

### DIFF
--- a/src/Modules/BuildList.lua
+++ b/src/Modules/BuildList.lua
@@ -33,7 +33,7 @@ function listMode:Init(selBuildName, subPath)
 	self.subPath = subPath or ""
 	self.list = { }
 
-	self.controls.new = new("ButtonControl", {"TOP",self.anchor,"TOP"}, -259, 0, 60, 20, "New", function()
+	self.controls.new = new("ButtonControl", {"TOP",self.anchor,"TOP"}, -293, 0, 60, 20, "New", function()
 		main:SetMode("BUILD", false, "Unnamed build")
 	end)
 	self.controls.newFolder = new("ButtonControl", {"LEFT",self.controls.new,"RIGHT"}, 8, 0, 90, 20, "New Folder", function()
@@ -42,8 +42,12 @@ function listMode:Init(selBuildName, subPath)
 	self.controls.open = new("ButtonControl", {"LEFT",self.controls.newFolder,"RIGHT"}, 8, 0, 60, 20, "Open", function()
 		self.controls.buildList:LoadBuild(self.controls.buildList.selValue)
 	end)
+	self.controls.random = new("ButtonControl", {"LEFT",self.controls.open,"RIGHT"}, 8, 0, 60, 20, "Random", function()
+		self.controls.buildList:LoadBuild(self.list[math.random(#self.list)])
+	end)
+	self.controls.random.enabled = function() return #self.list > 0 end
 	self.controls.open.enabled = function() return self.controls.buildList.selValue ~= nil end
-	self.controls.copy = new("ButtonControl", {"LEFT",self.controls.open,"RIGHT"}, 8, 0, 60, 20, "Copy", function()
+	self.controls.copy = new("ButtonControl", {"LEFT",self.controls.random,"RIGHT"}, 8, 0, 60, 20, "Copy", function()
 		self.controls.buildList:RenameBuild(self.controls.buildList.selValue, true)
 	end)
 	self.controls.copy.enabled = function() return self.controls.buildList.selValue ~= nil end


### PR DESCRIPTION
A lot of people make a bunch of builds and can't decide between them. This adds a button that loads a random build in the currently visible list of builds. It opens a folder if a folder is selected, it doesn't recursively pick a random build.

### Before screenshot:
![image](https://user-images.githubusercontent.com/5985728/184530890-d1b3ee2c-bef4-449b-9043-06ff5212ce52.png)
### After screenshot:
![image](https://user-images.githubusercontent.com/5985728/184530880-b20c2de4-53bc-4092-a3bf-0a61e86cf0a5.png)
