### PR TITLE
Add support for mutewind pennant warcry mod

### DIFF
--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -1446,6 +1446,7 @@ local modTagList = {
 	["if you[' ]h?a?ve used a warcry recently"] = { tag = { type = "Condition", var = "UsedWarcryRecently" } },
 	["if you[' ]h?a?ve warcried recently"] = { tag = { type = "Condition", var = "UsedWarcryRecently" } },
 	["for each time you[' ]h?a?ve warcried recently"] = { tag = { type = "Multiplier", var = "WarcryUsedRecently" } },
+	["when you warcry"] = { tag = { type = "Condition", var = "UsedWarcryRecently" } },
 	["if you[' ]h?a?ve warcried in the past 8 seconds"] = { tag = { type = "Condition", var = "UsedWarcryInPast8Seconds" } },
 	["for each of your mines detonated recently, up to (%d+)%%"] = function(num) return { tag = { type = "Multiplier", var = "MineDetonatedRecently", limit = num, limitTotal = true } } end,
 	["for each mine detonated recently, up to (%d+)%%"] = function(num) return { tag = { type = "Multiplier", var = "MineDetonatedRecently", limit = num, limitTotal = true } } end,


### PR DESCRIPTION
### Description of the problem being solved:
Adding mod for 'when you warcry' for Mutewind Pennant unique
### Steps taken to verify a working solution:
Have Mutewind Pennant equipped, see a 20% increased cast speed and movement speed with Spark when if you've warcried recently is enabled

### Link to a build that showcases this PR:
https://pastebin.com/dNH8K3Lz

![image](https://user-images.githubusercontent.com/3247221/208215602-8865ec54-a38d-4ec1-9fdc-df674ecd3b6e.png)
