### PR TITLE
Added the variants for the Monkey Paw and Avian Twins Talismans

### DIFF
--- a/src/Data/Bases/amulet.lua
+++ b/src/Data/Bases/amulet.lua
@@ -131,6 +131,134 @@ itemBases["Jet Amulet"] = {
 	req = { level = 12, },
 }
 
+itemBases["Avian Twins Talisman (Fire-To-Cold)"] = {
+	type = "Amulet",
+	subType = "Talisman",
+	tags = { default = true, talisman = true, amulet = true, },
+	implicit = "50% of Fire Damage from Hits taken as Cold Damage",
+	implicitModTypes = { { "elemental", "fire", "cold" }, },
+	req = { },
+}
+itemBases["Avian Twins Talisman (Fire-To-Lightning)"] = {
+	type = "Amulet",
+	subType = "Talisman",
+	tags = { default = true, talisman = true, amulet = true, },
+	implicit = "50% of Fire Damage from Hits taken as Lightning Damage",
+	implicitModTypes = { { "elemental", "fire", "lightning" }, },
+	req = { },
+}
+itemBases["Avian Twins Talisman (Cold-To-Lightning)"] = {
+	type = "Amulet",
+	subType = "Talisman",
+	tags = { default = true, talisman = true, amulet = true, },
+	implicit = "50% of Cold Damage from Hits taken as Fire Damage",
+	implicitModTypes = { { "elemental", "fire", "cold" }, },
+	req = { },
+}
+itemBases["Avian Twins Talisman (Cold-To-Fire)"] = {
+	type = "Amulet",
+	subType = "Talisman",
+	tags = { default = true, talisman = true, amulet = true, },
+	implicit = "50% of Cold Damage from Hits taken as Lightning Damage",
+	implicitModTypes = { { "elemental", "cold", "lightning" }, },
+	req = { },
+}
+itemBases["Avian Twins Talisman (Lightning-To-Cold)"] = {
+	type = "Amulet",
+	subType = "Talisman",
+	tags = { default = true, talisman = true, amulet = true, },
+	implicit = "50% of Lightning Damage from Hits taken as Cold Damage",
+	implicitModTypes = { { "elemental", "cold", "lightning" }, },
+	req = { },
+}
+itemBases["Avian Twins Talisman (Lightning-To-Fire)"] = {
+	type = "Amulet",
+	subType = "Talisman",
+	tags = { default = true, talisman = true, amulet = true, },
+	implicit = "50% of Lightning Damage from Hits taken as Fire Damage",
+	implicitModTypes = { { "elemental", "fire", "lightning" }, },
+	req = { },
+}
+itemBases["Monkey Paw Talisman (Power)"] = {
+	type = "Amulet",
+	subType = "Talisman",
+	tags = { default = true, talisman = true, amulet = true, },
+	implicit = "10% chance to gain a Power Charge on Kill",
+	implicitModTypes = { { "power_charge" }, },
+	req = { },
+}
+itemBases["Monkey Paw Talisman (Frenzy)"] = {
+	type = "Amulet",
+	subType = "Talisman",
+	tags = { default = true, talisman = true, amulet = true, },
+	implicit = "10% chance to gain a Frenzy Charge on Kill",
+	implicitModTypes = { { "frenzy_charge" }, },
+	req = { },
+}
+itemBases["Avian Twins Talisman"] = {
+	type = "Amulet",
+	subType = "Talisman",
+	tags = { default = true, talisman = true, amulet = true, },
+	implicit = "50% of Fire Damage from Hits taken as Cold Damage",
+	implicitModTypes = { { "elemental", "fire", "cold" }, },
+	req = { },
+}
+itemBases["Avian Twins Talisman"] = {
+	type = "Amulet",
+	subType = "Talisman",
+	tags = { default = true, talisman = true, amulet = true, },
+	implicit = "50% of Fire Damage from Hits taken as Lightning Damage",
+	implicitModTypes = { { "elemental", "fire", "lightning" }, },
+	req = { },
+}
+itemBases["Avian Twins Talisman"] = {
+	type = "Amulet",
+	subType = "Talisman",
+	tags = { default = true, talisman = true, amulet = true, },
+	implicit = "50% of Cold Damage from Hits taken as Fire Damage",
+	implicitModTypes = { { "elemental", "fire", "cold" }, },
+	req = { },
+}
+itemBases["Avian Twins Talisman"] = {
+	type = "Amulet",
+	subType = "Talisman",
+	tags = { default = true, talisman = true, amulet = true, },
+	implicit = "50% of Cold Damage from Hits taken as Lightning Damage",
+	implicitModTypes = { { "elemental", "cold", "lightning" }, },
+	req = { },
+}
+itemBases["Avian Twins Talisman"] = {
+	type = "Amulet",
+	subType = "Talisman",
+	tags = { default = true, talisman = true, amulet = true, },
+	implicit = "50% of Lightning Damage from Hits taken as Cold Damage",
+	implicitModTypes = { { "elemental", "cold", "lightning" }, },
+	req = { },
+}
+itemBases["Avian Twins Talisman"] = {
+	type = "Amulet",
+	subType = "Talisman",
+	tags = { default = true, talisman = true, amulet = true, },
+	implicit = "50% of Lightning Damage from Hits taken as Fire Damage",
+	implicitModTypes = { { "elemental", "fire", "lightning" }, },
+	req = { },
+}
+itemBases["Monkey Paw Talisman"] = {
+	type = "Amulet",
+	subType = "Talisman",
+	tags = { default = true, talisman = true, amulet = true, },
+	implicit = "10% chance to gain a Power Charge on Kill",
+	implicitModTypes = { { "power_charge" }, },
+	req = { },
+}
+itemBases["Monkey Paw Talisman"] = {
+	type = "Amulet",
+	subType = "Talisman",
+	tags = { default = true, talisman = true, amulet = true, },
+	implicit = "10% chance to gain a Frenzy Charge on Kill",
+	implicitModTypes = { { "frenzy_charge" }, },
+	req = { },
+}
 itemBases["Black Maw Talisman"] = {
 	type = "Amulet",
 	subType = "Talisman",

--- a/src/Export/Bases/amulet.txt
+++ b/src/Export/Bases/amulet.txt
@@ -12,4 +12,23 @@ local itemBases = ...
 #base Metadata/Items/Amulet/AmuletVictor1
 
 #subType Talisman
+#forceShow true
+#base Metadata/Items/Amulets/Talismans/Talisman2_6_1 Avian Twins Talisman (Fire-To-Cold)
+#base Metadata/Items/Amulets/Talismans/Talisman2_6_2 Avian Twins Talisman (Fire-To-Lightning)
+#base Metadata/Items/Amulets/Talismans/Talisman2_6_3 Avian Twins Talisman (Cold-To-Lightning)
+#base Metadata/Items/Amulets/Talismans/Talisman2_6_4 Avian Twins Talisman (Cold-To-Fire)
+#base Metadata/Items/Amulets/Talismans/Talisman2_6_5 Avian Twins Talisman (Lightning-To-Cold)
+#base Metadata/Items/Amulets/Talismans/Talisman2_6_6 Avian Twins Talisman (Lightning-To-Fire)
+#base Metadata/Items/Amulets/Talismans/Talisman3_6_1 Monkey Paw Talisman (Power)
+#base Metadata/Items/Amulets/Talismans/Talisman3_6_2 Monkey Paw Talisman (Frenzy)
+#forceShow false
+#base Metadata/Items/Amulets/Talismans/Talisman2_6_1
+#base Metadata/Items/Amulets/Talismans/Talisman2_6_2
+#base Metadata/Items/Amulets/Talismans/Talisman2_6_3
+#base Metadata/Items/Amulets/Talismans/Talisman2_6_4
+#base Metadata/Items/Amulets/Talismans/Talisman2_6_5
+#base Metadata/Items/Amulets/Talismans/Talisman2_6_6
+#base Metadata/Items/Amulets/Talismans/Talisman3_6_1
+#base Metadata/Items/Amulets/Talismans/Talisman3_6_2
+#forceShow true
 #baseMatch Metadata/Items/Amulets/Talismans/Talisman

--- a/src/Export/Scripts/bases.lua
+++ b/src/Export/Scripts/bases.lua
@@ -33,7 +33,7 @@ directiveTable.socketLimit = function(state, args, out)
 end
 
 directiveTable.base = function(state, args, out)
-	local baseTypeId, displayName = args:match("([%w/]+) (.+)")
+	local baseTypeId, displayName = args:match("([%w/_]+) (.+)")
 	if not baseTypeId then
 		baseTypeId = args
 	end

--- a/src/Export/spec.lua
+++ b/src/Export/spec.lua
@@ -1610,7 +1610,7 @@ return {
 			refTo="",
 			type="Int",
 			width=150
-		},
+		}
 	},
 	BuffVisualArtVariations={
 		[1]={


### PR DESCRIPTION
Fixes #2100  .

### Description of the problem being solved:
Due to the way that the Talismans are exported, we mark all the talismans with variants with the same key, thus only able to select 1 and not change the implicit. The new behaviour will now be the same as the Two Stone rings, where the variants will be listed.

### Steps taken to verify a working solution:
- Export is ran with new `amulet.txt` file
- Open PoB and go to the `Craft Item...` menu
- Select `Amulet: Talisman`
- Confirm that all the variants for Monkey Paw (3 of them) and Avian Twins (6 of them) are there
- Confirm the other talismans are also there

### Link to a build that showcases this PR:

### Before screenshot:
![image](https://user-images.githubusercontent.com/51249961/184997028-5072cdd4-686d-4fd2-b005-e76c101287a0.png)

### After screenshot:
![image](https://user-images.githubusercontent.com/51249961/184996966-211a1703-7080-4f4b-bdcc-c916079dc19b.png)
![image](https://user-images.githubusercontent.com/51249961/184996984-b412cbb8-cbe7-44b1-a383-01fddd529d4b.png)
