### PR TITLE
Fix Devotion not working with minion mods

### DIFF
--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -1138,7 +1138,7 @@ local modTagList = {
 	["per (%d+)%% chaos resistance"] = function(num) return { tag = { type = "PerStat", stat = "ChaosResist", div = num } } end,
 	["per (%d+)%% cold resistance above 75%%"] = function(num) return { tag  = { type = "PerStat", stat = "ColdResistOver75", div = num } } end,
 	["per (%d+)%% lightning resistance above 75%%"] = function(num) return { tag  = { type = "PerStat", stat = "LightningResistOver75", div = num } } end,
-	["per (%d+) devotion"] = function(num) return { tag = { type = "PerStat", stat = "Devotion", div = num } } end,
+	["per (%d+) devotion"] = function(num) return { tag = { type = "PerStat", stat = "Devotion", actor = "parent", div = num } } end,
 	["per (%d+)%% missing fire resistance, up to a maximum of (%d+)%%"] = function(num, _, limit) return { tag = { type = "PerStat", stat = "MissingFireResist", div = num, globalLimit = tonumber(limit), globalLimitKey = "ReplicaNebulisFire" } } end,
 	["per (%d+)%% missing cold resistance, up to a maximum of (%d+)%%"] = function(num, _, limit) return { tag = { type = "PerStat", stat = "MissingColdResist", div = num, globalLimit = tonumber(limit), globalLimitKey = "ReplicaNebulisCold" } } end,
 	["per endurance, frenzy or power charge"] = { tag = { type = "PerStat", stat = "TotalCharges" } },


### PR DESCRIPTION
Fixes #5057 .

### Description of the problem being solved:
Mods scaled by Devotion can apply to minions but they have none of it. Should be looking at player's Devotion instead.

### Link to a build that showcases this PR:
[https://pobb.in/Pav3tyBwN_5_](https://pobb.in/Pav3tyBwN_5_)
### Before screenshot:
![image](https://user-images.githubusercontent.com/18018499/195173541-6ce8176c-55b0-495e-bca4-1e76864c2d4f.png)
### After screenshot:
![image](https://user-images.githubusercontent.com/18018499/195173436-814114db-a58b-4ae6-97dd-5bd63cbd7c5f.png)
