### PR TITLE
Fix: add 'or 0' in case of 'nil' in compDPS

### DIFF
--- a/src/Classes/TradeQueryGenerator.lua
+++ b/src/Classes/TradeQueryGenerator.lua
@@ -512,7 +512,7 @@ function TradeQueryGeneratorClass:StartQuery(slot, options)
     -- Calculate base output with a blank item
     local calcFunc, _ = self.itemsTab.build.calcsTab:GetMiscCalculator()
     local baseOutput = calcFunc({ repSlotName = slot.slotName, repItem = testItem }, {})
-    local compDPS = GlobalCache.useFullDPS and baseOutput.FullDPS or m_max(baseOutput.TotalDPS, m_max(baseOutput.TotalDot, baseOutput.CombinedAvg))
+    local compDPS = GlobalCache.useFullDPS and baseOutput.FullDPS or m_max(baseOutput.TotalDPS or 0, m_max(baseOutput.TotalDot or 0, baseOutput.CombinedAvg or 0))
 
 	-- Test each mod one at a time and cache the normalized DPS diff to use as weight
     self.modWeights = { }


### PR DESCRIPTION
This is a "safety" fix. It definitely doesn't hurt have it and probably will fix a few niche edge-cases where one of the output parameters perhaps doesn't exist.