### PR TITLE
Fix incorrect wording for Ephemeral Edge

### DIFF
--- a/src/Data/Uniques/sword.lua
+++ b/src/Data/Uniques/sword.lua
@@ -77,7 +77,7 @@ Implicits: 2
 {variant:1,2,3}10% reduced maximum Life
 {variant:4}25% reduced maximum Life
 {variant:1,2,3}(0.6-1)% of Physical Attack Damage Leeched as Mana
-{variant:4}Attacks with this Weapon have Added maximum Lightning Damage equal to 20% of your Energy Shield
+{variant:4}Attacks with this Weapon have Added maximum Lightning Damage equal to 20% of your Maximum Energy Shield
 ]],[[
 The Goddess Scorned
 Elegant Sword

--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -3437,7 +3437,7 @@ local specialModList = {
 		flag("Condition:HaveManaStorm"),
 		mod("LightningMax", "BASE", 1, { type = "PercentStat", stat = "ManaUnreserved" , percent = num }, { type = "Condition", var = "SacrificeManaForLightning" }),
 	} end,
-	["attacks with this weapon have added maximum lightning damage equal to (%d+)%% of your energy shield"] = function(num) return {
+	["attacks with this weapon have added maximum lightning damage equal to (%d+)%% of your m?a?x?i?m?u?m? ?energy shield"] = function(num) return {
 		mod("LightningMax", "BASE", 1, { type = "PercentStat", stat = "EnergyShield" , percent = num }, { type = "Condition", var = "{Hand}Attack" }, { type = "SkillType", skillType = SkillType.Attack }),
 	} end,
 	["gain added chaos damage equal to (%d+)%% of ward"] = function(num) return {


### PR DESCRIPTION
### Description of the problem being solved:
Ephemeral edge's new energy shield mod was not being parsed properly due to changed wording
### Steps taken to verify a working solution:
- Imported build using Ephemeral Edge
- Used Ephemeral Edge from unique DB
- Verified both copies were parsed correctly

### Link to a build that showcases this PR:
https://pobb.in/92mU9nK4Jdf-

No screenshots of red text/non red text