### PR TITLE
Temp multistrike fix for shield crush

### DIFF
--- a/src/Data/Skills/sup_str.lua
+++ b/src/Data/Skills/sup_str.lua
@@ -3208,6 +3208,7 @@ skills["SupportMultistrike"] = {
 	statMap = {
 		["multistrike_damage_+%_final_on_first_repeat"] = {
 			mod("Damage", "MORE", nil, nil, nil, { type = "ModFlagOr", modFlags = bit.bor(ModFlag.WeaponMelee, ModFlag.Unarmed) }),
+			mod("Damage", "MORE", nil, nil, nil, { type = "SkillName", skillName = "Shield Crush" }),
 		},
 		["multistrike_damage_+%_final_on_second_repeat"] = {
 		},
@@ -3216,6 +3217,7 @@ skills["SupportMultistrike"] = {
 		},
 		["support_multiple_attacks_melee_attack_speed_+%_final"] = {
 			mod("Speed", "MORE", nil, ModFlag.Attack, nil, { type = "ModFlagOr", modFlags = bit.bor(ModFlag.WeaponMelee, ModFlag.Unarmed) }),
+			mod("Speed", "MORE", nil, ModFlag.Attack, nil, { type = "SkillName", skillName = "Shield Crush" }),
 		},
 		["multistrike_area_of_effect_+%_per_repeat"] = {
 			mod("AreaOfEffect", "INC", nil)
@@ -3306,6 +3308,7 @@ skills["SupportMultistrikePlus"] = {
 		},
 		["multistrike_damage_+%_final_on_third_repeat"] = {
 			mod("Damage", "MORE", nil, nil, nil, { type = "ModFlagOr", modFlags = bit.bor(ModFlag.WeaponMelee, ModFlag.Unarmed) }),
+			mod("Damage", "MORE", nil, nil, nil, { type = "SkillName", skillName = "Shield Crush" }),
 			div = 2,
 		},
 		["support_multiple_attack_damage_+%_final"] = {
@@ -3313,6 +3316,7 @@ skills["SupportMultistrikePlus"] = {
 		},
 		["support_multiple_attacks_melee_attack_speed_+%_final"] = {
 			mod("Speed", "MORE", nil, ModFlag.Attack, nil, { type = "ModFlagOr", modFlags = bit.bor(ModFlag.WeaponMelee, ModFlag.Unarmed) }),
+			mod("Speed", "MORE", nil, ModFlag.Attack, nil, { type = "SkillName", skillName = "Shield Crush" }),
 		},
 	},
 	qualityStats = {

--- a/src/Export/Skills/sup_str.txt
+++ b/src/Export/Skills/sup_str.txt
@@ -369,6 +369,7 @@ local skills, mod, flag, skill = ...
 	statMap = {
 		["multistrike_damage_+%_final_on_first_repeat"] = {
 			mod("Damage", "MORE", nil, nil, nil, { type = "ModFlagOr", modFlags = bit.bor(ModFlag.WeaponMelee, ModFlag.Unarmed) }),
+			mod("Damage", "MORE", nil, nil, nil, { type = "SkillName", skillName = "Shield Crush" }),
 		},
 		["multistrike_damage_+%_final_on_second_repeat"] = {
 		},
@@ -377,6 +378,7 @@ local skills, mod, flag, skill = ...
 		},
 		["support_multiple_attacks_melee_attack_speed_+%_final"] = {
 			mod("Speed", "MORE", nil, ModFlag.Attack, nil, { type = "ModFlagOr", modFlags = bit.bor(ModFlag.WeaponMelee, ModFlag.Unarmed) }),
+			mod("Speed", "MORE", nil, ModFlag.Attack, nil, { type = "SkillName", skillName = "Shield Crush" }),
 		},
 		["multistrike_area_of_effect_+%_per_repeat"] = {
 			mod("AreaOfEffect", "INC", nil)
@@ -393,6 +395,7 @@ local skills, mod, flag, skill = ...
 		},
 		["multistrike_damage_+%_final_on_third_repeat"] = {
 			mod("Damage", "MORE", nil, nil, nil, { type = "ModFlagOr", modFlags = bit.bor(ModFlag.WeaponMelee, ModFlag.Unarmed) }),
+			mod("Damage", "MORE", nil, nil, nil, { type = "SkillName", skillName = "Shield Crush" }),
 			div = 2,
 		},
 		["support_multiple_attack_damage_+%_final"] = {
@@ -400,6 +403,7 @@ local skills, mod, flag, skill = ...
 		},
 		["support_multiple_attacks_melee_attack_speed_+%_final"] = {
 			mod("Speed", "MORE", nil, ModFlag.Attack, nil, { type = "ModFlagOr", modFlags = bit.bor(ModFlag.WeaponMelee, ModFlag.Unarmed) }),
+			mod("Speed", "MORE", nil, ModFlag.Attack, nil, { type = "SkillName", skillName = "Shield Crush" }),
 		},
 	},
 #mods


### PR DESCRIPTION
This fix is very temporary, it should apply to shield crush but not any of the other shield skills

there is not shield ModFlag, but even if there was it would incorrectly apply it to the other shield skills