### PR TITLE
Fix arcanist brand giving brand skill flag to gems breaking stuff.

### DIFF
--- a/src/Modules/CalcOffence.lua
+++ b/src/Modules/CalcOffence.lua
@@ -1018,7 +1018,7 @@ function calcs.offence(env, actor, activeSkill)
 			}
 		end
 	end
-	if skillFlags.brand then
+	if skillCfg.skillName and skillCfg.skillName:match("Brand") then
 		output.BrandAttachmentRange = data.misc.BrandAttachmentRangeBase * calcLib.mod(skillModList, skillCfg, "BrandAttachmentRange")
 		output.ActiveBrandLimit = skillModList:Sum("BASE", skillCfg, "ActiveBrandLimit")
 		if breakdown then
@@ -1649,7 +1649,7 @@ function calcs.offence(env, actor, activeSkill)
 			output.HitTime = skillData.hitTimeOverride
 			output.HitSpeed = 1 / output.HitTime
 			--Brands always have hitTimeOverride
-			if skillFlags.brand then
+			if skillCfg.skillName and skillCfg.skillName:match("Brand") then
 				output.BrandTicks = m_floor(output.Duration * output.HitSpeed)
 			end
 		elseif skillData.hitTimeMultiplier and output.Time and not skillData.triggeredOnDeath then


### PR DESCRIPTION
Fixes https://github.com/PathOfBuildingCommunity/PathOfBuilding/issues/4962.

### Description of the problem being solved:
Arcanist brand is a support and active gem. It support gems and gives them the brand skill flag.
We use this to tell if a skill is a brand for calculations.
This means a skill can have the brand flag and not be a brand.
This changes it so we pick brands by name instead.

### Steps taken to verify a working solution:
- Adding orb of stroms and arcanist brand no longer crashes and brand stuff no longer appears on triggered skill.

### Link to a build that showcases this PR:
https://pobb.in/deAifYYBO5VR

### Before screenshot:
![image](https://user-images.githubusercontent.com/31533893/185898739-8f69ac67-d805-4fd7-9a4f-47990d434bf3.png)

### After screenshot:
![image](https://user-images.githubusercontent.com/31533893/185898684-817350d5-620f-415f-b555-77c1d5c19b90.png)
