### PR TITLE
Use Life/EnergyShieldRegenRecovery for power builder

### DIFF
--- a/src/Classes/CalcsTab.lua
+++ b/src/Classes/CalcsTab.lua
@@ -509,8 +509,8 @@ function CalcsTabClass:PowerBuilder()
 								(output.Armour - calcBase.Armour) / m_max(10000, calcBase.Armour) +
 								((output.EnergyShieldRecoveryCap or output.EnergyShield) - (calcBase.EnergyShieldRecoveryCap or calcBase.EnergyShield)) / m_max(3000, (calcBase.EnergyShieldRecoveryCap or calcBase.EnergyShield)) +
 								(output.Evasion - calcBase.Evasion) / m_max(10000, calcBase.Evasion) +
-								(output.LifeRegen - calcBase.LifeRegen) / 500 +
-								(output.EnergyShieldRegen - calcBase.EnergyShieldRegen) / 1000
+								(output.LifeRegenRecovery - calcBase.LifeRegenRecovery) / 500 +
+								(output.EnergyShieldRegenRecovery - calcBase.EnergyShieldRegenRecovery) / 1000
 				if node.path and not node.ascendancyName then
 					newPowerMax.offence = m_max(newPowerMax.offence, node.power.offence)
 					newPowerMax.defence = m_max(newPowerMax.defence, node.power.defence)


### PR DESCRIPTION
These values were changed in
3f5e2a6d865044f72ca9425f19a37a2f3c6977d8 but this part of the code wasnt
updated, this causes crash when importing builds.

Fixes #4951 

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>

![image](https://user-images.githubusercontent.com/5115805/185761224-f6fe0963-11d9-4f9a-8c6d-b738d31d666e.png)


## Example POB
https://pobb.in/u/thedeathbeam/occu-poison-hexblast-starter

This issue does not happen on release but happens on dev branch