### PR TITLE
Fix Import Tab not properly using your session ID

### DIFF
--- a/src/Classes/ImportTab.lua
+++ b/src/Classes/ImportTab.lua
@@ -106,6 +106,7 @@ You can get this from your web browser's cookies while logged into the Path of E
 	self.controls.sessionInput = new("EditControl", {"TOPLEFT",self.controls.sessionRetry,"BOTTOMLEFT"}, 0, 8, 350, 20, "", "POESESSID", "%X", 32)
 	self.controls.sessionInput:SetProtected(true)
 	self.controls.sessionGo = new("ButtonControl", {"LEFT",self.controls.sessionInput,"RIGHT"}, 8, 0, 60, 20, "Go", function()
+		main.POESESSID = self.controls.sessionInput.buf
 		self:DownloadCharacterList()
 	end)
 	self.controls.sessionGo.enabled = function()


### PR DESCRIPTION
Fixes #5287 .

### Description of the problem being solved:
Fetching private characters stopped working because the Import Tab used the session ID from the user's settings, but didn't save it there if you were importing for the first time.
### Steps taken to verify a working solution:
- Imported a private character