### PR TITLE
Fix jewel implict button crashing

### DIFF
--- a/src/Classes/ItemsTab.lua
+++ b/src/Classes/ItemsTab.lua
@@ -2654,6 +2654,9 @@ function ItemsTabClass:AddImplicitToDisplayItem()
 		controls.modSelect:SetSel(1)
 	end)
 	controls.modGroupSelectLabel.shown = function()
+		if sourceList[controls.source.selIndex].sourceId == "CUSTOM" then
+			controls.modSelectLabel.y = 45
+		end
 		return sourceList[controls.source.selIndex].sourceId ~= "CUSTOM"
 	end
 	controls.modGroupSelect.shown = function()
@@ -2668,7 +2671,7 @@ function ItemsTabClass:AddImplicitToDisplayItem()
 		end
 	end
 	controls.modSelectLabel = new("LabelControl", {"TOPRIGHT",nil,"TOPLEFT"}, 95, 70, 0, 16, "^7Modifier:")
-	controls.modSelect = new("DropDownControl", {"TOPLEFT",nil,"TOPLEFT"}, 100, 70, 600, 18, modList[modGroups[1].modListIndex])
+	controls.modSelect = new("DropDownControl", {"TOPLEFT",nil,"TOPLEFT"}, 100, 70, 600, 18, sourceList[controls.source.selIndex].sourceId ~= "CUSTOM" and modList[modGroups[1].modListIndex] or { })
 	controls.modSelect.shown = function()
 		return sourceList[controls.source.selIndex].sourceId ~= "CUSTOM"
 	end


### PR DESCRIPTION
Fixes https://github.com/PathOfBuildingCommunity/PathOfBuilding/issues/5108

### Description of the problem being solved:
When clicking the implicit button it would crash on jewels due to there being no actual mods.