### PR TITLE
Improve accuracy of mana cost calculations

### DIFF
--- a/src/Modules/CalcOffence.lua
+++ b/src/Modules/CalcOffence.lua
@@ -1290,10 +1290,13 @@ function calcs.offence(env, actor, activeSkill)
 		if hasCost then
 			local dec = val.upfront and 0 or 2
 			local costName = resource.."Cost"
-			local mult = skillModList:More(skillCfg, "SupportManaMultiplier")
+			local mult = 1
+			for _, value in ipairs(skillModList:Tabulate("MORE", skillCfg, "SupportManaMultiplier")) do
+				mult = m_floor(mult * (100 + value.mod.value)) / 100
+			end
 			local more = skillModList:More(skillCfg, val.type.."Cost", "Cost")
 			local inc = skillModList:Sum("INC", skillCfg, val.type.."Cost", "Cost")
-			output[costName] = val.baseCost * mult + val.baseCostNoMult
+			output[costName] = m_floor(val.baseCost * mult + val.baseCostNoMult)
 			output[costName] = m_max(0, (1 + inc / 100) * output[costName])
 			output[costName] = m_max(0, more * output[costName])
 			output[costName] = m_max(0, round(output[costName] + val.totalCost, dec)) -- There are some weird rounding issues producing off by one in here.

--- a/src/Modules/CalcOffence.lua
+++ b/src/Modules/CalcOffence.lua
@@ -1261,7 +1261,7 @@ function calcs.offence(env, actor, activeSkill)
 				local reservedFlat = activeSkill.skillData[val.text.."ReservationFlat"] or activeSkill.activeEffect.grantedEffectLevel[val.text.."ReservationFlat"] or 0
 				baseCost = baseCost + reservedFlat
 				local reservedPercent = activeSkill.skillData[val.text.."ReservationPercent"] or activeSkill.activeEffect.grantedEffectLevel[val.text.."ReservationPercent"] or 0
-				baseCost = baseCost + (m_floor((output[resource] or 0) * reservedPercent / 100))
+				baseCost = baseCost + (round((output[resource] or 0) * reservedPercent / 100))
 			end
 			if resource == "Mana" and skillData.baseManaCostIsAtLeastPercentUnreservedMana then -- Archmage
 				baseCost = m_max(baseCost, m_floor((output.ManaUnreserved or 0) * skillData.baseManaCostIsAtLeastPercentUnreservedMana / 100))


### PR DESCRIPTION
Resolves: https://github.com/PathOfBuildingCommunity/PathOfBuilding/issues/5268
There are still significant rounding issues after this patch relating to auras and divine blessing. Pet Blood is likely still problematic.

This fixes mana cost for skill afaik but other costs are incorrect still, see https://github.com/PathOfBuildingCommunity/PathOfBuilding/issues/5268 for a longer disscussion