### PR TITLE
Generalise Multistrike implemenation for shields.

### DIFF
--- a/src/Data/Skills/sup_str.lua
+++ b/src/Data/Skills/sup_str.lua
@@ -3209,7 +3209,7 @@ skills["SupportMultistrike"] = {
 	statMap = {
 		["multistrike_damage_+%_final_on_first_repeat"] = {
 			mod("Damage", "MORE", nil, nil, nil, { type = "ModFlagOr", modFlags = bit.bor(ModFlag.WeaponMelee, ModFlag.Unarmed) }),
-			mod("Damage", "MORE", nil, nil, nil, { type = "SkillName", skillName = "Shield Crush" }),
+			mod("Damage", "MORE", nil, nil, nil, { type = "SkillType", skillType = SkillType.RequiresShield }),
 		},
 		["multistrike_damage_+%_final_on_second_repeat"] = {
 		},
@@ -3218,7 +3218,7 @@ skills["SupportMultistrike"] = {
 		},
 		["support_multiple_attacks_melee_attack_speed_+%_final"] = {
 			mod("Speed", "MORE", nil, ModFlag.Attack, nil, { type = "ModFlagOr", modFlags = bit.bor(ModFlag.WeaponMelee, ModFlag.Unarmed) }),
-			mod("Speed", "MORE", nil, ModFlag.Attack, nil, { type = "SkillName", skillName = "Shield Crush" }),
+			mod("Speed", "MORE", nil, ModFlag.Attack, nil, { type = "SkillType", skillType = SkillType.RequiresShield }),
 		},
 		["multistrike_area_of_effect_+%_per_repeat"] = {
 			mod("AreaOfEffect", "INC", nil)
@@ -3309,7 +3309,7 @@ skills["SupportMultistrikePlus"] = {
 		},
 		["multistrike_damage_+%_final_on_third_repeat"] = {
 			mod("Damage", "MORE", nil, nil, nil, { type = "ModFlagOr", modFlags = bit.bor(ModFlag.WeaponMelee, ModFlag.Unarmed) }),
-			mod("Damage", "MORE", nil, nil, nil, { type = "SkillName", skillName = "Shield Crush" }),
+			mod("Damage", "MORE", nil, nil, nil, { type = "SkillType", skillType = SkillType.RequiresShield }),
 			div = 2,
 		},
 		["support_multiple_attack_damage_+%_final"] = {
@@ -3317,7 +3317,7 @@ skills["SupportMultistrikePlus"] = {
 		},
 		["support_multiple_attacks_melee_attack_speed_+%_final"] = {
 			mod("Speed", "MORE", nil, ModFlag.Attack, nil, { type = "ModFlagOr", modFlags = bit.bor(ModFlag.WeaponMelee, ModFlag.Unarmed) }),
-			mod("Speed", "MORE", nil, ModFlag.Attack, nil, { type = "SkillName", skillName = "Shield Crush" }),
+			mod("Speed", "MORE", nil, ModFlag.Attack, nil, { type = "SkillType", skillType = SkillType.RequiresShield }),
 		},
 	},
 	qualityStats = {

--- a/src/Export/Skills/sup_str.txt
+++ b/src/Export/Skills/sup_str.txt
@@ -369,7 +369,7 @@ local skills, mod, flag, skill = ...
 	statMap = {
 		["multistrike_damage_+%_final_on_first_repeat"] = {
 			mod("Damage", "MORE", nil, nil, nil, { type = "ModFlagOr", modFlags = bit.bor(ModFlag.WeaponMelee, ModFlag.Unarmed) }),
-			mod("Damage", "MORE", nil, nil, nil, { type = "SkillName", skillName = "Shield Crush" }),
+			mod("Damage", "MORE", nil, nil, nil, { type = "SkillType", skillType = SkillType.RequiresShield }),
 		},
 		["multistrike_damage_+%_final_on_second_repeat"] = {
 		},
@@ -378,7 +378,7 @@ local skills, mod, flag, skill = ...
 		},
 		["support_multiple_attacks_melee_attack_speed_+%_final"] = {
 			mod("Speed", "MORE", nil, ModFlag.Attack, nil, { type = "ModFlagOr", modFlags = bit.bor(ModFlag.WeaponMelee, ModFlag.Unarmed) }),
-			mod("Speed", "MORE", nil, ModFlag.Attack, nil, { type = "SkillName", skillName = "Shield Crush" }),
+			mod("Speed", "MORE", nil, ModFlag.Attack, nil, { type = "SkillType", skillType = SkillType.RequiresShield }),
 		},
 		["multistrike_area_of_effect_+%_per_repeat"] = {
 			mod("AreaOfEffect", "INC", nil)
@@ -395,7 +395,7 @@ local skills, mod, flag, skill = ...
 		},
 		["multistrike_damage_+%_final_on_third_repeat"] = {
 			mod("Damage", "MORE", nil, nil, nil, { type = "ModFlagOr", modFlags = bit.bor(ModFlag.WeaponMelee, ModFlag.Unarmed) }),
-			mod("Damage", "MORE", nil, nil, nil, { type = "SkillName", skillName = "Shield Crush" }),
+			mod("Damage", "MORE", nil, nil, nil, { type = "SkillType", skillType = SkillType.RequiresShield }),
 			div = 2,
 		},
 		["support_multiple_attack_damage_+%_final"] = {
@@ -403,7 +403,7 @@ local skills, mod, flag, skill = ...
 		},
 		["support_multiple_attacks_melee_attack_speed_+%_final"] = {
 			mod("Speed", "MORE", nil, ModFlag.Attack, nil, { type = "ModFlagOr", modFlags = bit.bor(ModFlag.WeaponMelee, ModFlag.Unarmed) }),
-			mod("Speed", "MORE", nil, ModFlag.Attack, nil, { type = "SkillName", skillName = "Shield Crush" }),
+			mod("Speed", "MORE", nil, ModFlag.Attack, nil, { type = "SkillType", skillType = SkillType.RequiresShield }),
 		},
 	},
 #mods


### PR DESCRIPTION
### Description of the problem being solved:
We were explicitly mentioning shield crush as it is the only multistrikable shield skill. Shields don't seem to be an attack type. But use a RequiresShield skilltype to display this. This swaps the explict shield crush condtion but doesn't elegantly resolve this issue. as it still requires two lines.
https://pobb.in/fpdwOfPuAyFI