### PR TITLE
Remove overkill damage and fix some bugs in eHP

### DIFF
--- a/src/Modules/CalcDefence.lua
+++ b/src/Modules/CalcDefence.lua
@@ -1672,8 +1672,9 @@ function calcs.defence(env, actor)
 				mana = m_min(mana + DamageIn.ManaWhenHit * (gainMult - 1), gainMult * (output.ManaUnreserved or 0))
 				energyShield = m_min(energyShield + DamageIn.EnergyShieldWhenHit * (gainMult - 1), gainMult * output.EnergyShieldRecoveryCap)
 			end
-			local lifeBeforeHit = life
+			local DamageAbsorbed = 0
 			for _, damageType in ipairs(dmgTypeList) do
+				DamageAbsorbed = DamageAbsorbed + Damage[damageType]
 				if Damage[damageType] > 0 then
 					if frostShield > 0 then
 						local tempDamage = m_min(Damage[damageType] * output["FrostShieldDamageMitigation"] / 100 / iterationMultiplier, frostShield)
@@ -1734,13 +1735,14 @@ function calcs.defence(env, actor)
 						if DamageIn["LifeLossBelowHalfLost"] > 0 then
 							output["LifeLossBelowHalfLost"] = output["LifeLossBelowHalfLost"] + Damage[damageType] * output.preventedLifeLoss / 100
 						end
-						Damage[damageType] = Damage[damageType] * (1 - output.preventedLifeLoss / 100)
+						local tempDamage = Damage[damageType] * output.preventedLifeLoss / 100
+						Damage[damageType] = Damage[damageType] - tempDamage
 					end
 					life = life - Damage[damageType]
 				end
 			end
 			if life < 0 then --don't count overkill damage
-				numHits = numHits + life / (lifeBeforeHit - life) * iterationMultiplier
+				numHits = numHits + life / DamageAbsorbed
 			end
 			if modDB:Flag(nil, "WardNotBreak") then
 				ward = restoreWard

--- a/src/Modules/CalcDefence.lua
+++ b/src/Modules/CalcDefence.lua
@@ -1617,7 +1617,7 @@ function calcs.defence(env, actor)
 	function numberOfHitsToDie(DamageIn)
 		local numHits = 0
 		DamageIn["cycles"] = DamageIn["cycles"] or 1
-		DamageIn["iterations"] = DamageIn["iterations"] or 1
+		DamageIn["iterations"] = DamageIn["iterations"] or 0
 		
 		-- check damage in isn't 0 and that ward doesn't mitigate all damage
 		for _, damageType in ipairs(dmgTypeList) do

--- a/src/Modules/CalcDefence.lua
+++ b/src/Modules/CalcDefence.lua
@@ -1771,11 +1771,11 @@ function calcs.defence(env, actor)
 				iterationMultiplier = m_max((numberOfHitsToDie(Damage) - 1) * speedUp - 1, 1)
 				DamageIn["cyclesRan"] = true
 			end
-			if life < 0 and DamageIn["cycles"] == 1 then --don't count overkill damage and only on final pass as to not break speedup.
+			if life < 0 and DamageIn["cycles"] == 1 and numHits ~= m_huge then -- Don't count overkill damage and only on final pass as to not break speedup.
 				numHits = numHits + life / DamageAbsorbed
 			end
 		end
-		if numHits >= maxHits then
+		if life > 0 and numHits >= maxHits then -- If still living and the number of hits exceeds the maximum then we surivived infinite hits.
 			return m_huge
 		end
 		return numHits

--- a/src/Modules/CalcDefence.lua
+++ b/src/Modules/CalcDefence.lua
@@ -1677,7 +1677,7 @@ function calcs.defence(env, actor)
 				DamageAbsorbed = DamageAbsorbed + Damage[damageType]
 				if Damage[damageType] > 0 then
 					if frostShield > 0 then
-						local tempDamage = m_min(Damage[damageType] * output["FrostShieldDamageMitigation"] / 100 / iterationMultiplier, frostShield)
+						local tempDamage = m_min(Damage[damageType] * output["FrostShieldDamageMitigation"] / 100, frostShield)
 						frostShield = frostShield - tempDamage
 						Damage[damageType] = Damage[damageType] - tempDamage
 					end
@@ -1697,12 +1697,12 @@ function calcs.defence(env, actor)
 						Damage[damageType] = Damage[damageType] - tempDamage
 					end
 					if guard[damageType] > 0 then
