### PR TITLE
WIP: Add support for connecting item sets and skill sets to passive trees

### DIFF
--- a/src/Classes/ItemsTab.lua
+++ b/src/Classes/ItemsTab.lua
@@ -1149,6 +1149,11 @@ function ItemsTabClass:SetActiveItemSet(itemSetId)
 			end
 		end
 	end
+	-- TreeTab is nil the first time we get here on initial load, but we can ignore as TreeTab:Load will set the list
+	if self.build.treeTab then
+		-- Keep track of spec:itemSet updates between build saves
+		self.build.itemSetIdList[self.build.treeTab.activeSpec] = itemSetId
+	end
 	self.build.buildFlag = true
 	self:PopulateSlots()
 end

--- a/src/Classes/PassiveSpec.lua
+++ b/src/Classes/PassiveSpec.lua
@@ -122,7 +122,7 @@ function PassiveSpecClass:Load(xml, dbFileName)
 	self:ResetUndo()
 end
 
-function PassiveSpecClass:Save(xml)
+function PassiveSpecClass:Save(xml, specId)
 	local allocNodeIdList = { }
 	for nodeId in pairs(self.allocNodes) do
 		t_insert(allocNodeIdList, nodeId)
@@ -131,14 +131,17 @@ function PassiveSpecClass:Save(xml)
 	for mastery, effect in pairs(self.masterySelections) do
 		t_insert(masterySelections, "{"..mastery..","..effect.."}")
 	end
