### PR TITLE
Disable ModCache when running in headless mode for github tests

### DIFF
--- a/src/HeadlessWrapper.lua
+++ b/src/HeadlessWrapper.lua
@@ -165,9 +165,12 @@ end
 
 
 dofile("Launch.lua")
+
 --Prevents loading of ModCache
---Allows running mod parsing related tests without pushing ModCache 
-mainObject.headlessMode = true 
+--Allows running mod parsing related tests without pushing ModCache
+--The CI env var will be true when ran from github workflows but should be false for other tools using the headless wrapper 
+mainObject.headlessMode = os.getenv("CI") 
+
 runCallback("OnInit")
 runCallback("OnFrame") -- Need at least one frame for everything to initialise
 

--- a/src/HeadlessWrapper.lua
+++ b/src/HeadlessWrapper.lua
@@ -165,7 +165,9 @@ end
 
 
 dofile("Launch.lua")
-
+--Prevents loading of ModCache
+--Allows running mod parsing related tests without pushing ModCache 
+mainObject.headlessMode = true 
 runCallback("OnInit")
 runCallback("OnFrame") -- Need at least one frame for everything to initialise
 

--- a/src/Modules/Main.lua
+++ b/src/Modules/Main.lua
@@ -55,9 +55,9 @@ function main:Init()
 	self.buildPath = self.defaultBuildPath
 	MakeDir(self.buildPath)
 
-	if launch.devMode and IsKeyDown("CTRL") then
-		self.rebuildModCache = true
-	else
+	if launch.devMode and IsKeyDown("CTRL")  then
+		self:RebuildModCache()
+	elseif not launch.headlessMode then
 		-- Load mod cache
 		LoadModule("Data/ModCache", modLib.parseModCache)
 	end
@@ -100,28 +100,6 @@ function main:Init()
 		elseif launch.devMode then
 			ConPrintf("Rare DB unrecognised item:\n%s", raw)
 		end
-	end
-
-	if self.rebuildModCache then
-		-- Update mod cache
-		local out = io.open("Data/ModCache.lua", "w")
-		out:write('local c=...')
-		for line, dat in pairs(modLib.parseModCache) do
-			if not dat[1] or not dat[1][1] or dat[1][1].name ~= "JewelFunc" then
-				out:write('c["', line:gsub("\n","\\n"), '"]={')
-				if dat[1] then
-					writeLuaTable(out, dat[1])
-				else
-					out:write('nil')
-				end
-				if dat[2] then
-					out:write(',"', dat[2]:gsub("\n","\\n"), '"}\n')
-				else
-					out:write(',nil}\n')
-				end
-			end
-		end
-		out:close()
 	end
 
 	self.sharedItemList = { }
@@ -229,6 +207,28 @@ the "Releases" section of the GitHub page.]])
 	self:LoadSettings(ignoreBuild)
 
 	self.onFrameFuncs = { }
+end
+
+function main:RebuildModCache()
+	-- Update mod cache
+	local out = io.open("Data/ModCache.lua", "w")
+	out:write('local c=...')
+	for line, dat in pairs(modLib.parseModCache) do
+		if not dat[1] or not dat[1][1] or dat[1][1].name ~= "JewelFunc" then
+			out:write('c["', line:gsub("\n","\\n"), '"]={')
+			if dat[1] then
+				writeLuaTable(out, dat[1])
+			else
+				out:write('nil')
+			end
+			if dat[2] then
+				out:write(',"', dat[2]:gsub("\n","\\n"), '"}\n')
+			else
+				out:write(',nil}\n')
+			end
+		end
+	end
+	out:close()
 end
 
 function main:LoadTree(treeVersion)


### PR DESCRIPTION
### Description of the problem being solved:

Tests fail if they're implemented in the same pr as parsing for a mod that they require due to the github tests runner using outdated mod cache.

This pr implements a headless flag that prevent loading of mod cache when running using the headless wrapper and also separates ModCache rebuilding code into a separate function.

### Steps taken to verify a working solution:
- Ran tests with different versions of mod cache.