### PR TITLE
FIX: add area flag to Minion Instability.

### DIFF
--- a/src/Data/Skills/minion.lua
+++ b/src/Data/Skills/minion.lua
@@ -1210,7 +1210,7 @@ skills["MinionInstability"] = {
 		area = true,
 		fire = true,
 	},
-	skillTypes = { [10] = true, },
+	skillTypes = { [10] = true, [11] = true },
 	baseMods = {
 		skill("FireMin", 1, { type = "PerStat", stat = "Life", div = 1/.33 }),
 		skill("FireMax", 1, { type = "PerStat", stat = "Life", div = 1/.33 }),

--- a/src/Export/Skills/minion.txt
+++ b/src/Export/Skills/minion.txt
@@ -202,7 +202,7 @@ skills["MinionInstability"] = {
 		area = true,
 		fire = true,
 	},
-	skillTypes = { [10] = true, },
+	skillTypes = { [10] = true, [11] = true },
 	baseMods = {
 		skill("FireMin", 1, { type = "PerStat", stat = "Life", div = 1/.33 }),
 		skill("FireMax", 1, { type = "PerStat", stat = "Life", div = 1/.33 }),


### PR DESCRIPTION
Fixes #5302

### Description of the problem being solved:
The minion instability minion skill is missing the area flag causing it to ignore area supports such as conc effect after merging https://github.com/PathOfBuildingCommunity/PathOfBuilding/pull/4628

### Steps taken to verify a working solution:
- Test minion instability with skills listed on [wiki](https://www.poewiki.net/wiki/Minion_Instability)
- Tested with spell echo