### PR TITLE
Rebuild all timeless data on load

### DIFF
--- a/src/Classes/TimelessJewelListControl.lua
+++ b/src/Classes/TimelessJewelListControl.lua
@@ -67,9 +67,9 @@ Timeless Jewel
 League: Legion
 Requires Level: 20
 Limited to: 1
-Variant: Cadiro
-Variant: Victario
-Variant: Caspiro
+Variant: Cadiro (Supreme Decadence)
+Variant: Victario (Supreme Grandstanding)
+Variant: Caspiro (Supreme Ostentation)
 Selected Variant:  ]] .. variant .. [[
 Radius: Large
 Implicits: 0
@@ -86,9 +86,9 @@ Timeless Jewel
 League: Legion
 Requires Level: 20
 Limited to: 1
-Variant: Doryani
-Variant: Xibaqua
-Variant: Ahuana
+Variant: Doryani (Corrupted Soul)
+Variant: Xibaqua (Divine Flesh)
+Variant: Ahuana (Immortal Ambition)
 Selected Variant: ]] .. variant .. [[
 Radius: Large
 Implicits: 0
@@ -105,9 +105,9 @@ Timeless Jewel
 League: Legion
 Requires Level: 20
 Limited to: 1
-Variant: Kaom
-Variant: Rakiata
-Variant: Akoya
+Variant: Kaom (Strength of Blood)
+Variant: Rakiata (Tempered by War)
+Variant: Akoya (Chainbreaker)
 Selected Variant: ]] .. variant .. [[
 Radius: Large
 Implicits: 0
@@ -124,9 +124,9 @@ Timeless Jewel
 League: Legion
 Requires Level: 20
 Limited to: 1
-Variant: Asenath
-Variant: Nasima
-Variant: Balbala
+Variant: Asenath (Dance with Death)
+Variant: Nasima (Second Sight)
+Variant: Balbala (The Traitor)
 Selected Variant: ]] .. variant .. [[
 Radius: Large
 Implicits: 0
@@ -150,9 +150,9 @@ Requires Level: 20
 Limited to: 1
 Has Alt Variant: true
 Has Alt Variant Two: true
-Variant: Avarius
-Variant: Dominus
-Variant: Maxarius
+Variant: Avarius (Power of Purpose)
+Variant: Dominus (Inner Conviction)
+Variant: Maxarius (Transcendence)
 Variant: Totem Damage
 Variant: Brand Damage
 Variant: Channelling Damage

--- a/src/Classes/TreeTab.lua
+++ b/src/Classes/TreeTab.lua
@@ -771,7 +771,17 @@ function TreeTabClass:FindTimelessJewel()
 		{ label = "Militant Faith", name = "templar", id = 4 },
 		{ label = "Elegant Hubris", name = "eternal", id = 5 }
 	}
-	timelessData.jewelType = next(timelessData.jewelType) and timelessData.jewelType or jewelTypes[1]
+	-- rebuild `timelessData.jewelType` as we only store the minimum amount of `jewelType` data in build XML
+	if next(timelessData.jewelType) then
+		for idx, jewelType in ipairs(jewelTypes) do
+			if jewelType.id == timelessData.jewelType.id then
+				timelessData.jewelType = jewelType
+				break
+			end
+		end
+	else
+		timelessData.jewelType = jewelTypes[1]
+	end
 	local conquerorTypes = {
 		[1] = {
 			{ label = "Doryani (Corrupted Soul)", id = 1 },
@@ -799,7 +809,17 @@ function TreeTabClass:FindTimelessJewel()
 			{ label = "Caspiro (Supreme Ostentation)", id = 3 }
 		}
 	}
-	timelessData.conquerorType = next(timelessData.conquerorType) and timelessData.conquerorType or conquerorTypes[timelessData.jewelType.id][1]
+	-- rebuild `timelessData.jewelType` as we only store the minimum amount of `conquerorType` data in build XML
+	if next(timelessData.conquerorType) then
+		for idx, conquerorType in ipairs(conquerorTypes[timelessData.jewelType.id]) do
+			if conquerorType.id == timelessData.conquerorType.id then
+				timelessData.conquerorType = conquerorType
+				break
+			end
+		end
+	else
+		timelessData.conquerorType = conquerorTypes[timelessData.jewelType.id][1]
+	end
 	local jewelSockets = { }
 	for socketId, socketData in pairs(self.build.spec.nodes) do
 		if socketData.isJewelSocket then
@@ -828,7 +848,17 @@ function TreeTabClass:FindTimelessJewel()
 		end
 	end
 	t_sort(jewelSockets, function(a, b) return a.label < b.label end)
-	timelessData.jewelSocket = next(timelessData.jewelSocket) and timelessData.jewelSocket or jewelSockets[1]
+	-- rebuild `timelessData.jewelSocket` as we only store the minimum amount of `jewelSocket` data in build XML
+	if next(timelessData.jewelSocket) then
+		for idx, jewelSocket in ipairs(jewelSockets) do
+			if jewelSocket.id == timelessData.jewelSocket.id then
+				timelessData.jewelSocket = jewelSocket
+				break
+			end
+		end
+	else
+		timelessData.jewelSocket = jewelSockets[1]
+	end
 
 	local function buildMods()
 		wipeTable(modData)
@@ -1010,13 +1040,6 @@ function TreeTabClass:FindTimelessJewel()
 		timelessData.jewelSocket = value
 		self.build.modFlag = true
 	end, self.build, socketViewer)
