### PR TITLE
FIX: fix jewels applying to the same node twice if overlapping

### DIFF
--- a/src/Modules/CalcSetup.lua
+++ b/src/Modules/CalcSetup.lua
@@ -87,10 +87,15 @@ function calcs.buildModListForNode(env, node)
 	else
 		modList:AddList(node.modList)
 	end
-
+	
+	-- Keep track of what jewels have been applied to this node to avoid applying the same jewel twice if they overlap
+	-- Ref https://github.com/PathOfBuildingCommunity/PathOfBuilding/issues/4873
+	local appliedJewels = {}
+	
 	-- Run first pass radius jewels
 	for _, rad in pairs(env.radiusJewelList) do
-		if rad.type == "Other" and rad.nodes[node.id] then
+		if rad.type == "Other" and rad.nodes[node.id] and not appliedJewels[rad.item.name] then
+			appliedJewels[rad.item.name] = true
 			rad.func(node, modList, rad.data)
 		end
 	end


### PR DESCRIPTION
Fixes #4873 .

### Description of the problem being solved:
In rare cases when two identical radius jewels overlapped on a node the radius jewel function (jewel mods) would be applied to that node twice.

Note that this pr focuses the the mentioned issue. There may be other edge cases that i was not able to find where the same solution may need to be applied. Only rad.type == "other" jewels are checked for duplicates and the name of the jewel is used for the check so this may cause issues with radius jewels that have different function but the same name (kind of like [Combat Focus](https://www.poewiki.net/wiki/Combat_Focus_(Crimson_Jewel))). I was not able to find any currently existing jewels that are both of type other and have other versions with different functionality under the same name but this may change in the future.

### Steps taken to verify a working solution:
- Test the case from the issue

### Link to a build that showcases this PR:

`https://pobb.in/L3gRCLGqQQFk`

### Before screenshot:
![obraz](https://user-images.githubusercontent.com/91493239/185768594-7d6bb1ff-cc4e-45d0-940f-d420a5c9ca73.png)

### After screenshot:
![obraz](https://user-images.githubusercontent.com/91493239/185768566-c766eab7-c141-49b3-8293-742080470991.png)
