### PR TITLE
Add support for Sandstorm Visage crit mod

### DIFF
--- a/src/Modules/CalcOffence.lua
+++ b/src/Modules/CalcOffence.lua
@@ -2214,7 +2214,8 @@ function calcs.offence(env, actor, activeSkill)
 			local critOverride = skillModList:Override(cfg, "CritChance")
 			local baseCrit = critOverride or source.CritChance or 0
 
-			if skillModList:Flag(cfg, "BaseSpellCritFromMainHand") then
+			local baseSpellCritFromMainHand = skillModList:Flag(cfg, "BaseSpellCritFromMainHand")
+			if baseSpellCritFromMainHand then
 				if actor.itemList["Weapon 1"] and actor.itemList["Weapon 1"].weaponData and actor.itemList["Weapon 1"].weaponData[1] then
 					baseCrit = actor.weaponData1.CritChance
 				end
@@ -2249,10 +2250,11 @@ function calcs.offence(env, actor, activeSkill)
 				end
 				if breakdown and output.CritChance ~= baseCrit then
 					breakdown.CritChance = { }
+					local spellBaseFromMainHandStr = baseSpellCritFromMainHand and " from main weapon" or ""
 					if base ~= 0 then
-						t_insert(breakdown.CritChance, s_format("(%g + %g) ^8(base)", baseCrit, base))
+						t_insert(breakdown.CritChance, s_format("(%g + %g) ^8(base%s)", baseCrit, base, spellBaseFromMainHandStr))
 					else
-						t_insert(breakdown.CritChance, s_format("%g ^8(base)", baseCrit + base))
+						t_insert(breakdown.CritChance, s_format("%g ^8(base%s)", baseCrit + base, spellBaseFromMainHandStr))
 					end
 					if inc ~= 0 then
 						t_insert(breakdown.CritChance, s_format("x %.2f", 1 + inc/100).." ^8(increased/reduced)")

--- a/src/Modules/CalcOffence.lua
+++ b/src/Modules/CalcOffence.lua
@@ -2214,8 +2214,8 @@ function calcs.offence(env, actor, activeSkill)
 			local critOverride = skillModList:Override(cfg, "CritChance")
 			local baseCrit = critOverride or source.CritChance or 0
 
-			local baseSpellCritFromMainHand = skillModList:Flag(cfg, "BaseSpellCritFromMainHand")
-			if baseSpellCritFromMainHand then
+			local baseCritFromMainHand = skillModList:Flag(cfg, "BaseCritFromMainHand")
+			if baseCritFromMainHand then
 				if actor.itemList["Weapon 1"] and actor.itemList["Weapon 1"].weaponData and actor.itemList["Weapon 1"].weaponData[1] then
 					baseCrit = actor.weaponData1.CritChance
 				end
@@ -2250,11 +2250,11 @@ function calcs.offence(env, actor, activeSkill)
 				end
 				if breakdown and output.CritChance ~= baseCrit then
 					breakdown.CritChance = { }
-					local spellBaseFromMainHandStr = baseSpellCritFromMainHand and " from main weapon" or ""
+					local baseCritFromMainHandStr = baseCritFromMainHand and " from main weapon" or ""
 					if base ~= 0 then
-						t_insert(breakdown.CritChance, s_format("(%g + %g) ^8(base%s)", baseCrit, base, spellBaseFromMainHandStr))
+						t_insert(breakdown.CritChance, s_format("(%g + %g) ^8(base%s)", baseCrit, base, baseCritFromMainHandStr))
 					else
-						t_insert(breakdown.CritChance, s_format("%g ^8(base%s)", baseCrit + base, spellBaseFromMainHandStr))
+						t_insert(breakdown.CritChance, s_format("%g ^8(base%s)", baseCrit + base, baseCritFromMainHandStr))
 					end
 					if inc ~= 0 then
 						t_insert(breakdown.CritChance, s_format("x %.2f", 1 + inc/100).." ^8(increased/reduced)")

