### PR TITLE
add search trade for timeless jewels

### DIFF
--- a/src/Classes/ListControl.lua
+++ b/src/Classes/ListControl.lua
@@ -19,6 +19,8 @@
 -- :OnSelCopy(index, value)  [Called when Ctrl+C is pressed while a list value is selected]
 -- :OnSelDelete(index, value)  [Called when backspace or delete is pressed while a list value is selected]
 -- :OnSelKeyDown(index, value)  [Called when any other key is pressed while a list value is selected]
+-- :OverrideSelectIndex(index) [Called when an index is selected, return true to prevent default action]
+-- :IsRowHighlighted(index, value) [Called when querying if a row is highlighted by parent element class]
 --
 local ipairs = ipairs
 local t_insert = table.insert
@@ -72,6 +74,9 @@ end)
 function ListClass:SelectIndex(index)
 	self.selValue = self.list[index]
 	if self.selValue then
+		if self.OverrideSelectIndex and self:OverrideSelectIndex(index) then
+			return false
+		end
 		self.selIndex = index
 		local width, height = self:GetSize()
 		if self.scroll then
@@ -82,6 +87,8 @@ function ListClass:SelectIndex(index)
 			self:OnSelect(self.selIndex, self.selValue)
 		end
 	end
+
+	return true
 end
 
 function ListClass:GetColumnProperty(column, property)
@@ -251,7 +258,11 @@ function ListClass:Draw(viewPort, noTooltip)
 				end
 				DrawImage(nil, colOffset, lineY + 1, not self.scroll and colWidth - 4 or colWidth, rowHeight - 2)
 			end
-			SetDrawColor(1, 1, 1)
+			if (self.IsRowHighlighted and self:IsRowHighlighted(index, value)) then
+				SetDrawColor(1, 1, 0)
+			else
+				SetDrawColor(1, 1, 1)
+			end
 			DrawString(colOffset, lineY + textOffsetY, "LEFT", textHeight, colFont, text)
 		end
 		if self.colLabels then
@@ -313,28 +324,14 @@ function ListClass:OnKeyDown(key, doubleClick)
 		return
 	end
 	if key == "LEFTBUTTON" then
-		self.selValue = nil
-		self.selIndex = nil
+		local newSelect = nil
 		local x, y = self:GetPos()
 		local cursorX, cursorY = GetCursorPos()
 		local rowRegion = self:GetRowRegion()
 		if cursorX >= x + rowRegion.x and cursorY >= y + rowRegion.y and cursorX < x + rowRegion.x + rowRegion.width and cursorY < y + rowRegion.y + rowRegion.height then
 			local index = math.floor((cursorY - y - rowRegion.y + self.controls.scrollBarV.offset) / self.rowHeight) + 1
-			self.selValue = self.list[index]
-			if self.selValue then
-				self.selIndex = index
-				if (self.isMutable or self.dragTargetList) and self:IsShown() then
-					self.selCX = cursorX
-					self.selCY = cursorY
-					self.selDragging = true
-					self.selDragActive = false
-				end
-				if self.OnSelect then
-					self:OnSelect(self.selIndex, self.selValue)
-				end
-				if self.OnSelClick then
-					self:OnSelClick(self.selIndex, self.selValue, doubleClick)
-				end
+			if self.list[index] then
+				newSelect = index
 			end
 		else
 			for colIndex, column in ipairs(self.colList) do
@@ -344,6 +341,18 @@ function ListClass:OnKeyDown(key, doubleClick)
 				if self:GetColumnProperty(column, "sortable") and mOver and self.ReSort then
 					self:ReSort(colIndex)
 				end
+			end
+		end
+
+		if (self:SelectIndex(newSelect)) then
+			if (self.isMutable or self.dragTargetList) and self:IsShown() then
+				self.selCX = cursorX
+				self.selCY = cursorY
+				self.selDragging = true
+				self.selDragActive = false
+			end
+			if self.OnSelClick then
+				self:OnSelClick(self.selIndex, self.selValue, doubleClick)
 			end
 		end
 	elseif #self.list > 0 and not self.selDragActive then

--- a/src/Classes/ListControl.lua
+++ b/src/Classes/ListControl.lua
@@ -258,7 +258,7 @@ function ListClass:Draw(viewPort, noTooltip)
 				end
 				DrawImage(nil, colOffset, lineY + 1, not self.scroll and colWidth - 4 or colWidth, rowHeight - 2)
 			end
