### PR TITLE
Fix issue preventing multiple jewel funcs from applying.

### DIFF
--- a/src/Modules/CalcSetup.lua
+++ b/src/Modules/CalcSetup.lua
@@ -88,14 +88,14 @@ function calcs.buildModListForNode(env, node)
 		modList:AddList(node.modList)
 	end
 	
-	-- Keep track of what jewels have been applied to this node to avoid applying the same jewel twice if they overlap
+	-- Keep track of what jewels functions have been applied to this node to avoid applying the same jewel twice if they overlap
 	-- Ref https://github.com/PathOfBuildingCommunity/PathOfBuilding/issues/4873
-	local appliedJewels = {}
+	local appliedJewelsFuncs = {}
 	
 	-- Run first pass radius jewels
 	for _, rad in pairs(env.radiusJewelList) do
-		if rad.type == "Other" and rad.nodes[node.id] and not appliedJewels[rad.item.name] then
-			appliedJewels[rad.item.name] = true
+		if rad.type == "Other" and rad.nodes[node.id] and not appliedJewelsFuncs[rad.func] then
+			appliedJewelsFuncs[rad.func] = true
 			rad.func(node, modList, rad.data)
 		end
 	end


### PR DESCRIPTION
Fixes an issue raised by @andomflyingtaco in discord about #4948 .

### Description of the problem being solved:
Using the name to check if a jewel has already been applied to a node causes a jewel with multiple functions only apply the first one. Using the function it self as the key should solve the problem.