### PR TITLE
Add 'Implicits: 0' where missing for unique items

### DIFF
--- a/src/Data/Uniques/Special/Generated.lua
+++ b/src/Data/Uniques/Special/Generated.lua
@@ -161,6 +161,7 @@ for index, mod in pairs(queensHungerMods) do
 end
 
 table.insert(queensHunger, "Requires Level 68, 194 Int")
+table.insert(queensHunger, "Implicits: 0")
 table.insert(queensHunger, "Trigger Level 20 Bone Offering, Flesh Offering or Spirit Offering every 5 seconds")
 table.insert(queensHunger, "Offering Skills Triggered this way also affect you")
 table.insert(queensHunger, "(5-10)% increased Cast Speed")
@@ -184,6 +185,7 @@ local megalomaniac = {
 	"Source: Drops from the Simulacrum Encounter",
 	"Has Alt Variant: true",
 	"Has Alt Variant Two: true",
+	"Implicits: 0",
 	"Adds 4 Passive Skills",
 	"Added Small Passive Skills grant Nothing",
 }
@@ -231,14 +233,19 @@ end
 table.sort(gems)
 for index, name in ipairs(gems) do
 	table.insert(forbiddenShako, "Variant: "..name.. " (Low Level)")
-	table.insert(forbiddenShako, "{variant:"..(index * 2 - 1).."}Socketed Gems are Supported by Level (1-10) "..name)
 	table.insert(forbiddenShako, "Variant: "..name.. " (High Level)")
-	table.insert(forbiddenShako, "{variant:"..(index * 2).."}Socketed Gems are Supported by Level (25-35) "..name)
 	table.insert(replicaForbiddenShako, "Variant: "..name.. " (Low Level)")
-	table.insert(replicaForbiddenShako, "{variant:"..(index * 2 - 1).."}Socketed Gems are Supported by Level (1-10) "..name)
 	table.insert(replicaForbiddenShako, "Variant: "..name.. " (High Level)")
+end
+table.insert(forbiddenShako, "Implicits: 0")
+table.insert(replicaForbiddenShako, "Implicits: 0")
+for index, name in ipairs(gems) do
+	table.insert(forbiddenShako, "{variant:"..(index * 2 - 1).."}Socketed Gems are Supported by Level (1-10) "..name)
+	table.insert(forbiddenShako, "{variant:"..(index * 2).."}Socketed Gems are Supported by Level (25-35) "..name)
+	table.insert(replicaForbiddenShako, "{variant:"..(index * 2 - 1).."}Socketed Gems are Supported by Level (1-10) "..name)
 	table.insert(replicaForbiddenShako, "{variant:"..(index * 2).."}Socketed Gems are Supported by Level (25-35) "..name)
 end
+
 table.insert(forbiddenShako, "+(25-30) to all Attributes")
 table.insert(replicaForbiddenShako, "+(25-30) to all Attributes")
 table.insert(data.uniques.generated, table.concat(forbiddenShako, "\n"))
@@ -453,6 +460,7 @@ for _, name in ipairs(impossibleEscapeKeystones) do
 	table.insert(impossibleEscape, "Variant: "..name)
 end
 table.insert(impossibleEscape, "Variant: Everything (QoL Test Variant)")
+table.insert(impossibleEscape, "Implicits: 0")
 local variantCount = #impossibleEscapeKeystones + 1
 for index, name in ipairs(impossibleEscapeKeystones) do
 	table.insert(impossibleEscape, "{variant:"..index..","..variantCount.."}Passives in radius of "..name.." can be allocated without being connected to your tree")
@@ -597,12 +605,16 @@ end
 
 table.insert(watchersEye,
 [[Limited to: 1
+Implicits: 0
 (4-6)% increased maximum Energy Shield
 (4-6)% increased maximum Life
 (4-6)% increased maximum Mana]])
 
+table.insert(sublimeVision, "Implicits: 0")
+
 table.insert(voranasMarch,
 [[Requires Level 69, 46 Str, 46 Dex, 46 Int
+Implicits: 0
 Has no Sockets
 Triggers Level 20 Summon Arbalists when Equipped
 25% increased Movement Speed]])

