### PR TITLE
Fix fullDPS having signifcantly larger numbers on second pass

### DIFF
--- a/src/Modules/CalcSetup.lua
+++ b/src/Modules/CalcSetup.lua
@@ -1242,7 +1242,12 @@ function calcs.initEnv(build, mode, override, specEnv)
 			calcs.buildActiveSkillModList(env, activeSkill)
 		end
 	end
-	
+
+	-- Always wipe dpsMultiplier
+	for _, activeSkill in pairs(env.player.activeSkillList) do
+		activeSkill.skillData.dpsMultiplier = nil
+	end
+
 	-- Merge Requirements Tables
 	env.requirementsTable = tableConcat(env.requirementsTableItems, env.requirementsTableGems)
 

--- a/src/Modules/CalcSetup.lua
+++ b/src/Modules/CalcSetup.lua
@@ -1241,11 +1241,26 @@ function calcs.initEnv(build, mode, override, specEnv)
 		for _, activeSkill in pairs(env.player.activeSkillList) do
 			calcs.buildActiveSkillModList(env, activeSkill)
 		end
-	end
-
-	-- Always wipe dpsMultiplier
-	for _, activeSkill in pairs(env.player.activeSkillList) do
-		activeSkill.skillData.dpsMultiplier = nil
+	else
+		-- Wipe skillData and readd required data the rest of the data will be added by the rest of code this stops iterative calculations on skillData not being reset
+		for _, activeSkill in pairs(env.player.activeSkillList) do
+			local skillData = copyTable(activeSkill.skillData, true)
+			activeSkill.skillData = { }
+			for _, value in ipairs(env.modDB:List(activeSkill.skillCfg, "SkillData")) do
+				activeSkill.skillData[value.key] = value.value
+			end
+			for _, value in ipairs(activeSkill.skillModList:List(activeSkill.skillCfg, "SkillData")) do
+				activeSkill.skillData[value.key] = value.value
+			end
+			-- These mods were modified with special expressions in buildActiveSkillModList() use old one to avoid more calculations
+			activeSkill.skillData.manaReservationPercent = skillData.manaReservationPercent
+			activeSkill.skillData.cooldown = skillData.cooldown
+			activeSkill.skillData.CritChance = skillData.CritChance
+			activeSkill.skillData.attackTime = skillData.attackTime
+			activeSkill.skillData.totemLevel = skillData.totemLevel
+			activeSkill.skillData.damageEffectiveness = skillData.damageEffectiveness
+			activeSkill.skillData.manaReservationPercent = skillData.manaReservationPercent
+		end
 	end
 
 	-- Merge Requirements Tables


### PR DESCRIPTION
Fixes https://github.com/PathOfBuildingCommunity/PathOfBuilding/issues/5258 https://github.com/PathOfBuildingCommunity/PathOfBuilding/issues/4982

### Description of the problem being solved:
preDamageFunc and other similar gem functions were getting called twice between comparisons, it uses previous dpsMultiplier in calculations this resulted in the numbers being ^2 on the second calculation always making every node seem more powerful then it should. This fixes it so it always wiped so this assumption / reuse of stacking multipliers is fine.

### Steps taken to verify a working solution:
![image](https://user-images.githubusercontent.com/31533893/207287797-038df962-09e6-4f9b-bfd8-de4d18ec9ebc.png)
![image](https://user-images.githubusercontent.com/31533893/207287844-89ca76d3-684f-431d-8461-5bcd73f61349.png)

### Link to a build that showcases this PR:
https://pobb.in/TfhBprEH-M3D