### PR TITLE
Fix timeless jewel node weight bugs

### DIFF
--- a/src/Classes/TreeTab.lua
+++ b/src/Classes/TreeTab.lua
@@ -1123,23 +1123,23 @@ function TreeTabClass:FindTimelessJewel()
 			controls.nodeSlider.val = 1
 			controls.nodeSliderValue.label = s_format("^7%.3f", 10)
 		else
-			controls.nodeSlider.val = m_min(m_max((tonumber(sliderData[2]) or 0) / 10, 0), 10)
+			controls.nodeSlider.val = m_min(m_max((tonumber(sliderData[2]) or 0) / 10, 0), 1)
 			controls.nodeSliderValue.label = s_format("^7%.3f", controls.nodeSlider.val * 10)
 		end
-		if not controls.nodeSlider2.enabled then
-			parseSearchList(1, controls.searchListFallback and controls.searchListFallback.shown or false)
-		elseif sliderData[3] == "required" then
-			controls.nodeSlider2.val = 1
-			controls.nodeSlider2Value.label = s_format("^7%.3f", 10)
-		else
-			controls.nodeSlider2.val = m_min(m_max((tonumber(sliderData[3]) or 0) / 10, 0), 10)
-			controls.nodeSlider2Value.label = s_format("^7%.3f", controls.nodeSlider2.val * 10)
+		if controls.nodeSlider2.enabled then
+			if sliderData[3] == "required" then
+				controls.nodeSlider2.val = 1
+				controls.nodeSlider2Value.label = s_format("^7%.3f", 10)
+			else
+				controls.nodeSlider2.val = m_min(m_max((tonumber(sliderData[3]) or 0) / 10, 0), 1)
+				controls.nodeSlider2Value.label = s_format("^7%.3f", controls.nodeSlider2.val * 10)
+			end
 		end
 		if sliderData[4] == "required" then
 			controls.nodeSlider3.val = 1
 			controls.nodeSlider3Value.label = "^7Required"
 		else
-			controls.nodeSlider3.val = m_min(m_max((tonumber(sliderData[4]) or 0) / 500, 0), 500)
+			controls.nodeSlider3.val = m_min(m_max((tonumber(sliderData[4]) or 0) / 500, 0), 1)
 			controls.nodeSlider3Value.label = s_format("^7%.f", controls.nodeSlider3.val * 500)
 		end
 	end


### PR DESCRIPTION
In the timeless jewel search UI, given the following desired nodes:
```
vaal_notable_curse_1, 777, 0, 111
vaal_small_aura_effect, 888, 0, 999
```

.. switching from ``vaal_notable_curse_1`` to ``vaal_small_aura_effect`` in the "search for node" dropdown list will incorrectly copy data from ``vaal_notable_curse_1`` to ``vaal_small_aura_effect``, setting the minimum node weight for both desired nodes to 111.

``controls.nodeSlider.val``, ``controls.nodeSlider2.val``, and ``controls.nodeSlider3.val`` were not properly constrained to valid slider values &mdash; they need to be between 0 and 1 (inclusive); 500 for example is not a valid position for ``controls.nodeSlider3.val``, that value is 500 times bigger than the maximum that slider can represent.

This PR fixes both issues.