### PR TITLE
Max hit improvement

### DIFF
--- a/spec/System/TestDefence_spec.lua
+++ b/spec/System/TestDefence_spec.lua
@@ -1,0 +1,191 @@
+describe("TestDefence", function()
+    before_each(function()
+        newBuild()
+    end)
+
+    teardown(function()
+        -- newBuild() takes care of resetting everything in setup()
+    end)
+
+    -- boring part
+    it("no armour max hits", function()
+        assert.are.equals(60, build.calcsTab.calcsOutput.PhysicalMaximumHitTaken)
+        assert.are.equals(38, build.calcsTab.calcsOutput.FireMaximumHitTaken)
+        assert.are.equals(38, build.calcsTab.calcsOutput.ColdMaximumHitTaken)
+        assert.are.equals(38, build.calcsTab.calcsOutput.LightningMaximumHitTaken)
+        assert.are.equals(38, build.calcsTab.calcsOutput.ChaosMaximumHitTaken)
+
+        build.configTab.input.customMods = "\z
+        +200 to all resistances\n\z
+        200% additional Physical Damage Reduction\n\z
+        "
+        build.configTab:BuildModList()
+        runCallback("OnFrame")
+        assert.are.equals(600, build.calcsTab.calcsOutput.PhysicalMaximumHitTaken)
+        assert.are.equals(240, build.calcsTab.calcsOutput.FireMaximumHitTaken)
+        assert.are.equals(240, build.calcsTab.calcsOutput.ColdMaximumHitTaken)
+        assert.are.equals(240, build.calcsTab.calcsOutput.LightningMaximumHitTaken)
+        assert.are.equals(240, build.calcsTab.calcsOutput.ChaosMaximumHitTaken)
+
+        build.configTab.input.customMods = "\z
+        +200 to all resistances\n\z
+        +200 to all maximum resistances\n\z
+        200% additional Physical Damage Reduction\n\z
+        "
+        build.configTab.input.enemyPhysicalOverwhelm = 15 -- should result 75% DR
+        build.configTab:BuildModList()
+        runCallback("OnFrame")
+        assert.are.equals(240, build.calcsTab.calcsOutput.PhysicalMaximumHitTaken)
+        assert.are.equals(600, build.calcsTab.calcsOutput.FireMaximumHitTaken)
+        assert.are.equals(600, build.calcsTab.calcsOutput.ColdMaximumHitTaken)
+        assert.are.equals(600, build.calcsTab.calcsOutput.LightningMaximumHitTaken)
+        assert.are.equals(600, build.calcsTab.calcsOutput.ChaosMaximumHitTaken)
+
+        build.configTab.input.customMods = "\z
+        +200 to all resistances\n\z
+        +200 to all maximum resistances\n\z
+        50% reduced damage taken\n\z
+        "
+        build.configTab:BuildModList()
+        runCallback("OnFrame")
+        assert.are.equals(120, build.calcsTab.calcsOutput.PhysicalMaximumHitTaken)
+        assert.are.equals(1200, build.calcsTab.calcsOutput.FireMaximumHitTaken)
+        assert.are.equals(1200, build.calcsTab.calcsOutput.ColdMaximumHitTaken)
+        assert.are.equals(1200, build.calcsTab.calcsOutput.LightningMaximumHitTaken)
+        assert.are.equals(1200, build.calcsTab.calcsOutput.ChaosMaximumHitTaken)
+
+        build.configTab.input.customMods = "\z
+        +200 to all resistances\n\z
+        +200 to all maximum resistances\n\z
+        50% reduced damage taken\n\z
+        50% less damage taken\n\z
+        "
+        build.configTab:BuildModList()
+        runCallback("OnFrame")
+        assert.are.equals(240, build.calcsTab.calcsOutput.PhysicalMaximumHitTaken)
+        assert.are.equals(2400, build.calcsTab.calcsOutput.FireMaximumHitTaken)
+        assert.are.equals(2400, build.calcsTab.calcsOutput.ColdMaximumHitTaken)
+        assert.are.equals(2400, build.calcsTab.calcsOutput.LightningMaximumHitTaken)
+        assert.are.equals(2400, build.calcsTab.calcsOutput.ChaosMaximumHitTaken)
+
+        build.configTab.input.customMods = "\z
+        +200 to all resistances\n\z
+        +200 to all maximum resistances\n\z
+        50% reduced damage taken\n\z
+        50% less damage taken\n\z
+        50% of physical damage taken as fire\n\z
+        "
+        build.configTab:BuildModList()
+        runCallback("OnFrame")
+        assert.are.equals(480, build.calcsTab.calcsOutput.PhysicalMaximumHitTaken)
+        assert.are.equals(2400, build.calcsTab.calcsOutput.FireMaximumHitTaken)
+        assert.are.equals(2400, build.calcsTab.calcsOutput.ColdMaximumHitTaken)
+        assert.are.equals(2400, build.calcsTab.calcsOutput.LightningMaximumHitTaken)
+        assert.are.equals(2400, build.calcsTab.calcsOutput.ChaosMaximumHitTaken)
+    end)
+
+    -- a small helper function to calculate damage taken from limited test parameters
+    local function takenHitFromDamage(damage, armour, resMulti, takenMulti, overwhelmDecimal)
+        local armourDR = 1 - (math.min(armour / (armour + 5 * damage * resMulti), 0.9) - overwhelmDecimal)
+        return round(damage * resMulti * armourDR * takenMulti)
+    end
+
+    -- fun part
+    it("armoured max hits", function()
+        build.configTab.input.customMods = "\z
+        +940 to maximum life\n\z
+        +10000 to armour\n\z
+        " -- hit of 2000 on 10000 armour results in 50% DR which reduces the damage to 1000 - total HP
+        build.configTab:BuildModList()
+        runCallback("OnFrame")
+        assert.are.equals(1000, takenHitFromDamage(build.calcsTab.calcsOutput.PhysicalMaximumHitTaken, 10000, 1, 1, 0))
+        assert.are.equals(625, build.calcsTab.calcsOutput.FireMaximumHitTaken)
+        assert.are.equals(625, build.calcsTab.calcsOutput.ColdMaximumHitTaken)
+        assert.are.equals(625, build.calcsTab.calcsOutput.LightningMaximumHitTaken)
+        assert.are.equals(625, build.calcsTab.calcsOutput.ChaosMaximumHitTaken)
+
+        build.configTab.input.customMods = "\z
+        +940 to maximum life\n\z
+        +100000 to armour\n\z
+        " -- hit of 5000 on 100000 armour results in 80% DR which reduces the damage to 1000 - total HP
+        build.configTab:BuildModList()
+        runCallback("OnFrame")
+        assert.are.equals(1000, takenHitFromDamage(build.calcsTab.calcsOutput.PhysicalMaximumHitTaken, 100000, 1, 1, 0))
+        assert.are.equals(625, build.calcsTab.calcsOutput.FireMaximumHitTaken)
+        assert.are.equals(625, build.calcsTab.calcsOutput.ColdMaximumHitTaken)
+        assert.are.equals(625, build.calcsTab.calcsOutput.LightningMaximumHitTaken)
+        assert.are.equals(625, build.calcsTab.calcsOutput.ChaosMaximumHitTaken)
+
+        build.configTab.input.customMods = "\z
+        +940 to maximum life\n\z
+        +1000000000 to armour\n\z
+        " -- 90% DR cap
+        build.configTab:BuildModList()
+        runCallback("OnFrame")
+        assert.are.equals(1000, takenHitFromDamage(build.calcsTab.calcsOutput.PhysicalMaximumHitTaken, 1000000000, 1, 1, 0))
+        assert.are.equals(625, build.calcsTab.calcsOutput.FireMaximumHitTaken)
+        assert.are.equals(625, build.calcsTab.calcsOutput.ColdMaximumHitTaken)
+        assert.are.equals(625, build.calcsTab.calcsOutput.LightningMaximumHitTaken)
+        assert.are.equals(625, build.calcsTab.calcsOutput.ChaosMaximumHitTaken)
+
+        build.configTab.input.customMods = "\z
+        +940 to maximum life\n\z
+        +1000000000 to armour\n\z
+        " -- 90% DR cap
+        build.configTab.input.enemyPhysicalOverwhelm = 15 -- should result 75% DR
+        build.configTab:BuildModList()
+        runCallback("OnFrame")
+        assert.are.equals(1000, takenHitFromDamage(build.calcsTab.calcsOutput.PhysicalMaximumHitTaken, 1000000000, 1, 1, 0.15))
+        assert.are.equals(625, build.calcsTab.calcsOutput.FireMaximumHitTaken)
+        assert.are.equals(625, build.calcsTab.calcsOutput.ColdMaximumHitTaken)
+        assert.are.equals(625, build.calcsTab.calcsOutput.LightningMaximumHitTaken)
+        assert.are.equals(625, build.calcsTab.calcsOutput.ChaosMaximumHitTaken)
+
+        build.configTab.input.customMods = "\z
+        +940 to maximum life\n\z
+        +10000 to armour\n\z
+        +60% to all elemental resistances\n\z
+        Armour applies to Fire, Cold and Lightning Damage taken from Hits instead of Physical Damage\n\z
+        " -- with no resistances results should be same as physical
+        build.configTab:BuildModList()
+        runCallback("OnFrame")
+        assert.are.equals(1000, build.calcsTab.calcsOutput.PhysicalMaximumHitTaken)
+        assert.are.equals(1000, takenHitFromDamage(build.calcsTab.calcsOutput.FireMaximumHitTaken, 10000, 1, 1, 0))
+        assert.are.equals(1000, takenHitFromDamage(build.calcsTab.calcsOutput.ColdMaximumHitTaken, 10000, 1, 1, 0))
+        assert.are.equals(1000, takenHitFromDamage(build.calcsTab.calcsOutput.LightningMaximumHitTaken, 10000, 1, 1, 0))
+        assert.are.equals(625, build.calcsTab.calcsOutput.ChaosMaximumHitTaken)
+
+        build.configTab.input.customMods = "\z
+        +940 to maximum life\n\z
+        +10000 to armour\n\z
+        +110% to all elemental resistances\n\z
+        Armour applies to Fire, Cold and Lightning Damage taken from Hits instead of Physical Damage\n\z
+        " -- max hit should be 4000
+        --       [res] [armour] [armour]            [res]
+        -- 4000 * 0.5 * (10000 / (10000 + 5 * 4000 * 0.5) = 1000
+        build.configTab:BuildModList()
+        runCallback("OnFrame")
+        assert.are.equals(1000, build.calcsTab.calcsOutput.PhysicalMaximumHitTaken)
+        assert.are.equals(1000, takenHitFromDamage(build.calcsTab.calcsOutput.FireMaximumHitTaken, 10000, 0.5, 1, 0))
+        assert.are.equals(1000, takenHitFromDamage(build.calcsTab.calcsOutput.ColdMaximumHitTaken, 10000, 0.5, 1, 0))
+        assert.are.equals(1000, takenHitFromDamage(build.calcsTab.calcsOutput.LightningMaximumHitTaken, 10000, 0.5, 1, 0))
+        assert.are.equals(625, build.calcsTab.calcsOutput.ChaosMaximumHitTaken)
+
+        build.configTab.input.customMods = "\z
+        +940 to maximum life\n\z
+        +10000 to armour\n\z
+        +110% to all elemental resistances\n\z
+        Armour applies to Fire, Cold and Lightning Damage taken from Hits instead of Physical Damage\n\z
+        50% less damage taken\n\z
+        " -- max hit should be 4000
+        --       [res] [armour] [armour]            [res]  [less]
+        -- 6472 * 0.5 * (10000 / (10000 + 5 * 6472 * 0.5) * 0.5 = 1000
+        build.configTab:BuildModList()
+        runCallback("OnFrame")
+        assert.are.equals(2000, build.calcsTab.calcsOutput.PhysicalMaximumHitTaken)
+        assert.are.equals(1000, takenHitFromDamage(build.calcsTab.calcsOutput.FireMaximumHitTaken, 10000, 0.5, 0.5, 0))
+        assert.are.equals(1000, takenHitFromDamage(build.calcsTab.calcsOutput.ColdMaximumHitTaken, 10000, 0.5, 0.5, 0))
+        assert.are.equals(1000, takenHitFromDamage(build.calcsTab.calcsOutput.LightningMaximumHitTaken, 10000, 0.5, 0.5, 0))
+        assert.are.equals(1250, build.calcsTab.calcsOutput.ChaosMaximumHitTaken)
+    end)
+end)

--- a/src/Modules/CalcDefence.lua
+++ b/src/Modules/CalcDefence.lua
@@ -2325,9 +2325,9 @@ function calcs.defence(env, actor)
 			local takenFromCalced = takenHitFromDamage(partMin)
 			local hpToCalcedRatio = m_sqrt(output[damageType.."TotalHitPool"] / takenFromCalced)
 
-			output[damageType.."MaximumHitTaken"] = partMin * hpToCalcedRatio
+			output[damageType.."MaximumHitTaken"] = round(partMin * hpToCalcedRatio)
 		else
-			output[damageType.."MaximumHitTaken"] = partMin
+			output[damageType.."MaximumHitTaken"] = round(partMin)
 		end
 
 		if breakdown then


### PR DESCRIPTION
Fixes #1645 ~~#4847~~.

### Description of the problem being solved:
Max hit taken should not depend on enemy damage. This aims to fix that by changing how max hit is calculated.

### Steps taken to verify a working solution:
- Flat damage reduction (i.e. endurance charges) checked at low, mid and extreme values
- Overwhelm checked at low, mid and extreme values
- Damage taken as checked at low, mid and extreme values
- Transcendence and/or unbreakable checked
- Damage taken-as was kept in mind
- Math?
- Spreadsheets

### Link to a build that showcases this PR:
https://pobb.in/KAH_0AClx7EI (stolen from poe ninja)

### Before screenshot:
Damage reduction for reported phys max hit (88% taken as phys = 108690) results in 2608539 / (2608539 + 5 * 108690) = 0.82758 reduction. Plugging that back in for damage received from physical portion of the "max hit" results in 108690 * 0.17242 * 1.1 (Aspect of Carnage) = 20614 damage. This character has total pool of 11956 (molten shell). Seems pretty dead to me.
![image](https://user-images.githubusercontent.com/36479307/204892573-4265db3a-becf-4313-9f03-2708cce3dbfb.png)

### After screenshot:
Damage reduction for reported phys max hit (88% taken as phys = 79898) results in 2608539 / (2608539 + 5 * 79898) = 0.86719 reduction. Lightning portion (10895 damage) after resists and penetration (1852 dmg) gets a 208683 / (208683 + 5 * 1852) = 0.9 reduction. Plugging that back in for damage received results in (79898 * 0.13281 + 1852 * 0.17 * 0.1) * 1.1 = 11707 damage. Not quite exact, but better?
![image](https://user-images.githubusercontent.com/36479307/205466556-2b6c89f9-97da-4e6b-9c14-dd3999730574.png)

The discrepancy happens due to complexity of calculations when taken-as modifiers are involved. With no conversions this is as accurate as floating point operations and rounding can get. With conversion to a single element, highest observed ratio between the pool and damage taken from the reported hit is ~40%. Converting to two elements go up to ~72%. Element to element conversion is still quite broken.
Some examples of produced deviations:
<details>
  <summary>Flashbang warning</summary>

![image](https://user-images.githubusercontent.com/36479307/205467471-e01c206b-e7a2-4000-9941-6b9343ffe7cc.png)
![image](https://user-images.githubusercontent.com/36479307/205467525-0346f93d-1586-4f6c-b147-f190a6fb1bba.png)
![image](https://user-images.githubusercontent.com/36479307/205467620-4202608f-c1ac-4d13-938a-0e82441b4114.png)
![image](https://user-images.githubusercontent.com/36479307/205467559-44f84ab4-1fc2-4403-82e3-501a1c7573f9.png)
![image](https://user-images.githubusercontent.com/36479307/205467569-6c6dba9c-bd20-459e-a742-aa31b2c20ed1.png)
![image](https://user-images.githubusercontent.com/36479307/205467593-c6553d1e-11cb-49b7-aabb-dbbee8f4bc89.png)

</details>