### PR TITLE
Fix count being nil when importing a build and add default altQu…

### DIFF
--- a/src/Classes/SkillsTab.lua
+++ b/src/Classes/SkillsTab.lua
@@ -604,8 +604,8 @@ function SkillsTabClass:CreateGemSlot(index)
 		slot.qualityId.list = self:getGemAltQualityList(gemInstance.gemData)
 		slot.qualityId:SelByValue(qualityId or "Default", "type")
 		gemInstance.qualityId = qualityId or "Default"
-		slot.level:SetText(tostring(gemInstance.level))
-		slot.count:SetText(tostring(gemInstance.count))
+		slot.level:SetText(gemInstance.level)
+		slot.count:SetText(gemInstance.count)
 		if addUndo then
 			self:AddUndoState()
 		end
@@ -908,7 +908,7 @@ function SkillsTabClass:getGemAltQualityList(gemData)
 			t_insert(altQualList, entry)
 		end
 	end
-	return altQualList
+	return #altQualList > 0 and altQualList or {{ label = "Default", type = "Default" }}
 end
 
 -- Update the gem slot controls to reflect the currently displayed socket group
@@ -927,7 +927,7 @@ function SkillsTabClass:UpdateGemSlots()
 			slot.quality:SetText("")
 			slot.qualityId:SelByValue("Default", "type")
 			slot.enabled.state = false
-			slot.count:SetText("")
+			slot.count:SetText(1)
 		else
 			slot.nameSpec.inactiveCol = self.displayGroup.gemList[slotIndex].color
 		end
@@ -1078,7 +1078,7 @@ function SkillsTabClass:SetDisplayGroup(socketGroup)
 			self.gemSlots[index].enabled.state = gemInstance.enabled
 			self.gemSlots[index].enableGlobal1.state = gemInstance.enableGlobal1
 			self.gemSlots[index].enableGlobal2.state = gemInstance.enableGlobal2
-			self.gemSlots[index].count:SetText(gemInstance.count)
+			self.gemSlots[index].count:SetText(gemInstance.count or 1)
 		end
 	end
 end


### PR DESCRIPTION
Fixes and issue mentioned in discord by @Nostrademous .

### Description of the problem being solved:
When importing a build the "Count" field next to the gem slot field would be nil. This pr fixes that and adds a defualt altQualList as a sane default fallback.

### Steps taken to verify a working solution:
- Import a build repeatedly

### Before screenshot:
![obraz](https://user-images.githubusercontent.com/91493239/188657541-76f4a722-5821-4998-964d-8e92e138dbde.png)

### After screenshot:
![obraz](https://user-images.githubusercontent.com/91493239/188657638-1c9878b3-0ba8-4396-a276-956f51e1961b.png)
