### PR TITLE
Fix unarmed sandstorm visage not setting spell crit to zero

### DIFF
--- a/src/Modules/CalcOffence.lua
+++ b/src/Modules/CalcOffence.lua
@@ -2221,9 +2221,7 @@ function calcs.offence(env, actor, activeSkill)
 
 			local baseCritFromMainHand = skillModList:Flag(cfg, "BaseCritFromMainHand")
 			if baseCritFromMainHand then
-				if actor.itemList["Weapon 1"] and actor.itemList["Weapon 1"].weaponData and actor.itemList["Weapon 1"].weaponData[1] then
-					baseCrit = actor.weaponData1.CritChance
-				end
+				baseCrit = actor.weaponData1.CritChance
 			end
 
 			if critOverride == 100 then


### PR DESCRIPTION
### Description of the problem being solved:
![image](https://user-images.githubusercontent.com/31533893/208568639-5710cc52-8cfb-4174-9d8b-56f870f720b4.png)
![image](https://user-images.githubusercontent.com/31533893/208568777-06b873b3-c1ec-4ccc-afed-f2b6dc5f0ba9.png)

Unarmed sets crit to zero when using sandstorm visage