### PR TITLE
Add rotting legion missing zombie mod

### DIFF
--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -1206,6 +1206,7 @@ local modTagList = {
 	["per summoned raging spirit"] = { tag = { type = "PerStat", stat = "ActiveRagingSpiritLimit" } },
 	["for each raised zombie"] = { tag = { type = "PerStat", stat = "ActiveZombieLimit" } },
 	["per zombie you own"] = { tag = { type = "PerStat", stat = "ActiveZombieLimit", actor = "parent" } },
+	["per raised zombie"] = { tag = { type = "PerStat", stat = "ActiveZombieLimit" } },
 	["per raised spectre"] = { tag = { type = "PerStat", stat = "ActiveSpectreLimit" } },
 	["per spectre you own"] = { tag = { type = "PerStat", stat = "ActiveSpectreLimit", actor = "parent" } },
 	["for each remaining chain"] = { tag = { type = "PerStat", stat = "ChainRemaining" } },


### PR DESCRIPTION
### Description of the problem being solved:
Add missing mod for Rotting Legion unique

### Steps taken to verify a working solution:
- Ensure mod works

### Link to a build that showcases this PR:
https://pastebin.com/8SMK5FtV

### After screenshot:
Damage with default zombie limit (6)
![image](https://user-images.githubusercontent.com/3247221/208217344-5ecb270b-7a90-40f2-af0b-2f8a9bd93281.png)

Elemental damage reduction with an additional +1 zombie amulet equipped
![image](https://user-images.githubusercontent.com/3247221/208217373-1a924114-5a11-400a-9cf8-156f716e9a6a.png)
