### PR TITLE
Fix Lucky Attack Damage Applying to spells

### DIFF
--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -1962,7 +1962,7 @@ local specialModList = {
 		mod("DoubleDamageChance", "BASE", 100, { type = "SkillName", skillName = "Vengeance" }),
 	},
 	["attack damage is lucky if you[' ]h?a?ve blocked in the past (%d+) seconds"] = function(num) return {
-		flag("LuckyHits", { type = "Condition", var = "BlockedRecently"} )
+		flag("LuckyHits", nil, ModFlag.Attack, { type = "Condition", var = "BlockedRecently"} )
 	} end,
 	["hits ignore enemy monster physical damage reduction if you[' ]h?a?ve blocked in the past (%d+) seconds"] = function(num) return {
 		flag("IgnoreEnemyPhysicalDamageReduction", { type = "Condition", var = "BlockedRecently"} )


### PR DESCRIPTION
Fixes https://github.com/PathOfBuildingCommunity/PathOfBuilding/issues/5058

### Steps taken to verify a working solution:
- Using a spell no longer gets lucky damage
- Using an attack still gets lucky damage