### PR TITLE
Add force precision to catalyst scaling for certain mods

### DIFF
--- a/src/Classes/ModStore.lua
+++ b/src/Classes/ModStore.lua
@@ -41,13 +41,13 @@ function ModStoreClass:ScaleAddMod(mod, scale)
 		local scaledMod = copyTable(mod)
 		if type(scaledMod.value) == "number" then
 			if data.highPrecisionMods[scaledMod.name] and data.highPrecisionMods[scaledMod.name][scaledMod.type] then
-				scaledMod.value = scaledMod.value * scale
+				scaledMod.value = m_floor(scaledMod.value * scale * 10 ^ data.highPrecisionMods[scaledMod.name][scaledMod.type]) / 10 ^ data.highPrecisionMods[scaledMod.name][scaledMod.type]
 			else
 				scaledMod.value = (m_floor(scaledMod.value) == scaledMod.value) and m_modf(round(scaledMod.value * scale, 2)) or scaledMod.value * scale
 			end
 		elseif type(scaledMod.value) == "table" and scaledMod.value.mod then
 			if data.highPrecisionMods[scaledMod.value.mod.name] and data.highPrecisionMods[scaledMod.value.mod.name][scaledMod.value.mod.type] then
-				scaledMod.value.mod.value = scaledMod.value.mod.value * scale
+				scaledMod.value.mod.value = m_floor(scaledMod.value.mod.value * scale * 10 ^ data.highPrecisionMods[scaledMod.value.mod.name][scaledMod.value.mod.type]) / 10 ^ data.highPrecisionMods[scaledMod.value.mod.name][scaledMod.value.mod.type]
 			else
 				scaledMod.value.mod.value = (m_floor(scaledMod.value.mod.value) == scaledMod.value.mod.value) and m_modf(round(scaledMod.value.mod.value * scale, 2)) or scaledMod.value.mod.value * scale
 			end

--- a/src/Classes/ModStore.lua
+++ b/src/Classes/ModStore.lua
@@ -39,18 +39,16 @@ function ModStoreClass:ScaleAddMod(mod, scale)
 	else
 		scale = m_max(scale, 0)
 		local scaledMod = copyTable(mod)
-		if type(scaledMod.value) == "number" then
-			if data.highPrecisionMods[scaledMod.name] and data.highPrecisionMods[scaledMod.name][scaledMod.type] then
-				scaledMod.value = m_floor(scaledMod.value * scale * 10 ^ data.highPrecisionMods[scaledMod.name][scaledMod.type]) / 10 ^ data.highPrecisionMods[scaledMod.name][scaledMod.type]
-			else
-				scaledMod.value = (m_floor(scaledMod.value) == scaledMod.value) and m_modf(round(scaledMod.value * scale, 2)) or scaledMod.value * scale
-			end
-		elseif type(scaledMod.value) == "table" and scaledMod.value.mod then
-			if data.highPrecisionMods[scaledMod.value.mod.name] and data.highPrecisionMods[scaledMod.value.mod.name][scaledMod.value.mod.type] then
-				scaledMod.value.mod.value = m_floor(scaledMod.value.mod.value * scale * 10 ^ data.highPrecisionMods[scaledMod.value.mod.name][scaledMod.value.mod.type]) / 10 ^ data.highPrecisionMods[scaledMod.value.mod.name][scaledMod.value.mod.type]
-			else
-				scaledMod.value.mod.value = (m_floor(scaledMod.value.mod.value) == scaledMod.value.mod.value) and m_modf(round(scaledMod.value.mod.value * scale, 2)) or scaledMod.value.mod.value * scale
-			end
+		local subMod = scaledMod
+		if type(scaledMod.value) == "table" and scaledMod.value.mod then
+			subMod = scaledMod.value.mod
+		end
+		local precision = ((data.highPrecisionMods[subMod.name] and data.highPrecisionMods[subMod.name][subMod.type])) or ((m_floor(subMod.value) == subMod.value) and 2) or nil
+		if precision then
+			local power = 10 ^ precision
+			subMod.value = math.floor(subMod.value * scale * power) / power
+		else
+			subMod.value = m_modf(round(subMod.value * scale, 2))
 		end
 		self:AddMod(scaledMod)
 	end

