### PR TITLE
Fix checbox not updating when selecting vaal skills

### DIFF
--- a/src/Classes/SkillsTab.lua
+++ b/src/Classes/SkillsTab.lua
@@ -587,6 +587,7 @@ function SkillsTabClass:CreateGemSlot(index)
 			slot.qualityId:SelByValue(gemInstance.qualityId)
 			slot.enabled.state = true
 			slot.enableGlobal1.state = true
+			slot.enableGlobal2.state = true
 			slot.count:SetText(gemInstance.count)
 		elseif gemId == gemInstance.gemId then
 			return


### PR DESCRIPTION
### Description of the problem being solved:
Selecting a vaal skill from the drop down also enabled the normal version but does not update the checkbox for it.

### Steps taken to verify a working solution:
- Test a few vaal skills

### Video showcasing fixed issue
https://user-images.githubusercontent.com/91493239/185367217-a092a9e6-163a-4688-91b5-2ac3d129a880.mp4


