### PR TITLE
Add support for Supports via Party tab

### DIFF
--- a/help.txt
+++ b/help.txt
@@ -131,3 +131,7 @@ Only the highest aura will apply, so if you and the support both run the same au
 Your curses will always apply before the supports though, so even if theres is a higher effect yours will be applied instead
 
 For now Enemy conditions and Modifiers are not exported but can be imported if its saved in the XML
+
+Advanced info:
+    The format for the data is the name of the skill, the %increased effect and then the mods that are applied
+	the mods are done similar to the style from modlib, where it the value applied, the "source" of the mod, the modname, the type added (eg base/inc), the flags, the keywordflags, and then any other tags

--- a/help.txt
+++ b/help.txt
@@ -122,16 +122,17 @@ The Party tab Allows you to import support characters and have thier auras and c
 
 To import a build it must be exported with "Export support" enabled in the import/export tab and must be imported in the party tab
 You can import a specific type like aura or curse, or import to all
-You can also set it to append to a section rather than replacing it (currently curses must be replaced due to more curse limits not working well)
-
+You can also set it to append to a section rather than replacing it (currently curses must be replaced if not empty due to more curse limits not working well)
+ 
 This does not add the auras or curses into the skills tab, but they do show up on calcs tab under "aura and buff skills" as well as "curses and debuffs" respectivly
-They also show other effects they add like physical damage reduction is applied by an aurabot with the gaurdian node
-
+They also show other effects they add, like when physical damage reduction is applied by an aurabot with the gaurdian node
+ 
 Only the highest aura will apply, so if you and the support both run the same aura and your % inc effect is higher it will apply (even if the actual amount yours gives is lower due to gem levels or whatever), this is how it works ingame
 Your curses will always apply before the supports though, so even if theres is a higher effect yours will be applied instead
-
-For now Enemy conditions and Modifiers are not exported but can be imported if its saved in the XML
-
+ 
+For now Enemy conditions and Modifiers are not exported but can be imported if its saved in the XML, and Links skills are not exported or parsed
+Some auras like Mines which use a stack value for thier effect will not apply as their stack value is missing
+ 
 Advanced info:
     The format for the data is the name of the skill, the %increased effect and then the mods that are applied
     The mods are done similar to the style from modlib, where it the value applied, the "source" of the mod, the modname, the type added (eg base/inc), the flags, the keywordflags, and then any other tags

--- a/help.txt
+++ b/help.txt
@@ -134,4 +134,5 @@ For now Enemy conditions and Modifiers are not exported but can be imported if i
 
 Advanced info:
     The format for the data is the name of the skill, the %increased effect and then the mods that are applied
-	the mods are done similar to the style from modlib, where it the value applied, the "source" of the mod, the modname, the type added (eg base/inc), the flags, the keywordflags, and then any other tags
+    The mods are done similar to the style from modlib, where it the value applied, the "source" of the mod, the modname, the type added (eg base/inc), the flags, the keywordflags, and then any other tags
+DEV[    The mods are done by modlib using modLib.formatModParams(mod)]

--- a/help.txt
+++ b/help.txt
@@ -10,6 +10,7 @@ This file contains a list of shortcuts, and other misc things PoB has
 4. Hotkeys
 5. Other Notable Things
 6. Timeless Jewels
+7. PartyTab
 
 ---[FAQ][3]
 
@@ -23,6 +24,7 @@ Ctrl + 3	Jump to items tab
 Ctrl + 4	Jump to calcs tab
 Ctrl + 5	Jump to config tab
 Ctrl + 6	Jump to notes tab
+Ctrl + 7	Jump to party tab
 Ctrl + I	Jump to import tab
 Ctrl + A	Select all
 Ctrl + C	Copy
@@ -114,4 +116,18 @@ Militant Faith jewels also have the option to select the other mods on the jewel
 Advanced tricks:
     For Militant Faith, if you don't want any nodes to change, you can just sort by devotion. As unchanged nodes add devotion, the ones with the most devotion will be the ones with unchanged nodes
 	
-	
+---[Party Tab][7]
+
+The Party tab Allows you to import support characters and have thier auras and curses apply
+
+To import a build it must be exported with "Export support" enabled in the import/export tab and must be imported in the party tab
+You can import a specific type like aura or curse, or import to all
+You can also set it to append to a section rather than replacing it (currently curses must be replaced due to more curse limits not working well)
+
+This does not add the auras or curses into the skills tab, but they do show up on calcs tab under "aura and buff skills" as well as "curses and debuffs" respectivly
+They also show other effects they add like physical damage reduction is applied by an aurabot with the gaurdian node
+
+Only the highest aura will apply, so if you and the support both run the same aura and your % inc effect is higher it will apply (even if the actual amount yours gives is lower due to gem levels or whatever), this is how it works ingame
+Your curses will always apply before the supports though, so even if theres is a higher effect yours will be applied instead
+
+For now Enemy conditions and Modifiers are not exported but can be imported if its saved in the XML

--- a/src/Classes/ImportTab.lua
+++ b/src/Classes/ImportTab.lua
@@ -162,7 +162,8 @@ You can get this from your web browser's cookies while logged into the Path of E
 	self.controls.enablePartyExportBuffs = new("CheckBoxControl", {"LEFT",self.controls.generateCode,"RIGHT"}, 100, 0, 18, "Export Support", function(state)
 		self.build.enableExportBuffs = state
 		self.build.buildFlag = true 
-	end, "This is for party play, to export support character, it enables the exporting of auras, curses and modifiers to the enemy", false)
+	--end, "This is for party play, to export support character, it enables the exporting of auras, curses and modifiers to the enemy", false)
+	end, "This is for party play, to export support character, it enables the exporting of auras and curses", false)
 	self.controls.generateCodeOut = new("EditControl", {"TOPLEFT",self.controls.generateCodeLabel,"BOTTOMLEFT"}, 0, 8, 250, 20, "", "Code", "%Z")
 	self.controls.generateCodeOut.enabled = function()
 		return #self.controls.generateCodeOut.buf > 0

--- a/src/Classes/ImportTab.lua
+++ b/src/Classes/ImportTab.lua
@@ -160,7 +160,7 @@ You can get this from your web browser's cookies while logged into the Path of E
 		self.controls.generateCodeOut:SetText(common.base64.encode(Deflate(self.build:SaveDB("code"))):gsub("+","-"):gsub("/","_"))
 	end)
 	self.controls.enablePartyExportBuffs = new("CheckBoxControl", {"LEFT",self.controls.generateCode,"RIGHT"}, 100, 0, 18, "Export Support", function(state)
-		self.build.enableExportBuffs = state
+		self.build.partyTab.enableExportBuffs = state
 		self.build.buildFlag = true 
 	--end, "This is for party play, to export support character, it enables the exporting of auras, curses and modifiers to the enemy", false)
 	end, "This is for party play, to export support character, it enables the exporting of auras and curses", false)

--- a/src/Classes/ImportTab.lua
+++ b/src/Classes/ImportTab.lua
@@ -26,7 +26,7 @@ local ImportTabClass = newClass("ImportTab", "ControlHost", "Control", function(
 
 	self.charImportMode = "GETACCOUNTNAME"
 	self.charImportStatus = "Idle"
-	self.controls.sectionCharImport = new("SectionControl", {"TOPLEFT",self,"TOPLEFT"}, 10, 18, 600, 250, "Character Import")
+	self.controls.sectionCharImport = new("SectionControl", {"TOPLEFT",self,"TOPLEFT"}, 10, 18, 650, 250, "Character Import")
 	self.controls.charImportStatusLabel = new("LabelControl", {"TOPLEFT",self.controls.sectionCharImport,"TOPLEFT"}, 6, 14, 200, 16, function()
 		return "^7Character import status: "..self.charImportStatus
 	end)
@@ -154,11 +154,15 @@ You can get this from your web browser's cookies while logged into the Path of E
 	end)
 
 	-- Build import/export
-	self.controls.sectionBuild = new("SectionControl", {"TOPLEFT",self.controls.sectionCharImport,"BOTTOMLEFT"}, 0, 18, 600, 182, "Build Sharing")
+	self.controls.sectionBuild = new("SectionControl", {"TOPLEFT",self.controls.sectionCharImport,"BOTTOMLEFT"}, 0, 18, 650, 182, "Build Sharing")
 	self.controls.generateCodeLabel = new("LabelControl", {"TOPLEFT",self.controls.sectionBuild,"TOPLEFT"}, 6, 14, 0, 16, "^7Generate a code to share this build with other Path of Building users:")
 	self.controls.generateCode = new("ButtonControl", {"LEFT",self.controls.generateCodeLabel,"RIGHT"}, 4, 0, 80, 20, "Generate", function()
 		self.controls.generateCodeOut:SetText(common.base64.encode(Deflate(self.build:SaveDB("code"))):gsub("+","-"):gsub("/","_"))
 	end)
+	self.controls.enablePartyExportBuffs = new("CheckBoxControl", {"LEFT",self.controls.generateCode,"RIGHT"}, 100, 0, 18, "Export Support", function(state)
+		self.build.enableExportBuffs = state
+		self.build.buildFlag = true 
+	end, "This is for party play, to export support character, it enables the exporting of auras, curses and modifiers to the enemy", false)
 	self.controls.generateCodeOut = new("EditControl", {"TOPLEFT",self.controls.generateCodeLabel,"BOTTOMLEFT"}, 0, 8, 250, 20, "", "Code", "%Z")
 	self.controls.generateCodeOut.enabled = function()
 		return #self.controls.generateCodeOut.buf > 0
@@ -337,6 +341,7 @@ function ImportTabClass:Load(xml, fileName)
 	self.lastRealm = xml.attrib.lastRealm
 	self.controls.accountRealm:SelByValue( self.lastRealm or main.lastRealm or "PC", "id" )
 	self.lastAccountHash = xml.attrib.lastAccountHash
+	self.controls.enablePartyExportBuffs.state = xml.attrib.exportParty == "true"
 	if self.lastAccountHash then
 		for accountName in pairs(main.gameAccounts) do
 			if common.sha1(accountName) == self.lastAccountHash then
@@ -352,6 +357,7 @@ function ImportTabClass:Save(xml)
 		lastRealm = self.lastRealm,
 		lastAccountHash = self.lastAccountHash,
 		lastCharacterHash = self.lastCharacterHash,
+		exportParty = tostring(self.controls.enablePartyExportBuffs.state),
 	}
 end
 

--- a/src/Classes/ImportTab.lua
+++ b/src/Classes/ImportTab.lua
@@ -343,6 +343,7 @@ function ImportTabClass:Load(xml, fileName)
 	self.controls.accountRealm:SelByValue( self.lastRealm or main.lastRealm or "PC", "id" )
 	self.lastAccountHash = xml.attrib.lastAccountHash
 	self.controls.enablePartyExportBuffs.state = xml.attrib.exportParty == "true"
+	self.build.partyTab.enableExportBuffs = self.controls.enablePartyExportBuffs.state
 	if self.lastAccountHash then
 		for accountName in pairs(main.gameAccounts) do
 			if common.sha1(accountName) == self.lastAccountHash then

