### PR TITLE
Fix shav's revelation removing life recharge.

### DIFF
--- a/src/Modules/CalcDefence.lua
+++ b/src/Modules/CalcDefence.lua
@@ -722,14 +722,17 @@ function calcs.defence(env, actor)
 			})
 		end
 	end
+	
+	
+	
 	-- Energy Shield Recharge
-	if modDB:Flag(nil, "NoEnergyShieldRecharge") then
-		output.EnergyShieldRecharge = 0
-	else
+	output.EnergyShieldRechargeAppliesToLife = modDB:Flag(nil, "EnergyShieldRechargeAppliesToLife")
+	output.EnergyShieldRechargeAppliesToEnergyShield = not (modDB:Flag(nil, "NoEnergyShieldRecharge") or output.EnergyShieldRechargeAppliesToLife)
+	
+	if output.EnergyShieldRechargeAppliesToLife or output.EnergyShieldRechargeAppliesToEnergyShield then
 		local inc = modDB:Sum("INC", nil, "EnergyShieldRecharge")
 		local more = modDB:More(nil, "EnergyShieldRecharge")
-		if modDB:Flag(nil, "EnergyShieldRechargeAppliesToLife") then
-			output.EnergyShieldRechargeAppliesToLife = true
+		if output.EnergyShieldRechargeAppliesToLife then
 			local recharge = output.Life * data.misc.EnergyShieldRechargeBase * (1 + inc/100) * more
 			output.LifeRecharge = round(recharge * output.LifeRecoveryRateMod)
 			if breakdown then
@@ -749,7 +752,6 @@ function calcs.defence(env, actor)
 				})	
 			end
 		else
-			output.EnergyShieldRechargeAppliesToEnergyShield = true
 			local recharge = output.EnergyShield * data.misc.EnergyShieldRechargeBase * (1 + inc/100) * more
 			output.EnergyShieldRecharge = round(recharge * output.EnergyShieldRecoveryRateMod)
 			if breakdown then
@@ -779,6 +781,8 @@ function calcs.defence(env, actor)
 				}
 			end
 		end
+	else
+		output.EnergyShieldRecharge = 0
 	end
 	
 	-- recoup

--- a/src/Modules/CalcSections.lua
+++ b/src/Modules/CalcSections.lua
@@ -1266,7 +1266,7 @@ return {
 	{ label = "Total Recoverable", haveOutput = "CappingLife", { format = "{0:output:LifeRecoverable}", { breakdown = "LifeUnreserved" }, }, },
 	{ label = "Recharge Rate", haveOutput = "EnergyShieldRechargeAppliesToLife", { format = "{1:output:LifeRecharge}", 
 		{ breakdown = "LifeRecharge" },
-		{ modName = { "EnergyShieldRecharge", "LifeRecoveryRate", "NoEnergyShieldRecharge", "EnergyShieldRechargeAppliesToLife" }, },
+		{ modName = { "EnergyShieldRecharge", "LifeRecoveryRate", "EnergyShieldRechargeAppliesToLife" }, },
 	}, },
 	{ label = "Recharge Delay", haveOutput = "EnergyShieldRechargeAppliesToLife", { format = "{2:output:EnergyShieldRechargeDelay}s", 
 		{ breakdown = "EnergyShieldRechargeDelay" },


### PR DESCRIPTION
Fixes https://github.com/PathOfBuildingCommunity/PathOfBuilding/issues/5163.

### Description of the problem being solved:
According to the mentioned issue life recharge ([Eternal Youth](https://www.poewiki.net/wiki/Eternal_Youth)) is not affected by "You cannot Recharge or Regenerate Energy Shield" from [Shavronne's Revelation](https://www.poewiki.net/wiki/Shavronne%27s_Revelation).

This pr stops "You cannot Recharge or Regenerate Energy Shield" from removing life recharge.


