### PR TITLE
Make socket group sort order persistent

### DIFF
--- a/src/Classes/ListControl.lua
+++ b/src/Classes/ListControl.lua
@@ -407,7 +407,7 @@ function ListClass:OnKeyUp(key)
 					end
 					t_insert(self.list, self.selDragIndex, self.selValue)
 					if self.OnOrderChange then
-						self:OnOrderChange()
+						self:OnOrderChange(self.selIndex, self.selDragIndex)
 					end
 					self.selValue = nil
 				elseif self.dragTarget then

--- a/src/Classes/SkillListControl.lua
+++ b/src/Classes/SkillListControl.lua
@@ -72,7 +72,23 @@ function SkillListClass:AddValueTooltip(tooltip, index, socketGroup)
 	end
 end
 
-function SkillListClass:OnOrderChange()
+function SkillListClass:OnOrderChange(selIndex, selDragIndex)
+	local skillsTabIndex = self.skillsTab.build.mainSocketGroup
+	if skillsTabIndex == selIndex then
+		self.skillsTab.build.mainSocketGroup = selDragIndex
+	elseif skillsTabIndex > selIndex and skillsTabIndex <= selDragIndex then
+		self.skillsTab.build.mainSocketGroup = skillsTabIndex - 1
+	elseif skillsTabIndex < selIndex and skillsTabIndex >= selDragIndex then
+		self.skillsTab.build.mainSocketGroup = skillsTabIndex + 1
+	end
+	local calcsTabIndex = self.skillsTab.build.calcsTab.input.skill_number
+	if calcsTabIndex == selIndex then
+		self.skillsTab.build.calcsTab.input.skill_number = selDragIndex
+	elseif calcsTabIndex > selIndex and calcsTabIndex <= selDragIndex then
+		self.skillsTab.build.calcsTab.input.skill_number = calcsTabIndex - 1
+	elseif calcsTabIndex < selIndex and calcsTabIndex >= selDragIndex then
+		self.skillsTab.build.calcsTab.input.skill_number = calcsTabIndex + 1
+	end
 	self.skillsTab:AddUndoState()
 	self.skillsTab.build.buildFlag = true
 end
@@ -88,6 +104,16 @@ function SkillListClass:OnSelCopy(index, socketGroup)
 end
 
 function SkillListClass:OnSelDelete(index, socketGroup)
+	local function updateActiveSocketGroupIndex()
+		local skillsTabIndex = self.skillsTab.build.mainSocketGroup or 0
+		if skillsTabIndex > self.selIndex then
+			self.skillsTab.build.mainSocketGroup = skillsTabIndex - 1
+		end
+		local calcsTabIndex = self.skillsTab.build.calcsTab.input.skill_number
+		if calcsTabIndex > self.selIndex then
+			self.skillsTab.build.calcsTab.input.skill_number = calcsTabIndex - 1
+		end
+	end
 	if socketGroup.source then
 		main:OpenMessagePopup("Delete Socket Group", "This socket group cannot be deleted as it is created by an equipped item.")
 	elseif not socketGroup.gemList[1] then
@@ -95,6 +121,7 @@ function SkillListClass:OnSelDelete(index, socketGroup)
 		if self.skillsTab.displayGroup == socketGroup then
 			self.skillsTab.displayGroup = nil
 		end
+		updateActiveSocketGroupIndex()
 		self.skillsTab:AddUndoState()
 		self.skillsTab.build.buildFlag = true
 		self.selValue = nil
@@ -104,6 +131,7 @@ function SkillListClass:OnSelDelete(index, socketGroup)
 			if self.skillsTab.displayGroup == socketGroup then
 				self.skillsTab:SetDisplayGroup()
 			end
+			updateActiveSocketGroupIndex()
 			self.skillsTab:AddUndoState()
 			self.skillsTab.build.buildFlag = true
 			self.selValue = nil
@@ -128,10 +156,9 @@ function SkillListClass:OnHoverKeyUp(key)
 			else
 				local index = self.ListControl:GetHoverIndex()
 				if index then
-					-- mirrors Build.lua:548
 					self.skillsTab.build.mainSocketGroup = index
+					self.skillsTab:AddUndoState()
 					self.skillsTab.build.buildFlag = true
-					self.skillsTab.build.modFlag = true
 				end
 			end
 		elseif key == "LEFTBUTTON" and IsKeyDown("CTRL") then

--- a/src/Classes/SkillsTab.lua
+++ b/src/Classes/SkillsTab.lua
@@ -1182,6 +1182,9 @@ function SkillsTabClass:CreateUndoState()
 		state.skillSets[skillSetIndex] = newSkillSet
 	end
 	state.skillSetOrderList = copyTable(self.skillSetOrderList)
+	-- Save active socket group for both skillsTab and calcsTab to UndoState
+	state.activeSocketGroup = self.build.mainSocketGroup
+	state.activeSocketGroup2 = self.build.calcsTab.input.skill_number
 	return state
 end
 
@@ -1200,6 +1203,9 @@ function SkillsTabClass:RestoreUndoState(state)
 	if self.controls.groupList.selValue then
 		self.controls.groupList.selValue = self.socketGroupList[self.controls.groupList.selIndex]
 	end
+	-- Load active socket group for both skillsTab and calcsTab from UndoState
+	self.build.mainSocketGroup = state.activeSocketGroup
+	self.build.calcsTab.input.skill_number = state.activeSocketGroup2
 end
 
 -- Opens the skill set manager


### PR DESCRIPTION
Prior to this PR doing basically *anything* to manipulate the order of your socket groups (deleting them, reordering them, etc) would cause your active socket group selection in both the skills tab and calcs tab to change.

This is not desirable behavior &mdash; users expect their active socket group to remain the same regardless of what they do (unless they delete the active socket group of course, and even then it should come back if they undo that).

This PR implements support for all of that, and hopefully in a bug-free manner.

Video Demo: https://www.youtube.com/watch?v=EcbuMPWKr3Q

Example PoB: https://pobb.in/JxITTra78keh