### PR TITLE
Fix relic uniques mod parsing changing

### DIFF
--- a/src/Classes/Item.lua
+++ b/src/Classes/Item.lua
@@ -95,7 +95,7 @@ function ItemClass:ParseRaw(raw)
 			if self.rarity == "UNIQUE" then
 				-- Hack for relics
 				for _, line in ipairs(self.rawLines) do
-					if line == "Relic Unique" then
+					if line == "Foil Unique" then
 						self.rarity = "RELIC"
 						break
 					end


### PR DESCRIPTION
### Description of the problem being solved:
3.20.1 The line has changed from "Relic Unique" to "Foil Unique" due to introduction of unique relics.

We parse this line into the rarity variable so the text "Relic Unique" isn't stored in the .xml so this means everything works expect old items codes.

New foil uniques https://www.pathofexile.com/trade/search/Sanctum/1qDlSg

XML save
![image](https://user-images.githubusercontent.com/31533893/208850765-e0586ef8-4da4-4564-900b-310e33542d42.png)
