### PR TITLE
Fix Assassian's Mark Crit not being high precision.

### DIFF
--- a/src/Modules/Data.lua
+++ b/src/Modules/Data.lua
@@ -353,6 +353,9 @@ data.nonDamagingAilment = {
 
 -- Used in ModStoreClass:ScaleAddMod(...) to identify high precision modifiers
 data.highPrecisionMods = {
+	["SelfCritChance"] = {
+		["BASE"] = true,
+	},
 	["CritChance"] = {
 		["BASE"] = true,
 	},


### PR DESCRIPTION
Fixes https://github.com/PathOfBuildingCommunity/PathOfBuilding/issues/5032

### Description of the problem being solved:
When assasian's mark gets to a whole number it's scaling behaves as a list as it wasn't in the high precision mod list.

### Link to a build that showcases this PR:
https://pobb.in/JOU5k3EjUwOk

### Before screenshot:
![image](https://user-images.githubusercontent.com/31533893/188346631-176ab63d-03bf-4a61-af14-cd6b789a91cd.png)

### After screenshot:
![image](https://user-images.githubusercontent.com/31533893/188346594-bf51d9be-93d6-42c1-bfb3-55b2f233936e.png)
