### PR TITLE
Adjust sample Brittle effects

### DIFF
--- a/src/Modules/CalcOffence.lua
+++ b/src/Modules/CalcOffence.lua
@@ -3711,7 +3711,7 @@ function calcs.offence(env, actor, activeSkill)
 				ramping = true,
 			},
 			["Brittle"] = {
-				effList = { 5, 10 },
+				effList = { 2, 4 },
 				effect = function(damage, effectMod) return 10 * ((damage / enemyThreshold) ^ 0.4) * effectMod end,
 				thresh = function(damage, value, effectMod) return damage * ((10 * effectMod / value) ^ 2.5) end,
 				ramping = true,


### PR DESCRIPTION
### Description of the problem being solved:
The list of sample Brittle effects was using values fitting pre-nerf range

### Link to a build that showcases this PR:
https://pobb.in/GS_k1kWBScby
### Before screenshot:
![image](https://user-images.githubusercontent.com/18018499/195679544-de12ed58-8279-4176-aa34-5549a04f2e82.png)
### After screenshot:
![image](https://user-images.githubusercontent.com/18018499/195679431-ec7be3d5-a414-4602-bf58-096939c01856.png)