-	xml.attrib = { 
+	xml.attrib = {
 		title = self.title,
 		treeVersion = self.treeVersion,
 		-- New format
-		classId = tostring(self.curClassId), 
-		ascendClassId = tostring(self.curAscendClassId), 
+		classId = tostring(self.curClassId),
+		ascendClassId = tostring(self.curAscendClassId),
 		nodes = table.concat(allocNodeIdList, ","),
-		masteryEffects = table.concat(masterySelections, ",")
+		masteryEffects = table.concat(masterySelections, ","),
+		-- Save ids to respective spec xml for TreeTab:Load
+		itemSetId = tostring(self.build.itemSetIdList[specId]) or "1",
+		skillSetId = tostring(self.build.skillSetIdList[specId]) or "1"
 	}
 	t_insert(xml, {
 		-- Legacy format

--- a/src/Classes/SkillsTab.lua
+++ b/src/Classes/SkillsTab.lua
@@ -1245,4 +1245,6 @@ function SkillsTabClass:SetActiveSkillSet(skillSetId)
 	self.controls.groupList.list = self.socketGroupList
 	self.activeSkillSetId = skillSetId
 	self.build.buildFlag = true
+	-- Track spec:skillSet updates between build saves
+	self.build.skillSetIdList[self.build.treeTab.activeSpec] = skillSetId
 end

--- a/src/Classes/TreeTab.lua
+++ b/src/Classes/TreeTab.lua
@@ -287,13 +287,17 @@ function TreeTabClass:Load(xml, dbFileName)
 		self.build.spec = self.specList[1]
 		return
 	end
-	for _, node in pairs(xml) do
+	for index, node in pairs(xml) do
 		if type(node) == "table" then
 			if node.elem == "Spec" then
 				if node.attrib.treeVersion and not treeVersions[node.attrib.treeVersion] then
 					main:OpenMessagePopup("Unknown Passive Tree Version", "The build you are trying to load uses an unrecognised version of the passive skill tree.\nYou may need to update the program before loading this build.")
 					return true
 				end
+				-- As we loop through the specs, update the lists from the xml data
+				-- Build.lua:264 handles PoB load and setting for all Tabs on init, this handles opening builds/importing builds etc
+				self.build["itemSetIdList"][index] = xml[index].attrib.itemSetId
+				self.build["skillSetIdList"][index] = xml[index].attrib.skillSetId
 				local newSpec = new("PassiveSpec", self.build, node.attrib.treeVersion or defaultTreeVersion)
 				newSpec:Load(node, dbFileName)
 				t_insert(self.specList, newSpec)
@@ -320,7 +324,7 @@ function TreeTabClass:Save(xml)
 		local child = {
 			elem = "Spec"
 		}
-		spec:Save(child)
+		spec:Save(child, specId)
 		t_insert(xml, child)
 	end
 end
@@ -355,6 +359,13 @@ function TreeTabClass:SetActiveSpec(specId)
 	end
 	-- Update the passive tree dropdown control in itemsTab
 	self.build.itemsTab.controls.specSelect.selIndex = specId
+	-- Set item and skill sets when switching passive trees
+	if self.build.itemsTab ~= nil and self.build.itemSetIdList ~= nil then
+		self.build.itemsTab:SetActiveItemSet(tonumber(self.build.itemSetIdList[specId]))
+	end
+	if self.build.skillsTab ~= nil and self.build.skillSetIdList ~= nil then
+		self.build.skillsTab:SetActiveSkillSet(tonumber(self.build.skillSetIdList[specId]))
+	end
 end
 
 function TreeTabClass:SetCompareSpec(specId)

--- a/src/Modules/Build.lua
+++ b/src/Modules/Build.lua
@@ -263,7 +263,7 @@ function buildMode:Init(dbFileName, buildName, buildXML, convertBuild)
 	-- set up the lists on initial load
 	if not self["itemSetIdList"] then
 		self["itemSetIdList"], self["skillSetIdList"] = {}, {}
-		if self.xmlSectionList ~= nil then
+		if self.xmlSectionList[5] ~= nil then
 			for index, spec in ipairs(self.xmlSectionList[5]) do
 				if spec.elem == "Spec" then
 					self["itemSetIdList"][index] = spec.attrib.itemSetId

--- a/src/Modules/Build.lua
+++ b/src/Modules/Build.lua
@@ -260,7 +260,16 @@ function buildMode:Init(dbFileName, buildName, buildXML, convertBuild)
 		self.spec:SetWindowTitleWithBuildClass()
 		self.buildFlag = true
 	end)
-
+	-- set up the lists on initial load
+	if not self["itemSetIdList"] then
+		self["itemSetIdList"], self["skillSetIdList"] = {}, {}
+		for index, spec in ipairs(self.xmlSectionList[5]) do
+			if spec.elem == "Spec" then
+				self["itemSetIdList"][index] = spec.attrib.itemSetId
+				self["skillSetIdList"][index] = spec.attrib.skillSetId
+			end
+		end
+	end
 	-- List of display stats
 	-- This defines the stats in the side bar, and also which stats show in node/item comparisons
 	-- This may be user-customisable in the future
@@ -1062,6 +1071,15 @@ function buildMode:OpenSavePopup(mode)
 		["UPDATE"] = "before updating?",
 	}
 	local controls = { }
+	local function resetItemAndSkillSets()
+		-- Reset item/skill set updates so there are no changes to the xml
+		for index, spec in ipairs(self.xmlSectionList[5]) do
+			if spec.elem == "Spec" then
+				self.itemSetIdList[index] = spec.attrib.itemSetId
+				self.skillSetIdList[index] = spec.attrib.skillSetId
+			end
+		end
+	end
 	controls.label = new("LabelControl", nil, 0, 20, 0, 16, "^7This build has unsaved changes.\nDo you want to save them "..modeDesc[mode])
 	controls.save = new("ButtonControl", nil, -90, 70, 80, 20, "Save", function()
 		main:ClosePopup()
@@ -1070,6 +1088,7 @@ function buildMode:OpenSavePopup(mode)
 	end)
 	controls.noSave = new("ButtonControl", nil, 0, 70, 80, 20, "Don't Save", function()
 		main:ClosePopup()
+		resetItemAndSkillSets()
 		if mode == "LIST" then
 			self:CloseBuild()
 		elseif mode == "EXIT" then

--- a/src/Modules/Build.lua
+++ b/src/Modules/Build.lua
@@ -263,10 +263,12 @@ function buildMode:Init(dbFileName, buildName, buildXML, convertBuild)
 	-- set up the lists on initial load
 	if not self["itemSetIdList"] then
 		self["itemSetIdList"], self["skillSetIdList"] = {}, {}
-		for index, spec in ipairs(self.xmlSectionList[5]) do
-			if spec.elem == "Spec" then
-				self["itemSetIdList"][index] = spec.attrib.itemSetId
-				self["skillSetIdList"][index] = spec.attrib.skillSetId
+		if self.xmlSectionList ~= nil then
+			for index, spec in ipairs(self.xmlSectionList[5]) do
+				if spec.elem == "Spec" then
+					self["itemSetIdList"][index] = spec.attrib.itemSetId
+					self["skillSetIdList"][index] = spec.attrib.skillSetId
+				end
 			end
 		end
 	end


### PR DESCRIPTION
Enhancement for #4569 

### Description of the problem being solved:
Often today with build guides (and just overall in general) there are certain item sets and skill sets that could be associated with certain passive trees but you have to manually set each individual piece to get the right stats/calcs. This PR saves the sets to the passive trees, allowing users to quickly switch between all three at once (from the Items and Tree tabs). This relationship is saved to the `<Spec>` of the build xml and is tracked before saves for immediate functionality and feedback.

Short overview of how it works, whenever you change the active item set or skill set, this is saved to the currently active passive tree (tracked in the app until official xml save). So either you go to the Tree tab, set active tree, go to Items and set there and then go to Skills tab and set there. Or you can start in the Items tab, set the passive tree, then set items, then flip to Skills tab and set. Either way you have to make the connection manually once per tree (I can only do so much 😄, though you could also manually update the xml file). But once everything is set, switching the passive tree will load the connected item and skill sets.

### Steps taken to verify a working solution:
There are a ton of different things to check here and I'm not even sure I tested all possible, but I can explain different test cases I've tried:
- For both Fresh Builds and Imported Builds (3.19 and some 3.17s)
1. Validate older builds and builds without set id data can load with no issue
2. Immediate save, verify itemSetId and skillSetId are "1" on "Tree 1" spec
3. Add new item and skill sets, set "Tree 1" to Item, Skill 2 > Save > Verify "Tree 1" spec has ids
4. Add new tree, item set, skill set, set "Tree 2" to Item, Skill 2 > Save > Verify "Tree 1" to Item, Skill 1 and the same for "Tree 2" to Item, Skill 2
5. Same build as (4), switch between Active Trees and verify item and skill sets are updating (Tree 1 to Item, Skill 1 etc)
6. Same build as (4), update "Tree 2" to have "Item 1" > Back > Do Not Save > Verify "Tree 2" still has itemSetId="2"

- Some delete cases, like setting Tree 2 to Item 2, deleting Item 2 and saving and then loading the build again to validate no issues and Tree 2 defaults back to Item 1.


- Special cases for generating codes/importing
1. Validate build code and build links like Pobb.in have the data on import
2. Validate working after import but before first save
3. Validate after import and after first save

### Link to a build that showcases this PR:
<pre>eNrtXF1z4rgSfZ79FS7eJwQbSLJFdosAmaEqzHBDZmb3aUoYAdrIEmvLJOyvvy3JBkOQkZV9uLeKPCSA-_THkdTqlk06v79G1FvjOCGc3dYaF5c1D7OQzwhb3Na-Pd1_vK79_tsvnTESy6_zu5RQeeW3Xz501GuP4jWmgKt5AsULLL7nmoKfoGmFmFhizkboLx5_4rPb2hfOcM2bIjYjIn8XUpQkX1CEb2uTEMA1DyUhZrPe7nMtGCHCJjx8xuJTzNOVMrsm-GXEZyAzHI2_Pj4VjBJWNAo-f-iMKdrgeCKQ8BL4dVvrQuhogT8TAaoQTUFP4_qmfdG8bjWvLpuNZrtWP46crDCe7UAXTf-6ddXIfptA4xgP5nMcCrLGvZiI3hKxEG-1GI1VlR2lVJAVJTgueNgyIZ64QLQ_nmxl_avLmwu_3bxpXV0FLb8cx3fUXZokfxCxvKNAmIOV4YIRgYvAKz-4aF4GQbPRavitZpnRt-CgGfgX7fa1f3PjN6-uysBjThLO3kGMg9O9lFJYYUWkkdUej6aE7ZNqGd4IMdTjyW7o_MAk-kDmeE_U6M9gYif3CCvOTlK6OcYxZANhB5DOVgJkFiY45JBxqtioAinE4WbMATmYuAAcDE3ELsv45kHHfxcF29cmwT5-tVA3ZMLOaFHwpsTomgu195yKVq3twefxLhLjyhkvNwkJER2hVxKlEWwyT-gZ72y0S0Z9sRQM8oAJGlyZ0_k9ibELrsfpzAm3RDxxAcq5bUEG7LThr1J2yEK7BfONxTjB8bqwQbdLAY8w3WUlMKXYErEzkS2a3UZ7ecLUArPM3sYunAeMw-UnKH4ekcB2yWYr1SqnVcpa0SoFj9DasgRUIEkCDSRd3JSBKtL0A8Uzi6TIcLzYTJYE04rSufs9tLLIoXIwimirQdk3V2leFaEViRusUVJMlY12eVRa3G6WYSgSATDDB9Xupbmi5n_JeppWg3XjiKex5bhoYasA8pTfRxEUOY94loZ228odhcbG1nvwitJKiK4QKHzu89kCVzJSHTFJVytY9XLIbXFyw3rECSkUGx_bFtJfYapbrS65s9kb2ElbG9ju1_ZWDiD2scjdtkIwO3FrE9sWdQTJJIK0rXpd6LJ3S944ONC-WPUuSnC_QzIvKv4Cni_lAUNSTRqqkl0lYnQlxuyfjbX-PXErAwM2S2O5FKxtHCKOmXkiEWTLJOkjgbwEozhcPsAo39ZqhXf3iNIprHz4VKI6dXVsI18NoxWPhfqwh2iYKJ1DtkqFx9SZS0SS8Oc0nc_l8QroFLE6Exrc3w96T8Pvg8yNIiR5JpT-ZGk0lQcP-u9uskywyoVekk4T_fK29p3gl4lE9bFAhAI1IacUrRI8u63NEU3AMoGXSmYC8YaiRJuSghJUZ1-Trp2AWdPgFccC4oUiIYwJNvq1vX7CKW1Q7s1y2Eza5FmKWZHO4T2UCL1PG5hS51JmLfJ4yBiOvFiChTmDqNFydvUEE2KzwgnsqmROQjnjy4f8CaS1VAkvYQiLJdyUjHe2E5l1qMMpkwJ90QzW50QmdHa1hFV1RmVkVV81w_s4RMbY9UUzeFv6cabOQI9r2UqVaPrCmZrksGi6hMpdwziyA4q3ImaFX8USx3orMmoaQY7KRUoXTkymqTAv44JECVeqXTUwJK-ZobolM8Qgr5Vkor0GxEBoUcasSnc8xkRWBs3rZQN9-mpJEHnLYPA_u2xWoCsY4_hl9VDZ-oZi2by-5UUzWK-PtypEnFpqUHO5j-cYslDpZN7KlGRRkbI-JDxRQqilKr0rddeczHSl_i5tKsjjynZMVdKlk8RR3iprVJ3Me6k_aHD-Ffqz8zJD_i6InFAEifdzydZup2lb-n_GiMo7IJy-T-Gbc8F3xclFgtisL486rAPt1PP6tqNKisRLoPD9hKPkbgPtx71Mmgf3UiIkYL_D0YO8u_nEZRGOQoHjB323MzOGFFFZZQp1t1_b15xP0hmeo5TKz_-TIkrERhb-hU8zrT58mCz5i5xfWo0sfhLIrg8P-kqXikyDtJH7odnKvPAEERRnxZPX0Iw0lEwmpO6idneuK3LUrVTCQprO8JBlTdw2UIqm0kF5Z1iekG5X34GmraEPHfAvE_5E-RRRP4fQXazF642tLdVCDMHEd4RoNw6Beyg7vL913ENV0ijiat4CR_L9CDqHGfRA9aEAVuqSmrryB15lSrZ4xfxBFCFPmVAEyCZGHvho454E1jVzWqFiup5TXcK7r3n3_x9419e3tI_TWKZJR7730bZs_0Br7PG51-NsTbLzMuXQiDCdd9Mo4rA4x1DGC5REJ4Yle6OW_FOMcb5SlTE_WzDwRhsBzFAtEuA1gUW-yQpKSXw2qkpJY--5BAmB6KA0j3YKGHTKgGtdXwcBgAFVeB6icZM96qChOoJvjw966JZCrJJf6_WXl5eLFRJLPsevhOKLkEf1FYDA_4_K3Y9Sbb0LP3eLrvrRVOSaOvoJiaSe0QJxHg_YPxWwfyJg_3854E5dxiBffOFQ1str8sP8jZoX8vAhOyuZiFiG_w_n0Z8qTplvYQ8UI7Tarkd5NUvWQZaroTXtE6AvVnt9Psml4B_58U5HrZNsDg41fYq8NMH6NusPjFacqY8ZoXp-ZoJHhTJ3srGSkm8yPeX5mYzGeY3JC1p53ekmSSC1acq8lh5PPT51I_QQ5tvByqXuOGzmjg4di-WEU3eYioqQe5i7z15g5ZJ_zKXAjV47Evx_CdZ0c7LtZq3tzqbLfDoxAp8xNBiiqqEjM6ntYufE9IMdei2bnuqKA_dV1HCx13SbCw23mdc8PTw2xFZVe2x6OQZulXdaDv445MDglJnZxtPHOxWH7zjLTvOr5QKyWpI2A-EUZ8uZVt9h3NtuKylwm75B9VnWdE_7DnO64Ux-YDMhmjZCDm6_o_ixHEn3UWg7zEr3YXjHdLFNyRJruWrsRR2YeyRsYVcJVE4URnod04X9eLqEE1jw1HAfhqYzWy2XaGzWi_skP-FSN0rpkb2tU8-aypMNpuxC99rLwwOtc3t5bi_P7eW5vTy3l-f28txentvLc3t5bi_P7eW5vTy3l-f2Ut-BVzc91cPlnM3J4s2j4off0t89YK6-rf_22XLMcLQZJnc8SU7KHv7fgZMA_Q8JjoqNKQrxktMZjoueZF__z59xvyp-n-2YvHyyOn8sPQcFFpj8OzQ5plUO2f_-UcG__FGobDQ69cP_6PBfVmO94g==</pre>

### Before screenshot:
![PR_Before](https://user-images.githubusercontent.com/92683202/185763254-3533e509-48ae-47f0-bf65-b827b6285564.gif)

### After screenshot:
![PR_After](https://user-images.githubusercontent.com/92683202/185763271-51e7dc22-12c5-4282-9705-60a213ea4322.gif)