-			if (not self.SetHighlightColor or not self:SetHighlightColor(index, value)) then
+			if not self.SetHighlightColor or not self:SetHighlightColor(index, value) then
 				SetDrawColor(1, 1, 1)
 			end
 			DrawString(colOffset, lineY + textOffsetY, "LEFT", textHeight, colFont, text)
@@ -342,7 +342,7 @@ function ListClass:OnKeyDown(key, doubleClick)
 			end
 		end
 
-		if (self:SelectIndex(newSelect)) then
+		if self:SelectIndex(newSelect) then
 			if (self.isMutable or self.dragTargetList) and self:IsShown() then
 				self.selCX = cursorX
 				self.selCY = cursorY

--- a/src/Classes/ListControl.lua
+++ b/src/Classes/ListControl.lua
@@ -20,7 +20,7 @@
 -- :OnSelDelete(index, value)  [Called when backspace or delete is pressed while a list value is selected]
 -- :OnSelKeyDown(index, value)  [Called when any other key is pressed while a list value is selected]
 -- :OverrideSelectIndex(index) [Called when an index is selected, return true to prevent default action]
--- :IsRowHighlighted(index, value) [Called when querying if a row is highlighted by parent element class]
+-- :SetHighlightColor(index, value) [Called when querying if a row is highlighted by parent element class]
 --
 local ipairs = ipairs
 local t_insert = table.insert
@@ -258,9 +258,7 @@ function ListClass:Draw(viewPort, noTooltip)
 				end
 				DrawImage(nil, colOffset, lineY + 1, not self.scroll and colWidth - 4 or colWidth, rowHeight - 2)
 			end
-			if (self.IsRowHighlighted and self:IsRowHighlighted(index, value)) then
-				SetDrawColor(1, 1, 0)
-			else
+			if (not self.SetHighlightColor or not self:SetHighlightColor(index, value)) then
 				SetDrawColor(1, 1, 1)
 			end
 			DrawString(colOffset, lineY + textOffsetY, "LEFT", textHeight, colFont, text)

--- a/src/Classes/TimelessJewelListControl.lua
+++ b/src/Classes/TimelessJewelListControl.lua
@@ -22,11 +22,23 @@ function TimelessJewelListControlClass:Draw(viewPort, noTooltip)
 	self.ListControl.Draw(self, viewPort)
 end
 
-function TimelessJewelListControlClass:IsRowHighlighted(index, value)
+function TimelessJewelListControlClass:SetHighlightColor(index, value)
 	if not self.highlightIndex or not self.selIndex then
 		return false
 	end
-	return m_min(self.selIndex, self.highlightIndex) <= index and m_max(self.selIndex, self.highlightIndex) >= index
+	local isHighlighted = m_min(self.selIndex, self.highlightIndex) <= index and m_max(self.selIndex, self.highlightIndex) >= index
+
+	if isHighlighted then
+		if self.selIndex == index or self.highlightIndex == index then
+			SetDrawColor(1, 0.5, 0)
+		else
+			SetDrawColor(1, 1, 0)
+		end
+
+		return true
+	end
+
+	return false
 end
 
 function TimelessJewelListControlClass:OverrideSelectIndex(index)

--- a/src/Classes/TimelessJewelListControl.lua
+++ b/src/Classes/TimelessJewelListControl.lua
@@ -42,7 +42,7 @@ function TimelessJewelListControlClass:SetHighlightColor(index, value)
 end
 
 function TimelessJewelListControlClass:OverrideSelectIndex(index)
-	if (IsKeyDown("SHIFT") and self.selIndex) then
+	if IsKeyDown("SHIFT") and self.selIndex then
 		self.highlightIndex = index
 		return true
 	else

--- a/src/Classes/TimelessJewelListControl.lua
+++ b/src/Classes/TimelessJewelListControl.lua
@@ -5,6 +5,8 @@
 --
 
 local m_random = math.random
+local m_min = math.min
+local m_max = math.max
 local t_concat = table.concat
 
 local TimelessJewelListControlClass = newClass("TimelessJewelListControl", "ListControl", function(self, anchor, x, y, width, height, build)
@@ -18,6 +20,24 @@ end)
 function TimelessJewelListControlClass:Draw(viewPort, noTooltip)
 	self.noTooltip = noTooltip
 	self.ListControl.Draw(self, viewPort)
