### PR TITLE
Deidbell patch note change.

### DIFF
--- a/src/Data/Uniques/helmet.lua
+++ b/src/Data/Uniques/helmet.lua
@@ -701,7 +701,7 @@ Requires Level 33, 38 Str, 38 Dex
 +(200-300) to Armour
 {variant:2}Adds 10-20 Physical Damage to Attacks
 {variant:1,2}20% increased Melee Damage
-{variant:3}Skills which Exert an Attack to have a (20-30)% chance to not count that Attack
+{variant:3}Skills which Exert an Attack to have a (20-40)% chance to not count that Attack
 Cannot Leech when on Low Life
 ]],[[
 Deidbellow


### PR DESCRIPTION
Old:
The Deidbell Unique Helmet no longer has 20% increased Melee Damage, or Adds 10 to 20 Physical Damage to Attacks. Instead, it now causes Skills which Exert an Attack to have a 20-30% chance to not count that Attack.
New:
The Deidbell Unique Helmet no longer has 20% increased Melee Damage, or Adds 10 to 20 Physical Damage to Attacks. Instead, it now causes Skills which Exert an Attack to have a 20-40% chance to not count that Attack.

The wording of this mod is also extremly like to be different in the final version.