### PR TITLE
Added Mod Tooltip

### DIFF
--- a/src/Classes/ItemsTab.lua
+++ b/src/Classes/ItemsTab.lua
@@ -741,7 +741,7 @@ holding Shift will put it in the second.]])
 					end
 					
 					-- Adding Mod
-					self:AddModComparisonTooltip(tooltip, { mod })
+					self:AddModComparisonTooltip(tooltip, mod)
 				end
 			end
 		end
@@ -1705,14 +1705,12 @@ function ItemsTabClass:UpdateDisplayItemRangeLines()
 	end
 end
 
-function ItemsTabClass:AddModComparisonTooltip(tooltip, mods)
+function ItemsTabClass:AddModComparisonTooltip(tooltip, mod)
 	local slotName = self.displayItem:GetPrimarySlot()
 	local newItem = new("Item", self.displayItem:BuildRaw())
 	
-	for _, mod in ipairs(mods) do
-		for _, subMod in ipairs(mod) do
-			t_insert(newItem.explicitModLines, { line = subMod, modTags = mod.modTags, [mod.type] = true })
-		end
+	for _, subMod in ipairs(mod) do
+		t_insert(newItem.explicitModLines, { line = subMod, modTags = mod.modTags, [mod.type] = true })
 	end
 
 	newItem:BuildAndParseRaw()
@@ -2276,7 +2274,7 @@ function ItemsTabClass:CorruptDisplayItem(modType)
 			for _, line in ipairs(value.mod) do
 				tooltip:AddLine(16, "^7"..line)
 			end
-			self:AddModComparisonTooltip(tooltip, { value.mod })
+			self:AddModComparisonTooltip(tooltip, value.mod)
 		end
 	end
 	controls.implicit2Label = new("LabelControl", {"TOPRIGHT",nil,"TOPLEFT"}, 75, 65, 0, 16, "^7Implicit #2:")
@@ -2289,7 +2287,7 @@ function ItemsTabClass:CorruptDisplayItem(modType)
 			for _, line in ipairs(value.mod) do
 				tooltip:AddLine(16, "^7"..line)
 			end
-			self:AddModComparisonTooltip(tooltip, { value.mod })
+			self:AddModComparisonTooltip(tooltip, value.mod)
 		end
 	end
 	controls.implicit3Label = new("LabelControl", {"TOPRIGHT",nil,"TOPLEFT"}, 75, 85, 0, 16, "^7Implicit #3:")
@@ -2302,7 +2300,7 @@ function ItemsTabClass:CorruptDisplayItem(modType)
 			for _, line in ipairs(value.mod) do
 				tooltip:AddLine(16, "^7"..line)
 			end
-			self:AddModComparisonTooltip(tooltip, { value.mod })
+			self:AddModComparisonTooltip(tooltip, value.mod)
 		end
 	end
 	controls.implicit3Label.shown = false
@@ -2317,7 +2315,7 @@ function ItemsTabClass:CorruptDisplayItem(modType)
 			for _, line in ipairs(value.mod) do
 				tooltip:AddLine(16, "^7"..line)
 			end
-			self:AddModComparisonTooltip(tooltip, { value.mod })
+			self:AddModComparisonTooltip(tooltip, value.mod)
 		end
 	end
 	controls.implicit4Label.shown = false
@@ -2509,7 +2507,7 @@ function ItemsTabClass:AddCustomModifierToDisplayItem()
 			for _, line in ipairs(value.mod) do
 				tooltip:AddLine(16, "^7"..line)
 			end
-			self:AddModComparisonTooltip(tooltip, { value.mod })
+			self:AddModComparisonTooltip(tooltip, value.mod)
 		end
 	end
 	controls.custom = new("EditControl", {"TOPLEFT",nil,"TOPLEFT"}, 100, 45, 440, 18)
@@ -2730,7 +2728,7 @@ function ItemsTabClass:AddImplicitToDisplayItem()
 			for _, line in ipairs(value.mod) do
 				tooltip:AddLine(16, "^7"..line)
 			end
-			self:AddModComparisonTooltip(tooltip, { value.mod })
+			self:AddModComparisonTooltip(tooltip, value.mod)
 		end
 	end
 	controls.modSelectLabel = new("LabelControl", {"TOPRIGHT",nil,"TOPLEFT"}, 95, 70, 0, 16, "^7Modifier:")
@@ -2744,7 +2742,7 @@ function ItemsTabClass:AddImplicitToDisplayItem()
 			for _, line in ipairs(value.mod) do
 				tooltip:AddLine(16, "^7"..line)
 			end
-			self:AddModComparisonTooltip(tooltip, { value.mod })
+			self:AddModComparisonTooltip(tooltip, value.mod)
 		end
 	end
 	controls.custom = new("EditControl", {"TOPLEFT",nil,"TOPLEFT"}, 100, 45, 440, 18)


### PR DESCRIPTION
Fixes https://github.com/PathOfBuildingCommunity/PathOfBuilding/issues/5166

### Description of the problem being solved:
This adds a preview of item mod when hovering over selection like how cluster jewel notables currently behave
It uses default item affix percent to determine what to preview for ranges.

### Steps taken to verify a working solution:
![image](https://user-images.githubusercontent.com/31533893/205828120-3d6339d0-431e-4f90-b51a-36bcfd1a903a.png)
![image](https://user-images.githubusercontent.com/31533893/205828176-8ffc2d67-b388-418c-aa6e-04a97cf76665.png)
![image](https://user-images.githubusercontent.com/31533893/205828251-74e48d2f-a75d-4a8f-8a30-3382609b97a9.png)
![image](https://user-images.githubusercontent.com/31533893/205828312-250104cb-3b94-453c-bf54-52f1b9ff26d4.png)
![image](https://user-images.githubusercontent.com/31533893/205828421-387cd544-d67f-480c-96e5-f545f11d9318.png)
![image](https://user-images.githubusercontent.com/31533893/205828494-b26f627d-2140-4fa0-bc8f-9121dac4f661.png)