+end
+
+function TimelessJewelListControlClass:IsRowHighlighted(index, value)
+	if not self.highlightIndex or not self.selIndex then
+		return false
+	end
+	return m_min(self.selIndex, self.highlightIndex) <= index and m_max(self.selIndex, self.highlightIndex) >= index
+end
+
+function TimelessJewelListControlClass:OverrideSelectIndex(index)
+	if (IsKeyDown("SHIFT") and self.selIndex) then
+		self.highlightIndex = index
+		return true
+	else
+		self.highlightIndex = nil
+	end
+
+	return false
 end
 
 function TimelessJewelListControlClass:GetRowValue(column, index, data)

--- a/src/Classes/TimelessJewelListControl.lua
+++ b/src/Classes/TimelessJewelListControl.lua
@@ -60,7 +60,7 @@ end
 function TimelessJewelListControlClass:OnSelClick(index, data, doubleClick)
 	if doubleClick and self.list[index].label:match("B2B2B2") == nil then
 		local label = "[" .. data.seed .. "; " .. data.total.. "; " .. self.sharedList.socket.keystone .. "]\n"
-		local variant = self.sharedList.conqueror .. "\n"
+		local variant = self.sharedList.conqueror.label .. "\n"
 		local itemData = [[
 Elegant Hubris ]] .. label .. [[
 Timeless Jewel

--- a/src/Classes/TreeTab.lua
+++ b/src/Classes/TreeTab.lua
@@ -1768,9 +1768,6 @@ function TreeTabClass:FindTimelessJewel()
 			return
 		end
 
-		controls.searchTradeButton.label = "Searching..."
-		controls.searchTradeButton.enabled = false
-
 		local seedTrades = {}
 		local maxSeeds = main.POESESSID ~= "" and 50 or 10
 		local page = controls.searchTradeButton.page
@@ -1807,21 +1804,13 @@ function TreeTabClass:FindTimelessJewel()
 			}
 		}
 
-		local league = "Sanctum"
 
-		self.tradeQueryRequests:PerformSearch(league, dkjson.encode(search), function(result, err)
-			controls.searchTradeButton.enabled = true
-			if not result or not result.id then
-				controls.searchTradeButton.label = "Trade Search"
-				error(dkjson.encode(result or {err}))
-				-- TODO
-				return
-			end
+		Copy("https://www.pathofexile.com/trade/search/?q=" .. (string.gsub(dkjson.encode(search), "[^a-zA-Z0-9]", function(a)
+			return string.format("%%%02X", string.byte(a))
+		end)))
 
-			controls.searchTradeButton.label = "Copied Page #" .. controls.searchTradeButton.page
-			controls.searchTradeButton.page = controls.searchTradeButton.page + 1
-			Copy("https://www.pathofexile.com/trade/search/" .. league .. "/" .. result.id)
-		end)
+		controls.searchTradeButton.label = "Copied Page #" .. controls.searchTradeButton.page
+		controls.searchTradeButton.page = controls.searchTradeButton.page + 1
 	end)
 	controls.searchTradeButton.enabled = timelessData.searchResults and #timelessData.searchResults > 0
 	controls.searchTradeButton.page = 1

