### PR TITLE
Adjusted seismic and spire wave count calculation

### DIFF
--- a/src/Data/Skills/act_dex.lua
+++ b/src/Data/Skills/act_dex.lua
@@ -3888,8 +3888,8 @@ skills["ShrapnelTrap"] = {
 			t_insert(breakdown.OverlapChance, "Chance for individual wave to land within range to damage enemy:")
 			t_insert(breakdown.OverlapChance, "^8= (area where wave can spawn to damage enemy) / (total area)")
 			t_insert(breakdown.OverlapChance, "^8= (^7secondary radius^8 + ^7enemy radius^8 - 1) ^ 2 / ^7radius^8 ^ 2")
-			t_insert(breakdown.OverlapChance, s_format("^8= (^7%d^8 + ^7%d^8 - 1) ^ 2 / ^7%d^8 ^ 2", waveRadius, enemyRadius, fullRadius))
-			t_insert(breakdown.OverlapChance, s_format("^8= ^7%.3f^8%%", overlapChance * 100))
+			t_insert(breakdown.OverlapChance, s_format("^8= (^7%d^8 +^7 %d^8 - 1) ^ 2 /^7 %d^8 ^ 2", waveRadius, enemyRadius, fullRadius))
+			t_insert(breakdown.OverlapChance, s_format("^8=^7 %.3f^8%%", overlapChance * 100))
 		end
 		local dpsMultiplier = 1
 		if skillPart == 2 then
@@ -3898,15 +3898,15 @@ skills["ShrapnelTrap"] = {
 				breakdown.SkillDPSMultiplier = {}
 				t_insert(breakdown.SkillDPSMultiplier, "DPS multiplier")
 				t_insert(breakdown.SkillDPSMultiplier, "^8= 1 + ^7small explosions^8 * ^7overlap chance^8")
-				t_insert(breakdown.SkillDPSMultiplier, s_format("^8= 1 + ^7%d^8 * ^7%.2f^8", smallExplosionsPerTrap, overlapChance))
-				t_insert(breakdown.SkillDPSMultiplier, s_format("^8= ^7%.3f", dpsMultiplier))
+				t_insert(breakdown.SkillDPSMultiplier, s_format("^8= 1 +^7 %d^8 *^7 %.2f^8", smallExplosionsPerTrap, overlapChance))
+				t_insert(breakdown.SkillDPSMultiplier, s_format("^8=^7 %.3f", dpsMultiplier))
 			end
 		elseif skillPart == 3 then
 			dpsMultiplier = 1 + smallExplosionsPerTrap
 			if breakdown then
 				breakdown.SkillDPSMultiplier = {}
 				t_insert(breakdown.SkillDPSMultiplier, "DPS multiplier")
-				t_insert(breakdown.SkillDPSMultiplier, s_format("^8= 1 + ^7%d (small explosions)", dpsMultiplier))
+				t_insert(breakdown.SkillDPSMultiplier, s_format("^8= 1 +^7 %d (small explosions)", dpsMultiplier))
 			end
 		end
 		if dpsMultiplier ~= 1 then
@@ -7774,8 +7774,9 @@ skills["PhysCascadeTrap"] = {
 		local wavePulseRate = incFrequency * moreFrequency / baseInterval
 		skillData.hitTimeOverride = 1 / wavePulseRate
 		output.WavePulseRate = wavePulseRate
+		local incDuration = (1 + skillModList:Sum("INC", skillCfg, "Duration") / 100)
 		local moreDuration = skillModList:More(skillCfg, "Duration")
-		local duration = output.Duration
+		local duration = skillData.duration * incDuration * moreDuration
 		local pulses = math.floor(duration * wavePulseRate)
 		output.PulsesPerTrap = pulses
 		local effectiveDuration = pulses / wavePulseRate
@@ -7797,8 +7798,8 @@ skills["PhysCascadeTrap"] = {
 			t_insert(breakdown.OverlapChance, "Chance for individual wave to land within range to damage enemy:")
 			t_insert(breakdown.OverlapChance, "^8= (area where wave can spawn to damage enemy) / (total area)")
 			t_insert(breakdown.OverlapChance, "^8= (^7secondary radius^8 + ^7enemy radius^8 - 1) ^ 2 / ^7radius^8 ^ 2")
-			t_insert(breakdown.OverlapChance, s_format("^8= (^7%d^8 + ^7%d^8 - 1) ^ 2 / ^7%d^8 ^ 2", waveRadius, enemyRadius, fullRadius))
-			t_insert(breakdown.OverlapChance, s_format("^8= ^7%.3f^8%%", overlapChance * 100))
+			t_insert(breakdown.OverlapChance, s_format("^8= (^7%d^8 +^7 %d^8 - 1) ^ 2 /^7 %d^8 ^ 2", waveRadius, enemyRadius, fullRadius))
+			t_insert(breakdown.OverlapChance, s_format("^8=^7 %.3f^8%%", overlapChance * 100))
 			breakdown.WavePulseRate = { }
 			t_insert(breakdown.WavePulseRate, "Pulse rate:")
 			t_insert(breakdown.WavePulseRate, s_format("%.2f ^8(base pulse rate)", 1 / baseInterval))
@@ -7807,16 +7808,22 @@ skills["PhysCascadeTrap"] = {
 			t_insert(breakdown.WavePulseRate, s_format("= %.2f^8/s", wavePulseRate))
 			breakdown.PulsesPerTrap = { }
 			t_insert(breakdown.PulsesPerTrap, "Pulses per trap:")
-			t_insert(breakdown.PulsesPerTrap, s_format("%.3f ^8(skill duration)", duration))
+			t_insert(breakdown.PulsesPerTrap, s_format("%.3f ^8(unrounded skill duration)", duration))
 			t_insert(breakdown.PulsesPerTrap, s_format("* %.2f ^8(pulse rate)", wavePulseRate))
 			t_insert(breakdown.PulsesPerTrap, s_format("= %.2f ^8pulses", duration * wavePulseRate))
 			t_insert(breakdown.PulsesPerTrap, "^8rounded down")
 			t_insert(breakdown.PulsesPerTrap, s_format("= %d ^8pulses", pulses))
-			t_insert(breakdown.PulsesPerTrap, s_format("^8Next breakpoint: %d%% increased Trap Throwing Speed / %d%% increased Duration", math.ceil(100 * (incFrequency * (pulses + 1) / (duration * wavePulseRate) - incFrequency)), math.ceil(100 * ((pulses + 1) / wavePulseRate / skillData.duration / moreDuration  - output.DurationMod / moreDuration ))))
-			t_insert(breakdown.PulsesPerTrap, s_format("^8Previous breakpoint: %d%% reduced Trap Throwing Speed / %d%% reduced Duration", -math.ceil(100 * (incFrequency * pulses / (duration * wavePulseRate) - incFrequency) - 1), -math.ceil(100 * (pulses / wavePulseRate / skillData.duration - output.DurationMod - 0.01) * moreDuration)))
+			t_insert(breakdown.PulsesPerTrap, s_format("^8Next breakpoint: %d%% increased Trap Throwing Speed / %d%% increased Duration",
+					math.ceil(100 * ((pulses + 1) * baseInterval / (duration * moreFrequency) - incFrequency)),
+					math.ceil(100 * ((pulses + 1) / (wavePulseRate * skillData.duration * moreDuration) - incDuration))
+			))
+			t_insert(breakdown.PulsesPerTrap, s_format("^8Previous breakpoint: %d%% reduced Trap Throwing Speed / %d%% reduced Duration",
+					-math.ceil(100 * (pulses * baseInterval / (duration * moreFrequency) - incFrequency) - 1),
+					-math.ceil(100 * (pulses / (wavePulseRate * skillData.duration * moreDuration) - incDuration) - 1)
+			))
 			breakdown.AverageActiveTraps = { }
 			t_insert(breakdown.AverageActiveTraps, "Average active traps, not considering stored cooldown uses:")
-			t_insert(breakdown.AverageActiveTraps, s_format("%.2f^8 / ^7%.2f^8 (pulses / pulse rate = effective skill duration)", pulses, wavePulseRate))
+			t_insert(breakdown.AverageActiveTraps, s_format("%.2f^8 /^7 %.2f^8 (pulses / pulse rate = effective skill duration)", pulses, wavePulseRate))
 			t_insert(breakdown.AverageActiveTraps, s_format("/ %.2f ^8(cooldown)", cooldown))
 			t_insert(breakdown.AverageActiveTraps, s_format("= %.2f traps", averageActiveTraps))
 		end
@@ -7828,22 +7835,22 @@ skills["PhysCascadeTrap"] = {
 				breakdown.SkillDPSMultiplier = {}
 				t_insert(breakdown.SkillDPSMultiplier, "DPS multiplier")
 				t_insert(breakdown.SkillDPSMultiplier, "^8= ^7maximum waves^8 * ^7overlap chance^8")
-				t_insert(breakdown.SkillDPSMultiplier, s_format("^8= ^7%d^8 * ^7%.2f^8", maxWaves, overlapChance))
-				t_insert(breakdown.SkillDPSMultiplier, s_format("^8= ^7%.3f", dpsMultiplier))
+				t_insert(breakdown.SkillDPSMultiplier, s_format("^8=^7 %d^8 *^7 %.2f^8", maxWaves, overlapChance))
+				t_insert(breakdown.SkillDPSMultiplier, s_format("^8=^7 %.3f", dpsMultiplier))
 			end
 		elseif skillPart == 3 then
 			dpsMultiplier = maxWaves
 			if breakdown then
 				breakdown.SkillDPSMultiplier = {}
 				t_insert(breakdown.SkillDPSMultiplier, "DPS multiplier")
-				t_insert(breakdown.SkillDPSMultiplier, s_format("^8= ^7%d (maximum waves)", dpsMultiplier))
+				t_insert(breakdown.SkillDPSMultiplier, s_format("^8=^7 %d (maximum waves)", dpsMultiplier))
 			end
 		elseif skillPart == 4 then
 			dpsMultiplier = averageActiveTraps
 			if breakdown then
 				breakdown.SkillDPSMultiplier = {}
 				t_insert(breakdown.SkillDPSMultiplier, "DPS multiplier")
-				t_insert(breakdown.SkillDPSMultiplier, s_format("^8= ^7%.2f (average active traps)", dpsMultiplier))
+				t_insert(breakdown.SkillDPSMultiplier, s_format("^8=^7 %.2f (average active traps)", dpsMultiplier))
 			end
 		elseif skillPart == 5 then
 			dpsMultiplier = averageActiveTraps * maxWaves * overlapChance
@@ -7851,8 +7858,8 @@ skills["PhysCascadeTrap"] = {
 				breakdown.SkillDPSMultiplier = {}
 				t_insert(breakdown.SkillDPSMultiplier, "DPS multiplier")
 				t_insert(breakdown.SkillDPSMultiplier, "^8= ^7average active traps^8 * ^7maximum waves^8 * ^7overlap chance^8")
-				t_insert(breakdown.SkillDPSMultiplier, s_format("^8= ^7%.2f^8 * ^7%d^8 * ^7%.2f", averageActiveTraps, maxWaves, overlapChance))
-				t_insert(breakdown.SkillDPSMultiplier, s_format("^8= ^7%.3f", dpsMultiplier))
+				t_insert(breakdown.SkillDPSMultiplier, s_format("^8=^7 %.2f^8 *^7 %d^8 *^7 %.2f", averageActiveTraps, maxWaves, overlapChance))
+				t_insert(breakdown.SkillDPSMultiplier, s_format("^8=^7 %.3f", dpsMultiplier))
 			end
 		elseif skillPart == 6 then
 			dpsMultiplier = averageActiveTraps * maxWaves
@@ -7860,8 +7867,8 @@ skills["PhysCascadeTrap"] = {
 				breakdown.SkillDPSMultiplier = {}
 				t_insert(breakdown.SkillDPSMultiplier, "DPS multiplier")
 				t_insert(breakdown.SkillDPSMultiplier, "^8= ^7average active traps^8 * ^7maximum waves")
-				t_insert(breakdown.SkillDPSMultiplier, s_format("^8= ^7%.2f^8 * ^7%d", averageActiveTraps, maxWaves))
-				t_insert(breakdown.SkillDPSMultiplier, s_format("^8= ^7%.3f", dpsMultiplier))
+				t_insert(breakdown.SkillDPSMultiplier, s_format("^8=^7 %.2f^8 *^7 %d", averageActiveTraps, maxWaves))
+				t_insert(breakdown.SkillDPSMultiplier, s_format("^8=^7 %.3f", dpsMultiplier))
 			end
 		end
 		if dpsMultiplier ~= 1 then

--- a/src/Data/Skills/act_int.lua
+++ b/src/Data/Skills/act_int.lua
@@ -6403,151 +6403,158 @@ skills["LightningTowerTrap"] = {
 	skillTypes = { [SkillType.Spell] = true, [SkillType.Duration] = true, [SkillType.Damage] = true, [SkillType.Mineable] = true, [SkillType.Area] = true, [SkillType.Trapped] = true, [SkillType.Lightning] = true, [SkillType.AreaSpell] = true, [SkillType.Cooldown] = true, },
 	statDescriptionScope = "skill_stat_descriptions",
 	castTime = 1,
-    parts = {
-        {
-            name = "One wave hitting",
-        },
-        {
-            name = "Average waves hitting configured size enemy",
-        },
-        {
-            name = "All waves hitting",
-        },
-        {
-            name = "Average active traps, one wave",
-        },
-        {
-            name = "Average active traps, average waves",
-        },
-        {
-            name = "Average active traps, all waves",
-        },
-    },
-    preDamageFunc = function(activeSkill, output, breakdown)
-        local skillCfg = activeSkill.skillCfg
-        local skillData = activeSkill.skillData
-        local skillPart = activeSkill.skillPart
-        local skillModList = activeSkill.skillModList
-        local t_insert = table.insert
-        local s_format = string.format
+	parts = {
+		{
+			name = "One wave hitting",
+		},
+		{
+			name = "Average waves hitting configured size enemy",
+		},
+		{
+			name = "All waves hitting",
+		},
+		{
+			name = "Average active traps, one wave",
+		},
+		{
+			name = "Average active traps, average waves",
+		},
+		{
+			name = "Average active traps, all waves",
+		},
+	},
+	preDamageFunc = function(activeSkill, output, breakdown)
+		local skillCfg = activeSkill.skillCfg
+		local skillData = activeSkill.skillData
+		local skillPart = activeSkill.skillPart
+		local skillModList = activeSkill.skillModList
+		local t_insert = table.insert
+		local s_format = string.format
 
-        -- seemingly the only mechanical difference with seismic trap - this one does not scale it's total radius with AoE modifiers
-        output.AreaOfEffectRadius = skillData.radius
-        if breakdown then
-            breakdown.AreaOfEffectRadius = {"Targeting area of this skill is not affected by Area of Effect modifiers."}
-        end
+		-- seemingly the only mechanical difference with seismic trap - this one does not scale it's total radius with AoE modifiers
+		output.AreaOfEffectRadius = skillData.radius
+		if breakdown then
+			breakdown.AreaOfEffectRadius = {"Targeting area of this skill is not affected by Area of Effect modifiers."}
+		end
 
-        local baseInterval = skillData.repeatInterval
-        local incFrequency = (1 + skillModList:Sum("INC", skillCfg, "TrapThrowingSpeed") / 100)
-        local moreFrequency = skillModList:More(skillCfg, "TrapThrowingSpeed")
-        local wavePulseRate = incFrequency * moreFrequency / baseInterval
-        skillData.hitTimeOverride = 1 / wavePulseRate
-        output.WavePulseRate = wavePulseRate
-        local moreDuration = skillModList:More(skillCfg, "Duration")
-        local duration = output.Duration
-        local pulses = math.floor(duration * wavePulseRate)
-        output.PulsesPerTrap = pulses
-        local effectiveDuration = pulses / wavePulseRate
-        local cooldown = output.TrapCooldown
-        local averageActiveTraps = effectiveDuration / cooldown
-        output.AverageActiveTraps = averageActiveTraps
-        local function hitChance(enemyRadius, areaDamageRadius, areaSpreadRadius) -- not to be confused with attack hit chance
-            local damagingAreaRadius = areaDamageRadius + enemyRadius - 1	-- radius where area damage can land to hit the enemy;
-            -- -1 because of two assumptions: PoE coordinates are integers and damage is not registered if the two areas only share a point or vertex. If either is not correct, then -1 is not needed.
-            return math.min(damagingAreaRadius * damagingAreaRadius / (areaSpreadRadius * areaSpreadRadius), 1)
-        end
+		local baseInterval = skillData.repeatInterval
+		local incFrequency = (1 + skillModList:Sum("INC", skillCfg, "TrapThrowingSpeed", "SeismicPulseFrequency") / 100)
+		local moreFrequency = skillModList:More(skillCfg, "TrapThrowingSpeed", "SeismicPulseFrequency")
+		local wavePulseRate = incFrequency * moreFrequency / baseInterval
+		skillData.hitTimeOverride = 1 / wavePulseRate
+		output.WavePulseRate = wavePulseRate
+		local incDuration = (1 + skillModList:Sum("INC", skillCfg, "Duration") / 100)
+		local moreDuration = skillModList:More(skillCfg, "Duration")
+		local duration = skillData.duration * incDuration * moreDuration
+		local pulses = math.floor(duration * wavePulseRate)
+		output.PulsesPerTrap = pulses
+		local effectiveDuration = pulses / wavePulseRate
+		local cooldown = output.TrapCooldown
+		local averageActiveTraps = effectiveDuration / cooldown
+		output.AverageActiveTraps = averageActiveTraps
+		local function hitChance(enemyRadius, areaDamageRadius, areaSpreadRadius) -- not to be confused with attack hit chance
+			local damagingAreaRadius = areaDamageRadius + enemyRadius - 1	-- radius where area damage can land to hit the enemy;
+			-- -1 because of two assumptions: PoE coordinates are integers and damage is not registered if the two areas only share a point or vertex. If either is not correct, then -1 is not needed.
+			return math.min(damagingAreaRadius * damagingAreaRadius / (areaSpreadRadius * areaSpreadRadius), 1)
+		end
 		local enemyRadius = skillModList:Override(skillCfg, "EnemyRadius") or skillModList:Sum("BASE", skillCfg, "EnemyRadius")
-        local waveRadius = output.AreaOfEffectRadiusSecondary
-        local fullRadius = output.AreaOfEffectRadius
-        local overlapChance = hitChance(enemyRadius, waveRadius, fullRadius)
-        output.OverlapChance = overlapChance * 100
-        if breakdown then
-            breakdown.OverlapChance = { }
-            t_insert(breakdown.OverlapChance, "Chance for individual wave to land within range to damage enemy:")
-            t_insert(breakdown.OverlapChance, "^8= (area where wave can spawn to damage enemy) / (total area)")
-            t_insert(breakdown.OverlapChance, "^8= (^7secondary radius^8 + ^7enemy radius^8 - 1) ^ 2 / ^7radius^8 ^ 2")
-            t_insert(breakdown.OverlapChance, s_format("^8= (^7%d^8 + ^7%d^8 - 1) ^ 2 / ^7%d^8 ^ 2", waveRadius, enemyRadius, fullRadius))
-            t_insert(breakdown.OverlapChance, s_format("^8= ^7%.3f^8%%", overlapChance * 100))
-            breakdown.WavePulseRate = { }
-            t_insert(breakdown.WavePulseRate, "Pulse rate:")
-            t_insert(breakdown.WavePulseRate, s_format("%.2f ^8(base pulse rate)", 1 / baseInterval))
-            t_insert(breakdown.WavePulseRate, s_format("* %.2f ^8(increased/reduced pulse frequency)", incFrequency))
-            t_insert(breakdown.WavePulseRate, s_format("* %.2f ^8(more/less pulse frequency)", moreFrequency))
-            t_insert(breakdown.WavePulseRate, s_format("= %.2f^8/s", wavePulseRate))
-            breakdown.PulsesPerTrap = { }
-            t_insert(breakdown.PulsesPerTrap, "Pulses per trap:")
-            t_insert(breakdown.PulsesPerTrap, s_format("%.3f ^8(skill duration)", duration))
-            t_insert(breakdown.PulsesPerTrap, s_format("* %.2f ^8(pulse rate)", wavePulseRate))
-            t_insert(breakdown.PulsesPerTrap, s_format("= %.2f ^8pulses", duration * wavePulseRate))
-            t_insert(breakdown.PulsesPerTrap, "^8rounded down")
-            t_insert(breakdown.PulsesPerTrap, s_format("= %d ^8pulses", pulses))
-            t_insert(breakdown.PulsesPerTrap, s_format("^8Next breakpoint: %d%% increased Trap Throwing Speed / %d%% increased Duration", math.ceil(100 * (incFrequency * (pulses + 1) / (duration * wavePulseRate) - incFrequency)), math.ceil(100 * ((pulses + 1) / wavePulseRate / skillData.duration / moreDuration  - output.DurationMod / moreDuration ))))
-            t_insert(breakdown.PulsesPerTrap, s_format("^8Previous breakpoint: %d%% reduced Trap Throwing Speed / %d%% reduced Duration", -math.ceil(100 * (incFrequency * pulses / (duration * wavePulseRate) - incFrequency) - 1), -math.ceil(100 * (pulses / wavePulseRate / skillData.duration - output.DurationMod - 0.01) * moreDuration)))
-            breakdown.AverageActiveTraps = { }
-            t_insert(breakdown.AverageActiveTraps, "Average active traps, not considering stored cooldown uses:")
-            t_insert(breakdown.AverageActiveTraps, s_format("%.2f^8 / ^7%.2f^8 (pulses / pulse rate = effective skill duration)", pulses, wavePulseRate))
-            t_insert(breakdown.AverageActiveTraps, s_format("/ %.2f ^8(cooldown)", cooldown))
-            t_insert(breakdown.AverageActiveTraps, s_format("= %.2f traps", averageActiveTraps))
-        end
-        local maxWaves = skillModList:Sum("BASE", skillCfg, "MaximumWaves")
-        local dpsMultiplier = 1
-        if skillPart == 2 then
-            dpsMultiplier = maxWaves * overlapChance
-            if breakdown then
-                breakdown.SkillDPSMultiplier = {}
-                t_insert(breakdown.SkillDPSMultiplier, "DPS multiplier")
-                t_insert(breakdown.SkillDPSMultiplier, "^8= ^7maximum waves^8 * ^7overlap chance^8")
-                t_insert(breakdown.SkillDPSMultiplier, s_format("^8= ^7%d^8 * ^7%.2f^8", maxWaves, overlapChance))
-                t_insert(breakdown.SkillDPSMultiplier, s_format("^8= ^7%.3f", dpsMultiplier))
-            end
-        elseif skillPart == 3 then
-            dpsMultiplier = maxWaves
-            if breakdown then
-                breakdown.SkillDPSMultiplier = {}
-                t_insert(breakdown.SkillDPSMultiplier, "DPS multiplier")
-                t_insert(breakdown.SkillDPSMultiplier, s_format("^8= ^7%d (maximum waves)", dpsMultiplier))
-            end
-        elseif skillPart == 4 then
-            dpsMultiplier = averageActiveTraps
-            if breakdown then
-                breakdown.SkillDPSMultiplier = {}
-                t_insert(breakdown.SkillDPSMultiplier, "DPS multiplier")
-                t_insert(breakdown.SkillDPSMultiplier, s_format("^8= ^7%.2f (average active traps)", dpsMultiplier))
-            end
-        elseif skillPart == 5 then
-            dpsMultiplier = averageActiveTraps * maxWaves * overlapChance
-            if breakdown then
-                breakdown.SkillDPSMultiplier = {}
-                t_insert(breakdown.SkillDPSMultiplier, "DPS multiplier")
-                t_insert(breakdown.SkillDPSMultiplier, "^8= ^7average active traps^8 * ^7maximum waves^8 * ^7overlap chance^8")
-                t_insert(breakdown.SkillDPSMultiplier, s_format("^8= ^7%.2f^8 * ^7%d^8 * ^7%.2f", averageActiveTraps, maxWaves, overlapChance))
-                t_insert(breakdown.SkillDPSMultiplier, s_format("^8= ^7%.3f", dpsMultiplier))
-            end
-        elseif skillPart == 6 then
-            dpsMultiplier = averageActiveTraps * maxWaves
-            if breakdown then
-                breakdown.SkillDPSMultiplier = {}
-                t_insert(breakdown.SkillDPSMultiplier, "DPS multiplier")
-                t_insert(breakdown.SkillDPSMultiplier, "^8= ^7average active traps^8 * ^7maximum waves")
-                t_insert(breakdown.SkillDPSMultiplier, s_format("^8= ^7%.2f^8 * ^7%d", averageActiveTraps, maxWaves))
-                t_insert(breakdown.SkillDPSMultiplier, s_format("^8= ^7%.3f", dpsMultiplier))
-            end
-        end
-        if dpsMultiplier ~= 1 then
-            skillData.dpsMultiplier = (skillData.dpsMultiplier or 1) * dpsMultiplier
-            output.SkillDPSMultiplier = (output.SkillDPSMultiplier or 1) * dpsMultiplier
-        end
-    end,
-    statMap = {
-        ["base_skill_show_average_damage_instead_of_dps"] = {},
-        ["lightning_tower_trap_base_interval_duration_ms"] = {
-            skill("repeatInterval", nil),
-            div = 1000,
-        },
-        ["lightning_tower_trap_number_of_beams"] = {
-            mod("MaximumWaves", "BASE", nil),
-        },
-    },
+		local waveRadius = output.AreaOfEffectRadiusSecondary
+		local fullRadius = output.AreaOfEffectRadius
+		local overlapChance = hitChance(enemyRadius, waveRadius, fullRadius)
+		output.OverlapChance = overlapChance * 100
+		if breakdown then
+			breakdown.OverlapChance = { }
+			t_insert(breakdown.OverlapChance, "Chance for individual wave to land within range to damage enemy:")
+			t_insert(breakdown.OverlapChance, "^8= (area where wave can spawn to damage enemy) / (total area)")
+			t_insert(breakdown.OverlapChance, "^8= (^7secondary radius^8 + ^7enemy radius^8 - 1) ^ 2 / ^7radius^8 ^ 2")
+			t_insert(breakdown.OverlapChance, s_format("^8= (^7%d^8 +^7 %d^8 - 1) ^ 2 /^7 %d^8 ^ 2", waveRadius, enemyRadius, fullRadius))
+			t_insert(breakdown.OverlapChance, s_format("^8=^7 %.3f^8%%", overlapChance * 100))
+			breakdown.WavePulseRate = { }
+			t_insert(breakdown.WavePulseRate, "Pulse rate:")
+			t_insert(breakdown.WavePulseRate, s_format("%.2f ^8(base pulse rate)", 1 / baseInterval))
+			t_insert(breakdown.WavePulseRate, s_format("* %.2f ^8(increased/reduced pulse frequency)", incFrequency))
+			t_insert(breakdown.WavePulseRate, s_format("* %.2f ^8(more/less pulse frequency)", moreFrequency))
+			t_insert(breakdown.WavePulseRate, s_format("= %.2f^8/s", wavePulseRate))
+			breakdown.PulsesPerTrap = { }
+			t_insert(breakdown.PulsesPerTrap, "Pulses per trap:")
+			t_insert(breakdown.PulsesPerTrap, s_format("%.3f ^8(unrounded skill duration)", duration))
+			t_insert(breakdown.PulsesPerTrap, s_format("* %.2f ^8(pulse rate)", wavePulseRate))
+			t_insert(breakdown.PulsesPerTrap, s_format("= %.2f ^8pulses", duration * wavePulseRate))
+			t_insert(breakdown.PulsesPerTrap, "^8rounded down")
+			t_insert(breakdown.PulsesPerTrap, s_format("= %d ^8pulses", pulses))
+			t_insert(breakdown.PulsesPerTrap, s_format("^8Next breakpoint: %d%% increased Trap Throwing Speed / %d%% increased Duration",
+					math.ceil(100 * ((pulses + 1) * baseInterval / (duration * moreFrequency) - incFrequency)),
+					math.ceil(100 * ((pulses + 1) / (wavePulseRate * skillData.duration * moreDuration) - incDuration))
+			))
+			t_insert(breakdown.PulsesPerTrap, s_format("^8Previous breakpoint: %d%% reduced Trap Throwing Speed / %d%% reduced Duration",
+					-math.ceil(100 * (pulses * baseInterval / (duration * moreFrequency) - incFrequency) - 1),
+					-math.ceil(100 * (pulses / (wavePulseRate * skillData.duration * moreDuration) - incDuration) - 1)
+			))
+			breakdown.AverageActiveTraps = { }
+			t_insert(breakdown.AverageActiveTraps, "Average active traps, not considering stored cooldown uses:")
+			t_insert(breakdown.AverageActiveTraps, s_format("%.2f^8 /^7 %.2f^8 (pulses / pulse rate = effective skill duration)", pulses, wavePulseRate))
+			t_insert(breakdown.AverageActiveTraps, s_format("/ %.2f ^8(cooldown)", cooldown))
+			t_insert(breakdown.AverageActiveTraps, s_format("= %.2f traps", averageActiveTraps))
+		end
+		local maxWaves = skillModList:Sum("BASE", skillCfg, "MaximumWaves")
+		local dpsMultiplier = 1
+		if skillPart == 2 then
+			dpsMultiplier = maxWaves * overlapChance
+			if breakdown then
+				breakdown.SkillDPSMultiplier = {}
+				t_insert(breakdown.SkillDPSMultiplier, "DPS multiplier")
+				t_insert(breakdown.SkillDPSMultiplier, "^8= ^7maximum waves^8 * ^7overlap chance^8")
+				t_insert(breakdown.SkillDPSMultiplier, s_format("^8=^7 %d^8 *^7 %.2f^8", maxWaves, overlapChance))
+				t_insert(breakdown.SkillDPSMultiplier, s_format("^8=^7 %.3f", dpsMultiplier))
+			end
+		elseif skillPart == 3 then
+			dpsMultiplier = maxWaves
+			if breakdown then
+				breakdown.SkillDPSMultiplier = {}
+				t_insert(breakdown.SkillDPSMultiplier, "DPS multiplier")
+				t_insert(breakdown.SkillDPSMultiplier, s_format("^8=^7 %d (maximum waves)", dpsMultiplier))
+			end
+		elseif skillPart == 4 then
+			dpsMultiplier = averageActiveTraps
+			if breakdown then
+				breakdown.SkillDPSMultiplier = {}
+				t_insert(breakdown.SkillDPSMultiplier, "DPS multiplier")
+				t_insert(breakdown.SkillDPSMultiplier, s_format("^8=^7 %.2f (average active traps)", dpsMultiplier))
+			end
+		elseif skillPart == 5 then
+			dpsMultiplier = averageActiveTraps * maxWaves * overlapChance
+			if breakdown then
+				breakdown.SkillDPSMultiplier = {}
+				t_insert(breakdown.SkillDPSMultiplier, "DPS multiplier")
+				t_insert(breakdown.SkillDPSMultiplier, "^8= ^7average active traps^8 * ^7maximum waves^8 * ^7overlap chance^8")
+				t_insert(breakdown.SkillDPSMultiplier, s_format("^8=^7 %.2f^8 *^7 %d^8 *^7 %.2f", averageActiveTraps, maxWaves, overlapChance))
+				t_insert(breakdown.SkillDPSMultiplier, s_format("^8=^7 %.3f", dpsMultiplier))
+			end
+		elseif skillPart == 6 then
+			dpsMultiplier = averageActiveTraps * maxWaves
+			if breakdown then
+				breakdown.SkillDPSMultiplier = {}
+				t_insert(breakdown.SkillDPSMultiplier, "DPS multiplier")
+				t_insert(breakdown.SkillDPSMultiplier, "^8= ^7average active traps^8 * ^7maximum waves")
+				t_insert(breakdown.SkillDPSMultiplier, s_format("^8=^7 %.2f^8 *^7 %d", averageActiveTraps, maxWaves))
+				t_insert(breakdown.SkillDPSMultiplier, s_format("^8=^7 %.3f", dpsMultiplier))
+			end
+		end
+		if dpsMultiplier ~= 1 then
+			skillData.dpsMultiplier = (skillData.dpsMultiplier or 1) * dpsMultiplier
+			output.SkillDPSMultiplier = (output.SkillDPSMultiplier or 1) * dpsMultiplier
+		end
+	end,
+	statMap = {
+		["base_skill_show_average_damage_instead_of_dps"] = {},
+		["lightning_tower_trap_base_interval_duration_ms"] = {
+			skill("repeatInterval", nil),
+			div = 1000,
+		},
+		["lightning_tower_trap_number_of_beams"] = {
+			mod("MaximumWaves", "BASE", nil),
+		},
+	},
 	baseFlags = {
 		spell = true,
 		trap = true,

--- a/src/Data/Skills/act_int.lua
+++ b/src/Data/Skills/act_int.lua
@@ -590,8 +590,8 @@ skills["BallLightning"] = {
 					local breakdownDpsMult = {}
 					t_insert(breakdownDpsMult, "Average DPS multiplier")
 					t_insert(breakdownDpsMult, s_format("^8= 1 * (^7super chance^8) + 1.5 * (1 - ^7super chance^8)"))
-					t_insert(breakdownDpsMult, s_format("^8= 1 * ^7%d%%^8 + 1.5 * ^7%d%%^8", superchance * 100, 100 - superchance * 100))
-					t_insert(breakdownDpsMult, s_format("^7= ^7%.3f", dpsMultiplier))
+					t_insert(breakdownDpsMult, s_format("^8= 1 *^7 %d%%^8 + 1.5 *^7 %d%%^8", superchance * 100, 100 - superchance * 100))
+					t_insert(breakdownDpsMult, s_format("^7=^7 %.3f", dpsMultiplier))
 					breakdown.SkillDPSMultiplier = breakdownDpsMult
 				end
 			else
@@ -669,10 +669,10 @@ skills["BallLightning"] = {
 					if superchance > 0 then
 						t_insert(breakdownHits, "Applicable to all balls:")
 					end
-					t_insert(breakdownHits, s_format("^8Balls travel at ^7%.2f^8 units/sec.", ballDistPerSec))
-					t_insert(breakdownHits, s_format("^8Lightning bolts strike all nearby enemies every ^7%.2f^8 seconds (^7%.2f^8 strikes/sec).", secsPerStrike, 1 / secsPerStrike))
-					t_insert(breakdownHits, s_format("^8Balls travel ^7%.2f^8 units between each bolt strike.", ballDistPerStrike))
-					t_insert(breakdownHits, s_format("^8Assumes balls are cast ^7%d^8 units from the enemy.", castDist))
+					t_insert(breakdownHits, s_format("^8Balls travel at^7 %.2f^8 units/sec.", ballDistPerSec))
+					t_insert(breakdownHits, s_format("^8Lightning bolts strike all nearby enemies every^7 %.2f^8 seconds (^7%.2f^8 strikes/sec).", secsPerStrike, 1 / secsPerStrike))
+					t_insert(breakdownHits, s_format("^8Balls travel^7 %.2f^8 units between each bolt strike.", ballDistPerStrike))
+					t_insert(breakdownHits, s_format("^8Assumes balls are cast^7 %d^8 units from the enemy.", castDist))
 					if superchance > 0 then
 						if isSuperball then
 							t_insert(breakdownHits, "Applicable to supercharged balls only:")
@@ -680,14 +680,14 @@ skills["BallLightning"] = {
 							t_insert(breakdownHits, "Applicable to normal balls only:")
 						end
 					end
-					t_insert(breakdownHits, s_format("^8Balls can strike enemies up to ^7%d^8 units away from themselves.", strikeRadius))
-					t_insert(breakdownHits, s_format("^8The first strike is at ^7%.2f^8 seconds after it is cast, when the ball is ^7%d^8 units from the cast point.", firstStrikeIdxThatHits * secsPerStrike, firstStrikeIdxThatHits * ballDistPerStrike))
-					t_insert(breakdownHits, s_format("^8The last strike is at ^7%.2f^8 seconds after it is cast, when the ball is ^7%d^8 units from the cast point.", lastStrikeIdxThatHits * secsPerStrike, lastStrikeIdxThatHits * ballDistPerStrike))
+					t_insert(breakdownHits, s_format("^8Balls can strike enemies up to^7 %d^8 units away from themselves.", strikeRadius))
+					t_insert(breakdownHits, s_format("^8The first strike is at^7 %.2f^8 seconds after it is cast, when the ball is^7 %d^8 units from the cast point.", firstStrikeIdxThatHits * secsPerStrike, firstStrikeIdxThatHits * ballDistPerStrike))
+					t_insert(breakdownHits, s_format("^8The last strike is at^7 %.2f^8 seconds after it is cast, when the ball is^7 %d^8 units from the cast point.", lastStrikeIdxThatHits * secsPerStrike, lastStrikeIdxThatHits * ballDistPerStrike))
 					if superchance > 0 then
 						if isSuperball then
-							t_insert(breakdownHits, s_format("^8Balls have a(n) ^7%.1f%%^8 chance to be supercharged.", superchance * 100))
+							t_insert(breakdownHits, s_format("^8Balls have a(n)^7 %.1f%%^8 chance to be supercharged.", superchance * 100))
 						else
-							t_insert(breakdownHits, s_format("^8Balls have a(n) ^7%.1f%%^8 chance to be normal.", 100 - superchance * 100))
+							t_insert(breakdownHits, s_format("^8Balls have a(n)^7 %.1f%%^8 chance to be normal.", 100 - superchance * 100))
 						end
 					end
 					if isSuperball then
@@ -704,8 +704,8 @@ skills["BallLightning"] = {
 					local breakdownDpsMult = {}
 					t_insert(breakdownDpsMult, "Average DPS multiplier")
 					t_insert(breakdownDpsMult, s_format("^8= 1 * (^7normal hits/cast^8) + 1.5 * (^7super hits/cast^8)"))
-					t_insert(breakdownDpsMult, s_format("^8= 1 * ^7%.3f^8 + 1.5 * ^7%.3f^8", output.NormalHitsPerCast, output.SuperchargedHitsPerCast))
-					t_insert(breakdownDpsMult, s_format("^8= ^7%.3f", dpsMultiplier))
+					t_insert(breakdownDpsMult, s_format("^8= 1 *^7 %.3f^8 + 1.5 *^7 %.3f^8", output.NormalHitsPerCast, output.SuperchargedHitsPerCast))
+					t_insert(breakdownDpsMult, s_format("^8=^7 %.3f", dpsMultiplier))
 					breakdown.SkillDPSMultiplier = breakdownDpsMult
 				end
 			end
@@ -4382,16 +4382,16 @@ skills["ForbiddenRite"] = {
 		if breakdown then
 			local FRDamageTaken = {}
 			t_insert(FRDamageTaken, "Damage Taken per Cast")
-			t_insert(FRDamageTaken, s_format("^8=^7 %d^8 (Life) * ^7%d%%^8 (of Life taken as Chaos Damage)", life, activeSkill.skillData.SelfDamageTakenLife * 100))
+			t_insert(FRDamageTaken, s_format("^8=^7 %d^8 (Life) *^7 %d%%^8 (of Life taken as Chaos Damage)", life, activeSkill.skillData.SelfDamageTakenLife * 100))
 			if energyShield ~= 0 then
-				t_insert(FRDamageTaken, s_format("^8+^7 %d^8 (ES) * ^7%d%%^8 (of ES taken as Chaos Damage)", energyShield, activeSkill.skillData.SelfDamageTakenES * 100))
+				t_insert(FRDamageTaken, s_format("^8+^7 %d^8 (ES) *^7 %d%%^8 (of ES taken as Chaos Damage)", energyShield, activeSkill.skillData.SelfDamageTakenES * 100))
 			end
-			t_insert(FRDamageTaken, s_format("^8=^7 %d^8 (Chaos Damage) * ^7%d%%^8 (Chaos Resistance)", life * activeSkill.skillData.SelfDamageTakenLife + energyShield * activeSkill.skillData.SelfDamageTakenES, chaosResistance))
+			t_insert(FRDamageTaken, s_format("^8=^7 %d^8 (Chaos Damage) *^7 %d%%^8 (Chaos Resistance)", life * activeSkill.skillData.SelfDamageTakenLife + energyShield * activeSkill.skillData.SelfDamageTakenES, chaosResistance))
 			if chaosFlat ~= 0 then
 				t_insert(FRDamageTaken, s_format("^8 -^7 %d^8 (Flat Damage reduction)", -basetakenFlat))
 			end
 			if chaosDamageTaken ~= 1 then
-				t_insert(FRDamageTaken, s_format("^8 * ^7%.2f^8 (Damage taken Multiplier)", chaosDamageTaken))
+				t_insert(FRDamageTaken, s_format("^8 *^7 %.2f^8 (Damage taken Multiplier)", chaosDamageTaken))
 			end
 			t_insert(FRDamageTaken, s_format("^8=^7 %d^8 (Damage taken)", SelfDamageTakenLife + SelfDamageTakenES + chaosFlat))
 			breakdown.FRDamageTaken = FRDamageTaken

--- a/src/Export/Skills/act_dex.txt
+++ b/src/Export/Skills/act_dex.txt
@@ -801,8 +801,8 @@ local skills, mod, flag, skill = ...
 			t_insert(breakdown.OverlapChance, "Chance for individual wave to land within range to damage enemy:")
 			t_insert(breakdown.OverlapChance, "^8= (area where wave can spawn to damage enemy) / (total area)")
 			t_insert(breakdown.OverlapChance, "^8= (^7secondary radius^8 + ^7enemy radius^8 - 1) ^ 2 / ^7radius^8 ^ 2")
-			t_insert(breakdown.OverlapChance, s_format("^8= (^7%d^8 + ^7%d^8 - 1) ^ 2 / ^7%d^8 ^ 2", waveRadius, enemyRadius, fullRadius))
-			t_insert(breakdown.OverlapChance, s_format("^8= ^7%.3f^8%%", overlapChance * 100))
+			t_insert(breakdown.OverlapChance, s_format("^8= (^7%d^8 +^7 %d^8 - 1) ^ 2 /^7 %d^8 ^ 2", waveRadius, enemyRadius, fullRadius))
+			t_insert(breakdown.OverlapChance, s_format("^8=^7 %.3f^8%%", overlapChance * 100))
 		end
 		local dpsMultiplier = 1
 		if skillPart == 2 then
@@ -811,15 +811,15 @@ local skills, mod, flag, skill = ...
 				breakdown.SkillDPSMultiplier = {}
 				t_insert(breakdown.SkillDPSMultiplier, "DPS multiplier")
 				t_insert(breakdown.SkillDPSMultiplier, "^8= 1 + ^7small explosions^8 * ^7overlap chance^8")
-				t_insert(breakdown.SkillDPSMultiplier, s_format("^8= 1 + ^7%d^8 * ^7%.2f^8", smallExplosionsPerTrap, overlapChance))
-				t_insert(breakdown.SkillDPSMultiplier, s_format("^8= ^7%.3f", dpsMultiplier))
+				t_insert(breakdown.SkillDPSMultiplier, s_format("^8= 1 +^7 %d^8 *^7 %.2f^8", smallExplosionsPerTrap, overlapChance))
+				t_insert(breakdown.SkillDPSMultiplier, s_format("^8=^7 %.3f", dpsMultiplier))
 			end
 		elseif skillPart == 3 then
 			dpsMultiplier = 1 + smallExplosionsPerTrap
 			if breakdown then
 				breakdown.SkillDPSMultiplier = {}
 				t_insert(breakdown.SkillDPSMultiplier, "DPS multiplier")
-				t_insert(breakdown.SkillDPSMultiplier, s_format("^8= 1 + ^7%d (small explosions)", dpsMultiplier))
+				t_insert(breakdown.SkillDPSMultiplier, s_format("^8= 1 +^7 %d (small explosions)", dpsMultiplier))
 			end
 		end
 		if dpsMultiplier ~= 1 then
@@ -1498,8 +1498,9 @@ local skills, mod, flag, skill = ...
 		local wavePulseRate = incFrequency * moreFrequency / baseInterval
 		skillData.hitTimeOverride = 1 / wavePulseRate
 		output.WavePulseRate = wavePulseRate
+		local incDuration = (1 + skillModList:Sum("INC", skillCfg, "Duration") / 100)
 		local moreDuration = skillModList:More(skillCfg, "Duration")
-		local duration = output.Duration
+		local duration = skillData.duration * incDuration * moreDuration
 		local pulses = math.floor(duration * wavePulseRate)
 		output.PulsesPerTrap = pulses
 		local effectiveDuration = pulses / wavePulseRate
@@ -1521,8 +1522,8 @@ local skills, mod, flag, skill = ...
 			t_insert(breakdown.OverlapChance, "Chance for individual wave to land within range to damage enemy:")
 			t_insert(breakdown.OverlapChance, "^8= (area where wave can spawn to damage enemy) / (total area)")
 			t_insert(breakdown.OverlapChance, "^8= (^7secondary radius^8 + ^7enemy radius^8 - 1) ^ 2 / ^7radius^8 ^ 2")
-			t_insert(breakdown.OverlapChance, s_format("^8= (^7%d^8 + ^7%d^8 - 1) ^ 2 / ^7%d^8 ^ 2", waveRadius, enemyRadius, fullRadius))
-			t_insert(breakdown.OverlapChance, s_format("^8= ^7%.3f^8%%", overlapChance * 100))
+			t_insert(breakdown.OverlapChance, s_format("^8= (^7%d^8 +^7 %d^8 - 1) ^ 2 /^7 %d^8 ^ 2", waveRadius, enemyRadius, fullRadius))
+			t_insert(breakdown.OverlapChance, s_format("^8=^7 %.3f^8%%", overlapChance * 100))
 			breakdown.WavePulseRate = { }
 			t_insert(breakdown.WavePulseRate, "Pulse rate:")
 			t_insert(breakdown.WavePulseRate, s_format("%.2f ^8(base pulse rate)", 1 / baseInterval))
@@ -1531,16 +1532,22 @@ local skills, mod, flag, skill = ...
 			t_insert(breakdown.WavePulseRate, s_format("= %.2f^8/s", wavePulseRate))
 			breakdown.PulsesPerTrap = { }
 			t_insert(breakdown.PulsesPerTrap, "Pulses per trap:")
-			t_insert(breakdown.PulsesPerTrap, s_format("%.3f ^8(skill duration)", duration))
+			t_insert(breakdown.PulsesPerTrap, s_format("%.3f ^8(unrounded skill duration)", duration))
 			t_insert(breakdown.PulsesPerTrap, s_format("* %.2f ^8(pulse rate)", wavePulseRate))
 			t_insert(breakdown.PulsesPerTrap, s_format("= %.2f ^8pulses", duration * wavePulseRate))
 			t_insert(breakdown.PulsesPerTrap, "^8rounded down")
 			t_insert(breakdown.PulsesPerTrap, s_format("= %d ^8pulses", pulses))
-			t_insert(breakdown.PulsesPerTrap, s_format("^8Next breakpoint: %d%% increased Trap Throwing Speed / %d%% increased Duration", math.ceil(100 * (incFrequency * (pulses + 1) / (duration * wavePulseRate) - incFrequency)), math.ceil(100 * ((pulses + 1) / wavePulseRate / skillData.duration / moreDuration  - output.DurationMod / moreDuration ))))
-			t_insert(breakdown.PulsesPerTrap, s_format("^8Previous breakpoint: %d%% reduced Trap Throwing Speed / %d%% reduced Duration", -math.ceil(100 * (incFrequency * pulses / (duration * wavePulseRate) - incFrequency) - 1), -math.ceil(100 * (pulses / wavePulseRate / skillData.duration - output.DurationMod - 0.01) * moreDuration)))
+			t_insert(breakdown.PulsesPerTrap, s_format("^8Next breakpoint: %d%% increased Trap Throwing Speed / %d%% increased Duration",
+					math.ceil(100 * ((pulses + 1) * baseInterval / (duration * moreFrequency) - incFrequency)),
+					math.ceil(100 * ((pulses + 1) / (wavePulseRate * skillData.duration * moreDuration) - incDuration))
+			))
+			t_insert(breakdown.PulsesPerTrap, s_format("^8Previous breakpoint: %d%% reduced Trap Throwing Speed / %d%% reduced Duration",
+					-math.ceil(100 * (pulses * baseInterval / (duration * moreFrequency) - incFrequency) - 1),
+					-math.ceil(100 * (pulses / (wavePulseRate * skillData.duration * moreDuration) - incDuration) - 1)
+			))
 			breakdown.AverageActiveTraps = { }
 			t_insert(breakdown.AverageActiveTraps, "Average active traps, not considering stored cooldown uses:")
-			t_insert(breakdown.AverageActiveTraps, s_format("%.2f^8 / ^7%.2f^8 (pulses / pulse rate = effective skill duration)", pulses, wavePulseRate))
+			t_insert(breakdown.AverageActiveTraps, s_format("%.2f^8 /^7 %.2f^8 (pulses / pulse rate = effective skill duration)", pulses, wavePulseRate))
 			t_insert(breakdown.AverageActiveTraps, s_format("/ %.2f ^8(cooldown)", cooldown))
 			t_insert(breakdown.AverageActiveTraps, s_format("= %.2f traps", averageActiveTraps))
 		end
@@ -1552,22 +1559,22 @@ local skills, mod, flag, skill = ...
 				breakdown.SkillDPSMultiplier = {}
 				t_insert(breakdown.SkillDPSMultiplier, "DPS multiplier")
 				t_insert(breakdown.SkillDPSMultiplier, "^8= ^7maximum waves^8 * ^7overlap chance^8")
-				t_insert(breakdown.SkillDPSMultiplier, s_format("^8= ^7%d^8 * ^7%.2f^8", maxWaves, overlapChance))
-				t_insert(breakdown.SkillDPSMultiplier, s_format("^8= ^7%.3f", dpsMultiplier))
+				t_insert(breakdown.SkillDPSMultiplier, s_format("^8=^7 %d^8 *^7 %.2f^8", maxWaves, overlapChance))
+				t_insert(breakdown.SkillDPSMultiplier, s_format("^8=^7 %.3f", dpsMultiplier))
 			end
 		elseif skillPart == 3 then
 			dpsMultiplier = maxWaves
 			if breakdown then
 				breakdown.SkillDPSMultiplier = {}
 				t_insert(breakdown.SkillDPSMultiplier, "DPS multiplier")
-				t_insert(breakdown.SkillDPSMultiplier, s_format("^8= ^7%d (maximum waves)", dpsMultiplier))
+				t_insert(breakdown.SkillDPSMultiplier, s_format("^8=^7 %d (maximum waves)", dpsMultiplier))
 			end
 		elseif skillPart == 4 then
 			dpsMultiplier = averageActiveTraps
 			if breakdown then
 				breakdown.SkillDPSMultiplier = {}
 				t_insert(breakdown.SkillDPSMultiplier, "DPS multiplier")
-				t_insert(breakdown.SkillDPSMultiplier, s_format("^8= ^7%.2f (average active traps)", dpsMultiplier))
+				t_insert(breakdown.SkillDPSMultiplier, s_format("^8=^7 %.2f (average active traps)", dpsMultiplier))
 			end
 		elseif skillPart == 5 then
 			dpsMultiplier = averageActiveTraps * maxWaves * overlapChance
@@ -1575,8 +1582,8 @@ local skills, mod, flag, skill = ...
 				breakdown.SkillDPSMultiplier = {}
 				t_insert(breakdown.SkillDPSMultiplier, "DPS multiplier")
 				t_insert(breakdown.SkillDPSMultiplier, "^8= ^7average active traps^8 * ^7maximum waves^8 * ^7overlap chance^8")
-				t_insert(breakdown.SkillDPSMultiplier, s_format("^8= ^7%.2f^8 * ^7%d^8 * ^7%.2f", averageActiveTraps, maxWaves, overlapChance))
-				t_insert(breakdown.SkillDPSMultiplier, s_format("^8= ^7%.3f", dpsMultiplier))
+				t_insert(breakdown.SkillDPSMultiplier, s_format("^8=^7 %.2f^8 *^7 %d^8 *^7 %.2f", averageActiveTraps, maxWaves, overlapChance))
+				t_insert(breakdown.SkillDPSMultiplier, s_format("^8=^7 %.3f", dpsMultiplier))
 			end
 		elseif skillPart == 6 then
 			dpsMultiplier = averageActiveTraps * maxWaves
@@ -1584,8 +1591,8 @@ local skills, mod, flag, skill = ...
 				breakdown.SkillDPSMultiplier = {}
 				t_insert(breakdown.SkillDPSMultiplier, "DPS multiplier")
 				t_insert(breakdown.SkillDPSMultiplier, "^8= ^7average active traps^8 * ^7maximum waves")
-				t_insert(breakdown.SkillDPSMultiplier, s_format("^8= ^7%.2f^8 * ^7%d", averageActiveTraps, maxWaves))
-				t_insert(breakdown.SkillDPSMultiplier, s_format("^8= ^7%.3f", dpsMultiplier))
+				t_insert(breakdown.SkillDPSMultiplier, s_format("^8=^7 %.2f^8 *^7 %d", averageActiveTraps, maxWaves))
+				t_insert(breakdown.SkillDPSMultiplier, s_format("^8=^7 %.3f", dpsMultiplier))
 			end
 		end
 		if dpsMultiplier ~= 1 then

--- a/src/Export/Skills/act_int.txt
+++ b/src/Export/Skills/act_int.txt
@@ -114,8 +114,8 @@ local skills, mod, flag, skill = ...
 					local breakdownDpsMult = {}
 					t_insert(breakdownDpsMult, "Average DPS multiplier")
 					t_insert(breakdownDpsMult, s_format("^8= 1 * (^7super chance^8) + 1.5 * (1 - ^7super chance^8)"))
-					t_insert(breakdownDpsMult, s_format("^8= 1 * ^7%d%%^8 + 1.5 * ^7%d%%^8", superchance * 100, 100 - superchance * 100))
-					t_insert(breakdownDpsMult, s_format("^7= ^7%.3f", dpsMultiplier))
+					t_insert(breakdownDpsMult, s_format("^8= 1 *^7 %d%%^8 + 1.5 *^7 %d%%^8", superchance * 100, 100 - superchance * 100))
+					t_insert(breakdownDpsMult, s_format("^7=^7 %.3f", dpsMultiplier))
 					breakdown.SkillDPSMultiplier = breakdownDpsMult
 				end
 			else
@@ -193,10 +193,10 @@ local skills, mod, flag, skill = ...
 					if superchance > 0 then
 						t_insert(breakdownHits, "Applicable to all balls:")
 					end
-					t_insert(breakdownHits, s_format("^8Balls travel at ^7%.2f^8 units/sec.", ballDistPerSec))
-					t_insert(breakdownHits, s_format("^8Lightning bolts strike all nearby enemies every ^7%.2f^8 seconds (^7%.2f^8 strikes/sec).", secsPerStrike, 1 / secsPerStrike))
-					t_insert(breakdownHits, s_format("^8Balls travel ^7%.2f^8 units between each bolt strike.", ballDistPerStrike))
-					t_insert(breakdownHits, s_format("^8Assumes balls are cast ^7%d^8 units from the enemy.", castDist))
+					t_insert(breakdownHits, s_format("^8Balls travel at^7 %.2f^8 units/sec.", ballDistPerSec))
+					t_insert(breakdownHits, s_format("^8Lightning bolts strike all nearby enemies every^7 %.2f^8 seconds (^7%.2f^8 strikes/sec).", secsPerStrike, 1 / secsPerStrike))
+					t_insert(breakdownHits, s_format("^8Balls travel^7 %.2f^8 units between each bolt strike.", ballDistPerStrike))
+					t_insert(breakdownHits, s_format("^8Assumes balls are cast^7 %d^8 units from the enemy.", castDist))
 					if superchance > 0 then
 						if isSuperball then
 							t_insert(breakdownHits, "Applicable to supercharged balls only:")
@@ -204,14 +204,14 @@ local skills, mod, flag, skill = ...
 							t_insert(breakdownHits, "Applicable to normal balls only:")
 						end
 					end
-					t_insert(breakdownHits, s_format("^8Balls can strike enemies up to ^7%d^8 units away from themselves.", strikeRadius))
-					t_insert(breakdownHits, s_format("^8The first strike is at ^7%.2f^8 seconds after it is cast, when the ball is ^7%d^8 units from the cast point.", firstStrikeIdxThatHits * secsPerStrike, firstStrikeIdxThatHits * ballDistPerStrike))
-					t_insert(breakdownHits, s_format("^8The last strike is at ^7%.2f^8 seconds after it is cast, when the ball is ^7%d^8 units from the cast point.", lastStrikeIdxThatHits * secsPerStrike, lastStrikeIdxThatHits * ballDistPerStrike))
+					t_insert(breakdownHits, s_format("^8Balls can strike enemies up to^7 %d^8 units away from themselves.", strikeRadius))
+					t_insert(breakdownHits, s_format("^8The first strike is at^7 %.2f^8 seconds after it is cast, when the ball is^7 %d^8 units from the cast point.", firstStrikeIdxThatHits * secsPerStrike, firstStrikeIdxThatHits * ballDistPerStrike))
+					t_insert(breakdownHits, s_format("^8The last strike is at^7 %.2f^8 seconds after it is cast, when the ball is^7 %d^8 units from the cast point.", lastStrikeIdxThatHits * secsPerStrike, lastStrikeIdxThatHits * ballDistPerStrike))
 					if superchance > 0 then
 						if isSuperball then
-							t_insert(breakdownHits, s_format("^8Balls have a(n) ^7%.1f%%^8 chance to be supercharged.", superchance * 100))
+							t_insert(breakdownHits, s_format("^8Balls have a(n)^7 %.1f%%^8 chance to be supercharged.", superchance * 100))
 						else
-							t_insert(breakdownHits, s_format("^8Balls have a(n) ^7%.1f%%^8 chance to be normal.", 100 - superchance * 100))
+							t_insert(breakdownHits, s_format("^8Balls have a(n)^7 %.1f%%^8 chance to be normal.", 100 - superchance * 100))
 						end
 					end
 					if isSuperball then
@@ -228,8 +228,8 @@ local skills, mod, flag, skill = ...
 					local breakdownDpsMult = {}
 					t_insert(breakdownDpsMult, "Average DPS multiplier")
 					t_insert(breakdownDpsMult, s_format("^8= 1 * (^7normal hits/cast^8) + 1.5 * (^7super hits/cast^8)"))
-					t_insert(breakdownDpsMult, s_format("^8= 1 * ^7%.3f^8 + 1.5 * ^7%.3f^8", output.NormalHitsPerCast, output.SuperchargedHitsPerCast))
-					t_insert(breakdownDpsMult, s_format("^8= ^7%.3f", dpsMultiplier))
+					t_insert(breakdownDpsMult, s_format("^8= 1 *^7 %.3f^8 + 1.5 *^7 %.3f^8", output.NormalHitsPerCast, output.SuperchargedHitsPerCast))
+					t_insert(breakdownDpsMult, s_format("^8=^7 %.3f", dpsMultiplier))
 					breakdown.SkillDPSMultiplier = breakdownDpsMult
 				end
 			end
@@ -978,16 +978,16 @@ local skills, mod, flag, skill = ...
 		if breakdown then
 			local FRDamageTaken = {}
 			t_insert(FRDamageTaken, "Damage Taken per Cast")
-			t_insert(FRDamageTaken, s_format("^8=^7 %d^8 (Life) * ^7%d%%^8 (of Life taken as Chaos Damage)", life, activeSkill.skillData.SelfDamageTakenLife * 100))
+			t_insert(FRDamageTaken, s_format("^8=^7 %d^8 (Life) *^7 %d%%^8 (of Life taken as Chaos Damage)", life, activeSkill.skillData.SelfDamageTakenLife * 100))
 			if energyShield ~= 0 then
-				t_insert(FRDamageTaken, s_format("^8+^7 %d^8 (ES) * ^7%d%%^8 (of ES taken as Chaos Damage)", energyShield, activeSkill.skillData.SelfDamageTakenES * 100))
+				t_insert(FRDamageTaken, s_format("^8+^7 %d^8 (ES) *^7 %d%%^8 (of ES taken as Chaos Damage)", energyShield, activeSkill.skillData.SelfDamageTakenES * 100))
 			end
-			t_insert(FRDamageTaken, s_format("^8=^7 %d^8 (Chaos Damage) * ^7%d%%^8 (Chaos Resistance)", life * activeSkill.skillData.SelfDamageTakenLife + energyShield * activeSkill.skillData.SelfDamageTakenES, chaosResistance))
+			t_insert(FRDamageTaken, s_format("^8=^7 %d^8 (Chaos Damage) *^7 %d%%^8 (Chaos Resistance)", life * activeSkill.skillData.SelfDamageTakenLife + energyShield * activeSkill.skillData.SelfDamageTakenES, chaosResistance))
 			if chaosFlat ~= 0 then
 				t_insert(FRDamageTaken, s_format("^8 -^7 %d^8 (Flat Damage reduction)", -basetakenFlat))
 			end
 			if chaosDamageTaken ~= 1 then
-				t_insert(FRDamageTaken, s_format("^8 * ^7%.2f^8 (Damage taken Multiplier)", chaosDamageTaken))
+				t_insert(FRDamageTaken, s_format("^8 *^7 %.2f^8 (Damage taken Multiplier)", chaosDamageTaken))
 			end
 			t_insert(FRDamageTaken, s_format("^8=^7 %d^8 (Damage taken)", SelfDamageTakenLife + SelfDamageTakenES + chaosFlat))
 			breakdown.FRDamageTaken = FRDamageTaken
@@ -1428,151 +1428,158 @@ local skills, mod, flag, skill = ...
 
 #skill LightningTowerTrap
 #flags spell trap duration area
-    parts = {
-        {
-            name = "One wave hitting",
-        },
-        {
-            name = "Average waves hitting configured size enemy",
-        },
-        {
-            name = "All waves hitting",
-        },
-        {
-            name = "Average active traps, one wave",
-        },
-        {
-            name = "Average active traps, average waves",
-        },
-        {
-            name = "Average active traps, all waves",
-        },
-    },
-    preDamageFunc = function(activeSkill, output, breakdown)
-        local skillCfg = activeSkill.skillCfg
-        local skillData = activeSkill.skillData
-        local skillPart = activeSkill.skillPart
-        local skillModList = activeSkill.skillModList
-        local t_insert = table.insert
-        local s_format = string.format
+	parts = {
+		{
+			name = "One wave hitting",
+		},
+		{
+			name = "Average waves hitting configured size enemy",
+		},
+		{
+			name = "All waves hitting",
+		},
+		{
+			name = "Average active traps, one wave",
+		},
+		{
+			name = "Average active traps, average waves",
+		},
+		{
+			name = "Average active traps, all waves",
+		},
+	},
+	preDamageFunc = function(activeSkill, output, breakdown)
+		local skillCfg = activeSkill.skillCfg
+		local skillData = activeSkill.skillData
+		local skillPart = activeSkill.skillPart
+		local skillModList = activeSkill.skillModList
+		local t_insert = table.insert
+		local s_format = string.format
 
-        -- seemingly the only mechanical difference with seismic trap - this one does not scale it's total radius with AoE modifiers
-        output.AreaOfEffectRadius = skillData.radius
-        if breakdown then
-            breakdown.AreaOfEffectRadius = {"Targeting area of this skill is not affected by Area of Effect modifiers."}
-        end
+		-- seemingly the only mechanical difference with seismic trap - this one does not scale it's total radius with AoE modifiers
+		output.AreaOfEffectRadius = skillData.radius
+		if breakdown then
+			breakdown.AreaOfEffectRadius = {"Targeting area of this skill is not affected by Area of Effect modifiers."}
+		end
 
-        local baseInterval = skillData.repeatInterval
-        local incFrequency = (1 + skillModList:Sum("INC", skillCfg, "TrapThrowingSpeed") / 100)
-        local moreFrequency = skillModList:More(skillCfg, "TrapThrowingSpeed")
-        local wavePulseRate = incFrequency * moreFrequency / baseInterval
-        skillData.hitTimeOverride = 1 / wavePulseRate
-        output.WavePulseRate = wavePulseRate
-        local moreDuration = skillModList:More(skillCfg, "Duration")
-        local duration = output.Duration
-        local pulses = math.floor(duration * wavePulseRate)
-        output.PulsesPerTrap = pulses
-        local effectiveDuration = pulses / wavePulseRate
-        local cooldown = output.TrapCooldown
-        local averageActiveTraps = effectiveDuration / cooldown
-        output.AverageActiveTraps = averageActiveTraps
-        local function hitChance(enemyRadius, areaDamageRadius, areaSpreadRadius) -- not to be confused with attack hit chance
-            local damagingAreaRadius = areaDamageRadius + enemyRadius - 1	-- radius where area damage can land to hit the enemy;
-            -- -1 because of two assumptions: PoE coordinates are integers and damage is not registered if the two areas only share a point or vertex. If either is not correct, then -1 is not needed.
-            return math.min(damagingAreaRadius * damagingAreaRadius / (areaSpreadRadius * areaSpreadRadius), 1)
-        end
+		local baseInterval = skillData.repeatInterval
+		local incFrequency = (1 + skillModList:Sum("INC", skillCfg, "TrapThrowingSpeed", "SeismicPulseFrequency") / 100)
+		local moreFrequency = skillModList:More(skillCfg, "TrapThrowingSpeed", "SeismicPulseFrequency")
+		local wavePulseRate = incFrequency * moreFrequency / baseInterval
+		skillData.hitTimeOverride = 1 / wavePulseRate
+		output.WavePulseRate = wavePulseRate
+		local incDuration = (1 + skillModList:Sum("INC", skillCfg, "Duration") / 100)
+		local moreDuration = skillModList:More(skillCfg, "Duration")
+		local duration = skillData.duration * incDuration * moreDuration
+		local pulses = math.floor(duration * wavePulseRate)
+		output.PulsesPerTrap = pulses
+		local effectiveDuration = pulses / wavePulseRate
+		local cooldown = output.TrapCooldown
+		local averageActiveTraps = effectiveDuration / cooldown
+		output.AverageActiveTraps = averageActiveTraps
+		local function hitChance(enemyRadius, areaDamageRadius, areaSpreadRadius) -- not to be confused with attack hit chance
+			local damagingAreaRadius = areaDamageRadius + enemyRadius - 1	-- radius where area damage can land to hit the enemy;
+			-- -1 because of two assumptions: PoE coordinates are integers and damage is not registered if the two areas only share a point or vertex. If either is not correct, then -1 is not needed.
+			return math.min(damagingAreaRadius * damagingAreaRadius / (areaSpreadRadius * areaSpreadRadius), 1)
+		end
 		local enemyRadius = skillModList:Override(skillCfg, "EnemyRadius") or skillModList:Sum("BASE", skillCfg, "EnemyRadius")
-        local waveRadius = output.AreaOfEffectRadiusSecondary
-        local fullRadius = output.AreaOfEffectRadius
-        local overlapChance = hitChance(enemyRadius, waveRadius, fullRadius)
-        output.OverlapChance = overlapChance * 100
-        if breakdown then
-            breakdown.OverlapChance = { }
-            t_insert(breakdown.OverlapChance, "Chance for individual wave to land within range to damage enemy:")
-            t_insert(breakdown.OverlapChance, "^8= (area where wave can spawn to damage enemy) / (total area)")
-            t_insert(breakdown.OverlapChance, "^8= (^7secondary radius^8 + ^7enemy radius^8 - 1) ^ 2 / ^7radius^8 ^ 2")
-            t_insert(breakdown.OverlapChance, s_format("^8= (^7%d^8 + ^7%d^8 - 1) ^ 2 / ^7%d^8 ^ 2", waveRadius, enemyRadius, fullRadius))
-            t_insert(breakdown.OverlapChance, s_format("^8= ^7%.3f^8%%", overlapChance * 100))
-            breakdown.WavePulseRate = { }
-            t_insert(breakdown.WavePulseRate, "Pulse rate:")
-            t_insert(breakdown.WavePulseRate, s_format("%.2f ^8(base pulse rate)", 1 / baseInterval))
-            t_insert(breakdown.WavePulseRate, s_format("* %.2f ^8(increased/reduced pulse frequency)", incFrequency))
-            t_insert(breakdown.WavePulseRate, s_format("* %.2f ^8(more/less pulse frequency)", moreFrequency))
-            t_insert(breakdown.WavePulseRate, s_format("= %.2f^8/s", wavePulseRate))
-            breakdown.PulsesPerTrap = { }
-            t_insert(breakdown.PulsesPerTrap, "Pulses per trap:")
-            t_insert(breakdown.PulsesPerTrap, s_format("%.3f ^8(skill duration)", duration))
-            t_insert(breakdown.PulsesPerTrap, s_format("* %.2f ^8(pulse rate)", wavePulseRate))
-            t_insert(breakdown.PulsesPerTrap, s_format("= %.2f ^8pulses", duration * wavePulseRate))
-            t_insert(breakdown.PulsesPerTrap, "^8rounded down")
-            t_insert(breakdown.PulsesPerTrap, s_format("= %d ^8pulses", pulses))
-            t_insert(breakdown.PulsesPerTrap, s_format("^8Next breakpoint: %d%% increased Trap Throwing Speed / %d%% increased Duration", math.ceil(100 * (incFrequency * (pulses + 1) / (duration * wavePulseRate) - incFrequency)), math.ceil(100 * ((pulses + 1) / wavePulseRate / skillData.duration / moreDuration  - output.DurationMod / moreDuration ))))
-            t_insert(breakdown.PulsesPerTrap, s_format("^8Previous breakpoint: %d%% reduced Trap Throwing Speed / %d%% reduced Duration", -math.ceil(100 * (incFrequency * pulses / (duration * wavePulseRate) - incFrequency) - 1), -math.ceil(100 * (pulses / wavePulseRate / skillData.duration - output.DurationMod - 0.01) * moreDuration)))
-            breakdown.AverageActiveTraps = { }
-            t_insert(breakdown.AverageActiveTraps, "Average active traps, not considering stored cooldown uses:")
-            t_insert(breakdown.AverageActiveTraps, s_format("%.2f^8 / ^7%.2f^8 (pulses / pulse rate = effective skill duration)", pulses, wavePulseRate))
-            t_insert(breakdown.AverageActiveTraps, s_format("/ %.2f ^8(cooldown)", cooldown))
-            t_insert(breakdown.AverageActiveTraps, s_format("= %.2f traps", averageActiveTraps))
-        end
-        local maxWaves = skillModList:Sum("BASE", skillCfg, "MaximumWaves")
-        local dpsMultiplier = 1
-        if skillPart == 2 then
-            dpsMultiplier = maxWaves * overlapChance
-            if breakdown then
-                breakdown.SkillDPSMultiplier = {}
-                t_insert(breakdown.SkillDPSMultiplier, "DPS multiplier")
-                t_insert(breakdown.SkillDPSMultiplier, "^8= ^7maximum waves^8 * ^7overlap chance^8")
-                t_insert(breakdown.SkillDPSMultiplier, s_format("^8= ^7%d^8 * ^7%.2f^8", maxWaves, overlapChance))
-                t_insert(breakdown.SkillDPSMultiplier, s_format("^8= ^7%.3f", dpsMultiplier))
-            end
-        elseif skillPart == 3 then
-            dpsMultiplier = maxWaves
-            if breakdown then
-                breakdown.SkillDPSMultiplier = {}
-                t_insert(breakdown.SkillDPSMultiplier, "DPS multiplier")
-                t_insert(breakdown.SkillDPSMultiplier, s_format("^8= ^7%d (maximum waves)", dpsMultiplier))
-            end
-        elseif skillPart == 4 then
-            dpsMultiplier = averageActiveTraps
-            if breakdown then
-                breakdown.SkillDPSMultiplier = {}
-                t_insert(breakdown.SkillDPSMultiplier, "DPS multiplier")
-                t_insert(breakdown.SkillDPSMultiplier, s_format("^8= ^7%.2f (average active traps)", dpsMultiplier))
-            end
-        elseif skillPart == 5 then
-            dpsMultiplier = averageActiveTraps * maxWaves * overlapChance
-            if breakdown then
-                breakdown.SkillDPSMultiplier = {}
-                t_insert(breakdown.SkillDPSMultiplier, "DPS multiplier")
-                t_insert(breakdown.SkillDPSMultiplier, "^8= ^7average active traps^8 * ^7maximum waves^8 * ^7overlap chance^8")
-                t_insert(breakdown.SkillDPSMultiplier, s_format("^8= ^7%.2f^8 * ^7%d^8 * ^7%.2f", averageActiveTraps, maxWaves, overlapChance))
-                t_insert(breakdown.SkillDPSMultiplier, s_format("^8= ^7%.3f", dpsMultiplier))
-            end
-        elseif skillPart == 6 then
-            dpsMultiplier = averageActiveTraps * maxWaves
-            if breakdown then
-                breakdown.SkillDPSMultiplier = {}
-                t_insert(breakdown.SkillDPSMultiplier, "DPS multiplier")
-                t_insert(breakdown.SkillDPSMultiplier, "^8= ^7average active traps^8 * ^7maximum waves")
-                t_insert(breakdown.SkillDPSMultiplier, s_format("^8= ^7%.2f^8 * ^7%d", averageActiveTraps, maxWaves))
-                t_insert(breakdown.SkillDPSMultiplier, s_format("^8= ^7%.3f", dpsMultiplier))
-            end
-        end
-        if dpsMultiplier ~= 1 then
-            skillData.dpsMultiplier = (skillData.dpsMultiplier or 1) * dpsMultiplier
-            output.SkillDPSMultiplier = (output.SkillDPSMultiplier or 1) * dpsMultiplier
-        end
-    end,
-    statMap = {
-        ["base_skill_show_average_damage_instead_of_dps"] = {},
-        ["lightning_tower_trap_base_interval_duration_ms"] = {
-            skill("repeatInterval", nil),
-            div = 1000,
-        },
-        ["lightning_tower_trap_number_of_beams"] = {
-            mod("MaximumWaves", "BASE", nil),
-        },
-    },
+		local waveRadius = output.AreaOfEffectRadiusSecondary
+		local fullRadius = output.AreaOfEffectRadius
+		local overlapChance = hitChance(enemyRadius, waveRadius, fullRadius)
+		output.OverlapChance = overlapChance * 100
+		if breakdown then
+			breakdown.OverlapChance = { }
+			t_insert(breakdown.OverlapChance, "Chance for individual wave to land within range to damage enemy:")
+			t_insert(breakdown.OverlapChance, "^8= (area where wave can spawn to damage enemy) / (total area)")
+			t_insert(breakdown.OverlapChance, "^8= (^7secondary radius^8 + ^7enemy radius^8 - 1) ^ 2 / ^7radius^8 ^ 2")
+			t_insert(breakdown.OverlapChance, s_format("^8= (^7%d^8 +^7 %d^8 - 1) ^ 2 /^7 %d^8 ^ 2", waveRadius, enemyRadius, fullRadius))
+			t_insert(breakdown.OverlapChance, s_format("^8=^7 %.3f^8%%", overlapChance * 100))
+			breakdown.WavePulseRate = { }
+			t_insert(breakdown.WavePulseRate, "Pulse rate:")
+			t_insert(breakdown.WavePulseRate, s_format("%.2f ^8(base pulse rate)", 1 / baseInterval))
+			t_insert(breakdown.WavePulseRate, s_format("* %.2f ^8(increased/reduced pulse frequency)", incFrequency))
+			t_insert(breakdown.WavePulseRate, s_format("* %.2f ^8(more/less pulse frequency)", moreFrequency))
+			t_insert(breakdown.WavePulseRate, s_format("= %.2f^8/s", wavePulseRate))
+			breakdown.PulsesPerTrap = { }
+			t_insert(breakdown.PulsesPerTrap, "Pulses per trap:")
+			t_insert(breakdown.PulsesPerTrap, s_format("%.3f ^8(unrounded skill duration)", duration))
+			t_insert(breakdown.PulsesPerTrap, s_format("* %.2f ^8(pulse rate)", wavePulseRate))
+			t_insert(breakdown.PulsesPerTrap, s_format("= %.2f ^8pulses", duration * wavePulseRate))
+			t_insert(breakdown.PulsesPerTrap, "^8rounded down")
+			t_insert(breakdown.PulsesPerTrap, s_format("= %d ^8pulses", pulses))
+			t_insert(breakdown.PulsesPerTrap, s_format("^8Next breakpoint: %d%% increased Trap Throwing Speed / %d%% increased Duration",
+					math.ceil(100 * ((pulses + 1) * baseInterval / (duration * moreFrequency) - incFrequency)),
+					math.ceil(100 * ((pulses + 1) / (wavePulseRate * skillData.duration * moreDuration) - incDuration))
+			))
+			t_insert(breakdown.PulsesPerTrap, s_format("^8Previous breakpoint: %d%% reduced Trap Throwing Speed / %d%% reduced Duration",
+					-math.ceil(100 * (pulses * baseInterval / (duration * moreFrequency) - incFrequency) - 1),
+					-math.ceil(100 * (pulses / (wavePulseRate * skillData.duration * moreDuration) - incDuration) - 1)
+			))
+			breakdown.AverageActiveTraps = { }
+			t_insert(breakdown.AverageActiveTraps, "Average active traps, not considering stored cooldown uses:")
+			t_insert(breakdown.AverageActiveTraps, s_format("%.2f^8 /^7 %.2f^8 (pulses / pulse rate = effective skill duration)", pulses, wavePulseRate))
+			t_insert(breakdown.AverageActiveTraps, s_format("/ %.2f ^8(cooldown)", cooldown))
+			t_insert(breakdown.AverageActiveTraps, s_format("= %.2f traps", averageActiveTraps))
+		end
+		local maxWaves = skillModList:Sum("BASE", skillCfg, "MaximumWaves")
+		local dpsMultiplier = 1
+		if skillPart == 2 then
+			dpsMultiplier = maxWaves * overlapChance
+			if breakdown then
+				breakdown.SkillDPSMultiplier = {}
+				t_insert(breakdown.SkillDPSMultiplier, "DPS multiplier")
+				t_insert(breakdown.SkillDPSMultiplier, "^8= ^7maximum waves^8 * ^7overlap chance^8")
+				t_insert(breakdown.SkillDPSMultiplier, s_format("^8=^7 %d^8 *^7 %.2f^8", maxWaves, overlapChance))
+				t_insert(breakdown.SkillDPSMultiplier, s_format("^8=^7 %.3f", dpsMultiplier))
+			end
+		elseif skillPart == 3 then
+			dpsMultiplier = maxWaves
+			if breakdown then
+				breakdown.SkillDPSMultiplier = {}
+				t_insert(breakdown.SkillDPSMultiplier, "DPS multiplier")
+				t_insert(breakdown.SkillDPSMultiplier, s_format("^8=^7 %d (maximum waves)", dpsMultiplier))
+			end
+		elseif skillPart == 4 then
+			dpsMultiplier = averageActiveTraps
+			if breakdown then
+				breakdown.SkillDPSMultiplier = {}
+				t_insert(breakdown.SkillDPSMultiplier, "DPS multiplier")
+				t_insert(breakdown.SkillDPSMultiplier, s_format("^8=^7 %.2f (average active traps)", dpsMultiplier))
+			end
+		elseif skillPart == 5 then
+			dpsMultiplier = averageActiveTraps * maxWaves * overlapChance
+			if breakdown then
+				breakdown.SkillDPSMultiplier = {}
+				t_insert(breakdown.SkillDPSMultiplier, "DPS multiplier")
+				t_insert(breakdown.SkillDPSMultiplier, "^8= ^7average active traps^8 * ^7maximum waves^8 * ^7overlap chance^8")
+				t_insert(breakdown.SkillDPSMultiplier, s_format("^8=^7 %.2f^8 *^7 %d^8 *^7 %.2f", averageActiveTraps, maxWaves, overlapChance))
+				t_insert(breakdown.SkillDPSMultiplier, s_format("^8=^7 %.3f", dpsMultiplier))
+			end
+		elseif skillPart == 6 then
+			dpsMultiplier = averageActiveTraps * maxWaves
+			if breakdown then
+				breakdown.SkillDPSMultiplier = {}
+				t_insert(breakdown.SkillDPSMultiplier, "DPS multiplier")
+				t_insert(breakdown.SkillDPSMultiplier, "^8= ^7average active traps^8 * ^7maximum waves")
+				t_insert(breakdown.SkillDPSMultiplier, s_format("^8=^7 %.2f^8 *^7 %d", averageActiveTraps, maxWaves))
+				t_insert(breakdown.SkillDPSMultiplier, s_format("^8=^7 %.3f", dpsMultiplier))
+			end
+		end
+		if dpsMultiplier ~= 1 then
+			skillData.dpsMultiplier = (skillData.dpsMultiplier or 1) * dpsMultiplier
+			output.SkillDPSMultiplier = (output.SkillDPSMultiplier or 1) * dpsMultiplier
+		end
+	end,
+	statMap = {
+		["base_skill_show_average_damage_instead_of_dps"] = {},
+		["lightning_tower_trap_base_interval_duration_ms"] = {
+			skill("repeatInterval", nil),
+			div = 1000,
+		},
+		["lightning_tower_trap_number_of_beams"] = {
+			mod("MaximumWaves", "BASE", nil),
+		},
+	},
 #baseMod skill("radius", 24)
 #baseMod skill("radiusLabel", "Targeting Area:")
 #baseMod skill("radiusSecondary", 10)


### PR DESCRIPTION
### Description of the problem being solved:
Number of waves that seismic (and lightning spire) traps produce does not line up with the number calculated when duration is rounded up to the nearest server tick. Also the reported stats required for next/previous breakpoints when near these rounding points would be incorrect.

### Steps taken to verify a working solution:
- In-game character seismic trap releases 20 waves. With duration rounding it would be calculated 21.02 waves; 20.99 without.

### Link to a build that showcases this PR:
https://pobb.in/WZ-m9QK64sC2

### Before screenshot:
![image](https://user-images.githubusercontent.com/36479307/208243371-62c18017-b419-43f8-9226-c46a71c7a0fb.png)

### After screenshot:
![image](https://user-images.githubusercontent.com/36479307/208243384-41501cac-b736-4ae1-90e0-e95ffcf77cd6.png)
