### PR TITLE
Add spell check github action

### DIFF
--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -36,3 +36,4 @@ jobs:
           files: '**' # needed as workaround for non-incremental runs (overrides in config still work ok)
           config: "cspell.json"
           incremental_files_only: ${{ github.event_name != 'workflow_dispatch' }}
+

--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -1,0 +1,38 @@
+name: 'spellcheck'
+
+on:
+  pull_request:
+    branches: [ dev ]
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: Branch, tag or SHA to checkout
+        default: dev
+        required: false
+
+jobs:
+  spellcheck:
+    runs-on: ubuntu-latest
+    env: 
+      CONFIG_URL:  https://raw.githubusercontent.com/Nightblade/pob-dict/main
+    steps:
+
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ inputs.ref }}
+
+      - name: Fetch config file and dictionaries
+        run: |
+          curl --silent --show-error --parallel --remote-name-all \
+            ${{ env.CONFIG_URL }}/cspell.json \
+            ${{ env.CONFIG_URL }}/pob-dict.txt \
+            ${{ env.CONFIG_URL }}/poe-dict.txt \
+            ${{ env.CONFIG_URL }}/ignore-dict.txt
+
+      - name: Run cspell
+        uses: streetsidesoftware/cspell-action@v2.4.0
+        with:
+          files: '**' # needed as workaround for non-incremental runs (overrides in config still work ok)
+          config: "cspell.json"
+          incremental_files_only: ${{ github.event_name != 'workflow_dispatch' }}


### PR DESCRIPTION
Current state:  proof of concept / testing / review.

Questions / suggestions / comments welcome.

* Automatically run [cspell-action](https://github.com/streetsidesoftware/cspell-action) on `pull-requests` made to `dev`.
* Trigger manually to fully check a branch/tag/SHA.
* Use `cspell` config/dictionary files from a secondary repo (temporarily [nightblade/pob-dict](https://github.com/Nightblade/pob-dict)).

I've been regularly running `cspell` locally on the `dev` branch and at the moment it reports zero spelling issues.  Keen observers will notice there are still ... a few.  These *should* only be pre-existing errors that are yet to be addressed, GGG errors, or idiomatic PoE/PoB words.

Further detail available upon request.

