### PR TITLE
Add missing poison multiplier breakdown for spells

### DIFF
--- a/src/Modules/CalcSections.lua
+++ b/src/Modules/CalcSections.lua
@@ -799,6 +799,7 @@ return {
 	}, },
 	{ label = "Total Increased", { format = "{0:mod:1}%", { modName = { "Damage", "ChaosDamage" }, modType = "INC", cfg = "poison" }, }, },
 	{ label = "Total More", { format = "{0:mod:1}%", { modName = { "Damage", "ChaosDamage" }, modType = "MORE", cfg = "poison" }, }, },
+	{ label = "Eff. DoT Multi", notFlag = "attack", haveOutput = "PoisonDotMulti", { format = "x {2:output:PoisonDotMulti}", { breakdown = "PoisonDotMulti" }, { modName = { "DotMultiplier", "ChaosDotMultiplier" }, modType = "BASE", cfg = "poison" }, }, },
 	{ label = "MH Eff. DoT Multi", bgCol = colorCodes.MAINHANDBG, flag = "weapon1Attack", haveOutput = "MainHand.PoisonDotMulti", { format = "x {2:output:MainHand.PoisonDotMulti}", { breakdown = "MainHand.PoisonDotMulti" }, { modName = { "DotMultiplier", "ChaosDotMultiplier" }, modType = "BASE", cfg = "poison" }, }, },
 	{ label = "OH Eff. DoT Multi", bgCol = colorCodes.OFFHANDBG, flag = "weapon2Attack", haveOutput = "OffHand.PoisonDotMulti", { format = "x {2:output:OffHand.PoisonDotMulti}", { breakdown = "OffHand.PoisonDotMulti" }, { modName = { "DotMultiplier", "ChaosDotMultiplier" }, modType = "BASE", cfg = "OHpoison" }, }, },
 	{ label = "Source Physical", textSize = 12, notFlag = "attack", haveOutput = "PoisonPhysicalMax", { format = "{0:output:PoisonPhysicalMin} to {0:output:PoisonPhysicalMax}", { breakdown = "PoisonPhysical" }, }, },


### PR DESCRIPTION
### Description of the problem being solved:
DoT Multi for poison wasn't showing up as a breakdown for spells
### Steps taken to verify a working solution:
- Add any physical or chaos spell
- Add herald of agony
- Add some DoT multi

