### PR TITLE
Fix parsing for some pobb.in links

### DIFF
--- a/src/Modules/BuildSiteTools.lua
+++ b/src/Modules/BuildSiteTools.lua
@@ -72,8 +72,8 @@ function buildSites.DownloadBuild(link, websiteInfo, callback)
 	-- Only called on program start via protocol handler
 	if not websiteInfo then
 		for _, siteInfo in ipairs(buildSites.websiteList) do
-			if link:match("^pob:[/\\]*" .. siteInfo.id:lower() .. "[/\\]+(%w+)") then
-				siteCodeURL = link:gsub("^pob:[/\\]*" .. siteInfo.id:lower() .. "[/\\]+(%w+)", "https://" .. siteInfo.downloadURL)
+			if link:match("^pob:[/\\]*" .. siteInfo.id:lower() .. "[/\\]+(.+)") then
+				siteCodeURL = link:gsub("^pob:[/\\]*" .. siteInfo.id:lower() .. "[/\\]+(.+)", "https://" .. siteInfo.downloadURL)
 				websiteInfo = siteInfo
 				break
 			end


### PR DESCRIPTION
Our current pob link matching pattern is not covering some pobb.in URLs.
This PR fixes the pattern to cover urlsafe base64 characters (used by pobb.in)

Following link is currently unloadable via the "Open" button on the page (using pob protocol link)
https://pobb.in/-bUISrt3agGa
