### PR TITLE
Passive count multipliers preview on nodes

### DIFF
--- a/src/Classes/PassiveSpec.lua
+++ b/src/Classes/PassiveSpec.lua
@@ -221,8 +221,14 @@ function PassiveSpecClass:AllocateMasteryEffects(masteryEffects)
 		self.masterySelections[id] = effectId
 		self.allocatedMasteryCount = self.allocatedMasteryCount + 1
 		if not self.allocatedMasteryTypes[self.allocNodes[id].name] then
-			self.allocatedMasteryTypes[self.allocNodes[id].name] = true
+			self.allocatedMasteryTypes[self.allocNodes[id].name] = 1
 			self.allocatedMasteryTypeCount = self.allocatedMasteryTypeCount + 1
+		else
+			local prevCount = self.allocatedMasteryTypes[self.allocNodes[id].name]
+			self.allocatedMasteryTypes[self.allocNodes[id].name] = prevCount + 1
+			if prevCount == 0 then
+				self.allocatedMasteryTypeCount = self.allocatedMasteryTypeCount + 1
+			end
 		end
 	end
 end
@@ -863,9 +869,15 @@ function PassiveSpecClass:BuildAllDependsAndPaths()
 				node.reminderText = { "Tip: Right click to select a different effect" }
 				self.tree:ProcessStats(node)
 				self.allocatedMasteryCount = self.allocatedMasteryCount + 1
-				if not self.allocatedMasteryTypes[node.name] then
-					self.allocatedMasteryTypes[node.name] = true
+				if not self.allocatedMasteryTypes[self.allocNodes[id].name] then
+					self.allocatedMasteryTypes[self.allocNodes[id].name] = 1
 					self.allocatedMasteryTypeCount = self.allocatedMasteryTypeCount + 1
+				else
+					local prevCount = self.allocatedMasteryTypes[self.allocNodes[id].name]
+					self.allocatedMasteryTypes[self.allocNodes[id].name] = prevCount + 1
+					if prevCount == 0 then
+						self.allocatedMasteryTypeCount = self.allocatedMasteryTypeCount + 1
+					end
 				end
 			else
 				self.nodes[id].alloc = false

--- a/src/Modules/CalcSetup.lua
+++ b/src/Modules/CalcSetup.lua
@@ -420,9 +420,8 @@ function calcs.initEnv(build, mode, override, specEnv)
 		modDB:NewMod("PerBrutalTripleDamageChance", "BASE", 3, "Base")
 		modDB:NewMod("PerAfflictionAilmentDamage", "BASE", 8, "Base")
 		modDB:NewMod("PerAfflictionNonDamageEffect", "BASE", 8, "Base")
-		modDB:NewMod("PerAbsorptionElementalEnergyShieldRecoup", "BASE", 12, "Base")
+		modDB:NewMod("PerAbsorptionElementalEnergyShieldRecoup", "BASE", 12, "Base")		
 		modDB:NewMod("Multiplier:AllocatedNotable", "BASE", env.spec.allocatedNotableCount, "")
-		modDB:NewMod("Multiplier:AllocatedMastery", "BASE", env.spec.allocatedMasteryCount, "")
 		modDB:NewMod("Multiplier:AllocatedMasteryType", "BASE", env.spec.allocatedMasteryTypeCount, "")
 
 		-- Add bandit mods
@@ -476,6 +475,8 @@ function calcs.initEnv(build, mode, override, specEnv)
 		end
 	end
 
+	local newCount = 0
+	local allocatedMasteryCount = env.spec.allocatedMasteryCount
 	if not accelerate.nodeAlloc then
 		-- Build list of passive nodes
 		local nodes
@@ -484,11 +485,18 @@ function calcs.initEnv(build, mode, override, specEnv)
 			if override.addNodes then
 				for node in pairs(override.addNodes) do
 					nodes[node.id] = node
+					if node.type == "Mastery" then
+						newCount = newCount + 1
+					end
 				end
 			end
 			for _, node in pairs(env.spec.allocNodes) do
 				if not override.removeNodes or not override.removeNodes[node] then
 					nodes[node.id] = node
+				elseif override.removeNodes[node] then
+					if node.type == "Mastery" then
+						newCount = newCount - 1
+					end
 				end
 			end
 		else
@@ -496,6 +504,8 @@ function calcs.initEnv(build, mode, override, specEnv)
 		end
 		env.allocNodes = nodes
 	end
+
+	modDB:NewMod("Multiplier:AllocatedMastery", "BASE", allocatedMasteryCount + newCount, "")
 
 	-- Build and merge item modifiers, and create list of radius jewels
 	if not accelerate.requirementsItems then

