### PR TITLE
Improve shock and chill multipliers

### DIFF
--- a/src/Modules/CalcPerform.lua
+++ b/src/Modules/CalcPerform.lua
@@ -1225,10 +1225,6 @@ function calcs.perform(env, avoidCache)
 		end
 		if (activeSkill.activeEffect.grantedEffect.name == "Vaal Lightning Trap" or activeSkill.activeEffect.grantedEffect.name == "Shock Ground") then
 			local effect = activeSkill.skillModList:Sum("BASE", nil, "ShockedGroundEffect")
-			local shockEffectMultiplier = enemyDB:Sum("BASE", nil, "Multiplier:ShockEffect")
-			if shockEffectMultiplier < effect then
-				enemyDB:NewMod("Multiplier:ShockEffect", "BASE", effect - shockEffectMultiplier, "Shocked Ground", { type = "ActorCondition", var = "OnShockedGround" })
-			end
 			modDB:NewMod("ShockOverride", "BASE", effect, "Shocked Ground", { type = "ActorCondition", actor = "enemy", var = "OnShockedGround" } )
 		end
 		if activeSkill.skillData.supportBonechill and (activeSkill.skillTypes[SkillType.ChillingArea] or activeSkill.skillTypes[SkillType.NonHitChill] or not activeSkill.skillModList:Flag(nil, "CannotChill")) then
@@ -1237,19 +1233,11 @@ function calcs.perform(env, avoidCache)
 		if activeSkill.activeEffect.grantedEffect.name == "Summon Skitterbots" then
 			if not activeSkill.skillModList:Flag(nil, "SkitterbotsCannotShock") then
 				local effect = data.nonDamagingAilment.Shock.default * (1 + activeSkill.skillModList:Sum("INC", { source = "Skill" }, "EnemyShockEffect") / 100)
-				local shockEffectMultiplier = enemyDB:Sum("BASE", nil, "Multiplier:ShockEffect")
-				if shockEffectMultiplier < effect then
-					enemyDB:NewMod("Multiplier:ShockEffect", "BASE", effect - shockEffectMultiplier, activeSkill.activeEffect.grantedEffect.name)
-				end
 				modDB:NewMod("ShockOverride", "BASE", effect, activeSkill.activeEffect.grantedEffect.name)
 				enemyDB:NewMod("Condition:Shocked", "FLAG", true, activeSkill.activeEffect.grantedEffect.name)
 			end
 			if not activeSkill.skillModList:Flag(nil, "SkitterbotsCannotChill") then
 				local effect = data.nonDamagingAilment.Chill.default * (1 + activeSkill.skillModList:Sum("INC", { source = "Skill" }, "EnemyChillEffect") / 100)
-				local chillEffectMultiplier = enemyDB:Sum("BASE", nil, "Multiplier:ChillEffect")
-				if chillEffectMultiplier < effect then
-					enemyDB:NewMod("Multiplier:ChillEffect", "BASE", effect - chillEffectMultiplier, activeSkill.activeEffect.grantedEffect.name)
-				end
 				modDB:NewMod("ChillOverride", "BASE", effect, activeSkill.activeEffect.grantedEffect.name)
 				enemyDB:NewMod("Condition:Chilled", "FLAG", true, activeSkill.activeEffect.grantedEffect.name)
 				if activeSkill.skillData.supportBonechill then
@@ -1258,10 +1246,6 @@ function calcs.perform(env, avoidCache)
 			end
 		elseif activeSkill.skillTypes[SkillType.ChillingArea] or (activeSkill.skillTypes[SkillType.NonHitChill] and not activeSkill.skillModList:Flag(nil, "CannotChill")) then
 			local effect = data.nonDamagingAilment.Chill.default * (1 + activeSkill.skillModList:Sum("INC", nil, "EnemyChillEffect") / 100)
