### PR TITLE
Fix Scorching Ray exposure not applying when using calculate maximum sustainable stages option.

### DIFF
--- a/src/Modules/CalcPerform.lua
+++ b/src/Modules/CalcPerform.lua
@@ -2343,6 +2343,109 @@ function calcs.perform(env, avoidCache)
 		end
 	end
 	
+	local function processBuffDebuff(activeSkill)
+		local skillModList = activeSkill.skillModList
+		local skillCfg = activeSkill.skillCfg
+		local newBuffs = {}
+		local newDebuffs = {}
+		local newMinionBuffs = {}
+		for _, buff in ipairs(activeSkill.buffList) do
+			if buff.cond and not skillModList:GetCondition(buff.cond, skillCfg) then
+			elseif buff.enemyCond and not enemyDB:GetCondition(buff.enemyCond) then
+			elseif buff.type == "Buff" and not buffs[buff.name] then
+				if env.mode_buffs and (not activeSkill.skillFlags.totem or buff.allowTotemBuff) then
+					local skillCfg = buff.activeSkillBuff and skillCfg
+					local modStore = buff.activeSkillBuff and skillModList or modDB
+					 if not buff.applyNotPlayer then
+						activeSkill.buffSkill = true
+						modDB.conditions["AffectedBy"..buff.name:gsub(" ","")] = true
+						local srcList = new("ModList")
+						local inc = modStore:Sum("INC", skillCfg, "BuffEffect", "BuffEffectOnSelf", "BuffEffectOnPlayer") + skillModList:Sum("INC", skillCfg, buff.name:gsub(" ", "").."Effect")
+						local more = modStore:More(skillCfg, "BuffEffect", "BuffEffectOnSelf")
+						srcList:ScaleAddList(buff.modList, (1 + inc / 100) * more)
+						mergeBuff(srcList, buffs, buff.name)
+						if activeSkill.skillData.thisIsNotABuff then
+							buffs[buff.name].notBuff = true
+						end
+						mergeBuff(srcList, newBuffs, buff.name)
+						if activeSkill.skillData.thisIsNotABuff then
+							newBuffs[buff.name].notBuff = true
+						end
+					end
+					if env.minion and (buff.applyMinions or buff.applyAllies) and not minionBuffs[buff.name] then
+						activeSkill.minionBuffSkill = true
+						env.minion.modDB.conditions["AffectedBy"..buff.name:gsub(" ","")] = true
+						local srcList = new("ModList")
+						local inc = modStore:Sum("INC", skillCfg, "BuffEffect", "BuffEffectOnMinion") + env.minion.modDB:Sum("INC", nil, "BuffEffectOnSelf")
+						local more = modStore:More(skillCfg, "BuffEffect", "BuffEffectOnMinion") * env.minion.modDB:More(nil, "BuffEffectOnSelf")
+						srcList:ScaleAddList(buff.modList, (1 + inc / 100) * more)
+						mergeBuff(srcList, minionBuffs, buff.name)
+						mergeBuff(srcList, newMinionBuffs, buff.name)
+					end
+				end
+			elseif (buff.type == "Debuff" or buff.type == "AuraDebuff") and not debuffs[buff.name] then
+				local stackCount
+				if buff.stackVar then
+					stackCount = skillModList:Sum("BASE", skillCfg, "Multiplier:"..buff.stackVar)
+					if buff.stackLimit then
+						stackCount = m_min(stackCount, buff.stackLimit)
+					elseif buff.stackLimitVar then
+						stackCount = m_min(stackCount, skillModList:Sum("BASE", skillCfg, "Multiplier:"..buff.stackLimitVar))
+					end
+				else
+					stackCount = activeSkill.skillData.stackCount or 1
+				end
+				if env.mode_effective and stackCount > 0 then
+					activeSkill.debuffSkill = true
+					modDB.conditions["AffectedBy"..buff.name:gsub(" ","")] = true
+					local srcList = new("ModList")
+					local mult = 1
+					if buff.type == "AuraDebuff" then
+						mult = 0
+						if not modDB:Flag(nil, "SelfAurasOnlyAffectYou") then
+							local inc = skillModList:Sum("INC", skillCfg, "AuraEffect", "BuffEffect", "DebuffEffect")
+							local more = skillModList:More(skillCfg, "AuraEffect", "BuffEffect", "DebuffEffect")
+							mult = (1 + inc / 100) * more
+						end
+					end
+					if buff.type == "Debuff" then
+						local inc = skillModList:Sum("INC", skillCfg, "DebuffEffect")
+						local more = skillModList:More(skillCfg, "DebuffEffect")
+						mult = (1 + inc / 100) * more
+					end
+					srcList:ScaleAddList(buff.modList, mult * stackCount)
+					if activeSkill.skillData.stackCount or buff.stackVar then
+						srcList:NewMod("Multiplier:"..buff.name.."Stack", "BASE", stackCount, buff.name)
+					end
+					mergeBuff(srcList, debuffs, buff.name)
+					mergeBuff(srcList, newDebuffs, buff.name)
+				end
+			end
+		end
+		-- Apply buff/debuff modifiers
+		for _, modList in pairs(newBuffs) do
+			modDB:AddList(modList)
+			if not modList.notBuff then
+				modDB.multipliers["BuffOnSelf"] = (modDB.multipliers["BuffOnSelf"] or 0) + 1
+			end
+			if env.minion then
+				for _, value in ipairs(modList:List(env.player.mainSkill.skillCfg, "MinionModifier")) do
+					if not value.type or env.minion.type == value.type then
+						env.minion.modDB:AddMod(value.mod)
+					end
+				end
+			end
+		end
+		if env.minion then
+			for _, modList in pairs(newMinionBuffs) do
+				env.minion.modDB:AddList(modList)
+			end
+		end
+		for _, modList in pairs(newDebuffs) do
+			enemyDB:AddList(modList)
+		end
+	end
+
 	for _, activeSkill in ipairs(env.player.activeSkillList) do -- Do another pass on the SkillList to catch effects of buffs, if needed
 		if activeSkill.activeEffect.grantedEffect.name == "Blight" and activeSkill.skillPart == 2 then
 			local rate = (1 / activeSkill.activeEffect.grantedEffect.castTime) * calcLib.mod(activeSkill.skillModList, activeSkill.skillCfg, "Speed") * calcs.actionSpeedMod(env.player)
