### PR TITLE
Update Ventor's Gamble and Soul RIpper

### DIFF
--- a/src/Data/Uniques/flask.lua
+++ b/src/Data/Uniques/flask.lua
@@ -359,7 +359,7 @@ Requires Level 27
 {variant:1}Vaal Skills deal (30-40)% more Damage during effect
 {variant:1}Vaal Skills used during effect do not apply Soul Gain Prevention
 {variant:1}Gains no Charges During effect of any Soul Ripper Flask
-{variant:2}+(-40 to 90) maximum Charges
+{variant:2}+(-40-90) maximum Charges
 {variant:2}Loses all Charges when you enter a new area
 {variant:2}Consumes Maximum Charges to use
 {variant:2}Gain Vaal Souls equal to Charges Consumed when used

--- a/src/Data/Uniques/ring.lua
+++ b/src/Data/Uniques/ring.lua
@@ -1248,9 +1248,9 @@ Implicits: 1
 {tags:life}+(0-60) to maximum Life
 (−10 to 10)% increased Quantity of Items found
 (−40 to 40)% increased Rarity of Items found
-{tags:jewellery_resistance}+(−25 to 50)% to Fire Resistance
-{tags:jewellery_resistance}+(−25 to 50)% to Cold Resistance
-{tags:jewellery_resistance}+(−25 to 50)% to Lightning Resistance
+{tags:jewellery_resistance}+(-25-50)% to Fire Resistance
+{tags:jewellery_resistance}+(-25-50)% to Cold Resistance
+{tags:jewellery_resistance}+(-25-50)% to Lightning Resistance
 ]],[[
 Vivinsect
 Unset Ring

--- a/src/Data/Uniques/ring.lua
+++ b/src/Data/Uniques/ring.lua
@@ -1246,8 +1246,8 @@ Requires Level 65
 Implicits: 1
 (6-15)% increased Rarity of Items found
 {tags:life}+(0-60) to maximum Life
-(−10 to 10)% increased Quantity of Items found
-(−40 to 40)% increased Rarity of Items found
+(-10-10)% increased Quantity of Items found
+(-40-40)% increased Rarity of Items found
 {tags:jewellery_resistance}+(-25-50)% to Fire Resistance
 {tags:jewellery_resistance}+(-25-50)% to Cold Resistance
 {tags:jewellery_resistance}+(-25-50)% to Lightning Resistance


### PR DESCRIPTION
Fixes #4891.

Ventor's Gamble and Soul Ripper were using outdated/custom formatting like this:
``+(-25 to 50)% to Fire Resistance``
.. instead of the formatting every other item uses:
``+(-25-50)% to Fire Resistance``

This appears to be a relic from 6+ years ago when Openarl was working on PoB &mdash; back then **everything** was formatted this way: cfdb7c0198f6e96e1b065979309a7473f3bd7d4b.

This will not automatically update existing items in builds, meaning if someone has Ventor's Gamble or Soul Ripper still in their build with the outdated formatting, the Lua pattern used in #4836 will still prevent that slider from working as ``{range:x}`` is never applied to them. Do we want to add support for these outdated items?