-						local tempDamage = m_min(Damage[damageType] * output[damageType.."GuardAbsorbRate"] / 100 / iterationMultiplier, guard[damageType])
+						local tempDamage = m_min(Damage[damageType] * output[damageType.."GuardAbsorbRate"] / 100, guard[damageType])
 						guard[damageType] = guard[damageType] - tempDamage
 						Damage[damageType] = Damage[damageType] - tempDamage
 					end
 					if guard["shared"] > 0 then
-						local tempDamage = m_min(Damage[damageType] * output["sharedGuardAbsorbRate"] / 100 / iterationMultiplier, guard["shared"])
+						local tempDamage = m_min(Damage[damageType] * output["sharedGuardAbsorbRate"] / 100, guard["shared"])
 						guard["shared"] = guard["shared"] - tempDamage
 						Damage[damageType] = Damage[damageType] - tempDamage
 					end
@@ -1760,6 +1760,12 @@ function calcs.defence(env, actor)
 				Damage = { }
 				for _, damageType in ipairs(dmgTypeList) do
 					Damage[damageType] = DamageIn[damageType] * speedUp
+				end
+				if DamageIn.GainWhenHit then
+					Damage.GainWhenHit = true
+					Damage.LifeWhenHit = DamageIn.LifeWhenHit
+					Damage.ManaWhenHit= DamageIn.ManaWhenHit
+					Damage.EnergyShieldWhenHit= DamageIn.EnergyShieldWhenHit
 				end
 				Damage["cycles"] = DamageIn["cycles"] * speedUp
 				iterationMultiplier = m_max((numberOfHitsToDie(Damage) - 1) * speedUp - 1, 1)

--- a/src/Modules/CalcDefence.lua
+++ b/src/Modules/CalcDefence.lua
@@ -1672,6 +1672,7 @@ function calcs.defence(env, actor)
 				mana = m_min(mana + DamageIn.ManaWhenHit * (gainMult - 1), gainMult * (output.ManaUnreserved or 0))
 				energyShield = m_min(energyShield + DamageIn.EnergyShieldWhenHit * (gainMult - 1), gainMult * output.EnergyShieldRecoveryCap)
 			end
+			local lifeBeforeHit = life
 			for _, damageType in ipairs(dmgTypeList) do
 				if Damage[damageType] > 0 then
 					if frostShield > 0 then
@@ -1737,6 +1738,9 @@ function calcs.defence(env, actor)
 					end
 					life = life - Damage[damageType]
 				end
+			end
+			if life < 0 then --don't count overkill damage
+				numHits = numHits + life / (lifeBeforeHit - life) * iterationMultiplier
 			end
 			if modDB:Flag(nil, "WardNotBreak") then
 				ward = restoreWard

--- a/src/Modules/CalcDefence.lua
+++ b/src/Modules/CalcDefence.lua
@@ -1629,7 +1629,7 @@ function calcs.defence(env, actor)
 		else
 			numHits = 0
 		end
-		
+
 		local life = output.LifeRecoverable or 0
 		local mana = output.ManaUnreserved or 0
 		local energyShield = output.EnergyShieldRecoveryCap
@@ -1656,7 +1656,7 @@ function calcs.defence(env, actor)
 		end
 		DamageIn["LifeLossBelowHalfLost"] = DamageIn["LifeLossBelowHalfLost"] or 0
 		DamageIn["WardBypass"] = DamageIn["WardBypass"] or modDB:Sum("BASE", nil, "WardBypass") or 0
-		
+
 		local iterationMultiplier = 1
 		local maxHits = data.misc.ehpCalcMaxHitsToCalc
 		maxHits = maxHits / DamageIn["cycles"]
@@ -1741,9 +1741,6 @@ function calcs.defence(env, actor)
 					life = life - Damage[damageType]
 				end
 			end
-			if life < 0 then --don't count overkill damage
-				numHits = numHits + life / DamageAbsorbed
-			end
 			if modDB:Flag(nil, "WardNotBreak") then
 				ward = restoreWard
 			elseif ward > 0 then
@@ -1763,10 +1760,13 @@ function calcs.defence(env, actor)
 				Damage = { }
 				for _, damageType in ipairs(dmgTypeList) do
 					Damage[damageType] = DamageIn[damageType] * speedUp
-				end	
+				end
 				Damage["cycles"] = DamageIn["cycles"] * speedUp
 				iterationMultiplier = m_max((numberOfHitsToDie(Damage) - 1) * speedUp - 1, 1)
-				DamageIn["cyclesRan"] = true 
+				DamageIn["cyclesRan"] = true
+			end
+			if life < 0 and DamageIn["cycles"] == 1 then --don't count overkill damage and only on final pass as to not break speedup.
+				numHits = numHits + life / DamageAbsorbed
 			end
 		end
 		if numHits >= maxHits then

