### PR TITLE
Add missing skilltype tags to minion skills.

### DIFF
--- a/src/Data/Skills/minion.lua
+++ b/src/Data/Skills/minion.lua
@@ -489,7 +489,7 @@ skills["RockGolemSlam"] = {
 	hidden = true,
 	color = 1,
 	baseEffectiveness = 0,
-	skillTypes = { [SkillType.Attack] = true, [SkillType.Area] = true, [SkillType.Triggerable] = true, },
+	skillTypes = { [SkillType.Attack] = true, [SkillType.Area] = true, [SkillType.Triggerable] = true, [SkillType.Melee] = true, [SkillType.Multistrikeable] = true, },
 	statDescriptionScope = "skill_stat_descriptions",
 	castTime = 1,
 	baseFlags = {

--- a/src/Data/Skills/minion.lua
+++ b/src/Data/Skills/minion.lua
@@ -40,13 +40,16 @@ skills["SandstormChaosElementalSummoned"] = {
 	color = 4,
 	baseEffectiveness = 6.1421999931335,
 	incrementalEffectiveness = 0.052099999040365,
-	skillTypes = { [SkillType.Spell] = true, [SkillType.Area] = true, [SkillType.Duration] = true, [SkillType.AreaSpell] = true, },
+	skillTypes = { [SkillType.Spell] = true, [SkillType.Area] = true, [SkillType.Duration] = true, [SkillType.AreaSpell] = true, [SkillType.DamageOverTime] = true },
 	statDescriptionScope = "skill_stat_descriptions",
 	castTime = 1,
 	baseFlags = {
 		spell = true,
 		duration = true,
 		area = true,
+	},
+	baseMods = {
+		skill("dotIsArea", true),
 	},
 	constantStats = {
 		{ "base_skill_effect_duration", 5000 },
@@ -1210,7 +1213,7 @@ skills["MinionInstability"] = {
 		area = true,
 		fire = true,
 	},
-	skillTypes = { [10] = true, [11] = true },
+	skillTypes = { [SkillType.Damage] = true, [SkillType.Area] = true },
 	baseMods = {
 		skill("FireMin", 1, { type = "PerStat", stat = "Life", div = 1/.33 }),
 		skill("FireMax", 1, { type = "PerStat", stat = "Life", div = 1/.33 }),

--- a/src/Data/Skills/minion.lua
+++ b/src/Data/Skills/minion.lua
@@ -1210,7 +1210,7 @@ skills["MinionInstability"] = {
 		area = true,
 		fire = true,
 	},
-	skillTypes = { [10] = true, },
+	skillTypes = { [10] = true, [11] = true },
 	baseMods = {
 		skill("FireMin", 1, { type = "PerStat", stat = "Life", div = 1/.33 }),
 		skill("FireMax", 1, { type = "PerStat", stat = "Life", div = 1/.33 }),

--- a/src/Data/Skills/minion.lua
+++ b/src/Data/Skills/minion.lua
@@ -40,7 +40,7 @@ skills["SandstormChaosElementalSummoned"] = {
 	color = 4,
 	baseEffectiveness = 6.1421999931335,
 	incrementalEffectiveness = 0.052099999040365,
-	skillTypes = { [SkillType.Spell] = true, [SkillType.Area] = true, [SkillType.Duration] = true, [SkillType.AreaSpell] = true, [SkillType.DamageOverTime] = true },
+	skillTypes = { [SkillType.Spell] = true, [SkillType.Area] = true, [SkillType.Duration] = true, [SkillType.AreaSpell] = true, [SkillType.DamageOverTime] = true, },
 	statDescriptionScope = "skill_stat_descriptions",
 	castTime = 1,
 	baseFlags = {

--- a/src/Export/Scripts/skills.lua
+++ b/src/Export/Scripts/skills.lua
@@ -173,6 +173,15 @@ directiveTable.noGem = function(state, args, out)
 	state.noGem = true
 end
 
+-- #addskillTypes <flag>[ <flag>[...]]
+-- skill types to be added to the skillTypes flags for this active skill
+directiveTable.addskillTypes = function(state, args, out)
+	state.addSkillTypes = {}
+	for flag in args:gmatch("%a+") do
+		table.insert(state.addSkillTypes, flag)
+	end
+end
+
 -- #skill <GrantedEffectId> [<Display name>]
 -- Initialises the skill data and emits the skill header
 directiveTable.skill = function(state, args, out)
@@ -215,6 +224,8 @@ directiveTable.skill = function(state, args, out)
 	local statMap = { }
 	skill.stats = { }
 	skill.constantStats = { }
+	skill.addSkillTypes = state.addSkillTypes
+	state.addSkillTypes = nil
 	out:write('\tcolor = ', granted.Attribute, ',\n')
 	if granted.GrantedEffectStatSets.BaseEffectiveness ~= 1 then
 		out:write('\tbaseEffectiveness = ', granted.GrantedEffectStatSets.BaseEffectiveness, ',\n')
@@ -270,6 +281,11 @@ directiveTable.skill = function(state, args, out)
 		out:write('\tskillTypes = { ')
 		for _, type in ipairs(granted.ActiveSkill.SkillTypes) do
 			out:write('[', mapAST(type), '] = true, ')
+		end
+		if skill.addSkillTypes then
+			for _, type in ipairs(skill.addSkillTypes) do
+				out:write('[SkillType.', type , '] = true, ')
+			end
 		end
 		out:write('},\n')
 		if granted.ActiveSkill.MinionSkillTypes[1] then

--- a/src/Export/Scripts/skills.lua
+++ b/src/Export/Scripts/skills.lua
@@ -173,9 +173,9 @@ directiveTable.noGem = function(state, args, out)
 	state.noGem = true
 end
 
--- #addskillTypes <flag>[ <flag>[...]]
+-- #addSkillTypes <flag>[ <flag>[...]]
 -- skill types to be added to the skillTypes flags for this active skill
-directiveTable.addskillTypes = function(state, args, out)
+directiveTable.addSkillTypes = function(state, args, out)
 	state.addSkillTypes = {}
 	for flag in args:gmatch("%a+") do
 		table.insert(state.addSkillTypes, flag)

--- a/src/Export/Skills/minion.txt
+++ b/src/Export/Skills/minion.txt
@@ -10,7 +10,9 @@ local skills, mod, flag, skill = ...
 #mods
 
 #skill SandstormChaosElementalSummoned Chaos Aura
+	skillTypes = { [SkillType.Spell] = true, [SkillType.Area] = true, [SkillType.Duration] = true, [SkillType.AreaSpell] = true, [SkillType.DamageOverTime] = true },
 #flags spell duration area
+#baseMod skill("dotIsArea", true)
 #mods
 
 #skill FireElementalFlameRedSummoned Immolate
@@ -202,7 +204,7 @@ skills["MinionInstability"] = {
 		area = true,
 		fire = true,
 	},
-	skillTypes = { [10] = true, [11] = true },
+	skillTypes = { [SkillType.Damage] = true, [SkillType.Area] = true },
 	baseMods = {
 		skill("FireMin", 1, { type = "PerStat", stat = "Life", div = 1/.33 }),
 		skill("FireMax", 1, { type = "PerStat", stat = "Life", div = 1/.33 }),

--- a/src/Export/Skills/minion.txt
+++ b/src/Export/Skills/minion.txt
@@ -9,36 +9,12 @@ local skills, mod, flag, skill = ...
 #flags spell area
 #mods
 
-skills["SandstormChaosElementalSummoned"] = {
-	name = "Chaos Aura",
-	hidden = true,
-	color = 4,
-	baseEffectiveness = 6.1421999931335,
-	incrementalEffectiveness = 0.052099999040365,
-	skillTypes = { [SkillType.Spell] = true, [SkillType.Area] = true, [SkillType.Duration] = true, [SkillType.AreaSpell] = true, [SkillType.DamageOverTime] = true },
-	statDescriptionScope = "skill_stat_descriptions",
-	castTime = 1,
-	baseFlags = {
-		spell = true,
-		duration = true,
-		area = true,
-	},
-	baseMods = {
-		skill("dotIsArea", true),
-	},
-	constantStats = {
-		{ "base_skill_effect_duration", 5000 },
-		{ "active_skill_area_of_effect_radius_+%_final", 20 },
-	},
-	stats = {
-		"base_chaos_damage_to_deal_per_minute",
-		"is_area_damage",
-		"spell_damage_modifiers_apply_to_skill_dot",
-	},
-	levels = {
-		[1] = { 16.666667039196, cooldown = 8, levelRequirement = 3, statInterpolation = { 3, }, },
-	},
-}
+#addskillTypes DamageOverTime
+#skill SandstormChaosElementalSummoned Chaos Aura
+#flags spell duration area
+#baseMod skill("dotIsArea", true)
+#mods
+
 #skill FireElementalFlameRedSummoned Immolate
 #flags spell projectile
 #mods

--- a/src/Export/Skills/minion.txt
+++ b/src/Export/Skills/minion.txt
@@ -9,12 +9,36 @@ local skills, mod, flag, skill = ...
 #flags spell area
 #mods
 
-#skill SandstormChaosElementalSummoned Chaos Aura
+skills["SandstormChaosElementalSummoned"] = {
+	name = "Chaos Aura",
+	hidden = true,
+	color = 4,
+	baseEffectiveness = 6.1421999931335,
+	incrementalEffectiveness = 0.052099999040365,
 	skillTypes = { [SkillType.Spell] = true, [SkillType.Area] = true, [SkillType.Duration] = true, [SkillType.AreaSpell] = true, [SkillType.DamageOverTime] = true },
-#flags spell duration area
-#baseMod skill("dotIsArea", true)
-#mods
-
+	statDescriptionScope = "skill_stat_descriptions",
+	castTime = 1,
+	baseFlags = {
+		spell = true,
+		duration = true,
+		area = true,
+	},
+	baseMods = {
+		skill("dotIsArea", true),
+	},
+	constantStats = {
+		{ "base_skill_effect_duration", 5000 },
+		{ "active_skill_area_of_effect_radius_+%_final", 20 },
+	},
+	stats = {
+		"base_chaos_damage_to_deal_per_minute",
+		"is_area_damage",
+		"spell_damage_modifiers_apply_to_skill_dot",
+	},
+	levels = {
+		[1] = { 16.666667039196, cooldown = 8, levelRequirement = 3, statInterpolation = { 3, }, },
+	},
+}
 #skill FireElementalFlameRedSummoned Immolate
 #flags spell projectile
 #mods

--- a/src/Export/Skills/minion.txt
+++ b/src/Export/Skills/minion.txt
@@ -82,6 +82,7 @@ local skills, mod, flag, skill = ...
 #flags spell projectile
 #mods
 
+#addskillTypes Melee Multistrikeable
 #skill RockGolemSlam Slam
 #flags attack melee area
 #mods

--- a/src/Export/Skills/minion.txt
+++ b/src/Export/Skills/minion.txt
@@ -9,7 +9,7 @@ local skills, mod, flag, skill = ...
 #flags spell area
 #mods
 
-#addskillTypes DamageOverTime
+#addSkillTypes DamageOverTime
 #skill SandstormChaosElementalSummoned Chaos Aura
 #flags spell duration area
 #baseMod skill("dotIsArea", true)
@@ -82,7 +82,7 @@ local skills, mod, flag, skill = ...
 #flags spell projectile
 #mods
 
-#addskillTypes Melee Multistrikeable
+#addSkillTypes Melee Multistrikeable
 #skill RockGolemSlam Slam
 #flags attack melee area
 #mods

--- a/src/Export/Skills/minion.txt
+++ b/src/Export/Skills/minion.txt
@@ -202,7 +202,7 @@ skills["MinionInstability"] = {
 		area = true,
 		fire = true,
 	},
-	skillTypes = { [10] = true, },
+	skillTypes = { [10] = true, [11] = true },
 	baseMods = {
 		skill("FireMin", 1, { type = "PerStat", stat = "Life", div = 1/.33 }),
 		skill("FireMax", 1, { type = "PerStat", stat = "Life", div = 1/.33 }),


### PR DESCRIPTION
Fixes #5313 .

### Description of the problem being solved:
Some minion skills seem to be missing flags and it's causing issues after https://github.com/PathOfBuildingCommunity/PathOfBuilding/pull/4628 was merged.


~~Still need to check that the template minion.txt file does not cause issues with exports.~~