### PR TITLE
Fix: correct size for raw data read bounds checking

### DIFF
--- a/src/Export/Classes/Dat64File.lua
+++ b/src/Export/Classes/Dat64File.lua
@@ -45,9 +45,9 @@ local dataTypes = {
 	String = {
 		size = 8,
 		read = function(b, o, d)
-			if o > #b - 3 then return "<no offset>" end
+			if o > #b - 7 then return "<no offset>" end
 			local stro = bytesToULong(b, o)
-			if stro > #b - 3 then return "<bad offset>" end
+			if stro > #b - 7 then return "<bad offset>" end
 			return convertUTF16to8(b, d + stro)
 		end,
 	},
@@ -71,7 +71,7 @@ local dataTypes = {
 		size = 16,
 		ref = true,
 		read = function(b, o, d)
-			if o > #b - 7 then return 1337 end
+			if o > #b - 15 then return 1337 end
 			return bytesToULong(b, o)
 		end,
 	},


### PR DESCRIPTION
Fixes potentially mis-calculating size of data against row boundary when processing a DAT file of type String or Key