### PR TITLE
Fix: Life and Mana Degen doesn't affect new chainbreaker and Kaom's Spirit and apply rage buff effect correctly

### DIFF
--- a/src/Modules/CalcDefence.lua
+++ b/src/Modules/CalcDefence.lua
@@ -618,6 +618,10 @@ function calcs.defence(env, actor)
 		end
 		local regen = base * (1 + output.ManaRegenInc/100) * more
 		local regenRate = round(regen * output.ManaRecoveryRateMod, 1)
+		if modDB:Flag(nil, "UnaffectedByManaRegen") then  --Chainbreaker Flag
+			output.ManaRegenRateToRageRegen = regenRate
+			regenRate = 0
+		end
 		local degen = modDB:Sum("BASE", nil, "ManaDegen")
 		output.ManaRegen = regenRate - degen
 		if breakdown then
@@ -664,6 +668,10 @@ function calcs.defence(env, actor)
 		else
 			output.LifeRegen = 0
 		end
+		if modDB:Flag(nil, "UnaffectedByLifeRegen") then  --Kaom's Spirit
+			output.LifeRegenRateToRageRegen = output.LifeRegen
+			output.LifeRegen = 0
+		end
 		-- Don't add life recovery mod for this
 		if output.LifeRegen and modDB:Flag(nil, "LifeRegenerationRecoversEnergyShield") and output.EnergyShield > 0 then
 			modDB:NewMod("EnergyShieldRecovery", "BASE", lifeBase * modDB:More(nil, "LifeRegen") * (1 + modDB:Sum("INC", nil, "LifeRegen") / 100), "Life Regeneration Recovers Energy Shield")
@@ -689,14 +697,6 @@ function calcs.defence(env, actor)
 	end
 	output.EnergyShieldRegen = output.EnergyShieldRegen + modDB:Sum("BASE", nil, "EnergyShieldRecovery") * output.EnergyShieldRecoveryRateMod
 	output.EnergyShieldRegenPercent = round(output.EnergyShieldRegen / output.EnergyShield * 100, 1)
-	if modDB:Flag(nil, "UnaffectedByManaRegen") then  --Chainbreaker Flag
-		output.WouldBeManaRegen = output.ManaRegen
-		output.ManaRegen = 0
-    end
-	if modDB:Flag(nil, "UnaffectedByLifeRegen") then  --Kaom's Spirit
-		output.WouldBeLifeRegen = output.LifeRegen
-		output.LifeRegen = 0
-    end
 	if modDB:Sum("BASE", nil, "RageRegen") > 0 then
 		modDB:NewMod("Condition:CanGainRage", "FLAG", true, "RageRegen")
 		local base = modDB:Sum("BASE", nil, "RageRegen")

--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -1537,7 +1537,10 @@ end
 -- List of special modifiers
 local specialModList = {
 	-- Keystones
-	["(%d+) rage regenerated for every (%d+) mana regeneration per second"] = function(num, _, div) return { mod("RageRegen", "BASE", num, {type = "PerStat", stat = "WouldBeManaRegen", div = tonumber(div) }) } end,
+	["(%d+) rage regenerated for every (%d+) mana regeneration per second"] = function(num, _, div) return { 
+		mod("RageRegen", "BASE", num, {type = "PerStat", stat = "ManaRegenRateToRageRegen", div = tonumber(div) }) ,
+		flag("Condition:CanGainRage"),
+	} end,
 	["(%w+) recovery from regeneration is not applied"] = function(_, type) return { flag("UnaffectedBy" .. firstToUpper(type) .. "Regen") } end,
 	["(%d+)%% less damage taken for every (%d+)%% life recovery per second from leech"] = function(num, _, div)
 		return {  mod("DamageTaken", "MORE", -num, { type = "PerStat", stat = "MaxLifeLeechRatePercent", div = tonumber(div) }) }
@@ -3481,7 +3484,10 @@ local specialModList = {
 	["attacks with axes or swords grant (%d+) rage on hit, no more than once every second"] = {
 		flag("Condition:CanGainRage", { type = "Condition", varList = { "UsingAxe", "UsingSword" } }),
 	},
-	["regenerate (%d+) rage per second for every (%d+) life recovery per second from regeneration"] = function(num, _, div) return { mod("RageRegen", "BASE", num, {type = "PerStat", stat = "WouldBeLifeRegen", div = tonumber(div) }) } end,
+	["regenerate (%d+) rage per second for every (%d+) life recovery per second from regeneration"] = function(num, _, div) return { 
+		mod("RageRegen", "BASE", num, {type = "PerStat", stat = "LifeRegenRateToRageRegen", div = tonumber(div) }),
+		flag("Condition:CanGainRage"),
+	} end,
 	["your critical strike multiplier is (%d+)%%"] = function(num) return { mod("CritMultiplier", "OVERRIDE", num) } end,
 	["base critical strike chance for attacks with weapons is ([%d%.]+)%%"] = function(num) return { mod("WeaponBaseCritChance", "OVERRIDE", num) } end,
 	["critical strike chance is (%d+)%% for hits with this weapon"] = function(num) return { mod("CritChance", "OVERRIDE", num, nil, ModFlag.Hit, { type = "Condition", var = "{Hand}Attack" }, { type = "SkillType", skillType = SkillType.Attack }) } end, 


### PR DESCRIPTION
Fixes #4855 .
Fixes #4863 .

### Description of the problem being solved:
The new Chainbreaker and Kaom's spirit rage regeneration was based on total life/mana regeneration after calculating degens. Its calculation time is now based on after calculating the recovery rate from regeneration and before any other calcuations work with LifeRegen/ManaRegen because of the `UnaffectedBy` mod.
Additionally, rage regeneration from these two sources didn't add the `Condition:CanGainRage` flag which prevented any rage buffs to apply.
### Steps taken to verify a working solution:
- checked that chainbreaker and kaom's spirit apply still apply rage regen and their respective `UnaffectedBy` mod.
- checked that with 50 rage selected in the configuration tab dps is increased when selecting either of the two.
- checked that both ragen regen stack 
- checked that the life degen and triple rage buff affect apply from Rite of Ruin 

### Link to a build that showcases this PR:
https://pobb.in/2oYNHZUtTqFD

### After screenshot:
![ragebuff_fixed](https://user-images.githubusercontent.com/100538010/184933964-96ad1076-28d2-4c47-a4ed-3184739c8982.png)
![rage_riteofruin](https://user-images.githubusercontent.com/100538010/184934070-568e752a-f7dd-4db4-a7a3-2f146c18b3aa.png)

