### PR TITLE
Revert Elementalist highest ignite change

### DIFF
--- a/src/Modules/CalcOffence.lua
+++ b/src/Modules/CalcOffence.lua
@@ -2479,7 +2479,7 @@ function calcs.offence(env, actor, activeSkill)
 				end
 			end
 		end
-		if not (skillModList:Flag(nil, "Condition:PhysicalIsHighestDamageType") or skillModList:Flag(nil, "Condition:LightningIsHighestDamageType") or skillModList:Flag(nil, "Condition:ColdIsHighestDamageType") or skillModList:Flag(nil, "Condition:FireIsHighestDamageType") or skillModList:Flag(nil, "Condition:ChaosIsHighestDamageType")) then
+		if not skillModList:Flag(nil, "IsHighestDamageTypeOVERRIDE") then
 			skillModList:NewMod("Condition:"..highestType.."IsHighestDamageType", "FLAG", true, "Config")
 		end
 

--- a/src/Modules/CalcOffence.lua
+++ b/src/Modules/CalcOffence.lua
@@ -2471,17 +2471,17 @@ function calcs.offence(env, actor, activeSkill)
 		for _, damageType in ipairs(dmgTypeList) do
 			if output[damageType.."HitAverage"] > 0 then
 				local portion = output[damageType.."HitAverage"] / totalHitAvg * 100
-				local highestPortion = output[highestType.."HitAverage"] / totalHitAvg * 100
-				if portion > highestPortion then
+				if output[damageType.."HitAverage"] > output[highestType.."HitAverage"] then
 					highestType = damageType
-					highestPortion = portion
 				end
 				if breakdown then
 					t_insert(breakdown[damageType], s_format("Portion of total damage: %d%%", portion))
 				end
 			end
 		end
-		skillModList:NewMod("Condition:"..highestType.."IsHighestDamageType", "FLAG", true, "Config")
+		if not (skillModList:Flag(nil, "Condition:PhysicalIsHighestDamageType") or skillModList:Flag(nil, "Condition:LightningIsHighestDamageType") or skillModList:Flag(nil, "Condition:ColdIsHighestDamageType") or skillModList:Flag(nil, "Condition:FireIsHighestDamageType") or skillModList:Flag(nil, "Condition:ChaosIsHighestDamageType")) then
+			skillModList:NewMod("Condition:"..highestType.."IsHighestDamageType", "FLAG", true, "Config")
+		end
 
 		local hitRate = output.HitChance / 100 * (globalOutput.HitSpeed or globalOutput.Speed) * (skillData.dpsMultiplier or 1)
 

--- a/src/Modules/CalcOffence.lua
+++ b/src/Modules/CalcOffence.lua
@@ -2465,15 +2465,23 @@ function calcs.offence(env, actor, activeSkill)
 			enemyDB.conditions.HitByLightningDamage = output.LightningHitAverage > 0
 		end
 		
-		-- For each damage type, calculate percentage of total damage.
+		local highestType = "Physical"
+
+		-- For each damage type, calculate percentage of total damage. Also tracks the highest damage type and outputs a Condition:TypeIsHighestDamageType flag for whichever the highest type is
 		for _, damageType in ipairs(dmgTypeList) do
 			if output[damageType.."HitAverage"] > 0 then
 				local portion = output[damageType.."HitAverage"] / totalHitAvg * 100
+				local highestPortion = output[highestType.."HitAverage"] / totalHitAvg * 100
+				if portion > highestPortion then
+					highestType = damageType
+					highestPortion = portion
+				end
 				if breakdown then
 					t_insert(breakdown[damageType], s_format("Portion of total damage: %d%%", portion))
 				end
 			end
 		end
+		skillModList:NewMod("Condition:"..highestType.."IsHighestDamageType", "FLAG", true, "Config")
 
 		local hitRate = output.HitChance / 100 * (globalOutput.HitSpeed or globalOutput.Speed) * (skillData.dpsMultiplier or 1)
 

--- a/src/Modules/ConfigOptions.lua
+++ b/src/Modules/ConfigOptions.lua
@@ -1000,7 +1000,7 @@ return {
 			modList:NewMod("Condition:IgnitingConflux", "FLAG", true, "Config", { type = "Condition", var = "Combat" })
 		end
 	end },