### Link to a build that showcases this PR:
```bash
eNq1W9132jgWf-78FRyeKdjYGJhDZg4hpGE2NGxI292nHmEL0ERYjC0noX_9Xkk2GIIcG3vz0Brrful3P3Ql24M_3za09oKDkDD_qm42jXoN-y7ziL-6qn97uv3cq__5x2-DGeLrh-V1RKgY-eO3TwN5XaP4BVPgq9c4ClaYf08kWT9B0hb5fI2ZP0V_s-AL867qX5mP67UF8j3Ck18uRWH4FW3wVX3uAnO9hkIX-97ocF8RbhDx58x9xvxLwKKtVPtC8OuUeUAzmc4eHp9SSomfVgo2fxrMKNrhYM4Rr4Xwz1V9CFNHK3xHOIhCNAI5pmM0DcPoGabRMe166zzjfIuxt-dp68hA8DGl2XRSf10d3yzA4-USu5y84FFA-GiNfBfvpTg6vqK004hysqUEBykLOzqOJ8YRvZnND_N2HJhPzzDMbqdt2dl87ICxoaP8Qfj6mgJgF2gRvJOVTzi-gHnGSMj8NKPTa9p25wN6tIHoOUBnOc1eP8u-92oss91s93NDmGa1O03H0no3ohRSNU2vRX3ENgviH4Oe065hgNHDUsXqI_JIFB7Q0Eb3FPloxMJ0zulI78kSH5FqJzGe56N7BI_loxRmznAAtYjnYxDGFmKINcyxy6DeFdFRhCU1j8uUXcA5nl_CcIGiOT-UrrY2XW_w24FKHxr4nzSh2dHKm_ip4DUMvdoXxuWS9tE0ZH6P72Z7yq5-bVjvQuIiOkVvZBNtYIl5Qs_4oKNr6925WnMfqoKO1XaaegxvSYAvYhwx6l3GuEYsvIhTBG4OQGBtdn8XtBPfzZcN3_wAhzh4SS3pWXgv8SPEsmgyFhTn5DioiDMiT6QpVSvsx_p2qfXc7mVx3WPsrr9Aa_WIOM5XTPZUfSMTWUGbC1lBeAZZp5uP4RSnrg1L9-EvS8h5zGDpy2IqCNkPFHg5CqCPg9VuviaYFqROzB-hbY56KRyT5s7loGN15yDLxVoQuPELCtPVU98mqFkp8nwRh6HLBAYPn7TLhr4lZ3-LhpwWYxsGGxYFOf2iiHNNIFkFVAv6iL3IzbfSXFPYQuW1HqyitBDHkHPkPt8wb4ULKSnOMY-2W6gAwuV5-cQS9ohDkmosPjs5qB8g1HNll1jq8is4UOdWsF_C82s5Yck_F7H6FpjMgTy3iv0edwrFZAMlXG6WYT9_SHmtc2B_k2tzIwmPN076pGKvYPlaHGWExaihSzlsnbSmBNj_tcst_4g8l4Kx70WBSIXcOk45zql5IhuolmF4gziqhRgF7voevHxVr6d-3SJKF5D5cFdwDVrygEhcTTZbFnB5c4SoG0qZE38b8ZovT3c2JHR_LqLlUhzkgEweyNOn8e3tePQ0-T6OzUizhM-E0p9-tFmIkwv1_yFY5ljWwloYLUJ1eVX_TvDrXHDdYI4IBWhcRinahti7qi8RDUEzgUtJM4f5ujxDmqSCljQ5ADgv60CglzR-wwGH-UKT4AYEa-3aj39glFIo1mbhNp00cRijF6Rq-AiFXK3TGqTkwZZeijhf0k5HDGbwQswgqtUcj36ABN9tcQirKlkSV0R8tsufgFpRZeDiupAs7i7D3_FKpJchT7d0AtSgnlkdH-m449EMVOXpmBZVNapnv8Eu0s5dDeqZ960f8-Vp63kpe6oMSV_jczdImiGhYtXQenZM8Z5EL_CBr3GgliKtpCnUqIQkM3ECsoi4Po1TFBlYyd2rBiExpmdV2zPNHMRYRiU62oBoAE3T6EWpHY-2kGWxJv2yBj41mjGJZMugsT8e1gtQHYzWf3E_lJXf0Czr81sM6plVfrwXwYMopwQZyzd4iaEKZQbzniajivLIv4GCxzMAzSlKrUrDF0Y81amXkiYneV7YAalCslSROItbYYlyJ1MW-pMNTiXwx-dnmvqdIvlAEBTeu4ylPZ-kfet_hxEVD0YYLSfw3TlhqXkyHiLfuxFHHbknOmgl_e1AthRhLYTG9wvehNc72H7ciqJ58rBlgzisd3hzL56jPjHRhCOX4-BePVeNlSEJVNyZcvnc80hyEqQeXqKIivv_jhAlfCca_9TdWKpPAOpwzV5FgCk5ovsJobze36uRIeWxCKEkMUTBFZshITDlvfimfEA7PNgq0ZDWEt-lkYcnfrxri22gaCHsEY-cxfnoPtlO5OzVfBqANTHxF8oWiLYTlvhBdNuoH42bybjcMExkAUUe_g6zFgf9_6g5TmT_IlGKKWcoUDiv8EaMTmHT4MH2pzXhgEdLgNKStsHVOYkS-JNZ7QUfcHFZ5Cs9YlsjjoBiA2uxvJaCV-n6GGqJalmwBfVHcMu5TIkPyXLi6tyOuMMBot7Dcrhi_u69RCmslH9OFGR45pwbFHeNLWvvDTwxfr4lHg5ga82T5j3tsfgSMkaWCFUZxOVTgHGS2lKlGScY_Ei_AiHmZwg_hVAYdnETKhzpw3YZLrpWr9fo9HqW1eh0-obTsCy722-0na5tNOyeafYaVs-wew3H6ndh1LbbVqPd6Xdh1LEETbvrGA3TsPsGSLC6VsPutjtmwzGsfk_csdr1GgdrU293mP34xQ1lnZr0t8d7FThrzrfh763W6-trc4v4mi3xG6G46bJNawtMMOXPEs_PQmxrCH_Xq-FwfP3LbW_-NXprr43oJ_rGZj5b-x51g2_j7euKfebrr9Ffs6DLV8_AcqWQTrQO1LshYStGHWCUiAucxcVXBl23GBM3kx_SC-JsID7KmPNAQPuLsc1_wSNmv9s0DNPpO6ouwmLFp2gbp5SgimtqP66osIO8IeCiQC7JSYAJwv9c1e1-v2mY7X5fPV0YyGCNQ0BcJ8U9CrF6BPoDoy3kg7idZOUgJtQSHddlyqBQA8dsATDJoJHnJ4qnZs5f0bY2XOzCENGawq_WqUsO5dhWPjmnMtoXyCjAcs1gfa7C7nPzL2L7Naa8DP8tpNBzzSpuefuc5VYFnrsAxfb_Q4ZdwVycCuxwKvJN6fAu4tw7DPsZXsqEM4HtlLagSGpA3_AitmIlVVoVVQWztCV2BdFoVpAVdsEwKOyzUgrPhX4VyBWvyp2yZpddSKxCBni7mjodKxMz5x1YPvY7pSUULz6FHV4eqE41HmuXjTyngjJhVZB0VskMsCtafMtmolmNX63CIWkX5ig71aq66EvCpyJvO2XTpyJ3VxW9Fy1_QtAlVeBCvrJ-eCT-6oL2sFzl1Hquivp5YRCVhsAqirpZkbvtarDvlEagcP5XlKdFLB9uInqmRRm04uMdeXIlz4fkezPMX5LVu7dgTj91Orw7Iz95ev_aDPbxZjcJr1kYfkh7-vHWhwzqq66zZDOKXLxm1MNB2pL406jk9Z1u-vXmc_TipZHkjZuEycrBk7wemPB0slmOX61M2Zc85Ym9MWidfhb3Pybyjp4=
```
### Before screenshot:
![image](https://user-images.githubusercontent.com/1209372/191147907-88e55c0a-4e66-4df9-8b6d-322f8cfde784.png)

### After screenshot:
![image](https://user-images.githubusercontent.com/1209372/191147976-1e5dc030-4744-49f7-8164-fe9651f5fffa.png)
