### PR TITLE
Fix support gems not adding their flags if they themselves require a flag added by a support gem lower in the supportList

### DIFF
--- a/src/Modules/CalcActiveSkill.lua
+++ b/src/Modules/CalcActiveSkill.lua
@@ -111,7 +111,7 @@ function calcs.createActiveSkill(activeEffect, supportList, actor, socketGroup, 
 	end
 
 	-- loop over rejected supports unitl none are added.
-	-- Makes sure that all skillType flags that should be added are added regardless or support gem order in group
+	-- Makes sure that all skillType flags that should be added are added regardless of support gem order in group
 	local notAddedNewSupport = true
 	repeat
 		notAddedNewSupport = true

--- a/src/Modules/CalcActiveSkill.lua
+++ b/src/Modules/CalcActiveSkill.lua
@@ -110,7 +110,7 @@ function calcs.createActiveSkill(activeEffect, supportList, actor, socketGroup, 
 		end
 	end
 
-	-- loop over rejected supports unitl none are added.
+	-- loop over rejected supports until none are added.
 	-- Makes sure that all skillType flags that should be added are added regardless of support gem order in group
 	local notAddedNewSupport = true
 	repeat


### PR DESCRIPTION
Fixes #4851

### Description of the problem being solved:

In some cases support gems that required skillTypes flags added by support gems lower in the socket group would not work.

### Steps taken to verify a working solution:
- Test some gem setups

### See issue for screenshots