### PR TITLE
Fix Skill Costs

### DIFF
--- a/src/Classes/ModList.lua
+++ b/src/Classes/ModList.lua
@@ -95,17 +95,19 @@ end
 function ModListClass:MoreInternal(context, cfg, flags, keywordFlags, source, ...)
 	local result = 1
 	for i = 1, select('#', ...) do
+		local modResult = 1 --The more multipliers for each mod are computed to the nearest percent then applied.
 		local modName = select(i, ...)
 		for i = 1, #self do
 			local mod = self[i]
 			if mod.name == modName and mod.type == "MORE" and band(flags, mod.flags) == mod.flags and MatchKeywordFlags(keywordFlags, mod.keywordFlags) and (not source or mod.source:match("[^:]+") == source) then
 				if mod[1] then
-					result = result * (1 + (context:EvalMod(mod, cfg) or 0) / 100)
+					modResult = modResult * (1 + (context:EvalMod(mod, cfg) or 0) / 100)
 				else
-					result = result * (1 + mod.value / 100)
+					modResult = modResult * (1 + mod.value / 100)
 				end
 			end
 		end
+		result = result * round(modResult,2)
 	end
 	if self.parent then
 		result = result * self.parent:MoreInternal(context, cfg, flags, keywordFlags, source, ...)


### PR DESCRIPTION
Fixes https://github.com/PathOfBuildingCommunity/PathOfBuilding/issues/5007.

### Description of the problem being solved:
Mana cost was applying to mana and divine blessing wasn't handled correctly with blood magic or life as extra cost of mana

There are some really weird rounding issues. That I don't know how to fix so these calculations are often off by one when gem mana multipliers are in play.

Lifetap / Petrified Blood Implemenation could be converted to be more generic as if in the future we saw mana to es conversion or similar.

### Steps taken to verify a working solution:
- Total cost only applies for the resource with no conversions
- % cost correctly still doesn't apply for bloodmagic divine blessing
- flat aura and extra mana cost behave correctly
- Blood magic still overrides life as extra cost of mana.

https://pastebin.com/tft9bXja

Petrified Blood
![image](https://user-images.githubusercontent.com/31533893/187358995-d1a80cda-9014-4a0f-b8fb-0bd28a8d654b.png)
![image](https://user-images.githubusercontent.com/31533893/187359198-b3a0fb76-61cd-498c-8771-08b14dbb216d.png)
![image](https://user-images.githubusercontent.com/31533893/187359167-8d7f7a9c-80a1-4477-92b3-e0b13e4c7d01.png)

Blood Magic
![image](https://user-images.githubusercontent.com/31533893/187359482-1f1f0d7b-01ba-46c4-afdb-94172c82182f.png)
![image](https://user-images.githubusercontent.com/31533893/187359323-699d867e-44cc-498a-84b5-8fd6e76be953.png)
![image](https://user-images.githubusercontent.com/31533893/187359347-6bbccf39-ed09-499c-8f3a-78806a61433e.png)
