### PR TITLE
Fix: crash on crafting certain quirky items

### DIFF
--- a/src/Classes/Item.lua
+++ b/src/Classes/Item.lua
@@ -378,10 +378,6 @@ function ItemClass:ParseRaw(raw)
 				foundExplicit = true
 				gameModeStage = "EXPLICIT"
 			end
-			-- for weapons, when copy/pasting from trade site or importing via PoB Trader the base name of the weapon is repeated, skip it
-			if self.base and (line == self.base.type or self.base.subType and line == self.base.subType .. " " .. self.base.type) then
-				specName = line
-			end
 			if not specName or foundExplicit or foundImplicit then
 				local varSpec = line:match("{variant:([%d,]+)}")
 				local variantList
@@ -559,7 +555,7 @@ function ItemClass:ParseRaw(raw)
 						foundExplicit = true
 					end
 				elseif mode == "GAME" then
-					if gameModeStage == "IMPLICIT" or gameModeStage == "EXPLICIT" or (gameModeStage == "FINDIMPLICIT" and (not data.itemBases[line]) and not (self.name == line) and not line:find("Two%-Toned")) then
+					if gameModeStage == "IMPLICIT" or gameModeStage == "EXPLICIT" or (gameModeStage == "FINDIMPLICIT" and (not data.itemBases[line]) and not (self.name == line) and not line:find("Two%-Toned") and not (self.base and (line == self.base.type or self.base.subType and line == self.base.subType .. " " .. self.base.type))) then
 						t_insert(modLines, { line = line, extra = line, modList = { }, modTags = { }, variantList = variantList, scourge = scourge, crafted = crafted, custom = custom, fractured = fractured, exarch = exarch, eater = eater, synthesis = synthesis, implicit = implicit })
 					elseif gameModeStage == "FINDEXPLICIT" then
 						gameModeStage = "DONE"


### PR DESCRIPTION
Fixes #5109

### Description of the problem being solved:
The short-cut to strip a repeat of the base name of an item appear as a modifier when copy/pasting from trade website was incorrectly implemented to short-circuit entry into the subsequent `if` block by setting `specName` to a value.

This caused certain parameters of quirky items like a Fishing Rod, Timeless Jewel or Ring of subtype Ring (basically any item with a subType equal to the main base item Type) to not be properly initalized.

### Steps taken to verify a working solution:
- Verified creation of all items reported in Issue #5109 without error
- Verified that copy/paste from PoE Tradesite does not treat the subType of the item as a modifier.

### Link to a build that showcases this PR:
Just make any build and Item -> `Craft item...` OR `Create Custom...`

### Before screenshot:
Would throw error when mousing over `Base` of Fishing Rod
![Before](https://user-images.githubusercontent.com/1735956/205946372-8bb8c1ef-b937-49f6-9820-9a8628df91d0.png)

### After screenshot:
![After](https://user-images.githubusercontent.com/1735956/205946491-34695a01-5325-48ae-b4d3-9429c8446529.png)
