### PR TITLE
Fix: Use actual Sweep Radii

### DIFF
--- a/src/Data/Skills/act_str.lua
+++ b/src/Data/Skills/act_str.lua
@@ -3400,7 +3400,7 @@ skills["FrozenSweep"] = {
 		melee = true,
 	},
 	baseMods = {
-		skill("radius", 26),
+		skill("radius", 25),
 	},
 	qualityStats = {
 		Default = {
@@ -7804,7 +7804,7 @@ skills["Sweep"] = {
 		area = true,
 	},
 	baseMods = {
-		skill("radius", 26),
+		skill("radius", 24),
 	},
 	qualityStats = {
 		Default = {

--- a/src/Export/Skills/act_str.txt
+++ b/src/Export/Skills/act_str.txt
@@ -636,7 +636,7 @@ local skills, mod, flag, skill = ...
 
 #skill FrozenSweep
 #flags spell attack area melee
-#baseMod skill("radius", 26)
+#baseMod skill("radius", 25)
 #mods
 
 #skill GeneralsCry
@@ -1402,7 +1402,7 @@ end,
 
 #skill Sweep
 #flags attack melee area
-#baseMod skill("radius", 26)
+#baseMod skill("radius", 24)
 #mods
 
 #skill EnduranceChargeSlam


### PR DESCRIPTION
Based on info I got from GGG, this corrects the radius values for: `Sweep` and `Frozen Sweep` (which are not the same apparently)
