### PR TITLE
Feat: add support for Lightning Conduit's New Trigger Flag

### DIFF
--- a/src/Modules/CalcPerform.lua
+++ b/src/Modules/CalcPerform.lua
@@ -179,7 +179,7 @@ local function calcActualTriggerRate(env, source, sourceAPS, spellCount, output,
 		end
 	else
 		if minion then 
-			output.ActionTriggerRate = getTriggerActionTriggerRate(env.minion.mainSkill.skillData.cooldown + extraTriggerCD, env, breakdown, false, minion)
+			output.ActionTriggerRate = getTriggerActionTriggerRate(env.minion.mainSkill.skillData.cooldown, env, breakdown, false, minion)
 		else 
 			output.ActionTriggerRate = getTriggerActionTriggerRate(env.player.mainSkill.skillData.cooldown + extraTriggerCD, env, breakdown, false, minion)
 		end

--- a/src/Modules/CalcPerform.lua
+++ b/src/Modules/CalcPerform.lua
@@ -160,6 +160,11 @@ end
 
 -- Calculate the actual Trigger rate of active skill causing the trigger
 local function calcActualTriggerRate(env, source, sourceAPS, spellCount, output, breakdown, dualWield, minion)
+	-- Check if we need to add Spell CastTime to Trigger Cooldown
+	local extraTriggerCD = 0
+	if not minion and env.player.mainSkill.skillModList:Flag(skillCfg, "SpellCastTimeAddedToCooldownIfTriggered") then
+		extraTriggerCD = env.player.mainSkill.activeEffect.grantedEffect.castTime
+	end
 	-- Get action trigger rate
 	if sourceAPS == nil and source.skillTypes[SkillType.Channel] then
 		output.ActionTriggerRate = 1 / (source.skillData.triggerTime or 1)
@@ -174,9 +179,9 @@ local function calcActualTriggerRate(env, source, sourceAPS, spellCount, output,
 		end
 	else
 		if minion then 
-			output.ActionTriggerRate = getTriggerActionTriggerRate(env.minion.mainSkill.skillData.cooldown, env, breakdown, false, minion)
+			output.ActionTriggerRate = getTriggerActionTriggerRate(env.minion.mainSkill.skillData.cooldown + extraTriggerCD, env, breakdown, false, minion)
 		else 
-			output.ActionTriggerRate = getTriggerActionTriggerRate(env.player.mainSkill.skillData.cooldown, env, breakdown, false, minion)
+			output.ActionTriggerRate = getTriggerActionTriggerRate(env.player.mainSkill.skillData.cooldown + extraTriggerCD, env, breakdown, false, minion)
 		end
 	end
 	local trigRate


### PR DESCRIPTION
The upcoming Lightning Conduit skill has a new flag to add it's castTime to the trigger CD if it's triggered.
![image](https://user-images.githubusercontent.com/1735956/184554556-3e06f8aa-7d27-43d0-9ad3-d1e1d1c50ab1.png)

While we don't know what the actual stat name will be, we can implement the logic given that we will be treating it as a flag.
Sorry for the long flag name but it's basically what the skill image states.
```
["some_stat_name_we_will_get_from_ggpk"] = {
	flag("SpellCastTimeAddedToCooldownIfTriggered"),
},
```

Tested with a CoC + Cyclone trigger setup. CoC has a default trigger rate of `0.15`

### Before screenshot:
![Before](https://user-images.githubusercontent.com/1735956/184554648-620d2195-ec4e-444b-b418-786df605fbe2.png)

### After screenshot:
![After](https://user-images.githubusercontent.com/1735956/184554650-8de10314-1339-4298-b36f-a70955852b44.png)