@@ -2350,6 +2453,7 @@ function calcs.perform(env, avoidCache)
 			local maximum = m_min((m_floor(rate * duration) - 1), 19)
 			activeSkill.skillModList:NewMod("Multiplier:BlightMaxStages", "BASE", maximum, "Base")
 			activeSkill.skillModList:NewMod("Multiplier:BlightStageAfterFirst", "BASE", maximum, "Base")
+			processBuffDebuff(activeSkill)
 		end
 		if activeSkill.activeEffect.grantedEffect.name == "Penance Brand" and activeSkill.skillPart == 2 then
 			local rate = 1 / (activeSkill.skillData.repeatFrequency / (1 + env.player.mainSkill.skillModList:Sum("INC", env.player.mainSkill.skillCfg, "Speed", "BrandActivationFrequency") / 100) / activeSkill.skillModList:More(activeSkill.skillCfg, "BrandActivationFrequency"))
@@ -2357,6 +2461,7 @@ function calcs.perform(env, avoidCache)
 			local ticks = m_min((m_floor(rate * duration) - 1), 19)
 			activeSkill.skillModList:NewMod("Multiplier:PenanceBrandMaxStages", "BASE", ticks, "Base")
 			activeSkill.skillModList:NewMod("Multiplier:PenanceBrandStageAfterFirst", "BASE", ticks, "Base")
+			processBuffDebuff(activeSkill)
 		end
 		if activeSkill.activeEffect.grantedEffect.name == "Scorching Ray" and activeSkill.skillPart == 2 then
 			local rate = (1 / activeSkill.activeEffect.grantedEffect.castTime) * calcLib.mod(activeSkill.skillModList, activeSkill.skillCfg, "Speed") * calcs.actionSpeedMod(env.player)
@@ -2364,6 +2469,7 @@ function calcs.perform(env, avoidCache)
 			local maximum = m_min((m_floor(rate * duration) - 1), 7)
 			activeSkill.skillModList:NewMod("Multiplier:ScorchingRayMaxStages", "BASE", maximum, "Base")
 			activeSkill.skillModList:NewMod("Multiplier:ScorchingRayStageAfterFirst", "BASE", maximum, "Base")
+			processBuffDebuff(activeSkill)
 		end
 	end
 


### PR DESCRIPTION
Fixes https://github.com/PathOfBuildingCommunity/PathOfBuilding/issues/5162 .

### Description of the problem being solved:
Scorching ray applies exposure when at maximum stages. https://github.com/PathOfBuildingCommunity/PathOfBuilding/commit/222a1c53e97dd4edc9997213d689e9b682f4d055 moved the logic that calculates maximum sustainable stages for a few skills to after buffs/debuffs are applied to take arcane surge cast speed buff into consideration causing mods that use stage count as thresholds to not be added when they should.

```LUA
mod("FireExposure", "BASE", nil, 0, 0, { type = "GlobalEffect", effectType = "Debuff", effectName = "Fire Exposure", effectCond = "ScorchingRayMaxStages" }),
```

### Before screenshot:
![obraz](https://user-images.githubusercontent.com/91493239/199443248-3186f612-e22c-42ca-9acb-77a1525b6e17.png)
### After screenshot:
![obraz](https://user-images.githubusercontent.com/91493239/199442732-61507a84-f93a-4a07-88cb-7eda799b587e.png)
