### PR TITLE
Calculate maximum sustainable trauma stacks

### DIFF
--- a/src/Data/Skills/act_str.lua
+++ b/src/Data/Skills/act_str.lua
@@ -1422,7 +1422,7 @@ skills["Boneshatter"] = {
 			area = true,
 		},
 	},
-	preDamageFunc = function(activeSkill, output, breakdown)
+	preDotFunc = function(activeSkill, output, breakdown)
 		local t_insert = table.insert
 		local s_format = string.format
 		local ipairs = ipairs

--- a/src/Data/Skills/act_str.lua
+++ b/src/Data/Skills/act_str.lua
@@ -1503,6 +1503,10 @@ skills["Boneshatter"] = {
 		["trauma_strike_self_damage_per_trauma"] = {
 			skill("SelfDamageTakenLife", nil),
 		},
+		["trauma_base_duration_ms"] = {
+			skill("duration", nil),
+			div = 1000,
+		},
 	},
 	baseFlags = {
 		attack = true,

--- a/src/Data/Skills/act_str.lua
+++ b/src/Data/Skills/act_str.lua
@@ -1499,6 +1499,7 @@ skills["Boneshatter"] = {
 		},
 		["attack_speed_+%_per_trauma"] = {
 			mod("Speed", "INC", nil, ModFlag.Attack, 0, { type = "Multiplier", var = "TraumaStacks" }),
+			mod("SpeedPerTrauma", "INC", nil, ModFlag.Attack, 0),
 		},
 		["trauma_strike_self_damage_per_trauma"] = {
 			skill("SelfDamageTakenLife", nil),

--- a/src/Export/Skills/act_str.txt
+++ b/src/Export/Skills/act_str.txt
@@ -281,7 +281,7 @@ local skills, mod, flag, skill = ...
 			area = true,
 		},
 	},
-	preDamageFunc = function(activeSkill, output, breakdown)
+	preDotFunc = function(activeSkill, output, breakdown)
 		local t_insert = table.insert
 		local s_format = string.format
 		local ipairs = ipairs

--- a/src/Export/Skills/act_str.txt
+++ b/src/Export/Skills/act_str.txt
@@ -358,6 +358,7 @@ local skills, mod, flag, skill = ...
 		},
 		["attack_speed_+%_per_trauma"] = {
 			mod("Speed", "INC", nil, ModFlag.Attack, 0, { type = "Multiplier", var = "TraumaStacks" }),
+			mod("SpeedPerTrauma", "INC", nil, ModFlag.Attack, 0),
 		},
 		["trauma_strike_self_damage_per_trauma"] = {
 			skill("SelfDamageTakenLife", nil),

--- a/src/Export/Skills/act_str.txt
+++ b/src/Export/Skills/act_str.txt
@@ -362,6 +362,10 @@ local skills, mod, flag, skill = ...
 		["trauma_strike_self_damage_per_trauma"] = {
 			skill("SelfDamageTakenLife", nil),
 		},
+		["trauma_base_duration_ms"] = {
+			skill("duration", nil),
+			div = 1000,
+		},
 	},
 #baseMod skill("radius", 14, { type = "SkillPart", skillPart = 2 })
 #mods

