### PR TITLE
Use default item affix quality rather than 50%

### DIFF
--- a/src/Classes/TradeQueryGenerator.lua
+++ b/src/Classes/TradeQueryGenerator.lua
@@ -369,8 +369,8 @@ function TradeQueryGeneratorClass:GenerateModWeights(modsToTest)
                 goto continue
             end
 
-            -- Test with a value halfway between the min and max available for this mod in this slot. Note that this can generate slightly different values for the same mod as implicit vs explicit.
-            local modValue = math.ceil((entry[self.calcContext.itemCategory].max - entry[self.calcContext.itemCategory].min) / 2 + entry[self.calcContext.itemCategory].min)
+            -- Test with a value halfway (or configured default Item Affix Quality) between the min and max available for this mod in this slot. Note that this can generate slightly different values for the same mod as implicit vs explicit.
+            local modValue = math.ceil((entry[self.calcContext.itemCategory].max - entry[self.calcContext.itemCategory].min) * ( main.defaultItemAffixQuality or 0.5 ) + entry[self.calcContext.itemCategory].min)
             local modValueStr = (entry.sign and entry.sign or "") .. tostring(modValue)
 
             -- Apply override text for special cases


### PR DESCRIPTION
Use default item affix quality rather than 50%

This generates different searches on 0%, 50% and 100% but only minorly different
![image](https://user-images.githubusercontent.com/49933620/208224340-c4637a03-27b1-4340-be7f-f92ff60a46b2.png)

https://www.pathofexile.com/trade/search/Standard/X94aJB7iP
https://www.pathofexile.com/trade/search/Standard/vDk5blMCE

main difference is order of mods with only slight change to the weights, thus tends to find similar items anyway
