### PR TITLE
Fix odd edit behavior with protected inputs

### DIFF
--- a/src/Classes/EditControl.lua
+++ b/src/Classes/EditControl.lua
@@ -105,7 +105,7 @@ function EditClass:SetPlaceholder(text, notify)
 end
 
 function EditClass:SetProtected(bool)
-	self.protected = bool or false
+	self.protected = bool or true
 	-- set the font to be fixed to prevent strange
 	-- spacing
 	self.font = "FIXED"
@@ -365,7 +365,7 @@ function EditClass:Draw(viewPort, noTooltip)
 		local sel = self.selCol .. StripEscapes(self.buf:sub(left, right - 1))
 		local post = self.textCol .. self.buf:sub(right)
 		if self.protected then
-			DrawString(textX, textY, "LEFT", textHeight, self.font, string.rep(protected_replace, #pre-#self.textCol))
+			DrawString(textX, textY, "LEFT", textHeight, self.font, self.textCol .. string.rep(protected_replace, #pre-#self.textCol))
 		else
 			DrawString(textX, textY, "LEFT", textHeight, self.font, pre)
 		end
@@ -374,12 +374,12 @@ function EditClass:Draw(viewPort, noTooltip)
 		SetDrawColor(self.selBGCol)
 		DrawImage(nil, textX, textY, selWidth, textHeight)
 		if self.protected then
-			DrawString(textX, textY, "LEFT", textHeight, self.font, string.rep(protected_replace, #sel))
+			DrawString(textX, textY, "LEFT", textHeight, self.font, self.selCol .. string.rep(protected_replace, #sel-#self.selCol))
 		else
 			DrawString(textX, textY, "LEFT", textHeight, self.font, sel)
 		end
 		if self.protected and #post > 0 then
-			DrawString(textX, textY, "LEFT", textHeight, self.font, string.rep(protected_replace, #post-#self.textCol))
+			DrawString(textX + selWidth, textY, "LEFT", textHeight, self.font, self.textCol .. string.rep(protected_replace, #post-#self.textCol))
 		else
 			DrawString(textX + selWidth, textY, "LEFT", textHeight, self.font, post)
 		end
@@ -392,7 +392,7 @@ function EditClass:Draw(viewPort, noTooltip)
 		local pre = self.textCol .. self.buf:sub(1, self.caret - 1)
 		local post = self.buf:sub(self.caret)
 		if self.protected then
-			DrawString(textX, textY, "LEFT", textHeight, self.font, string.rep(protected_replace, #pre-#self.textCol))
+			DrawString(textX, textY, "LEFT", textHeight, self.font, self.textCol .. string.rep(protected_replace, #pre-#self.textCol))
 		else
 			DrawString(textX, textY, "LEFT", textHeight, self.font, pre)
 		end
@@ -499,7 +499,7 @@ function EditClass:OnKeyDown(key, doubleClick)
 		end
 	elseif key == "a" and ctrl then
 		self:SelectAll()
-	elseif (key == "c" or key == "x") and ctrl then
+	elseif (key == "c" or key == "x") and ctrl and not self.protected then
 		if self.sel and self.sel ~= self.caret then
 			local left = m_min(self.caret, self.sel)
 			local right = m_max(self.caret, self.sel)


### PR DESCRIPTION
### Description of the problem being solved:
Highlighting and clicking on the protected session ID values resulted in some odd behavior.  This PR also disables copying/cutting from the protected fields
### Steps taken to verify a working solution:
- Messed around with various selection and caret placement in the session ID fields to ensure they looked correct

### Link to a build that showcases this PR:
N/A
### Before screenshot:
Clicked in, hovering
![image](https://user-images.githubusercontent.com/1209372/207748043-486292c8-ef12-4abe-afb2-e46dba13fb89.png)
Clicked in
![image](https://user-images.githubusercontent.com/1209372/207748190-c51786b0-bd50-49c6-8f56-049edc78f7b6.png)
Highlighting
![image](https://user-images.githubusercontent.com/1209372/207748235-96385fba-fbd3-4f8c-b32d-0b959ca961e8.png)

### After screenshot:
Clicked in, hovering
![image](https://user-images.githubusercontent.com/1209372/207748131-075b5402-201f-406d-a6f2-38ab188ecb48.png)
Clicked in
![image](https://user-images.githubusercontent.com/1209372/207748166-0ff1bb53-fc4e-4100-b2fb-0287b727afbc.png)
Highlighting
![image](https://user-images.githubusercontent.com/1209372/207748259-08905410-7958-4ac9-b6c4-f608c32ae6fc.png)
