### PR TITLE
Fix global energy shield being mistaken for local

### DIFF
--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -1688,6 +1688,7 @@ local specialModList = {
 		mod("ManaDegen", "BASE", 1, { type = "PercentStat", stat = "Mana", percent = num }, { type = "Condition", var = "FullLife", neg = true }),
 		mod("LifeRecovery", "BASE", 1, { type = "PercentStat", stat = "Mana", percent = num }, { type = "Condition", var = "FullLife", neg = true })
 	} end,
+	["(%d+)%% increased maximum energy shield"] = function(num) return { mod("EnergyShield", "INC", num, { type = "Global" }) } end, -- Override as increased maximum is always global
 	["you are blind"] = { flag("Condition:Blinded") },
 	["armour applies to fire, cold and lightning damage taken from hits instead of physical damage"] = {
 		mod("ArmourAppliesToFireDamageTaken", "BASE", 100),


### PR DESCRIPTION
Fixes https://github.com/PathOfBuildingCommunity/PathOfBuilding/issues/99

### Description of the problem being solved:
Global energy shield implicit with wording "#% increased maximum energy shield" was applying locally even though all instances of this mod apply globally.

![image](https://user-images.githubusercontent.com/31533893/194791923-899ecbc6-f383-4463-a101-c89ca5e73859.png)
![image](https://user-images.githubusercontent.com/31533893/194791940-bfcf6b8f-cea7-46e0-b224-47497239e816.png)

### Steps taken to verify a working solution:
- Switching between nothing, the local variant and global see appropriate energy shield changes.

### Link to a build that showcases this PR:
https://pobb.in/IpxDlGdH-nb6