### PR TITLE
August 18th Replica Adjustment

### DIFF
--- a/src/Data/Uniques/amulet.lua
+++ b/src/Data/Uniques/amulet.lua
@@ -548,18 +548,22 @@ Replica Hyrri's Truth
 Jade Amulet
 League: Heist
 Variant: Pre 3.16.0
+Variant: Pre 3.19.0
 Variant: Current
 Requires Level 64
 Implicits: 1
 {tags:jewellery_attribute}+(20-30) to Dexterity
 Grants Level 22 Hatred Skill
-{tags:jewellery_attribute}+(25-35) to Dexterity
-{tags:attack,physical}Adds (12-15) to (24-28) Physical Damage to Attacks
-{tags:jewellery_elemental,attack}Adds (11-15) to (23-28) Cold Damage to Attacks
-{tags:critical}+(23-28)% to Global Critical Strike Multiplier
-{tags:life}(0.8-1.0)% of Cold Damage Leeched as Life
+{variant:1,2}{tags:jewellery_attribute}+(25-35) to Dexterity
+{variant:3}{tags:jewellery_attribute}+(30-55) to Dexterity
+{variant:1,2}{tags:attack,physical}Adds (12-15) to (24-28) Physical Damage to Attacks
+{variant:1,2}{tags:jewellery_elemental,attack}Adds (11-15) to (23-28) Cold Damage to Attacks
+{variant:3}Bow Attacks have Culling Strike
+{variant:1,2}{tags:critical}+(23-28)% to Global Critical Strike Multiplier
+{variant:3}{tags:critical}+(18-35)% to Global Critical Strike Multiplier
+{variant:1,2}{tags:life}(0.8-1.0)% of Cold Damage Leeched as Life
 {variant:1}Hatred has 50% less Reservation
-{variant:2}Hatred has 100% increased Mana Reservation Efficiency
+{variant:2,3}Hatred has 100% increased Mana Reservation Efficiency
 ]],[[
 The Ignomon
 Gold Amulet

--- a/src/Data/Uniques/boots.lua
+++ b/src/Data/Uniques/boots.lua
@@ -736,12 +736,16 @@ Adds 1 to 80 Chaos Damage to Attacks
 ]],[[
 Replica Alberon's Warpath
 Soldier Boots
+Variant: Pre 3.19.0
+Variant: Current
 League: Heist
 Requires Level 49, 47 Str, 47 Int
 (15-18)% increased Strength
 +(180-220) to Armour
-+(9-12)% to Chaos Resistance
-20% increased Movement Speed
+{variant:1}+(9-12)% to Chaos Resistance
+{variant:2}+(13-19)% to Chaos Resistance
+{variant:1}20% increased Movement Speed
+{variant:2}25% increased Movement Speed
 Cannot deal non-Chaos Damage
 Adds 1 to 80 Chaos Damage to Attacks per 80 Strength
 ]],[[

--- a/src/Data/Uniques/helmet.lua
+++ b/src/Data/Uniques/helmet.lua
@@ -1263,11 +1263,15 @@ Requires Level 28, 33 Dex, 33 Int
 ]],[[
 Replica Leer Cast
 Festival Mask
+Variant: Pre 3.19.0
+Variant: Current
 League: Heist
 Requires Level 28, 33 Dex, 33 Int
 +(20-30) to Dexterity
-+(20-30) to maximum Life
-+(20-30) to maximum Mana
+{variant:1}+(20-30) to maximum Life
+{variant:2}+(60-100) to maximum Life
+{variant:1}+(20-30) to maximum Mana
+{variant:2}+(60-100) to maximum Mana
 60% reduced Mana Regeneration Rate
 You and nearby Allies have 30% increased Mana Regeneration Rate
 ]],[[

--- a/src/Data/Uniques/ring.lua
+++ b/src/Data/Uniques/ring.lua
@@ -385,16 +385,20 @@ Implicits: 1
 Replica Doedre's Damning
 Paua Ring
 Variant: Pre 3.16.0
+Variant: Pre 3.19.0
 Variant: Current
 League: Heist
 Implicits: 1
 {tags:mana}+(20-30) to maximum Mana
-{tags:jewellery_attribute}+(5-10) to Intelligence
-{tags:jewellery_resistance}+5% to all Elemental Resistances
-{tags:mana}+5 Mana gained on Kill
+{variant:1,2}{tags:jewellery_attribute}+(5-10) to Intelligence
+{variant:3}{tags:jewellery_attribute}+(5-20) to Intelligence 
+{variant:1,2}{tags:jewellery_resistance}+5% to all Elemental Resistances
+{variant:3}{tags:jewellery_resistance}+(5-20)% to all Elemental Resistances
+{variant:1,2}{tags:mana}+5 Mana Gained on Kill
+{variant:3}{tags:mana}+(5-20) Mana gained on Kill
 {tags:caster}You can apply one fewer Curse
 {variant:1}{tags:caster}(25-35)% increased Effect of your Curses
-{variant:2}{tags:caster}(15-25)% increased Effect of your Curses
+{variant:2,3}{tags:caster}(15-25)% increased Effect of your Curses
 ]],[[
 Dream Fragments
 Sapphire Ring


### PR DESCRIPTION
> Added the following notes:
>  The Replica Alberon's Warpath Unique Boots now has +13-19% to Chaos Resistance (previously +9-12%), and 25% increased 
Movement Speed (previously 20%). Existing versions of this unique can be updated to these new values using a Divine Orb.

> The Replica Leer Cast Unique Helmet now has +60-100 to maximum Life (previously +20-30) and +60-100 to maximum Mana (previously +20-30). Existing versions of this unique can be updated to these new values using a Divine Orb.

> The Replica Doedre's Damning Unique Ring now grants +5-20 to Intelligence (previously 5-10), +5-20% to all Elemental Resistances (previously +5%), and +5-20 Mana gained on Kill (previously +5). Existing versions of this item can be updated to the new values with a Divine Orb.

> The Replica Hyrri's Truth Unique Amulet no longer Adds 12-15 to 24-28 Physical Damage to Attacks, or Adds 11-15 to 23-28 Cold Damage to Attacks, or has 0.8-1% of Cold Damage Leeched as Life. Instead, it now has "Bow Attacks have Culling Strike". It also now has +18-35% to Global Critical Strike Multiplier (previously +23-28%), and +30-55 to Dexterity (previously +25-35).