--- a/src/Classes/TreeTab.lua
+++ b/src/Classes/TreeTab.lua
@@ -1486,7 +1486,6 @@ function TreeTabClass:FindTimelessJewel()
 
 	controls.searchTradeButton = new("ButtonControl", { "BOTTOMRIGHT", controls.searchResults, "TOPRIGHT" }, 0, -5, 170, 20, "Copy Trade URL", function()
 		local seedTrades = {}
-		controls.searchResults:SelectIndex()
 		local startRow = controls.searchResults.selIndex
 		if not startRow then
 			startRow = 1
@@ -1820,16 +1819,18 @@ function TreeTabClass:FindTimelessJewel()
 				end
 			end
 			t_sort(timelessData.searchResults, function(a, b) return a.total > b.total end)
-			controls.searchTradeButton.enabled = true
+			controls.searchTradeButton.enabled = timelessData.searchResults and #timelessData.searchResults > 0		
 			controls.searchTradeButton.lastSearch = nil
 			controls.searchTradeButton.label = "Copy Trade URL"
 			controls.searchResults.highlightIndex = nil
+			controls.searchResults.selIndex = 1
 		end
 	end)
 	controls.resetButton = new("ButtonControl", nil, buttonX + (width + divider), 485, width, 20, "Reset", function()
 		updateSearchList("", true)
 		updateSearchList("", false)
 		wipeTable(timelessData.searchResults)
+		controls.searchTradeButton.enabled = false
 	end)
 	controls.closeButton = new("ButtonControl", nil, buttonX + (width + divider) * 2, 485, width, 20, "Cancel", function()
 		main:ClosePopup()

--- a/src/Classes/TreeTab.lua
+++ b/src/Classes/TreeTab.lua
@@ -31,11 +31,6 @@ local TreeTabClass = newClass("TreeTab", "ControlHost", function(self, build)
 	self:SetCompareSpec(1)
 
 	self.anchorControls = new("Control", nil, 0, 0, 0, 20)
-	
-	self.tradeQueryRequests = new("TradeQueryRequests", self)
-	table.insert(main.onFrameFuncs, function()
-		self.tradeQueryRequests:ProcessQueue()
-	end)
 
 	self.controls.specSelect = new("DropDownControl", {"LEFT",self.anchorControls,"RIGHT"}, 0, 0, 190, 20, nil, function(index, value)
 		if self.specList[index] then

--- a/src/Classes/TreeTab.lua
+++ b/src/Classes/TreeTab.lua
@@ -1484,7 +1484,7 @@ function TreeTabClass:FindTimelessJewel()
 	controls.searchResultsLabel = new("LabelControl", { "TOPLEFT", nil, "TOPRIGHT" }, -450, 250, 0, 16, "^7Search Results:")
 	controls.searchResults = new("TimelessJewelListControl", { "TOPLEFT", nil, "TOPRIGHT" }, -450, 275, 438, 200, self.build)
 
-	controls.searchTradeButton = new("ButtonControl", { "BOTTOMRIGHT", controls.searchResults, "TOPRIGHT" }, 0, -5, 130, 20, "Copy Trade URL", function()
+	controls.searchTradeButton = new("ButtonControl", { "BOTTOMRIGHT", controls.searchResults, "TOPRIGHT" }, 0, -5, 170, 20, "Copy Trade URL", function()
 		local seedTrades = {}
 		controls.searchResults:SelectIndex()
 		local startRow = controls.searchResults.selIndex
@@ -1547,6 +1547,8 @@ function TreeTabClass:FindTimelessJewel()
 		Copy("https://www.pathofexile.com/trade/search/?q=" .. (s_gsub(dkjson.encode(search), "[^a-zA-Z0-9]", function(a)
 			return s_format("%%%02X", s_byte(a))
 		end)))
+
+		controls.searchTradeButton.label = "Copy Next Trade URL"
 	end)
 	controls.searchTradeButton.enabled = timelessData.searchResults and #timelessData.searchResults > 0
 
@@ -1820,6 +1822,8 @@ function TreeTabClass:FindTimelessJewel()
 			t_sort(timelessData.searchResults, function(a, b) return a.total > b.total end)
 			controls.searchTradeButton.enabled = true
 			controls.searchTradeButton.lastSearch = nil
+			controls.searchTradeButton.label = "Copy Trade URL"
+			controls.searchResults.highlightIndex = nil
 		end
 	end)
 	controls.resetButton = new("ButtonControl", nil, buttonX + (width + divider), 485, width, 20, "Reset", function()

--- a/src/Classes/TreeTab.lua
+++ b/src/Classes/TreeTab.lua
@@ -1769,7 +1769,7 @@ function TreeTabClass:FindTimelessJewel()
 		end
 
 		local seedTrades = {}
-		local maxSeeds = main.POESESSID ~= "" and 50 or 10
+		local maxSeeds = 50
 		local page = controls.searchTradeButton.page
 		for i = (page - 1) * maxSeeds + 1, math.min(#timelessData.searchResults, page * maxSeeds) do
 			local result = timelessData.searchResults[i]

--- a/src/Classes/TreeTab.lua
+++ b/src/Classes/TreeTab.lua
@@ -1485,14 +1485,10 @@ function TreeTabClass:FindTimelessJewel()
 	controls.searchResults = new("TimelessJewelListControl", { "TOPLEFT", nil, "TOPRIGHT" }, -450, 275, 438, 200, self.build)
 
 	controls.searchTradeButton = new("ButtonControl", { "BOTTOMRIGHT", controls.searchResults, "TOPRIGHT" }, 0, -5, 130, 20, "Copy Trade URL", function()
-		if (not controls.searchTradeButton.enabled) then
-			return
-		end
-
 		local seedTrades = {}
 		controls.searchResults:SelectIndex()
 		local startRow = controls.searchResults.selIndex
-		if (not startRow) then
+		if not startRow then
 			startRow = 1
 			controls.searchResults:SelectIndex(startRow)
 		end
@@ -1503,7 +1499,7 @@ function TreeTabClass:FindTimelessJewel()
 		controls.searchResults.highlightIndex = startRow + seedCount - 1
 
 		local prevSearch = controls.searchTradeButton.lastSearch
-		if (prevSearch and prevSearch[1] == startRow and prevSearch[2] == seedCount) then
+		if prevSearch and prevSearch[1] == startRow and prevSearch[2] == seedCount then
 			startRow = startRow + seedCount
 			if (startRow > #timelessData.searchResults) then
 				return

--- a/src/Classes/TreeTab.lua
+++ b/src/Classes/TreeTab.lua
@@ -11,6 +11,7 @@ local t_concat = table.concat
 local m_max = math.max
 local m_min = math.min
 local m_floor = math.floor
+local m_abs = math.abs
 local s_format = string.format
 local s_gsub = string.gsub
 local s_byte = string.byte
@@ -1486,27 +1487,27 @@ function TreeTabClass:FindTimelessJewel()
 
 	controls.searchTradeButton = new("ButtonControl", { "BOTTOMRIGHT", controls.searchResults, "TOPRIGHT" }, 0, -5, 170, 20, "Copy Trade URL", function()
 		local seedTrades = {}
-		local startRow = controls.searchResults.selIndex
-		if not startRow then
-			startRow = 1
-			controls.searchResults:SelectIndex(startRow)
+		local startRow = controls.searchResults.selIndex or 1
+		local endRow = startRow + 10
+		if controls.searchResults.highlightIndex then
+			startRow = m_min(controls.searchResults.selIndex, controls.searchResults.highlightIndex)
+			endRow = m_max(controls.searchResults.selIndex, controls.searchResults.highlightIndex)
 		end
 
-		local seedCount = controls.searchResults.highlightIndex and controls.searchResults.highlightIndex - startRow + 1 or 10
-		seedCount = m_min(#timelessData.searchResults - startRow + 1, seedCount)
+		local seedCount = m_min(#timelessData.searchResults - startRow, endRow - startRow) + 1
 		-- update if not highlighted already
-		controls.searchResults.highlightIndex = startRow + seedCount - 1
 
 		local prevSearch = controls.searchTradeButton.lastSearch
 		if prevSearch and prevSearch[1] == startRow and prevSearch[2] == seedCount then
-			startRow = startRow + seedCount
+			startRow = endRow + 1
 			if (startRow > #timelessData.searchResults) then
 				return
 			end
-			controls.searchResults.selIndex = startRow
 			seedCount = m_min(#timelessData.searchResults - startRow + 1, seedCount)
-			controls.searchResults.highlightIndex = startRow + seedCount - 1
+			endRow = startRow + seedCount - 1
 		end
+		controls.searchResults.selIndex = startRow
+		controls.searchResults.highlightIndex = endRow
 
 		controls.searchTradeButton.lastSearch = {startRow, seedCount}
 

--- a/src/Classes/TreeTab.lua
+++ b/src/Classes/TreeTab.lua
@@ -28,11 +28,6 @@ local TreeTabClass = newClass("TreeTab", "ControlHost", function(self, build)
 	self:SetCompareSpec(1)
 
 	self.anchorControls = new("Control", nil, 0, 0, 0, 20)
-	
-	self.tradeQueryRequests = new("TradeQueryRequests", self)
-	table.insert(main.onFrameFuncs, function()
-		self.tradeQueryRequests:ProcessQueue()
-	end)
 
 	self.controls.specSelect = new("DropDownControl", {"LEFT",self.anchorControls,"RIGHT"}, 0, 0, 190, 20, nil, function(index, value)
 		if self.specList[index] then


### PR DESCRIPTION
Fixes #5401.

### Description of the problem being solved:
Currently, there is no easy way to access the Trade website to find the Timeless Jewels from the resultant list in the Timeless Jewel Finder. This PR creates a button to search the website for jewels in bulk.

### Steps taken to verify a working solution:
- I have interacted with the Timeless Jewel Finder
- I have tested this in a working build.
- I have accessed the URLs created by the Searcher to ensure they are correct under Rakiata

### Link to a build that showcases this PR:

### Before screenshot:
![image](https://user-images.githubusercontent.com/6186313/208281635-6c0e6113-f1d4-4546-9d79-d0a158731ab8.png)

### After screenshot:
![image](https://user-images.githubusercontent.com/6186313/208281568-50fa89a2-3ecd-4824-9dcb-5a45855cbbe8.png)


