### PR TITLE
Improve item pricer error handling

### DIFF
--- a/src/Classes/TradeQuery.lua
+++ b/src/Classes/TradeQuery.lua
@@ -446,7 +446,13 @@ function TradeQueryClass:PriceItemRowDisplay(str_cnt, slotTbl, top_pane_alignmen
 	local activeSlotRef = slotTbl.ref and self.itemsTab.activeItemSet[slotTbl.ref] or self.itemsTab.activeItemSet[slotTbl.name]
 	controls["name"..str_cnt] = new("LabelControl", top_pane_alignment_ref, top_pane_alignment_width, top_pane_alignment_height, 100, row_height-4, "^7"..slotTbl.name)
 	controls["bestButton"..str_cnt] = new("ButtonControl", {"TOPLEFT",controls["name"..str_cnt],"TOPLEFT"}, 100 + 8, 0, 80, row_height, "Find best", function()
-		self.tradeQueryGenerator:RequestQuery(slotTbl.ref and self.itemsTab.sockets[slotTbl.ref] or self.itemsTab.slots[slotTbl.name], { slotTbl = slotTbl, controls = controls, str_cnt = str_cnt }, function(context, query)
+		self.tradeQueryGenerator:RequestQuery(slotTbl.ref and self.itemsTab.sockets[slotTbl.ref] or self.itemsTab.slots[slotTbl.name], { slotTbl = slotTbl, controls = controls, str_cnt = str_cnt }, function(context, query, errMsg)
+			if errMsg then
+				self:SetNotice(context.controls.pbNotice, colorCodes.NEGATIVE .. errMsg)
+				return
+			else
+				self:SetNotice(context.controls.pbNotice, "")
+			end
 			self.pbSortSelectionIndex = 1
 			context.controls["priceButton"..context.str_cnt].label = "Searching..."
 			self.tradeQueryRequests:SearchWithQuery(self.pbLeague, query, 

--- a/src/Classes/TradeQueryGenerator.lua
+++ b/src/Classes/TradeQueryGenerator.lua
@@ -648,8 +648,17 @@ function TradeQueryGeneratorClass:FinishQuery()
         }
     end
 
+    local errMsg = nil
+    if #queryTable.query.stats[1].filters == 0 then
+        -- No mods to filter
+        errMsg = "Could not generate search, found no mods to search for"
+        if GlobalCache.numActiveSkillInFullDPS == 0 then
+            errMsg = "Could not generate search, change active skill or enable FullDPS on some skills"
+        end
+    end
+
     local queryJson = dkjson.encode(queryTable)
-    self.requesterCallback(self.requesterContext, queryJson)
+    self.requesterCallback(self.requesterContext, queryJson, errMsg)
 
     -- Close blocker popup
     main:ClosePopup()

--- a/src/Classes/TradeQueryRequests.lua
+++ b/src/Classes/TradeQueryRequests.lua
@@ -78,7 +78,7 @@ end
 ---@param callback fun(response:table, errMsg:string)
 function TradeQueryRequestsClass:PerformSearch(league, query, callback)
 	table.insert(self.requestQueue["search"], {
-		url = "https://www.pathofexile.com/api/trade/search/"..league,
+		url = "https://www.pathofexile.com/api/trade/search/"..league:gsub(" ", "+"),
 		body = query,
 		callback = function(response, errMsg)
 			if errMsg and not errMsg:find("Response code: 400") then
@@ -184,7 +184,7 @@ function TradeQueryRequestsClass:SearchWithURL(urlEditControl, callback)
 		if errMsg then
 			return callback(nil, errMsg)
 		end
-		urlEditControl:SetText("https://www.pathofexile.com/trade/search/" .. self.tradeQuery.pbLeague .. "/" .. queryId)
+		urlEditControl:SetText("https://www.pathofexile.com/trade/search/" .. self.tradeQuery.pbLeague:gsub(" ", "+") .. "/" .. queryId)
 		self:SearchWithQuery(self.tradeQuery.pbLeague, query, callback)
 	end)
 end
@@ -194,7 +194,7 @@ end
 ---@param league string
 ---@param callback fun(query:string, errMsg:string)
 function TradeQueryRequestsClass:FetchSearchQuery(queryId, callback)
-	local url = "https://www.pathofexile.com/api/trade/search/" .. self.tradeQuery.pbLeague .. "/" .. queryId
+	local url = "https://www.pathofexile.com/api/trade/search/" .. self.tradeQuery.pbLeague:gsub(" ", "+") .. "/" .. queryId
 	table.insert(self.requestQueue["search"], {
 		url = url,
 		callback = function(response, errMsg)
@@ -222,7 +222,7 @@ function TradeQueryRequestsClass:FetchSearchQueryHTML(queryId, callback)
 	end
 	local header = "Cookie: POESESSID=" .. main.POESESSID
 	-- the league doesn't affect query so we set it to Standard as it doesn't change
-	launch:DownloadPage("https://www.pathofexile.com/trade/search/" .. self.tradeQuery.pbLeague .. "/" .. queryId, 
+	launch:DownloadPage("https://www.pathofexile.com/trade/search/" .. self.tradeQuery.pbLeague:gsub(" ", "+") .. "/" .. queryId, 
 		function(response, errMsg)
 			if errMsg then
 				return callback(nil, errMsg)

--- a/src/Classes/TradeQueryRequests.lua
+++ b/src/Classes/TradeQueryRequests.lua
@@ -91,14 +91,20 @@ function TradeQueryRequestsClass:PerformSearch(league, query, callback)
 			end
 			if not response.result or #response.result == 0 then
 				if response.error then
-					if response.error.code == 2 then
+					if not (response.error.code and response.error.message) then
+						errMsg = "Encountered unknown error, check console for details."
+						ConPrintf("Unknown error: %s", stringify(response.error))
+						callback(response, errMsg)
+					end
+					if response.error.message:find("Logging in will increase this limit") then
 						if main.POESESSID ~= "" then
 							errMsg = "POESESSID is invalid. Please Re-Log and reset"
 						else
-							errMsg = "Complex Query - Please provide your POESESSID"
+							errMsg = "Session is invalid. Please add your POESESSID"
 						end
-					elseif response.error.message then
-						errMsg = response.error.message
+					else
+						-- Report unhandled error
+						errMsg = "[ " .. response.error.code .. ": " .. response.error.message .. " ]"
 					end
 				else
 					ConPrintf("Found 0 results for " .. "https://www.pathofexile.com/trade/search/" .. league .. "/" .. response.id)
@@ -220,6 +226,10 @@ function TradeQueryRequestsClass:FetchSearchQueryHTML(queryId, callback)
 		function(response, errMsg)
 			if errMsg then
 				return callback(nil, errMsg)
+			end
+			-- check if response.header includes "Cache-Control: must-revalidate" which indicates an invalid session
+			if response.header:lower():match("cache%-control:.+must%-revalidate") then
+				return callback(nil, "Failed to get search query, check POESESSID")
 			end
 			-- full json state obj from HTML
 			local dataStr = response.body:match('require%(%["main"%].+ t%((.+)%);}%);}%);')


### PR DESCRIPTION
Fixes #5365, #5331, #5316

- Improved error handling so that we don't get generic "Invalid POESESSID" errors for unrelated problems. This is not a fix for the issues reported in [#5316](https://github.com/PathOfBuildingCommunity/PathOfBuilding/issues/5316) but we shall get more descriptive errors for similar problems. (Those problems are caused by the active skill not having an actionable DPS value, which is already being worked on by other PRs)

- Added more URL encoding to fix problems caused by league names with spaces. [#5365](https://github.com/PathOfBuildingCommunity/PathOfBuilding/issues/5365)

- Added error handling to catch invalid generator outputs earlier. When the generator cannot find any useful filters to search for, it shouldn't attempt to create a search query.