### PR TITLE
Update affix limit for corrupted abyss jewels.

### DIFF
--- a/src/Classes/Item.lua
+++ b/src/Classes/Item.lua
@@ -565,7 +565,7 @@ function ItemClass:ParseRaw(raw)
 		elseif self.rarity == "MAGIC" then
 			self.affixLimit = 2
 		elseif self.rarity == "RARE" then
-			self.affixLimit = ((self.type == "Jewel" and self.base.subType == "Abyss" and self.corrupted) and 6 or self.type == "Jewel" and 4 or 6)
+			self.affixLimit = ((self.type == "Jewel" and not (self.base.subType == "Abyss" and self.corrupted)) and 4 or 6)
 		else
 			self.crafted = false
 		end

--- a/src/Classes/Item.lua
+++ b/src/Classes/Item.lua
@@ -565,7 +565,7 @@ function ItemClass:ParseRaw(raw)
 		elseif self.rarity == "MAGIC" then
 			self.affixLimit = 2
 		elseif self.rarity == "RARE" then
-			self.affixLimit = (self.type == "Jewel" and 4 or 6)
+			self.affixLimit = ((self.type == "Jewel" and self.base.subType == "Abyss" and self.corrupted) and 6 or self.type == "Jewel" and 4 or 6)
 		else
 			self.crafted = false
 		end


### PR DESCRIPTION
Fixes https://github.com/PathOfBuildingCommunity/PathOfBuilding/issues/5096

### Description of the problem being solved:
Corrupted abyss jewels can now have 6 affixes. This pr updates that.

Note that if a user manually removes the corrupted tag the extra suffix and prefix mods are not removed.