--- a/src/Modules/CalcSetup.lua
+++ b/src/Modules/CalcSetup.lua
@@ -499,7 +499,7 @@ function calcs.initEnv(build, mode, override, specEnv)
 							end
 						end
 					elseif node.type == "Notable" then
-						allocatedNotableCount = allocatedNotableCount - 1
+						allocatedNotableCount = allocatedNotableCount + 1
 					end
 				end
 			end

--- a/src/Modules/CalcSetup.lua
+++ b/src/Modules/CalcSetup.lua
@@ -474,12 +474,9 @@ function calcs.initEnv(build, mode, override, specEnv)
 	end
 
 	local allocatedNotableCount = env.spec.allocatedNotableCount
-	local newNotableCount = 0
 	local allocatedMasteryCount = env.spec.allocatedMasteryCount
-	local newMasteryCount = 0
 	local allocatedMasteryTypeCount = env.spec.allocatedMasteryTypeCount
 	local allocatedMasteryTypes = copyTable(env.spec.allocatedMasteryTypes)
-	local newTypeCount = 0
 	if not accelerate.nodeAlloc then
 		-- Build list of passive nodes
 		local nodes
@@ -489,20 +486,20 @@ function calcs.initEnv(build, mode, override, specEnv)
 				for node in pairs(override.addNodes) do
 					nodes[node.id] = node
 					if node.type == "Mastery" then
-						newMasteryCount = newMasteryCount + 1
+						allocatedMasteryCount = allocatedMasteryCount + 1
 
 						if not allocatedMasteryTypes[node.name] then
 							allocatedMasteryTypes[node.name] = 1
-							newTypeCount = newTypeCount + 1
+							allocatedMasteryTypeCount = allocatedMasteryTypeCount + 1
 						else
 							local prevCount = allocatedMasteryTypes[node.name]
 							allocatedMasteryTypes[node.name] = prevCount + 1
 							if prevCount == 0 then
-								newTypeCount = newTypeCount + 1
+								allocatedMasteryTypeCount = allocatedMasteryTypeCount + 1
 							end
 						end
 					elseif node.type == "Notable" then
-						newNotableCount = newNotableCount - 1
+						allocatedNotableCount = allocatedNotableCount - 1
 					end
 				end
 			end
@@ -511,14 +508,14 @@ function calcs.initEnv(build, mode, override, specEnv)
 					nodes[node.id] = node
 				elseif override.removeNodes[node] then
 					if node.type == "Mastery" then
-						newMasteryCount = newMasteryCount - 1
+						allocatedMasteryCount = allocatedMasteryCount - 1
 
 						allocatedMasteryTypes[node.name] = allocatedMasteryTypes[node.name] - 1
 						if allocatedMasteryTypes[node.name] == 0 then
-							newTypeCount = newTypeCount - 1
+							allocatedMasteryTypeCount = allocatedMasteryTypeCount - 1
 						end
 					elseif node.type == "Notable" then
-						newNotableCount = newNotableCount - 1
+						allocatedNotableCount = allocatedNotableCount - 1
 					end
 				end
 			end
@@ -528,9 +525,9 @@ function calcs.initEnv(build, mode, override, specEnv)
 		env.allocNodes = nodes
 	end
 	
-	modDB:NewMod("Multiplier:AllocatedNotable", "BASE", allocatedNotableCount + newNotableCount, "")
-	modDB:NewMod("Multiplier:AllocatedMastery", "BASE", allocatedMasteryCount + newMasteryCount, "")
-	modDB:NewMod("Multiplier:AllocatedMasteryType", "BASE", allocatedMasteryTypeCount + newTypeCount, "")
+	modDB:NewMod("Multiplier:AllocatedNotable", "BASE", allocatedNotableCount, "")
+	modDB:NewMod("Multiplier:AllocatedMastery", "BASE", allocatedMasteryCount, "")
+	modDB:NewMod("Multiplier:AllocatedMasteryType", "BASE", allocatedMasteryTypeCount, "")
 
 	-- Build and merge item modifiers, and create list of radius jewels
 	if not accelerate.requirementsItems then

--- a/src/Modules/CalcSetup.lua
+++ b/src/Modules/CalcSetup.lua
@@ -420,9 +420,7 @@ function calcs.initEnv(build, mode, override, specEnv)
 		modDB:NewMod("PerBrutalTripleDamageChance", "BASE", 3, "Base")
 		modDB:NewMod("PerAfflictionAilmentDamage", "BASE", 8, "Base")
 		modDB:NewMod("PerAfflictionNonDamageEffect", "BASE", 8, "Base")