-	{ var = "highestDamageType", type = "list", ifFlag = "ChecksHighestDamage", label = "Highest damage type:", tooltip = "Determines whether modifiers that depend on the highest damage type apply.", list = {{val="NONE",label="Default"},{val="Physical",label="Physical"},{val="Lightning",label="Lightning"},{val="Cold",label="Cold"},{val="Fire",label="Fire"},{val="Chaos",label="Chaos"}}, apply = function(val, modList, enemyModList)
+	{ var = "highestDamageType", type = "list", ifFlag = "ChecksHighestDamage", label = "Highest damage type Override:", tooltip = "Determines whether modifiers that depend on the highest damage type apply.", list = {{val="NONE",label="Default"},{val="Physical",label="Physical"},{val="Lightning",label="Lightning"},{val="Cold",label="Cold"},{val="Fire",label="Fire"},{val="Chaos",label="Chaos"}}, apply = function(val, modList, enemyModList)
 		modList:NewMod("Condition:"..val.."IsHighestDamageType", "FLAG", true, "Config")
 	end },
 	{ var = "buffHeartstopper", type = "list", label = "Is Heartstopper active?", ifCond = "HeartstopperHIT", list = {{val=0,label="None"},{val="AVERAGE",label="average"},{val="HIT",label="Hit"},{val="DOT",label="Damage over time"}}, apply = function(val, modList, enemyModList)

--- a/src/Modules/ConfigOptions.lua
+++ b/src/Modules/ConfigOptions.lua
@@ -579,9 +579,6 @@ return {
 
 	-- Section: Combat options
 	{ section = "When In Combat", col = 1 },
-	{ var = "highestDamageType", type = "list", ifFlag = "ChecksHighestDamage", label = "Highest damage type:", tooltip = "Determines whether modifiers that depend on the highest damage type apply.", list = {{val="Physical",label="Physical"},{val="Lightning",label="Lightning"},{val="Cold",label="Cold"},{val="Fire",label="Fire"},{val="Chaos",label="Chaos"}}, apply = function(val, modList, enemyModList)
-		modList:NewMod("Condition:"..val.."IsHighestDamageType", "FLAG", true, "Config")
-	end },
 	{ var = "usePowerCharges", type = "check", label = "Do you use Power Charges?", apply = function(val, modList, enemyModList)
 		modList:NewMod("UsePowerCharges", "FLAG", true, "Config", { type = "Condition", var = "Combat" })
 	end },
@@ -1002,6 +999,9 @@ return {
 		if val == "IGNITING" or val == "ALL" then
 			modList:NewMod("Condition:IgnitingConflux", "FLAG", true, "Config", { type = "Condition", var = "Combat" })
 		end
+	end },
+	{ var = "highestDamageType", type = "list", ifFlag = "ChecksHighestDamage", label = "Highest damage type:", tooltip = "Determines whether modifiers that depend on the highest damage type apply.", list = {{val="NONE",label="Default"},{val="Physical",label="Physical"},{val="Lightning",label="Lightning"},{val="Cold",label="Cold"},{val="Fire",label="Fire"},{val="Chaos",label="Chaos"}}, apply = function(val, modList, enemyModList)
+		modList:NewMod("Condition:"..val.."IsHighestDamageType", "FLAG", true, "Config")
 	end },
 	{ var = "buffHeartstopper", type = "list", label = "Is Heartstopper active?", ifCond = "HeartstopperHIT", list = {{val=0,label="None"},{val="AVERAGE",label="average"},{val="HIT",label="Hit"},{val="DOT",label="Damage over time"}}, apply = function(val, modList, enemyModList)
 		if val == "HIT" then

--- a/src/Modules/ConfigOptions.lua
+++ b/src/Modules/ConfigOptions.lua
@@ -1001,7 +1001,10 @@ return {
 		end
 	end },
 	{ var = "highestDamageType", type = "list", ifFlag = "ChecksHighestDamage", label = "Highest damage type Override:", tooltip = "Determines whether modifiers that depend on the highest damage type apply.", list = {{val="NONE",label="Default"},{val="Physical",label="Physical"},{val="Lightning",label="Lightning"},{val="Cold",label="Cold"},{val="Fire",label="Fire"},{val="Chaos",label="Chaos"}}, apply = function(val, modList, enemyModList)
-		modList:NewMod("Condition:"..val.."IsHighestDamageType", "FLAG", true, "Config")
+		if val ~= "NONE" then
+			modList:NewMod("Condition:"..val.."IsHighestDamageType", "FLAG", true, "Config")
+			modList:NewMod("IsHighestDamageTypeOVERRIDE", "FLAG", true, "Config")
+		end
 	end },
 	{ var = "buffHeartstopper", type = "list", label = "Is Heartstopper active?", ifCond = "HeartstopperHIT", list = {{val=0,label="None"},{val="AVERAGE",label="average"},{val="HIT",label="Hit"},{val="DOT",label="Damage over time"}}, apply = function(val, modList, enemyModList)
 		if val == "HIT" then


### PR DESCRIPTION
This makes Elementalist Shaper of flames apply automatically again if fire is the highest, though this would allow for multiple to be the highest, the problem is the dropdown doesn't configure a default "does not deal damage" so making it an override rather than adding a condition would be a bit harder

also moves the config option to a more appropriate place

partial revert of #4790