### PR TITLE
Fixed nil comparison if maxPrice is empty

### DIFF
--- a/src/Classes/TradeQueryGenerator.lua
+++ b/src/Classes/TradeQueryGenerator.lua
@@ -637,7 +637,7 @@ function TradeQueryGeneratorClass:FinishQuery()
         end
     end
 
-    if options.maxPrice > 0 then
+    if options.maxPrice ~= nil and options.maxPrice > 0 then
         queryTable.query.filters.trade_filters = {
             filters = {
                 price = {


### PR DESCRIPTION
This error occurs on the dev branch

### Description of the problem being solved:
When max price was being left empty, options.maxPrice is nil. This lead to a nil comparison error

### Steps taken to verify a working solution:
- Import a build
- Go to items and click "Trade for these items"
- dont put a value into Max Price
- Click Execute
