### PR TITLE
Fix: make URL update to league selection

### DIFF
--- a/src/Classes/TradeQuery.lua
+++ b/src/Classes/TradeQuery.lua
@@ -497,7 +497,7 @@ function TradeQueryClass:PriceItemRowDisplay(str_cnt, slotTbl, top_pane_alignmen
 	controls["priceButton"..str_cnt] = new("ButtonControl", {"TOPLEFT",controls["uri"..str_cnt],"TOPRIGHT"}, 8, 0, 100, row_height, "Price Item",
 		function()
 			controls["priceButton"..str_cnt].label = "Searching..."
-			self.tradeQueryRequests:SearchWithURL(controls["uri"..str_cnt].buf, function(items, errMsg)
+			self.tradeQueryRequests:SearchWithURL(controls["uri"..str_cnt], function(items, errMsg)
 				if errMsg then
 					self:SetNotice(controls.pbNotice, "Error: " .. errMsg)
 				else

--- a/src/Classes/TradeQueryRequests.lua
+++ b/src/Classes/TradeQueryRequests.lua
@@ -172,12 +172,13 @@ function TradeQueryRequestsClass:FetchResultBlock(url, callback)
 end
 
 ---@param callback fun(items:table, errMsg:string)
-function TradeQueryRequestsClass:SearchWithURL(url, callback)
-	local _, queryId = url:match("https://www.pathofexile.com/trade/search/(.+)/(.+)$")
+function TradeQueryRequestsClass:SearchWithURL(urlEditControl, callback)
+	local _, queryId = urlEditControl.buf:match("https://www.pathofexile.com/trade/search/(.+)/(.+)$")
 	self:FetchSearchQueryHTML(queryId, function(query, errMsg)
 		if errMsg then
 			return callback(nil, errMsg)
 		end
+		urlEditControl:SetText("https://www.pathofexile.com/trade/search/" .. self.tradeQuery.pbLeagueRealName .. "/" .. queryId)
 		self:SearchWithQuery(self.tradeQuery.pbLeagueRealName, query, callback)
 	end)
 end


### PR DESCRIPTION
in Trader for a give item slot, when we parse the URL we take out the `league` and `queryId` using a regex. Then we use the League DropDown selection when we do the fetch and search for items (which might not match the league regex'ed out) by concatenating together a new URL. 

However, the URL in the control element for that item slot does not get updated with the League drop down. 

This leads to the return of the `Price item` function potentially having different item returns then if you CTRL+click the URL to bring it up in the web-browser.

This PR fixes this, by auto-correcting the URL in the control element for that item slot to the correct league name so when it is CTRL+clicked it results in the same query against the same league.