### PR TITLE
Fix two export script errors

### DIFF
--- a/src/Export/Main.lua
+++ b/src/Export/Main.lua
@@ -459,6 +459,9 @@ function main:LoadSettings()
 			end
 		end
 	end
+	if type(self.datSources) ~= "table" then
+		self.datSources = { }
+	end
 	if not next(self.datSources) then
 		t_insert(self.datSources, self.datSource)
 	end

--- a/src/Export/spec.lua
+++ b/src/Export/spec.lua
@@ -1611,7 +1611,6 @@ return {
 			type="Int",
 			width=150
 		},
-		}
 	},
 	BuffVisualArtVariations={
 		[1]={


### PR DESCRIPTION
Removes erroneous ``}`` in spec.lua and adds a sanity check in ``Main.lua`` to ensure ``self.datSources`` is actually a table before attempting to call ``next(...)`` on it.