### PR TITLE
Fix typo breaking tests

### DIFF
--- a/spec/System/TestItemMods_spec.lua
+++ b/spec/System/TestItemMods_spec.lua
@@ -75,7 +75,8 @@ describe("TetsItemMods", function()
         runCallback("OnFrame")
 
         assert.are_not.equals(farDPS, build.calcsTab.mainOutput.TotalDPS)
-
+	end)
+	
     it("Kalandra's Touch mod copy", function()
         local initialInt = build.calcsTab.mainOutput.Int
 


### PR DESCRIPTION
### Description of the problem being solved:

Missing `end` breaks tests.