### PR TITLE
Implement parsing for some currently unsupported reflected mods.

### DIFF
--- a/src/Modules/CalcDefence.lua
+++ b/src/Modules/CalcDefence.lua
@@ -913,6 +913,7 @@ function calcs.defence(env, actor)
 		local enemyCritChance = env.configInput["enemyCritChance"] or env.configPlaceholder["enemyCritChance"] or 0
 		local enemyCritDamage = env.configInput["enemyCritDamage"] or env.configPlaceholder["enemyCritDamage"] or 0
 		output["EnemyCritEffect"] = 1 + enemyCritChance / 100 * (enemyCritDamage / 100) * (1 - output.CritExtraDamageReduction / 100)
+		local enemyCfg = {keywordFlags = bit.bnot(KeywordFlag.MatchAll)} -- Match all keywordFlags parameter for enemy min-max damage mods
 		for _, damageType in ipairs(dmgTypeList) do
 			local enemyDamageMult = calcLib.mod(enemyDB, nil, "Damage", damageType.."Damage", isElemental[damageType] and "ElementalDamage" or nil) -- missing taunt from allies
 			local enemyDamage = tonumber(env.configInput["enemy"..damageType.."Damage"])
@@ -929,7 +930,10 @@ function calcs.defence(env, actor)
 			if enemyOverwhelm == nil then
 				enemyOverwhelm = tonumber(env.configPlaceholder["enemy"..damageType.."enemyOverwhelm"]) or 0
 			end
-
+			
+			-- Add min-max enemy damage from mods
+			enemyDamage = enemyDamage + (enemyDB:Sum("BASE", enemyCfg, (damageType.."Min")) + enemyDB:Sum("BASE", enemyCfg, (damageType.."Max"))) / 2
+			
 			output[damageType.."EnemyPen"] = enemyPen
 			output[damageType.."EnemyOverwhelm"] = enemyOverwhelm
 			output["totalEnemyDamageIn"] = output["totalEnemyDamageIn"] + enemyDamage

--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -48,7 +48,7 @@ local formList = {
 	["^([%+%-]?[%d%.]+)%%? of"] = "BASE",
 	["^([%+%-][%d%.]+)%%? base"] = "BASE",
 	["^([%+%-]?[%d%.]+)%%? additional"] = "BASE",
-	["cost ([%+%-]%d+) mana"] = "BASEMANACOST",
+	["cost ([%+%-]%d+)"] = "BASECOST",
 	["(%d+) additional hits?"] = "BASE",
 	["^you gain ([%d%.]+)"] = "BASE",
 	["^gains? ([%d%.]+)%% of"] = "BASE",
@@ -4308,8 +4308,11 @@ local function parseMod(line, order)
 		modType = "MORE"
 	elseif modForm == "BASE" then
 		modSuffix, line = scan(line, suffixTypes, true)
-	elseif modForm == "BASEMANACOST" then
-		modName = "ManaCost"
+	elseif modForm == "BASECOST" then
+		if not modName then
+			return { }, line
+		end
+		modName = modName.."Cost"
 		modValue = tonumber(formCap[1])
 	elseif modForm == "CHANCE" then
 	elseif modForm == "REGENPERCENT" then


### PR DESCRIPTION
Fixes #4999 Partially.

### Description of the problem being solved:
Implement some currently unsupported reflected mods.

- Hexes you inflict have -19 to maximum Doom 
    Implemented
- Adds 7 to 13 Cold Damage to Hits against you per Frenzy Charge
- The rest of generic damage against you
    Implemented with piecewise parsing using the "against you" key word.
    Might potentially cause issues in the future if "against you" is used in different contexts.
- #% of Physical Attack Damage Leeched by Enemy as Life
-  15% of Damage Leeched by Enemy as Life while Focused
- The rest of other leech types
     Not implemented.
    I don't see where it would be used currently as enemy calculations are limited and  i'm not sure how to implement cleanly.
- Curse Enemies with Flammability on Hit, with 44% reduced Effect
    Implemented
- Channelling Skills Cost +8 Mana
    Implemented
- Non-Channelling Skills Cost +13 Mana
    Implemented
- Focus has 9% reduced Cooldown Recovery Rate
    Implemented
- Hits against you gain 10% of Physical Damage as Extra Fire Damage
    Implemented. Currently not used by enemy damage calculations.
- Shock yourself for 4 Seconds when you Focus
    Implemented.
- 10% chance to lose 10% of Mana when you use a Skill
- (3-4)% chance to lose an [chargetype] Charge on Kill
     Not implemented.
    As far as i'm aware POB does not support chance mods like these.

![obraz](https://user-images.githubusercontent.com/91493239/187504290-23f18e12-08be-43a4-95d9-027e2983713d.png)