-			local chillEffectMultiplier = enemyDB:Sum("BASE", nil, "Multiplier:ChillEffect")
-			if chillEffectMultiplier < effect then
-				enemyDB:NewMod("Multiplier:ChillEffect", "BASE", effect - chillEffectMultiplier, activeSkill.activeEffect.grantedEffect.name)
-			end
 			modDB:NewMod("ChillOverride", "BASE", effect, activeSkill.activeEffect.grantedEffect.name)
 			enemyDB:NewMod("Condition:Chilled", "FLAG", true, activeSkill.activeEffect.grantedEffect.name)
 			if activeSkill.skillData.supportBonechill then
@@ -3069,14 +3053,14 @@ function calcs.perform(env, avoidCache)
 		end
 	end
 
-	-- Cap chill and shock multipliers
-	local chillValMultiplier = enemyDB:Sum("BASE", nil, "Multiplier:ChillEffect")
-	if chillValMultiplier > output["MaximumChill"] then
-		enemyDB:NewMod("Multiplier:ChillEffect", "BASE", output["MaximumChill"] - chillValMultiplier, "Maximum Chill")
+	-- Update chill and shock multipliers
+	local chillEffectMultiplier = enemyDB:Sum("BASE", nil, "Multiplier:ChillEffect")
+	if chillEffectMultiplier < output["CurrentChill"] then
+		enemyDB:NewMod("Multiplier:ChillEffect", "BASE", output["CurrentChill"] - chillEffectMultiplier, "")
 	end
-	local shockValMultiplier = enemyDB:Sum("BASE", nil, "Multiplier:ShockEffect")
-	if shockValMultiplier > output["MaximumShock"] then
-		enemyDB:NewMod("Multiplier:ShockEffect", "BASE", output["MaximumShock"] - shockValMultiplier, "Maximum Shock")
+	local shockEffectMultiplier = enemyDB:Sum("BASE", nil, "Multiplier:ShockEffect")
+	if shockEffectMultiplier < output["CurrentShock"] then
+		enemyDB:NewMod("Multiplier:ShockEffect", "BASE", output["CurrentShock"] - shockEffectMultiplier, "")
 	end
 
 	-- Check for extra auras

--- a/src/Modules/ConfigOptions.lua
+++ b/src/Modules/ConfigOptions.lua
@@ -1277,7 +1277,6 @@ return {
 		enemyModList:NewMod("Condition:ChilledConfig", "FLAG", true, "Config", { type = "Condition", var = "Effective" })
 	end },
 	{ var = "conditionEnemyChilledEffect", type = "count", label = "Effect of ^x3F6DB3Chill:", ifOption = "conditionEnemyChilled", apply = function(val, modList, enemyModList)
-		enemyModList:NewMod("Multiplier:ChillEffect", "BASE", val, "Config", { type = "Condition", var = "ChilledConfig" })
 		enemyModList:NewMod("ChillVal", "BASE", val, "Chill", { type = "Condition", var = "ChilledConfig" })
 		enemyModList:NewMod("DesiredChillVal", "BASE", val, "Chill", { type = "Condition", var = "ChilledConfig", neg = true })
 	end },
@@ -1305,7 +1304,6 @@ return {
 		enemyModList:NewMod("Condition:ShockedConfig", "FLAG", true, "Config", { type = "Condition", var = "Effective" })
 	end },
 	{ var = "conditionShockEffect", type = "count", label = "Effect of ^xADAA47Shock:", tooltip = "If you have a guaranteed source of ^xADAA47Shock^7,\nthe strongest one will apply instead unless this option would apply a stronger ^xADAA47Shock.", apply = function(val, modList, enemyModList)
-		enemyModList:NewMod("Multiplier:ShockEffect", "BASE", val, "Config", { type = "Condition", var = "ShockedConfig" })
 		enemyModList:NewMod("ShockVal", "BASE", val, "Shock", { type = "Condition", var = "ShockedConfig" })
 		enemyModList:NewMod("DesiredShockVal", "BASE", val, "Shock", { type = "Condition", var = "ShockedConfig", neg = true })
 	end },


### PR DESCRIPTION
This is an improvement on #4770 that simply uses the current shock and chill values from the output directly, rather than trying to reconstruct their values and duplicate a bunch of code.