### PR TITLE
Fix rare templates not getting implicit mod tags

### DIFF
--- a/src/Modules/Main.lua
+++ b/src/Modules/Main.lua
@@ -90,8 +90,10 @@ function main:Init()
 			if newItem.crafted then
 				if newItem.base.implicit and #newItem.implicitModLines == 0 then
 					-- Automatically add implicit
+					local implicitIndex = 1
 					for line in newItem.base.implicit:gmatch("[^\n]+") do
-						t_insert(newItem.implicitModLines, { line = line })
+						t_insert(newItem.implicitModLines, { line = line, modTags = newItem.base.implicitModTypes and newItem.base.implicitModTypes[implicitIndex] or { } })
+						implicitIndex = implicitIndex + 1
 					end
 				end
 				newItem:Craft()


### PR DESCRIPTION
### Description of the problem being solved:
When editing an item from the rare template list, implicit mods were not affected by catalysts
### Steps taken to verify a working solution:
- Used the crystal belt rare template
- Added Tempering Catalyst
- Noticed the energy shield implicit changed properly after my fix

### Link to a build that showcases this PR:
N/A, import from the rare template list instead
### Before screenshot:
![image](https://user-images.githubusercontent.com/1209372/197056839-f30361e7-68cf-42d8-8e0c-d04e865d28aa.png)
![image](https://user-images.githubusercontent.com/1209372/197056953-d2953cf5-2c26-4e46-a22b-52ef3f44fb06.png)

### After screenshot:
![image](https://user-images.githubusercontent.com/1209372/197056876-6b09fcda-25b1-4ed2-acbd-ee23c9c59b2d.png)
![image](https://user-images.githubusercontent.com/1209372/197057053-d85bbf2c-99e5-413b-9f59-0e534f52d6e9.png)
