### PR TITLE
Fix inconsistent display of additional quality and gem levels in skill group tooltip

### DIFF
--- a/src/Classes/SkillsTab.lua
+++ b/src/Classes/SkillsTab.lua
@@ -1153,9 +1153,9 @@ function SkillsTabClass:AddSocketGroupTooltip(tooltip, socketGroup)
 			tooltip:AddLine(20, string.format("%s%s ^7%d%s/%d%s",
 				data.skillColorMap[skillEffect.grantedEffect.color],
 				skillEffect.grantedEffect.name,
-				skillEffect.level,
+				skillEffect.srcInstance and skillEffect.srcInstance.level or skillEffect.level,
 				(skillEffect.srcInstance and skillEffect.level > skillEffect.srcInstance.level) and colorCodes.MAGIC.."+"..(skillEffect.level - skillEffect.srcInstance.level).."^7" or "",
-				skillEffect.quality,
+				skillEffect.srcInstance and skillEffect.srcInstance.quality or skillEffect.quality,
 				(skillEffect.srcInstance and skillEffect.quality > skillEffect.srcInstance.quality) and colorCodes.MAGIC.."+"..(skillEffect.quality - skillEffect.srcInstance.quality).."^7" or ""
 			))
 			if skillEffect.srcInstance then
@@ -1169,9 +1169,9 @@ function SkillsTabClass:AddSocketGroupTooltip(tooltip, socketGroup)
 			tooltip:AddLine(20, string.format("%s%s ^7%d%s/%d%s",
 				data.skillColorMap[activeEffect.grantedEffect.color],
 				activeEffect.grantedEffect.name,
-				activeEffect.level,
+				activeEffect.srcInstance and activeEffect.srcInstance.level or activeEffect.level,
 				(activeEffect.srcInstance and activeEffect.level > activeEffect.srcInstance.level) and colorCodes.MAGIC .. "+" .. (activeEffect.level - activeEffect.srcInstance.level) .. "^7" or "",
-				activeEffect.quality,
+				activeEffect.srcInstance and activeEffect.srcInstance.quality or activeEffect.quality,
 				(activeEffect.srcInstance and activeEffect.quality > activeEffect.srcInstance.quality) and colorCodes.MAGIC .. "+" .. (activeEffect.quality - activeEffect.srcInstance.quality) .. "^7" or ""
 			))
 			if activeEffect.srcInstance then


### PR DESCRIPTION
### Description of the problem being solved:
I think this issue is best described with pictures.


### Before screenshot:
![before](https://user-images.githubusercontent.com/91493239/204551999-8ac7fdee-9ac9-4c27-9ea2-885e31796106.jpg)

### After screenshot:
![after](https://user-images.githubusercontent.com/91493239/204552006-03e7fc16-9fd9-4e31-8996-4a1456644fc2.jpg)
