### PR TITLE
Fix: Tornado calculates DPS with hit rate instead of cast rate

### DIFF
--- a/src/Data/Skills/act_dex.lua
+++ b/src/Data/Skills/act_dex.lua
@@ -9486,6 +9486,15 @@ skills["Tornado"] = {
 	skillTypes = { [SkillType.Spell] = true, [SkillType.Duration] = true, [SkillType.Trappable] = true, [SkillType.Totemable] = true, [SkillType.Mineable] = true, [SkillType.Triggerable] = true, [SkillType.Damage] = true, [SkillType.Physical] = true, [SkillType.Area] = true, [SkillType.Orb] = true, [SkillType.AreaSpell] = true, },
 	statDescriptionScope = "skill_stat_descriptions",
 	castTime = 0.75,
+	preDamageFunc = function(activeSkill, output)
+		activeSkill.skillData.hitTimeOverride = activeSkill.skillData.damageInterval
+	end,
+	statMap = {
+		["tornado_base_damage_interval_ms"] = {
+			skill("damageInterval", nil ),
+			div = 1000, 
+			},
+		},
 	baseFlags = {
 		spell = true,
 		duration = true,

--- a/src/Export/Skills/act_dex.txt
+++ b/src/Export/Skills/act_dex.txt
@@ -1636,6 +1636,15 @@ local skills, mod, flag, skill = ...
 
 #skill Tornado
 #flags spell duration physical area
+	preDamageFunc = function(activeSkill, output)
+		activeSkill.skillData.hitTimeOverride = activeSkill.skillData.damageInterval
+	end,
+	statMap = {
+		["tornado_base_damage_interval_ms"] = {
+			skill("damageInterval", nil ),
+			div = 1000, 
+			},
+		},
 #mods
 
 #skill IntuitiveLink


### PR DESCRIPTION
Fixes #4791 .

### Description of the problem being solved:
Tornado ignored its inherent hit rate and instead behaved like a normal spell.
Now Tornado uses a fixed 0.25 second interval to apply damage. Cast speed does not scale its damage.

### Steps taken to verify a working solution:

![tornado_scaling](https://user-images.githubusercontent.com/100538010/184645860-8cba2375-2cb9-4f8a-b301-bb957edcf90f.png)

### Link to a build that showcases this PR:
https://pastebin.com/y8C8NXjN