--- a/src/Modules/CalcDefence.lua
+++ b/src/Modules/CalcDefence.lua
@@ -1781,6 +1781,9 @@ function calcs.defence(env, actor)
 				numHits = numHits + life / DamageAbsorbed
 			end
 		end
+		if DamageIn["iterations"] == maxIterations then -- Apply remaining hits if ran into cap.
+			numHits = numHits + iterationMultiplier
+		end
 		if life > 0 and damageTotal >= maxDamage then -- If still living and the amount of damage exceeds maximum threshold we survived infinite number of hits.
 			return m_huge
 		end

--- a/src/Modules/CalcSections.lua
+++ b/src/Modules/CalcSections.lua
@@ -1814,7 +1814,7 @@ return {
 			{ modName = { "FrostGlobeHealth", "FrostGlobeDamageMitigation" } },
 		},
 	},
-	{ label = "Hits before death",{ format = "{output:NumberOfDamagingHits}", },
+	{ label = "Hits before death",{ format = "{2:output:NumberOfDamagingHits}", },
 	}
 }, }, { defaultCollapsed = false, label = "Effective \"Health\" Pool", data = {
 	extra = "{0:output:TotalEHP}",

--- a/src/Modules/Data.lua
+++ b/src/Modules/Data.lua
@@ -472,8 +472,8 @@ data.misc = { -- magic numbers
 	uberBossPen = 40 / 5,
 	-- ehp helper function magic numbers
 	ehpCalcSpeedUp = 8,
-		-- depth needs to be a power of speedUp (in this case 8^5, will run 5 recursive calls deep)
-	ehpCalcMaxDepth = 4096,
+		-- depth needs to be a power of speedUp (in this case 8^3, will run 3 recursive calls deep)
+	ehpCalcMaxDepth = 512,
 		-- max hits can be increased for more accuracy
 	ehpCalcMaxHitsToCalc = 1031,
 	-- PvP scaling used for hogm

--- a/src/Modules/Data.lua
+++ b/src/Modules/Data.lua
@@ -475,7 +475,7 @@ data.misc = { -- magic numbers
 	-- max damage can be increased for more accuracy
 	ehpCalcMaxDamage = 100000000,
 	-- max iterations can be increased for more accuracy this should be perfectly accurate unless it runs out of iterations and so high eHP values might have some precision issues.
-	ehpCalcMaxIterationsToCalc = 40,
+	ehpCalcMaxIterationsToCalc = 50,
 	-- PvP scaling used for hogm
 	PvpElemental1 = 0.55,
 	PvpElemental2 = 150,

--- a/src/Modules/Data.lua
+++ b/src/Modules/Data.lua
@@ -472,10 +472,10 @@ data.misc = { -- magic numbers
 	uberBossPen = 40 / 5,
 	-- ehp helper function magic numbers
 	ehpCalcSpeedUp = 8,
-		-- depth needs to be a power of speedUp (in this case 8^3, will run 3 recursive calls deep)
-	ehpCalcMaxDepth = 512,
-		-- max hits can be increased for more accuracy
-	ehpCalcMaxHitsToCalc = 1031,
+	-- max damage can be increased for more accuracy
+	ehpCalcMaxDamage = 100000000,
+	-- max iterations can be increased for more accuracy this should be perfectly accurate unless it runs out of iterations and so high eHP values might have some precision issues.
+	ehpCalcMaxIterationsToCalc = 40,
 	-- PvP scaling used for hogm
 	PvpElemental1 = 0.55,
 	PvpElemental2 = 150,

--- a/src/Modules/Data.lua
+++ b/src/Modules/Data.lua
@@ -474,14 +474,13 @@ data.misc = { -- magic numbers
 	ehpCalcSpeedUp = 8,
 	-- max damage can be increased for more accuracy
 	ehpCalcMaxDamage = 100000000,
-	-- max iterations can be increased for more accuracy this should be perfectly accurate unless it runs out of iterations and so high eHP values might have some precision issues.
+	-- max iterations can be increased for more accuracy this should be perfectly accurate unless it runs out of iterations and so high eHP values will be underestimated.
 	ehpCalcMaxIterationsToCalc = 50,
 	-- PvP scaling used for hogm
 	PvpElemental1 = 0.55,
 	PvpElemental2 = 150,
 	PvpNonElemental1 = 0.57,
 	PvpNonElemental2 = 90,
-	
 }
 
 data.bossSkills = {

--- a/src/Modules/Data.lua
+++ b/src/Modules/Data.lua
@@ -472,7 +472,7 @@ data.misc = { -- magic numbers
 	uberBossPen = 40 / 5,
 	-- ehp helper function magic numbers
 	ehpCalcSpeedUp = 8,
-		-- depth needs to be a power of speedUp (in this case 8^3, will run 3 recursive calls deep)
+		-- depth needs to be a power of speedUp (in this case 8^5, will run 5 recursive calls deep)
 	ehpCalcMaxDepth = 4096,
 		-- max hits can be increased for more accuracy
 	ehpCalcMaxHitsToCalc = 1031,

--- a/src/Modules/Data.lua
+++ b/src/Modules/Data.lua
@@ -474,7 +474,7 @@ data.misc = { -- magic numbers
 	ehpCalcSpeedUp = 8,
 		-- depth needs to be a power of speedUp (in this case 8^3, will run 3 recursive calls deep)
 	ehpCalcMaxDepth = 512,
-		-- max hits is currently depth + speedup - 1 to give as much accuracy with as few cycles as possible, but can be increased for more accuracy
+		-- max hits can be increased for more accuracy
 	ehpCalcMaxHitsToCalc = 1031,
 	-- PvP scaling used for hogm
 	PvpElemental1 = 0.55,

--- a/src/Modules/Data.lua
+++ b/src/Modules/Data.lua
@@ -473,7 +473,7 @@ data.misc = { -- magic numbers
 	-- ehp helper function magic numbers
 	ehpCalcSpeedUp = 8,
 		-- depth needs to be a power of speedUp (in this case 8^3, will run 3 recursive calls deep)
-	ehpCalcMaxDepth = 512,
+	ehpCalcMaxDepth = 4096,
 		-- max hits can be increased for more accuracy
 	ehpCalcMaxHitsToCalc = 1031,
 	-- PvP scaling used for hogm

--- a/src/Modules/Data.lua
+++ b/src/Modules/Data.lua
@@ -475,7 +475,7 @@ data.misc = { -- magic numbers
 		-- depth needs to be a power of speedUp (in this case 8^3, will run 3 recursive calls deep)
 	ehpCalcMaxDepth = 512,
 		-- max hits is currently depth + speedup - 1 to give as much accuracy with as few cycles as possible, but can be increased for more accuracy
-	ehpCalcMaxHitsToCalc = 519,
+	ehpCalcMaxHitsToCalc = 1031,
 	-- PvP scaling used for hogm
 	PvpElemental1 = 0.55,
 	PvpElemental2 = 150,


### PR DESCRIPTION
Fixes: #4992 #5161 #5178
For reference: https://github.com/PathOfBuildingCommunity/PathOfBuilding/issues/4993
### Description of the problem being solved:
eHP has breakpoints. This means when you have very low hits to death eHP won't change on moderate increases in health or damage reduction e.g. 20%.

This also refactors how infinite eHP is determined and when to stop. This is done by checking the current damage mitigated and if over a threshold declare infinite hits. Stopping is now determined if passing over a threshold of maximum number of iterations (number of times running the damage mitigation passes).

Guard skills were causing weird breakpointing behaviour due to iteration multiplier causing effective differences between speedup iterations and iteration multiplier iterations. This removes this from guard skill as the logic behind it doesn't make sense and causes undesirable behaviour.

This also includes a fix suggested by Regisle to fix recovery not being applied in future cycles leading to inefficient calculations on infinite hp recovery builds.

### Steps taken to verify a working solution:
You now have partial hits before death.

### Link to a build that showcases this PR:
https://pobb.in/vHR-vtTGMMrQ
https://pobb.in/5_CR0d50ihde
https://pobb.in/oFHTWXt9FMua
https://poe.ninja/pob/Kqz

### Before screenshot:
![image](https://user-images.githubusercontent.com/31533893/185532095-5441ad55-9156-434d-a691-f315376229d2.png)
![image](https://user-images.githubusercontent.com/31533893/185551547-a0c4a3f6-0740-48d5-be12-41d07c6247e5.png)
![image](https://user-images.githubusercontent.com/31533893/204114694-58e442ce-ee8d-4086-852e-6e94fd730e50.png)
![image](https://user-images.githubusercontent.com/31533893/204114767-90b35c17-a211-4004-8142-156fb7897127.png)

### After screenshot:
![image](https://user-images.githubusercontent.com/31533893/185551109-a0da142a-4f6b-4dd3-8464-5a4ddc73a6e9.png)
![image](https://user-images.githubusercontent.com/31533893/187011517-f3818c2a-4a7a-493d-b812-bff645a1f55a.png)
![image](https://user-images.githubusercontent.com/31533893/204114705-a3903313-f8c9-4016-853c-42b3bfea75d6.png)
![image](https://user-images.githubusercontent.com/31533893/204114753-74d5ddd1-7add-4aeb-bcd5-05fd7d3d49a9.png)
