### PR TITLE
Shock effect should apply to shocked ground

### DIFF
--- a/src/Modules/CalcPerform.lua
+++ b/src/Modules/CalcPerform.lua
@@ -1225,7 +1225,8 @@ function calcs.perform(env, avoidCache)
 			modDB.multipliers["HexDoom"] =  m_min(m_max(hexDoom, modDB.multipliers["HexDoom"] or 0), output.HexDoomLimit)
 		end
 		if (activeSkill.activeEffect.grantedEffect.name == "Vaal Lightning Trap" or activeSkill.activeEffect.grantedEffect.name == "Shock Ground") then
-			local effect = activeSkill.skillModList:Sum("BASE", nil, "ShockedGroundEffect")
+			-- Shock effect applies to shocked ground
+			local effect = activeSkill.skillModList:Sum("BASE", nil, "ShockedGroundEffect") * (1 + activeSkill.skillModList:Sum("INC", nil, "EnemyShockEffect") / 100)
 			modDB:NewMod("ShockOverride", "BASE", effect, "Shocked Ground", { type = "ActorCondition", actor = "enemy", var = "OnShockedGround" } )
 		end
 		if activeSkill.skillData.supportBonechill and (activeSkill.skillTypes[SkillType.ChillingArea] or activeSkill.skillTypes[SkillType.NonHitChill] or not activeSkill.skillModList:Flag(nil, "CannotChill")) then


### PR DESCRIPTION
Fixes #5020 .

### Description of the problem being solved:
Shock effect currently does not apply to shocked ground created by the player.

### Before screenshot:
![obraz](https://user-images.githubusercontent.com/91493239/188527578-d9d7e3ec-3ace-46df-b3e1-73019a40e8c1.png)

### After screenshot:
![obraz](https://user-images.githubusercontent.com/91493239/188527503-c8a41b59-3953-42c0-afcf-bf114a52c3ea.png)
