### PR TITLE
+Flask effect works with silver flask

### DIFF
--- a/src/Modules/CalcPerform.lua
+++ b/src/Modules/CalcPerform.lua
@@ -930,9 +930,9 @@ local function doActorMisc(env, actor)
 		end
 		if modDB:Flag(nil, "Onslaught") then
 			local effect
-			--Loop detects if a Silver flask is used to grant Onslaught. If statement adds flask effect to claculation if one is being used
+			--Loop detects if a Silver flask is used to grant Onslaught. If statement adds flask effect to calculation if one is being used
 			local onslaughtFromFlask
-			--This value is set to negitive and not 0 or else reduced effect would not properly apply
+			--This value is set to negative and not 0 or else reduced effect would not properly apply
 			local flaskEffectInc = -100			
 			for item in pairs(env.flasks) do
 				if item.baseName:match("Silver Flask") then

--- a/src/Modules/CalcPerform.lua
+++ b/src/Modules/CalcPerform.lua
@@ -931,14 +931,16 @@ local function doActorMisc(env, actor)
 		if modDB:Flag(nil, "Onslaught") then
 			local effect
 			--Loop detects if a Silver flask is used to grant Onslaught. If statement adds flask effect to claculation if one is being used
-			local onslaughtFromFlask			
+			local onslaughtFromFlask
+			local flaskEffectInc			
 			for item in pairs(env.flasks) do
 				if item.baseName:match("Silver Flask") then
 					onslaughtFromFlask = true
+					flaskEffectInc =  (item.flaskData.effectInc + modDB:Sum("INC", nil, "FlaskEffect")) / 100
 				end
 			end
 			if onslaughtFromFlask then
-				effect = m_floor(20 * (1 + modDB:Sum("INC", nil, "OnslaughtEffect", "BuffEffectOnSelf", "FlaskEffect") / 100))
+				effect = m_floor(20 * (1 + flaskEffectInc + modDB:Sum("INC", nil, "OnslaughtEffect", "BuffEffectOnSelf") / 100))
 			else
 				effect = m_floor(20 * (1 + modDB:Sum("INC", nil, "OnslaughtEffect", "BuffEffectOnSelf") / 100))
 			end

--- a/src/Modules/CalcPerform.lua
+++ b/src/Modules/CalcPerform.lua
@@ -929,7 +929,19 @@ local function doActorMisc(env, actor)
 			modDB.multipliers["BuffOnSelf"] = (modDB.multipliers["BuffOnSelf"] or 0) + 1
 		end
 		if modDB:Flag(nil, "Onslaught") then
-			local effect = m_floor(20 * (1 + modDB:Sum("INC", nil, "OnslaughtEffect", "BuffEffectOnSelf") / 100))
+			local effect
+			--Loop detects if a Silver flask is used to grant Onslaught. If statement adds flask effect to claculation if one is being used
+			local onslaughtFromFlask			
+			for item in pairs(env.flasks) do
+				if item.baseName:match("Silver Flask") then
+					onslaughtFromFlask = true
+				end
+			end
+			if onslaughtFromFlask then
+				effect = m_floor(20 * (1 + modDB:Sum("INC", nil, "OnslaughtEffect", "BuffEffectOnSelf", "FlaskEffect") / 100))
+			else
+				effect = m_floor(20 * (1 + modDB:Sum("INC", nil, "OnslaughtEffect", "BuffEffectOnSelf") / 100))
+			end
 			modDB:NewMod("Speed", "INC", effect, "Onslaught")
 			modDB:NewMod("MovementSpeed", "INC", effect, "Onslaught")
 		end

--- a/src/Modules/CalcPerform.lua
+++ b/src/Modules/CalcPerform.lua
@@ -932,12 +932,14 @@ local function doActorMisc(env, actor)
 			local effect
 			--Loop detects if a Silver flask is used to grant Onslaught. If statement adds flask effect to claculation if one is being used
 			local onslaughtFromFlask
-			local flaskEffectInc			
+			--This value is set to negitive and not 0 or else reduced effect would not properly apply
+			local flaskEffectInc = -100			
 			for item in pairs(env.flasks) do
 				if item.baseName:match("Silver Flask") then
 					onslaughtFromFlask = true
-					flaskEffectInc =  (item.flaskData.effectInc + modDB:Sum("INC", nil, "FlaskEffect")) / 100
-					break
+					if flaskEffectInc < (item.flaskData.effectInc + modDB:Sum("INC", nil, "FlaskEffect")) / 100 then 
+						flaskEffectInc =  (item.flaskData.effectInc + modDB:Sum("INC", nil, "FlaskEffect")) / 100
+					end
 				end
 			end
 			if onslaughtFromFlask then

--- a/src/Modules/CalcPerform.lua
+++ b/src/Modules/CalcPerform.lua
@@ -937,6 +937,7 @@ local function doActorMisc(env, actor)
 				if item.baseName:match("Silver Flask") then
 					onslaughtFromFlask = true
 					flaskEffectInc =  (item.flaskData.effectInc + modDB:Sum("INC", nil, "FlaskEffect")) / 100
+					break
 				end
 			end
 			if onslaughtFromFlask then


### PR DESCRIPTION
Fixes #5242

### Description of the problem being solved:

PoB would not take into account +Flask effect when calculating silver flask onslaught. This change adds a check when calculating onslaught and adds flask effect to the equation if a silver flask is active.

### Steps taken to verify a working solution:

- Checked +flask effect increases relevant stats when a normal or magic silver flask is active
- Checked other flasks are not adding relevant onslaught stats when active
- Checked onslaught from sources that is not a silver flask is not benefited 
- Checked if onslaught is allocated from a non silver flask source and a silver flask that the +flask effect is still properly active

### Link to a build that showcases this PR: 
https://pobb.in/MdzvxLSfWxbr

### Before screenshot:
![Before](https://user-images.githubusercontent.com/103657562/208343403-37d208fb-cc6f-42f7-b569-60c3100e93f5.png)

### After screenshot:
![After](https://user-images.githubusercontent.com/103657562/208343390-1435291f-bfb2-4387-a2b3-f675d18680e9.png)
