### PR TITLE
Revert "FIX: fix jewels applying to the same node twice if overlapping"

### DIFF
--- a/src/Modules/CalcSetup.lua
+++ b/src/Modules/CalcSetup.lua
@@ -87,15 +87,10 @@ function calcs.buildModListForNode(env, node)
 	else
 		modList:AddList(node.modList)
 	end
-	
-	-- Keep track of what jewels have been applied to this node to avoid applying the same jewel twice if they overlap
-	-- Ref https://github.com/PathOfBuildingCommunity/PathOfBuilding/issues/4873
-	local appliedJewels = {}
-	
+
 	-- Run first pass radius jewels
 	for _, rad in pairs(env.radiusJewelList) do
-		if rad.type == "Other" and rad.nodes[node.id] and not appliedJewels[rad.item.name] then
-			appliedJewels[rad.item.name] = true
+		if rad.type == "Other" and rad.nodes[node.id] then
 			rad.func(node, modList, rad.data)
 		end
 	end


### PR DESCRIPTION
Reverts PathOfBuildingCommunity/PathOfBuilding#4948

The solution seems to cause more issues than it solves. Likely it is not how it works in game. More testing is needed.