### PR TITLE
Fix: Flasks can have flags; those can be described as well

### DIFF
--- a/src/Data/Bases/flask.lua
+++ b/src/Data/Bases/flask.lua
@@ -382,7 +382,7 @@ itemBases["Corundum Flask"] = {
 	subType = "Utility",
 	tags = { flask = true, utility_flask = true, not_for_sale = true, default = true, },
 	implicitModTypes = { },
-	flask = { duration = 7.5, chargesUsed = 20, chargesMax = 50, buff = { "30% increased Stun Threshold" }, },
+	flask = { duration = 7.5, chargesUsed = 20, chargesMax = 50, buff = { "30% increased Stun Threshold", "Cannot be Stunned if you've been Stunned during Effect" }, },
 	req = { level = 27, },
 }
 itemBases["Iron Flask"] = {

--- a/src/Export/Scripts/bases.lua
+++ b/src/Export/Scripts/bases.lua
@@ -171,6 +171,9 @@ directiveTable.base = function(state, args, out)
 			for i, stat in ipairs(flask.Buff.Stats) do
 				stats[stat.Id] = { min = flask.BuffMagnitudes[i], max = flask.BuffMagnitudes[i] }
 			end
+			for i, stat in ipairs(flask.Buff.GrantedFlags) do
+				stats[stat.Id] = { min = 1, max = 1 }
+			end
 			out:write('buff = { "', table.concat(describeStats(stats), '", "'), '" }, ')
 		end
 		out:write('},\n')


### PR DESCRIPTION
Fixes having to manually re-add "Onslaught" to Silver Flasks.
Apparently fixes Corundum Flasks as well.