### PR TITLE
fix: Add Armour Cruncher to the list of spectres.

### DIFF
--- a/src/Data/Spectres.lua
+++ b/src/Data/Spectres.lua
@@ -3370,3 +3370,24 @@ minions["Metadata/Monsters/LeagueDelve/GhostEncounter/Wraith"] = {
 		-- MonsterNoMapDrops [monster_no_map_drops = 1]
 	},
 }
+
+-- Armour Cruncher
+minions["Metadata/Monsters/Beasts/CurseOnHit/Vulnerability"] = {
+	name = "Armour Cruncher",
+	life = 1.68,
+	fireResist = 0,
+	coldResist = 0,
+	lightningResist = 0,
+	chaosResist = 0,
+	damage = 1.5,
+	damageSpread = 0.2,
+	attackTime = 1.095,
+	attackRange = 14,
+	accuracy = 1,
+	skillList = {
+		"MeleeAtAnimationSpeed",
+	},
+	modList = {
+		-- MonsterCurseOnHitVulnerability [effect = 1.04 ]
+	},
+}


### PR DESCRIPTION
Fixes #5127  .

### Description of the problem being solved:
Armour Cruncher was missing from the Spectre list.

### Steps taken to verify a working solution:
- Checked that Armour Cruncher wasn't in the original list
- Added an entry for Armour Cruncher into the Spectre list
- Checked that the values are correct and values are calculated when adding Armour Cruncher to the list of spectres in the build

### Link to a build that showcases this PR:
N/A

### Before screenshot:
![Raise Spectre 0](https://user-images.githubusercontent.com/8795161/194782376-7dec5e7d-b064-4ca7-ac41-8151f313ed3f.png)
Armour Cruncher missing from list.

### After screenshot:
![Raise Spectre 1](https://user-images.githubusercontent.com/8795161/194782384-e162d36a-4dd1-4d3a-bf39-26335285c5b2.png)
Raise Spectre added to the Build.

![Raise Spectre 2](https://user-images.githubusercontent.com/8795161/194782393-b15084b0-f2c6-4c6e-a5f4-b63251a3e83a.png)
Armour Cruncher now displays on the list and values are calculated.

![Raise Spectre 3](https://user-images.githubusercontent.com/8795161/194782413-197d22c5-d40c-4668-997e-c919a3cbc5a9.png)
When spectre is added the build calculations update accordingly.