--- a/src/Modules/CalcOffence.lua
+++ b/src/Modules/CalcOffence.lua
@@ -2213,6 +2213,13 @@ function calcs.offence(env, actor, activeSkill)
 		else
 			local critOverride = skillModList:Override(cfg, "CritChance")
 			local baseCrit = critOverride or source.CritChance or 0
+
+			if skillModList:Flag(cfg, "BaseSpellCritFromMainHand") then
+				if actor.itemList["Weapon 1"] and actor.itemList["Weapon 1"].weaponData and actor.itemList["Weapon 1"].weaponData[1] then
+					baseCrit = actor.weaponData1.CritChance
+				end
+			end
+
 			if critOverride == 100 then
 				output.PreEffectiveCritChance = 100
 				output.CritChance = 100

--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -3668,7 +3668,7 @@ local specialModList = {
 	["when you lose temporal chains you gain maximum rage"] = { flag("Condition:CanGainRage") },
 	["your critical strike multiplier is (%d+)%%"] = function(num) return { mod("CritMultiplier", "OVERRIDE", num) } end,
 	["base critical strike chance for attacks with weapons is ([%d%.]+)%%"] = function(num) return { mod("WeaponBaseCritChance", "OVERRIDE", num) } end,
-	["base critical strike chance of spells is the critical strike chance of your main hand weapon"] = { flag("BaseSpellCritFromMainHand", nil, ModFlag.Spell) },
+	["base critical strike chance of spells is the critical strike chance of your main hand weapon"] = { flag("BaseCritFromMainHand", nil, ModFlag.Spell) },
 	["critical strike chance is (%d+)%% for hits with this weapon"] = function(num) return { mod("CritChance", "OVERRIDE", num, nil, ModFlag.Hit, { type = "Condition", var = "{Hand}Attack" }, { type = "SkillType", skillType = SkillType.Attack }) } end, 
 	["maximum critical strike chance is (%d+)%%"] = function(num) return {
 		mod("CritChanceCap", "OVERRIDE", num),

--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -3668,6 +3668,7 @@ local specialModList = {
 	["when you lose temporal chains you gain maximum rage"] = { flag("Condition:CanGainRage") },
 	["your critical strike multiplier is (%d+)%%"] = function(num) return { mod("CritMultiplier", "OVERRIDE", num) } end,
 	["base critical strike chance for attacks with weapons is ([%d%.]+)%%"] = function(num) return { mod("WeaponBaseCritChance", "OVERRIDE", num) } end,
+	["base critical strike chance of spells is the critical strike chance of your main hand weapon"] = { flag("BaseSpellCritFromMainHand", nil, ModFlag.Spell) },
 	["critical strike chance is (%d+)%% for hits with this weapon"] = function(num) return { mod("CritChance", "OVERRIDE", num, nil, ModFlag.Hit, { type = "Condition", var = "{Hand}Attack" }, { type = "SkillType", skillType = SkillType.Attack }) } end, 
 	["maximum critical strike chance is (%d+)%%"] = function(num) return {
 		mod("CritChanceCap", "OVERRIDE", num),


### PR DESCRIPTION
### Description of the problem being solved:
Add support for Sandstorm Visage main hand crit -> spell base crit

### Steps taken to verify a working solution:
- Ensured crit chance is not affected when main hand is empty
- Base chance is set to main hand's critical strike chance when a weapon is equipped in the main hand
- Base chance is increased with b

### Link to a build that showcases this PR:
https://pastebin.com/KVyAewuk

### After screenshot:
![image](https://user-images.githubusercontent.com/3247221/208254498-3909f46d-399c-4036-9a3b-302cc53dd9f8.png)
![image](https://user-images.githubusercontent.com/3247221/208254447-9e55dc96-5639-4fd5-b9f8-9bbe0c83ec6d.png)