### PR TITLE
Fix missing elemental resist calculation

### DIFF
--- a/src/Modules/CalcDefence.lua
+++ b/src/Modules/CalcDefence.lua
@@ -105,7 +105,7 @@ function calcs.defence(env, actor)
 		output[elem.."ResistTotal"] = total
 		output[elem.."ResistOverCap"] = m_max(0, total - max)
 		output[elem.."ResistOver75"] = m_max(0, final - 75)
-		output["Missing"..elem.."Resist"] = m_max(0, totemMax - final)
+		output["Missing"..elem.."Resist"] = m_max(0, max - final)
 		output["Totem"..elem.."Resist"] = totemFinal
 		output["Totem"..elem.."ResistTotal"] = totemTotal
 		output["Totem"..elem.."ResistOverCap"] = m_max(0, totemTotal - totemMax)


### PR DESCRIPTION
### Description of the problem being solved:
Missing resistance calculations were using totem's maximum resistance instead of player's
### Steps taken to verify a working solution:
- Equip Replica Nebulis
- Get fire resist close to max
- Observe amount of increased fire damage

### Link to a build that showcases this PR:
https://pobb.in/go2n11_TF6bs
### Before screenshot:
![image](https://user-images.githubusercontent.com/18018499/195665773-2370fd1d-a765-4efb-af92-d064685e2a59.png)

### After screenshot:
![image](https://user-images.githubusercontent.com/18018499/195665676-61b2ade3-cff4-4d3c-845d-7a163b87b719.png)