-	-- we need to search through `jewelSockets` for the correct `id` as the `idx` can become stale due to dynamic sorting
-	for idx, jewelSocket in ipairs(jewelSockets) do
-		if jewelSocket.id == timelessData.jewelSocket.id then
-			controls.socketSelect.selIndex = idx
-			break
-		end
-	end
 
 	controls.socketFilterLabel = new("LabelControl", { "TOPRIGHT", nil, "TOPLEFT" }, 405, 100, 0, 16, "^7Filter Nodes:")
 	controls.socketFilter = new("CheckBoxControl", { "LEFT", controls.socketFilterLabel, "RIGHT" }, 10, 0, 18, nil, function(value)

--- a/src/Classes/TreeTab.lua
+++ b/src/Classes/TreeTab.lua
@@ -809,7 +809,7 @@ function TreeTabClass:FindTimelessJewel()
 			{ label = "Caspiro (Supreme Ostentation)", id = 3 }
 		}
 	}
-	-- rebuild `timelessData.jewelType` as we only store the minimum amount of `conquerorType` data in build XML
+	-- rebuild `timelessData.conquerorType` as we only store the minimum amount of `conquerorType` data in build XML
 	if next(timelessData.conquerorType) then
 		for idx, conquerorType in ipairs(conquerorTypes[timelessData.jewelType.id]) do
 			if conquerorType.id == timelessData.conquerorType.id then

--- a/src/Modules/Build.lua
+++ b/src/Modules/Build.lua
@@ -793,7 +793,6 @@ function buildMode:Load(xml, fileName)
 			end
 		elseif child.elem == "TimelessData" then
 			self.timelessData.jewelType = {
-				name = child.attrib.jewelTypeName,
 				id = tonumber(child.attrib.jewelTypeId)
 			}
 			self.timelessData.conquerorType = {
@@ -874,7 +873,6 @@ function buildMode:Save(xml)
 	local timelessData = {
 		elem = "TimelessData",
 		attrib = {
-			jewelTypeName = next(self.timelessData.jewelType) and tostring(self.timelessData.jewelType.name),
 			jewelTypeId = next(self.timelessData.jewelType) and tostring(self.timelessData.jewelType.id),
 			conquerorTypeId = next(self.timelessData.conquerorType) and tostring(self.timelessData.conquerorType.id),
 			jewelSocketId = next(self.timelessData.jewelSocket) and tostring(self.timelessData.jewelSocket.id),


### PR DESCRIPTION
This PR shifts ``timelessData`` to a system where only the ``id`` for each relevant table is stored in build XML and on load each relevant structure is rebuilt. This fixes #4889.

This also adds keystone names to generated timeless jewel variants, to match the changes in #4882.