### PR TITLE
Fix: Weighted Search Category fix Jewels

### DIFF
--- a/src/Classes/TradeQueryGenerator.lua
+++ b/src/Classes/TradeQueryGenerator.lua
@@ -469,6 +469,11 @@ function TradeQueryGeneratorClass:StartQuery(slot, options)
     elseif slot.slotName:find("Jewel") ~= nil then
         itemCategoryQueryStr = "jewel"
         itemCategory = options.jewelType .. "Jewel"
+        if itemCategory == "AbyssJewel" then
+            itemCategoryQueryStr = "jewel.abyss"
+        elseif itemCategory == "BaseJewel" then
+            itemCategoryQueryStr = "jewel.base"
+        end
     else
         logToFile("'%s' is not supported for weighted trade query generation", existingItem and existingItem.type or "n/a")
         return


### PR DESCRIPTION
PoB Trader: Base and Abyss jewel subTypes were not properly limit weighted search to those item category subtypes. This fixes it.

Fixes: #5024, #4896

### Description of the problem being solved:
For tree sockets that can take any type of jewel, the itemCategory was not being reset based on user set query specification options.

Needed to add the last 5 lines (if .. end) here:
```
    elseif slot.slotName:find("Jewel") ~= nil then
        itemCategoryQueryStr = "jewel"
        itemCategory = options.jewelType .. "Jewel"
        if itemCategory == "AbyssJewel" then
            itemCategoryQueryStr = "jewel.abyss"
        elseif itemCategory == "BaseJewel" then
            itemCategoryQueryStr = "jewel.base"
        end
```
to force the search to only consider a more limited subType pool.

### Steps taken to verify a working solution:
- Did the searches and opened up website based filters to very the proper item category was specified


### Link to a build that showcases this PR:
https://pastebin.com/EK07NwQd

### Before screenshot:

### After screenshot:
