### PR TITLE
Show Increased Global Energy Shield on Calcs

### DIFF
--- a/src/Modules/CalcDefence.lua
+++ b/src/Modules/CalcDefence.lua
@@ -329,11 +329,13 @@ function calcs.defence(env, actor)
 				energyShield = energyShield + energyShieldBase * calcLib.mod(modDB, nil, "EnergyShield", "Defences")
 			end
 			if breakdown then
+				local inc = modDB:Sum("INC", slotCfg, "Defences", "EnergyShield")
 				local more = modDB:More(slotCfg, "EnergyShield", "Defences")
 				t_insert(breakdown["EnergyShield"].slots, {
 					base = energyShieldBase,
+					inc = (inc ~= 0) and s_format(" x %.2f", 1 + inc/100),
 					more = (more ~= 1) and s_format(" x %.2f", more),
-					total = s_format("%.2f", energyShieldBase * more),
+					total = s_format("%.2f", energyShieldBase * (1 + inc / 100) * more),
 					source = "Global",
 					item = actor.itemList["Global"],
 				})


### PR DESCRIPTION
Fixes #3418

### Description of the problem being solved:
In the Calcs > Energy Shield > Total breakdown, global source were missing their increased/reduced multiplier. The Total number is correct, it just was missing the information in the breakdown.

### Steps taken to verify a working solution:
- Imported build with global ES sources and increased ES modifiers
- Opened the Energy Shield > Total breakdown on the Calcs tab

### Link to a build that showcases this PR:
https://pastebin.com/YXgXm3JY
Or just allocate Foresight

### Before screenshot:
![image](https://user-images.githubusercontent.com/7892106/189487957-99ba78ab-a1b2-4775-aadc-d09abe8101d2.png)

### After screenshot:
![image](https://user-images.githubusercontent.com/7892106/189487964-d2269b16-dd75-438c-b2f6-357be48eabf2.png)
