### PR TITLE
Fix: Fetching Search Query via HTML is no longer allowed

### DIFF
--- a/src/Classes/TradeQueryRequests.lua
+++ b/src/Classes/TradeQueryRequests.lua
@@ -59,7 +59,7 @@ end
 ---@param params table @ params = { callbackQueryId = fun(queryId:string) }
 function TradeQueryRequestsClass:SearchWithQuery(league, query, callback, params)
 	params = params or {}
-	ConPrintf("Query json: %s", query)
+	--ConPrintf("Query json: %s", query)
 	self:PerformSearch(league, query, function(response, errMsg)
 		if params.callbackQueryId and response and response.id then
 			params.callbackQueryId(response.id)
@@ -174,7 +174,7 @@ end
 ---@param callback fun(items:table, errMsg:string)
 function TradeQueryRequestsClass:SearchWithURL(url, callback)
 	local league, queryId = url:match("https://www.pathofexile.com/trade/search/(.+)/(.+)$")
-	self:FetchSearchQueryHTML(queryId, function(query, errMsg)
+	self:FetchSearchQuery(queryId, league, function(query, errMsg)
 		if errMsg then
 			return callback(nil, errMsg)
 		end
@@ -185,8 +185,8 @@ end
 ---Fetch query data needed to perform the search
 ---@param queryId string
 ---@param callback fun(query:string, errMsg:string)
-function TradeQueryRequestsClass:FetchSearchQuery(queryId, callback)
-	local url = "https://www.pathofexile.com/api/trade/search/" .. queryId
+function TradeQueryRequestsClass:FetchSearchQuery(queryId, league, callback)
+	local url = "https://www.pathofexile.com/api/trade/search/" .. league .. "/" .. queryId
 	table.insert(self.requestQueue["search"], {
 		url = url,
 		callback = function(response, errMsg)


### PR DESCRIPTION
PoB Trader Related: 

When you click the `Price item` button with a correct URL it no longer worked. We used to fetch search parameters over HTML to circumvent extra API calls for query fetching, but this is now disallowed. As a result, this code switches us back to using the GET API standard. However, apparently the GET API standard has also changed to force league name specification now being required. 

This PR fixes both of these so we have the ability to retrieve items given a URL now.