--- a/src/Modules/Data.lua
+++ b/src/Modules/Data.lua
@@ -356,6 +356,9 @@ data.highPrecisionMods = {
 	["CritChance"] = {
 		["BASE"] = 2,
 	},
+	["SelfCritChance"] = {
+		["BASE"] = 2,
+	},
 	["LifeRegenPercent"] = {
 		["BASE"] = 2,
 	},

--- a/src/Modules/Data.lua
+++ b/src/Modules/Data.lua
@@ -354,73 +354,88 @@ data.nonDamagingAilment = {
 -- Used in ModStoreClass:ScaleAddMod(...) to identify high precision modifiers
 data.highPrecisionMods = {
 	["CritChance"] = {
-		["BASE"] = true,
+		["BASE"] = 2,
 	},
 	["LifeRegenPercent"] = {
-		["BASE"] = true,
+		["BASE"] = 2,
+	},
+	["ManaRegenPercent"] = {
+		["BASE"] = 2,
+	},
+	["EnergyShieldRegenPercent"] = {
+		["BASE"] = 2,
+	},
+	["LifeRegen"] = {
+		["BASE"] = 1,
+	},
+	["ManaRegen"] = {
+		["BASE"] = 1,
+	},
+	["EnergyShieldRegen"] = {
+		["BASE"] = 1,
 	},
 	["DamageLifeLeech"] = {
-		["BASE"] = true,
+		["BASE"] = 2,
 	},
 	["PhysicalDamageLifeLeech"] = {
-		["BASE"] = true,
+		["BASE"] = 2,
 	},
 	["ElementalDamageLifeLeech"] = {
-		["BASE"] = true,
+		["BASE"] = 2,
 	},
 	["FireDamageLifeLeech"] = {
-		["BASE"] = true,
+		["BASE"] = 2,
 	},
 	["ColdDamageLifeLeech"] = {
-		["BASE"] = true,
+		["BASE"] = 2,
 	},
 	["LightningDamageLifeLeech"] = {
-		["BASE"] = true,
+		["BASE"] = 2,
 	},
 	["ChaosDamageLifeLeech"] = {
-		["BASE"] = true,
+		["BASE"] = 2,
 	},
 	["DamageManaLeech"] = {
-		["BASE"] = true,
+		["BASE"] = 2,
 	},
 	["PhysicalDamageManaLeech"] = {
-		["BASE"] = true,
+		["BASE"] = 2,
 	},
 	["ElementalDamageManaLeech"] = {
-		["BASE"] = true,
+		["BASE"] = 2,
 	},
 	["FireDamageManaLeech"] = {
-		["BASE"] = true,
+		["BASE"] = 2,
 	},
 	["ColdDamageManaLeech"] = {
-		["BASE"] = true,
+		["BASE"] = 2,
 	},
 	["LightningDamageManaLeech"] = {
-		["BASE"] = true,
+		["BASE"] = 2,
 	},
 	["ChaosDamageManaLeech"] = {
-		["BASE"] = true,
+		["BASE"] = 2,
 	},
 	["DamageEnergyShieldLeech"] = {
-		["BASE"] = true,
+		["BASE"] = 2,
 	},
 	["PhysicalDamageEnergyShieldLeech"] = {
-		["BASE"] = true,
+		["BASE"] = 2,
 	},
 	["ElementalDamageEnergyShieldLeech"] = {
-		["BASE"] = true,
+		["BASE"] = 2,
 	},
 	["FireDamageEnergyShieldLeech"] = {
-		["BASE"] = true,
+		["BASE"] = 2,
 	},
 	["ColdDamageEnergyShieldLeech"] = {
-		["BASE"] = true,
+		["BASE"] = 2,
 	},
 	["LightningDamageEnergyShieldLeech"] = {
-		["BASE"] = true,
+		["BASE"] = 2,
 	},
 	["ChaosDamageEnergyShieldLeech"] = {
-		["BASE"] = true,
+		["BASE"] = 2,
 	},
 }
 

--- a/src/Modules/ItemTools.lua
+++ b/src/Modules/ItemTools.lua
@@ -27,11 +27,12 @@ itemLib.influenceInfo = {
 function itemLib.applyValueScalar(line, valueScalar, numbers, precision)
 	if valueScalar and type(valueScalar) == "number" and valueScalar ~= 1 then
 		if not precision and line:match("(%d+%.%d*)") then
-			precision = 2 -- default precision is two for decimals
+			precision  = 2 -- default precision is two for decimals
 		end
 		if precision then
 			return line:gsub("(%d+%.?%d*)", function(num)
-				local numVal = m_floor(tonumber(num) * valueScalar * 10 ^ precision + 0.001) / 10 ^ precision
+				local power = 10 ^ precision
+				local numVal = m_floor(tonumber(num) * valueScalar * power) / power
 				return tostring(numVal)
 			end, numbers)
 		else


### PR DESCRIPTION
Fixes https://github.com/PathOfBuildingCommunity/PathOfBuilding/issues/4997 https://github.com/PathOfBuildingCommunity/PathOfBuilding/issues/5032

Includes https://github.com/PathOfBuildingCommunity/PathOfBuilding/pull/5034 to avoid merge conflicts

### Description of the problem being solved:
When catalysts scaled mods became an integer they switch to being scaled like an int

This was solved by running mod parser on the mods and seeing if they match our high precision mods then scaling with certain number of decimals

### Steps taken to verify a working solution:
- Test mods at ints and see they scale correctly.