### PR TITLE
Fix importing characters with barrage support

### DIFF
--- a/src/Modules/Data.lua
+++ b/src/Modules/Data.lua
@@ -950,7 +950,11 @@ for gemId, gem in pairs(data.gems) do
 	gem.id = gemId
 	gem.grantedEffect = data.skills[gem.grantedEffectId]
 	data.gemForSkill[gem.grantedEffect] = gemId
-	data.gemForBaseName[gem.name .. (gem.grantedEffect.support and " Support" or "")] = gemId
+	local baseName = gem.name
+	if gem.grantedEffect.support and gem.grantedEffectId ~= "SupportBarrage" then
+		baseName = baseName .. " Support"
+	end
+	data.gemForBaseName[baseName] = gemId
 	gem.secondaryGrantedEffect = gem.secondaryGrantedEffectId and data.skills[gem.secondaryGrantedEffectId]
 	gem.grantedEffectList = {
 		gem.grantedEffect,


### PR DESCRIPTION
#5029 renamed "Barrage" to "Barrage Support"

### Description of the problem being solved:

Importing characters with Barrage Support socketed dropped the gem

### Steps taken to verify a working solution:
Imported my own character (raylu/rayluWand)

### Link to a build that showcases this PR:

This doesn't affect XML imports

### Before screenshot:

![image](https://user-images.githubusercontent.com/90059/207159461-9ad0cd45-a002-41fb-92d3-2e5305815a2c.png)

### After screenshot:

![image](https://user-images.githubusercontent.com/90059/207159484-ff2b5fec-89e2-4f05-a589-fef48918cf01.png)