### PR TITLE
Re-order the leagues dropdown in the import menu

### DIFF
--- a/src/Classes/ImportTab.lua
+++ b/src/Classes/ImportTab.lua
@@ -434,15 +434,15 @@ function ImportTabClass:DownloadCharacterList()
 			end
 			table.sort(leagueList)
 			wipeTable(self.controls.charSelectLeague.list)
-			t_insert(self.controls.charSelectLeague.list, {
-				label = "All",
-			})
 			for _, league in ipairs(leagueList) do
 				t_insert(self.controls.charSelectLeague.list, {
 					label = league,
 					league = league,
 				})
 			end
+			t_insert(self.controls.charSelectLeague.list, {
+				label = "All",
+			})
 			if self.controls.charSelectLeague.selIndex > #self.controls.charSelectLeague.list then
 				self.controls.charSelectLeague.selIndex = 1
 			end


### PR DESCRIPTION


### Description of the problem being solved:
For many users, after loading the account's characters, there are many characters to select from. They then have to select the current league to reduce the clutter.

### Proposed solution
Set the "All" league last so that for most people the current league
where they play in should be the first option in the dropdown.


### Steps taken to verify a working solution:
- In the import menu, select an account and click Start
- The League dropdown should default to Kalandra (for most softcore players I guess)
- The character dropdown will only contain characters from the current (Kalandra) league
