### PR TITLE
FIX: Ailement mods from skill active skill gems not applying

### DIFF
--- a/src/Modules/CalcPerform.lua
+++ b/src/Modules/CalcPerform.lua
@@ -3049,7 +3049,7 @@ function calcs.perform(env, avoidCache)
 				end
 				override = m_max(override, effect or 0)
 			end
-			output["Maximum"..ailment] = modDB:Override(nil, ailment.."Max") or (ailmentData[ailment].max + modDB:Sum("BASE", nil, ailment.."Max"))
+			output["Maximum"..ailment] = modDB:Override(nil, ailment.."Max") or (ailmentData[ailment].max + modDB:Sum("BASE", nil, ailment.."Max") + env.player.mainSkill.baseSkillModList:Sum("BASE", nil, ailment.."Max"))
 			output["Current"..ailment] = m_floor(m_min(m_max(override, enemyDB:Sum("BASE", nil, ailment.."Val")), output["Maximum"..ailment]) * (10 ^ ailmentData[ailment].precision)) / (10 ^ ailmentData[ailment].precision)
 			for _, mod in ipairs(val.mods(output["Current"..ailment])) do
 				enemyDB:AddMod(mod)


### PR DESCRIPTION
Fixes #5000  .

### Description of the problem being solved:
The issue is that mods from active skill gems are not in env.modDB and thus the Sum function returns 0. Looking for ailment mods in env.player.mainSkill.baseSkillModList resolves the issue but i'm not sure if it's the correct approach to solving this.