--- a/src/Classes/PartyTab.lua
+++ b/src/Classes/PartyTab.lua
@@ -234,7 +234,7 @@ local PartyTabClass = newClass("PartyTab", "ControlHost", "Control", function(se
 		return self.importCodeDetail or ""
 	end
 	self.controls.importCodeDestination = new("DropDownControl", {"TOPLEFT",self.controls.importCodeIn,"BOTTOMLEFT"}, 0, 4, 160, 20, partyDestinations)
-	self.controls.importCodeDestination.tooltipText = "Destination for Import/clear\nCurrently EnemyCondtions, EnemyMods and Links Skills do not export"
+	self.controls.importCodeDestination.tooltipText = "Destination for Import/clear\nCurrently EnemyConditions, EnemyMods and Links Skills do not export"
 	self.controls.importCodeGo = new("ButtonControl", {"LEFT",self.controls.importCodeDestination,"RIGHT"}, 8, 0, 160, 20, "Import", function()
 		local importCodeFetching = false
 		if self.importCodeSite and not self.importCodeXML then

--- a/src/Classes/PartyTab.lua
+++ b/src/Classes/PartyTab.lua
@@ -427,7 +427,7 @@ function PartyTabClass:exportBuffs(buffType)
 	if self.buffExports[buffType].ConvertedToText then
 		return self.buffExports[buffType].string
 	end
-	local buf = ((buffType == "Curse") and tostring(self.buffExports["CurseLimit"])) or ""
+	local buf = ((buffType == "Curse") and tostring(self.buffExports["CurseLimit"] or 0)) or ""
 	for buffName, buff in pairs(self.buffExports[buffType]) do
 		if #buf > 0 then
 			buf = buf.."\n"
@@ -436,9 +436,9 @@ function PartyTabClass:exportBuffs(buffType)
 		if buffType == "Curse" then
 			buf = buf.."\n"..tostring(buff.effectMult * 100)
 			if buff.isMark then
-				buf = buf.."true\n"
+				buf = buf.."\ntrue"
 			else
-				buf = buf.."false\n"
+				buf = buf.."\nfalse"
 			end
 		elseif buffType == "Aura" and buffName ~= "extraAura" then
 			buf = buf.."\n"..tostring(buff.effectMult * 100)

--- a/src/Classes/PartyTab.lua
+++ b/src/Classes/PartyTab.lua
@@ -412,7 +412,7 @@ function PartyTabClass:ParseBuffs(list, buf, buffType)
 				for line2 in line:gmatch("([^|]*)|?") do
 					t_insert(modStrings, line2)
 				end
-				local tags = nil -- modStrings[7], should be done with a mdofified version of "PartyTabClass:ParseTags" where conditions check vs the party and check that the ones in the build are NOT true, such that your effects override the supports
+				local tags = nil -- modStrings[7], should be done with a modified version of "PartyTabClass:ParseTags" where conditions check vs the party and check that the ones in the build are NOT true, such that your effects override the supports
 				list:NewMod(modStrings[3], modStrings[4], tonumber(modStrings[1]), "Party"..modStrings[2], ModFlag[modStrings[5]] or 0, KeywordFlag[modStrings[6]] or 0, tags)
 			end
 		end
@@ -464,12 +464,9 @@ function PartyTabClass:ParseBuffs(list, buf, buffType)
 					keywordFlags = KeywordFlag[modStrings[6]] or 0,
 				}
 				local modType, Tags = self:ParseTags(modStrings[7], currentModType)
-				ConPrintf("---")
-				ConPrintTable(Tags)
 				for _, tag in ipairs(Tags) do
 					t_insert(mod, tag)
 				end
-				ConPrintTable(mod)
 				currentModType = modType
 				if not list[modType] then
 					list[modType] = {}

--- a/src/Classes/PartyTab.lua
+++ b/src/Classes/PartyTab.lua
@@ -58,24 +58,29 @@ local PartyTabClass = newClass("PartyTab", "ControlHost", "Control", function(se
 	
 	local clearInputText = function()
 		if partyDestinations[self.controls.importCodeDestination.selIndex] == "All" or partyDestinations[self.controls.importCodeDestination.selIndex] == "Aura" then
+			self.controls.simpleAuras.label = ""
 			self.controls.editAuras:SetText("")
 			wipeTable(self.processedInput["Aura"])
 			self.processedInput["Aura"] = {}
 		end
 		if partyDestinations[self.controls.importCodeDestination.selIndex] == "All" or partyDestinations[self.controls.importCodeDestination.selIndex] == "Curse" then
+			self.controls.simpleCurses.label = ""
 			self.controls.editCurses:SetText("")
 			wipeTable(self.processedInput["Curse"])
 			self.processedInput["Curse"] = {}
 		end
 		if partyDestinations[self.controls.importCodeDestination.selIndex] == "All" or partyDestinations[self.controls.importCodeDestination.selIndex] == "Link Skills" then
+			self.controls.simpleLinks.label = "^7Link Skills are not currently supported"
 			self.controls.editCurses:SetText("")
 			wipeTable(self.processedInput["Link"])
 			self.processedInput["Link"] = {}
 		end
 		if partyDestinations[self.controls.importCodeDestination.selIndex] == "All" or partyDestinations[self.controls.importCodeDestination.selIndex] == "EnemyConditions" then
+			self.controls.simpleEnemyCond.label = "^7Enemy Conditions are not exported but will still work if correctly added"
 			self.controls.enemyCond:SetText("")
 		end
 		if partyDestinations[self.controls.importCodeDestination.selIndex] == "All" or partyDestinations[self.controls.importCodeDestination.selIndex] == "EnemyMods" then
+			self.controls.simpleEnemyMods.label = "^7Enemy Modifiers are not exported but will still work if correctly added"
 			self.controls.enemyMods:SetText("")
 		end
 	end
@@ -280,7 +285,7 @@ local PartyTabClass = newClass("PartyTab", "ControlHost", "Control", function(se
 	end)
 	self.controls.clear.tooltipText = "^7Clears all the party tab imported data"
 	
-	self.controls.ShowAdvanceTools = new("CheckBoxControl", {"TOPLEFT",self.controls.importCodeDestination,"BOTTOMLEFT"}, 140, 4, 20, "Show Advanced Info", function(state)
+	self.controls.ShowAdvanceTools = new("CheckBoxControl", {"TOPLEFT",self.controls.importCodeDestination,"BOTTOMLEFT"}, 140, 4, 20, "^7Show Advanced Info", function(state)
 	end, "This shows the advanced info like what stats each aura/curse etc are adding, as well as enables the ability to edit them without a re-export\nDo not edit any boxes unless you know what you are doing, use copy/paste or import instead", false)
 	self.controls.ShowAdvanceTools.y = function()
 		return (self.width > 1350) and 4 or 32
@@ -295,7 +300,7 @@ local PartyTabClass = newClass("PartyTab", "ControlHost", "Control", function(se
 	end)
 	self.controls.removeEffects.tooltipText = "^7Removes the effects of the supports, without removing the data\nUse \"rebuild all\" to apply the effects again"
 	
-	self.controls.rebuild = new("ButtonControl", {"LEFT",self.controls.removeEffects,"RIGHT"}, 8, 0, 160, 20, "Rebuild All", function() 
+	self.controls.rebuild = new("ButtonControl", {"LEFT",self.controls.removeEffects,"RIGHT"}, 8, 0, 160, 20, "^7Rebuild All", function() 
 		wipeTable(self.processedInput)
 		wipeTable(self.enemyModList)
 		self.processedInput = { Aura = {}, Curse = {}, Link = {} }
@@ -317,7 +322,7 @@ local PartyTabClass = newClass("PartyTab", "ControlHost", "Control", function(se
 
 	self.controls.editAurasLabel = new("LabelControl", {"TOPLEFT",self.controls.ShowAdvanceTools,"TOPLEFT"}, -140, 40, 150, 16, "^7Auras")
 	self.controls.editAurasLabel.y = function()
-		return 40 + (self.controls.ShowAdvanceTools.state and ((self.width <= 1350) and 28 or 0) or 0)
+		return 40 + ((self.width <= 1350) and 28 or 0)
 	end
 	self.controls.editAuras = new("EditControl", {"TOPLEFT",self.controls.editAurasLabel,"TOPLEFT"}, 0, 18, 0, 0, "", nil, "^%C\t\n", nil, nil, 14, true)
 	self.controls.editAuras.width = function()
@@ -357,7 +362,7 @@ local PartyTabClass = newClass("PartyTab", "ControlHost", "Control", function(se
 	self.controls.editLinks.shown = function()
 		return self.controls.ShowAdvanceTools.state
 	end
-	self.controls.simpleLinks = new("LabelControl", {"TOPLEFT",self.controls.editLinksLabel,"TOPLEFT"}, 0, 18, 0, 16, "Link Skills are not currently supported")
+	self.controls.simpleLinks = new("LabelControl", {"TOPLEFT",self.controls.editLinksLabel,"TOPLEFT"}, 0, 18, 0, 16, "^7Link Skills are not currently supported")
 	self.controls.simpleLinks.shown = function()
 		return not self.controls.ShowAdvanceTools.state
 	end
@@ -373,7 +378,7 @@ local PartyTabClass = newClass("PartyTab", "ControlHost", "Control", function(se
 	self.controls.enemyCond.shown = function()
 		return self.controls.ShowAdvanceTools.state
 	end
-	self.controls.simpleEnemyCond = new("LabelControl", {"TOPLEFT",self.controls.enemyCondLabel,"TOPLEFT"}, 0, 18, 0, 16, "Enemy Conditions are not exported but will still work if correctly added")
+	self.controls.simpleEnemyCond = new("LabelControl", {"TOPLEFT",self.controls.enemyCondLabel,"TOPLEFT"}, 0, 18, 0, 16, "^7Enemy Conditions are not exported but will still work if correctly added")
 	self.controls.simpleEnemyCond.shown = function()
 		return not self.controls.ShowAdvanceTools.state
 	end
@@ -401,7 +406,7 @@ local PartyTabClass = newClass("PartyTab", "ControlHost", "Control", function(se
 	self.controls.enemyMods.shown = function()
 		return self.controls.ShowAdvanceTools.state
 	end
-	self.controls.simpleEnemyMods = new("LabelControl", {"TOPLEFT",self.controls.enemyModsLabel,"TOPLEFT"}, 0, 18, 0, 16, "Enemy Modifiers are not exported but will still work if correctly added")
+	self.controls.simpleEnemyMods = new("LabelControl", {"TOPLEFT",self.controls.enemyModsLabel,"TOPLEFT"}, 0, 18, 0, 16, "^7Enemy Modifiers are not exported but will still work if correctly added")
 	self.controls.simpleEnemyMods.shown = function()
 		return not self.controls.ShowAdvanceTools.state
 	end
@@ -684,7 +689,7 @@ function PartyTabClass:ParseBuffs(list, buf, buffType, label)
 		if label then
 			if buffType == "Aura" then
 				local count = 0
-				label.label = "---------------------------\n"
+				label.label = "^7---------------------------\n"
 				for aura, auraMod in pairs(list["Aura"] or {}) do
 					label.label = label.label..aura..": "..auraMod.effectMult.."%\n"
 					count = count + 1
@@ -705,7 +710,7 @@ function PartyTabClass:ParseBuffs(list, buf, buffType, label)
 				end
 			elseif buffType == "Curse" then
 				local count = 0
-				label.label = "---------------------------\n"
+				label.label = "^7---------------------------\n"
 				for curse, curseMod in pairs(list["Curse"] or {}) do
 					label.label = label.label..curse..": "..curseMod.effectMult.."%\n"
 					count = count + 1

--- a/src/Classes/PartyTab.lua
+++ b/src/Classes/PartyTab.lua
@@ -26,7 +26,9 @@ local PartyTabClass = newClass("PartyTab", "ControlHost", "Control", function(se
 	self.lastEnableExportBuffs = true
 	self.showColorCodes = false
 
-	local notesDesc = [[^7Party stuff	DO NOT EDIT ANY BOXES UNLESS YOU KNOW WHAT YOU ARE DOING, use copy/paste instead, or import]]
+	local notesDesc = [[^7Party stuff	DO NOT EDIT ANY BOXES UNLESS YOU KNOW WHAT YOU ARE DOING, use copy/paste instead, or import
+	To import a build that build must have been saved with Enable Export ticked
+	]]
 	self.controls.notesDesc = new("LabelControl", {"TOPLEFT",self,"TOPLEFT"}, 8, 8, 150, 16, notesDesc)
 	self.controls.notesDesc.width = function()
 		return self.width / 2 - 16
@@ -58,6 +60,9 @@ local PartyTabClass = newClass("PartyTab", "ControlHost", "Control", function(se
 	end
 	
 	self.controls.importCodeIn = new("EditControl", {"TOPLEFT",self.controls.importCodeHeader,"BOTTOMLEFT"}, 0, 4, 328, 20, "", nil, nil, nil, importCodeHandle)
+	self.controls.importCodeIn.width = function()
+		return (self.width > 880) and 328 or (self.width / 2 - 100)
+	end
 	self.controls.importCodeIn.enterFunc = function()
 		if self.importCodeValid then
 			self.controls.importCodeGo.onClick()
@@ -141,6 +146,12 @@ local PartyTabClass = newClass("PartyTab", "ControlHost", "Control", function(se
 		self:ParseBuffs(self.enemyModList, self.controls.enemyMods.buf, "EnemyMods")
 		self.build.buildFlag = true 
 	end)
+	self.controls.rebuild.x = function()
+		return (self.width > 1260) and 8 or (-328)
+	end
+	self.controls.rebuild.y = function()
+		return (self.width > 1260) and 0 or 28
+	end
 	self.controls.enableExportBuffs = new("CheckBoxControl", {"LEFT",self.controls.rebuild,"RIGHT"}, 100, 0, 18, "Enable Export", function(state)
 		self.enableExportBuffs = state
 	end, "Enables the exporting of auras, cruses and modifiers to the enemy", false)
@@ -149,8 +160,11 @@ local PartyTabClass = newClass("PartyTab", "ControlHost", "Control", function(se
 	self.controls.editAuras.width = function()
 		return self.width / 2 - 16
 	end
+	self.controls.editAuras.y = function()
+		return (self.width > 1260) and 40 or 68
+	end
 	self.controls.editAuras.height = function()
-		return self.height - 148
+		return self.height - 148 - ((self.width > 1260) and 28 or 0)
 	end
 
 	self.controls.enemyCond = new("EditControl", {"TOPLEFT",self.controls.notesDesc,"TOPRIGHT"}, 8, 0, 0, 0, "", nil, "^%C\t\n", nil, nil, 14, true)
@@ -427,7 +441,7 @@ function PartyTabClass:exportBuffs(buffType)
 	if self.buffExports[buffType].ConvertedToText then
 		return self.buffExports[buffType].string
 	end
-	local buf = ((buffType == "Curse") and tostring(self.buffExports["CurseLimit"] or 0)) or ""
+	local buf = ((buffType == "Curse") and tostring(self.buffExports["CurseLimit"])) or ""
 	for buffName, buff in pairs(self.buffExports[buffType]) do
 		if #buf > 0 then
 			buf = buf.."\n"

--- a/src/Classes/PartyTab.lua
+++ b/src/Classes/PartyTab.lua
@@ -505,7 +505,9 @@ function PartyTabClass:ParseBuffs(list, buf, buffType)
 	local isMark
 	local currentModType = "Unknown"
 	for line in buf:gmatch("([^\n]*)\n?") do
-		if mode == "CurseLimit" and line ~= "" then
+		if line ~= "---" and line:match("%-%-%-") then
+			-- comment but not dividor, skip the line
+		elseif mode == "CurseLimit" and line ~= "" then
 			list.limit = tonumber(line)
 			mode = "Name"
 		elseif mode == "Name" and line ~= "" then
@@ -586,7 +588,7 @@ function PartyTabClass:exportBuffs(buffType)
 	if self.buffExports[buffType].ConvertedToText then
 		return self.buffExports[buffType].string
 	end
-	local buf = ((buffType == "Curse") and (tostring(self.buffExports["CurseLimit"]))) or ""
+	local buf = ((buffType == "Curse") and ("--- Curse Limit ---" .. tostring(self.buffExports["CurseLimit"]))) or ""
 	for buffName, buff in pairs(self.buffExports[buffType]) do
 		if #buf > 0 then
 			buf = buf.."\n"

--- a/src/Classes/PartyTab.lua
+++ b/src/Classes/PartyTab.lua
@@ -681,6 +681,10 @@ function PartyTabClass:ParseBuffs(list, buf, buffType, label)
 								list[modType][currentName].isMark = true
 							end
 						end
+						if mod.source:match("Item") then
+							_, mod.source = mod.source:match("Item:(%d+):(.+)")
+							mod.source = "Party, "..mod.source
+						end
 						list[modType][currentName].modList:AddMod(mod)
 					end
 				end

--- a/src/Classes/PartyTab.lua
+++ b/src/Classes/PartyTab.lua
@@ -24,10 +24,11 @@ local PartyTabClass = newClass("PartyTab", "ControlHost", "Control", function(se
 	self.lastContentEnemyCond = ""
 	self.lastContentEnemyMods = ""
 	self.lastEnableExportBuffs = true
-	self.showColorCodes = false
+	
+	local partyDestinations = { "All", "Aura", "Curse", "EnemyConditions", "EnemyMods" }
 
-	local notesDesc = [[^7DO NOT EDIT ANY BOXES UNLESS YOU KNOW WHAT YOU ARE DOING, use copy/paste instead, or import
-	To import a build, you must export that build with "Export Support" ticked
+	local notesDesc = [[^7Do not edit any boxes unless you know what you are doing, use copy/paste or import instead
+	To import a build, you must export that build with "Export Support" ticked after it has been saved
 	The Strongest Aura applies, but your curses override the supports regardless of strength
 	]]
 	
@@ -98,35 +99,29 @@ local PartyTabClass = newClass("PartyTab", "ControlHost", "Control", function(se
 			return
 		end
 	
-		if self.controls.importCodeMode2.selIndex == 1 then
-			if self.controls.importCodeMode.selIndex == 1 or self.controls.importCodeMode.selIndex == 2 then
+		if self.controls.importCodeApplication.selIndex == 1 then
+			if partyDestinations[self.controls.importCodeDestination.selIndex] == "All" or partyDestinations[self.controls.importCodeDestination.selIndex] == "Aura" then
 				self.controls.editAuras:SetText("")
 				wipeTable(self.processedInput["Aura"])
 				self.processedInput["Aura"] = {}
 			end
-			if self.controls.importCodeMode.selIndex == 1 or self.controls.importCodeMode.selIndex == 3 then
+			if partyDestinations[self.controls.importCodeDestination.selIndex] == "All" or partyDestinations[self.controls.importCodeDestination.selIndex] == "Curse" then
 				self.controls.editCurses:SetText("")
 				wipeTable(self.processedInput["Curse"])
 				self.processedInput["Curse"] = {}
 			end
-			if self.controls.importCodeMode.selIndex == 1 or self.controls.importCodeMode.selIndex == 4 then
+			if partyDestinations[self.controls.importCodeDestination.selIndex] == "All" or partyDestinations[self.controls.importCodeDestination.selIndex] == "EnemyConditions" then
 				self.controls.enemyCond:SetText("")
 			end
-			if self.controls.importCodeMode.selIndex == 1 or self.controls.importCodeMode.selIndex == 5 then
+			if partyDestinations[self.controls.importCodeDestination.selIndex] == "All" or partyDestinations[self.controls.importCodeDestination.selIndex] == "EnemyMods" then
 				self.controls.enemyMods:SetText("")
 			end
-			if self.controls.importCodeMode2.selIndex == 3 then
-				wipeTable(self.enemyModList)
-				self.enemyModList = new("ModList")
-				self.build.buildFlag = true 
-				return
-			end
 		else
-			if self.controls.importCodeMode.selIndex == 1 or self.controls.importCodeMode.selIndex == 2 then
+			if partyDestinations[self.controls.importCodeDestination.selIndex] == "All" or partyDestinations[self.controls.importCodeDestination.selIndex] == "Aura" then
 				wipeTable(self.processedInput["Aura"])
 				self.processedInput["Aura"] = {}
 			end
-			if self.controls.importCodeMode.selIndex == 1 or self.controls.importCodeMode.selIndex == 3 then
+			if partyDestinations[self.controls.importCodeDestination.selIndex] == "All" or partyDestinations[self.controls.importCodeDestination.selIndex] == "Curse" then
 				self.controls.editCurses:SetText("") --curses do not play nicely with append atm, need to fix
 				wipeTable(self.processedInput["Curse"])
 				self.processedInput["Curse"] = {}
@@ -146,33 +141,33 @@ local PartyTabClass = newClass("PartyTab", "ControlHost", "Control", function(se
 		-- Load data
 		for _, node in ipairs(dbXML[1]) do
 			if type(node) == "table" and node.elem == "Party" then
-				if self.controls.importCodeMode.selIndex == 1 or self.controls.importCodeMode.selIndex == 2 then
+				if partyDestinations[self.controls.importCodeDestination.selIndex] == "All" or partyDestinations[self.controls.importCodeDestination.selIndex] == "Aura" then
 					if #self.controls.editAuras.buf > 0 then
 						node[5].attrib.string = self.controls.editAuras.buf.."\n"..node[5].attrib.string
 					end
 					self.controls.editAuras:SetText(node[5].attrib.string)
 					self:ParseBuffs(self.processedInput["Aura"], self.controls.editAuras.buf, "Aura")
 				end
-				if self.controls.importCodeMode.selIndex == 1 or self.controls.importCodeMode.selIndex == 3 then
+				if partyDestinations[self.controls.importCodeDestination.selIndex] == "All" or partyDestinations[self.controls.importCodeDestination.selIndex] == "Curse" then
 					if #self.controls.editCurses.buf > 0 then
 						node[6].attrib.string = self.controls.editCurses.buf.."\n"..node[6].attrib.string
 					end
 					self.controls.editCurses:SetText(node[6].attrib.string)
 					self:ParseBuffs(self.processedInput["Curse"], self.controls.editCurses.buf, "Curse")
 				end
-				if self.controls.importCodeMode.selIndex == 1 or self.controls.importCodeMode.selIndex == 4 then
+				if partyDestinations[self.controls.importCodeDestination.selIndex] == "All" or partyDestinations[self.controls.importCodeDestination.selIndex] == "EnemyConditions" then
 					if #self.controls.enemyCond.buf > 0 then
 						node[7].attrib.string = self.controls.enemyCond.buf.."\n"..node[7].attrib.string
 					end
 					self.controls.enemyCond:SetText(node[7].attrib.string)
 				end
-				if self.controls.importCodeMode.selIndex == 1 or self.controls.importCodeMode.selIndex == 5 then
+				if partyDestinations[self.controls.importCodeDestination.selIndex] == "All" or partyDestinations[self.controls.importCodeDestination.selIndex] == "EnemyMods" then
 					if #self.controls.enemyMods.buf > 0 then
 						node[8].attrib.string = self.controls.enemyMods.buf.."\n"..node[8].attrib.string
 					end
 					self.controls.enemyMods:SetText(node[8].attrib.string)
 				end
-				if self.controls.importCodeMode.selIndex == 1 or self.controls.importCodeMode.selIndex == 4 or self.controls.importCodeMode.selIndex == 5 then
+				if partyDestinations[self.controls.importCodeDestination.selIndex] == "All" or partyDestinations[self.controls.importCodeDestination.selIndex] == "EnemyConditions" or partyDestinations[self.controls.importCodeDestination.selIndex] == "EnemyMods" then
 					wipeTable(self.enemyModList)
 					self.enemyModList = new("ModList")
 					self:ParseBuffs(self.enemyModList, self.controls.enemyCond.buf, "EnemyConditions")
@@ -197,27 +192,27 @@ local PartyTabClass = newClass("PartyTab", "ControlHost", "Control", function(se
 	self.controls.importCodeState.label = function()
 		return self.importCodeDetail or ""
 	end
-	self.controls.importCodeMode = new("DropDownControl", {"TOPLEFT",self.controls.importCodeIn,"BOTTOMLEFT"}, 0, 4, 160, 20, { "All", "Aura", "Curse", "EnemyConditions", "EnemyMods" })
-	self.controls.importCodeMode.enabled = function()
+	self.controls.importCodeDestination = new("DropDownControl", {"TOPLEFT",self.controls.importCodeIn,"BOTTOMLEFT"}, 0, 4, 160, 20, partyDestinations)
+	self.controls.importCodeDestination.enabled = function()
 		return self.importCodeValid
 	end
-	self.controls.importCodeMode2 = new("DropDownControl", {"LEFT",self.controls.importCodeMode,"RIGHT"}, 8, 0, 160, 20, { "Replace", "Append", "Clear" })
-	self.controls.importCodeGo = new("ButtonControl", {"LEFT",self.controls.importCodeMode2,"RIGHT"}, 8, 0, 160, 20, "Import", function()
-		if self.controls.importCodeMode2.selIndex == 3 then
-			if self.controls.importCodeMode.selIndex == 1 or self.controls.importCodeMode.selIndex == 2 then
+	self.controls.importCodeApplication = new("DropDownControl", {"LEFT",self.controls.importCodeDestination,"RIGHT"}, 8, 0, 160, 20, { "Replace", "Append", "Clear" })
+	self.controls.importCodeGo = new("ButtonControl", {"LEFT",self.controls.importCodeApplication,"RIGHT"}, 8, 0, 160, 20, "Import", function()
+		if self.controls.importCodeApplication.selIndex == 3 then
+			if partyDestinations[self.controls.importCodeDestination.selIndex] == "All" or partyDestinations[self.controls.importCodeDestination.selIndex] == "Aura" then
 				self.controls.editAuras:SetText("")
 				wipeTable(self.processedInput["Aura"])
 				self.processedInput["Aura"] = {}
 			end
-			if self.controls.importCodeMode.selIndex == 1 or self.controls.importCodeMode.selIndex == 3 then
+			if partyDestinations[self.controls.importCodeDestination.selIndex] == "All" or partyDestinations[self.controls.importCodeDestination.selIndex] == "Curse" then
 				self.controls.editCurses:SetText("")
 				wipeTable(self.processedInput["Curse"])
 				self.processedInput["Curse"] = {}
 			end
-			if self.controls.importCodeMode.selIndex == 1 or self.controls.importCodeMode.selIndex == 4 then
+			if partyDestinations[self.controls.importCodeDestination.selIndex] == "All" or partyDestinations[self.controls.importCodeDestination.selIndex] == "EnemyConditions" then
 				self.controls.enemyCond:SetText("")
 			end
-			if self.controls.importCodeMode.selIndex == 1 or self.controls.importCodeMode.selIndex == 5 then
+			if partyDestinations[self.controls.importCodeDestination.selIndex] == "All" or partyDestinations[self.controls.importCodeDestination.selIndex] == "EnemyMods" then
 				self.controls.enemyMods:SetText("")
 			end
 			wipeTable(self.enemyModList)
@@ -245,10 +240,10 @@ local PartyTabClass = newClass("PartyTab", "ControlHost", "Control", function(se
 		finishImport()
 	end)
 	self.controls.importCodeGo.label = function()
-		return self.controls.importCodeMode2.selIndex == 3 and "Clear" or "Import"
+		return self.controls.importCodeApplication.selIndex == 3 and "Clear" or "Import"
 	end
 	self.controls.importCodeGo.enabled = function()
-		return (self.importCodeValid and not self.importCodeFetching) or self.controls.importCodeMode2.selIndex == 3
+		return (self.importCodeValid and not self.importCodeFetching) or self.controls.importCodeApplication.selIndex == 3
 	end
 	self.controls.importCodeGo.x = function()
 		return (self.width > 1350) and 8 or (-328)
@@ -267,7 +262,7 @@ local PartyTabClass = newClass("PartyTab", "ControlHost", "Control", function(se
 		wipeTable(self.enemyModList)
 		self.processedInput = { Aura = {}, Curse = {} }
 		self.enemyModList = new("ModList")
-		if self.controls.importCodeMode2.selIndex ~= 3 then
+		if self.controls.importCodeApplication.selIndex ~= 3 then
 			self:ParseBuffs(self.processedInput["Aura"], self.controls.editAuras.buf, "Aura")
 			self:ParseBuffs(self.processedInput["Curse"], self.controls.editCurses.buf, "Curse")
 			self:ParseBuffs(self.enemyModList, self.controls.enemyCond.buf, "EnemyConditions")
@@ -276,11 +271,11 @@ local PartyTabClass = newClass("PartyTab", "ControlHost", "Control", function(se
 		self.build.buildFlag = true 
 	end)
 	self.controls.rebuild.label = function()
-		return self.controls.importCodeMode2.selIndex == 3 and "Remove effects" or "Rebuild All"
+		return self.controls.importCodeApplication.selIndex == 3 and "Remove effects" or "Rebuild All"
 	end
-	self.controls.rebuild.tooltipText = "^7Reparse all the inputs incase they have changed since loading the build or importing"
+	self.controls.rebuild.tooltip = "^7Reparse all the inputs incase they have changed since loading the build or importing"
 
-	self.controls.editAurasLabel = new("LabelControl", {"TOPLEFT",self.controls.importCodeMode,"TOPLEFT"}, 0, 40, 150, 16, "^7Auras")
+	self.controls.editAurasLabel = new("LabelControl", {"TOPLEFT",self.controls.importCodeDestination,"TOPLEFT"}, 0, 40, 150, 16, "^7Auras")
 	self.controls.editAurasLabel.y = function()
 		return (self.width > 1350) and 40 or 68
 	end
@@ -427,7 +422,8 @@ function PartyTabClass:Draw(viewPort, inputEvents)
 			or self.lastEnableExportBuffs ~= self.enableExportBuffs)
 end
 
-function PartyTabClass:ParseTags(line, currentModType) -- should parse this correctly instead of string match
+function PartyTabClass:ParseTags(line, currentModType)
+	 -- should parse this correctly instead of string match
 	if not line then
 		return "none", {}
 	end
@@ -491,8 +487,12 @@ function PartyTabClass:ParseBuffs(list, buf, buffType)
 				for line2 in line:gmatch("([^|]*)|?") do
 					t_insert(modStrings, line2)
 				end
-				local tags = nil -- modStrings[7], should be done with a modified version of "PartyTabClass:ParseTags" where conditions check vs the party and check that the ones in the build are NOT true, such that your effects override the supports
-				list:NewMod(modStrings[3], modStrings[4], tonumber(modStrings[1]), "Party"..modStrings[2], ModFlag[modStrings[5]] or 0, KeywordFlag[modStrings[6]] or 0, tags)
+				if #modStrings >= 7 then
+					-- should be done with a modified version of "PartyTabClass:ParseTags" where conditions check vs the party
+					-- and check that the ones in the build are NOT true, such that your effects override the supports
+					local tags = nil -- modStrings[7]
+					list:NewMod(modStrings[3], modStrings[4], tonumber(modStrings[1]), "Party"..modStrings[2], ModFlag[modStrings[5]] or 0, KeywordFlag[modStrings[6]] or 0, tags)
+				end
 			end
 		end
 	end
@@ -506,7 +506,7 @@ function PartyTabClass:ParseBuffs(list, buf, buffType)
 	local currentModType = "Unknown"
 	for line in buf:gmatch("([^\n]*)\n?") do
 		if line ~= "---" and line:match("%-%-%-") then
-			-- comment but not dividor, skip the line
+			-- comment but not divider, skip the line
 		elseif mode == "CurseLimit" and line ~= "" then
 			list.limit = tonumber(line)
 			mode = "Name"
@@ -536,38 +536,40 @@ function PartyTabClass:ParseBuffs(list, buf, buffType)
 				for line2 in line:gmatch("([^|]*)|?") do
 					t_insert(modStrings, line2)
 				end
-				local mod = {
-					value = (modStrings[1] == "true" and true) or tonumber(modStrings[1]) or 0,
-					source = modStrings[2],
-					name = modStrings[3],
-					type = modStrings[4],
-					flags = ModFlag[modStrings[5]] or 0,
-					keywordFlags = KeywordFlag[modStrings[6]] or 0,
-				}
-				local modType, Tags = self:ParseTags(modStrings[7], currentModType)
-				for _, tag in ipairs(Tags) do
-					t_insert(mod, tag)
-				end
-				currentModType = modType
-				if not list[modType] then
-					list[modType] = {}
-					list[modType][currentName] = {
-						modList = new("ModList"),
-						effectMult = currentEffect
+				if #modStrings >= 4 then
+					local mod = {
+						value = (modStrings[1] == "true" and true) or tonumber(modStrings[1]) or 0,
+						source = modStrings[2],
+						name = modStrings[3],
+						type = modStrings[4],
+						flags = ModFlag[modStrings[5]] or 0,
+						keywordFlags = KeywordFlag[modStrings[6]] or 0,
 					}
-					if isMark then
-						list[modType][currentName].isMark = true
+					local modType, Tags = self:ParseTags(modStrings[7], currentModType)
+					for _, tag in ipairs(Tags) do
+						t_insert(mod, tag)
 					end
-				elseif not list[modType][currentName] then
-					list[modType][currentName] = {
-						modList = new("ModList"),
-						effectMult = currentEffect
-					}
-					if isMark then
-						list[modType][currentName].isMark = true
+					currentModType = modType
+					if not list[modType] then
+						list[modType] = {}
+						list[modType][currentName] = {
+							modList = new("ModList"),
+							effectMult = currentEffect
+						}
+						if isMark then
+							list[modType][currentName].isMark = true
+						end
+					elseif not list[modType][currentName] then
+						list[modType][currentName] = {
+							modList = new("ModList"),
+							effectMult = currentEffect
+						}
+						if isMark then
+							list[modType][currentName].isMark = true
+						end
 					end
+					list[modType][currentName].modList:AddMod(mod)
 				end
-				list[modType][currentName].modList:AddMod(mod)
 			end
 		end
 	end

--- a/src/Classes/PartyTab.lua
+++ b/src/Classes/PartyTab.lua
@@ -23,6 +23,9 @@ local PartyTabClass = newClass("PartyTab", "ControlHost", "Control", function(se
 
 	local notesDesc = [[^7Party stuff	DO NOT EDIT ANY BOXES UNLESS YOU KNOW WHAT YOU ARE DOING, use copy/paste instead, or import]]
 	self.controls.notesDesc = new("LabelControl", {"TOPLEFT",self,"TOPLEFT"}, 8, 8, 150, 16, notesDesc)
+	self.controls.notesDesc.width = function()
+		return self.width / 2 - 16
+	end
 	self.controls.importCodeHeader = new("LabelControl", {"TOPLEFT",self.controls.notesDesc,"BOTTOMLEFT"}, 0, 26, 0, 16, "^7To import a build, enter code here: (NOT URL)")
 	
 	local importCodeHandle = function (buf)
@@ -117,18 +120,29 @@ local PartyTabClass = newClass("PartyTab", "ControlHost", "Control", function(se
 
 	self.controls.editAuras = new("EditControl", {"TOPLEFT",self.controls.importCodeMode,"TOPLEFT"}, 0, 40, 0, 0, "", nil, "^%C\t\n", nil, nil, 14, true)
 	self.controls.editAuras.width = function()
-		return self.width / 2 - self.controls.editAuras.x - 18
+		return self.width / 2 - 16
 	end
 	self.controls.editAuras.height = function()
 		return self.height - 148
 	end
 
-	self.controls.editCurses = new("EditControl", {"TOPLEFT",self.controls.editAuras,"TOPRIGHT"}, 8, 0, 0, 0, "", nil, "^%C\t\n", nil, nil, 14, true)
+	self.controls.editMisc = new("EditControl", {"TOPLEFT",self.controls.notesDesc,"TOPRIGHT"}, 8, 0, 0, 0, "", nil, "^%C\t\n", nil, nil, 14, true)
+	self.controls.editMisc.width = function()
+		return self.width / 2 - 16
+	end
+	local extraHeight = function()
+		return false
+	end
+	self.controls.editMisc.height = function()
+		return (extraHeight() and (self.height - 148) or 116)
+	end
+
+	self.controls.editCurses = new("EditControl", {"TOPLEFT",self.controls.editMisc,"BOTTOMLEFT"}, 0, 10, 0, 0, "", nil, "^%C\t\n", nil, nil, 14, true)
 	self.controls.editCurses.width = function()
 		return self.width / 2 - 16
 	end
 	self.controls.editCurses.height = function()
-		return self.height - 148
+		return (not extraHeight() and (self.height - 148) or 116)
 	end
 	self:SelectControl(self.controls.editAuras)
 end)
@@ -222,6 +236,9 @@ function PartyTabClass:ParseBuffs(list, buf, buffType)
 			mode = "Name"
 		elseif mode == "Name" and line ~= "" then
 			currentName = line
+			if line == "extraAura" then
+				currentModType = "extraAura"
+			end
 			mode = "Effect"
 		elseif mode == "Effect" then
 			currentEffect = tonumber(line)

--- a/src/Classes/PartyTab.lua
+++ b/src/Classes/PartyTab.lua
@@ -464,6 +464,8 @@ function PartyTabClass:ParseBuffs(list, buf, buffType)
 			mode = "Stats"
 		elseif line == "---" then
 			mode = "Name"
+		elseif line:match("---") then -- comment line, just ignore it
+			
 		else
 			if line:find("|") then
 				local modStrings = {}
@@ -522,7 +524,7 @@ function PartyTabClass:exportBuffs(buffType)
 	if self.buffExports[buffType].ConvertedToText then
 		return self.buffExports[buffType].string
 	end
-	local buf = ((buffType == "Curse") and tostring(self.buffExports["CurseLimit"])) or ""
+	local buf = ((buffType == "Curse") and ("--- Curse Limit ---\n" .. tostring(self.buffExports["CurseLimit"]))) or ""
 	for buffName, buff in pairs(self.buffExports[buffType]) do
 		if #buf > 0 then
 			buf = buf.."\n"

--- a/src/Classes/PartyTab.lua
+++ b/src/Classes/PartyTab.lua
@@ -366,24 +366,41 @@ end
 function PartyTabClass:ParseTags(line, currentModType) -- should parse this correctly instead of string match
 	local extraTags = {}
 	local modType = currentModType
-	if line:find("type=GlobalEffect/effectType=AuraDebuff") then
-		t_insert(extraTags, {
-			type = "GlobalEffect",
-			effectType = "AuraDebuff"
-		})
-		modType = "AuraDebuff"
-	elseif line:find("type=GlobalEffect/effectType=Aura") then
-		t_insert(extraTags, {
-			type = "GlobalEffect",
-			effectType = "Aura"
-		})
-		modType = "Aura"
-	elseif line:find("type=GlobalEffect/effectType=Curse") then
-		t_insert(extraTags, {
-			type = "GlobalEffect",
-			effectType = "Curse"
-		})
-		modType = "Curse"
+	for line2 in line:gmatch("([^,]*),?") do
+		if line2:find("type=GlobalEffect/") then
+			if line2:find("type=GlobalEffect/effectType=AuraDebuff") then
+				t_insert(extraTags, {
+					type = "GlobalEffect",
+					effectType = "AuraDebuff"
+				})
+				modType = "AuraDebuff"
+			elseif line2:find("type=GlobalEffect/effectType=Aura") then
+				t_insert(extraTags, {
+					type = "GlobalEffect",
+					effectType = "Aura"
+				})
+				modType = "Aura"
+			elseif line2:find("type=GlobalEffect/effectType=Curse") then
+				t_insert(extraTags, {
+					type = "GlobalEffect",
+					effectType = "Curse"
+				})
+				modType = "Curse"
+			end
+		elseif line2:find("type=Condition/") then
+			if line2:find("type=Condition/neg=true/var=RareOrUnique") then
+				t_insert(extraTags, {
+					type = "Condition",
+					neg = true,
+					var = "RareOrUnique"
+				})
+			elseif line2:find("type=Condition/var=RareOrUnique") then
+				t_insert(extraTags, {
+					type = "Condition",
+					var = "RareOrUnique"
+				})
+			end
+		end
 	end
 	return modType, extraTags
 end
@@ -459,7 +476,12 @@ function PartyTabClass:ParseBuffs(list, buf, buffType)
 					keywordFlags = KeywordFlag[modStrings[6]] or 0,
 				}
 				local modType, Tags = self:ParseTags(modStrings[7], currentModType)
-				mod[1] = Tags[1]
+				ConPrintf("---")
+				ConPrintTable(Tags)
+				for _, tag in ipairs(Tags) do
+					t_insert(mod, tag)
+				end
+				ConPrintTable(mod)
 				currentModType = modType
 				if not list[modType] then
 					list[modType] = {}

--- a/src/Classes/PartyTab.lua
+++ b/src/Classes/PartyTab.lua
@@ -28,12 +28,13 @@ local PartyTabClass = newClass("PartyTab", "ControlHost", "Control", function(se
 
 	local notesDesc = [[^7Party stuff	DO NOT EDIT ANY BOXES UNLESS YOU KNOW WHAT YOU ARE DOING, use copy/paste instead, or import
 	To import a build that build must have been saved with Enable Export ticked
+	The Strongest Aura applies, but your curses override the supports regardless of strength
 	]]
 	self.controls.notesDesc = new("LabelControl", {"TOPLEFT",self,"TOPLEFT"}, 8, 8, 150, 16, notesDesc)
 	self.controls.notesDesc.width = function()
 		return self.width / 2 - 16
 	end
-	self.controls.importCodeHeader = new("LabelControl", {"TOPLEFT",self.controls.notesDesc,"BOTTOMLEFT"}, 0, 26, 0, 16, "^7To import a build, enter code here: (NOT URL)")
+	self.controls.importCodeHeader = new("LabelControl", {"TOPLEFT",self.controls.notesDesc,"BOTTOMLEFT"}, 0, 32, 0, 16, "^7To import a build, enter code here: (NOT URL)")
 	
 	local importCodeHandle = function (buf)
 		self.importCodeSite = nil
@@ -164,7 +165,7 @@ local PartyTabClass = newClass("PartyTab", "ControlHost", "Control", function(se
 		return (self.width > 1260) and 40 or 68
 	end
 	self.controls.editAuras.height = function()
-		return self.height - 148 - ((self.width > 1260) and 28 or 0)
+		return self.height - 154 - ((self.width > 1260) and 0 or 28)
 	end
 
 	self.controls.enemyCond = new("EditControl", {"TOPLEFT",self.controls.notesDesc,"TOPRIGHT"}, 8, 0, 0, 0, "", nil, "^%C\t\n", nil, nil, 14, true)
@@ -172,7 +173,7 @@ local PartyTabClass = newClass("PartyTab", "ControlHost", "Control", function(se
 		return self.width / 2 - 16
 	end
 	self.controls.enemyCond.height = function()
-		return (self.controls.enemyCond.hasFocus and (self.height - 270) or 116)
+		return (self.controls.enemyCond.hasFocus and (self.height - 286) or 122)
 	end
 
 	self.controls.enemyMods = new("EditControl", {"TOPLEFT",self.controls.enemyCond,"BOTTOMLEFT"}, 0, 10, 0, 0, "", nil, "^%C\t\n", nil, nil, 14, true)
@@ -180,7 +181,7 @@ local PartyTabClass = newClass("PartyTab", "ControlHost", "Control", function(se
 		return self.width / 2 - 16
 	end
 	self.controls.enemyMods.height = function()
-		return (self.controls.enemyMods.hasFocus and (self.height - 270) or 116)
+		return (self.controls.enemyMods.hasFocus and (self.height - 286) or 122)
 	end
 
 	self.controls.editCurses = new("EditControl", {"TOPLEFT",self.controls.enemyMods,"BOTTOMLEFT"}, 0, 10, 0, 0, "", nil, "^%C\t\n", nil, nil, 14, true)
@@ -188,7 +189,7 @@ local PartyTabClass = newClass("PartyTab", "ControlHost", "Control", function(se
 		return self.width / 2 - 16
 	end
 	self.controls.editCurses.height = function()
-		return ((not self.controls.enemyCond.hasFocus and not self.controls.enemyMods.hasFocus) and (self.height - 148) or 116)
+		return ((not self.controls.enemyCond.hasFocus and not self.controls.enemyMods.hasFocus) and (self.height - 286) or 122)
 	end
 	self:SelectControl(self.controls.editAuras)
 end)

--- a/src/Classes/PartyTab.lua
+++ b/src/Classes/PartyTab.lua
@@ -434,20 +434,20 @@ function PartyTabClass:exportBuffs(buffType)
 		end
 		buf = buf..buffName
 		if buffType == "Curse" then
-			buf = buf.."\n"..tostring(buff.effectMult * 100).."\n"
+			buf = buf.."\n"..tostring(buff.effectMult * 100)
 			if buff.isMark then
 				buf = buf.."true\n"
 			else
 				buf = buf.."false\n"
 			end
 		elseif buffType == "Aura" and buffName ~= "extraAura" then
-			buf = buf.."\n"..tostring(buff.effectMult * 100).."\n"
+			buf = buf.."\n"..tostring(buff.effectMult * 100)
 		end
 		if buffType == "Curse" or buffType == "Aura"  then
 			for _, mod in ipairs(buff.modList) do
-				buf = buf..tostring(mod.value).."|"..mod.source.."|"..modLib.formatModParams(mod).."\n"
+				buf = buf.."\n"..tostring(mod.value).."|"..mod.source.."|"..modLib.formatModParams(mod)
 			end
-			buf = buf.."---"
+			buf = buf.."\n---"
 		elseif buffType == "EnemyMods" then
 			buf = buf.."\n"..tostring(buff.value).."|"..buff.source.."|"..modLib.formatModParams(buff)
 		end

--- a/src/Classes/PartyTab.lua
+++ b/src/Classes/PartyTab.lua
@@ -693,7 +693,7 @@ function PartyTabClass:ParseBuffs(list, buf, buffType, label)
 						if currentName ~= "SKIP" then
 							if mod.source:match("Item") then
 								_, mod.source = mod.source:match("Item:(%d+):(.+)")
-								mod.source = "Party, "..mod.source
+								mod.source = "Party - "..mod.source
 							end
 							list[modType][currentName].modList:AddMod(mod)
 						end

--- a/src/Classes/PartyTab.lua
+++ b/src/Classes/PartyTab.lua
@@ -132,29 +132,29 @@ local PartyTabClass = newClass("PartyTab", "ControlHost", "Control", function(se
 			if type(node) == "table" and node.elem == "Party" then
 				if self.controls.importCodeMode.selIndex == 1 or self.controls.importCodeMode.selIndex == 2 then
 					if #self.controls.editAuras.buf > 0 then
-						node[6].attrib.string = self.controls.editAuras.buf.."\n"..node[6].attrib.string
+						node[5].attrib.string = self.controls.editAuras.buf.."\n"..node[5].attrib.string
 					end
-					self.controls.editAuras:SetText(node[6].attrib.string)
+					self.controls.editAuras:SetText(node[5].attrib.string)
 					self:ParseBuffs(self.processedInput["Aura"], self.controls.editAuras.buf, "Aura")
 				end
 				if self.controls.importCodeMode.selIndex == 1 or self.controls.importCodeMode.selIndex == 3 then
 					if #self.controls.editCurses.buf > 0 then
-						node[7].attrib.string = self.controls.editCurses.buf.."\n"..node[7].attrib.string
+						node[6].attrib.string = self.controls.editCurses.buf.."\n"..node[6].attrib.string
 					end
-					self.controls.editCurses:SetText(node[7].attrib.string)
+					self.controls.editCurses:SetText(node[6].attrib.string)
 					self:ParseBuffs(self.processedInput["Curse"], self.controls.editCurses.buf, "Curse")
 				end
 				if self.controls.importCodeMode.selIndex == 1 or self.controls.importCodeMode.selIndex == 4 then
 					if #self.controls.enemyCond.buf > 0 then
-						node[8].attrib.string = self.controls.enemyCond.buf.."\n"..node[8].attrib.string
+						node[7].attrib.string = self.controls.enemyCond.buf.."\n"..node[7].attrib.string
 					end
-					self.controls.enemyCond:SetText(node[8].attrib.string)
+					self.controls.enemyCond:SetText(node[7].attrib.string)
 				end
 				if self.controls.importCodeMode.selIndex == 1 or self.controls.importCodeMode.selIndex == 5 then
 					if #self.controls.enemyMods.buf > 0 then
-						node[9].attrib.string = self.controls.enemyMods.buf.."\n"..node[9].attrib.string
+						node[8].attrib.string = self.controls.enemyMods.buf.."\n"..node[8].attrib.string
 					end
-					self.controls.enemyMods:SetText(node[9].attrib.string)
+					self.controls.enemyMods:SetText(node[8].attrib.string)
 				end
 				if self.controls.importCodeMode.selIndex == 1 or self.controls.importCodeMode.selIndex == 4 or self.controls.importCodeMode.selIndex == 5 then
 					wipeTable(self.enemyModList)
@@ -203,15 +203,6 @@ local PartyTabClass = newClass("PartyTab", "ControlHost", "Control", function(se
 		return self.controls.importCodeMode2.selIndex == 3 and "Remove effects" or "Rebuild All"
 	end
 	self.controls.rebuild.tooltipText = "^7Reparse all the inputs incase they have changed since loading the build or importing"
-	self.controls.enableExportBuffs = new("CheckBoxControl", {"LEFT",self.controls.rebuild,"RIGHT"}, 100, 0, 18, "Enable Export", function(state)
-		self.enableExportBuffs = state
-	end, "Enables the exporting of auras, curses and modifiers to the enemy", false)
-	self.controls.enableExportBuffs.x = function()
-		return (self.width > 1580) and 100 or ((self.width > 1350) and (-528) or (self.width > 910) and 100 or (-228))
-	end
-	self.controls.enableExportBuffs.y = function()
-		return (self.width > 1580) and 0 or (self.width > 1350) and 28 or (self.width > 910) and 0 or 28
-	end
 
 	self.controls.editAurasLabel = new("LabelControl", {"TOPLEFT",self.controls.importCodeMode,"TOPLEFT"}, 0, 40, 150, 16, "^7Auras")
 	self.controls.editAurasLabel.y = function()
@@ -256,12 +247,7 @@ end)
 
 function PartyTabClass:Load(xml, fileName)
 	for _, node in ipairs(xml) do
-		if node.elem == "TabStuff" then
-			if node.attrib.name == "enableExportBuffs" then
-				self.enableExportBuffs = node.attrib.string == "true"
-				self.controls.enableExportBuffs.state = self.enableExportBuffs
-			end
-		elseif node.elem == "ImportedText" then
+		if node.elem == "ImportedText" then
 			if not node.attrib.name then
 				ConPrintf("missing name")
 			elseif node.attrib.name == "Aura" then
@@ -298,9 +284,6 @@ function PartyTabClass:Load(xml, fileName)
 end
 
 function PartyTabClass:Save(xml)
-	local child = { elem = "TabStuff", attrib = { name = "enableExportBuffs" } }
-	child.attrib.string = tostring(self.enableExportBuffs)
-	t_insert(xml, child)
 	local child = { elem = "ImportedText", attrib = { name = "Aura" } }
 	child.attrib.string = self.controls.editAuras.buf
 	t_insert(xml, child)

--- a/src/Classes/PartyTab.lua
+++ b/src/Classes/PartyTab.lua
@@ -306,9 +306,6 @@ local PartyTabClass = newClass("PartyTab", "ControlHost", "Control", function(se
 	self.controls.rebuild.y = function()
 		return (self.width > 1350) and 0 or 28
 	end
-	self.controls.rebuild.shown = function()
-		return self.controls.ShowAdvanceTools.state
-	end
 
 	self.controls.editAurasLabel = new("LabelControl", {"TOPLEFT",self.controls.ShowAdvanceTools,"TOPLEFT"}, -140, 40, 150, 16, "^7Auras")
 	self.controls.editAurasLabel.y = function()

--- a/src/Classes/PartyTab.lua
+++ b/src/Classes/PartyTab.lua
@@ -205,7 +205,7 @@ local PartyTabClass = newClass("PartyTab", "ControlHost", "Control", function(se
 	self.controls.rebuild.tooltipText = "^7Reparse all the inputs incase they have changed since loading the build or importing"
 	self.controls.enableExportBuffs = new("CheckBoxControl", {"LEFT",self.controls.rebuild,"RIGHT"}, 100, 0, 18, "Enable Export", function(state)
 		self.enableExportBuffs = state
-	end, "Enables the exporting of auras, cruses and modifiers to the enemy", false)
+	end, "Enables the exporting of auras, curses and modifiers to the enemy", false)
 	self.controls.enableExportBuffs.x = function()
 		return (self.width > 1580) and 100 or ((self.width > 1350) and (-528) or (self.width > 910) and 100 or (-228))
 	end

--- a/src/Classes/PartyTab.lua
+++ b/src/Classes/PartyTab.lua
@@ -108,7 +108,7 @@ local PartyTabClass = newClass("PartyTab", "ControlHost", "Control", function(se
 				self.processedInput["Aura"] = {}
 			end
 			if self.controls.importCodeMode.selIndex == 1 or self.controls.importCodeMode.selIndex == 3 then
-				self.controls.editCurses:SetText("") --curses dont play nicly with append atm, need to fix
+				self.controls.editCurses:SetText("") --curses do not play nicely with append atm, need to fix
 				wipeTable(self.processedInput["Curse"])
 				self.processedInput["Curse"] = {}
 			end

--- a/src/Classes/PartyTab.lua
+++ b/src/Classes/PartyTab.lua
@@ -367,6 +367,9 @@ function PartyTabClass:Draw(viewPort, inputEvents)
 end
 
 function PartyTabClass:ParseTags(line, currentModType) -- should parse this correctly instead of string match
+	if not line then
+		return "none", {}
+	end
 	local extraTags = {}
 	local modType = currentModType
 	for line2 in line:gmatch("([^,]*),?") do

--- a/src/Classes/PartyTab.lua
+++ b/src/Classes/PartyTab.lua
@@ -430,24 +430,11 @@ local PartyTabClass = newClass("PartyTab", "ControlHost", "Control", function(se
 end)
 
 function PartyTabClass:OpenHelpPopup()	
-	local helpText = [[The Party tab Allows you to import support characters and have thier auras and curses apply
-
-To import a build it must be exported with "Export support" enabled in the import/export tab and must be imported in the party tab
-You can import a specific type like aura or curse, or import to all
-You can also set it to append to a section rather than replacing it (currently curses must be replaced if not empty due to more curse limits not working well)
+	local helpText = [[To import a build it must be exported with "Export support" enabled in the import/export tab and must be imported in the party tab.
+All of these effects can be found in the Calcs tab
  
-This does not add the auras or curses into the skills tab, but they do show up on calcs tab under "aura and buff skills" as well as "curses and debuffs" respectivly
-They also show other effects they add, like when physical damage reduction is applied by an aurabot with the gaurdian node
- 
-Only the highest aura will apply, so if you and the support both run the same aura and your % inc effect is higher it will apply (even if the actual amount yours gives is lower due to gem levels or whatever), this is how it works ingame
-Your curses will always apply before the supports though, so even if theres is a higher effect yours will be applied instead
- 
-For now Enemy conditions and Modifiers are not exported but can be imported if its saved in the XML, and Links skills are not exported or parsed
-Some auras like Mines which use a stack value for thier effect will not apply as their stack value is missing
- 
-Advanced info:
-    The format for the data is the name of the skill, the %increased effect and then the mods that are applied
-    The mods are done similar to the style from modlib, where it the value applied, the "source" of the mod, the modname, the type added (eg base/inc), the flags, the keywordflags, and then any other tags]]
+Auras with the highest effect will take priority
+Your curses will take priority over a support's]]
 	local helpList = { }
 	for line in helpText:gmatch("[^\r\n]+") do
 		local innerLines = main:WrapString(line, 16, 560)

--- a/src/Classes/PartyTab.lua
+++ b/src/Classes/PartyTab.lua
@@ -214,6 +214,7 @@ function PartyTabClass:ParseBuffs(list, buf, buffType)
 	end
 	local currentName
 	local currentEffect
+	local isMark
 	local currentModType = "Unknown"
 	for line in buf:gmatch("([^\n]*)\n?") do
 		if mode == "CurseLimit" and line ~= "" then
@@ -224,6 +225,13 @@ function PartyTabClass:ParseBuffs(list, buf, buffType)
 			mode = "Effect"
 		elseif mode == "Effect" then
 			currentEffect = tonumber(line)
+			if buffType == "Curse" then
+				mode = "isMark"
+			else
+				mode = "Stats"
+			end
+		elseif mode == "isMark" then
+			isMark = line=="true"
 			mode = "Stats"
 		elseif line == "---" then
 			mode = "Name"
@@ -272,11 +280,17 @@ function PartyTabClass:ParseBuffs(list, buf, buffType)
 						modList = new("ModList"),
 						effectMult = currentEffect
 					}
+					if isMark then
+						list[modType][currentName].isMark = true
+					end
 				elseif not list[modType][currentName] then
 					list[modType][currentName] = {
 						modList = new("ModList"),
 						effectMult = currentEffect
 					}
+					if isMark then
+						list[modType][currentName].isMark = true
+					end
 				end
 				list[modType][currentName].modList:AddMod(mod)
 			end
@@ -302,6 +316,13 @@ function PartyTabClass:exportBuffs(buffType)
 			buf = buf.."\n"
 		end
 		buf = buf..buffName.."\n"..tostring(buff.effectMult * 100).."\n"
+		if buffType == "Curse" then
+			if buff.isMark then
+				buf = buf.."true\n"
+			else
+				buf = buf.."false\n"
+			end
+		end
 		for _, mod in ipairs(buff.modList) do
 			buf = buf..tostring(mod.value).."|"..mod.source.."|"..modLib.formatModParams(mod).."\n"
 			--buf = buf..s_format("%s|%s|%s|%s|-|-|-", tostring(mod.value), mod.source, mod.name, mod.type).."\n"

--- a/src/Classes/PartyTab.lua
+++ b/src/Classes/PartyTab.lua
@@ -168,6 +168,9 @@ local PartyTabClass = newClass("PartyTab", "ControlHost", "Control", function(se
 		end
 		
 	end)
+	self.controls.importCodeGo.label = function()
+		return self.controls.importCodeMode2.selIndex == 3 and "Clear" or "Import"
+	end
 	self.controls.importCodeGo.enabled = function()
 		return (self.importCodeValid and not self.importCodeFetching) or self.controls.importCodeMode2.selIndex == 3
 	end

--- a/src/Classes/PartyTab.lua
+++ b/src/Classes/PartyTab.lua
@@ -357,10 +357,10 @@ function PartyTabClass:Draw(viewPort, inputEvents)
 	self:DrawControls(viewPort)
 
 	self.modFlag = (self.lastContentAura ~= self.controls.editAuras.buf 
-			and self.lastContentCurse ~= self.controls.editCurses.buf
-			and self.lastContentEnemyCond ~= self.controls.enemyCond.buf
-			and self.lastContentEnemyMods ~= self.controls.enemyMods.buf
-			and self.lastEnableExportBuffs ~= self.enableExportBuffs)
+			or self.lastContentCurse ~= self.controls.editCurses.buf
+			or self.lastContentEnemyCond ~= self.controls.enemyCond.buf
+			or self.lastContentEnemyMods ~= self.controls.enemyMods.buf
+			or self.lastEnableExportBuffs ~= self.enableExportBuffs)
 end
 
 function PartyTabClass:ParseTags(line, currentModType) -- should parse this correctly instead of string match

--- a/src/Classes/PartyTab.lua
+++ b/src/Classes/PartyTab.lua
@@ -167,43 +167,43 @@ local PartyTabClass = newClass("PartyTab", "ControlHost", "Control", function(se
 						elseif node.attrib.name == "Aura" then
 							if partyDestinations[self.controls.importCodeDestination.selIndex] == "All" or partyDestinations[self.controls.importCodeDestination.selIndex] == "Aura" then
 								if #self.controls.editAuras.buf > 0 then
-									node.attrib.string = self.controls.editAuras.buf.."\n"..node.attrib.string
+									node[1] = self.controls.editAuras.buf.."\n"..(node[1] or "")
 								end
-								self.controls.editAuras:SetText(node.attrib.string)
+								self.controls.editAuras:SetText(node[1] or "")
 								self:ParseBuffs(self.processedInput["Aura"], self.controls.editAuras.buf, "Aura", self.controls.simpleAuras)
 							end
 						elseif node.attrib.name == "Curse" then
 							if partyDestinations[self.controls.importCodeDestination.selIndex] == "All" or partyDestinations[self.controls.importCodeDestination.selIndex] == "Curse" then
 								if #self.controls.editCurses.buf > 0 then
-									node.attrib.string = self.controls.editCurses.buf.."\n"..node.attrib.string
+									node[1] = self.controls.editCurses.buf.."\n"..(node[1] or "")
 								end
-								if currentCurseBuffer and node.attrib.string =="--- Curse Limit ---\n1" then
-									node.attrib.string = currentCurseBuffer
+								if currentCurseBuffer and node[1] =="--- Curse Limit ---\n1" then
+									node[1] = currentCurseBuffer
 								end
-								self.controls.editCurses:SetText(node.attrib.string)
+								self.controls.editCurses:SetText(node[1] or "")
 								self:ParseBuffs(self.processedInput["Curse"], self.controls.editCurses.buf, "Curse", self.controls.simpleCurses)
 							end
 						elseif node.attrib.name == "Link Skills" then
 							if partyDestinations[self.controls.importCodeDestination.selIndex] == "All" or partyDestinations[self.controls.importCodeDestination.selIndex] == "Link Skills" then
 								if #self.controls.editLinks.buf > 0 then
-									node.attrib.string = self.controls.editLinks.buf.."\n"..node.attrib.string
+									node[1] = self.controls.editLinks.buf.."\n"..(node[1] or "")
 								end
-								self.controls.editLinks:SetText(node.attrib.string)
+								self.controls.editLinks:SetText(node[1] or "")
 								self:ParseBuffs(self.processedInput["Link"], self.controls.editLinks.buf, "Link", self.controls.simpleLinks)
 							end
 						elseif node.attrib.name == "EnemyConditions" then
 							if partyDestinations[self.controls.importCodeDestination.selIndex] == "All" or partyDestinations[self.controls.importCodeDestination.selIndex] == "EnemyConditions" then
 								if #self.controls.enemyCond.buf > 0 then
-									node.attrib.string = self.controls.enemyCond.buf.."\n"..node.attrib.string
+									node[1] = self.controls.enemyCond.buf.."\n"..(node[1] or "")
 								end
-								self.controls.enemyCond:SetText(node.attrib.string)
+								self.controls.enemyCond:SetText(node[1] or "")
 							end
 						elseif node.attrib.name == "EnemyMods" then
 							if partyDestinations[self.controls.importCodeDestination.selIndex] == "All" or partyDestinations[self.controls.importCodeDestination.selIndex] == "EnemyMods" then
 								if #self.controls.enemyMods.buf > 0 then
-									node.attrib.string = self.controls.enemyMods.buf.."\n"..node.attrib.string
+									node[1] = self.controls.enemyMods.buf.."\n"..(node[1] or "")
 								end
-								self.controls.enemyMods:SetText(node.attrib.string)
+								self.controls.enemyMods:SetText(node[1] or "")
 							end
 						end
 					end
@@ -438,37 +438,37 @@ end)
 
 function PartyTabClass:Load(xml, fileName)
 	for _, node in ipairs(xml) do
-		if node.elem == "ImportedText" then
+		if node.elem == "ImportedBuffs" then
 			if not node.attrib.name then
 				ConPrintf("missing name")
 			elseif node.attrib.name == "Aura" then
-				self.controls.editAuras:SetText(node.attrib.string)
-				self:ParseBuffs(self.processedInput["Aura"], node.attrib.string, "Aura", self.controls.simpleAuras)
+				self.controls.editAuras:SetText(node[1] or "")
+				self:ParseBuffs(self.processedInput["Aura"], node[1] or "", "Aura", self.controls.simpleAuras)
 			elseif node.attrib.name == "Curse" then
-				self.controls.editCurses:SetText(node.attrib.string)
-				self:ParseBuffs(self.processedInput["Curse"], node.attrib.string, "Curse", self.controls.simpleCurses)
+				self.controls.editCurses:SetText(node[1] or "")
+				self:ParseBuffs(self.processedInput["Curse"], node[1] or "", "Curse", self.controls.simpleCurses)
 			elseif node.attrib.name == "Link Skills" then
-				self.controls.editLinks:SetText(node.attrib.string)
-				self:ParseBuffs(self.processedInput["Link"], node.attrib.string, "Link", self.controls.simpleLinks)
+				self.controls.editLinks:SetText(node[1] or "")
+				self:ParseBuffs(self.processedInput["Link"], node[1] or "", "Link", self.controls.simpleLinks)
 			elseif node.attrib.name == "EnemyConditions" then
-				self.controls.enemyCond:SetText(node.attrib.string)
-				self:ParseBuffs(self.enemyModList, node.attrib.string, "EnemyConditions")
+				self.controls.enemyCond:SetText(node[1] or "")
+				self:ParseBuffs(self.enemyModList, node[1] or "", "EnemyConditions")
 			elseif node.attrib.name == "EnemyMods" then
-				self.controls.enemyMods:SetText(node.attrib.string)
-				self:ParseBuffs(self.enemyModList, node.attrib.string, "EnemyMods")
+				self.controls.enemyMods:SetText(node[1] or "")
+				self:ParseBuffs(self.enemyModList, node[1] or "", "EnemyMods")
 			end
 		elseif node.elem == "ExportedBuffs" then
 			if not node.attrib.name then
 				ConPrintf("missing name")
 			end
 			if node.attrib.name ~= "EnemyConditions" and node.attrib.name ~= "EnemyMods" then
-				self:ParseBuffs(self.buffExports, node.attrib.string, node.attrib.name)
+				self:ParseBuffs(self.buffExports, node[1] or "", node.attrib.name)
 			end
-			--self:ParseBuffs(self.buffExports, node.attrib.string, "Aura")
-			--self:ParseBuffs(self.buffExports, node.attrib.string, "Curse")
-			--self:ParseBuffs(self.buffExports, node.attrib.string, "Link")
-			--self:ParseBuffs(self.buffExports, node.attrib.string, "EnemyConditions")
-			--self:ParseBuffs(self.buffExports, node.attrib.string, "EnemyMods")
+			--self:ParseBuffs(self.buffExports, node[1] or "", "Aura")
+			--self:ParseBuffs(self.buffExports, node[1] or "", "Curse")
+			--self:ParseBuffs(self.buffExports, node[1] or "", "Link")
+			--self:ParseBuffs(self.buffExports, node[1] or "", "EnemyConditions")
+			--self:ParseBuffs(self.buffExports, node[1] or "", "EnemyMods")
 		end
 	end
 	self.lastContent.Aura = self.controls.editAuras.buf
@@ -487,35 +487,35 @@ function PartyTabClass:Load(xml, fileName)
 end
 
 function PartyTabClass:Save(xml)
-	local child = { elem = "ImportedText", attrib = { name = "Aura" } }
-	child.attrib.string = self.controls.editAuras.buf
+	local child = { elem = "ImportedBuffs", attrib = { name = "Aura" } }
+	t_insert(child, self.controls.editAuras.buf or "")
 	t_insert(xml, child)
-	child = { elem = "ImportedText", attrib = { name = "Curse" } }
-	child.attrib.string = self.controls.editCurses.buf
+	child = { elem = "ImportedBuffs", attrib = { name = "Curse" } }
+	t_insert(child, self.controls.editCurses.buf or "")
 	t_insert(xml, child)
-	child = { elem = "ImportedText", attrib = { name = "Link Skills" } }
-	child.attrib.string = self.controls.editLinks.buf
+	child = { elem = "ImportedBuffs", attrib = { name = "Link Skills" } }
+	t_insert(child, self.controls.editLinks.buf or "")
 	t_insert(xml, child)
-	child = { elem = "ImportedText", attrib = { name = "EnemyConditions" } }
-	child.attrib.string = self.controls.enemyCond.buf
+	child = { elem = "ImportedBuffs", attrib = { name = "EnemyConditions" } }
+	t_insert(child, self.controls.enemyCond.buf or "")
 	t_insert(xml, child)
-	child = { elem = "ImportedText", attrib = { name = "EnemyMods" } }
-	child.attrib.string = self.controls.enemyMods.buf
+	child = { elem = "ImportedBuffs", attrib = { name = "EnemyMods" } }
+	t_insert(child, self.controls.enemyMods.buf or "")
 	t_insert(xml, child)
 	child = { elem = "ExportedBuffs", attrib = { name = "Aura" } }
-	child.attrib.string = self:exportBuffs("Aura")
+	t_insert(child, self:exportBuffs("Aura") or "")
 	t_insert(xml, child)
 	child = { elem = "ExportedBuffs", attrib = { name = "Curse" } }
-	child.attrib.string = self:exportBuffs("Curse")
+	t_insert(child, self:exportBuffs("Curse") or "")
 	t_insert(xml, child)
 	child = { elem = "ExportedBuffs", attrib = { name = "Link Skills" } }
-	child.attrib.string = self:exportBuffs("Link")
+	t_insert(child, self:exportBuffs("Link") or "")
 	t_insert(xml, child)
 	child = { elem = "ExportedBuffs", attrib = { name = "EnemyConditions" } }
-	child.attrib.string = self:exportBuffs("EnemyConditions")
+	t_insert(child, self:exportBuffs("EnemyConditions") or "")
 	t_insert(xml, child)
 	child = { elem = "ExportedBuffs", attrib = { name = "EnemyMods" } }
-	child.attrib.string = self:exportBuffs("EnemyMods")
+	t_insert(child, self:exportBuffs("EnemyMods") or "")
 	t_insert(xml, child)
 	self.lastContent.Aura = self.controls.editAuras.buf
 	self.lastContent.Curse = self.controls.editCurses.buf

--- a/src/Classes/PartyTab.lua
+++ b/src/Classes/PartyTab.lua
@@ -579,7 +579,7 @@ function PartyTabClass:exportBuffs(buffType)
 	if self.buffExports[buffType].ConvertedToText then
 		return self.buffExports[buffType].string
 	end
-	local buf = ((buffType == "Curse") and ("--- Curse Limit ---" .. tostring(self.buffExports["CurseLimit"]))) or ""
+	local buf = ((buffType == "Curse") and ("--- Curse Limit ---\n" .. tostring(self.buffExports["CurseLimit"]))) or ""
 	for buffName, buff in pairs(self.buffExports[buffType]) do
 		if #buf > 0 then
 			buf = buf.."\n"

--- a/src/Classes/PartyTab.lua
+++ b/src/Classes/PartyTab.lua
@@ -264,7 +264,7 @@ local PartyTabClass = newClass("PartyTab", "ControlHost", "Control", function(se
 		end
 	end
 	self.controls.appendNotReplace = new("CheckBoxControl", {"LEFT",self.controls.importCodeGo,"RIGHT"}, 60, 0, 20, "Append", function(state)
-	end, "This sets the impornt button to append to the current party lists isntead of replacing them (curses will still replace)", false)
+	end, "This sets the import button to append to the current party lists instead of replacing them (curses will still replace)", false)
 	self.controls.appendNotReplace.x = function()
 		return (self.width > 1350) and 60 or (-276)
 	end
@@ -592,7 +592,7 @@ function PartyTabClass:ParseBuffs(list, buf, buffType, label)
 					t_insert(modStrings, line2)
 				end
 				if #modStrings >= 7 then
-					-- should be done with a modified version of "modlib.ParseTags" where conditions check vs the party
+					-- should be done with a modified version of "modLib.parseTags" where conditions check vs the party
 					-- and check that the ones in the build are NOT true, such that your effects override the supports
 					local tags = nil -- modStrings[7]
 					list:NewMod(modStrings[3], modStrings[4], tonumber(modStrings[1]), "Party"..modStrings[2], ModFlag[modStrings[5]] or 0, KeywordFlag[modStrings[6]] or 0, tags)
@@ -638,7 +638,7 @@ function PartyTabClass:ParseBuffs(list, buf, buffType, label)
 				mode = "Name"
 			else
 				if line:find("|") then
-					local modType, mod = modLib.parseFormatedSourceMod(line, currentModType)
+					local modType, mod = modLib.parseFormattedSourceMod(line, currentModType)
 					if mod then
 						currentModType = modType
 						list[modType] = list[modType] or {}

--- a/src/Classes/PartyTab.lua
+++ b/src/Classes/PartyTab.lua
@@ -312,6 +312,9 @@ local PartyTabClass = newClass("PartyTab", "ControlHost", "Control", function(se
 	self.controls.rebuild.y = function()
 		return (self.width > 1350) and 0 or 28
 	end
+	self.controls.help = new("ButtonControl", {"LEFT",self.controls.rebuild,"RIGHT"}, 8, 0, 72, 20, "Help", function() 
+		self:OpenHelpPopup()
+	end)
 
 	self.controls.editAurasLabel = new("LabelControl", {"TOPLEFT",self.controls.ShowAdvanceTools,"TOPLEFT"}, -140, 40, 150, 16, "^7Auras")
 	self.controls.editAurasLabel.y = function()
@@ -425,6 +428,40 @@ local PartyTabClass = newClass("PartyTab", "ControlHost", "Control", function(se
 	end
 	self:SelectControl(self.controls.editAuras)
 end)
+
+function PartyTabClass:OpenHelpPopup()	
+	local helpText = [[The Party tab Allows you to import support characters and have thier auras and curses apply
+
+To import a build it must be exported with "Export support" enabled in the import/export tab and must be imported in the party tab
+You can import a specific type like aura or curse, or import to all
+You can also set it to append to a section rather than replacing it (currently curses must be replaced if not empty due to more curse limits not working well)
+ 
+This does not add the auras or curses into the skills tab, but they do show up on calcs tab under "aura and buff skills" as well as "curses and debuffs" respectivly
+They also show other effects they add, like when physical damage reduction is applied by an aurabot with the gaurdian node
+ 
+Only the highest aura will apply, so if you and the support both run the same aura and your % inc effect is higher it will apply (even if the actual amount yours gives is lower due to gem levels or whatever), this is how it works ingame
+Your curses will always apply before the supports though, so even if theres is a higher effect yours will be applied instead
+ 
+For now Enemy conditions and Modifiers are not exported but can be imported if its saved in the XML, and Links skills are not exported or parsed
+Some auras like Mines which use a stack value for thier effect will not apply as their stack value is missing
+ 
+Advanced info:
+    The format for the data is the name of the skill, the %increased effect and then the mods that are applied
+    The mods are done similar to the style from modlib, where it the value applied, the "source" of the mod, the modname, the type added (eg base/inc), the flags, the keywordflags, and then any other tags]]
+	local helpList = { }
+	for line in helpText:gmatch("[^\r\n]+") do
+		local innerLines = main:WrapString(line, 16, 560)
+		for i, innerLine in ipairs(innerLines) do
+			t_insert(helpList, { height = 16, (i == 1 and "^7" or "^7  ")..innerLine })
+		end
+	end
+	local controls = { }
+	controls.close = new("ButtonControl", {"TOPRIGHT",nil,"TOPRIGHT"}, -10, 10, 50, 20, "Close", function()
+		main:ClosePopup()
+	end)
+	controls.help = new("TextListControl", nil, 0, 33, 630, 457, {{ x = 1, align = "LEFT" }, { x = 110, align = "LEFT" }}, helpList)
+	main:OpenPopup(650, 500, "Help", controls)
+end
 
 function PartyTabClass:Load(xml, fileName)
 	for _, node in ipairs(xml) do

--- a/src/Classes/PartyTab.lua
+++ b/src/Classes/PartyTab.lua
@@ -30,11 +30,26 @@ local PartyTabClass = newClass("PartyTab", "ControlHost", "Control", function(se
 	To import a build, you must export that build with "Export Support" ticked
 	The Strongest Aura applies, but your curses override the supports regardless of strength
 	]]
+	
 	self.controls.notesDesc = new("LabelControl", {"TOPLEFT",self,"TOPLEFT"}, 8, 8, 150, 16, notesDesc)
 	self.controls.notesDesc.width = function()
-		return self.width / 2 - 16
+		local width = self.width / 2 - 16
+		if width ~= self.controls.notesDesc.lastWidth then
+			self.controls.notesDesc.lastWidth = width
+			self.controls.notesDesc.label = table.concat(main:WrapString(notesDesc, 16, width - 50), "\n")
+		end
+		return width
 	end
 	self.controls.importCodeHeader = new("LabelControl", {"TOPLEFT",self.controls.notesDesc,"BOTTOMLEFT"}, 0, 32, 0, 16, "^7Enter a build code below: (NOT URL)")
+	self.controls.importCodeHeader.y = function()
+		local lineCount = 1
+		for i = 1, #self.controls.notesDesc.label do
+			local c = self.controls.notesDesc.label:sub(i, i)
+			if c == '\n' then lineCount = lineCount + 1 end
+		end
+
+		return (lineCount - 2) * 16
+	end
 	
 	local importCodeHandle = function (buf)
 		self.importCodeSite = nil

--- a/src/Classes/PartyTab.lua
+++ b/src/Classes/PartyTab.lua
@@ -52,7 +52,7 @@ local PartyTabClass = newClass("PartyTab", "ControlHost", "Control", function(se
 		return (lineCount - 2) * 16
 	end
 	
-	local clearInputBufs = function()
+	local clearInputText = function()
 		if partyDestinations[self.controls.importCodeDestination.selIndex] == "All" or partyDestinations[self.controls.importCodeDestination.selIndex] == "Aura" then
 			self.controls.editAuras:SetText("")
 			wipeTable(self.processedInput["Aura"])
@@ -119,7 +119,7 @@ local PartyTabClass = newClass("PartyTab", "ControlHost", "Control", function(se
 		end
 	
 		if self.controls.importCodeApplication.selIndex == 1 then
-			clearInputBufs()
+			clearInputText()
 		else
 			if partyDestinations[self.controls.importCodeDestination.selIndex] == "All" or partyDestinations[self.controls.importCodeDestination.selIndex] == "Aura" then
 				wipeTable(self.processedInput["Aura"])
@@ -203,7 +203,7 @@ local PartyTabClass = newClass("PartyTab", "ControlHost", "Control", function(se
 	self.controls.importCodeApplication = new("DropDownControl", {"LEFT",self.controls.importCodeDestination,"RIGHT"}, 8, 0, 160, 20, { "Replace", "Append", "Clear" })
 	self.controls.importCodeGo = new("ButtonControl", {"LEFT",self.controls.importCodeApplication,"RIGHT"}, 8, 0, 160, 20, "Import", function()
 		if self.controls.importCodeApplication.selIndex == 3 then
-			clearInputBufs()
+			clearInputText()
 			wipeTable(self.enemyModList)
 			self.enemyModList = new("ModList")
 			self.build.buildFlag = true 

--- a/src/Classes/PartyTab.lua
+++ b/src/Classes/PartyTab.lua
@@ -186,17 +186,22 @@ local PartyTabClass = newClass("PartyTab", "ControlHost", "Control", function(se
 		end
 	end
 	
-	self.controls.rebuild = new("ButtonControl", {"LEFT",self.controls.importCodeGo,"RIGHT"}, 8, 0, 160, 20, "Rebuild", function() 
+	self.controls.rebuild = new("ButtonControl", {"LEFT",self.controls.importCodeGo,"RIGHT"}, 8, 0, 160, 20, "Rebuild All", function() 
 		wipeTable(self.processedInput)
 		wipeTable(self.enemyModList)
 		self.processedInput = { Aura = {}, Curse = {} }
 		self.enemyModList = new("ModList")
-		self:ParseBuffs(self.processedInput["Aura"], self.controls.editAuras.buf, "Aura")
-		self:ParseBuffs(self.processedInput["Curse"], self.controls.editCurses.buf, "Curse")
-		self:ParseBuffs(self.enemyModList, self.controls.enemyCond.buf, "EnemyConditions")
-		self:ParseBuffs(self.enemyModList, self.controls.enemyMods.buf, "EnemyMods")
+		if self.controls.importCodeMode2.selIndex ~= 3 then
+			self:ParseBuffs(self.processedInput["Aura"], self.controls.editAuras.buf, "Aura")
+			self:ParseBuffs(self.processedInput["Curse"], self.controls.editCurses.buf, "Curse")
+			self:ParseBuffs(self.enemyModList, self.controls.enemyCond.buf, "EnemyConditions")
+			self:ParseBuffs(self.enemyModList, self.controls.enemyMods.buf, "EnemyMods")
+		end
 		self.build.buildFlag = true 
 	end)
+	self.controls.rebuild.label = function()
+		return self.controls.importCodeMode2.selIndex == 3 and "Remove effects" or "Rebuild All"
+	end
 	self.controls.rebuild.tooltipText = "^7Reparse all the inputs incase they have changed since loading the build or importing"
 	self.controls.enableExportBuffs = new("CheckBoxControl", {"LEFT",self.controls.rebuild,"RIGHT"}, 100, 0, 18, "Enable Export", function(state)
 		self.enableExportBuffs = state
@@ -424,7 +429,7 @@ function PartyTabClass:ParseBuffs(list, buf, buffType)
 				for line2 in line:gmatch("([^|]*)|?") do
 					t_insert(modStrings, line2)
 				end
-				local tags = nil -- modStrings[7]
+				local tags = nil -- modStrings[7], should be done with a mdofified version of "PartyTabClass:ParseTags" where conditions check vs the party and check that the ones in the build are NOT true, such that your effects override the supports
 				list:NewMod(modStrings[3], modStrings[4], tonumber(modStrings[1]), "Party"..modStrings[2], ModFlag[modStrings[5]] or 0, KeywordFlag[modStrings[6]] or 0, tags)
 			end
 		end

--- a/src/Classes/PartyTab.lua
+++ b/src/Classes/PartyTab.lua
@@ -296,7 +296,7 @@ end
 function PartyTabClass:ParseBuffs(list, buf, buffType)
 	if buffType == "EnemyConditions" then
 		for line in buf:gmatch("([^\n]*)\n?") do
-			list:NewMod(line:gsub("Condition:", "Condition:Party"), "FLAG", true, "Party")
+			list:NewMod(line:gsub("Condition:", "Condition:Party:"), "FLAG", true, "Party")
 		end
 	elseif buffType == "EnemyMods" then
 		local modeName = true
@@ -357,7 +357,7 @@ function PartyTabClass:ParseBuffs(list, buf, buffType)
 					t_insert(modStrings, line2)
 				end
 				local mod = {
-					value = tonumber(modStrings[1]),
+					value = (modStrings[1] == "true" and true) or tonumber(modStrings[1]) or 0,
 					source = modStrings[2],
 					name = modStrings[3],
 					type = modStrings[4],

--- a/src/Classes/PartyTab.lua
+++ b/src/Classes/PartyTab.lua
@@ -165,7 +165,7 @@ local PartyTabClass = newClass("PartyTab", "ControlHost", "Control", function(se
 									node.attrib.string = self.controls.editAuras.buf.."\n"..node.attrib.string
 								end
 								self.controls.editAuras:SetText(node.attrib.string)
-								self:ParseBuffs(self.processedInput["Aura"], self.controls.editAuras.buf, "Aura")
+								self:ParseBuffs(self.processedInput["Aura"], self.controls.editAuras.buf, "Aura", self.controls.simpleAuras)
 							end
 						elseif node.attrib.name == "Curse" then
 							if partyDestinations[self.controls.importCodeDestination.selIndex] == "All" or partyDestinations[self.controls.importCodeDestination.selIndex] == "Curse" then
@@ -173,7 +173,7 @@ local PartyTabClass = newClass("PartyTab", "ControlHost", "Control", function(se
 									node.attrib.string = self.controls.editCurses.buf.."\n"..node.attrib.string
 								end
 								self.controls.editCurses:SetText(node.attrib.string)
-								self:ParseBuffs(self.processedInput["Curse"], self.controls.editCurses.buf, "Curse")
+								self:ParseBuffs(self.processedInput["Curse"], self.controls.editCurses.buf, "Curse", self.controls.simpleCurses)
 							end
 						elseif node.attrib.name == "Link Skills" then
 							if partyDestinations[self.controls.importCodeDestination.selIndex] == "All" or partyDestinations[self.controls.importCodeDestination.selIndex] == "Link Skills" then
@@ -181,7 +181,7 @@ local PartyTabClass = newClass("PartyTab", "ControlHost", "Control", function(se
 									node.attrib.string = self.controls.editLinks.buf.."\n"..node.attrib.string
 								end
 								self.controls.editLinks:SetText(node.attrib.string)
-								self:ParseBuffs(self.processedInput["Link"], self.controls.editLinks.buf, "Link")
+								self:ParseBuffs(self.processedInput["Link"], self.controls.editLinks.buf, "Link", self.controls.simpleLinks)
 							end
 						elseif node.attrib.name == "EnemyConditions" then
 							if partyDestinations[self.controls.importCodeDestination.selIndex] == "All" or partyDestinations[self.controls.importCodeDestination.selIndex] == "EnemyConditions" then
@@ -272,47 +272,89 @@ local PartyTabClass = newClass("PartyTab", "ControlHost", "Control", function(se
 		self.build.buildFlag = true
 	end)
 	
-	self.controls.rebuild = new("ButtonControl", {"TOPLEFT",self.controls.importCodeDestination,"BOTTOMLEFT"}, 0, 4, 160, 20, "Rebuild All", function() 
-		wipeTable(self.processedInput)
-		wipeTable(self.enemyModList)
-		self.processedInput = { Aura = {}, Curse = {}, Link = {} }
-		self.enemyModList = new("ModList")
-		self:ParseBuffs(self.processedInput["Aura"], self.controls.editAuras.buf, "Aura")
-		self:ParseBuffs(self.processedInput["Curse"], self.controls.editCurses.buf, "Curse")
-		self:ParseBuffs(self.processedInput["Link"], self.controls.editLinks.buf, "Link")
-		self:ParseBuffs(self.enemyModList, self.controls.enemyCond.buf, "EnemyConditions")
-		self:ParseBuffs(self.enemyModList, self.controls.enemyMods.buf, "EnemyMods")
+	self.controls.ShowAdvanceTools = new("CheckBoxControl", {"TOPLEFT",self.controls.importCodeDestination,"BOTTOMLEFT"}, 140, 4, 20, "Show Advanced Info", function(state)
 		self.build.buildFlag = true 
-	end)
-	self.controls.rebuild.tooltip = "^7Reparse all the inputs incase they have changed since loading the build or importing" -- buttons cant have tooltips?
-	self.controls.rebuild.y = function()
+	end, "This shows the advanced info like what stats each aura/curse etc are adding, as well as enables the ability to edit them without a re-export", false)
+	self.controls.ShowAdvanceTools.y = function()
 		return (self.width > 1350) and 4 or 32
 	end
 	
-	self.controls.removeEffects = new("ButtonControl", {"LEFT",self.controls.rebuild,"RIGHT"}, 8, 0, 160, 20, "Disable Party Effects", function() 
+	self.controls.removeEffects = new("ButtonControl", {"LEFT",self.controls.ShowAdvanceTools,"RIGHT"}, 8, 0, 160, 20, "Disable Party Effects", function() 
 		wipeTable(self.processedInput)
 		wipeTable(self.enemyModList)
 		self.processedInput = { Aura = {}, Curse = {}, Link = {} }
 		self.enemyModList = new("ModList")
 		self.build.buildFlag = true
 	end)
+	
+	self.controls.rebuild = new("ButtonControl", {"LEFT",self.controls.removeEffects,"RIGHT"}, 8, 0, 160, 20, "Rebuild All", function() 
+		wipeTable(self.processedInput)
+		wipeTable(self.enemyModList)
+		self.processedInput = { Aura = {}, Curse = {}, Link = {} }
+		self.enemyModList = new("ModList")
+		self:ParseBuffs(self.processedInput["Aura"], self.controls.editAuras.buf, "Aura", self.controls.simpleAuras)
+		self:ParseBuffs(self.processedInput["Curse"], self.controls.editCurses.buf, "Curse", self.controls.simpleCurses)
+		self:ParseBuffs(self.processedInput["Link"], self.controls.editLinks.buf, "Link", self.controls.simpleLinks)
+		self:ParseBuffs(self.enemyModList, self.controls.enemyCond.buf, "EnemyConditions")
+		self:ParseBuffs(self.enemyModList, self.controls.enemyMods.buf, "EnemyMods")
+		self.build.buildFlag = true 
+	end)
+	self.controls.rebuild.tooltip = "^7Reparse all the inputs incase they have changed since loading the build or importing" -- buttons cant have tooltips?
+	self.controls.rebuild.x = function()
+		return (self.width > 1350) and 8 or (-328)
+	end
+	self.controls.rebuild.y = function()
+		return (self.width > 1350) and 0 or 28
+	end
+	self.controls.rebuild.shown = function()
+		return self.controls.ShowAdvanceTools.state
+	end
 
-	self.controls.editAurasLabel = new("LabelControl", {"TOPLEFT",self.controls.rebuild,"TOPLEFT"}, 0, 40, 150, 16, "^7Auras")
+	self.controls.editAurasLabel = new("LabelControl", {"TOPLEFT",self.controls.ShowAdvanceTools,"TOPLEFT"}, -140, 40, 150, 16, "^7Auras")
+	self.controls.editAurasLabel.y = function()
+		return 40 + (self.controls.ShowAdvanceTools.state and ((self.width <= 1350) and 28 or 0) or 0)
+	end
 	self.controls.editAuras = new("EditControl", {"TOPLEFT",self.controls.editAurasLabel,"TOPLEFT"}, 0, 18, 0, 0, "", nil, "^%C\t\n", nil, nil, 14, true)
 	self.controls.editAuras.width = function()
 		return self.width / 2 - 16
 	end
 	self.controls.editAuras.height = function()
-		return self.controls.editLinks.hasFocus and 106 or (self.height - 296 - ((self.width > 1350) and 0 or 28) - self.controls.importCodeHeader.y())
+		return self.controls.editLinks.hasFocus and 106 or (self.height - 256 - ((self.width > 1350) and 0 or 28) - self.controls.importCodeHeader.y() - self.controls.editAurasLabel.y())
+	end
+	self.controls.editAuras.shown = function()
+		return self.controls.ShowAdvanceTools.state
+	end
+	self.controls.simpleAuras = new("LabelControl", {"TOPLEFT",self.controls.editAurasLabel,"TOPLEFT"}, 0, 18, 0, 16, "")
+	self.controls.simpleAuras.shown = function()
+		return not self.controls.ShowAdvanceTools.state
 	end
 
-	self.controls.editLinksLabel = new("LabelControl", {"TOPLEFT",self.controls.editAuras,"BOTTOMLEFT"}, 0, 8, 150, 16, "^7Link Skills")
+	self.controls.editLinksLabel = new("LabelControl", {"TOPLEFT",self.controls.editAurasLabel,"BOTTOMLEFT"}, 0, 8, 150, 16, "^7Link Skills")
+	self.controls.editLinksLabel.y = function()
+		if self.controls.ShowAdvanceTools.state then
+			return (8 + self.controls.editAuras.height())
+		end
+		local lineCount = 0
+		for i = 1, #self.controls.simpleAuras.label do
+			local c = self.controls.simpleAuras.label:sub(i, i)
+			if c == '\n' then lineCount = lineCount + 1 end
+		end
+
+		return (lineCount) * 16 + 4
+	end
 	self.controls.editLinks = new("EditControl", {"TOPLEFT",self.controls.editLinksLabel,"TOPLEFT"}, 0, 18, 0, 0, "", nil, "^%C\t\n", nil, nil, 14, true)
 	self.controls.editLinks.width = function()
 		return self.width / 2 - 16
 	end
 	self.controls.editLinks.height = function()
-		return (self.controls.editLinks.hasFocus and (self.height - 296 - ((self.width > 1350) and 0 or 28) - self.controls.importCodeHeader.y()) or 106)
+		return (self.controls.editLinks.hasFocus and (self.height - 256 - ((self.width > 1350) and 0 or 28) - self.controls.importCodeHeader.y() - self.controls.editAurasLabel.y()) or 106)
+	end
+	self.controls.editLinks.shown = function()
+		return self.controls.ShowAdvanceTools.state
+	end
+	self.controls.simpleLinks = new("LabelControl", {"TOPLEFT",self.controls.editLinksLabel,"TOPLEFT"}, 0, 18, 0, 16, "")
+	self.controls.simpleLinks.shown = function()
+		return not self.controls.ShowAdvanceTools.state
 	end
 
 	self.controls.enemyCondLabel = new("LabelControl", {"TOPLEFT",self.controls.notesDesc,"TOPRIGHT"}, 8, 0, 150, 16, "^7Enemy Conditions")
@@ -323,8 +365,23 @@ local PartyTabClass = newClass("PartyTab", "ControlHost", "Control", function(se
 	self.controls.enemyCond.height = function()
 		return (self.controls.enemyCond.hasFocus and (self.height - 304) or 106)
 	end
+	self.controls.enemyCond.shown = function()
+		return self.controls.ShowAdvanceTools.state
+	end
 
-	self.controls.enemyModsLabel = new("LabelControl", {"TOPLEFT",self.controls.enemyCond,"BOTTOMLEFT"}, 0, 8, 150, 16, "^7Enemy Modifiers")
+	self.controls.enemyModsLabel = new("LabelControl", {"TOPLEFT",self.controls.enemyCondLabel,"BOTTOMLEFT"}, 0, 8, 150, 16, "^7Enemy Modifiers")
+	self.controls.enemyModsLabel.y = function()
+		if self.controls.ShowAdvanceTools.state then
+			return (8 + self.controls.enemyCond.height())
+		end
+		local lineCount = 0
+		--[[for i = 1, #self.controls.simpleAuras.label do
+			local c = self.controls.simpleAuras.label:sub(i, i)
+			if c == '\n' then lineCount = lineCount + 1 end
+		end--]]
+
+		return (lineCount) * 16 + 4
+	end
 	self.controls.enemyMods = new("EditControl", {"TOPLEFT",self.controls.enemyModsLabel,"BOTTOMLEFT"}, 0, 2, 0, 0, "", nil, "^%C\t\n", nil, nil, 14, true)
 	self.controls.enemyMods.width = function()
 		return self.width / 2 - 16
@@ -332,14 +389,36 @@ local PartyTabClass = newClass("PartyTab", "ControlHost", "Control", function(se
 	self.controls.enemyMods.height = function()
 		return (self.controls.enemyMods.hasFocus and (self.height - 304) or 106)
 	end
+	self.controls.enemyMods.shown = function()
+		return self.controls.ShowAdvanceTools.state
+	end
 
-	self.controls.editCursesLabel = new("LabelControl", {"TOPLEFT",self.controls.enemyMods,"BOTTOMLEFT"}, 0, 8, 150, 16, "^7Curses")
+	self.controls.editCursesLabel = new("LabelControl", {"TOPLEFT",self.controls.enemyModsLabel,"BOTTOMLEFT"}, 0, 8, 150, 16, "^7Curses")
+	self.controls.editCursesLabel.y = function()
+		if self.controls.ShowAdvanceTools.state then
+			return (8 + self.controls.enemyMods.height())
+		end
+		local lineCount = 0
+		--[[for i = 1, #self.controls.simpleAuras.label do
+			local c = self.controls.simpleAuras.label:sub(i, i)
+			if c == '\n' then lineCount = lineCount + 1 end
+		end--]]
+
+		return (lineCount) * 16 + 4
+	end
 	self.controls.editCurses = new("EditControl", {"TOPLEFT",self.controls.editCursesLabel,"BOTTOMLEFT"}, 0, 2, 0, 0, "", nil, "^%C\t\n", nil, nil, 14, true)
 	self.controls.editCurses.width = function()
 		return self.width / 2 - 16
 	end
 	self.controls.editCurses.height = function()
 		return ((not self.controls.enemyCond.hasFocus and not self.controls.enemyMods.hasFocus) and (self.height - 304) or 106)
+	end
+	self.controls.editCurses.shown = function()
+		return self.controls.ShowAdvanceTools.state
+	end
+	self.controls.simpleCurses = new("LabelControl", {"TOPLEFT",self.controls.editCursesLabel,"TOPLEFT"}, 0, 18, 0, 16, "")
+	self.controls.simpleCurses.shown = function()
+		return not self.controls.ShowAdvanceTools.state
 	end
 	self:SelectControl(self.controls.editAuras)
 end)
@@ -351,13 +430,13 @@ function PartyTabClass:Load(xml, fileName)
 				ConPrintf("missing name")
 			elseif node.attrib.name == "Aura" then
 				self.controls.editAuras:SetText(node.attrib.string)
-				self:ParseBuffs(self.processedInput["Aura"], node.attrib.string, "Aura")
+				self:ParseBuffs(self.processedInput["Aura"], node.attrib.string, "Aura", self.controls.simpleAuras)
 			elseif node.attrib.name == "Curse" then
 				self.controls.editCurses:SetText(node.attrib.string)
-				self:ParseBuffs(self.processedInput["Curse"], node.attrib.string, "Curse")
+				self:ParseBuffs(self.processedInput["Curse"], node.attrib.string, "Curse", self.controls.simpleCurses)
 			elseif node.attrib.name == "Link Skills" then
 				self.controls.editLinks:SetText(node.attrib.string)
-				self:ParseBuffs(self.processedInput["Link"], node.attrib.string, "Link")
+				self:ParseBuffs(self.processedInput["Link"], node.attrib.string, "Link", self.controls.simpleLinks)
 			elseif node.attrib.name == "EnemyConditions" then
 				self.controls.enemyCond:SetText(node.attrib.string)
 				self:ParseBuffs(self.enemyModList, node.attrib.string, "EnemyConditions")
@@ -439,12 +518,16 @@ function PartyTabClass:Draw(viewPort, inputEvents)
 					self.controls.editAuras:Undo()
 				elseif self.controls.editCurses.hasFocus then
 					self.controls.editCurses:Undo()
+				elseif self.controls.editLinks.hasFocus then
+					self.controls.editLinks:Undo()
 				end
 			elseif event.key == "y" and IsKeyDown("CTRL") then
 				if self.controls.editAuras.hasFocus then
 					self.controls.editAuras:Redo()
 				elseif self.controls.editCurses.hasFocus then
 					self.controls.editCurses:Redo()
+				elseif self.controls.editLinks.hasFocus then
+					self.controls.editLinks:Redo()
 				end
 			end
 		end
@@ -509,7 +592,7 @@ function PartyTabClass:ParseTags(line, currentModType)
 	return modType, extraTags
 end
 
-function PartyTabClass:ParseBuffs(list, buf, buffType)
+function PartyTabClass:ParseBuffs(list, buf, buffType, label)
 	if buffType == "EnemyConditions" then
 		for line in buf:gmatch("([^\n]*)\n?") do
 			list:NewMod(line:gsub("Condition:", "Condition:Party:"), "FLAG", true, "Party")
@@ -536,81 +619,100 @@ function PartyTabClass:ParseBuffs(list, buf, buffType)
 				end
 			end
 		end
-	end
-	local mode = "Name"
-	if buffType == "Curse" then
-		mode = "CurseLimit"
-	end
-	local currentName
-	local currentEffect
-	local isMark
-	local currentModType = "Unknown"
-	for line in buf:gmatch("([^\n]*)\n?") do
-		if line ~= "---" and line:match("%-%-%-") then
-			-- comment but not divider, skip the line
-		elseif mode == "CurseLimit" and line ~= "" then
-			list.limit = tonumber(line)
-			mode = "Name"
-		elseif mode == "Name" and line ~= "" then
-			currentName = line
-			if line == "extraAura" then
-				currentModType = "extraAura"
-				mode = "Stats"
-			else
-				mode = "Effect"
-			end
-		elseif mode == "Effect" then
-			currentEffect = tonumber(line)
-			if buffType == "Curse" then
-				mode = "isMark"
-			else
-				mode = "Stats"
-			end
-		elseif mode == "isMark" then
-			isMark = line=="true"
-			mode = "Stats"
-		elseif line == "---" then
-			mode = "Name"
-		else
-			if line:find("|") then
-				local modStrings = {}
-				for line2 in line:gmatch("([^|]*)|?") do
-					t_insert(modStrings, line2)
+	else
+		local mode = "Name"
+		if buffType == "Curse" then
+			mode = "CurseLimit"
+		end
+		local currentName
+		local currentEffect
+		local isMark
+		local currentModType = "Unknown"
+		for line in buf:gmatch("([^\n]*)\n?") do
+			if line ~= "---" and line:match("%-%-%-") then
+				-- comment but not divider, skip the line
+			elseif mode == "CurseLimit" and line ~= "" then
+				list.limit = tonumber(line)
+				mode = "Name"
+			elseif mode == "Name" and line ~= "" then
+				currentName = line
+				if line == "extraAura" then
+					currentModType = "extraAura"
+					mode = "Stats"
+				else
+					mode = "Effect"
 				end
-				if #modStrings >= 4 then
-					local mod = {
-						value = (modStrings[1] == "true" and true) or tonumber(modStrings[1]) or 0,
-						source = modStrings[2],
-						name = modStrings[3],
-						type = modStrings[4],
-						flags = ModFlag[modStrings[5]] or 0,
-						keywordFlags = KeywordFlag[modStrings[6]] or 0,
-					}
-					local modType, Tags = self:ParseTags(modStrings[7], currentModType)
-					for _, tag in ipairs(Tags) do
-						t_insert(mod, tag)
-					end
-					currentModType = modType
-					if not list[modType] then
-						list[modType] = {}
-						list[modType][currentName] = {
-							modList = new("ModList"),
-							effectMult = currentEffect
-						}
-						if isMark then
-							list[modType][currentName].isMark = true
-						end
-					elseif not list[modType][currentName] then
-						list[modType][currentName] = {
-							modList = new("ModList"),
-							effectMult = currentEffect
-						}
-						if isMark then
-							list[modType][currentName].isMark = true
-						end
-					end
-					list[modType][currentName].modList:AddMod(mod)
+			elseif mode == "Effect" then
+				currentEffect = tonumber(line)
+				if buffType == "Curse" then
+					mode = "isMark"
+				else
+					mode = "Stats"
 				end
+			elseif mode == "isMark" then
+				isMark = line=="true"
+				mode = "Stats"
+			elseif line == "---" then
+				mode = "Name"
+			else
+				if line:find("|") then
+					local modStrings = {}
+					for line2 in line:gmatch("([^|]*)|?") do
+						t_insert(modStrings, line2)
+					end
+					if #modStrings >= 4 then
+						local mod = {
+							value = (modStrings[1] == "true" and true) or tonumber(modStrings[1]) or 0,
+							source = modStrings[2],
+							name = modStrings[3],
+							type = modStrings[4],
+							flags = ModFlag[modStrings[5]] or 0,
+							keywordFlags = KeywordFlag[modStrings[6]] or 0,
+						}
+						local modType, Tags = self:ParseTags(modStrings[7], currentModType)
+						for _, tag in ipairs(Tags) do
+							t_insert(mod, tag)
+						end
+						currentModType = modType
+						if not list[modType] then
+							list[modType] = {}
+							list[modType][currentName] = {
+								modList = new("ModList"),
+								effectMult = currentEffect
+							}
+							if isMark then
+								list[modType][currentName].isMark = true
+							end
+						elseif not list[modType][currentName] then
+							list[modType][currentName] = {
+								modList = new("ModList"),
+								effectMult = currentEffect
+							}
+							if isMark then
+								list[modType][currentName].isMark = true
+							end
+						end
+						list[modType][currentName].modList:AddMod(mod)
+					end
+				end
+			end
+		end
+		if label then
+			if buffType == "Aura" then
+				label.label = "---------------------------\n"
+				for aura, auraMod in pairs(list["Aura"] or {}) do
+					label.label = label.label..aura..": "..auraMod.effectMult.."%\n"
+				end
+				for aura, auraMod in pairs(list["AuraDebuff"] or {}) do
+					label.label = label.label..aura..": "..auraMod.effectMult.."%\n"
+				end
+				label.label = label.label.."---------------------------\n"
+			elseif buffType == "Curse" then
+				label.label = "---------------------------\n"
+				for curse, curseMod in pairs(list["Curse"] or {}) do
+					label.label = label.label..curse..": "..curseMod.effectMult.."%\n"
+				end
+				label.label = label.label.."---------------------------\n"
 			end
 		end
 	end

--- a/src/Classes/PartyTab.lua
+++ b/src/Classes/PartyTab.lua
@@ -667,7 +667,7 @@ function PartyTabClass:ParseBuffs(list, buf, buffType, label)
 			elseif line == "---" then
 				mode = "Name"
 			else
-				if line:find("|") then
+				if line:find("|") and currentName ~= "SKIP" then
 					local modType, mod = modLib.parseFormattedSourceMod(line, currentModType)
 					if mod then
 						currentModType = modType
@@ -680,12 +680,23 @@ function PartyTabClass:ParseBuffs(list, buf, buffType, label)
 							if isMark then
 								list[modType][currentName].isMark = true
 							end
+						elseif list[modType][currentName].effectMult ~= currentEffect then
+							if list[modType][currentName].effectMult < currentEffect then
+								list[modType][currentName] = {
+									modList = new("ModList"),
+									effectMult = currentEffect
+								}
+							else
+								currentName = "SKIP"
+							end
 						end
-						if mod.source:match("Item") then
-							_, mod.source = mod.source:match("Item:(%d+):(.+)")
-							mod.source = "Party, "..mod.source
+						if currentName ~= "SKIP" then
+							if mod.source:match("Item") then
+								_, mod.source = mod.source:match("Item:(%d+):(.+)")
+								mod.source = "Party, "..mod.source
+							end
+							list[modType][currentName].modList:AddMod(mod)
 						end
-						list[modType][currentName].modList:AddMod(mod)
 					end
 				end
 			end

--- a/src/Classes/PartyTab.lua
+++ b/src/Classes/PartyTab.lua
@@ -487,35 +487,60 @@ end
 
 function PartyTabClass:Save(xml)
 	local child = { elem = "ImportedBuffs", attrib = { name = "Aura" } }
-	t_insert(child, self.controls.editAuras.buf or "")
-	t_insert(xml, child)
-	child = { elem = "ImportedBuffs", attrib = { name = "Curse" } }
-	t_insert(child, self.controls.editCurses.buf or "")
-	t_insert(xml, child)
-	child = { elem = "ImportedBuffs", attrib = { name = "Link Skills" } }
-	t_insert(child, self.controls.editLinks.buf or "")
-	t_insert(xml, child)
-	child = { elem = "ImportedBuffs", attrib = { name = "EnemyConditions" } }
-	t_insert(child, self.controls.enemyCond.buf or "")
-	t_insert(xml, child)
-	child = { elem = "ImportedBuffs", attrib = { name = "EnemyMods" } }
-	t_insert(child, self.controls.enemyMods.buf or "")
-	t_insert(xml, child)
-	child = { elem = "ExportedBuffs", attrib = { name = "Aura" } }
-	t_insert(child, self:exportBuffs("Aura") or "")
-	t_insert(xml, child)
-	child = { elem = "ExportedBuffs", attrib = { name = "Curse" } }
-	t_insert(child, self:exportBuffs("Curse") or "")
-	t_insert(xml, child)
-	child = { elem = "ExportedBuffs", attrib = { name = "Link Skills" } }
-	t_insert(child, self:exportBuffs("Link") or "")
-	t_insert(xml, child)
-	child = { elem = "ExportedBuffs", attrib = { name = "EnemyConditions" } }
-	t_insert(child, self:exportBuffs("EnemyConditions") or "")
-	t_insert(xml, child)
-	child = { elem = "ExportedBuffs", attrib = { name = "EnemyMods" } }
-	t_insert(child, self:exportBuffs("EnemyMods") or "")
-	t_insert(xml, child)
+	if self.controls.editAuras.buf and self.controls.editAuras.buf ~= "" then
+		t_insert(child, self.controls.editAuras.buf)
+		t_insert(xml, child)
+	end
+	if self.controls.editCurses.buf and self.controls.editCurses.buf ~= "" then
+		child = { elem = "ImportedBuffs", attrib = { name = "Curse" } }
+		t_insert(child, self.controls.editCurses.buf)
+		t_insert(xml, child)
+	end
+	if self.controls.editLinks.buf and self.controls.editLinks.buf ~= "" then
+		child = { elem = "ImportedBuffs", attrib = { name = "Link Skills" } }
+		t_insert(child, self.controls.editLinks.buf)
+		t_insert(xml, child)
+	end
+	if self.controls.enemyCond.buf and self.controls.enemyCond.buf ~= "" then
+		child = { elem = "ImportedBuffs", attrib = { name = "EnemyConditions" } }
+		t_insert(child, self.controls.enemyCond.buf)
+		t_insert(xml, child)
+	end
+	if self.controls.enemyMods.buf and self.controls.enemyMods.buf ~= "" then
+		child = { elem = "ImportedBuffs", attrib = { name = "EnemyMods" } }
+		t_insert(child, self.controls.enemyMods.buf)
+		t_insert(xml, child)
+	end
+	local exportString = self:exportBuffs("Aura")
+	if exportString ~= "" then
+		child = { elem = "ExportedBuffs", attrib = { name = "Aura" } }
+		t_insert(child, self:exportBuffs("Aura"))
+		t_insert(xml, child)
+	end
+	exportString = self:exportBuffs("Curse")
+	if exportString ~= "" then
+		child = { elem = "ExportedBuffs", attrib = { name = "Curse" } }
+		t_insert(child, self:exportBuffs("Curse"))
+		t_insert(xml, child)
+	end
+	exportString = self:exportBuffs("Link")
+	if exportString ~= "" then
+		child = { elem = "ExportedBuffs", attrib = { name = "Link Skills" } }
+		t_insert(child, self:exportBuffs("Link"))
+		t_insert(xml, child)
+	end
+	exportString = self:exportBuffs("EnemyConditions")
+	if exportString ~= "" then
+		child = { elem = "ExportedBuffs", attrib = { name = "EnemyConditions" } }
+		t_insert(child, self:exportBuffs("EnemyConditions"))
+		t_insert(xml, child)
+	end
+	exportString = self:exportBuffs("EnemyMods")
+	if exportString ~= "" then
+		child = { elem = "ExportedBuffs", attrib = { name = "EnemyMods" } }
+		t_insert(child, self:exportBuffs("EnemyMods"))
+		t_insert(xml, child)
+	end
 	self.lastContent.Aura = self.controls.editAuras.buf
 	self.lastContent.Curse = self.controls.editCurses.buf
 	self.lastContent.Link = self.controls.editLinks.buf

--- a/src/Classes/PartyTab.lua
+++ b/src/Classes/PartyTab.lua
@@ -52,6 +52,25 @@ local PartyTabClass = newClass("PartyTab", "ControlHost", "Control", function(se
 		return (lineCount - 2) * 16
 	end
 	
+	local clearInputBufs = function()
+		if partyDestinations[self.controls.importCodeDestination.selIndex] == "All" or partyDestinations[self.controls.importCodeDestination.selIndex] == "Aura" then
+			self.controls.editAuras:SetText("")
+			wipeTable(self.processedInput["Aura"])
+			self.processedInput["Aura"] = {}
+		end
+		if partyDestinations[self.controls.importCodeDestination.selIndex] == "All" or partyDestinations[self.controls.importCodeDestination.selIndex] == "Curse" then
+			self.controls.editCurses:SetText("")
+			wipeTable(self.processedInput["Curse"])
+			self.processedInput["Curse"] = {}
+		end
+		if partyDestinations[self.controls.importCodeDestination.selIndex] == "All" or partyDestinations[self.controls.importCodeDestination.selIndex] == "EnemyConditions" then
+			self.controls.enemyCond:SetText("")
+		end
+		if partyDestinations[self.controls.importCodeDestination.selIndex] == "All" or partyDestinations[self.controls.importCodeDestination.selIndex] == "EnemyMods" then
+			self.controls.enemyMods:SetText("")
+		end
+	end
+	
 	local importCodeHandle = function (buf)
 		self.importCodeSite = nil
 		self.importCodeDetail = ""
@@ -100,22 +119,7 @@ local PartyTabClass = newClass("PartyTab", "ControlHost", "Control", function(se
 		end
 	
 		if self.controls.importCodeApplication.selIndex == 1 then
-			if partyDestinations[self.controls.importCodeDestination.selIndex] == "All" or partyDestinations[self.controls.importCodeDestination.selIndex] == "Aura" then
-				self.controls.editAuras:SetText("")
-				wipeTable(self.processedInput["Aura"])
-				self.processedInput["Aura"] = {}
-			end
-			if partyDestinations[self.controls.importCodeDestination.selIndex] == "All" or partyDestinations[self.controls.importCodeDestination.selIndex] == "Curse" then
-				self.controls.editCurses:SetText("")
-				wipeTable(self.processedInput["Curse"])
-				self.processedInput["Curse"] = {}
-			end
-			if partyDestinations[self.controls.importCodeDestination.selIndex] == "All" or partyDestinations[self.controls.importCodeDestination.selIndex] == "EnemyConditions" then
-				self.controls.enemyCond:SetText("")
-			end
-			if partyDestinations[self.controls.importCodeDestination.selIndex] == "All" or partyDestinations[self.controls.importCodeDestination.selIndex] == "EnemyMods" then
-				self.controls.enemyMods:SetText("")
-			end
+			clearInputBufs()
 		else
 			if partyDestinations[self.controls.importCodeDestination.selIndex] == "All" or partyDestinations[self.controls.importCodeDestination.selIndex] == "Aura" then
 				wipeTable(self.processedInput["Aura"])
@@ -199,22 +203,7 @@ local PartyTabClass = newClass("PartyTab", "ControlHost", "Control", function(se
 	self.controls.importCodeApplication = new("DropDownControl", {"LEFT",self.controls.importCodeDestination,"RIGHT"}, 8, 0, 160, 20, { "Replace", "Append", "Clear" })
 	self.controls.importCodeGo = new("ButtonControl", {"LEFT",self.controls.importCodeApplication,"RIGHT"}, 8, 0, 160, 20, "Import", function()
 		if self.controls.importCodeApplication.selIndex == 3 then
-			if partyDestinations[self.controls.importCodeDestination.selIndex] == "All" or partyDestinations[self.controls.importCodeDestination.selIndex] == "Aura" then
-				self.controls.editAuras:SetText("")
-				wipeTable(self.processedInput["Aura"])
-				self.processedInput["Aura"] = {}
-			end
-			if partyDestinations[self.controls.importCodeDestination.selIndex] == "All" or partyDestinations[self.controls.importCodeDestination.selIndex] == "Curse" then
-				self.controls.editCurses:SetText("")
-				wipeTable(self.processedInput["Curse"])
-				self.processedInput["Curse"] = {}
-			end
-			if partyDestinations[self.controls.importCodeDestination.selIndex] == "All" or partyDestinations[self.controls.importCodeDestination.selIndex] == "EnemyConditions" then
-				self.controls.enemyCond:SetText("")
-			end
-			if partyDestinations[self.controls.importCodeDestination.selIndex] == "All" or partyDestinations[self.controls.importCodeDestination.selIndex] == "EnemyMods" then
-				self.controls.enemyMods:SetText("")
-			end
+			clearInputBufs()
 			wipeTable(self.enemyModList)
 			self.enemyModList = new("ModList")
 			self.build.buildFlag = true 

--- a/src/Classes/PartyTab.lua
+++ b/src/Classes/PartyTab.lua
@@ -17,7 +17,8 @@ local PartyTabClass = newClass("PartyTab", "ControlHost", "Control", function(se
 	self.processedInput = { Aura = {}, Curse = {} }
 	self.buffExports = {}
 
-	self.lastContent = ""
+	self.lastContentAura = ""
+	self.lastContentCurse = ""
 	self.showColorCodes = false
 
 	local notesDesc = [[^7Party stuff	DO NOT EDIT ANY BOXES UNLESS YOU KNOW WHAT YOU ARE DOING, use copy/paste instead, or import]]
@@ -153,7 +154,8 @@ function PartyTabClass:Load(xml, fileName)
 			self:ParseBuffs(self.buffExports, node.attrib.string, "Curse")
 		end
 	end
-	self.lastContent = self.controls.editAuras.buf
+	self.lastContentAura = self.controls.editAuras.buf
+	self.lastContentCurse = self.controls.editCurses.buf
 end
 
 function PartyTabClass:Save(xml)
@@ -169,7 +171,8 @@ function PartyTabClass:Save(xml)
 	child = { elem = "ExportedBuffs", attrib = { name = "Curse" } }
 	child.attrib.string = self:exportBuffs("Curse")
 	t_insert(xml, child)
-	self.lastContent = self.controls.editAuras.buf
+	self.lastContentAura = self.controls.editAuras.buf
+	self.lastContentCurse = self.controls.editCurses.buf
 end
 
 function PartyTabClass:Draw(viewPort, inputEvents)
@@ -181,9 +184,17 @@ function PartyTabClass:Draw(viewPort, inputEvents)
 	for id, event in ipairs(inputEvents) do
 		if event.type == "KeyDown" then
 			if event.key == "z" and IsKeyDown("CTRL") then
-				self.controls.editAuras:Undo()
+				if self.controls.editAuras.hasFocus then
+					self.controls.editAuras:Undo()
+				elseif self.controls.editCurses.hasFocus then
+					self.controls.editCurses:Undo()
+				end
 			elseif event.key == "y" and IsKeyDown("CTRL") then
-				self.controls.editAuras:Redo()
+				if self.controls.editAuras.hasFocus then
+					self.controls.editAuras:Redo()
+				elseif self.controls.editCurses.hasFocus then
+					self.controls.editCurses:Redo()
+				end
 			end
 		end
 	end
@@ -193,7 +204,7 @@ function PartyTabClass:Draw(viewPort, inputEvents)
 
 	self:DrawControls(viewPort)
 
-	self.modFlag = (self.lastContent ~= self.controls.editAuras.buf)
+	self.modFlag = (self.lastContentAura ~= self.controls.editAuras.buf and self.lastContentCurse ~= self.controls.editCurses.buf)
 end
 
 function PartyTabClass:ParseBuffs(list, buf, buffType)

--- a/src/Classes/PartyTab.lua
+++ b/src/Classes/PartyTab.lua
@@ -26,15 +26,15 @@ local PartyTabClass = newClass("PartyTab", "ControlHost", "Control", function(se
 	self.lastEnableExportBuffs = true
 	self.showColorCodes = false
 
-	local notesDesc = [[^7Party stuff	DO NOT EDIT ANY BOXES UNLESS YOU KNOW WHAT YOU ARE DOING, use copy/paste instead, or import
-	To import a build that build must have been saved with Enable Export ticked
+	local notesDesc = [[^7DO NOT EDIT ANY BOXES UNLESS YOU KNOW WHAT YOU ARE DOING, use copy/paste instead, or import
+	To import a build, you must export that build with "Export Support" ticked
 	The Strongest Aura applies, but your curses override the supports regardless of strength
 	]]
 	self.controls.notesDesc = new("LabelControl", {"TOPLEFT",self,"TOPLEFT"}, 8, 8, 150, 16, notesDesc)
 	self.controls.notesDesc.width = function()
 		return self.width / 2 - 16
 	end
-	self.controls.importCodeHeader = new("LabelControl", {"TOPLEFT",self.controls.notesDesc,"BOTTOMLEFT"}, 0, 32, 0, 16, "^7To import a build, enter code here: (NOT URL)")
+	self.controls.importCodeHeader = new("LabelControl", {"TOPLEFT",self.controls.notesDesc,"BOTTOMLEFT"}, 0, 32, 0, 16, "^7Enter a build code below: (NOT URL)")
 	
 	local importCodeHandle = function (buf)
 		self.importCodeSite = nil

--- a/src/Classes/PartyTab.lua
+++ b/src/Classes/PartyTab.lua
@@ -285,7 +285,7 @@ function PartyTabClass:exportBuffs(buffType)
 	if self.buffExports[buffType].ConvertedToText then
 		return self.buffExports[buffType].string
 	end
-	local buf = ""
+	local buf = ((buffType == "Curse") and tostring(self.buffExports["CurseLimit"])) or ""
 	for buffName, buff in pairs(self.buffExports[buffType]) do
 		if #buf > 0 then
 			buf = buf.."\n"

--- a/src/Classes/PartyTab.lua
+++ b/src/Classes/PartyTab.lua
@@ -41,7 +41,7 @@ local PartyTabClass = newClass("PartyTab", "ControlHost", "Control", function(se
 		end
 		return width
 	end
-	self.controls.importCodeHeader = new("LabelControl", {"TOPLEFT",self.controls.notesDesc,"BOTTOMLEFT"}, 0, 32, 0, 16, "^7Enter a build code below: (NOT URL)")
+	self.controls.importCodeHeader = new("LabelControl", {"TOPLEFT",self.controls.notesDesc,"BOTTOMLEFT"}, 0, 32, 0, 16, "^7Enter a build code/URL below:")
 	self.controls.importCodeHeader.y = function()
 		local lineCount = 1
 		for i = 1, #self.controls.notesDesc.label do

--- a/src/Classes/PartyTab.lua
+++ b/src/Classes/PartyTab.lua
@@ -528,8 +528,6 @@ function PartyTabClass:ParseBuffs(list, buf, buffType)
 			mode = "Stats"
 		elseif line == "---" then
 			mode = "Name"
-		elseif line:match("---") then -- comment line, just ignore it
-			
 		else
 			if line:find("|") then
 				local modStrings = {}
@@ -588,7 +586,7 @@ function PartyTabClass:exportBuffs(buffType)
 	if self.buffExports[buffType].ConvertedToText then
 		return self.buffExports[buffType].string
 	end
-	local buf = ((buffType == "Curse") and ("--- Curse Limit ---\n" .. tostring(self.buffExports["CurseLimit"]))) or ""
+	local buf = ((buffType == "Curse") and (tostring(self.buffExports["CurseLimit"]))) or ""
 	for buffName, buff in pairs(self.buffExports[buffType]) do
 		if #buf > 0 then
 			buf = buf.."\n"

--- a/src/Classes/PartyTab.lua
+++ b/src/Classes/PartyTab.lua
@@ -478,7 +478,6 @@ function PartyTabClass:Load(xml, fileName)
 	self.lastContent.EnemyMods = self.controls.enemyMods.buf
 	self.lastContent.EnableExportBuffs = self.enableExportBuffs
 	
-	self.controls.importCodeIn:SetText(xml.attrib.currentImportCode or "")
 	self.controls.importCodeDestination:SelByValue(xml.attrib.destination or "All")
 	self.controls.appendNotReplace.state = xml.attrib.append == "true"
 	self.controls.ShowAdvanceTools.state = xml.attrib.ShowAdvanceTools == "true"
@@ -524,7 +523,6 @@ function PartyTabClass:Save(xml)
 	self.lastContent.EnemyMods = self.controls.enemyMods.buf
 	self.lastContent.EnableExportBuffs = self.enableExportBuffs
 	xml.attrib = {
-		currentImportCode = self.controls.importCodeIn.buf,
 		destination = self.controls.importCodeDestination.list[self.controls.importCodeDestination.selIndex],
 		append = tostring(self.controls.appendNotReplace.state),
 		ShowAdvanceTools = tostring(self.controls.ShowAdvanceTools.state)

--- a/src/Classes/PartyTab.lua
+++ b/src/Classes/PartyTab.lua
@@ -640,7 +640,7 @@ function PartyTabClass:ParseBuffs(list, buf, buffType, label)
 				list.limit = tonumber(line)
 				mode = "Name"
 			elseif mode == "Name" and line ~= "" then
-				currentName = line
+				currentName = line:gsub("_Debuff", "")
 				currentEffect = 0
 				if line == "extraAura" then
 					currentModType = "extraAura"

--- a/src/Modules/Build.lua
+++ b/src/Modules/Build.lua
@@ -443,19 +443,23 @@ function buildMode:Init(dbFileName, buildName, buildXML, convertBuild)
 
 	-- Controls: Side bar
 	self.anchorSideBar = new("Control", nil, 4, 36, 0, 0)
-	self.controls.modeImport = new("ButtonControl", {"TOPLEFT",self.anchorSideBar,"TOPLEFT"}, 0, 0, 134, 20, "Import/Export Build", function()
+	self.controls.modeImport = new("ButtonControl", {"TOPLEFT",self.anchorSideBar,"TOPLEFT"}, 0, 0, 148, 20, "Import/Export Build", function()
 		self.viewMode = "IMPORT"
 	end)
 	self.controls.modeImport.locked = function() return self.viewMode == "IMPORT" end
-	self.controls.modeNotes = new("ButtonControl", {"LEFT",self.controls.modeImport,"RIGHT"}, 4, 0, 58, 20, "Notes", function()
+	self.controls.modeNotes = new("ButtonControl", {"LEFT",self.controls.modeImport,"RIGHT"}, 4, 0, 148, 20, "Notes", function()
 		self.viewMode = "NOTES"
 	end)
 	self.controls.modeNotes.locked = function() return self.viewMode == "NOTES" end
-	self.controls.modeConfig = new("ButtonControl", {"TOPRIGHT",self.anchorSideBar,"TOPLEFT"}, 300, 0, 100, 20, "Configuration", function()
+	self.controls.modeParty = new("ButtonControl", {"TOPLEFT",self.anchorSideBar,"TOPLEFT"}, 0, 26, 148, 20, "Party", function()
+		self.viewMode = "PARTY"
+	end)
+	self.controls.modeParty.locked = function() return self.viewMode == "PARTY" end
+	self.controls.modeConfig = new("ButtonControl", {"TOPRIGHT",self.anchorSideBar,"TOPLEFT"}, 300, 26, 148, 20, "Configuration", function()
 		self.viewMode = "CONFIG"
 	end)
 	self.controls.modeConfig.locked = function() return self.viewMode == "CONFIG" end
-	self.controls.modeTree = new("ButtonControl", {"TOPLEFT",self.anchorSideBar,"TOPLEFT"}, 0, 26, 72, 20, "Tree", function()
+	self.controls.modeTree = new("ButtonControl", {"TOPLEFT",self.anchorSideBar,"TOPLEFT"}, 0, 52, 72, 20, "Tree", function()
 		self.viewMode = "TREE"
 	end)
 	self.controls.modeTree.locked = function() return self.viewMode == "TREE" end
@@ -472,7 +476,7 @@ function buildMode:Init(dbFileName, buildName, buildXML, convertBuild)
 	end)
 	self.controls.modeCalcs.locked = function() return self.viewMode == "CALCS" end
 	-- Skills
-	self.controls.mainSkillLabel = new("LabelControl", {"TOPLEFT",self.anchorSideBar,"TOPLEFT"}, 0, 54, 300, 16, "^7Main Skill:")
+	self.controls.mainSkillLabel = new("LabelControl", {"TOPLEFT",self.anchorSideBar,"TOPLEFT"}, 0, 80, 300, 16, "^7Main Skill:")
 	self.controls.mainSocketGroup = new("DropDownControl", {"TOPLEFT",self.controls.mainSkillLabel,"BOTTOMLEFT"}, 0, 2, 300, 18, nil, function(index, value)
 		self.mainSocketGroup = index
 		self.modFlag = true

--- a/src/Modules/Build.lua
+++ b/src/Modules/Build.lua
@@ -1064,7 +1064,7 @@ function buildMode:OnFrame(inputEvents)
 		self.calcsTab:Draw(tabViewPort, inputEvents)
 	end
 
-	self.unsaved = self.modFlag or self.notesTab.modFlag or self.configTab.modFlag or self.treeTab.modFlag or self.treeTab.searchFlag or self.spec.modFlag or self.skillsTab.modFlag or self.itemsTab.modFlag or self.calcsTab.modFlag
+	self.unsaved = self.modFlag or self.notesTab.modFlag or self.partyTab.modFlag or self.configTab.modFlag or self.treeTab.modFlag or self.treeTab.searchFlag or self.spec.modFlag or self.skillsTab.modFlag or self.itemsTab.modFlag or self.calcsTab.modFlag
 
 	SetDrawLayer(5)
 

--- a/src/Modules/CalcPerform.lua
+++ b/src/Modules/CalcPerform.lua
@@ -1926,7 +1926,7 @@ function calcs.perform(env, avoidCache, fullDPSSkipEHP)
 		limit = 1,
 	}
 	local allyBuffs = env.build.partyTab.processedInput["Aura"]
-	local buffExports = { Aura = {}, Curse = {} }
+	local buffExports = { Aura = {}, Curse = {}, EnemyMods = {}, EnemyConditions = {} }
 	for spectreId = 1, #env.spec.build.spectreList do
 		local spectreData = data.minions[env.spec.build.spectreList[spectreId]]
 		for modId = 1, #spectreData.modList do
@@ -3685,30 +3685,27 @@ function calcs.perform(env, avoidCache, fullDPSSkipEHP)
 		enemyDB:NewMod("DamageTaken", "INC", enemyDB:Sum("INC", nil, "DamageTakenConsecratedGround") * effect, "Consecrated Ground")
 	end
 	
-	for k, v in pairs(enemyDB.mods) do
-		if (k:find("Condition")) then
-			if buffExports["EnemyConditions"] then
+	if env.build.partyTab.enableExportBuffs then
+		for k, v in pairs(enemyDB.mods) do
+			if (k:find("Condition")) then
 				buffExports["EnemyConditions"][k] = true
-			else
-				buffExports["EnemyConditions"] = { [k] = true }
 			end
 		end
-	end
-	buffExports["EnemyMods"] = {}
-	for k, v in pairs(enemyDB.mods) do
-		if (k:find("Resist") and not k:find("Totem") and not k:find("Max")) or k:find("Damage") or k:find("ActionSpeed") or k:find("SelfCrit") or (k:find("Multiplier") and not k:find("Max") and not k:find("Impale")) then
-			for k2, v2 in ipairs(v) do
-				if v2.value ~= 0 and not (v2[1] and v2[1].effectType == "Curse") then
-					if not v2[1] or ((v2[1].type ~= "Condition" or (enemyDB.mods["Condition:"..v2[1].var] and enemyDB.mods["Condition:"..v2[1].var][1].value)) and (v2[1].type ~= "Multiplier" or (enemyDB.mods["Multiplier:"..v2[1].var] and enemyDB.mods["Multiplier:"..v2[1].var][1].value))) then
-						--ConPrintf(k)
-						--ConPrintTable(v2)
-						buffExports["EnemyMods"][k] = v2
+		for k, v in pairs(enemyDB.mods) do
+			if (k:find("Resist") and not k:find("Totem") and not k:find("Max")) or k:find("Damage") or k:find("ActionSpeed") or k:find("SelfCrit") or (k:find("Multiplier") and not k:find("Max") and not k:find("Impale")) then
+				for k2, v2 in ipairs(v) do
+					if v2.value ~= 0 and not (v2[1] and v2[1].effectType == "Curse") then
+						if not v2[1] or ((v2[1].type ~= "Condition" or (enemyDB.mods["Condition:"..v2[1].var] and enemyDB.mods["Condition:"..v2[1].var][1].value)) and (v2[1].type ~= "Multiplier" or (enemyDB.mods["Multiplier:"..v2[1].var] and enemyDB.mods["Multiplier:"..v2[1].var][1].value))) then
+							--ConPrintf(k)
+							--ConPrintTable(v2)
+							buffExports["EnemyMods"][k] = v2
+						end
 					end
 				end
 			end
 		end
+		env.build.partyTab:setBuffExports(buffExports)
 	end
-	env.build.partyTab:setBuffExports(buffExports)
 
 	-- Defence/offence calculations
 	calcs.defence(env, env.player)

--- a/src/Modules/CalcPerform.lua
+++ b/src/Modules/CalcPerform.lua
@@ -3689,7 +3689,8 @@ function calcs.perform(env, avoidCache, fullDPSSkipEHP)
 	end
 	
 	-- Export modifiers to enemy conditions and stats for party tab
-	if env.build.partyTab.enableExportBuffs and false then -- disabled for now
+	if env.build.partyTab.enableExportBuffs then
+		--[[  -- disabled for now
 		for k, v in pairs(enemyDB.mods) do
 			if k:find("Condition") and not k:find("Party") then
 				buffExports["EnemyConditions"][k] = true
@@ -3706,6 +3707,7 @@ function calcs.perform(env, avoidCache, fullDPSSkipEHP)
 				end
 			end
 		end
+		--]]
 		env.build.partyTab:setBuffExports(buffExports)
 	end
 

--- a/src/Modules/CalcPerform.lua
+++ b/src/Modules/CalcPerform.lua
@@ -2007,7 +2007,7 @@ function calcs.perform(env, avoidCache, fullDPSSkipEHP)
 						local mult = (1 + inc / 100) * more
 						if modDB:Flag(nil, "AlliesAurasCannotAffectSelf") or not allyBuffs["Aura"] or not allyBuffs["Aura"][buff.name] or allyBuffs["Aura"][buff.name].effectMult / 100 <= mult then
 							activeSkill.buffSkill = true
-							affectedByAura[env.player] = true
+							modDB.conditions["AffectedByAura"] = true
 							if buff.name:sub(1,4) == "Vaal" then
 								modDB.conditions["AffectedBy"..buff.name:sub(6):gsub(" ","")] = true
 							end
@@ -2025,8 +2025,8 @@ function calcs.perform(env, avoidCache, fullDPSSkipEHP)
 							local mult = (1 + inc / 100) * more
 							if not allyBuffs["Aura"] or  not allyBuffs["Aura"][buff.name] or allyBuffs["Aura"][buff.name].effectMult / 100 <= mult then
 								activeSkill.minionBuffSkill = true
-								affectedByAura[env.minion] = true
 								env.minion.modDB.conditions["AffectedBy"..buff.name:gsub(" ","")] = true
+								env.minion.modDB.conditions["AffectedByAura"] = true
 								local srcList = new("ModList")
 								srcList:ScaleAddList(buff.modList, mult)
 								srcList:ScaleAddList(extraAuraModList, mult)
@@ -2253,7 +2253,7 @@ function calcs.perform(env, avoidCache, fullDPSSkipEHP)
 		for auraName, aura in pairs(allyBuffs["Aura"]) do
 			local auraNameCompressed = auraName:gsub(" ","")
 			if not modDB:Flag(nil, "AlliesAurasCannotAffectSelf") and not modDB.conditions["AffectedBy"..auraNameCompressed] then
-				affectedByAura[env.player] = true
+				modDB.conditions["AffectedByAura"] = true
 				if auraName:sub(1,4) == "Vaal" then
 					modDB.conditions["AffectedBy"..auraName:sub(6):gsub(" ","")] = true
 				end
@@ -2263,7 +2263,7 @@ function calcs.perform(env, avoidCache, fullDPSSkipEHP)
 				mergeBuff(srcList, buffs, auraName)
 			end
 			if env.minion and not env.minion.modDB.conditions["AffectedBy"..auraNameCompressed] then
-				affectedByAura[env.minion] = true
+				env.minion.modDB.conditions["AffectedByAura"] = true
 				env.minion.modDB.conditions["AffectedBy"..auraNameCompressed] = true
 				local srcList = new("ModList")
 				srcList:ScaleAddList(aura.modList, aura.effectMult / 100)

--- a/src/Modules/CalcPerform.lua
+++ b/src/Modules/CalcPerform.lua
@@ -2141,7 +2141,9 @@ function calcs.perform(env, avoidCache, fullDPSSkipEHP)
 					if buff.type == "Curse" then
 						curse.modList = new("ModList")
 						curse.modList:ScaleAddList(buff.modList, mult)
-						buffExports["Curse"][buff.name] = { isMark = curse.isMark, effectMult = curse.isMark and mult or (1 + inc / 100) * moreMark, modList = buff.modList }
+						if env.build.partyTab.enableExportBuffs then
+							buffExports["Curse"][buff.name] = { isMark = curse.isMark, effectMult = curse.isMark and mult or (1 + inc / 100) * moreMark, modList = buff.modList }
+						end
 					else
 						-- Curse applies a buff; scale by curse effect, then buff effect
 						local temp = new("ModList")
@@ -3685,6 +3687,7 @@ function calcs.perform(env, avoidCache, fullDPSSkipEHP)
 		enemyDB:NewMod("DamageTaken", "INC", enemyDB:Sum("INC", nil, "DamageTakenConsecratedGround") * effect, "Consecrated Ground")
 	end
 	
+	-- Export modifiers to enemy conditons and stats for party tab
 	if env.build.partyTab.enableExportBuffs then
 		for k, v in pairs(enemyDB.mods) do
 			if k:find("Condition") and not k:find("Party") then

--- a/src/Modules/CalcPerform.lua
+++ b/src/Modules/CalcPerform.lua
@@ -3688,26 +3688,7 @@ function calcs.perform(env, avoidCache, fullDPSSkipEHP)
 		enemyDB:NewMod("DamageTaken", "INC", enemyDB:Sum("INC", nil, "DamageTakenConsecratedGround") * effect, "Consecrated Ground")
 	end
 	
-	-- Export modifiers to enemy conditions and stats for party tab
 	if env.build.partyTab.enableExportBuffs then
-		--[[  -- disabled for now
-		for k, v in pairs(enemyDB.mods) do
-			if k:find("Condition") and not k:find("Party") then
-				buffExports["EnemyConditions"][k] = true
-			end
-		end
-		for k, v in pairs(enemyDB.mods) do
-			if (k:find("Resist") and not k:find("Totem") and not k:find("Max")) or k:find("Damage") or k:find("ActionSpeed") or k:find("SelfCrit") or (k:find("Multiplier") and not k:find("Max") and not k:find("Impale")) then
-				for k2, v2 in ipairs(v) do
-					if not v2.party and v2.value ~= 0 and v2.source ~= "EnemyConfig" and not v2.source:find("Delirious") and not (v2[1] and v2[1].effectType == "Curse") then
-						if not v2[1] or ((v2[1].type ~= "Condition" or (enemyDB.mods["Condition:"..v2[1].var] and enemyDB.mods["Condition:"..v2[1].var][1].value)) and (v2[1].type ~= "Multiplier" or (enemyDB.mods["Multiplier:"..v2[1].var] and enemyDB.mods["Multiplier:"..v2[1].var][1].value))) then
-							buffExports["EnemyMods"][k] = v2
-						end
-					end
-				end
-			end
-		end
-		--]]
 		env.build.partyTab:setBuffExports(buffExports)
 	end
 

--- a/src/Modules/CalcPerform.lua
+++ b/src/Modules/CalcPerform.lua
@@ -2141,7 +2141,7 @@ function calcs.perform(env, avoidCache, fullDPSSkipEHP)
 					if buff.type == "Curse" then
 						curse.modList = new("ModList")
 						curse.modList:ScaleAddList(buff.modList, mult)
-						buffExports["Curse"][buff.name] = { effectMult = curse.isMark and mult or (1 + inc / 100) * moreMark, modList = buff.modList }
+						buffExports["Curse"][buff.name] = { isMark = curse.isMark, effectMult = curse.isMark and mult or (1 + inc / 100) * moreMark, modList = buff.modList }
 					else
 						-- Curse applies a buff; scale by curse effect, then buff effect
 						local temp = new("ModList")
@@ -2376,9 +2376,19 @@ function calcs.perform(env, avoidCache, fullDPSSkipEHP)
 		allyPartyCurses = { Curse = {} }
 	end
 	for curseName, curse in pairs(allyPartyCurses["Curse"]) do
-		curse.name = curseName
-		curse.priority = 0
-		t_insert(allyCurses, curse) --these need to be scaled
+		local newCurse = {
+			name = curseName,
+			priority = 0,
+			modList = new("ModList")
+		}
+		local mult = curse.effectMult / 100
+		if curse.isMark then
+			newCurse.isMark = true
+		else
+			mult = mult * enemyDB:More(nil, "CurseEffectOnSelf")
+		end
+		newCurse.modList:ScaleAddList(curse.modList, mult)
+		t_insert(allyCurses, newCurse)
 	end
 	
 

--- a/src/Modules/CalcPerform.lua
+++ b/src/Modules/CalcPerform.lua
@@ -2395,7 +2395,7 @@ function calcs.perform(env, avoidCache, fullDPSSkipEHP)
 	output.PowerChargesMax = m_max(modDB:Sum("BASE", nil, "PowerChargesMax"), 0) -- precalculate max charges for this.
 	output.EnemyCurseLimit = modDB:Flag(nil, "CurseLimitIsMaximumPowerCharges") and output.PowerChargesMax or modDB:Sum("BASE", nil, "EnemyCurseLimit")
 	curses.limit = output.EnemyCurseLimit
-	env.build.partyTab.buffExports["CurseLimit"] = curses.limit
+	buffExports["CurseLimit"] = curses.limit
 	-- Assign curses to slots
 	local curseSlots = { }
 	env.curseSlots = curseSlots

--- a/src/Modules/CalcPerform.lua
+++ b/src/Modules/CalcPerform.lua
@@ -2369,12 +2369,17 @@ function calcs.perform(env, avoidCache, fullDPSSkipEHP)
 		end
 	end
 	local allyCurses = {}
-	for curseName, curse in pairs(env.build.partyTab.processedInput["Curse"]["Curse"]) do
+	local allyPartyCurses = env.build.partyTab.processedInput["Curse"]
+	if allyPartyCurses["Curse"] then
+		allyCurses.limit = allyPartyCurses.limit
+	else	
+		allyPartyCurses = { Curse = {} }
+	end
+	for curseName, curse in pairs(allyPartyCurses["Curse"]) do
 		curse.name = curseName
 		curse.priority = 0
 		t_insert(allyCurses, curse) --these need to be scaled
 	end
-	allyCurses.limit = env.build.partyTab.processedInput["Curse"].limit
 	
 
 	-- Set curse limit

--- a/src/Modules/CalcPerform.lua
+++ b/src/Modules/CalcPerform.lua
@@ -2372,7 +2372,7 @@ function calcs.perform(env, avoidCache, fullDPSSkipEHP)
 	for curseName, curse in pairs(env.build.partyTab.processedInput["Curse"]["Curse"]) do
 		curse.name = curseName
 		curse.priority = 0
-		t_insert(allyCurses, curse)
+		t_insert(allyCurses, curse) --these need to be scaled
 	end
 	allyCurses.limit = env.build.partyTab.processedInput["Curse"].limit
 	
@@ -2381,6 +2381,7 @@ function calcs.perform(env, avoidCache, fullDPSSkipEHP)
 	output.PowerChargesMax = m_max(modDB:Sum("BASE", nil, "PowerChargesMax"), 0) -- precalculate max charges for this.
 	output.EnemyCurseLimit = modDB:Flag(nil, "CurseLimitIsMaximumPowerCharges") and output.PowerChargesMax or modDB:Sum("BASE", nil, "EnemyCurseLimit")
 	curses.limit = output.EnemyCurseLimit
+	env.build.partyTab.buffExports["CurseLimit"] = curses.limit
 	-- Assign curses to slots
 	local curseSlots = { }
 	env.curseSlots = curseSlots

--- a/src/Modules/CalcPerform.lua
+++ b/src/Modules/CalcPerform.lua
@@ -2039,6 +2039,9 @@ function calcs.perform(env, avoidCache, fullDPSSkipEHP)
 						local newModList = new("ModList")
 						newModList:AddList(buff.modList)
 						newModList:AddList(extraAuraModList)
+						if buffExports["Aura"][buff.name] then
+							buffExports["Aura"][buff.name.."_Debuff"] = buffExports["Aura"][buff.name]
+						end
 						buffExports["Aura"][buff.name] = { effectMult = mult, modList = newModList }
 					end
 					if env.player.mainSkill.skillFlags.totem and not (modDB:Flag(nil, "SelfAurasCannotAffectAllies") or modDB:Flag(nil, "SelfAuraSkillsCannotAffectAllies")) then
@@ -2095,7 +2098,7 @@ function calcs.perform(env, avoidCache, fullDPSSkipEHP)
 							local inc = skillModList:Sum("INC", skillCfg, "AuraEffect", "BuffEffect", "DebuffEffect")
 							local more = skillModList:More(skillCfg, "AuraEffect", "BuffEffect", "DebuffEffect")
 							mult = (1 + inc / 100) * more
-							buffExports["Aura"][buff.name] = { effectMult = mult, modList = buff.modList }
+							buffExports["Aura"][buff.name..(buffExports["Aura"][buff.name] and "_Debuff" or "")] = { effectMult = mult, modList = buff.modList }
 							if allyBuffs["AuraDebuff"] and allyBuffs["AuraDebuff"][buff.name] and allyBuffs["AuraDebuff"][buff.name].effectMult / 100 > mult then
 								mult = 0
 							end

--- a/src/Modules/CalcPerform.lua
+++ b/src/Modules/CalcPerform.lua
@@ -2036,10 +2036,10 @@ function calcs.perform(env, avoidCache, fullDPSSkipEHP)
 						local inc = skillModList:Sum("INC", skillCfg, "AuraEffect", "BuffEffect")
 						local more = skillModList:More(skillCfg, "AuraEffect", "BuffEffect")
 						local mult = (1 + inc / 100) * more
-						local newModlist = new("ModList")
-						newModlist:AddList(buff.modList)
-						newModlist:AddList(extraAuraModList)
-						buffExports["Aura"][buff.name] = { effectMult = mult, modList = newModlist }
+						local newModList = new("ModList")
+						newModList:AddList(buff.modList)
+						newModList:AddList(extraAuraModList)
+						buffExports["Aura"][buff.name] = { effectMult = mult, modList = newModList }
 					end
 					if env.player.mainSkill.skillFlags.totem and not (modDB:Flag(nil, "SelfAurasCannotAffectAllies") or modDB:Flag(nil, "SelfAuraSkillsCannotAffectAllies")) then
 						activeSkill.totemBuffSkill = true
@@ -3688,8 +3688,8 @@ function calcs.perform(env, avoidCache, fullDPSSkipEHP)
 		enemyDB:NewMod("DamageTaken", "INC", enemyDB:Sum("INC", nil, "DamageTakenConsecratedGround") * effect, "Consecrated Ground")
 	end
 	
-	-- Export modifiers to enemy conditons and stats for party tab
-	if env.build.partyTab.enableExportBuffs then
+	-- Export modifiers to enemy conditions and stats for party tab
+	if env.build.partyTab.enableExportBuffs and false then -- disabled for now
 		for k, v in pairs(enemyDB.mods) do
 			if k:find("Condition") and not k:find("Party") then
 				buffExports["EnemyConditions"][k] = true
@@ -3700,8 +3700,6 @@ function calcs.perform(env, avoidCache, fullDPSSkipEHP)
 				for k2, v2 in ipairs(v) do
 					if not v2.party and v2.value ~= 0 and v2.source ~= "EnemyConfig" and not v2.source:find("Delirious") and not (v2[1] and v2[1].effectType == "Curse") then
 						if not v2[1] or ((v2[1].type ~= "Condition" or (enemyDB.mods["Condition:"..v2[1].var] and enemyDB.mods["Condition:"..v2[1].var][1].value)) and (v2[1].type ~= "Multiplier" or (enemyDB.mods["Multiplier:"..v2[1].var] and enemyDB.mods["Multiplier:"..v2[1].var][1].value))) then
-							--ConPrintf(k)
-							--ConPrintTable(v2)
 							buffExports["EnemyMods"][k] = v2
 						end
 					end

--- a/src/Modules/CalcPerform.lua
+++ b/src/Modules/CalcPerform.lua
@@ -3687,14 +3687,14 @@ function calcs.perform(env, avoidCache, fullDPSSkipEHP)
 	
 	if env.build.partyTab.enableExportBuffs then
 		for k, v in pairs(enemyDB.mods) do
-			if (k:find("Condition")) then
+			if k:find("Condition") and not k:find("Party") then
 				buffExports["EnemyConditions"][k] = true
 			end
 		end
 		for k, v in pairs(enemyDB.mods) do
 			if (k:find("Resist") and not k:find("Totem") and not k:find("Max")) or k:find("Damage") or k:find("ActionSpeed") or k:find("SelfCrit") or (k:find("Multiplier") and not k:find("Max") and not k:find("Impale")) then
 				for k2, v2 in ipairs(v) do
-					if v2.value ~= 0 and not (v2[1] and v2[1].effectType == "Curse") then
+					if not v2.party and v2.value ~= 0 and not (v2[1] and v2[1].effectType == "Curse") then
 						if not v2[1] or ((v2[1].type ~= "Condition" or (enemyDB.mods["Condition:"..v2[1].var] and enemyDB.mods["Condition:"..v2[1].var][1].value)) and (v2[1].type ~= "Multiplier" or (enemyDB.mods["Multiplier:"..v2[1].var] and enemyDB.mods["Multiplier:"..v2[1].var][1].value))) then
 							--ConPrintf(k)
 							--ConPrintTable(v2)

--- a/src/Modules/CalcPerform.lua
+++ b/src/Modules/CalcPerform.lua
@@ -3600,6 +3600,7 @@ function calcs.perform(env, avoidCache, fullDPSSkipEHP)
 			end
 			totemMod.name = totemModName
 			modDB:AddMod(totemMod)
+		end
 	end
 	if allyBuffs["extraAura"] then
 		for _, buff in pairs(allyBuffs["extraAura"]) do

--- a/src/Modules/CalcPerform.lua
+++ b/src/Modules/CalcPerform.lua
@@ -3697,7 +3697,7 @@ function calcs.perform(env, avoidCache, fullDPSSkipEHP)
 		for k, v in pairs(enemyDB.mods) do
 			if (k:find("Resist") and not k:find("Totem") and not k:find("Max")) or k:find("Damage") or k:find("ActionSpeed") or k:find("SelfCrit") or (k:find("Multiplier") and not k:find("Max") and not k:find("Impale")) then
 				for k2, v2 in ipairs(v) do
-					if not v2.party and v2.value ~= 0 and not (v2[1] and v2[1].effectType == "Curse") then
+					if not v2.party and v2.value ~= 0 and v2.source ~= "EnemyConfig" and not v2.source:find("Delirious") and not (v2[1] and v2[1].effectType == "Curse") then
 						if not v2[1] or ((v2[1].type ~= "Condition" or (enemyDB.mods["Condition:"..v2[1].var] and enemyDB.mods["Condition:"..v2[1].var][1].value)) and (v2[1].type ~= "Multiplier" or (enemyDB.mods["Multiplier:"..v2[1].var] and enemyDB.mods["Multiplier:"..v2[1].var][1].value))) then
 							--ConPrintf(k)
 							--ConPrintTable(v2)

--- a/src/Modules/CalcSetup.lua
+++ b/src/Modules/CalcSetup.lua
@@ -498,6 +498,9 @@ function calcs.initEnv(build, mode, override, specEnv)
 		-- Add mods from the config tab
 		env.modDB:AddList(build.configTab.modList)
 		env.enemyDB:AddList(build.configTab.enemyModList)
+		
+		-- Add mods from the party tab
+		env.enemyDB:AddList(build.partyTab.enemyModList)
 
 		cachedPlayerDB, cachedEnemyDB, cachedMinionDB = specCopy(env)
 	else

--- a/src/Modules/ConfigOptions.lua
+++ b/src/Modules/ConfigOptions.lua
@@ -1722,19 +1722,19 @@ Huge sets the radius to 11.
 		end
 	end },
 	{ var = "enemyPhysicalReduction", type = "integer", label = "Enemy Phys. Damage Reduction:", apply = function(val, modList, enemyModList)
-		enemyModList:NewMod("PhysicalDamageReduction", "BASE", val, "EnemyConfig")
+		enemyModList:NewMod("PhysicalDamageReduction", "BASE", val, "Config")
 	end },
 	{ var = "enemyLightningResist", type = "integer", label = "Enemy ^xADAA47Lightning Resistance:", apply = function(val, modList, enemyModList)
-		enemyModList:NewMod("LightningResist", "BASE", val, "EnemyConfig")
+		enemyModList:NewMod("LightningResist", "BASE", val, "Config")
 	end },
 	{ var = "enemyColdResist", type = "integer", label = "Enemy ^x3F6DB3Cold Resistance:", apply = function(val, modList, enemyModList)
-		enemyModList:NewMod("ColdResist", "BASE", val, "EnemyConfig")
+		enemyModList:NewMod("ColdResist", "BASE", val, "Config")
 	end },
 	{ var = "enemyFireResist", type = "integer", label = "Enemy ^xB97123Fire Resistance:", apply = function(val, modList, enemyModList)
-		enemyModList:NewMod("FireResist", "BASE", val, "EnemyConfig")
+		enemyModList:NewMod("FireResist", "BASE", val, "Config")
 	end },
 	{ var = "enemyChaosResist", type = "integer", label = "Enemy ^xD02090Chaos Resistance:", apply = function(val, modList, enemyModList)
-		enemyModList:NewMod("ChaosResist", "BASE", val, "EnemyConfig")
+		enemyModList:NewMod("ChaosResist", "BASE", val, "Config")
 	end },
 	{ var = "enemyBlockChance", type = "integer", label = "Enemy Block Chance:", apply = function(val, modList, enemyModList)
 		enemyModList:NewMod("BlockChance", "BASE", val, "Config")

--- a/src/Modules/ConfigOptions.lua
+++ b/src/Modules/ConfigOptions.lua
@@ -1722,19 +1722,19 @@ Huge sets the radius to 11.
 		end
 	end },
 	{ var = "enemyPhysicalReduction", type = "integer", label = "Enemy Phys. Damage Reduction:", apply = function(val, modList, enemyModList)
-		enemyModList:NewMod("PhysicalDamageReduction", "BASE", val, "Config")
+		enemyModList:NewMod("PhysicalDamageReduction", "BASE", val, "EnemyConfig")
 	end },
 	{ var = "enemyLightningResist", type = "integer", label = "Enemy ^xADAA47Lightning Resistance:", apply = function(val, modList, enemyModList)
-		enemyModList:NewMod("LightningResist", "BASE", val, "Config")
+		enemyModList:NewMod("LightningResist", "BASE", val, "EnemyConfig")
 	end },
 	{ var = "enemyColdResist", type = "integer", label = "Enemy ^x3F6DB3Cold Resistance:", apply = function(val, modList, enemyModList)
-		enemyModList:NewMod("ColdResist", "BASE", val, "Config")
+		enemyModList:NewMod("ColdResist", "BASE", val, "EnemyConfig")
 	end },
 	{ var = "enemyFireResist", type = "integer", label = "Enemy ^xB97123Fire Resistance:", apply = function(val, modList, enemyModList)
-		enemyModList:NewMod("FireResist", "BASE", val, "Config")
+		enemyModList:NewMod("FireResist", "BASE", val, "EnemyConfig")
 	end },
 	{ var = "enemyChaosResist", type = "integer", label = "Enemy ^xD02090Chaos Resistance:", apply = function(val, modList, enemyModList)
-		enemyModList:NewMod("ChaosResist", "BASE", val, "Config")
+		enemyModList:NewMod("ChaosResist", "BASE", val, "EnemyConfig")
 	end },
 	{ var = "enemyBlockChance", type = "integer", label = "Enemy Block Chance:", apply = function(val, modList, enemyModList)
 		enemyModList:NewMod("BlockChance", "BASE", val, "Config")

--- a/src/Modules/Main.lua
+++ b/src/Modules/Main.lua
@@ -1003,7 +1003,7 @@ function main:OpenAboutPopup()
 								t_insert(helpList, { height = 12, "^7"..outdent, "^7"..indent })
 							end
 						else
-							local Lines = self:WrapString(line, 12, 610)
+							local Lines = self:WrapString(line, 12, 560)
 							for i, line2 in ipairs(Lines) do
 								t_insert(helpList, { height = 12, "^7"..(i > 1 and "    " or "")..line2 })
 							end

--- a/src/Modules/ModTools.lua
+++ b/src/Modules/ModTools.lua
@@ -47,6 +47,75 @@ end
 
 modLib.parseMod, modLib.parseModCache = LoadModule("Modules/ModParser", launch)
 
+function modLib.parseTags(line, currentModType)
+	 -- should parse this correctly instead of string match
+	if not line then
+		return "none", {}
+	end
+	local extraTags = {}
+	local modType = currentModType
+	for line2 in line:gmatch("([^,]*),?") do
+		if line2:find("type=GlobalEffect/") then
+			if line2:find("type=GlobalEffect/effectType=AuraDebuff") then
+				t_insert(extraTags, {
+					type = "GlobalEffect",
+					effectType = "AuraDebuff"
+				})
+				modType = "AuraDebuff"
+			elseif line2:find("type=GlobalEffect/effectType=Aura") then
+				t_insert(extraTags, {
+					type = "GlobalEffect",
+					effectType = "Aura"
+				})
+				modType = "Aura"
+			elseif line2:find("type=GlobalEffect/effectType=Curse") then
+				t_insert(extraTags, {
+					type = "GlobalEffect",
+					effectType = "Curse"
+				})
+				modType = "Curse"
+			end
+		elseif line2:find("type=Condition/") then
+			if line2:find("type=Condition/neg=true/var=RareOrUnique") then
+				t_insert(extraTags, {
+					type = "Condition",
+					neg = true,
+					var = "RareOrUnique"
+				})
+			elseif line2:find("type=Condition/var=RareOrUnique") then
+				t_insert(extraTags, {
+					type = "Condition",
+					var = "RareOrUnique"
+				})
+			end
+		end
+	end
+	return modType, extraTags
+end
+
+function modLib.parseFormatedSourceMod(line, currentModType)
+	local modStrings = {}
+	for line2 in line:gmatch("([^|]*)|?") do
+		t_insert(modStrings, line2)
+	end
+	if #modStrings >= 4 then
+		local mod = {
+			value = (modStrings[1] == "true" and true) or tonumber(modStrings[1]) or 0,
+			source = modStrings[2],
+			name = modStrings[3],
+			type = modStrings[4],
+			flags = ModFlag[modStrings[5]] or 0,
+			keywordFlags = KeywordFlag[modStrings[6]] or 0,
+		}
+		local modType, Tags = modLib.parseTags(modStrings[7], currentModType)
+		for _, tag in ipairs(Tags) do
+			t_insert(mod, tag)
+		end
+		return modType, mod
+	end
+	return currentModType, nil
+end
+
 function modLib.compareModParams(modA, modB)
 	if modA.name ~= modB.name or modA.type ~= modB.type or modA.flags ~= modB.flags or modA.keywordFlags ~= modB.keywordFlags or #modA ~= #modB then
 		return false
@@ -159,6 +228,10 @@ end
 
 function modLib.formatMod(mod)
 	return modLib.formatValue(mod.value) .. " = " .. modLib.formatModParams(mod)
+end
+
+function modLib.formatSourceMod(mod)
+    return s_format("%s|%s|%s", mod.value, mod.source, modLib.formatModParams(mod))
 end
 
 function modLib.setSource(mod, source)

--- a/src/Modules/ModTools.lua
+++ b/src/Modules/ModTools.lua
@@ -93,7 +93,7 @@ function modLib.parseTags(line, currentModType)
 	return modType, extraTags
 end
 
-function modLib.parseFormatedSourceMod(line, currentModType)
+function modLib.parseFormattedSourceMod(line, currentModType)
 	local modStrings = {}
 	for line2 in line:gmatch("([^|]*)|?") do
 		t_insert(modStrings, line2)


### PR DESCRIPTION
This adds support for auras, aura debuffs and curses, all of which should be fully supported other than some condition tags and any stack variables (eg mine auras)
It also adds support for extra auras like tailwind and mana guardian and these seem to work correctly

"function modLib:parseTags" needs to be modified to correctly grab tags like conditions etc

So far the only missing one seems to be Slipstream but this could be because its applied by a minion and none of the minion mods are exported

It also adds support for enemy conditions and multipliers are modifiers, these are not handled well atm but will apply
Conditions are tagged as "Condition:Party:" instead for later filtering
The modifiers added are missing their mod tags (things like conditions etc) and thus always apply

The export was for them was disabled due to issues but will be added back in a future update
