### PR TITLE
Add missing physical tag to Heartbound Loop

### DIFF
--- a/src/Data/Uniques/ring.lua
+++ b/src/Data/Uniques/ring.lua
@@ -377,7 +377,7 @@ Variant: Current
 Implicits: 1
 {tags:mana}+(20-30) to maximum Mana
 {variant:1}{tags:jewellery_attribute}+(5-10) to Intelligence
-{variant:2}{tags:jewellery_attribute}+(5-20) to Intelligence 
+{variant:2}{tags:jewellery_attribute}+(5-20) to Intelligence
 {variant:1}{tags:jewellery_resistance}+5% to all Elemental Resistances
 {variant:2}{tags:jewellery_resistance}+(5-20)% to all Elemental Resistances
 {variant:1}{tags:mana}Gain 5 Mana per Enemy Killed
@@ -395,7 +395,7 @@ Source: Steal from a unique{Curio Display} during a Grand Heist
 Implicits: 1
 {tags:mana}+(20-30) to maximum Mana
 {variant:1,2}{tags:jewellery_attribute}+(5-10) to Intelligence
-{variant:3,4}{tags:jewellery_attribute}+(5-20) to Intelligence 
+{variant:3,4}{tags:jewellery_attribute}+(5-20) to Intelligence
 {variant:1,2}{tags:jewellery_resistance}+5% to all Elemental Resistances
 {variant:3,4}{tags:jewellery_resistance}+(5-20)% to all Elemental Resistances
 {variant:1,2}{tags:mana}Gain 5 Mana per Enemy Killed
@@ -499,7 +499,7 @@ Implicits: 1
 {tags:mana}(20-40)% increased Mana Regeneration Rate
 Minions have 15% increased maximum Life
 Minions have 10% increased Area of Effect
-350 Physical Damage taken on Minion Death
+{tags:physical}350 Physical Damage taken on Minion Death
 ]],[[
 Anathema
 Moonstone Ring


### PR DESCRIPTION
Fix Heartbound Loop unique modifier missing physical tag

### Description of the problem being solved:

The mod `%d+ Physical Damage taken on Minion Death` on the Heartbound Loop does not have a physical modifier.
When adding the Noxious catalyst in PoB the base value 350 does not change to 420 as expected.

### Steps taken to verify a working solution:
- Create Heartbound Loop unique ring from template.
- Apply Noxious catalyst 
- Verify self hit value changes from 350 to 420 (nice) -> OK

- Import existing ring from game.
- Verify the value is 420 and not 504 -> OK

### Link to a build that showcases this PR:
https://pobb.in/_XqWDTDoH_nN

### Before screenshot:

![before](https://user-images.githubusercontent.com/19748542/208698116-dca68d93-b13b-4066-b4e2-941e7868b81b.png)

### After screenshot:
![after](https://user-images.githubusercontent.com/19748542/208698004-72dda1a8-e4fe-4808-adeb-5cb247884f05.png)
