### PR TITLE
FIX crash when generating fall back weights caused by missing source

### DIFF
--- a/src/Classes/ModDB.lua
+++ b/src/Classes/ModDB.lua
@@ -96,7 +96,7 @@ function ModDBClass:SumInternal(context, modType, cfg, flags, keywordFlags, sour
 		if modList then
 			for i = 1, #modList do
 				local mod = modList[i]
-				if mod.type == modType and band(flags, mod.flags) == mod.flags and MatchKeywordFlags(keywordFlags, mod.keywordFlags) and (not source or mod.source:match("[^:]+") == source) then
+				if mod.type == modType and band(flags, mod.flags) == mod.flags and MatchKeywordFlags(keywordFlags, mod.keywordFlags) and (not source or ( mod.source and mod.source:match("[^:]+") == source )) then
 					if mod[1] then
 						local value = context:EvalMod(mod, cfg) or 0
 						if mod[1].globalLimit and mod[1].globalLimitKey then


### PR DESCRIPTION
Fixes ##5053 .

### Description of the problem being solved:
Nodes coming from timeless jewels do not have their source property set. When running sum on a modDB with such a mod and the source property set in the cfg causes a match call to be called on nil which causes the crash.