--- a/src/Data/Uniques/Special/New.lua
+++ b/src/Data/Uniques/Special/New.lua
@@ -8,6 +8,7 @@ data.uniques.new = {
 [[
 Soul Ascension
 Carnal Mitts
+Implicits: 0
 137% increased Evasion and Energy Shield
 +26% to Chaos Resistance
 Eat a Soul when you Hit a unique Enemy, no more than once every second
@@ -16,6 +17,7 @@ Maximum 50 Eaten Souls
 ]],[[
 Ghostwrithe
 Silken Vest
+Implicits: 0
 +137 to maximum Energy Shield
 +96 to maximum Life
 +50% to Chaos Resistance
@@ -24,12 +26,14 @@ Silken Vest
 Kalandra's Touch
 Iron Ring
 League: Kalandra
+Implicits: 0
 Reflects your other Ring
 Mirrored
 ]],[[
 Kaom's Spirit
 Titan Gauntlets
 League: Kalandra
+Implicits: 0
 +(50-70) to Maximum Life
 +(20-30)% to Fire Resistance
 0.44% of Physical Attack Damage Leeched as Life
@@ -49,6 +53,7 @@ Adds 0 to 3 Lightning Damage to Attacks per 10 Intelligence
 ]],[[
 Elevore
 Wolf Pelt
+Implicits: 0
 +23% chance to Suppress Spell Damage
 85% increased Evasion Rating
 22% chance to Avoid Elemental Ailments

--- a/src/Data/Uniques/body.lua
+++ b/src/Data/Uniques/body.lua
@@ -658,12 +658,14 @@ Inflicts a random Hex on you when your Totems die, with 80% more Effect
 Tabula Rasa
 Simple Robe
 Sockets: W-W-W-W-W-W
+Implicits: 0
 ]],[[
 Thousand Ribbons
 Simple Robe
 Variant: Pre 3.0.0
 Variant: Pre 3.19.0
 Variant: Current
+Implicits: 0
 Socketed Gems are Supported by Level 5 Elemental Proliferation
 {variant:1,2}Adds 2 to 3 Fire Damage to Spells and Attacks
 {variant:3}Adds (2-4) to (5-9) Fire Damage to Spells and Attacks

--- a/src/Data/Uniques/boots.lua
+++ b/src/Data/Uniques/boots.lua
@@ -8,6 +8,7 @@ Goliath Greaves
 League: Bestiary
 Source: Drops from unique{Craiceann, First of the Deep}
 Requires Level 54, 95 Str
+Implicits: 0
 (150-180)% increased Armour
 +(50-70) to maximum Life
 +(25-30)% to Cold Resistance
@@ -29,6 +30,7 @@ Variant: Purity of Lightning: Fire
 Variant: Purity of Lightning: Cold
 Variant: Purity of Lightning: Lightning
 Requires Level 68, 120 Str
+Implicits: 0
 {variant:1,2,3}Grants Level 25 Purity of Fire Skill
 {variant:4,5,6}Grants Level 25 Purity of Ice Skill
 {variant:7,8,9}Grants Level 25 Purity of Lightning Skill
@@ -45,6 +47,7 @@ League: Breach
 Source: Drops in Uul-Netol Breach or from unique{Uul-Netol, Unburdened Flesh}
 Upgrade: Upgrades to unique{The Red Trail} using currency{Blessing of Uul-Netol}
 Requires Level 54, 95 Str
+Implicits: 0
 +(30-60) to maximum Life
 20% increased Movement Speed
 Moving while Bleeding doesn't cause you to take extra Damage
@@ -56,6 +59,7 @@ Titan Greaves
 League: Breach
 Source: Upgraded from unique{The Infinite Pursuit} using currency{Blessing of Uul-Netol}
 Requires Level 68, 120 Str
+Implicits: 0
 (60-80)% increased Armour
 +(50-70) to maximum Life
 25% increased Movement Speed
@@ -69,6 +73,7 @@ Replica Red Trail
 Titan Greaves
 League: Heist
 Requires Level 68, 120 Str
+Implicits: 0
 (60-80)% increased Armour
 +(60-70) to maximum Life
 25% increased Movement Speed
@@ -83,6 +88,7 @@ Titan Greaves
 Variant: Pre 2.6.0
 Variant: Current
 Requires Level 68, 120 Str
+Implicits: 0
 Has no Sockets
 Cannot be Knocked Back
 {variant:1}+(120-150) to maximum Life
@@ -96,6 +102,7 @@ League: Warbands
 Variant: Pre 2.6.0
 Variant: Current
 Requires Level 46, 82 Str
+Implicits: 0
 {variant:2}+(50-70) to maximum Life
 Adds (2-5) to (7-10) Physical Damage to Attacks
 (5-10)% reduced Enemy Stun Threshold
@@ -110,6 +117,7 @@ Plated Greaves
 Variant: Pre 3.19.0
 Variant: Current
 Requires Level: 23, 44 Str
+Implicits: 0
 +(1-50)% to Lightning Resistance 
 {variant:1}20% increased Movement Speed
 {variant:2}(1-40)% increased Movement Speed
@@ -125,6 +133,7 @@ Antique Greaves
 Variant: Pre 3.16.0
 Variant: Current
 Requires Level 37, 67 Str
+Implicits: 0
 (80-120)% increased Armour
 {variant:1}(30-50)% increased Totem Life
 {variant:2}(20-30)% increased Totem Life
@@ -139,6 +148,7 @@ Variant: Pre 2.6.0
 Variant: Pre 3.19.0
 Variant: Current
 Requires Level 33, 60 Str
+Implicits: 0
 (50-80)% increased Armour
 +(10-15)% to all Elemental Resistances
 {variant:1}10% increased Movement Speed
@@ -153,6 +163,7 @@ Windshriek
 Reinforced Greaves
 Source: No longer obtainable
 Requires Level 60, 60 Str
+Implicits: 0
 (200-250)% increased Armour
 +(10-15)% to all Elemental Resistances
 25% increased Movement Speed
@@ -165,6 +176,7 @@ Enemies can have 1 additional Curse
 Abberath's Hooves
 Goathide Boots
 Requires Level 12, 26 Dex
+Implicits: 0
 Triggers Level 7 Abberath's Fury when Equipped
 +(20-30) to Strength
 15% increased Movement Speed
@@ -179,6 +191,7 @@ Source: Drops from unique{Atziri, Queen of the Vaal} in normal{The Apex of Sacri
 Variant: Pre 3.16.0
 Variant: Current
 Requires Level 69, 120 Dex
+Implicits: 0
 180% increased Evasion Rating
 +(55-75) to maximum Life
 30% increased Movement Speed
@@ -192,6 +205,7 @@ Variant: Pre 2.1.0
 Variant: Pre 3.11.0
 Variant: Current
 Requires Level 44, 79 Dex
+Implicits: 0
 +(30-40) to Dexterity
 20% increased Movement Speed
 2% increased Movement Speed per Frenzy Charge
@@ -212,6 +226,7 @@ Variant: Pre 2.6.0
 Variant: Pre 3.19.0
 Variant: Current
 Requires Level 22, 42 Dex
+Implicits: 0
 {variant:1,2}Socketed Gems are Supported by level 11 Trap
 {variant:3}Socketed Gems are Supported by level 15 Trap
 (160-200)% increased Evasion Rating
@@ -235,6 +250,7 @@ Variant: Purity of Lightning: Fire
 Variant: Purity of Lightning: Cold
 Variant: Purity of Lightning: Lightning
 Requires Level 69, 120 Dex
+Implicits: 0
 {variant:1,2,3}Grants Level 25 Purity of Fire Skill
 {variant:4,5,6}Grants Level 25 Purity of Ice Skill
 {variant:7,8,9}Grants Level 25 Purity of Lightning Skill
@@ -250,6 +266,7 @@ Slink Boots
 League: Bestiary
 Source: Drops from unique{Farrul, First of the Plains}
 Requires Level 69, 120 Dex
+Implicits: 0
 Trigger Level 20 Intimidating Cry when you lose Cat's Stealth
 (110-150)% increased Evasion Rating
 +(50-70) to maximum Life
@@ -262,6 +279,7 @@ Nubuck Boots
 Variant: Pre 1.1.0
 Variant: Current
 Requires Level 34, 62 Dex
+Implicits: 0
 60% increased Mana Regeneration Rate
 {variant:1}(20-30)% increased Quantity of Items Found
 {variant:2}(14-20)% increased Quantity of Items Found
@@ -274,6 +292,7 @@ Variant: Pre 3.5.0
 Variant: Pre 3.16.0
 Variant: Current
 Requires Level 62, 117 Dex
+Implicits: 0
 +(30-40) to Dexterity
 {variant:1}(80-120)% increased Evasion Rating
 {variant:2}(320-380)% increased Evasion Rating
@@ -287,6 +306,7 @@ Regenerate 100 Life per second while moving
 Seven-League Step
 Rawhide Boots
 League: Perandus
+Implicits: 0
 50% increased Movement Speed
 ]],[[
 Sin Trek
@@ -296,6 +316,7 @@ Variant: Pre 2.6.0
 Variant: Pre 3.5.0
 Variant: Current
 Requires Level 62, 117 Dex
+Implicits: 0
 +(20-30) to Dexterity
 +(20-30) to Intelligence
 (80-100)% increased Evasion Rating
@@ -310,6 +331,7 @@ Temptation Step
 Shagreen Boots
 League: Ultimatum
 Requires Level 55, 97 Dex
+Implicits: 0
 (170-250)% increased Evasion Rating
 +(19-29)% to Chaos Resistance
 15% increased Damage for each Poison on you up to a maximum of 75%
@@ -322,6 +344,7 @@ Variant: Pre 2.6.0
 Variant: Pre 3.16.0
 Variant: Current
 Requires Level 55, 97 Dex
+Implicits: 0
 +(25-35) to Dexterity
 (20-40)% increased Evasion Rating
 {variant:1}40% increased Evasion Rating while you have Onslaught
@@ -337,6 +360,7 @@ Replica Three-step Assault
 Shagreen Boots
 League: Heist
 Requires Level 55, 97 Dex
+Implicits: 0
 +(25-35) to Dexterity
 (20-40)% increased Evasion Rating
 +(50-70) to maximum Life
@@ -350,6 +374,7 @@ Variant: Pre 2.6.0
 Variant: Pre 3.19.0
 Variant: Current
 Requires Level 12, 26 Dex
+Implicits: 0
 +15 to Dexterity
 +15 to Intelligence
 (100-150)% increased Evasion Rating
@@ -368,6 +393,7 @@ Silk Slippers
 Variant: Pre 3.8.0
 Variant: Current
 Requires Level 22, 42 Int
+Implicits: 0
 +20 to maximum Life
 +20 to maximum Mana
 (40-60)% increased Energy Shield
@@ -381,6 +407,7 @@ Replica Bones of Ullr
 Silk Slippers
 League: Heist
 Requires Level 22, 42 Int
+Implicits: 0
 (40-60)% increased Energy Shield
 +20 to maximum Life
 +20 to maximum Mana
@@ -411,6 +438,7 @@ Variant: Purity of Lightning: Fire
 Variant: Purity of Lightning: Cold
 Variant: Purity of Lightning: Lightning
 Requires Level 67, 120 Int
+Implicits: 0
 {variant:1,2,3,10,11,12}Grants Level 25 Purity of Fire Skill
 {variant:4,5,6,13,14,15}Grants Level 25 Purity of Ice Skill
 {variant:7,8,9,16,17,18}Grants Level 25 Purity of Lightning Skill
@@ -425,6 +453,7 @@ Requires Level 67, 120 Int
 Inya's Epiphany
 Arcanist Slippers
 Requires Level 61, 119 Int
+Implicits: 0
 +(50-70) to maximum Life
 25% increased Movement Speed
 (5-8)% increased Intelligence
@@ -436,6 +465,7 @@ Replica Inya's Epiphany
 Arcanist Slippers
 League: Heist
 Requires Level 61, 119 Int
+Implicits: 0
 (5-8)% increased Intelligence
 +(50-70) to maximum Life
 5% increased Damage per Power Charge
@@ -451,6 +481,7 @@ Variant: Pre 3.4.0
 Variant: Pre 3.19.0
 Variant: Current
 Requires Level 53, 94 Int
+Implicits: 0
 {variant:1,2,3,4}(6-7)% Chance to Block Spell Damage
 {variant:5}(4-6)% Chance to Block Spell Damage
 {variant:6}(15-20)% Chance to Block Spell Damage
@@ -470,6 +501,7 @@ Variant: Pre 2.6.0
 Variant: Pre 3.19.0
 Variant: Current
 Requires Level 32, 54 Int
+Implicits: 0
 {variant:1,2,3}+10 to Dexterity
 {variant:1}+10 to Intelligence
 {variant:2,3,4}+(20-30) to Intelligence
@@ -487,6 +519,7 @@ Source: No longer obtainable
 Variant: Pre 2.6.0
 Variant: Pre 3.17.0
 Requires Level 32, 54 Int
+Implicits: 0
 +10 to Dexterity
 +(20-30) to Intelligence
 (100-140)% increased Energy Shield
@@ -501,6 +534,7 @@ Skyforth
 Sorcerer Boots
 Energy Shield: 64
 Requires Level 67, 123 Int
+Implicits: 0
 +(60-120) to maximum Mana
 30% increased Movement Speed
 25% chance to gain a Power Charge on Critical Strike
@@ -514,6 +548,7 @@ League: Warbands
 Variant: Pre 3.0.0
 Variant: Current
 Requires Level 67, 123 Int
+Implicits: 0
 {variant:1}(110-140)% increased Energy Shield
 {variant:2}(50-80)% increased Energy Shield
 +(20-30) to maximum Energy Shield
@@ -525,6 +560,7 @@ Unaffected by Desecrated Ground
 ]],[[
 Wanderlust
 Wool Shoes
+Implicits: 0
 +5 to Dexterity
 (20-40)% increased Mana Regeneration Rate
 +(10-20) to maximum Energy Shield
@@ -537,6 +573,7 @@ Variant: Pre 1.0.0
 Variant: Pre 3.19.0
 Variant: Current
 Requires Level 9, 21 Int
+Implicits: 0
 {variant:1,2}+(5-10) to Strength
 {variant:3}+(5-30) to Strength
 {variant:1,2}+(5-10) to Dexterity
@@ -554,6 +591,7 @@ Greedtrap
 Velvet Slippers
 Source: No longer obtainable
 Requires Level 52, 21 Int
+Implicits: 0
 +(5-10) to Strength
 +(5-10) to Dexterity
 +(5-10) to Intelligence
@@ -591,6 +629,7 @@ Variant: Pre 2.6.0
 Variant: Pre 3.16.0
 Variant: Current
 Requires Level 65, 62 Str, 62 Dex
+Implicits: 0
 {variant:2,3}(40-70)% increased Armour and Evasion
 +(20-40)% to Lightning Resistance
 5% increased Movement Speed per Frenzy Charge
@@ -607,6 +646,7 @@ Variant: Pre 2.6.0
 Variant: Pre 3.19.0
 Variant: Current
 Requires Level 18, 19 Str, 19 Dex
+Implicits: 0
 {variant:1,2}(40-60)% increased Armour and Evasion
 {variant:3}(60-100)% increased Armour and Evasion
 {variant:1}+(10-20) to maximum Life
@@ -624,6 +664,7 @@ Dusktoe
 Leatherscale Boots
 Variant: Pre 2.0.0
 Requires Level 18, 19 Str, 19 Dex
+Implicits: 0
 (40-60)% increased Armour and Evasion
 +(10-20) to maximum Life
 +(10-20) to maximum Mana
@@ -638,6 +679,7 @@ Source: No longer obtainable
 Variant: Pre 3.11.0
 Variant: Current
 Requires Level 40, 19 Str, 19 Dex
+Implicits: 0
 {variant:1}Socketed Gems are Supported by Level 15 Added Chaos Damage
 {variant:2}Trigger Level 1 Stalking Pustule on Kill
 (120-150)% increased Armour and Evasion
@@ -654,6 +696,7 @@ Variant: Pre 3.17.0
 Variant: Current
 League: Ritual
 Requires Level 69, 48 Str, 48 Dex
+Implicits: 0
 (200-300)% increased Armour and Evasion
 {variant:1}-(15-10)% to all Elemental Resistances
 30% increased Movement Speed
@@ -669,6 +712,7 @@ Source: Drops from Eternal Legion
 Variant: Pre 3.7.0
 Variant: Current
 Requires Level 30, 30 Str, 30 Dex
+Implicits: 0
 {variant:2}Trigger Level 5 Rain of Arrows when you Attack with a Bow
 +(40-60) to Strength
 +(40-60) to Dexterity
@@ -682,6 +726,7 @@ Replica Lioneye's Paws
 Bronzescale Boots
 League: Heist
 Requires Level 30, 30 Str, 30 Dex
+Implicits: 0
 Trigger Level 5 Toxic Rain when you Attack with a Bow
 +(40-60) to Strength
 +(40-60) to Dexterity
@@ -695,6 +740,7 @@ League: Warbands
 Variant: Pre 2.6.0
 Variant: Current
 Requires Level 42, 40 Str, 40 Dex
+Implicits: 0
 {variant:1}Adds (15-19) to (28-35) Cold Damage to Spells
 {variant:2}Adds (25-30) to (40-50) Cold Damage to Spells
 {variant:1}(20-40)% increased Critical Strike Chance for Spells
@@ -710,6 +756,7 @@ Hydrascale Boots
 League: Bestiary
 Source: Drops from unique{Saqawal, First of the Sky}
 Requires Level 59, 56 Str, 56 Dex
+Implicits: 0
 Grants Level 20 Aspect of the Avian Skill
 (100-150)% increased Armour and Evasion
 (20-30)% increased Movement Speed
@@ -724,6 +771,7 @@ Soldier Boots
 Variant: Pre 3.19.0
 Variant: Current
 Requires Level 49, 47 Str, 47 Int
+Implicits: 0
 Adds 1 to 80 Chaos Damage to Attacks
 +(180-220) to Armour
 {variant:1}+(9-12)% to Chaos Resistance
@@ -740,6 +788,7 @@ Variant: Pre 3.19.0
 Variant: Current
 League: Heist
 Requires Level 49, 47 Str, 47 Int
+Implicits: 0
 (15-18)% increased Strength
 +(180-220) to Armour
 {variant:1}+(9-12)% to Chaos Resistance
@@ -753,6 +802,7 @@ Death's Door
 Crusader Boots
 Source: Drops in The Eternal Labyrinth
 Requires Level 64, 62 Str, 62 Int
+Implicits: 0
 +(20-40) to Strength
 200% increased Armour and Energy Shield
 +(10-15)% to all Elemental Resistances
@@ -766,6 +816,7 @@ Legion Boots
 Variant: Pre 2.6.0
 Variant: Current
 Requires Level 58, 54 Str, 54 Int
+Implicits: 0
 (160-180)% increased Armour and Energy Shield
 +(50-60)% to Fire Resistance
 25% increased Movement Speed
@@ -780,6 +831,7 @@ Variant: Pre 3.17.0
 Variant: Current
 League: Synthesis
 Requires Level 58, 54 Str, 54 Int
+Implicits: 0
 {variant:1}+2 to Level of Socketed Aura Gems
 {variant:2}+(3-5) to Level of Socketed Aura Gems
 Socketed Gems are Supported by Level 25 Divine Blessing
@@ -792,6 +844,7 @@ Riveted Boots
 Variant: Pre 3.19.0
 Variant: Current
 Requires Level 36, 35 Str, 35 Int
+Implicits: 0
 +(15-25)% to Cold Resistance 
 +(15-25)% to Chaos Resistance 
 {variant:1}20% increased Movement Speed 
@@ -806,6 +859,7 @@ Variant: Pre 2.6.0
 Variant: Pre 3.11.0
 Variant: Current
 Requires Level 28, 28 Str, 28 Int
+Implicits: 0
 Adds 1 to 120 Lightning Damage to Attacks
 (20-60)% increased Armour and Energy Shield
 +(10-20) Life gained on Kill
@@ -822,6 +876,7 @@ Variant: Pre 2.6.0
 Variant: Pre 3.0.0
 Variant: Current
 Requires Level 41, 40 Dex, 40 Int
+Implicits: 0
 {variant:1}+(60-80) to maximum Energy Shield
 {variant:2}+(120-150) to maximum Energy Shield
 {variant:3}+(80-100) to maximum Energy Shield
@@ -839,6 +894,7 @@ Source: Drops from Abyssal Liches
 Variant: One Abyssal Socket
 Variant: Two Abyssal Sockets
 Requires Level 69, 82 Dex, 42 Int
+Implicits: 0
 {variant:1}Has 1 Abyssal Socket
 {variant:2}Has 2 Abyssal Sockets
 Triggers level 20 Death Walk when Equipped
@@ -870,6 +926,7 @@ League: Incursion
 Upgrade: Upgrades to unique{Omeyocan} via currency{Vial of the Ritual}
 {variant:1}Requires Level 34, 34 Dex, 34 Int
 {variant:2}Requires Level 55, 52 Dex, 52 Int
+Implicits: 0
 +(50-60) to maximum Mana
 {variant:1}+(15-20)% to Lightning Resistance
 {variant:2}+(25-30)% to Lightning Resistance
@@ -885,6 +942,7 @@ Variant: Current
 League: Incursion
 Source: Upgraded from unique{Dance of the Offered} via currency{Vial of the Ritual}
 Requires Level 55, 52 Dex, 52 Int
+Implicits: 0
 (15-20)% increased maximum Mana
 +(25-30)% to Lightning Resistance
 30% increased Movement Speed
@@ -898,6 +956,7 @@ Assassin's Boots
 League: Bestiary
 Source: Drops from unique{Fenumus, First of the Night}
 Requires Level 63, 62 Dex, 62 Int
+Implicits: 0
 (160-200)% increased Evasion and Energy Shield
 +(20-30)% to Lightning Resistance
 +(17-23)% to Chaos Resistance
@@ -925,6 +984,7 @@ Variant: Pre 2.0.0
 Variant: Pre 2.6.0
 Variant: Current
 Requires Level 16, 18 Dex, 18 Int
+Implicits: 0
 +(20-30) to Dexterity
 +(30-50) to Evasion Rating
 +(15-30) to maximum Energy Shield
@@ -938,6 +998,7 @@ Requires Level 16, 18 Dex, 18 Int
 The Stampede
 Assassin's Boots
 Requires Level 63, 62 Dex, 62 Int
+Implicits: 0
 League: Blight
 (100-150)% increased Evasion and Energy Shield
 (30-40)% increased Stun and Block Recovery
@@ -950,6 +1011,7 @@ Replica Stampede
 Assassin's Boots
 League: Heist
 Requires Level 63, 62 Dex, 62 Int
+Implicits: 0
 (100-150)% increased Evasion and Energy Shield
 (30-40)% increased Stun and Block Recovery
 Socketed Travel Skills deal 80% more Damage
@@ -962,6 +1024,7 @@ Clasped Boots
 Variant: Pre 2.6.0
 Variant: Current
 Requires Level 27, 27 Dex, 27 Int
+Implicits: 0
 10% increased Attack Speed
 (80-120)% increased Evasion Rating
 (20-30)% increased Rarity of Items found
@@ -973,6 +1036,7 @@ Sunspite
 Clasped Boots
 Source: No longer obtainable
 Requires Level 59, 27 Dex, 27 Int
+Implicits: 0
 10% increased Attack Speed
 (260-300)% increased Evasion and Energy Shield
 (20-30)% increased Rarity of Items found
@@ -988,6 +1052,7 @@ Source: Drops from unique{The Shaper}
 Variant: Pre 3.0.0
 Variant: Current
 Requires Level 69, 82 Dex, 42 Int
+Implicits: 0
 +(30-50) to Dexterity
 (140-180)% increased Evasion and Energy Shield
 30% increased Movement Speed
@@ -1003,6 +1068,7 @@ Murder Boots
 Shaper Item
 League: Heist
 Requires Level 69, 82 Dex, 42 Int
+Implicits: 0
 +(30-50) to Dexterity
 (140-180)% increased Evasion and Energy Shield
 30% increased Movement Speed
@@ -1017,6 +1083,7 @@ Olroth's Charge
 Runic Sollerets
 League: Expedition
 Requires Level 48, 37 Str, 37 Dex, 37 Int
+Implicits: 0
 (50–80)% increased Ward
 (30–50)% slower Restoration of Ward
 20% increased Movement Speed

--- a/src/Data/Uniques/bow.lua
+++ b/src/Data/Uniques/bow.lua
@@ -228,6 +228,7 @@ The Gluttonous Tide
 Citadel Bow
 Source: Drops from unique{The Eater of Worlds}
 Requires Level 58, 185 Dex
+Implicits: 0
 (120-160)% increased Physical Damage
 (16-20)% increased Attack Speed
 Lose all Frenzy Charges on reaching Maximum Frenzy Charges to make the next Bow Attack you perform fire that many additional Arrows
@@ -240,6 +241,7 @@ Source: Drops from unique{The Elder} (Tier 6+)
 Variant: Pre 3.4.0
 Variant: Current
 Requires Level 60, 212 Dex
+Implicits: 0
 Adds (130-150) to (270-300) Cold Damage
 4% increased Movement Speed per Frenzy Charge
 +(400-500) to Accuracy Rating
@@ -340,6 +342,7 @@ Ranger Bow
 Variant: Pre 3.14.0
 Variant: Current
 Requires Level 60, 212 Dex, 212 Int
+Implicits: 0
 Adds (50-80) to (130-180) Chaos Damage
 (7-12)% increased Attack Speed
 +(7-11)% to Chaos Resistance
@@ -369,6 +372,7 @@ Variant: Pre 2.6.0
 Variant: Pre 3.9.0
 Variant: Current
 Requires Level 5, 26 Dex
+Implicits: 0
 +(10-20) to Dexterity
 {variant:2,3}100% increased Physical Damage
 100% increased Attack Speed
@@ -383,6 +387,7 @@ Replica Quill Rain
 Short Bow
 League: Heist
 Requires Level 5, 26 Dex
+Implicits: 0
 Socketed Gems are Supported by Level 1 Arrow Nova
 +(10-20) to Dexterity
 100% increased Physical Damage
@@ -400,6 +405,7 @@ Variant: Pre 3.11.0
 Variant: Pre 3.17.0
 Variant: Current
 Requires Level 64, 212 Dex
+Implicits: 0
 {variant:4,5,6}Socketed Gems are Supported by Level 20 Greater Volley
 {variant:1}(50-70)% increased Physical Damage
 {variant:2,3}(40-50)% increased Physical Damage
@@ -437,6 +443,7 @@ Crude Bow
 Variant: Pre 2.0.0
 Variant: Current
 Requires Level 2
+Implicits: 0
 +1 to Level of Socketed Bow Gems
 {variant:1}(50-80)% increased Physical Damage
 {variant:2}(80-100)% increased Physical Damage
@@ -448,6 +455,7 @@ Silverbough
 Crude Bow
 Source: No longer obtainable
 Requires Level 36
+Implicits: 0
 +1 to Level of Socketed Gems
 +1 to Level of Socketed Bow Gems
 (80-100)% increased Physical Damage
@@ -480,6 +488,7 @@ Long Bow
 Variant: Pre 2.0.0
 Variant: Current
 Requires Level 9, 38 Dex
+Implicits: 0
 No Physical Damage
 {variant:1}Adds 1 to 75 Lightning Damage
 {variant:2}Adds 1 to 85 Lightning Damage
@@ -489,6 +498,7 @@ The Tempest
 Long Bow
 Source: No longer obtainable
 Requires Level 32, 38 Dex
+Implicits: 0
 No Physical Damage
 100% increased Lightning Damage
 Adds 1 to 85 Lightning Damage
@@ -499,6 +509,7 @@ Spine Bow
 Variant: Pre 3.9.0
 Variant: Current
 Requires Level 64, 212 Dex
+Implicits: 0
 Adds 1 to (275-325) Lightning Damage
 (10-15)% increased Attack Speed
 60% of Lightning Damage Converted to Chaos Damage
@@ -552,6 +563,7 @@ League: Breach
 Source: Drops in Xoph Breach or from unique{Xoph, Dark Embers}
 Upgrade: Upgrades to unique{Xoph's Nurture} using currency{Blessing of Xoph}
 Requires Level 23, 80 Dex
+Implicits: 0
 (70-90)% increased Physical Damage
 +(20-30) Life gained on Killing Ignited Enemies
 Gain 20% of Physical Damage as Extra Fire Damage
@@ -566,6 +578,7 @@ Variant: Pre 3.9.0
 Variant: Pre 3.17.0
 Variant: Current
 Requires Level 64, 185 Dex
+Implicits: 0
 {variant:3,4}Socketed Gems are Supported by Level 20 Ignite Proliferation
 {variant:1,2,3}(250-300)% increased Physical Damage
 {variant:4}(165-195)% increased Physical Damage

--- a/src/Data/Uniques/fishing.lua
+++ b/src/Data/Uniques/fishing.lua
@@ -8,6 +8,7 @@ Fishing Rod
 Variant: Pre 2.6.0
 Variant: Current
 Requires 8 Str, 8 Dex
+Implicits: 0
 (30-40)% increased Cast Speed
 Thaumaturgical Lure
 {variant:1}(30-40)% increased Quantity of Fish Caught

--- a/src/Data/Uniques/flask.lua
+++ b/src/Data/Uniques/flask.lua
@@ -12,6 +12,7 @@ Variant: Pre 3.15.0
 Variant: Pre 3.16.0
 Variant: Current
 Requires Level 50
+Implicits: 0
 {variant:3}100% increased Life Recovered
 {variant:4,5}50% increased Life Recovered
 {variant:1}(20-30)% reduced Recovery rate
@@ -47,6 +48,7 @@ Lavianga's Spirit
 Sanctified Mana Flask
 League: Domination, Nemesis
 Requires Level 50
+Implicits: 0
 (30-50)% increased Amount Recovered
 100% increased Recovery rate
 Your Skills have no Mana Cost during Flask effect
@@ -55,6 +57,7 @@ Replica Lavianga's Spirit
 Sanctified Mana Flask
 League: Heist
 Requires Level 50
+Implicits: 0
 (30-50)% increased Amount Recovered
 50% reduced Recovery rate
 (5-15)% increased Attack Speed during Flask effect
@@ -67,6 +70,7 @@ Variant: Pre 3.2.0
 Variant: Current
 League: Perandus
 Requires Level 18
+Implicits: 0
 50% increased Charges used
 {variant:1}Grants Last Breath when you Use a Skill during Flask Effect, for 800% of Mana Cost
 {variant:2}Grants Last Breath when you Use a Skill during Flask Effect, for (450-600)% of Mana Cost
@@ -81,6 +85,7 @@ Variant: Pre 3.5.0
 Variant: Pre 3.15.0
 Variant: Current
 Requires Level 30
+Implicits: 0
 {variant:1,2,3,4}(40-60)% increased Rarity of Items found during Flask effect
 {variant:5}(20-30)% increased Rarity of Items found during Flask effect
 {variant:1}(20-25)% increased Quantity of Items found during Flask effect
@@ -94,6 +99,7 @@ Requires Level 30
 The Writhing Jar
 Hallowed Hybrid Flask
 Requires Level 60
+Implicits: 0
 (75-65)% reduced Amount Recovered
 Instant Recovery
 2 Enemy Writhing Worms escape the Flask when used
@@ -108,6 +114,7 @@ Variant: Pre 3.0.0
 Variant: Pre 3.15.0
 Variant: Current
 Requires Level 68
+Implicits: 0
 2% of Chaos Damage Leeched as Life during Flask effect
 {variant:1}Gain (22-25)% of Physical Damage as Extra Chaos Damage during effect
 {variant:2}Gain (15-20)% of Physical Damage as Extra Chaos Damage during effect
@@ -124,6 +131,7 @@ Variant: Pre 3.15.0
 Variant: Pre 3.16.0
 Variant: Current
 Requires Level 35
+Implicits: 0
 Creates Consecrated Ground on Use
 {variant:1}(30-50)% increased Duration
 {variant:2}(20-40)% increased Duration
@@ -136,6 +144,7 @@ Consecrated Ground created during Effect applies (7-10)% increased Damage taken 
 Coralito's Signature
 Diamond Flask
 Requires Level 27
+Implicits: 0
 Variant: Pre 3.15.0
 Variant: Current
 {variant:1}Take 30 Chaos Damage per Second during Flask effect
@@ -203,6 +212,7 @@ Variant: Pre 3.15.0
 Variant: Pre 3.16.0
 Variant: Current
 Requires Level 68
+Implicits: 0
 {variant:2}(-10-10)% increased Charges used
 {variant:3,4}(125-150)% increased Charges used
 {variant:3}(40-60)% reduced duration
@@ -219,6 +229,7 @@ Variant: Pre 2.6.0
 Variant: Pre 3.15.0
 Variant: Current
 Requires Level 27
+Implicits: 0
 {variant:1,2}50% increased Charges used
 {variant:1}Recover 50% of your maximum Life on use
 {variant:2}Recover 75% of your maximum Life on use
@@ -246,6 +257,7 @@ Variant: Pre 3.0.0
 Variant: Pre 3.15.0
 Variant: Current
 Requires Level 27
+Implicits: 0
 Adds Knockback to Melee Attacks during Flask effect
 75% chance to cause Enemies to Flee on use
 {variant:1}(70-100)% increased Charges used
@@ -262,6 +274,7 @@ Variant: Pre 2.6.0
 Variant: Pre 3.15.0
 Variant: Current
 Requires Level 40
+Implicits: 0
 {variant:1}(100-150)% increased Charges used
 {variant:2,3}(50-100)% increased Charges used
 {variant:3}50% increased Duration
@@ -280,6 +293,7 @@ Variant: Pre 2.5.0
 Variant: Pre 3.15.0
 Variant: Current
 Requires Level 68
+Implicits: 0
 {variant:1}(30-40)% Chance to Block during Flask effect
 {variant:2}(20-30)% Chance to Block during Flask effect
 {variant:3}(14-20)% Chance to Block during Flask effect
@@ -293,6 +307,7 @@ Replica Rumi's Concoction
 Granite Flask
 League: Heist
 Requires Level 68
+Implicits: 0
 You gain an Endurance Charge on use
 +(35-50)% Chance to Block Attack Damage during Flask effect
 +(20-30)% Chance to Block Spell Damage during Flask effect
@@ -338,6 +353,7 @@ Variant: Pre 3.10.0
 Variant: Pre 3.15.0
 Variant: Current
 Requires Level 27
+Implicits: 0
 Cannot gain Mana during effect
 {variant:2}Vaal Skills have (80-120)% increased Critical Strike Chance during effect
 {variant:3}Vaal Skills have (60-80)% increased Critical Strike Chance during effect
@@ -355,6 +371,7 @@ Source: Upgraded from unique{Soul Catcher} via currency{Vial of the Ghost}
 Variant: Pre 3.10.0
 Variant: Current
 Requires Level 27
+Implicits: 0
 {variant:1}100% increased Charges used
 {variant:1}Vaal Skills deal (30-40)% more Damage during effect
 {variant:1}Vaal Skills used during effect do not apply Soul Gain Prevention
@@ -371,6 +388,7 @@ Variant: Pre 3.0.0
 Variant: Pre 3.15.0
 Variant: Current
 Requires Level 18
+Implicits: 0
 {variant:1}30% of Physical Damage from Hits taken as Cold Damage during Flask effect
 {variant:2,3}20% of Physical Damage from Hits taken as Cold Damage during Flask effect
 {variant:4}(10-15)% of Physical Damage from Hits taken as Cold Damage during Flask effect
@@ -416,6 +434,7 @@ Variant: Current (Penetration)
 Variant: Current (Spells)
 Variant: Current (Attacks)
 Requires Level 68
+Implicits: 0
 {variant:5,6,7,8,9,10,11,12,13,14,15}(80-100)% increased Charges used
 {variant:16,17,18}(125-150)% increased Charges used
 {variant:1,2,3,4,5,6,7,8}Shocks nearby Enemies during Flask effect
@@ -445,6 +464,7 @@ Variant: Pre 3.0.0
 Variant: Pre 3.15.0
 Variant: Current
 Requires Level 8
+Implicits: 0
 {variant:1,2}During Flask Effect, 10% reduced Damage taken of each Element for which your Uncapped Elemental Resistance is lowest
 {variant:3}During Flask Effect, 6% reduced Damage taken of each Element for which your Uncapped Elemental Resistance is lowest
 {variant:1}During Flask Effect, Damage Penetrates 20% Resistance of each Element for which your Uncapped Elemental Resistance is highest
@@ -471,6 +491,7 @@ Elixir of the Unbroken Circle
 Iron Flask
 League: Expedition
 Requires Level 40
+Implicits: 0
 (20–40)% increased Duration
 Recover 4% of Life per Endurance Charge on use
 Lose all Endurance Charges on use
@@ -480,6 +501,7 @@ Olroth's Resolve
 Iron Flask
 League: Expedition
 Requires Level 40
+Implicits: 0
 (40–50)% increased Charges used
 Ward does not Break during Flask effect
 70% less Ward during Flask Effect
@@ -488,6 +510,7 @@ Starlight Chalice
 Iron Flask
 League: Expedition
 Requires Level 40
+Implicits: 0
 (20–30)% increased Charge Recovery
 Inflict Fire, Cold and Lightning Exposure on nearby Enemies when used
 (20–30)% increased Effect of Non-Damaging Ailments you inflict during Flask Effect
@@ -496,6 +519,7 @@ Vorana's Preparation
 Iron Flask
 League: Expedition
 Requires Level 40
+Implicits: 0
 (-10–10)% reduced Charges used
 Debilitate nearby Enemies for 2 Seconds when Flask Effect ends
 Flask Effect is removed when Ward Breaks

--- a/src/Data/Uniques/gloves.lua
+++ b/src/Data/Uniques/gloves.lua
@@ -10,6 +10,7 @@ Variant: Pre 3.1.0
 Variant: Pre 3.16.0
 Variant: Current
 Requires Level 75, 100 Str
+Implicits: 0
 +(60-80) to Intelligence
 +(60-75) to maximum Life
 (200-220)% increased Armour
@@ -22,6 +23,7 @@ Replica Atziri's Acuity
 Vaal Gauntlets
 League: Heist
 Requires Level 63, 100 Str
+Implicits: 0
 +(60-80) to Intelligence
 (25-35)% increased Global Critical Strike Chance
 (200-220)% increased Armour
@@ -45,6 +47,7 @@ Titan Gauntlets
 League: Bestiary
 Source: Drops from unique{Craiceann, First of the Deep}
 Requires Level 69, 98 Str
+Implicits: 0
 (150-200)% increased Armour
 (50-70) Life Regenerated per second
 +(30-40)% to Fire Resistance
@@ -59,6 +62,7 @@ Variant: Pre 3.5.0
 Variant: Pre 3.10.0
 Variant: Current
 Requires Level 63, 100 Str
+Implicits: 0
 {variant:2,3,4}Grants level 20 Doryani's Touch Skill
 {variant:1,2,3}+30 to maximum Energy Shield
 {variant:4}+(80-100) to maximum Energy Shield
@@ -76,6 +80,7 @@ Hateforge
 Ancient Gauntlets
 League: Ultimatum
 Requires Level 47, 68 Str
+Implicits: 0
 Socketed Gems are Supported by Level 30 Rage
 (120-150)% increased Armour
 (10-25)% reduced Rage Cost of Skills
@@ -85,6 +90,7 @@ You cannot gain Rage during Soul Gain Prevention
 Empire's Grasp
 Goliath Gauntlets
 Requires Level 53, 76 Str
+Implicits: 0
 +(400-600) to Armour
 Knockback direction is reversed
 Socketed Gems are Supported by level 10 Knockback
@@ -94,6 +100,7 @@ Bronze Gauntlets
 Variant: Pre 3.19.0
 Variant: Current
 Requires Level: 23, 36 Str
+Implicits: 0
 +(30-40) to Strength
 {variant:1}Adds (3-6) to (10-12) Physical Damage to Attacks
 {variant:2}Adds (5-8) to (12-16) Physical Damage to Attacks
@@ -107,6 +114,7 @@ Iron Gauntlets
 Variant: Pre 2.6.0
 Variant: Pre 3.19.0
 Variant: Current
+Implicits: 0
 (10-15)% increased Attack Speed
 {variant:1}+(10-20) to Armour
 {variant:2}+(20-30) to maximum Life
@@ -123,6 +131,7 @@ Variant: Pre 2.6.0
 Variant: Pre 3.19.0
 Variant: Current
 Requires Level 35, 52 Str
+Implicits: 0
 {variant:1,2,3}10% increased Global Physical Damage
 {variant:1,2,3}+100 to Strength
 {variant:4}+50 to Strength
@@ -136,6 +145,7 @@ Requires Level 35, 52 Str
 Veruso's Battering Rams
 Titan Gauntlets
 Requires Level 69, 98 Str
+Implicits: 0
 (8-13)% increased Attack Speed
 (120-180)% increased Armour
 (3-5)% increased Movement Speed
@@ -159,6 +169,7 @@ Source: Drops in The Lord's Labyrinth
 Variant: Pre 2.6.0
 Variant: Current
 Requires Level 47, 68 Str
+Implicits: 0
 +(30-60) to maximum Life
 30% increased Projectile Speed
 {variant:1}10% reduced Movement Speed
@@ -171,6 +182,7 @@ Requires Level 47, 68 Str
 Great Old One's Tentacles
 Eelskin Gloves
 Requires Level 38, 56 Dex
+Implicits: 0
 Adds (8-12) to (15-20) Physical Damage to Attacks
 +(50-70) to maximum Life
 (10-20)% chance to Impale Enemies on Hit with Attacks
@@ -182,6 +194,7 @@ Variant: Pre 2.6.0
 Variant: Pre 3.19.0
 Variant: Current
 Requires Level 9, 17 Dex
+Implicits: 0
 +(20-30) to Strength
 {variant:1}50% increased Evasion Rating
 {variant:2,3}+(40-50) to Evasion Rating
@@ -200,6 +213,7 @@ Source: No longer obtainable
 Variant: Pre 2.6.0
 Variant: Current
 Requires Level 24, 17 Dex
+Implicits: 0
 +(20-30) to Strength
 {variant:1}50% increased Evasion Rating
 {variant:2}+(40-50) to Evasion Rating
@@ -220,6 +234,7 @@ Variant: Pre 3.0.0
 Variant: Pre 3.7.0
 Variant: Current
 Requires Level 21, 33 Dex
+Implicits: 0
 +(20-30) to Dexterity
 5% increased Attack Speed
 50% increased Global Critical Strike Chance
@@ -233,6 +248,7 @@ Mercenary's Lot
 Slink Gloves
 League: Heist
 Requires Level 70, 95 Dex
+Implicits: 0
 +(80-120) to Evasion Rating
 (5-8)% increased Attack and Cast Speed
 Mark Skills have (10-15)% increased Cast Speed
@@ -244,6 +260,7 @@ Nubuck Gloves
 Variant: Pre 3.16.0
 Variant: Current
 Requires Level 52, 50 Dex
+Implicits: 0
 Trigger Level 10 Assassin's Mark when you Hit a Rare or Unique Enemy
 (30-40)% increased Accuracy Rating
 +(40-50) to maximum Life
@@ -255,6 +272,7 @@ Trigger Level 10 Assassin's Mark when you Hit a Rare or Unique Enemy
 Painseeker
 Shagreen Gloves
 Requires Level 54, 78 Dex
+Implicits: 0
 Adds (16-19) to (25-29) Fire Damage
 Adds (16-19) to (25-29) Cold Damage
 Adds (6-10) to (33-38) Lightning Damage
@@ -269,6 +287,7 @@ Allelopathy
 {variant:2}Satin Gloves
 Variant: Pre 3.19.0
 Variant: Current
+Implicits: 0
 Grants level 22 Blight Skill
 {variant:1}(20-30)% increased Damage over Time
 (100-120)% increased Energy Shield
@@ -282,6 +301,7 @@ Replica Allelopathy
 Variant: Pre 3.19.0
 Variant: Current
 League: Heist
+Implicits: 0
 Grants Level 22 Wintertide Brand
 {variant:1}(20-30)% increased Damage over Time
 (100-120)% increased Energy Shield
@@ -297,6 +317,7 @@ Variant: Pre 2.6.0
 Variant: Pre 3.7.0
 Variant: Current
 Requires Level 25, 39 Int
+Implicits: 0
 +(20-30) to Intelligence
 {variant:1,2}+(20-30) to maximum Life
 {variant:3}+(60-80) to maximum Life
@@ -328,6 +349,7 @@ Variant: Pre 3.19.0
 Variant: Current
 League: Delve
 Requires Level 41, 60 Int
+Implicits: 0
 (15-20)% increased Cast Speed
 {variant:1}+(50-70) to maximum Energy Shield
 {variant:2}+(100-120) to maximum Energy Shield
@@ -342,6 +364,7 @@ Variant: Pre 2.6.0
 Variant: Pre 3.19.0
 Variant: Current
 Requires Level 12, 21 Int
+Implicits: 0
 {variant:1}(40-50)% increased Spell Damage
 {variant:2}(50-60)% increased Spell Damage
 {variant:3}100% increased Spell Damage
@@ -360,6 +383,7 @@ Source: No longer obtainable
 Variant: Pre 3.11.0
 Variant: Current
 Requires Level 64, 21 Int
+Implicits: 0
 (50-60)% increased Spell Damage
 +20 to Intelligence
 Adds (48-56) to (73-84) Chaos Damage to Spells
@@ -371,6 +395,7 @@ Adds (48-56) to (73-84) Chaos Damage to Spells
 Grip of the Council
 Arcanist Gloves
 Requires Level 60, 95 Int
+Implicits: 0
 +30 to Strength
 +(30-50) to maximum Life
 +(20-40)% to Cold Resistance
@@ -382,6 +407,7 @@ Replica Grip of the Council
 Arcanist Gloves
 League: Heist
 Requires Level 60, 95 Int
+Implicits: 0
 +30 to Strength
 +(30-50) to maximum Life
 +(20-40)% to Fire Resistance
@@ -392,6 +418,7 @@ Minions gain 20% of Physical Damage as Extra Fire Damage
 Kalisa's Grace
 Samite Gloves
 Requires Level 55, 68 Int
+Implicits: 0
 Socketed Gems are Supported by Level 18 Faster Casting
 +(20-30) to Intelligence
 +(50-80) to maximum Energy Shield
@@ -402,6 +429,7 @@ Replica Kalisa's Grace
 Samite Gloves
 League: Heist
 Requires Level 55, 68 Int
+Implicits: 0
 Socketed Gems are Supported by Level 18 Unleash
 +(20-30) to Intelligence
 +(50-80) to maximum Energy Shield
@@ -414,6 +442,7 @@ Variant: Pre 1.1.0
 Variant: Pre 3.5.0
 Variant: Current
 Requires Level 11
+Implicits: 0
 Adds 4 to 8 Fire Damage to Attacks
 Adds 1 to 13 Lightning Damage to Attacks
 +18 to maximum Energy Shield
@@ -428,6 +457,7 @@ Variant: Pre 3.0.0
 Variant: Pre 3.11.0
 Variant: Current
 Requires Level 55, 79 Int
+Implicits: 0
 +1 to Level of Socketed Elemental Gems
 (125-150)% increased Critical Strike Chance for Spells
 {variant:1,2}(280-350)% increased Energy Shield
@@ -442,6 +472,7 @@ Requires Level 55, 79 Int
 Aurseize
 Steelscale Gauntlets
 Requires Level 36, 29 Str, 29 Dex
+Implicits: 0
 (40-60)% increased Armour and Evasion
 +15% to all Elemental Resistances
 (40-50)% increased Rarity of Items found
@@ -451,6 +482,7 @@ Breathstealer
 Hydrascale Gauntlets
 Requires Level 59, 45 Str, 45 Dex
 League: Blight
+Implicits: 0
 (100-150)% increased Armour and Evasion
 +(30-50) to maximum Mana
 +(10-16)% to all Elemental Resistances
@@ -464,6 +496,7 @@ Hydrascale Gauntlets
 League: Bestiary
 Source: Drops from unique{Farrul, First of the Plains}
 Requires Level 59, 45 Str, 45 Dex
+Implicits: 0
 (100-140)% increased Armour and Evasion
 +(50-70) to maximum Life
 +(400-500) to Accuracy against Bleeding Enemies
@@ -475,6 +508,7 @@ Flesh and Spirit
 Ironscale Gauntlets
 League: Rampage
 Requires Level 15
+Implicits: 0
 (6-9)% increased Attack Speed
 (80-120)% increased Armour and Evasion
 (3-4) Life Regenerated per second
@@ -494,6 +528,7 @@ Nearby Enemies Killed by anyone count as being Killed by you instead
 Haemophilia
 Serpentscale Gauntlets
 Requires Level 43, 34 Str, 34 Dex
+Implicits: 0
 +(20-30) to Strength
 25% increased Damage over Time
 Attacks have 25% chance to cause Bleeding
@@ -507,6 +542,7 @@ Bronzescale Gauntlets
 Variant: Pre 2.6.0
 Variant: Current
 Requires Level 27, 22 Str, 22 Dex
+Implicits: 0
 +(40-50) to Dexterity
 {variant:1}5% increased Attack Speed
 {variant:2}(5-10)% increased Attack Speed
@@ -519,6 +555,7 @@ Dragonscale Gauntlets
 Variant: Pre 2.6.0
 Variant: Current
 Requires Level 67, 51 Str, 51 Dex
+Implicits: 0
 (90-110)% increased Armour and Evasion
 (4-7)% increased Elemental Damage per Frenzy Charge
 (4-7)% increased Physical Damage per Endurance Charge
@@ -535,6 +572,7 @@ Variant: Pre 3.6.0 Two Abyssal Sockets
 Variant: Current One Abyssal Socket
 Variant: Current Two Abyssal Sockets
 Requires Level: 36, 29 Str, 29 Int
+Implicits: 0
 {variant:1,3}Has 1 Abyssal Socket
 {variant:2,4}Has 2 Abyssal Sockets
 {variant:1,2}(6-10)% increased Attack Speed
@@ -549,6 +587,7 @@ Variant: Pre 2.6.0
 Variant: Pre 3.19.0
 Variant: Current
 Requires Level 27, 22 Str, 22 Dex
+Implicits: 0
 {variant:1,2}+2 to Level of Socketed Vaal Gems
 {variant:3}-5 to Level of Socketed Non-Vaal Gems
 {variant:3}+5 to Level of Socketed Vaal Gems
@@ -564,6 +603,7 @@ Worldcarver
 Dragonscale Gauntlets
 Source: No longer obtainable
 Requires Level 67, 51 Str, 51 Dex
+Implicits: 0
 Trigger Level 20 Arcane Wake after Spending a total of 200 Mana
 +(200-300) to Accuracy Rating
 (120-150)% increased Armour and Evasion
@@ -574,6 +614,7 @@ Trigger Level 20 Arcane Wake after Spending a total of 200 Mana
 Wyrmsign
 Wyrmscale Gauntlets
 Requires Level 49, 38 Str, 38 Dex
+Implicits: 0
 Socketed Gems are Supported by level 5 Concentrated Effect
 (120-160)% increased Armour and Evasion
 +(50-70) to maximum Life
@@ -590,6 +631,7 @@ Source: Drops from unique{Kurgal, the Blackblooded}
 Variant: One Abyssal Socket
 Variant: Two Abyssal Sockets
 Requires Level 37, 29 Str, 29 Int
+Implicits: 0
 {variant:1}Has 1 Abyssal Socket
 {variant:2}Has 2 Abyssal Sockets
 (6-10)% increased Cast Speed
@@ -601,6 +643,7 @@ Hand of the Fervent
 Zealot Gloves
 League: Ritual
 Requires Level 43, 34 Str, 34 Int
+Implicits: 0
 (70-130)% increased Armour and Energy Shield
 +(50-70) to maximum Life
 Gain Sacrificial Zeal when you use a Skill, dealing you 150% of the Skill's Mana Cost as Physical Damage per Second
@@ -609,6 +652,7 @@ Hits Overwhelm (10-15)% of Physical Damage Reduction while you have Sacrificial 
 Hands of the High Templar
 Crusader Gloves
 Requires Level 66, 51 Str, 51 Int
+Implicits: 0
 Can be modified while Corrupted
 Can have up to 5 Implicit Modifiers while Item has this Modifier
 (150-200)% increased Armour and Energy Shield
@@ -619,6 +663,7 @@ Null and Void
 Legion Gloves
 League: Rampage
 Requires Level 57, 44 Str, 44 Int
+Implicits: 0
 +(20-30) to Strength
 (150-180)% increased Armour and Energy Shield
 +(50-70) to maximum Life
@@ -632,6 +677,7 @@ Legion Gloves
 League: Synthesis
 Source: Drops from unique{Synthete Nightmare} in normal{The Cortex}
 Requires Level 57, 44 Str, 44 Int
+Implicits: 0
 +(15-25) to all Attributes
 (150-200)% increased Armour and Energy Shield
 50% reduced Maximum Recovery per Life Leech
@@ -644,6 +690,7 @@ Crusader Gloves
 Variant: Pre 3.19.0
 Variant: Current
 Requires Level 66, 306 Str, 306 Int
+Implicits: 0
 {variant:1}(0-30)% reduced Spell Damage
 {variant:1}(120-180)% increased Armour and Energy Shield
 {variant:2}(400-500)% increased Armour and Energy Shield
@@ -657,6 +704,7 @@ Soldier Gloves
 League: Bestiary
 Source: Drops from unique{Saqawal, First of the Sky}
 Requires Level 51, 40 Str, 40 Int
+Implicits: 0
 (140-180)% increased Armour and Energy Shield
 +(30-60) to maximum Life
 +(20-25)% to Cold and Lightning Resistances
@@ -669,6 +717,7 @@ Chain Gloves
 Variant: Pre 1.2.0
 Variant: Current
 Requires Level 7, 17 Dex
+Implicits: 0
 (40-60)% increased Stun Recovery
 Hexes applied by Socketed Curse Skills are Reflected back to you
 You cannot be Chilled for 3 seconds after being Chilled
@@ -685,6 +734,7 @@ Variant: Pre 2.6.0
 Variant: Pre 3.10.0
 Variant: Current
 Requires Level 66, 51 Str, 51 Int
+Implicits: 0
 (80-120)% increased Armour and Energy Shield
 {variant:1}+2 Accuracy Rating per 2 Intelligence
 {variant:2,3}+4 Accuracy Rating per 2 Intelligence
@@ -705,6 +755,7 @@ Variant: Pre 2.6.0
 Variant: Pre 3.19.0
 Variant: Current
 Requires Level 51, 40 Str, 40 Int
+Implicits: 0
 {variant:1,2}Adds (30-36) to (44-50) Cold Damage to Attacks
 {variant:3}Adds (60-72) to (88-100) Cold Damage to Attacks
 (12-16)% increased maximum Life
@@ -717,6 +768,7 @@ Your Hits can only Kill Frozen enemies
 Triad Grip
 Mesh Gloves
 Requires Level 32, 26 Str, 26 Int
+Implicits: 0
 (80-120)% increased Armour and Energy Shield
 Minions convert 25% of Physical Damage to Fire Damage per Red Socket
 Minions convert 25% of Physical Damage to Cold Damage per Green Socket
@@ -730,6 +782,7 @@ Variant: Fire
 Variant: Cold
 Variant: Lightning
 Requires Level 43, 34 Str, 34 Int
+Implicits: 0
 {variant:1}Adds (16-20) to (25-30) Fire Damage to Spells and Attacks
 {variant:2}Adds (16-20) to (25-30) Cold Damage to Spells and Attacks
 {variant:3}Adds (1-3) to (42-47) Lightning Damage to Spells and Attacks
@@ -749,6 +802,7 @@ Replica Volkuur's Guidance
 Zealot Gloves
 League: Heist
 Requires Level 43, 34 Str, 34 Int
+Implicits: 0
 Adds (17-23) to (29-31) Chaos Damage
 +(50-70) to maximum Life
 +(29-41)% to Chaos Resistance
@@ -762,6 +816,7 @@ Abhorrent Interrogation
 Ambush Mitts
 League: Harvest
 Requires Level 45, 35 Dex, 35 Int
+Implicits: 0
 (100-150)% increased Evasion and Energy Shield
 (5-7)% increased Attack and Cast Speed
 (20-25)% chance to inflict Withered for 2 seconds on Hit
@@ -774,6 +829,7 @@ Carnal Mitts
 League: Delirium
 Source: Drops from the Simulacrum Encounter
 Requires Level 50, 39 Dex, 39 Int
+Implicits: 0
 +(50-70) to maximum Energy Shield
 +(15-20)% to Cold and Lightning Resistances
 (20-30)% chance to Sap Enemies in Chilling Areas
@@ -785,6 +841,7 @@ Clasped Mitts
 League: Legion
 Source: Drops from Maraketh Legion
 Requires Level 31, 25 Dex 25 Int
+Implicits: 0
 +(30-40) to Dexterity
 (5-7)% increased Cast Speed
 (100-150)% increased Evasion and Energy Shield
@@ -799,6 +856,7 @@ Variant: Current
 {variant:2}Ambush Mitts
 League: Incursion
 Upgrade: Upgrades to unique{Slavedriver's Hand} via currency{Vial of Dominance}
+Implicits: 0
 {variant:1}Requires Level 16
 {variant:2}Requires Level 45, 35 Dex, 35 Int
 +(30-40) to Dexterity
@@ -814,6 +872,7 @@ Ambush Mitts
 League: Incursion
 Source: Upgraded from unique{Architect's Hand} via currency{Vial of Dominance}
 Requires Level 45, 35 Dex, 35 Int
+Implicits: 0
 +(30-40) to Dexterity
 (200-250)% increased Evasion and Energy Shield
 (20-30)% reduced Trap Throwing Speed
@@ -826,6 +885,7 @@ Blasphemer's Grasp
 Assassin's Mitts
 Source: Drops from unique{The Elder}
 Requires Level 58, 45 Dex, 45 Int
+Implicits: 0
 +(40-50) to Dexterity
 (150-200)% increased Evasion and Energy Shield
 +(50-60) to maximum Life
@@ -838,6 +898,7 @@ Elder Item
 The Embalmer
 Carnal Mitts
 Requires Level 50, 39 Dex, 39 Int
+Implicits: 0
 Socketed Gems are Supported by Level 20 Vile Toxins
 Adds (13-17) to (23-29) Chaos Damage
 +(50-70) to maximum Life
@@ -852,6 +913,7 @@ Variant: Pre 2.5.0
 Variant: Pre 3.0.0
 Variant: Current
 Requires Level 16, 14 Dex, 14 Int
+Implicits: 0
 {variant:1,2}+60% to Global Critical Strike Multiplier
 {variant:3}+90% to Global Critical Strike Multiplier
 {variant:4}+45% to Global Critical Strike Multiplier
@@ -866,6 +928,7 @@ Carnal Mitts
 League: Bestiary
 Source: Drops from unique{Fenumus, First of the Night}
 Requires Level 50, 39 Dex, 39 Int
+Implicits: 0
 Grants Level 20 Aspect of the Spider Skill
 (120-170)% increased Evasion and Energy Shield
 +(40-50) to maximum Life
@@ -877,6 +940,7 @@ Machina Mitts
 Murder Mitts
 Requires Level: 67
 League: Blight
+Implicits: 0
 (200-250)% increased Evasion and Energy Shield
 1% of Damage dealt by your Mines is Leeched to you as Life
 (20-30)% reduced Recovery rate of Life and Energy Shield
@@ -889,6 +953,7 @@ Variant: Pre 1.1.0
 Variant: Pre 3.19.0
 Variant: Current
 Requires Level 5
+Implicits: 0
 {variant:1}20% increased Attack Speed when on Full Life
 {variant:2,3}30% increased Attack Speed when on Full Life
 {variant:1,2}Adds 1 to 13 Lightning Damage to Attacks
@@ -901,6 +966,7 @@ Requires Level 5
 Malachai's Mark
 Murder Mitts
 Requires Level 67, 51 Dex, 51 Int
+Implicits: 0
 (80-100)% increased Evasion and Energy Shield
 +(60-80) to maximum Life
 +(15-25) Life gained on Kill
@@ -914,6 +980,7 @@ Variant: Pre 2.2.0
 Variant: Pre 3.0.0
 Variant: Current
 Requires Level 31, 25 Dex, 25 Int
+Implicits: 0
 (20-30)% increased Global Critical Strike Chance
 {variant:1}+(15-30)% to Global Critical Strike Multiplier
 {variant:2}+(25-45)% to Global Critical Strike Multiplier
@@ -930,6 +997,7 @@ Variant: Pre 3.0.0
 Variant: Pre 3.9.0
 Variant: Current
 Requires Level 58, 45 Dex, 45 Int
+Implicits: 0
 (150-180)% increased Evasion Rating
 +(60-70) to maximum Life
 2% increased Attack Speed per Frenzy Charge
@@ -944,6 +1012,7 @@ Assassin's Mitts
 League: Synthesis
 Source: Drops from unique{Altered/Augmented/Rewritten/Twisted Synthete}
 Requires Level 58, 45 Dex, 45 Int
+Implicits: 0
 (20-30)% increased Damage over Time
 (250-300)% increased Evasion and Energy Shield
 +(20-30)% to Lightning Resistance
@@ -957,6 +1026,7 @@ Variant: Pre 2.6.0
 Variant: Pre 3.19.0
 Variant: Current
 Requires Level 67, 51 Dex, 51 Int
+Implicits: 0
 {variant:1,2,3}Socketed Gems are Supported by level 18 Added Lightning Damage
 {variant:4}Socketed Gems are Supported by level 30 Added Lightning Damage
 {variant:1,3}Adds 1 to 100 Lightning Damage to Attacks
@@ -974,6 +1044,7 @@ Medved's Challenge
 Runic Gauntlets
 Requires Level 69, 38 Str, 38 Dex, 38 Int
 League: Expedition
+Implicits: 0
 800% increased Attribute Requirements
 (30–50)% increased Ward
 +(15–25)% to all Elemental Resistances
@@ -986,6 +1057,7 @@ Variant: Pre 3.16.0
 Variant: Current
 League: Expedition
 Requires Level 48, 31 Str, 31 Dex, 31 Int
+Implicits: 0
 (33–48)% increased Ward
 +(17–23)% to Chaos Resistance
 {variant:1}Gain Added Chaos Damage equal to 25% of Ward

--- a/src/Data/Uniques/helmet.lua
+++ b/src/Data/Uniques/helmet.lua
@@ -8,6 +8,7 @@ Variant: Pre 2.2.0
 Variant: Pre 3.0.0
 Variant: Current
 Requires Level 60, 138 Str
+Implicits: 0
 Adds 40 to 60 Physical Damage to Attacks
 +(20-25) to all Attributes
 {variant:1}+(100-150)% to Melee Critical Strike Multiplier
@@ -20,6 +21,7 @@ Replica Abyssus
 Ezomyte Burgonet
 League: Heist
 Requires Level 60, 138 Str
+Implicits: 0
 +(20-25) to all Attributes
 Adds 40 to 75 Fire Damage to Attacks
 Adds 30 to 65 Cold Damage to Attacks
@@ -33,6 +35,7 @@ Close Helmet
 Variant: Pre 3.10.0
 Variant: Current
 Requires Level 26, 58 Str
+Implicits: 0
 +2 to Level of Socketed Minion Gems
 {variant:1}+(20-40) to Strength
 {variant:1}Minions have 20% increased maximum Life
@@ -47,6 +50,7 @@ Ezomyte Peak
 Iron Hat
 Variant: Pre 3.19.0
 Variant: Current
+Implicits: 0
 {variant:1}20% increased Global Physical Damage
 {variant:1}+(15-25) to Armour
 {variant:2}+(75-100) to Armour
@@ -58,6 +62,7 @@ Variant: Current
 Ezomyte Hold
 Iron Hat
 Source: No longer obtainable
+Implicits: 0
 20% increased Physical Damage
 +(15-25) to Armour
 +(25-50) to maximum Life
@@ -72,6 +77,7 @@ Upgrade: Upgrades to unique{The Formless Inferno} using currency{Blessing of Xop
 Variant: Pre 3.16.0
 Variant: Current
 Requires Level 48, 101 Str
+Implicits: 0
 +(100-120) to Armour
 +(40-50) to maximum Life
 -20 Fire Damage taken when Hit
@@ -85,6 +91,7 @@ Source: Upgraded from unique{The Formless Flame} using currency{Blessing of Xoph
 Variant: Pre 3.16.0
 Variant: Current
 Requires Level 65, 148 Str
+Implicits: 0
 (80-120)% increased Armour
 +(40-50) to maximum Life
 -30% to Fire Resistance
@@ -98,6 +105,7 @@ Variant: Pre 2.0.0
 Variant: Pre 2.6.0
 Variant: Current
 Requires Level 55, 114 Str
+Implicits: 0
 {variant:1}(10-30)% increased Fire Damage
 {variant:2,3}(30-40)% increased Fire Damage
 {variant:1}(40-60)% increased Armour
@@ -113,6 +121,7 @@ Usurper's Penance
 Eternal Burgonet
 League: Expedition
 Requires Level 69, 138 Str
+Implicits: 0
 (50-80)% increased Armour
 Attacks have 15% chance to cause Bleeding
 50% reduced Light Radius
@@ -125,6 +134,7 @@ Bleeding you inflict deals Damage 4% faster per Frenzy Charge
 Alpha's Howl
 Sinner Tricorne
 Requires Level 64, 138 Dex
+Implicits: 0
 +2 to Level of Socketed Aura Gems
 (80-100)% increased Evasion Rating
 +(20-30)% to Cold Resistance
@@ -136,6 +146,7 @@ Replica Alpha's Howl
 Sinner Tricorne
 League: Heist
 Requires Level 64, 138 Dex
+Implicits: 0
 +4 to Level of Socketed Herald Gems
 (80-100)% increased Evasion Rating
 +(20-30)% to Chaos Resistance
@@ -159,6 +170,7 @@ Tricorne
 Variant: Pre 3.19.0
 Variant: Current
 Requires Level 12, 27 Dex
+Implicits: 0
 {variant:1}Adds 6 to 12 Cold Damage to Attacks
 {variant:2}Adds 15 to 25 Cold Damage to Attacks
 70% increased Evasion Rating
@@ -170,6 +182,7 @@ Cannot be Shocked
 ]],[[
 Goldrim
 Leather Cap
+Implicits: 0
 +(30-50) to Evasion Rating
 10% increased Rarity of Items found
 +(30-40)% to all Elemental Resistances
@@ -181,6 +194,7 @@ Variant: Pre 3.0.0
 Variant: Pre 3.19.0
 Variant: Current
 Requires Level 20, 46 Dex
+Implicits: 0
 {variant:1}+1 to Level of Socketed Fire Gems
 {variant:1}+1 to Level of Socketed Cold Gems
 {variant:2}(20-30)% increased Cold Damage if you have used a Fire Skill Recently
@@ -198,6 +212,7 @@ Frostferno
 Leather Hood
 Source: No longer obtainable
 Requires Level 60, 46 Dex
+Implicits: 0
 +2 to Level of Socketed Fire Gems
 +2 to Level of Socketed Cold Gems
 Socketed Gems are Supported by Level 30 Cold to Fire
@@ -211,6 +226,7 @@ Source: Drops from unique{Guardian of the Chimera}
 Variant: Pre 3.5.0
 Variant: Current
 Requires Level 70, 150 Dex
+Implicits: 0
 {variant:1}+(300-500) to Accuracy Rating
 {variant:2}+(800-1000) to Accuracy Rating
 (100-120)% increased Evasion Rating
@@ -220,6 +236,7 @@ Requires Level 70, 150 Dex
 Rat's Nest
 Ursine Pelt
 Requires Level 55, 114 Dex
+Implicits: 0
 15% increased Attack Speed
 (60-75)% increased Global Critical Strike Chance
 150% increased Evasion Rating
@@ -232,6 +249,7 @@ Silken Hood
 League: Bestiary
 Source: Drops from unique{Saqawal, First of the Sky}
 Requires Level 60, 138 Dex
+Implicits: 0
 Trigger Level 20 Twister when you gain Avian's Might or Avian's Flight
 (60-80)% increased Evasion Rating
 +(40-60) to maximum Life
@@ -243,6 +261,7 @@ Silken Hood
 Variant: Pre 2.6.0
 Variant: Current
 Requires Level 60, 138 Dex
+Implicits: 0
 50% reduced Damage when on Low Life
 {variant:2}(100-130)% increased Evasion Rating
 {variant:1}+(30-50) to Dexterity
@@ -261,6 +280,7 @@ Variant: Pre 2.6.0
 Variant: Pre 3.19.0
 Variant: Current
 Requires Level 8, 23 Int
+Implicits: 0
 {variant:3}Trigger a Socketed Spell when you Attack with a Bow, with a 0.3 second Cooldown
 {variant:3}(30-60)% increased Spell Damage
 (10-15)% increased Attack Speed
@@ -277,6 +297,7 @@ Source: No longer obtainable
 Variant: Pre 3.9.0
 Variant: Current
 Requires Level 45, 23 Int
+Implicits: 0
 {variant:1}25% chance to Trigger a Socketed Spell when you Attack with a Bow, with a 0.3 second Cooldown
 {variant:2}Trigger a Socketed Spell when you Attack with a Bow, with a 0.3 second Cooldown
 (10-15)% increased Attack Speed
@@ -289,6 +310,7 @@ Requires Level 45, 23 Int
 Cowl of the Ceraunophile
 Solaris Circlet
 Requires Level 59, 122 Int
+Implicits: 0
 League: Blight
 Can have a second Enchantment Modifier
 +(20-30) to all Attributes
@@ -301,6 +323,7 @@ This item can be anointed by Cassia
 Cowl of the Cryophile
 Silken Hood
 Requires Level 60, 138 Dex
+Implicits: 0
 League: Blight
 Can have a second Enchantment Modifier
 +(20-30) to all Attributes
@@ -313,6 +336,7 @@ This item can be anointed by Cassia
 Cowl of the Thermophile
 Ezomyte Burgonet
 Requires Level 60, 138 Str
+Implicits: 0
 League: Blight
 Can have a second Enchantment Modifier
 +(20-30) to all Attributes
@@ -325,6 +349,7 @@ This item can be anointed by Cassia
 Chitus' Apex
 Necromancer Circlet
 Requires Level 54, 112 Int
+Implicits: 0
 +(20-30) to Strength
 +(20-30) to maximum Mana
 +10% to all Elemental Resistances
@@ -336,6 +361,7 @@ Hubris Circlet
 Variant: Pre 3.7.0
 Variant: Current
 Requires Level 69, 154 Int
+Implicits: 0
 {variant:1}+(200-250) to Accuracy Rating
 {variant:2}+(300-350) to Accuracy Rating
 (120-150)% increased Energy Shield
@@ -349,6 +375,7 @@ Vine Circlet
 Variant: Pre 1.2.0
 Variant: Pre 3.19.0
 Variant: Current
+Implicits: 0
 {variant:1}+(12-24) to maximum Energy Shield
 {variant:2}+(60-80) to maximum Energy Shield
 {variant:3}+(150-225) to maximum Energy Shield
@@ -363,6 +390,7 @@ Source: No longer obtainable
 Variant: Pre 3.0.0
 Variant: Pre 3.17.0
 Requires Level 52
+Implicits: 0
 {variant:1}+(260-300) to maximum Energy Shield
 {variant:2}+(170-210) to maximum Energy Shield
 Reflects 5 Physical Damage to Melee Attackers
@@ -374,6 +402,7 @@ Necromancer Circlet
 League: Betrayal
 Source: Drops from unique{Catarina, Master of Undeath}
 Requires Level 54, 112 Int
+Implicits: 0
 Variant: Strength and Quality Pre 3.16.0
 Variant: Dexterity and Quality Pre 3.16.0
 Variant: Intelligence and Quality Pre 3.16.0
@@ -425,6 +454,7 @@ Variant: Pre 2.6.0
 Variant: Pre 3.19.0
 Variant: Current
 Requires Level 39, 83 Int
+Implicits: 0
 {variant:1}+1 to Level of Socketed Curse Gems
 {variant:2,3}+2 to Level of Socketed Curse Gems
 {variant:2,3}+(100-120) to maximum Energy Shield
@@ -449,6 +479,7 @@ Necromancer Circlet
 League: Bestiary
 Source: Drops from unique{Fenumus, First of the Night}
 Requires Level 65, 112 Int
+Implicits: 0
 Adds (16-21) to (31-36) Chaos Damage to Spells
 (220-250)% increased Energy Shield
 10% chance to gain a Power Charge on hitting an Enemy affected by a Spider's Web
@@ -461,6 +492,7 @@ Solaris Circlet
 Variant: Pre 3.19.0
 Variant: Current
 Requires Level 59, 122 Int
+Implicits: 0
 (240-280)% increased Energy Shield
 +(30-40)% to Fire Resistance
 (30-40)% increased Elemental Damage
@@ -474,6 +506,7 @@ Solaris Circlet
 Variant: Pre 3.19.0
 Variant: Current
 Requires Level 59, 122 Int
+Implicits: 0
 (240-280)% increased Energy Shield
 +(30-40)% to Cold Resistance
 (30-40)% increased Elemental Damage
@@ -489,6 +522,7 @@ Source: Drops from unique{Kurgal, the Blackblooded}
 Variant: One Abyssal Socket
 Variant: Two Abyssal Sockets
 Requires Level 65, 138 Int
+Implicits: 0
 {variant:1}Has 1 Abyssal Socket
 {variant:2}Has 2 Abyssal Sockets
 (6-8)% increased maximum Life
@@ -504,6 +538,7 @@ Source: Drops from unique{The Elder} (Uber)
 Variant: Pre 3.5.0
 Variant: Current
 Requires Level 69, 154 Int
+Implicits: 0
 (150-180)% increased Energy Shield
 (6-10)% increased maximum Mana
 Recover (8-10)% of maximum Life when you use a Mana Flask
@@ -519,6 +554,7 @@ Variant: Pre 3.11.0
 Variant: Pre 3.19.0
 Variant: Current
 Requires Level 26, 58 Int
+Implicits: 0
 +(30-50) to maximum Energy Shield
 {variant:1}Minions have (10-15)% increased Movement Speed
 {variant:2}Minions have (25-45)% increased Movement Speed
@@ -534,6 +570,7 @@ Steel Circlet
 League: Legion
 Source: Drops from Maraketh Legion
 Requires Level 48, 101 Int
+Implicits: 0
 (60-80)% increased Critical Strike Chance for Spells
 (200-250)% increased Energy Shield
 +(50-70) to maximum Life
@@ -544,6 +581,7 @@ Plume of Pursuit
 Bone Circlet
 League: Harvest
 Requires Level 64, 73 Int
+Implicits: 0
 (30-20)% reduced Cast Speed
 (80-130)% increased Energy Shield
 Non-critical strikes deal 80% less Damage
@@ -558,6 +596,7 @@ Variant: Pre 3.16.0
 Variant: Pre 3.19.0
 Variant: Current
 Requires Level 65, 138 Int
+Implicits: 0
 {variant:1}Socketed Gems are Supported by level 15 Concentrated Effect
 {variant:2,3,4,5}Socketed Gems are Supported by level 20 Concentrated Effect
 {variant:1,2,3,4}30% increased Cold Damage
@@ -576,6 +615,7 @@ Scold's Bridle
 Mind Cage
 League: Torment
 Requires Level 65, 138 Int
+Implicits: 0
 (80-100)% increased Spell Damage
 15% reduced Cast Speed
 +(30-60) to maximum Mana
@@ -585,6 +625,7 @@ Sudden Dawn
 Steel Circlet
 Source: Drops from unique{The Black Star}
 Requires Level 48, 101 Int
+Implicits: 0
 (300–350)% increased Energy Shield
 +(50–70) to maximum Mana
 (10–20)% chance for Energy Shield Recharge to start when you Kill an Enemy
@@ -595,6 +636,7 @@ Solaris Circlet
 Variant: Pre 3.19.0
 Variant: Current
 Requires Level 59, 122 Int
+Implicits: 0
 (240-280)% increased Energy Shield
 +(30-40)% to Lightning Resistance
 (30-40)% increased Elemental Damage
@@ -608,6 +650,7 @@ Bone Circlet
 Variant: Pre 3.19.0
 Variant: Current
 Requires Level: 34, 73 Int
+Implicits: 0
 +2 to Level of Socketed Minion Gems
 (120-150)% increased Energy Shield
 {variant:1}Minions Regenerate 1% Life per second
@@ -620,6 +663,7 @@ Iron Circlet
 League: Legion
 Source: Drops from Eternal Legion
 Requires Level 8
+Implicits: 0
 Has no Attribute Requirements
 Increases and Reductions to Light Radius also apply to Area of Effect at 50% of their value
 Increases and Reductions to Light Radius also apply to Damage
@@ -632,6 +676,7 @@ League: Tempest
 Variant: Pre 2.6.0
 Variant: Current
 Requires Level 69, 154 Int
+Implicits: 0
 {variant:2}Trigger Level 10 Shock Ground when Hit
 Adds 1 to (60-80) Lightning Damage to Spells and Attacks
 (130-170)% increased Energy Shield
@@ -645,6 +690,7 @@ Adds 1 to (60-80) Lightning Damage to Spells and Attacks
 Black Sun Crest
 Lacquered Helmet
 Requires Level 51, 57 Str, 57 Dex
+Implicits: 0
 +1 to Level of Socketed Gems
 (100-150)% increased Armour
 40% reduced Light Radius
@@ -660,6 +706,7 @@ Variant: Pre 3.5.0
 Variant: Pre 3.19.0
 Variant: Current
 Requires Level 67, 62 Str, 85 Dex
+Implicits: 0
 {variant:1,2,3,4}Socketed Gems are Supported by level 18 Melee Physical Damage
 {variant:5}Socketed Gems are Supported by level 30 Melee Physical Damage
 {variant:1,4}Socketed Gems are Supported by level 18 Faster Attacks
@@ -684,6 +731,7 @@ Crest of Desire
 Fluted Bascinet
 League: Heist
 Requires Level 58, 64 Str, 64 Dex
+Implicits: 0
 Has 1 Socket
 +(5-8) to Level of Socketed Gems
 +(30-50)% to Quality of Socketed Gems
@@ -696,6 +744,7 @@ Variant: Pre 2.6.0
 Variant: Pre 3.19.0
 Variant: Current
 Requires Level 33, 38 Str, 38 Dex
+Implicits: 0
 +(20-30) to Strength
 +(20-30) to Dexterity
 +(200-300) to Armour
@@ -710,6 +759,7 @@ Source: No longer obtainable
 Variant: Pre 2.6.0
 Variant: Pre 3.17.0
 Requires Level 33, 38 Str, 38 Dex
+Implicits: 0
 +(20-30) to Strength
 +(20-30) to Dexterity
 +(200-300) to Armour
@@ -722,6 +772,7 @@ Speed if you've used a Warcry Recently
 Devoto's Devotion
 Nightmare Bascinet
 Requires Level 67, 62 Str, 85 Dex
+Implicits: 0
 10% reduced Physical Damage
 +(50-65) to Dexterity
 16% increased Attack Speed
@@ -735,6 +786,7 @@ Lacquered Helmet
 League: Heist
 Source: Drops from unique{Nashta, The Usurper}
 Requires Level 51, 57 Str, 57 Dex
+Implicits: 0
 (150-200)% increased Armour and Evasion
 (30-50)% increased Projectile Speed
 (30-50)% increased Projectile Damage
@@ -748,6 +800,7 @@ Variant: Pre 2.6.0
 Variant: Pre 3.7.0
 Variant: Current
 Requires Level 23, 28 Str, 28 Dex
+Implicits: 0
 {variant:1}+100 to Accuracy Rating
 {variant:2}+300 to Accuracy Rating
 {variant:3}+500 to Accuracy Rating
@@ -764,6 +817,7 @@ Variant: Pre 2.6.0
 Variant: Pre 3.19.0
 Variant: Current
 Requires Level 36, 42 Str, 42 Dex
+Implicits: 0
 (60-80)% increased Armour and Evasion
 {variant:1,2}+(50-70) to maximum Life
 {variant:1,2}+(50-70) to maximum Mana
@@ -780,6 +834,7 @@ Requires Level 36, 42 Str, 42 Dex
 Ahn's Contempt
 Praetor Crown
 Requires Level 68, 62 Str, 91 Int
+Implicits: 0
 +(15-20) to all Attributes
 (60-140)% increased Armour and Energy Shield
 +(60-70) to maximum Life
@@ -805,6 +860,7 @@ Variant: Pre 3.5.0
 Variant: Pre 3.19.0
 Variant: Current
 Requires Level 63, 85 Str, 62 Int
+Implicits: 0
 {variant:1}(100-120)% increased Armour and Energy Shield
 {variant:2,3}(240-300)% increased Armour and Energy Shield
 {variant:1}+(50-70) to maximum Life
@@ -824,6 +880,7 @@ Variant: Pre 2.6.0
 Variant: Pre 3.0.0
 Variant: Current
 Requires Level 63, 85 Str, 62 Int
+Implicits: 0
 Socketed Gems are supported by level 20 Cast on Death
 20% increased Damage when on Low Life
 +(10-15) to all Attributes
@@ -841,6 +898,7 @@ Variant: Current
 League: Bestiary
 Source: Drops from unique{Craiceann, First of the Deep}
 Requires Level 58, 64 Str, 64 Int
+Implicits: 0
 {variant:1}+(7-9)% chance to Block Spell Damage
 {variant:2}+(4-6)% chance to Block Spell Damage
 (140-180)% increased Armour and Energy Shield
@@ -852,6 +910,7 @@ Cannot lose Crab Barriers if you have lost Crab Barriers Recently
 Crown of the Inward Eye
 Prophet Crown
 Requires Level 63, 85 Str, 62 Int
+Implicits: 0
 333% increased Armour and Energy Shield
 (9-21)% increased maximum Life, Mana and Global Energy Shield
 Transfiguration of Soul
@@ -865,6 +924,7 @@ Source: Drops from unique{Aul, the Crystal King}
 Variant: Pre 3.11.0
 Variant: Current
 Requires Level 58, 64 Str, 64 Int
+Implicits: 0
 Has 1 Socket
 {variant:1}+(50-100) to maximum Life
 {variant:2}+(50-175) to maximum Life
@@ -880,6 +940,7 @@ Variant: Pre 3.17.0
 Variant: Pre 3.19.0
 Variant: Current
 Requires Level 53, 59 Str, 59 Int
+Implicits: 0
 {variant:1,2}+1 to Level of Socketed Gems
 {variant:2}(60-80)% increased Armour and Energy Shield
 {variant:3}(120-150)% increased Armour and Energy Shield
@@ -897,6 +958,7 @@ Geofri's Legacy
 Great Crown
 Source: No longer obtainable
 Requires Level 62, 59 Str, 59 Int
+Implicits: 0
 +1 to Level of Socketed Gems
 (60-80)% increased Armour and Energy Shield
 +(15-20)% to Fire Resistance
@@ -914,6 +976,7 @@ Variant: Pre 3.7.0
 Variant: Pre 3.19.0
 Variant: Current
 Requires Level 12, 16 Str, 16 Int
+Implicits: 0
 {variant:2}+(1-2) to Level of Socketed Gems
 {variant:3}+2 to Level of Socketed Gems
 {variant:1}Adds 1 to 13 Lightning Damage to Attacks
@@ -932,6 +995,7 @@ Zealot Helmet
 Variant: Pre 3.11.0
 Variant: Current
 Requires Level 44, 50 Str, 50 Int
+Implicits: 0
 15% reduced Cast Speed
 (70-80)% increased Armour and Energy Shield
 +(30-50) to maximum Mana
@@ -947,6 +1011,7 @@ Variant: Two Abyssal Sockets
 {variant:1}Has 1 Abyssal Socket
 {variant:2}Has 2 Abyssal Sockets
 Requires Level 53, 59 Str, 59 Int
+Implicits: 0
 Trigger Level 20 Spirit Burst when you Use a Skill while you have a Spirit Charge
 +(10-15)% to all Elemental Resistances
 Recover (4-5)% of Life when a Spirit Charge expires or is consumed
@@ -961,6 +1026,7 @@ Variant: Pre 3.11.0
 Variant: Pre 3.19.0
 Variant: Current
 Requires Level 68, 62 Str, 91 Int
+Implicits: 0
 Adds (13-17) to (29-37) Chaos Damage
 {variant:1}+(200-250) to maximum Energy Shield
 {variant:2,3,4}+(150-200) to maximum Energy Shield
@@ -981,6 +1047,7 @@ League: Incursion
 Upgrade: Upgrades to unique{Mask of the Stitched Demon} via currency{Vial of Summoning}
 {variant:1}Requires Level 31, 36 Str, 36 Int
 {variant:2}Requires Level 58, 64 Str, 64 Int
+Implicits: 0
 {variant:2}+(30-60) to maximum Energy Shield
 {variant:1}(60-80)% increased Armour and Energy Shield
 {variant:2}(140-220)% increased Armour and Energy Shield
@@ -997,6 +1064,7 @@ Magistrate Crown
 League: Incursion
 Source: Upgraded from unique{Mask of the Spirit Drinker} via currency{Vial of Summoning}
 Requires Level 58, 64 Str, 64 Int
+Implicits: 0
 +(40-50) to Intelligence
 +(160-180) to maximum Energy Shield
 Strength provides no bonus to Maximum Life
@@ -1013,6 +1081,7 @@ Source: Drops from unique{Altered/Augmented/Rewritten/Twisted Synthete}
 Variant: Pre 3.16.0
 Variant: Current
 Requires Level 58, 64 Str, 64 Int
+Implicits: 0
 +(25-30) to all Attributes
 (150-200)% increased Armour and Energy Shield
 {variant:1}Nearby Allies have (4-6)% increased Defences per 100 Strength you have
@@ -1038,6 +1107,7 @@ Source: Drops from unique{The Enslaver}
 Variant: Pre 3.16.0
 Variant: Current
 Requires Level 68, 62 Str, 91 Int
+Implicits: 0
 +(130-160) to maximum Energy Shield
 +(150-200) to maximum Mana
 (30-40)% increased Mana Regeneration Rate
@@ -1053,6 +1123,7 @@ Variant: Pre 3.0.0
 Variant: Pre 3.19.0
 Variant: Current
 Requires Level 37, 42 Str, 42 Int
+Implicits: 0
 {variant:1,2}(10-15)% increased Cold Damage
 {variant:1,2}(10-15)% increased Lightning Damage
 {variant:1}+(100-150) to maximum Mana
@@ -1067,6 +1138,7 @@ Cannot Leech Mana
 Speaker's Wreath
 Prophet Crown
 Requires Level 63, 85 Str, 62 Int
+Implicits: 0
 +(20-40) to Dexterity
 (10-15)% increased Skill Effect Duration
 2% increased Minion Attack Speed per 50 Dexterity
@@ -1076,6 +1148,7 @@ Minions' Hits can only Kill Ignited Enemies
 Veil of the Night
 Great Helmet
 Requires Level 22, 27 Str, 27 Int
+Implicits: 0
 (20-22)% increased Stun Recovery
 40% reduced Light Radius
 Reflects 1 to (180-220) Lightning Damage to Attackers on Block
@@ -1086,6 +1159,7 @@ Replica Veil of the Night
 Great Helmet
 League: Heist
 Requires Level 22, 27 Str, 27 Int
+Implicits: 0
 (20-22)% increased Stun and Block Recovery
 40% reduced Light Radius
 Reflects 1 to (180-220) Lightning Damage to Attackers on Block
@@ -1097,6 +1171,7 @@ Praetor Crown
 Variant: Pre 3.19.0
 Variant: Current
 Requires Level 68, 62 Str, 91 Int
+Implicits: 0
 +(260-300) to Armour
 +(26-32)% to Fire Resistance
 +(8-16)% to Chaos Resistance
@@ -1114,6 +1189,7 @@ Variant: Pre 2.6.0
 Variant: Pre 3.19.0
 Variant: Current
 Requires Level 52, 58 Dex, 58 Int
+Implicits: 0
 (150-200)% increased Evasion and Energy Shield
 {variant:2,3}+(60-80) to maximum Life
 (0.4-0.8)% of Physical Attack Damage Leeched as Life
@@ -1124,6 +1200,7 @@ Reflects 100 to 150 Physical Damage to Melee Attackers
 Curtain Call
 Plague Mask
 Requires Level 20
+Implicits: 0
 +23 to maximum Life
 (15-10)% reduced Mine Throwing Speed
 Mines have (40-50)% increased Detonation Speed
@@ -1133,6 +1210,7 @@ Skills which Place Mines place up to 1 additional Mine if you have at least 800 
 Eye of Malice
 Callous Mask
 Requires Level 45, 51 Dex, 51 Int
+Implicits: 0
 (400-500)% increased Evasion and Energy Shield
 +(20-40)% to Fire Resistance
 +(20-40)% to Cold Resistance
@@ -1145,6 +1223,7 @@ Harlequin Mask
 League: Bestiary
 Source: Drops from unique{Farrul, First of the Plains}
 Requires Level 57, 64 Dex, 64 Int
+Implicits: 0
 Grants Level 20 Aspect of the Cat Skill
 (180-220)% increased Evasion and Energy Shield
 +(25-35)% to Cold Resistance
@@ -1156,6 +1235,7 @@ Fractal Thoughts
 Vaal Mask
 League: Legion
 Requires Level: 62, 79 Dex, 72 Int
+Implicits: 0
 (140-180)% increased Evasion and Energy Shield
 +(25-40)% to Critical Strike Multiplier if Dexterity is higher than Intelligence
 15% increased Dexterity if Strength is higher than Intelligence
@@ -1218,6 +1298,7 @@ Variant: Pre 2.6.0
 Variant: Pre 3.0.0
 Variant: Current
 Requires Level 38, 44 Dex, 44 Int
+Implicits: 0
 {variant:2,3}Trigger level 1 Create Lesser Shrine when you Kill an Enemy
 (120-150)% increased Evasion and Energy Shield
 {variant:2}+(40-65) to maximum Energy Shield
@@ -1237,6 +1318,7 @@ Variant: Pre 3.0.0
 Variant: Pre 3.16.0
 Variant: Current
 Requires Level 67, 73 Dex, 88 Int
+Implicits: 0
 +(40-50) to maximum Energy Shield
 {variant:1,2}(130-150)% increased Evasion and Energy Shield
 {variant:3,4}(90-110)% increased Evasion and Energy Shield
@@ -1251,6 +1333,7 @@ Festival Mask
 Variant: Pre 3.19.0
 Variant: Current
 Requires Level 28, 33 Dex, 33 Int
+Implicits: 0
 {variant:1}30% reduced Damage
 {variant:2}25% reduced Damage
 +(20-30) to Dexterity
@@ -1267,6 +1350,7 @@ Variant: Pre 3.19.0
 Variant: Current
 League: Heist
 Requires Level 28, 33 Dex, 33 Int
+Implicits: 0
 +(20-30) to Dexterity
 {variant:1}+(20-30) to maximum Life
 {variant:2}+(60-100) to maximum Life
@@ -1284,6 +1368,7 @@ Variant: Pre 3.17.0
 Variant: Pre 3.19.0
 Variant: Current
 Requires Level 17, 21 Dex, 21 Int
+Implicits: 0
 {variant:1,2,3,4,5}(15-30)% increased Spell Damage
 +20 to Strength
 {variant:1,2,3,4,5}(20-30)% increased Lightning Damage
@@ -1302,6 +1387,7 @@ Variant: Pre 3.7.0
 Variant: Pre 3.17.0
 Variant: Current
 Requires Level 60, 21 Dex, 21 Int
+Implicits: 0
 (15-30)% increased Spell Damage
 +20 to Strength
 +10% to all Elemental Resistances
@@ -1316,6 +1402,7 @@ Harlequin Mask
 Variant: Pre 3.10.0
 Variant: Current
 Requires Level 57, 64 Dex, 64 Int
+Implicits: 0
 (230-260)% increased Evasion and Energy Shield
 {variant:2}+(15-20) to maximum Energy Shield
 (20-30)% increased maximum Mana
@@ -1331,6 +1418,7 @@ Callous Mask
 League: Harbinger
 Upgrade: Upgrades to unique{The Tempest's Liberation} via currency{Deregulation Scroll}
 Requires Level 45, 51 Dex, 51 Int
+Implicits: 0
 Socketed Gems are Supported by Level 18 Ice Bite
 Socketed Gems are Supported by Level 18 Innervate
 Grants Summon Harbinger of Storms Skill
@@ -1344,6 +1432,7 @@ Callous Mask
 League: Harvest
 Source: Upgraded from unique{The Tempest's Binding} via currency{Deregulation Scroll}
 Requires Level 60, 51 Dex, 51 Int
+Implicits: 0
 Socketed Gems are Supported by Level 18 Ice Bite
 Socketed Gems are Supported by Level 18 Innervate
 Grants Summon Greater Harbinger of Storms Skill
@@ -1355,6 +1444,7 @@ Grants Summon Greater Harbinger of Storms Skill
 The Three Dragons
 Golden Mask
 Requires Level 35, 40 Dex, 40 Int
+Implicits: 0
 +(26-30)% to all Elemental Resistances
 Your Fire Damage can Shock but not Ignite
 Your Cold Damage can Ignite but not Freeze or Chill
@@ -1364,6 +1454,7 @@ The Vertex
 Vaal Mask
 Source: Drops from unique{Atziri, Queen of the Vaal} in normal{The Alluring Abyss}
 Requires Level 62, 79 Dex, 72 Int
+Implicits: 0
 +1 to Level of Socketed Gems
 (245-280)% increased Evasion and Energy Shield
 +(30-40) to maximum Energy Shield
@@ -1375,6 +1466,7 @@ Viridi's Veil
 Praetor Crown
 League: Ritual
 Requires Level 68, 62 Str, 91 Int
+Implicits: 0
 +(1-2) to Level of Socketed Gems
 (120-160)% increased Armour and Energy Shield
 +(15-25)% to all Elemental Resistances
@@ -1386,6 +1478,7 @@ Willclash
 Golden Mask
 League: Heist
 Requires Level 35, 40 Dex, 40 Int
+Implicits: 0
 (350-400)% increased Evasion and Energy Shield
 +5% Chance to Block Spell Damage per Power Charge
 (3-5)% increased Elemental Damage per Power charge
@@ -1400,6 +1493,7 @@ League: Expedition
 Variant: Pre 3.19.0
 Variant: Current
 Requires Level 25, 30 Str, 30 Dex, 30 Int
+Implicits: 0
 +(20-30) to Intelligence
 (25-35)% increased Ward
 {variant:1}(20-30)% faster Restoration of Ward
@@ -1411,6 +1505,7 @@ Cadigan's Crown
 Runic Crown
 League: Expedition
 Requires Level 68, 66 Str, 66 Dex, 66 Int
+Implicits: 0
 Never deal Critical Strikes
 Nearby Enemies cannot deal Critical Strikes
 Battlemage
@@ -1420,6 +1515,7 @@ Royal Burgonet
 Source: Drops from unique{The Shaper}
 Shaper Item
 Requires Level 65, 148 Str
+Implicits: 0
 Socketed Warcry Skills have +1 Cooldown Use
 (80-120)% increased Armour
 +(50-70) to maximum Life
@@ -1428,6 +1524,7 @@ Skills deal (10-15)% more Damage for each Warcry Exerting them
 ]],[[
 Thrillsteel
 Barbute Helmet
+Implicits: 0
 Onslaught
 ]]
 }

--- a/src/Data/Uniques/jewel.lua
+++ b/src/Data/Uniques/jewel.lua
@@ -6,6 +6,7 @@ return {
 Anatomical Knowledge
 Cobalt Jewel
 Radius: Large
+Implicits: 0
 (6-8)% increased maximum Life
 Adds 1 to Maximum Life per 3 Intelligence Allocated in Radius
 ]],[[
@@ -13,6 +14,7 @@ The Anima Stone
 Prismatic Jewel
 Source: Vendor Recipe
 Limited to: 1
+Implicits: 0
 +1 to maximum number of Golems
 +1 to maximum number of Summoned Golems if you have 3 Primordial Items Socketed or Equipped
 ]],[[
@@ -21,12 +23,14 @@ Cobalt Jewel
 League: Heist
 Limited to: 1
 Requires Level 20
+Implicits: 0
 (20-25)% increased Spell Damage
 Spells have 10% reduced Critical Strike Chance per Intensity
 Spells which have gained Intensity Recently gain 1 Intensity every 0.5 Seconds
 ]],[[
 Apparitions
 Viridian Jewel
+Implicits: 0
 Minions have (5-10)% increased Movement Speed
 Minions have +(2-5)% chance to Suppress Spell Damage
 ]],[[
@@ -36,6 +40,7 @@ League: Breach
 Source: Drops in Chayula Breach or from unique{Chayula, Who Dreamt}
 Upgrade: Upgrades to unique{The Blue Nightmare} using currency{Blessing of Chayula}
 Radius: Large
+Implicits: 0
 Gain 5% of Lightning Damage as Extra Chaos Damage
 Passives granting Lightning Resistance or all Elemental Resistances in Radius
 also grant an equal chance to gain a Power Charge on Kill
@@ -46,6 +51,7 @@ League: Breach
 Source: Upgraded from unique{The Blue Dream} using currency{Blessing of Chayula}
 Limited to: 1
 Radius: Large
+Implicits: 0
 Gain 5% of Lightning Damage as Extra Chaos Damage
 Passives granting Lightning Resistance or all Elemental Resistances in Radius
 also grant Chance to Block Spell Damage at 35% of its value
@@ -54,6 +60,7 @@ also grant an equal chance to gain a Power Charge on Kill
 ]],[[
 Brawn
 Crimson Jewel
+Implicits: 0
 (4-6)% increased Dexterity
 (4-6)% increased Strength
 (10-15)% reduced Intelligence
@@ -61,6 +68,7 @@ Crimson Jewel
 Brute Force Solution
 Cobalt Jewel
 Radius: Large
+Implicits: 0
 +(16-24) to Intelligence
 Strength from Passives in Radius is Transformed to Intelligence
 ]],[[
@@ -68,17 +76,20 @@ Calamitous Visions
 Small Cluster Jewel
 League: Delirium
 Source: Drops from unique Delirium bosses in maps
+Implicits: 0
 Adds Lone Messenger
 ]],[[
 Careful Planning
 Viridian Jewel
 Radius: Large
+Implicits: 0
 +(16-24) to Dexterity
 Intelligence from Passives in Radius is Transformed to Dexterity
 ]],[[
 Cheap Construction
 Viridian Jewel
 Source: No longer obtainable
+Implicits: 0
 10% reduced Trap Duration
 Can have up to 1 additional Trap placed at a time
 ]],[[
@@ -86,18 +97,21 @@ Replica Cheap Construction
 Viridian Jewel
 Source: No longer obtainable
 League: Heist
+Implicits: 0
 (100-120)% increased Critical Strike Chance with Traps
 Can have 5 fewer Traps placed at a time
 ]],[[
 Clear Mind
 Cobalt Jewel
 Limited to: 1
+Implicits: 0
 (20-30)% increased Mana Regeneration Rate
 (40-60)% increased Spell Damage while no Mana is Reserved
 ]],[[
 Coated Shrapnel
 Crimson Jewel
 Radius: Small
+Implicits: 0
 Variant: Pre 3.8.0
 Variant: Current
 {variant:1}Traps and Mines deal (3-5) to (10-15) additional Physical Damage
@@ -107,6 +121,7 @@ Traps and Mines have a 25% chance to Poison on Hit
 Cold Steel
 Viridian Jewel
 Radius: Large
+Implicits: 0
 Increases and Reductions to Physical Damage in Radius are Transformed to apply to Cold Damage
 Increases and Reductions to Cold Damage in Radius are Transformed to apply to Physical Damage
 ]],[[
@@ -114,6 +129,7 @@ Dissolution of the Flesh
 Prismatic Jewel
 Source: Drops from unique{The Searing Exarch}
 Limited to: 1
+Implicits: 0
 Removes all Energy Shield
 Life that would be lost by taking Damage is instead Reserved
 until you take no Damage to Life for 2 seconds
@@ -123,18 +139,21 @@ Divine Inferno
 Crimson Jewel
 Limited to: 1
 Radius: Medium
+Implicits: 0
 With at least 40 Strength in Radius, Combust is Disabled
 With at least 40 Strength in Radius, Attacks Exerted by Infernal Cry deal (40-60)% more Damage with Ignite
 ]],[[
 Efficient Training
 Crimson Jewel
 Radius: Large
+Implicits: 0
 +(16-24) to Strength
 Intelligence from Passives in Radius is Transformed to Strength
 ]],[[
 Eldritch Knowledge
 Cobalt Jewel
 Radius: Medium
+Implicits: 0
 5% increased Chaos Damage per 10 Intelligence from Allocated Passives in Radius
 ]],[[
 Endless Misery
@@ -142,6 +161,7 @@ Cobalt Jewel
 League: Heist
 Limited to: 1
 Radius: Medium
+Implicits: 0
 (7-10)% increased Elemental Damage
 With at least 40 Intelligence in Radius, Discharge has 60% less Area of Effect
 With at least 40 Intelligence in Radius, Discharge Cooldown is 250 ms
@@ -150,6 +170,7 @@ With at least 40 Intelligence in Radius, Discharge deals 60% less Damage
 Energised Armour
 Crimson Jewel
 Radius: Large
+Implicits: 0
 (15-20)% increased Armour
 Increases and Reductions to Energy Shield in Radius are Transformed to apply to Armour at 200% of their value
 ]],[[
@@ -158,6 +179,7 @@ Cobalt Jewel
 Variant: Pre 2.5.0
 Variant: Current
 Radius: Large
+Implicits: 0
 {variant:1}(8-12)% increased maximum Energy Shield
 {variant:2}(3-6)% increased maximum Energy Shield
 Increases and Reductions to Life in Radius are Transformed to apply to Energy Shield
@@ -165,23 +187,27 @@ Increases and Reductions to Life in Radius are Transformed to apply to Energy Sh
 Fertile Mind
 Cobalt Jewel
 Radius: Large
+Implicits: 0
 +(16-24) to Intelligence
 Dexterity from Passives in Radius is Transformed to Intelligence
 ]],[[
 Fireborn
 Crimson Jewel
 Radius: Medium
+Implicits: 0
 Increases and Reductions to other Damage Types in Radius are Transformed to apply to Fire Damage
 ]],[[
 Fluid Motion
 Viridian Jewel
 Radius: Large
+Implicits: 0
 +(16-24) to Dexterity
 Strength from Passives in Radius is Transformed to Dexterity
 ]],[[
 Fortified Legion
 Cobalt Jewel
 Limited to: 1
+Implicits: 0
 Minions have (5-15)% increased maximum Life
 Minions Recover 2% of their Maximum Life when they Block
 ]],[[
@@ -190,6 +216,7 @@ Cobalt Jewel
 Requires Level: 20
 Limited to: 1
 Radius: Medium
+Implicits: 0
 Minions deal (35-45)% increased Damage
 Minions have +(10-12)% Chance to Block Attack Damage
 Minions have +(10-12)% Chance to Block Spell Damage
@@ -198,6 +225,7 @@ Notable Passive Skills in Radius are Transformed to instead grant: Minions take 
 Fragile Bloom
 Crimson Jewel
 Limited to: 1
+Implicits: 0
 Variant: Pre 3.11.0
 Variant: Current
 {variant:1}2% of Life Regenerated per Second
@@ -231,10 +259,12 @@ The Front Line
 Small Cluster Jewel
 League: Delirium
 Source: Drops from unique Delirium bosses in maps
+Implicits: 0
 Adds Veteran's Awareness
 ]],[[
 The Golden Rule
 Viridian Jewel
+Implicits: 0
 (30-40)% increased Armour while Bleeding 
 Bleeding you inflict is Reflected to you 
 +1% to Chaos Resistance per Poison on you 
@@ -248,6 +278,7 @@ Variant: Pre 3.10.0
 Variant: Current - Crit Chance
 Variant: Current - Minion Crit Multi
 Variant: Current - Min Power Charge
+Implicits: 0
 {variant:1}Gain 15 Mana per Grand Spectrum
 {variant:2}Gain 30 Mana per Grand Spectrum
 {variant:3}25% increased Critical Strike Chance per Grand Spectrum
@@ -262,6 +293,7 @@ Variant: Pre 3.10.0
 Variant: Current - Elemental Resistances
 Variant: Current - Maximum Life
 Variant: Current - Min Endurance Charge
+Implicits: 0
 {variant:1}Gain 75 Armour per Grand Spectrum
 {variant:2}Gain 200 Armour per Grand Spectrum
 {variant:3}+7% to all Elemental Resistances per Grand Spectrum
@@ -277,6 +309,7 @@ Variant: Pre 3.10.0
 Variant: Current
 Variant: Current - Chance to avoid Ailments
 Variant: Current - Min Frenzy Charge
+Implicits: 0
 {variant:1}5% increased Elemental Damage per Grand Spectrum
 {variant:2}4% increased Elemental Damage per Grand Spectrum
 {variant:3}12% increased Elemental Damage per Grand Spectrum
@@ -290,6 +323,7 @@ League: Breach
 Source: Drops in Chayula Breach or from unique{Chayula, Who Dreamt}
 Upgrade: Upgrades to unique{The Green Nightmare} using currency{Blessing of Chayula}
 Radius: Large
+Implicits: 0
 Gain 5% of Cold Damage as Extra Chaos Damage
 Passives granting Cold Resistance or all Elemental Resistances in Radius
 also grant an equal chance to gain a Frenzy Charge on Kill
@@ -302,6 +336,7 @@ League: Breach
 Source: Upgraded from unique{The Green Dream} using currency{Blessing of Chayula}
 Limited to: 1
 Radius: Large
+Implicits: 0
 Gain 5% of Cold Damage as Extra Chaos Damage
 {variant:1}Passives granting Cold Resistance or all Elemental Resistances in Radius
 {variant:1}also grant Chance to Suppress Spell Damage at 35% of its value
@@ -314,6 +349,7 @@ Hair Trigger
 Viridian Jewel
 Variant: Pre 2.6.0
 Variant: Current
+Implicits: 0
 (15-25)% increased Trap Damage
 {variant:1}(20-30)% increased Trap Trigger Radius
 {variant:2}(40-60)% increased Trap Trigger Area of Effect
@@ -322,12 +358,14 @@ Healthy Mind
 Cobalt Jewel
 Limited to: 1
 Radius: Large
+Implicits: 0
 (15-20)% increased maximum Mana
 Increases and Reductions to Life in Radius are Transformed to apply to Mana at 200% of their value
 ]],[[
 Hidden Potential
 Viridian Jewel
 Limited to: 1
+Implicits: 0
 (20-25)% increased Damage for each Magic Item Equipped
 ]],[[
 Hotheaded
@@ -335,6 +373,7 @@ Viridian Jewel
 Limited to: 1
 Variant: Pre 3.11.0
 Variant: Current
+Implicits: 0
 {variant:1}(10-15)% increased Movement Speed while Ignited
 {variant:2}(10-20)% increased Movement Speed while Ignited
 {variant:2}(10-20)% increased Attack Speed while Ignited
@@ -344,6 +383,7 @@ Replica Hotheaded
 Viridian Jewel
 League: Heist
 Limited to: 1
+Implicits: 0
 (10-20)% increased Attack Speed while Chilled
 (10-20)% increased Cast Speed while Chilled
 (10-20)% increased Movement Speed while Chilled
@@ -351,28 +391,33 @@ Limited to: 1
 Inertia
 Crimson Jewel
 Radius: Large
+Implicits: 0
 +(16-24) to Strength
 Dexterity from Passives in Radius is Transformed to Strength
 ]],[[
 Inspired Learning
 Crimson Jewel
 Radius: Small
+Implicits: 0
 With 4 Notables Allocated in Radius, When you Kill a Rare monster, you gain 1 of its Modifiers for 20 seconds
 ]],[[
 The Interrogation
 Small Cluster Jewel
 League: Delirium
 Source: Drops from unique Delirium bosses in maps
+Implicits: 0
 Adds Secrets of Suffering
 ]],[[
 Intuitive Leap
 Viridian Jewel
 Radius: Small
+Implicits: 0
 Passives in Radius can be Allocated without being connected to your tree
 ]],[[
 Izaro's Turmoil
 Crimson Jewel
 Source: No longer obtainable
+Implicits: 0
 (18-25)% increased Fire Damage
 (18-25)% increased Cold Damage
 2% chance to Freeze
@@ -382,11 +427,13 @@ Kitava's Teachings
 Small Cluster Jewel
 League: Delirium
 Source: Drops from unique Delirium bosses in maps
+Implicits: 0
 Adds Disciple of Kitava
 ]],[[
 Lioneye's Fall
 Viridian Jewel
 Radius: Medium
+Implicits: 0
 Melee and Melee Weapon Type modifiers in Radius are Transformed to Bow Modifiers
 ]],[[
 Lord of Steel
@@ -399,6 +446,7 @@ Variant: Impale Effect (Pre 3.13.0)
 Variant: Impale Chance (Current)
 Variant: Impale Overwhelm (Current)
 Variant: Impale Effect (Current)
+Implicits: 0
 {variant:1,4}10% chance to Impale Enemies on Hit with Attacks
 {variant:2,5}Impale Damage dealt to Enemies Impaled by you Overwhelms 10% Physical Damage Reduction
 {variant:3,6}5% increased Impale Effect
@@ -409,11 +457,13 @@ Variant: Impale Effect (Current)
 ]],[[
 Malicious Intent
 Cobalt Jewel
+Implicits: 0
 5% chance to Gain Unholy Might for 4 seconds on Melee Kill
 ]],[[
 Mantra of Flames
 Crimson Jewel
 Limited to: 1
+Implicits: 0
 Adds (3-5) to (8-12) Fire Attack Damage per Buff on You
 Adds (2-3) to (5-8) Fire Spell Damage per Buff on You
 ]],[[
@@ -423,6 +473,7 @@ Limited to: 1
 Variant: Pre 3.11.0
 Variant: Current
 Radius: Small
+Implicits: 0
 {variant:1}(10-15)% increased Area of Effect while Unarmed
 {variant:2}+(3-4) to Melee Strike Range while Unarmed
 {variant:2}Passive Skills in Radius also grant: 1% increased Unarmed Attack Speed with Melee Skills
@@ -433,6 +484,7 @@ Variant: Pre 3.19.0
 Variant: Current
 Source: Drops from unique{The Eater of Worlds}
 Limited to: 1
+Implicits: 0
 -(80-70)% to All Elemental Resistances
 {variant:2}-(4-6)% to all maximum Elemental Resistances
 Elemental Resistances are capped by your highest Maximum Elemental Resistance instead
@@ -440,11 +492,13 @@ Elemental Resistances are capped by your highest Maximum Elemental Resistance in
 Might in All Forms
 Crimson Jewel
 Radius: Medium
+Implicits: 0
 Dexterity and Intelligence from passives in Radius count towards Strength Melee Damage bonus
 ]],[[
 Might of the Meek
 Crimson Jewel
 Radius: Large
+Implicits: 0
 50% increased Effect of non-Keystone Passive Skills in Radius
 Notable Passive Skills in Radius grant nothing
 ]],[[
@@ -453,6 +507,7 @@ Cobalt Jewel
 League: Heist
 Limited to: 1
 Item Level: 82
+Implicits: 0
 (20-25)% increased Spell Damage
 Spells have 30% increased Critical Strike Chance per Intensity
 Spells which have gained Intensity Recently lose 1 Intensity every 0.50 Seconds
@@ -461,16 +516,19 @@ Natural Affinity
 Small Cluster Jewel
 League: Delirium
 Source: Drops from unique Delirium bosses in maps
+Implicits: 0
 Adds Nature's Patience
 ]],[[
 One With Nothing
 Small Cluster Jewel
 League: Delirium
 Source: Drops from unique Delirium bosses in maps
+Implicits: 0
 Adds Hollow Palm Technique
 ]],[[
 Primordial Eminence
 Viridian Jewel
+Implicits: 0
 Golems have (16-20)% increased Attack and Cast Speed
 30% increased Effect of Buffs granted by your Golems
 Golems have +(800-1000) to Armour
@@ -480,6 +538,7 @@ Primordial Harmony
 Cobalt Jewel
 Variant: Pre 3.3.0
 Variant: Current
+Implicits: 0
 Golem Skills have (20-30)% increased Cooldown Recovery Rate
 {variant:1}Summoned Golems have (10-15)% increased Cooldown Recovery Rate
 {variant:2}Summoned Golems have (30-45)% increased Cooldown Recovery Rate
@@ -489,6 +548,7 @@ Primordial
 ]],[[
 Primordial Might
 Crimson Jewel
+Implicits: 0
 (25-30)% increased Damage if you Summoned a Golem in the past 8 seconds
 Golems Summoned in the past 8 seconds deal (35-45)% increased Damage
 Golems have (18-22)% increased Maximum Life
@@ -498,6 +558,7 @@ Primordial
 Replica Primordial Might
 Crimson Jewel
 League: Heist
+Implicits: 0
 -1 to maximum number of Golems
 (25-30)% increased Damage if you Summoned a Golem in the past 8 seconds
 Golems Summoned in the past 8 seconds deal (100-125)% increased Damage
@@ -508,6 +569,7 @@ Summoned Golems are Aggressive
 Pugilist
 Viridian Jewel
 Radius: Large
+Implicits: 0
 1% increased Evasion Rating per 3 Dexterity Allocated in Radius
 1% increased Claw Physical Damage per 3 Dexterity Allocated in Radius
 1% increased Melee Physical Damage while Unarmed per 3 Dexterity Allocated in Radius
@@ -515,6 +577,7 @@ Radius: Large
 Pure Talent
 Viridian Jewel
 Limited to: 1
+Implicits: 0
 While your Passive Skill Tree connects to a class' Starting location, you gain:
 Marauder: Melee Skills have 15% increased Area of Effect
 Duelist: 1% of Attack Damage Leeched as Life
@@ -528,6 +591,7 @@ Replica Pure Talent
 Viridian Jewel
 League: Heist
 Limited to: 1
+Implicits: 0
 While your Passive Skill Tree connects to a class' starting location, you gain:
 Marauder: 1% of Life Regenerated per second
 Duelist: +2 to Melee Strike Range
@@ -542,6 +606,7 @@ Viridian Jewel
 Requires Level: 20
 Limited to: 1
 Radius: Medium
+Implicits: 0
 Minions have (12-16)% increased Attack Speed
 Minions have (12-16)% increased Cast Speed
 Minions have (20-24)% chance to Suppress Spell Damage
@@ -550,6 +615,7 @@ Notable Passive Skills in Radius are Transformed to instead grant: Minions have 
 Rain of Splinters
 Crimson Jewel
 Limited to: 1
+Implicits: 0
 (30-50)% reduced Totem Damage
 Totems Fire 2 additional Projectiles
 ]],[[
@@ -557,6 +623,7 @@ Reckless Defence
 Cobalt Jewel
 Variant: Pre 3.4.0
 Variant: Current
+Implicits: 0
 {variant:1}+6% chance to Block Spell Damage
 {variant:2}+(2-4)% chance to Block Spell Damage
 (2-4)% chance to Block Attack Damage
@@ -565,6 +632,7 @@ Hits have (140-200)% increased Critical Strike Chance against you
 Replica Reckless Defence
 Cobalt Jewel
 League: Heist
+Implicits: 0
 +(2-4)% Chance to Block Spell Damage
 +(2-4)% Chance to Block Attack Damage
 +10% chance to be Frozen, Shocked and Ignited
@@ -575,6 +643,7 @@ League: Breach
 Source: Drops in Chayula Breach or from unique{Chayula, Who Dreamt}
 Upgrade: Upgrades to unique{The Red Nightmare} using currency{Blessing of Chayula}
 Radius: Large
+Implicits: 0
 Gain 5% of Fire Damage as Extra Chaos Damage
 Passives granting Fire Resistance or all Elemental Resistances in Radius
 also grant an equal chance to gain an Endurance Charge on Kill
@@ -585,6 +654,7 @@ League: Breach
 Source: Upgraded from unique{The Red Dream} using currency{Blessing of Chayula}
 Limited to: 1
 Radius: Large
+Implicits: 0
 Gain 5% of Fire Damage as Extra Chaos Damage
 Passives granting Fire Resistance or all Elemental Resistances in Radius
 also grant Chance to Block Attack Damage at 35% of its value
@@ -595,11 +665,13 @@ The Siege
 Small Cluster Jewel
 League: Delirium
 Source: Drops from unique Delirium bosses in maps
+Implicits: 0
 Adds Kineticism
 ]],[[
 Soul's Wick
 Cobalt Jewel
 Limited to: 1
+Implicits: 0
 +2 to maximum number of Spectres
 (40-50)% reduced Mana Cost of Raise Spectre 
 Spectres have (800-1000)% increased Critical Strike Chance 
@@ -610,12 +682,14 @@ Spire of Stone
 Crimson Jewel
 Limited to: 1
 Radius: Large
+Implicits: 0
 3% increased Totem Life per 10 Strength Allocated in Radius
 Totems cannot be Stunned
 ]],[[
 Static Electricity
 Viridian Jewel
 Radius: Large
+Implicits: 0
 Adds 1 maximum Lightning Damage to Attacks per 1 Dexterity Allocated in Radius
 Adds 1 to 2 Lightning Damage to Attacks
 ]],[[
@@ -628,6 +702,7 @@ Variant: Pre 3.8.0
 Variant: Pre 3.10.0
 Variant: Current
 Radius: Medium
+Implicits: 0
 -1 Strength per 1 Strength on Allocated Passives in Radius
 {variant:1}+5% to Critical Strike Multiplier per 10 Strength on Unallocated Passives in Radius
 {variant:2}+7% to Critical Strike Multiplier per 10 Strength on Unallocated Passives in Radius
@@ -641,6 +716,7 @@ Variant: Pre 3.8.0
 Variant: Pre 3.10.0
 Variant: Current
 Radius: Medium
+Implicits: 0
 -1 Strength per 1 Strength on Allocated Passives in Radius
 {variant:1,2}1% additional Physical Damage Reduction per 10 Strength on Allocated Passives in Radius
 {variant:1}+5% to Critical Strike Multiplier per 10 Strength on Unallocated Passives in Radius
@@ -657,6 +733,7 @@ Variant: Pre 3.8.0
 Variant: Pre 3.10.0
 Variant: Current
 Radius: Medium
+Implicits: 0
 -1 Intelligence per 1 Intelligence on Allocated Passives in Radius
 {variant:1}+100 to Accuracy Rating per 10 Intelligence on Unallocated Passives in Radius
 {variant:2}+125 to Accuracy Rating per 10 Intelligence on Unallocated Passives in Radius
@@ -670,6 +747,7 @@ Variant: Pre 3.8.0
 Variant: Pre 3.10.0
 Variant: Current
 Radius: Medium
+Implicits: 0
 -1 Intelligence per 1 Intelligence on Allocated Passives in Radius
 {variant:1,2}0.4% of Energy Shield Regenerated per Second for
 every 10 Intelligence on Allocated Passives in Radius
@@ -687,6 +765,7 @@ Upgrade: Upgrades to unique{Transcendent Spirit} via currency{Vial of Transcende
 Variant: Pre 3.10.0
 Variant: Current
 Radius: Medium
+Implicits: 0
 -1 Dexterity per 1 Dexterity on Allocated Passives in Radius
 {variant:1}+15 to Maximum Mana per 10 Dexterity on Unallocated Passives in Radius
 {variant:2}2% increased Movement Speed per 10 Dexterity on Allocated Passives in Radius
@@ -698,6 +777,7 @@ Source: Upgraded from unique{Tempered Spirit} via currency{Vial of Transcendence
 Variant: Pre 3.10.0
 Variant: Current
 Radius: Medium
+Implicits: 0
 -1 Dexterity per 1 Dexterity on Allocated Passives in Radius
 {variant:1}2% increased Movement Speed per 10 Dexterity on Allocated Passives in Radius
 {variant:1}+15 to Maximum Mana per 10 Dexterity on Unallocated Passives in Radius
@@ -727,6 +807,7 @@ To Dust
 Cobalt Jewel
 Variant: Pre 3.0.0
 Variant: Current
+Implicits: 0
 (10-20)% reduced Skeleton Duration
 Minions deal (8-12)% increased Damage
 {variant:1}2% increased Skeleton Attack Speed
@@ -738,11 +819,13 @@ Unnatural Instinct
 Viridian Jewel
 Limited to: 1
 Radius: Small
+Implicits: 0
 Allocated Small Passive Skills in Radius grant nothing
 Grants all bonuses of Unallocated Small Passive Skills in Radius
 ]],[[
 Unstable Payload
 Cobalt Jewel
+Implicits: 0
 (8-12)% Chance for Traps to Trigger an additional time
 ]],[[
 Replica Unstable Payload
@@ -759,6 +842,7 @@ Variant: Adds 1 Small Passive Skill
 Variant: Adds 3 Small Passive Skills
 Variant: Adds 5 Small Passive Skills
 Variant: Adds 7 Small Passive Skills
+Implicits: 0
 Adds 3 Jewel Socket Passive Skills
 {variant:1}Adds 1 Small Passive Skill which grants nothing
 {variant:2}Adds 3 Small Passive Skills which grant nothing
@@ -780,6 +864,7 @@ Variant: Armour
 Variant: Evasion Rating
 Variant: Accuracy Rating
 Limited to: 2
+Implicits: 0
 This Jewel's Socket has 25% increased effect per Allocated Passive Skill between
 it and your Class' starting location
 {variant:1}+5 to Strength
@@ -903,6 +988,7 @@ Variant: Zealotry: Crit Strike Elemental Pen on CG
 Variant: Zealotry: Arcane Surge when you create CG
 Variant: Zealotry: Inc. Max Recovery from ES Leech
 Limited to: 1
+Implicits: 0
 (4-6)% increased maximum Energy Shield
 (4-6)% increased maximum Life 
 (4-6)% increased maximum Mana
@@ -1015,17 +1101,20 @@ Limited to: 1
 [[
 Amanamu's Gaze
 Ghastly Eye Jewel
+Implicits: 0
 +(5-10) to all Attributes
 Minions have +6% to Damage over Time Multiplier per Ghastly Eye Jewel affecting you, up to a maximum of +30%
 ]],[[
 Kurgal's Gaze
 Hypnotic Eye Jewel
+Implicits: 0
 +(10-20) to Intelligence
 8% increased Effect of Arcane Surge on you per Hypnotic Eye Jewel affecting you, up to a maximum of 40%
 ]],[[
 Tecrod's Gaze
 Murderous Eye Jewel
 Requires Level 40
+Implicits: 0
 +(10-20) to Strength
 20% increased Main Hand Critical Strike Chance per Murderous Eye Jewel affecting you, up to a maximum of 100%
 +10% to Off Hand Critical Strike Multiplier per Murderous Eye Jewel affecting you, up to a maximum of +50%
@@ -1033,6 +1122,7 @@ Requires Level 40
 Ulaman's Gaze
 Searching Eye Jewel
 Requires Level 40
+Implicits: 0
 +(10-20) to Dexterity
 Projectiles have 4% chance to be able to Chain when colliding with terrain per Searching Eye Jewel affecting you, up to a maximum of 20%
 ]],
@@ -1042,6 +1132,7 @@ Combat Focus
 Crimson Jewel
 Limited to: 2
 Radius: Medium
+Implicits: 0
 (10-15)% increased Elemental Damage with Attack Skills
 With 40 total Strength and Intelligence in Radius, Prismatic Skills cannot choose Cold
 With 40 total Strength and Intelligence in Radius, Prismatic Skills deal 50% less Cold Damage
@@ -1050,6 +1141,7 @@ Combat Focus
 Cobalt Jewel
 Limited to: 2
 Radius: Medium
+Implicits: 0
 (10-15)% increased Elemental Damage with Attack Skills
 With 40 total Intelligence and Dexterity in Radius, Prismatic Skills cannot choose Fire
 With 40 total Intelligence and Dexterity in Radius, Prismatic Skills deal 50% less Fire Damage
@@ -1058,6 +1150,7 @@ Combat Focus
 Viridian Jewel
 Limited to: 2
 Radius: Medium
+Implicits: 0
 (10-15)% increased Elemental Damage with Attack Skills
 With 40 total Dexterity and Strength in Radius, Prismatic Skills Strike cannot choose Lightning
 With 40 total Dexterity and Strength in Radius, Prismatic Skills deal 50% less Lightning Damage
@@ -1068,6 +1161,7 @@ Limited to: 2
 Variant: Pre 3.9.0
 Variant: Current
 Radius: Medium
+Implicits: 0
 (10-15)% increased Global Physical Damage
 {variant:1}With at least 40 Dexterity in Radius, Shrapnel Shot has 25% increased Area of Effect
 {variant:1}With at least 40 Dexterity in Radius, Shrapnel Shot's
@@ -1084,6 +1178,7 @@ Variant: Pre 3.0.0
 Variant: Pre 3.8.0
 Variant: Current
 Radius: Medium
+Implicits: 0
 Minions have +(7-10)% to all Elemental Resistances
 {variant:1}With at least 40 Intelligence in Radius, can summon up to 3 Skeleton Mages with Summon Skeletons
 {variant:2}With at least 40 Intelligence in Radius, can summon up to 5 Skeleton Mages with Summon Skeletons
@@ -1097,6 +1192,7 @@ League: Legion
 Requires Level: 20
 Limited to: 1
 Radius: Medium
+Implicits: 0
 (10-15)% increased Attack Damage while holding a Shield
 {variant:1}+0.2% to Off Hand Critical Strike Chance per 10 Maximum Energy Shield on Shield
 {variant:2}+0.15% to Off Hand Critical Strike Chance per 10 Maximum Energy Shield on Shield
@@ -1106,6 +1202,7 @@ Fight for Survival
 Viridian Jewel
 Limited to: 2
 Radius: Medium
+Implicits: 0
 (10-15)% increased Cold Damage
 With at least 40 Dexterity in Radius, Melee Damage 
 dealt by Frost Blades Penetrates 15% Cold Resistance
@@ -1116,6 +1213,7 @@ Cobalt Jewel
 Source: No longer obtainable
 Limited to: 2
 Radius: Medium
+Implicits: 0
 (7-10)% increased Projectile Damage 
 With at least 40 Intelligence in Radius, Freezing Pulse fires 2 additional Projectiles
 With at least 40 Intelligence in Radius, 25% increased Freezing Pulse Damage if
@@ -1126,6 +1224,7 @@ Cobalt Jewel
 Source: No longer obtainable
 Limited to: 2
 Radius: Medium
+Implicits: 0
 (7-10)% increased Projectile Damage
 With at least 40 Intelligence in Radius, Frostbolt fires 2 additional Projectiles
 With at least 40 Intelligence in Radius, Frostbolt Projectiles gain 40% increased Projectile
@@ -1138,6 +1237,7 @@ Variant: Pre 2.6.0
 Variant: Pre 3.17.0
 Limited to: 1
 Radius: Medium
+Implicits: 0
 {variant:1}(4-12)% increased Damage over Time
 {variant:2}(8-12)% increased Damage over Time
 With at least 40 Dexterity in Radius, Viper Strike deals 2% increased Damage with Hits and Poison for each Poison on the Enemy
@@ -1149,6 +1249,7 @@ Variant: Pre 3.17.0
 Variant: Current
 Limited to: 1
 Radius: Medium
+Implicits: 0
 (10-15)% increased Lightning Damage
 {variant:1}With at least 40 Intelligence in Radius, Spark fires 2 additional Projectiles
 With at least 40 Intelligence in Radius, Spark fires Projectiles in a Nova
@@ -1160,6 +1261,7 @@ Variant: Pre 3.11.0
 Variant: Current
 Limited to: 1
 Radius: Medium
+Implicits: 0
 (10-15)% increased Fire Damage
 {variant:1}With at least 40 Intelligence in Radius, Rolling Magma fires an additional Projectile
 {variant:2}With at least 40 Intelligence in Radius, Rolling Magma deals 50% less Damage
@@ -1171,6 +1273,7 @@ The Long Winter
 Cobalt Jewel
 Limited to: 2
 Radius: Medium
+Implicits: 0
 (10-15)% increased Cold Damage 
 With 40 Intelligence in Radius, 20% of Glacial Cascade Physical Damage
 Converted to Cold Damage
@@ -1187,6 +1290,7 @@ Variant: Mace
 Variant: Sword
 Limited to: 1
 Radius: Medium
+Implicits: 0
 {variant:1}(10-15)% increased Physical Damage
 {variant:1}With at least 40 Dexterity in Radius, Dual Strike has a 20% chance
 to deal Double Damage with the Main-Hand Weapon
@@ -1210,6 +1314,7 @@ Variant: Pre 3.1.0
 Variant: Current
 Limited to: 2
 Radius: Medium
+Implicits: 0
 (15-20)% increased Damage with Hits against Chilled Enemies
 With at least 40 Dexterity in Radius, Ice Shot has 25% increased Area of Effect
 {variant:1}With at least 40 Dexterity in Radius, Ice Shot Pierces 5 additional Targets
@@ -1220,6 +1325,7 @@ Crimson Jewel
 Source: No longer obtainable
 Limited to: 1
 Radius: Medium
+Implicits: 0
 (10-15)% increased Global Physical Damage
 With at least 40 Strength in Radius, Cleave grants Fortify on Hit
 With at least 40 Strength in Radius, Cleave has +1 to Radius per Nearby Enemy, up to +10
@@ -1230,6 +1336,7 @@ Variant: Pre 2.6.0
 Variant: Pre 3.16.0
 Variant: Current
 Radius: Medium
+Implicits: 0
 {variant:1}(5-15)% increased Fire Damage
 {variant:2,3}(10-15)% increased Fire Damage
 {variant:3}+10% to Fire Damage over Time Multiplier
@@ -1244,6 +1351,7 @@ Variant: Pre 3.3.0
 Variant: Pre 3.17.0
 Limited to: 2
 Radius: Medium
+Implicits: 0
 {variant:1}(4-12)% increased Physical Damage
 {variant:2,3}(8-12)% increased Physical Damage
 {variant:1}With at least 40 Strength in Radius, Ground Slam has a 20% increased angle
@@ -1259,6 +1367,7 @@ Variant: Pre 3.17.0
 Variant: Current
 Limited to: 1
 Radius: Medium
+Implicits: 0
 (10-15)% increased Physical Damage 
 With at least 40 Dexterity in Radius, Ethereal Knives fires Projectiles in a Nova
 {variant:1}With at least 40 Dexterity in Radius, Ethereal Knives fires 10 additional Projectiles
@@ -1271,6 +1380,7 @@ Variant: Pre 3.11.0
 Variant: Current
 Limited to: 1
 Radius: Medium
+Implicits: 0
 {variant:1}(5-15)% increased Fire Damage
 {variant:2,3}(10-15)% increased Fire Damage
 {variant:1}With at least 40 Intelligence in Radius, Fireball Projectiles gain Area as they travel farther, up to 50% increased Area of Effect
@@ -1283,6 +1393,7 @@ Crimson Jewel
 Variant: Pre 2.6.0
 Variant: Current
 Radius: Medium
+Implicits: 0
 {variant:1}(5-15)% increased Cold Damage
 {variant:2}(10-15)% increased Cold Damage
 With at least 40 Strength in Radius, 20% increased Rarity of Items dropped by Enemies Shattered by Glacial Hammer
@@ -1293,6 +1404,7 @@ Variant: Pre 2.6.0
 Variant: Current
 Limited to: 2
 Radius: Medium
+Implicits: 0
 Minions deal (8-12)% increased Damage
 {variant:1}With at least 40 Dexterity in Radius, Animate Weapon can Animate up to 4 Ranged Weapons
 {variant:2}With at least 40 Dexterity in Radius, Animate Weapon can Animate up to 8 Ranged Weapons
@@ -1303,6 +1415,7 @@ Variant: Pre 2.6.0
 Variant: Current
 Limited to: 1
 Radius: Medium
+Implicits: 0
 {variant:1}(5-10)% increased maximum Mana
 {variant:2}(7-10)% increased maximum Mana
 With at least 40 Intelligence in Radius, 10% of Damage taken Recouped as Mana if you've Warcried Recently
@@ -1314,6 +1427,7 @@ Variant: Pre 3.17.0
 Variant: Current
 Limited to: 1
 Radius: Medium
+Implicits: 0
 (7-13)% increased Chaos Damage
 {variant:1,2}With at least 40 Intelligence in Radius, Blight has 50% increased Hinder Duration
 {variant:3}With at least 40 Intelligence in Radius, Blight has 30% reduced Cast Speed
@@ -1326,6 +1440,7 @@ Source: No longer obtainable
 Variant: Pre 2.6.0
 Variant: Pre 3.17.0
 Radius: Medium
+Implicits: 0
 {variant:1}(6-10)% increased Projectile Damage
 {variant:2}(7-10)% increased Projectile Damage
 {variant:1}With at least 40 Dexterity in Radius, each Spectral Throw Projectile gains 4% increased Damage each time it Hits.
@@ -1337,6 +1452,7 @@ Variant: Current
 Viridian Jewel
 Limited to: 1
 Radius: Medium
+Implicits: 0
 (10-15)% increased Fire Damage 
 {variant:1}With at least 40 Dexterity in Radius, Burning Arrow can inflict an additional Ignite on an Enemy
 {Variant:2}Ignited Enemies Killed by your Hits are destroyed
@@ -1347,6 +1463,7 @@ Variant: Pre 2.6.0
 Variant: Current
 Limited to: 2
 Radius: Medium
+Implicits: 0
 {variant:1}Minions have (5-8)% increased Area of Effect of Area Skills
 {variant:2}Minions have (6-8)% increased Area of Effect of Area Skills
 With at least 40 Intelligence in Radius, Raised Spectres have a 50% chance to gain Soul Eater for 20 seconds on Kill
@@ -1358,6 +1475,7 @@ Variant: Pre 3.14.0
 Variant: Current
 Limited to: 1
 Radius: Medium
+Implicits: 0
 (8-15)% increased Armour
 {variant:1}With at least 40 Strength in Radius, Vigilant Strike also Fortifies Nearby Allies for 3 seconds.
 {variant:2}With at least 40 Strength in Radius, Vigilant Strike Fortifies you and Nearby Allies for 12 seconds
@@ -1367,6 +1485,7 @@ Violent Dead
 Cobalt Jewel
 Limited to: 2
 Radius: Medium
+Implicits: 0
 Minions deal (10-15)% increased Damage 
 With at least 40 Intelligence in Radius, Raised
 Zombies' Slam Attack has 100% increased Cooldown Recovery Speed
@@ -1380,6 +1499,7 @@ Variant: Pre 3.9.0
 Variant: Current
 Limited to: 1
 Radius: Medium
+Implicits: 0
 {variant:1}(6-10)% increased Projectile Damage
 {variant:2,3}(7-10)% increased Projectile Damage
 {variant:1,2}With at least 40 Dexterity in Radius, Barrage fires an additional 2 projectiles simultaneously on the first and final attacks
@@ -1390,6 +1510,7 @@ Crimson Jewel
 Source: No longer obtainable
 Limited to: 2
 Radius: Medium
+Implicits: 0
 (8-12)% increased Physical Damage
 With at least 40 Strength in Radius, Heavy Strike has a 20% chance to deal Double Damage
 ]],[[
@@ -1399,6 +1520,7 @@ Variant: Pre 3.11.0
 Variant: Current
 Limited to: 1
 Radius: Medium
+Implicits: 0
 (10-15)% increased Fire Damage 
 {variant:1}With at least 40 Strength in Radius, Molten Strike fires 2 additional Projectiles
 {variant:1}With at least 40 Strength in Radius, Molten Strike has 25% increased Area of Effect
@@ -1411,6 +1533,7 @@ Crimson Jewel
 Source: No longer obtainable
 Limited to: 2
 Radius: Medium
+Implicits: 0
 (10-15)% increased Cold Damage
 With at least 40 Strength in Radius, Glacial Hammer deals
 Cold-only Splash Damage to surrounding targets
@@ -1424,6 +1547,7 @@ Variant: Pre 3.3.0
 Variant: Current
 Limited to: 1
 Radius: Medium
+Implicits: 0
 {variant:1}(5-15)% increased Cold Damage
 {variant:2,3}(10-15)% increased Cold Damage
 {variant:1}With at least 40 Intelligence in Radius, Cold Snap has a 25% chance to grant a Power Charge on Kill
@@ -1436,6 +1560,7 @@ Radius: Medium
 Ancient Waystones
 Crimson Jewel
 Limited to: 1
+Implicits: 0
 60% reduced Cost of Aura Skills that summon Totems
 Corrupted
 ]],[[
@@ -1444,12 +1569,14 @@ Crimson Jewel
 Variant: Pre 3.14.0
 Variant: Current
 Limited to: 1
+Implicits: 0
 {variant:1,2}(15-20)% increased Vaal Skill Effect Duration
 {variant:2}Vaal Skills have (15-20)% chance to regain consumed Souls when used
 Corrupted
 ]],[[
 Blood Sacrifice
 Crimson Jewel
+Implicits: 0
 Lose 1% of Life on Kill
 Recover 1% of Mana on Kill
 Lose 1% of Energy Shield on Kill
@@ -1465,6 +1592,7 @@ Cannot Leech or Regenerate Mana
 ]],[[
 Brittle Barrier
 Cobalt Jewel
+Implicits: 0
 20% faster start of Energy Shield Recharge
 10% increased Damage taken while on Full Energy Shield
 Corrupted
@@ -1472,11 +1600,13 @@ Corrupted
 Chill of Corruption
 Viridian Jewel
 Limited to: 1
+Implicits: 0
 50% chance to gain an additional Vaal Soul per Enemy Shattered
 Corrupted
 ]],[[
 Combustibles
 Crimson Jewel
+Implicits: 0
 10% reduced Quantity of Items found
 (20-30)% increased Burning Damage
 Corrupted
@@ -1494,6 +1624,7 @@ Variant: Pre 3.11.0
 Variant: Current
 Limited to: 1
 Radius: Small
+Implicits: 0
 {variant:1}(20-30)% increased Spell Damage
 {variant:2}(30-40)% increased Spell Damage
 {variant:1}100% increased Mana Cost of Skills
@@ -1504,51 +1635,60 @@ Corrupted
 ]],[[
 Fragility
 Crimson Jewel
+Implicits: 0
 −1 Maximum Endurance Charges
 Corrupted
 ]],[[
 Hungry Abyss
 Viridian Jewel
 Limited to: 1
+Implicits: 0
 With 5 Corrupted Items Equipped: Life Leech recovers based on your Chaos Damage instead
 Corrupted
 ]],[[
 Mutated Growth
 Cobalt Jewel
 Limited to: 1
+Implicits: 0
 10% increased Experience Gain of Corrupted Gems
 Corrupted
 ]],[[
 Pacifism
 Viridian Jewel
+Implicits: 0
 −1 Maximum Frenzy Charges
 Corrupted
 ]],[[
 Powerlessness
 Cobalt Jewel
+Implicits: 0
 −1 Maximum Power Charges
 Corrupted
 ]],[[
 Sacrificial Harvest
 Viridian Jewel
 Limited to: 1
+Implicits: 0
 (20-30)% chance to gain an additional Vaal Soul on Kill
 Corrupted
 ]],[[
 Self-Flagellation
 Viridian Jewel
 Limited to: 1
+Implicits: 0
 An additional Curse can be applied to you
 (10-20)% increased Damage per Curse on you
 Corrupted
 ]],[[
 Vaal Sentencing
 Cobalt Jewel
+Implicits: 0
 (80-120)% increased Vaal Skill Critical Strike Chance
 Corrupted
 ]],[[
 Weight of Sin
 Viridian Jewel
+Implicits: 0
 (15-20)% increased Chaos Damage
 15% reduced Movement Speed
 Corrupted
@@ -1558,6 +1698,7 @@ Corrupted
 Assassin's Haste
 Cobalt Jewel
 Limited to: 1
+Implicits: 0
 10% increased Mana Regeneration Rate
 4% increased Movement Speed
 4% increased Attack and Cast Speed
@@ -1565,6 +1706,7 @@ Limited to: 1
 Conqueror's Efficiency
 Crimson Jewel
 Limited to: 1
+Implicits: 0
 3% reduced Mana Cost of Skills
 4% increased Skill Effect Duration
 4% increased Mana Reservation Efficiency of Skills
@@ -1573,6 +1715,7 @@ Replica Conqueror's Efficiency
 Crimson Jewel
 League: Heist
 Limited to: 1
+Implicits: 0
 4% increased Skill Effect Duration
 +5 to Maximum Rage
 Non-Channelling Skills have -9 to Total Mana Cost
@@ -1582,6 +1725,7 @@ Viridian Jewel
 Variant: Pre 3.16.0
 Variant: Current
 Limited to: 1
+Implicits: 0
 {variant:1}3% chance to Avoid Elemental Ailments
 {variant:2}10% chance to Avoid Elemental Ailments
 {variant:1}8% increased Life Recovery from Flasks
@@ -1592,6 +1736,7 @@ Limited to: 1
 Conqueror's Potency
 Cobalt Jewel
 Limited to: 1
+Implicits: 0
 4% increased Effect of your Curses
 8% increased effect of Flasks
 3% increased effect of Non-Curse Auras you Cast
@@ -1599,6 +1744,7 @@ Limited to: 1
 Poacher's Aim
 Viridian Jewel
 Limited to: 1
+Implicits: 0
 Projectiles Pierce an additional Target
 10% increased Projectile Damage
 ]],[[
@@ -1607,6 +1753,7 @@ Viridian Jewel
 Limited to: 1 Survival
 Variant: Pre 3.16.0
 Variant: Current
+Implicits: 0
 {variant:1}+20 to Dexterity
 {variant:1}+6% to all Elemental Resistances
 {variant:2}20% reduced Flask Charges gained
@@ -1618,6 +1765,7 @@ Cobalt Jewel
 Limited to: 1 Survival
 Variant: Pre 3.16.0
 Variant: Current
+Implicits: 0
 {variant:1}3 Mana Regenerated per second
 {variant:1}10% increased Elemental Damage
 {variant:2}Flasks applied to you have 20% reduced Effect
@@ -1629,6 +1777,7 @@ Crimson Jewel
 Limited to: 1 Survival
 Variant: Pre 3.16.0
 Variant: Current
+Implicits: 0
 {variant:1}10% increased Global Physical Damage
 {variant:1}+50 to Armour
 {variant:2}Flasks gain 2 Charges when you hit a Non-Unique Enemy, no more than once per second
@@ -1640,6 +1789,7 @@ Crimson Jewel
 Variant: Pre 3.16.0
 Variant: Current
 Limited to: 1
+Implicits: 0
 {variant:1}8% increased Attack Damage
 {variant:1}+1 Melee Strike Range
 {variant:2}10% increased Attack Damage
@@ -1651,6 +1801,7 @@ Emperor's Cunning
 Viridian Jewel
 Source: Fastest Normal Labyrinth
 Limited to: 1
+Implicits: 0
 20% increased Global Accuracy Rating
 3% increased Character Size
 (4-6)% increased Dexterity
@@ -1659,6 +1810,7 @@ Emperor's Mastery
 Prismatic Jewel
 Source: Fastest Eternal Labyrinth
 Limited to: 1
+Implicits: 0
 4% increased maximum Life
 3% increased Character Size
 5% increased Global Defences
@@ -1668,6 +1820,7 @@ Emperor's Might
 Crimson Jewel
 Source: Fastest Merciless Labyrinth
 Limited to: 1
+Implicits: 0
 10% increased Damage
 3% increased Character Size
 (4-6)% increased Strength
@@ -1676,6 +1829,7 @@ Emperor's Wit
 Cobalt Jewel
 Source: Fastest Cruel Labyrinth
 Limited to: 1
+Implicits: 0
 30% increased Global Critical Strike Chance
 3% increased Character Size
 (4-6)% increased Intelligence

--- a/src/Data/Uniques/shield.lua
+++ b/src/Data/Uniques/shield.lua
@@ -428,6 +428,7 @@ Variant: Fire and Lightning Damage
 Variant: Energy Shield and Life
 Variant: Armour during Soul Gain Prevention
 Variant: Level of Socketed Support Gems
+Implicits: 0
 (30-50)% increased Spell Damage
 (180-220)% increased Energy Shield
 Spectres have (50-100)% increased maximum Life

--- a/src/Data/Uniques/staff.lua
+++ b/src/Data/Uniques/staff.lua
@@ -191,6 +191,7 @@ Dying Breath
 Coiled Staff
 Variant: Pre 2.6.0
 Requires Level 23, 34 Str, 34 Int
+Implicits: 0
 (18-20)% Chance to Block Attack Damage while wielding a Staff
 18% increased Cast Speed
 18% increased maximum Mana


### PR DESCRIPTION
Fixes Data inconsistency.

### Description of the problem being solved:
Only some items had an Implicits statement

### Steps taken to verify a working solution:
- in lua, validate that each item has an Implicits statement 
 for f in *.lua;do echo $f;grep '\[\[' $f | wc -l;grep Implicits: $f | wc -l;done
- when converted to xml, validate each item has an Implicits statement
```python
        u = read_xml(Path(self.pob_config.exe_dir, "Data/uniques.xml"))
        for child in list(u.getroot()):
            for _item in child.findall("Item"):
                if "Implicits:" not in _item.text:
                    lines = [y for y in (x.strip() for x in _item.text.splitlines()) if y]
                    print(lines[0])
                print()
```

- when converted to xml, validate each item had only one Implicits statement
```python
        u = read_xml(Path(self.pob_config.exe_dir, "Data/uniques.xml"))
        for child in list(u.getroot()):
            for _item in child.findall("Item"):
                lines = [y for y in (x.strip() for x in _item.text.splitlines()) if y]
                count = 0
                for line in lines:
                    if "Implicits:" in line:
                        count += 1
                        print(count, lines[0])
                print()
```

- Choose a dozen or so items at random that were changed and confirm the tooltip hasn't changed, when compared against the live version of PoB.

### Link to a build that showcases this PR:
N/A
### Before screenshot:
N/A
### After screenshot:
![image](https://user-images.githubusercontent.com/4302241/190861635-0fcc3f5f-89b6-4996-94ea-dd7b4d30736d.png)