--- a/src/Modules/Build.lua
+++ b/src/Modules/Build.lua
@@ -265,6 +265,7 @@ function buildMode:Init(dbFileName, buildName, buildXML, convertBuild)
 	-- This defines the stats in the side bar, and also which stats show in node/item comparisons
 	-- This may be user-customisable in the future
 	self.displayStats = {
+		{ stat = "SustainableTrauma", label = "Sustainable Trauma", fmt = "d", color = colorCodes.RAGE },
 		{ stat = "ActiveMinionLimit", label = "Active Minion Limit", fmt = "d" },
 		{ stat = "AverageHit", label = "Average Hit", fmt = ".1f", compPercent = true },
 		{ stat = "PvpAverageHit", label = "PvP Average Hit", fmt = ".1f", compPercent = true, flag = "isPvP" },
@@ -318,7 +319,6 @@ function buildMode:Init(dbFileName, buildName, buildXML, convertBuild)
 		{ stat = "AreaOfEffectRadius", label = "AoE Radius", fmt = "d" },
 		{ stat = "BrandAttachmentRange", label = "Attachment Range", fmt = "d", flag = "brand" },
 		{ stat = "BrandTicks", label = "Activations per Brand", fmt = "d", flag = "brand" },
-		{ stat = "Trauma", label = "Trauma", fmt = "d" },
 		{ stat = "ManaCost", label = "Mana Cost", fmt = "d", color = colorCodes.MANA, compPercent = true, lowerIsBetter = true, condFunc = function(v,o) return o.ManaHasCost end },
 		{ stat = "LifeCost", label = "Life Cost", fmt = "d", color = colorCodes.LIFE, compPercent = true, lowerIsBetter = true, condFunc = function(v,o) return o.LifeHasCost end },
 		{ stat = "ESCost", label = "Energy Shield Cost", fmt = "d", color = colorCodes.ES, compPercent = true, lowerIsBetter = true, condFunc = function(v,o) return o.ESHasCost end },

--- a/src/Modules/Build.lua
+++ b/src/Modules/Build.lua
@@ -265,7 +265,7 @@ function buildMode:Init(dbFileName, buildName, buildXML, convertBuild)
 	-- This defines the stats in the side bar, and also which stats show in node/item comparisons
 	-- This may be user-customisable in the future
 	self.displayStats = {
-		{ stat = "SustainableTrauma", label = "Sustainable Trauma", fmt = "d", color = colorCodes.RAGE },
+		{ stat = "SustainableTrauma", label = "Sustainable Trauma", fmt = "d", color = colorCodes.PHYS },
 		{ stat = "ActiveMinionLimit", label = "Active Minion Limit", fmt = "d" },
 		{ stat = "AverageHit", label = "Average Hit", fmt = ".1f", compPercent = true },
 		{ stat = "PvpAverageHit", label = "PvP Average Hit", fmt = ".1f", compPercent = true, flag = "isPvP" },

--- a/src/Modules/Build.lua
+++ b/src/Modules/Build.lua
@@ -265,7 +265,6 @@ function buildMode:Init(dbFileName, buildName, buildXML, convertBuild)
 	-- This defines the stats in the side bar, and also which stats show in node/item comparisons
 	-- This may be user-customisable in the future
 	self.displayStats = {
-		{ stat = "SustainableTrauma", label = "Sustainable Trauma", fmt = "d", color = colorCodes.PHYS },
 		{ stat = "ActiveMinionLimit", label = "Active Minion Limit", fmt = "d" },
 		{ stat = "AverageHit", label = "Average Hit", fmt = ".1f", compPercent = true },
 		{ stat = "PvpAverageHit", label = "PvP Average Hit", fmt = ".1f", compPercent = true, flag = "isPvP" },

--- a/src/Modules/Build.lua
+++ b/src/Modules/Build.lua
@@ -318,6 +318,7 @@ function buildMode:Init(dbFileName, buildName, buildXML, convertBuild)
 		{ stat = "AreaOfEffectRadius", label = "AoE Radius", fmt = "d" },
 		{ stat = "BrandAttachmentRange", label = "Attachment Range", fmt = "d", flag = "brand" },
 		{ stat = "BrandTicks", label = "Activations per Brand", fmt = "d", flag = "brand" },
+		{ stat = "Trauma", label = "Trauma", fmt = "d" },
 		{ stat = "ManaCost", label = "Mana Cost", fmt = "d", color = colorCodes.MANA, compPercent = true, lowerIsBetter = true, condFunc = function(v,o) return o.ManaHasCost end },
 		{ stat = "LifeCost", label = "Life Cost", fmt = "d", color = colorCodes.LIFE, compPercent = true, lowerIsBetter = true, condFunc = function(v,o) return o.LifeHasCost end },
 		{ stat = "ESCost", label = "Energy Shield Cost", fmt = "d", color = colorCodes.ES, compPercent = true, lowerIsBetter = true, condFunc = function(v,o) return o.ESHasCost end },

--- a/src/Modules/CalcOffence.lua
+++ b/src/Modules/CalcOffence.lua
@@ -1612,10 +1612,7 @@ function calcs.offence(env, actor, activeSkill)
 				local configTrauma = skillModList:Sum("BASE", skillCfg, "Multiplier:TraumaStacks")
 				local inc = skillModList:Sum("INC", cfg, "Speed") - incAttackSpeedPerTrauma * configTrauma -- remove trauma attack speed added by config.
 				local attackSpeedBeforeInc = 1 / baseTime * globalOutput.ActionSpeedMod * more
-				local incAttackSpeedPerTraumaCap = 0
-				if m_min(attackSpeedBeforeInc * (1 + inc / 100), effectiveAttackRateCap) < effectiveAttackRateCap then
-					incAttackSpeedPerTraumaCap = (effectiveAttackRateCap - attackSpeedBeforeInc * (1 + inc / 100)) / attackSpeedBeforeInc * 100
-				end
+				local incAttackSpeedPerTraumaCap = (effectiveAttackRateCap - attackSpeedBeforeInc * (1 + inc / 100)) / attackSpeedBeforeInc * 100
 				local traumaRateBeforeInc = traumaPerAttack * (output.HitChance / 100) * attackSpeedBeforeInc / output.Repeats
 				local trauma = traumaRateBeforeInc * (1 + inc / 100) / ( 1 / duration - traumaRateBeforeInc * incAttackSpeedPerTrauma / 100 )
 				local traumaBreakdown = trauma

--- a/src/Modules/CalcOffence.lua
+++ b/src/Modules/CalcOffence.lua
@@ -1604,12 +1604,13 @@ function calcs.offence(env, actor, activeSkill)
 
 			--Calculates the max number of trauma stacks you can sustain
 			if activeSkill.activeEffect.grantedEffect.name == "Boneshatter" then
-				local speedPerTrauma = skillModList:Sum("INC", skillCfg, "SpeedPerTrauma")
 				local duration = calcSkillDuration(activeSkill.skillModList, activeSkill.skillCfg, activeSkill.skillData, env, enemyDB)
 				local traumaPerAttack = 1 + m_min(skillModList:Sum("BASE", cfg, "ExtraTrauma"), 100) / 100
-				-- compute trauma using exact form.
-				local effectiveRate = traumaPerAttack * output.HitChance / 100 / baseTime * more * globalOutput.ActionSpeedMod / output.Repeats
-				local trauma = effectiveRate * (1 + inc / 100)  / ( 1 / duration - effectiveRate * speedPerTrauma / 100 )
+				local incAttackSpeedPerTrauma = skillModList:Sum("INC", skillCfg, "SpeedPerTrauma")
+				-- compute trauma using an exact form.
+				local attackSpeedBeforeInc = 1 / baseTime * globalOutput.ActionSpeedMod * more
+				local traumaRateBeforeInc = traumaPerAttack * (output.HitChance / 100) * attackSpeedBeforeInc / output.Repeats
+				local trauma = traumaRateBeforeInc * (1 + inc / 100) / ( 1 / duration - traumaRateBeforeInc * incAttackSpeedPerTrauma / 100 )
 				skillModList:NewMod("Multiplier:SustainableTraumaStacks", "BASE", trauma, "Maximum Sustainable Trauma Stacks")
 			end
 			if skillModList:Sum("BASE", skillCfg, "Multiplier:TraumaStacks") == 0 then

--- a/src/Modules/CalcOffence.lua
+++ b/src/Modules/CalcOffence.lua
@@ -1643,7 +1643,9 @@ function calcs.offence(env, actor, activeSkill)
 							{ "%.2f ^8(chance to hit)", (output.HitChance / 100) },
 							{ "%.2f ^8(duration)", duration }
 						})
-						t_insert(storedSustainedTraumaBreakdown, s_format("/ %.2f ^8(repeats)", output.Repeats))
+						if output.Repeats ~= 1 then
+							t_insert(storedSustainedTraumaBreakdown, s_format("/ %.2f ^8(repeats)", output.Repeats))
+						end
 					else
 						breakdown.multiChain(storedSustainedTraumaBreakdown, {
 							label = "Attack Speed before increased Attack Speed",
@@ -1658,14 +1660,16 @@ function calcs.offence(env, actor, activeSkill)
 							{ "%.2f ^8(trauma per attack)", traumaPerAttack },
 							{ "%.2f ^8(chance to hit)", (output.HitChance / 100) },
 						})
-						t_insert(storedSustainedTraumaBreakdown, s_format("/ %.2f ^8(repeats)", output.Repeats))
+						if output.Repeats ~= 1 then
+							t_insert(storedSustainedTraumaBreakdown, s_format("/ %.2f ^8(repeats)", output.Repeats))
+						end
 						t_insert(storedSustainedTraumaBreakdown, s_format("= %.2f ^8trauma per second", traumaRateBeforeInc))
 						t_insert(storedSustainedTraumaBreakdown, "Trauma")
 						t_insert(storedSustainedTraumaBreakdown, s_format("%.2f ^8(base)", traumaRateBeforeInc))
 						t_insert(storedSustainedTraumaBreakdown, s_format("x %.2f ^8(increased/reduced)", (1 + inc / 100)))
 						t_insert(storedSustainedTraumaBreakdown, s_format("/ %.4f ^8(1 / duration - trauma per second * increased attack speed per trauma / 100)", ( 1 / duration - traumaRateBeforeInc * incAttackSpeedPerTrauma / 100 )))
 					end
-					t_insert(storedSustainedTraumaBreakdown, s_format("= "..(invalid and "^1" or "").."%d ^8(trauma)", traumaBreakdown))
+					t_insert(storedSustainedTraumaBreakdown, s_format("= "..(invalid and "^1" or "").."%d ^8trauma", traumaBreakdown))
 					if invalid then
 						t_insert(storedSustainedTraumaBreakdown, "Attack Speed exceeds cap recalculating")
 						breakdown.multiChain(storedSustainedTraumaBreakdown, {
@@ -1674,8 +1678,10 @@ function calcs.offence(env, actor, activeSkill)
 							{ "%.2f ^8(chance to hit)", (output.HitChance / 100) },
 							{ "%.2f ^8(duration)", (duration) },
 						})
-						t_insert(storedSustainedTraumaBreakdown, s_format("/ %.2f ^8(repeats)", output.Repeats))
-						t_insert(storedSustainedTraumaBreakdown, s_format("= %d ^8(trauma)", trauma))
+						if output.Repeats ~= 1 then
+							t_insert(storedSustainedTraumaBreakdown, s_format("/ %.2f ^8(repeats)", output.Repeats))
+						end
+						t_insert(storedSustainedTraumaBreakdown, s_format("= %d ^8trauma", trauma))
 					end
 				end
 			end

--- a/src/Modules/CalcOffence.lua
+++ b/src/Modules/CalcOffence.lua
@@ -2053,6 +2053,13 @@ function calcs.offence(env, actor, activeSkill)
 			skillModList:NewMod("Multiplier:ExplosiveArrowStageAfterFirst", "BASE", maximum - 1, "Base")
 		end
 
+		--Calculates the max number of trauma stacks you can sustain
+		if activeSkill.activeEffect.grantedEffect.name == "Boneshatter" and skillModList:Sum("BASE", skillCfg, "Multiplier:TraumaStacks") == 0 then
+			local hitRate = m_floor(output.HitChance / 100 * globalOutput.Speed * globalOutput.ActionSpeedMod)
+			local duration = calcSkillDuration(activeSkill.skillModList, activeSkill.skillCfg, activeSkill.skillData, env, enemyDB)
+			skillModList:NewMod("Multiplier:TraumaStacks", "BASE", hitRate * duration, "Base")
+		end
+
 		-- Calculate crit chance, crit multiplier, and their combined effect
 		if skillModList:Flag(nil, "NeverCrit") then
 			output.PreEffectiveCritChance = 0

--- a/src/Modules/CalcOffence.lua
+++ b/src/Modules/CalcOffence.lua
@@ -1603,14 +1603,17 @@ function calcs.offence(env, actor, activeSkill)
 			output.Repeats = 1 + (skillModList:Sum("BASE", cfg, "RepeatCount") or 0)
 
 			--Calculates the max number of trauma stacks you can sustain
-			if activeSkill.activeEffect.grantedEffect.name == "Boneshatter" and skillModList:Sum("BASE", skillCfg, "Multiplier:TraumaStacks") == 0 then
+			if activeSkill.activeEffect.grantedEffect.name == "Boneshatter" then
 				local speedPerTrauma = skillModList:Sum("INC", skillCfg, "SpeedPerTrauma")
 				local duration = calcSkillDuration(activeSkill.skillModList, activeSkill.skillCfg, activeSkill.skillData, env, enemyDB)
 				local traumaPerAttack = 1 + m_min(skillModList:Sum("BASE", cfg, "ExtraTrauma"), 100) / 100
 				-- compute trauma using exact form.
 				local effectiveRate = traumaPerAttack * output.HitChance / 100 / baseTime * more * globalOutput.ActionSpeedMod / output.Repeats
 				local trauma = effectiveRate * (1 + inc / 100)  / ( 1 / duration - effectiveRate * speedPerTrauma / 100 )
-				skillModList:NewMod("Multiplier:TraumaStacks", "BASE", trauma, "Base")
+				skillModList:NewMod("Multiplier:SustainableTraumaStacks", "BASE", trauma, "Maximum Sustainable Trauma Stacks")
+			end
+			if skillModList:Sum("BASE", skillCfg, "Multiplier:TraumaStacks") == 0 then
+				skillModList:NewMod("Multiplier:TraumaStacks", "BASE", skillModList:Sum("BASE", skillCfg, "Multiplier:SustainableTraumaStacks"), "Maximum Sustainable Trauma Stacks")
 				inc = skillModList:Sum("INC", cfg, "Speed")
 			end
 			output.Speed = 1 / baseTime * round((1 + inc/100) * more, 2)
@@ -1685,7 +1688,7 @@ function calcs.offence(env, actor, activeSkill)
 		end
 	end
 
-	output.Trauma = activeSkill.activeEffect.grantedEffect.name == "Boneshatter" and skillModList:Sum("BASE", skillCfg, "Multiplier:TraumaStacks")
+	output.SustainableTrauma = activeSkill.activeEffect.grantedEffect.name == "Boneshatter" and skillModList:Sum("BASE", skillCfg, "Multiplier:SustainableTraumaStacks")
 
 	if isAttack then
 		-- Combine hit chance and attack speed

--- a/src/Modules/CalcOffence.lua
+++ b/src/Modules/CalcOffence.lua
@@ -1608,7 +1608,8 @@ function calcs.offence(env, actor, activeSkill)
 				local duration = calcSkillDuration(activeSkill.skillModList, activeSkill.skillCfg, activeSkill.skillData, env, enemyDB)
 				local traumaPerAttack = 1 + m_min(skillModList:Sum("BASE", cfg, "ExtraTrauma"), 100) / 100
 				-- compute trauma using exact form.
-				local trauma = traumaPerAttack * output.HitChance / 100 / baseTime * (1 + inc / 100) * more * globalOutput.ActionSpeedMod / output.Repeats / ( 1 / duration - traumaPerAttack * output.HitChance / 100 / baseTime * speedPerTrauma / 100 * more * globalOutput.ActionSpeedMod / output.Repeats )
+				local effectiveRate = traumaPerAttack * output.HitChance / 100 / baseTime * more * globalOutput.ActionSpeedMod / output.Repeats
+				local trauma = effectiveRate * (1 + inc / 100)  / ( 1 / duration - effectiveRate * speedPerTrauma / 100 )
 				skillModList:NewMod("Multiplier:TraumaStacks", "BASE", trauma, "Base")
 				inc = skillModList:Sum("INC", cfg, "Speed")
 			end

--- a/src/Modules/CalcOffence.lua
+++ b/src/Modules/CalcOffence.lua
@@ -1603,6 +1603,7 @@ function calcs.offence(env, actor, activeSkill)
 
 			--Calculates the max number of trauma stacks you can sustain
 			if activeSkill.activeEffect.grantedEffect.name == "Boneshatter" then
+				local effectiveAttackRateCap = data.misc.ServerTickRate * output.Repeats
 				local duration = calcSkillDuration(activeSkill.skillModList, activeSkill.skillCfg, activeSkill.skillData, env, enemyDB)
 				local traumaPerAttack = 1 + m_min(skillModList:Sum("BASE", cfg, "ExtraTrauma"), 100) / 100
 				local incAttackSpeedPerTrauma = skillModList:Sum("INC", skillCfg, "SpeedPerTrauma")
@@ -1611,13 +1612,13 @@ function calcs.offence(env, actor, activeSkill)
 				local inc = skillModList:Sum("INC", cfg, "Speed") - incAttackSpeedPerTrauma * configTrauma -- remove trauma attack speed added by config.
 				local attackSpeedBeforeInc = 1 / baseTime * globalOutput.ActionSpeedMod * more
 				local incAttackSpeedPerTraumaCap = 0
-				if m_min(attackSpeedBeforeInc * (1 + inc / 100), data.misc.ServerTickRate) < data.misc.ServerTickRate then
-					incAttackSpeedPerTraumaCap = (data.misc.ServerTickRate - attackSpeedBeforeInc * (1 + inc / 100)) / attackSpeedBeforeInc * 100
+				if m_min(attackSpeedBeforeInc * (1 + inc / 100), effectiveAttackRateCap) < effectiveAttackRateCap then
+					incAttackSpeedPerTraumaCap = (effectiveAttackRateCap - attackSpeedBeforeInc * (1 + inc / 100)) / attackSpeedBeforeInc * 100
 				end
 				local traumaRateBeforeInc = traumaPerAttack * (output.HitChance / 100) * attackSpeedBeforeInc / output.Repeats
 				local trauma = traumaRateBeforeInc * (1 + inc / 100) / ( 1 / duration - traumaRateBeforeInc * incAttackSpeedPerTrauma / 100 )
 				if trauma < 0 or incAttackSpeedPerTrauma * trauma > incAttackSpeedPerTraumaCap then -- invalid long term trauma generation as maximum attack rate is once per tick.
-					trauma = traumaPerAttack * (output.HitChance / 100) * data.misc.ServerTickRate / output.Repeats * duration
+					trauma = traumaPerAttack * (output.HitChance / 100) * effectiveAttackRateCap / output.Repeats * duration
 				end
 				skillModList:NewMod("Multiplier:SustainableTraumaStacks", "BASE", trauma, "Maximum Sustainable Trauma Stacks")
 			end

--- a/src/Modules/CalcOffence.lua
+++ b/src/Modules/CalcOffence.lua
@@ -1610,10 +1610,8 @@ function calcs.offence(env, actor, activeSkill)
 				-- compute trauma using exact form.
 				local trauma = traumaPerAttack * output.HitChance / 100 / baseTime * (1 + inc / 100) * more * globalOutput.ActionSpeedMod / output.Repeats / ( 1 / duration - traumaPerAttack * output.HitChance / 100 / baseTime * speedPerTrauma / 100 * more * globalOutput.ActionSpeedMod / output.Repeats )
 				skillModList:NewMod("Multiplier:TraumaStacks", "BASE", trauma, "Base")
-				ConPrintf(trauma)
 				inc = skillModList:Sum("INC", cfg, "Speed")
 			end
-
 			output.Speed = 1 / baseTime * round((1 + inc/100) * more, 2)
 			output.CastRate = output.Speed
 			if skillFlags.selfCast then
@@ -1685,6 +1683,8 @@ function calcs.offence(env, actor, activeSkill)
 			output.HitSpeed = 1 / output.HitTime
 		end
 	end
+
+	output.Trauma = activeSkill.activeEffect.grantedEffect.name == "Boneshatter" and skillModList:Sum("BASE", skillCfg, "Multiplier:TraumaStacks")
 
 	if isAttack then
 		-- Combine hit chance and attack speed
@@ -2065,8 +2065,6 @@ function calcs.offence(env, actor, activeSkill)
 			skillModList:NewMod("Multiplier:ExplosiveArrowStage", "BASE", maximum, "Base")
 			skillModList:NewMod("Multiplier:ExplosiveArrowStageAfterFirst", "BASE", maximum - 1, "Base")
 		end
-
-
 
 		-- Calculate crit chance, crit multiplier, and their combined effect
 		if skillModList:Flag(nil, "NeverCrit") then

--- a/src/Modules/CalcSections.lua
+++ b/src/Modules/CalcSections.lua
@@ -605,6 +605,7 @@ return {
 	{ label = "Secondary Duration", flag = "duration", haveOutput = "DurationSecondary", { format = "{3:output:DurationSecondary}s", { breakdown = "DurationSecondary" }, }, },
 	{ label = "Aura Duration", haveOutput = "AuraDuration", { format = "{3:output:AuraDuration}s", { breakdown = "AuraDuration" }, }, },
 	{ label = "Reserve Duration", haveOutput = "ReserveDuration", { format = "{3:output:ReserveDuration}s", { breakdown = "ReserveDuration" }, }, },
+	{ label = "Sustainable Trauma", haveOutput = "SustainableTrauma", { format = "{0:output:SustainableTrauma}", { breakdown = "SustainableTrauma" }, { modName = { "SpeedPerTrauma", "ExtraTrauma", "RepeatCount", "Duration", "PrimaryDuration", "SecondaryDuration", "SkillAndDamagingAilmentDuration"}, cfg = "skill" }, }, },
 	{ label = "Projectile Count", flag = "projectile", { format = "{output:ProjectileCount}", { modName = { "NoAdditionalProjectiles" , "ProjectileCount" }, cfg = "skill" }, }, },
 	{ label = "Pierce Count", haveOutput = "PierceCount", { format = "{output:PierceCountString}", { modName = { "CannotPierce", "PierceCount", "PierceAllTargets" }, cfg = "skill" }, }, },
 	{ label = "Fork Count", haveOutput = "ForkCountMax", { format = "{output:ForkCountString}", { modName = { "CannotFork", "ForkCountMax" }, cfg = "skill" }, }, },

--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -2720,7 +2720,6 @@ local specialModList = {
 	["warcries count as having (%d+) additional nearby enemies"] = function(num) return {
 		mod("Multiplier:WarcryNearbyEnemies", "BASE", num),
 	} end,
-	["boneshatter has (%d+)%% chance to grant %+1 trauma"] = function(num) return { mod("ExtraTrauma", "BASE", num, { type = "SkillName", skillName = "Boneshatter"}) } end,
 	["enemies taunted by your warcries take (%d+)%% increased damage"] = function(num) return { mod("EnemyModifier", "LIST", { mod = mod("DamageTaken", "INC", num, { type = "Condition", var = "Taunted" }) }, { type = "Condition", var = "UsedWarcryRecently" }) } end,
 	["warcries share their cooldown"] = { flag("WarcryShareCooldown") },
 	["warcries have minimum of (%d+) power"] = { flag("CryWolfMinimumPower") },
@@ -3339,6 +3338,7 @@ local specialModList = {
 	["added small passive skills have (%d+)%% increased effect"] = function(num) return { mod("JewelData", "LIST", { key = "clusterJewelIncEffect", value = num }) } end,
 	["this jewel's socket has (%d+)%% increased effect per allocated passive skill between it and your class' starting location"] = function(num) return { mod("JewelData", "LIST", { key = "jewelIncEffectFromClassStart", value = num }) } end,
 	-- Misc
+	["boneshatter has (%d+)%% chance to grant %+1 trauma"] = function(num) return { mod("ExtraTrauma", "BASE", num, { type = "SkillName", skillName = "Boneshatter"}) } end,
 	["your minimum frenzy, endurance and power charges are equal to your maximum while you are stationary"] = {
 		flag("MinimumFrenzyChargesIsMaximumFrenzyCharges", {type = "Condition", var = "Stationary"}),
 		flag("MinimumEnduranceChargesIsMaximumEnduranceCharges", {type = "Condition", var = "Stationary"}),

--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -2720,6 +2720,7 @@ local specialModList = {
 	["warcries count as having (%d+) additional nearby enemies"] = function(num) return {
 		mod("Multiplier:WarcryNearbyEnemies", "BASE", num),
 	} end,
+	["boneshatter has (%d+)%% chance to grant %+1 trauma"] = function(num) return { mod("ExtraTrauma", "BASE", num, { type = "SkillName", skillName = "Boneshatter"}) } end,
 	["enemies taunted by your warcries take (%d+)%% increased damage"] = function(num) return { mod("EnemyModifier", "LIST", { mod = mod("DamageTaken", "INC", num, { type = "Condition", var = "Taunted" }) }, { type = "Condition", var = "UsedWarcryRecently" }) } end,
 	["warcries share their cooldown"] = { flag("WarcryShareCooldown") },
 	["warcries have minimum of (%d+) power"] = { flag("CryWolfMinimumPower") },


### PR DESCRIPTION
Fixes https://github.com/PathOfBuildingCommunity/PathOfBuilding/issues/5001

#### Handles
- Increased Attack speed per trauma
- Skill Duration
- Extra repeats not gaining trauma
- Helm Enchant
- Server Tick Rate Cap
- Breakdown
![image](https://user-images.githubusercontent.com/31533893/190287479-e132e16d-0b53-4dd7-96b2-7f9c37fe94c3.png)
![image](https://user-images.githubusercontent.com/31533893/190287501-5aa2a965-b4eb-404b-a052-00d051764722.png)
![image](https://user-images.githubusercontent.com/31533893/190287519-2b3a7a9b-449f-4133-80c4-73ca156d08c3.png)
![image](https://user-images.githubusercontent.com/31533893/191716209-763eba94-d7b3-47e0-9434-f31528a039e9.png)

#### Issues
- #5069
e.g. this build is missing a lot of effective duration https://pobb.in/Q6FSp4NO2LIF
- #5070 
- The calculated value is assuming you have reached maximum steady state of taruma this can take over a minute in many cases due to the iterative growth from attack speed per trauma. The build code starts at 8 APS but is effectivly 2 APS due to awakened multistrike this means assuming no growth 400 seconds to reach the ~800 stacks estimated by the build but due to the attack speed per it will be significantly less and only reaches the attack speed cap near the end of the ramp leading to it likey being a few minutes.
- As this uses multiChain it will have issues with https://github.com/PathOfBuildingCommunity/PathOfBuilding/pull/5011 which changes the format slightly.
- It is very easy to game unsurvivable sustainable trauma with this implemenation. This should hopefully be mitigated by https://github.com/PathOfBuildingCommunity/PathOfBuilding/pull/4734.