### PR TITLE
Fix parsing of Grand Spectrum for minions

### DIFF
--- a/src/Classes/Item.lua
+++ b/src/Classes/Item.lua
@@ -1174,7 +1174,9 @@ function ItemClass:BuildModListForSlotNum(baseList, slotNum)
 		end
 	elseif self.type == "Jewel" then
 		if self.name:find("Grand Spectrum") then
-			modList:NewMod("Multiplier:GrandSpectrum", "BASE", 1, self.name)
+			local spectrumMod = modLib.createMod("Multiplier:GrandSpectrum", "BASE", 1, self.name)
+			modList:AddMod(spectrumMod)
+			modList:NewMod("MinionModifier", "LIST", { mod = spectrumMod }, self.name)
 		end
 
 		local jewelData = self.jewelData


### PR DESCRIPTION
The grand spectrum multiplier was missing for minions.

Fixes #4964

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>

### Example POB

Showcasing both minion and player mods working simultaneously
https://pobb.in/6TICxfDd81dt