### PR TITLE
Fix spacing issue in portrait mode on the Items tab

### DIFF
--- a/src/Classes/ItemsTab.lua
+++ b/src/Classes/ItemsTab.lua
@@ -224,7 +224,7 @@ local ItemsTabClass = newClass("ItemsTab", "UndoHandler", "ControlHost", "Contro
 
 	-- All items list
 	if main.portraitMode then
-		self.controls.itemList = new("ItemListControl", {"TOPRIGHT",self.controls.specButton,"BOTTOMRIGHT"}, 0, 20, 360, 308, self, true)
+		self.controls.itemList = new("ItemListControl", {"TOPRIGHT",self.lastSlot,"BOTTOMRIGHT"}, 0, 0, 360, 308, self, true)
 	else
 		self.controls.itemList = new("ItemListControl", {"TOPLEFT",self.controls.setManage,"TOPRIGHT"}, 20, 20, 360, 308, self, true)
 	end
@@ -1240,7 +1240,7 @@ function ItemsTabClass:UpdateSockets()
 	end
 
 	if main.portraitMode then
-		self.controls.itemList:SetAnchor("TOPRIGHT",self.controls.specButton,"BOTTOMRIGHT", 0, 40)
+		self.controls.itemList:SetAnchor("TOPRIGHT",self.lastSlot,"BOTTOMRIGHT", 0, 40)
 	end
 end
 


### PR DESCRIPTION
Fixes #5332 .

### Description of the problem being solved:
Previous spacing fixes set the wrong anchor in portrait mode
### Steps taken to verify a working solution:
- Load PoB in portrait mode
- Add sockets to verify spacing

### Before screenshot:
See issue
### After screenshot:
![image](https://user-images.githubusercontent.com/1209372/207514988-acd5fac1-f6fd-4b7e-8249-88ab22060000.png)