-		modDB:NewMod("PerAbsorptionElementalEnergyShieldRecoup", "BASE", 12, "Base")		
-		modDB:NewMod("Multiplier:AllocatedNotable", "BASE", env.spec.allocatedNotableCount, "")
-		
+		modDB:NewMod("PerAbsorptionElementalEnergyShieldRecoup", "BASE", 12, "Base")
 
 		-- Add bandit mods
 		if env.configInput.bandit == "Alira" then
@@ -475,8 +473,10 @@ function calcs.initEnv(build, mode, override, specEnv)
 		end
 	end
 
+	local allocatedNotableCount = env.spec.allocatedNotableCount
+	local newNotableCount = 0
 	local allocatedMasteryCount = env.spec.allocatedMasteryCount
-	local newCount = 0
+	local newMasteryCount = 0
 	local allocatedMasteryTypeCount = env.spec.allocatedMasteryTypeCount
 	local allocatedMasteryTypes = copyTable(env.spec.allocatedMasteryTypes)
 	local newTypeCount = 0
@@ -489,7 +489,7 @@ function calcs.initEnv(build, mode, override, specEnv)
 				for node in pairs(override.addNodes) do
 					nodes[node.id] = node
 					if node.type == "Mastery" then
-						newCount = newCount + 1
+						newMasteryCount = newMasteryCount + 1
 
 						if not allocatedMasteryTypes[node.name] then
 							allocatedMasteryTypes[node.name] = 1
@@ -501,6 +501,8 @@ function calcs.initEnv(build, mode, override, specEnv)
 								newTypeCount = newTypeCount + 1
 							end
 						end
+					elseif node.type == "Notable" then
+						newNotableCount = newNotableCount - 1
 					end
 				end
 			end
@@ -509,12 +511,14 @@ function calcs.initEnv(build, mode, override, specEnv)
 					nodes[node.id] = node
 				elseif override.removeNodes[node] then
 					if node.type == "Mastery" then
-						newCount = newCount - 1
+						newMasteryCount = newMasteryCount - 1
 
 						allocatedMasteryTypes[node.name] = allocatedMasteryTypes[node.name] - 1
 						if allocatedMasteryTypes[node.name] == 0 then
 							newTypeCount = newTypeCount - 1
 						end
+					elseif node.type == "Notable" then
+						newNotableCount = newNotableCount - 1
 					end
 				end
 			end
@@ -523,8 +527,9 @@ function calcs.initEnv(build, mode, override, specEnv)
 		end
 		env.allocNodes = nodes
 	end
-
-	modDB:NewMod("Multiplier:AllocatedMastery", "BASE", allocatedMasteryCount + newCount, "")
+	
+	modDB:NewMod("Multiplier:AllocatedNotable", "BASE", allocatedNotableCount + newNotableCount, "")
+	modDB:NewMod("Multiplier:AllocatedMastery", "BASE", allocatedMasteryCount + newMasteryCount, "")
 	modDB:NewMod("Multiplier:AllocatedMasteryType", "BASE", allocatedMasteryTypeCount + newTypeCount, "")
 
 	-- Build and merge item modifiers, and create list of radius jewels


### PR DESCRIPTION
Fixes #4850 

### Description of the problem being solved:
When building a new tree for removing/adding nodes it was not updating the values of the multipliers for notables, masteries, or mastery types.

Mastery types are reworked to count how many are allocated per type instead of simply being true, while notables and masteries are simply adjusted so they properly include a potential new/removed node in the count.

### Steps taken to verify a working solution:
- Checked elementalist Bastion of Elements (allocated notable), unclear if it works since it does not show up on tooltip regardless, but it still adds to calc tab as it should
- Attribute masteries (allocated mastery), works great
- Trickster Polymath, works great, though recover on kill does not show up on tooltip

### Before screenshot:
(With no other masteries selected)
![image](https://user-images.githubusercontent.com/5985728/184920708-56c1bceb-2982-42bb-a66c-d25e98fe009b.png)
(With Polymath and no other masteries)
![image](https://user-images.githubusercontent.com/5985728/184921199-bf54c204-eb93-42d9-bbad-621f7649a0b7.png)


### After screenshot:
(With no other masteries selected)
![image](https://user-images.githubusercontent.com/5985728/184920817-f4e46b42-f9a3-49fd-87e2-6675fd71b1bd.png)
(With Polymath and no other masteries)
![image](https://user-images.githubusercontent.com/5985728/184921233-9c0d19f1-5948-4222-bfe4-bfc2e1143d41.png)

