### PR TITLE
Fix POESESSID not saving to settings.xml when pressing the save button in the "Change session ID" popup.

### DIFF
--- a/src/Classes/TradeQuery.lua
+++ b/src/Classes/TradeQuery.lua
@@ -233,6 +233,7 @@ function TradeQueryClass:PriceItem()
 		poesessid_controls.save = new("ButtonControl", {"TOPRIGHT", poesessid_controls.sessionInput, "TOP"}, -8, 24, 90, row_height, "Save", function()
 			main.POESESSID = poesessid_controls.sessionInput.buf
 			main:ClosePopup()
+			main:SaveSettings()
 		end)
 		poesessid_controls.save.enabled = function() return #poesessid_controls.sessionInput.buf == 32 or poesessid_controls.sessionInput.buf == "" end
 		poesessid_controls.cancel = new("ButtonControl", {"TOPLEFT", poesessid_controls.sessionInput, "TOP"}, 8, 24, 90, row_height, "Cancel", function()


### PR DESCRIPTION
Fixes #5025 .

### Description of the problem being solved:

Settings were not saved to settings.xml after entering a new session id making it non persistent.

The session id can be saved using the save button in the options popup as a workaround.