### PR TITLE
Fix maximum shock double counting.

### DIFF
--- a/src/Modules/CalcPerform.lua
+++ b/src/Modules/CalcPerform.lua
@@ -3082,7 +3082,7 @@ function calcs.perform(env, avoidCache)
 				end
 				override = m_max(override, effect or 0)
 			end
-			output["Maximum"..ailment] = modDB:Override(nil, ailment.."Max") or (ailmentData[ailment].max + modDB:Sum("BASE", nil, ailment.."Max") + env.player.mainSkill.baseSkillModList:Sum("BASE", nil, ailment.."Max"))
+			output["Maximum"..ailment] = modDB:Override(nil, ailment.."Max") or (ailmentData[ailment].max + env.player.mainSkill.baseSkillModList:Sum("BASE", nil, ailment.."Max"))
 			output["Current"..ailment] = m_floor(m_min(m_max(override, enemyDB:Sum("BASE", nil, ailment.."Val")), output["Maximum"..ailment]) * (10 ^ ailmentData[ailment].precision)) / (10 ^ ailmentData[ailment].precision)
 			for _, mod in ipairs(val.mods(output["Current"..ailment])) do
 				enemyDB:AddMod(mod)


### PR DESCRIPTION
### Description of the problem being solved:
Maximum shock double counting as raised by @Diyu on discord.
Introduced in https://github.com/PathOfBuildingCommunity/PathOfBuilding/pull/5003

### Steps taken to verify a working solution:
- Maximum shock seems to work with shock nova, tree, voltatic rift and shocked grounds.
- Paliak seemed to suggest there might be an edge case this doesn't work with.

### Link to a build that showcases this PR:
https://pobb.in/eyUrFjTSZLfi

### Before screenshot:
![image](https://user-images.githubusercontent.com/31533893/203279426-84f5f416-78c9-49cc-a0a4-65f88700b5e1.png)
![image](https://user-images.githubusercontent.com/31533893/203279464-c96b5aa4-ddfc-4b82-82a2-a0c7f6aa67b9.png)
![image](https://user-images.githubusercontent.com/31533893/203279487-9dfd0c5a-c08b-4540-89e1-270cad6498e7.png)

### After screenshot:
![image](https://user-images.githubusercontent.com/31533893/203279157-ded51bf9-8d2d-4dcc-8369-a1e2d828cb64.png)
![image](https://user-images.githubusercontent.com/31533893/203279271-3c804b01-b3d8-4d22-8b88-c7765e914121.png)
![image](https://user-images.githubusercontent.com/31533893/203279309-4ee92958-e659-42a6-b1ff-95265d350ea9.png)
