### PR TITLE
Apply enemy damage multiplier to max hit taken

### DIFF
--- a/spec/System/TestDefence_spec.lua
+++ b/spec/System/TestDefence_spec.lua
@@ -67,6 +67,21 @@ describe("TestDefence", function()
         assert.are.equals(2400, build.calcsTab.calcsOutput.ColdMaximumHitTaken)
         assert.are.equals(2400, build.calcsTab.calcsOutput.LightningMaximumHitTaken)
         assert.are.equals(2400, build.calcsTab.calcsOutput.ChaosMaximumHitTaken)
+
+        build.configTab.input.customMods = "\z
+        +200 to all resistances\n\z
+        +200 to all maximum resistances\n\z
+        50% reduced damage taken\n\z
+        50% less damage taken\n\z
+        Nearby enemies deal 20% less damage\n\z
+        "
+        build.configTab:BuildModList()
+        runCallback("OnFrame")
+        assert.are.equals(300, build.calcsTab.calcsOutput.PhysicalMaximumHitTaken)
+        assert.are.equals(3000, build.calcsTab.calcsOutput.FireMaximumHitTaken)
+        assert.are.equals(3000, build.calcsTab.calcsOutput.ColdMaximumHitTaken)
+        assert.are.equals(3000, build.calcsTab.calcsOutput.LightningMaximumHitTaken)
+        assert.are.equals(3000, build.calcsTab.calcsOutput.ChaosMaximumHitTaken)
     end)
 
     -- a small helper function to calculate damage taken from limited test parameters


### PR DESCRIPTION
Fixes #4446

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>

### Description of the problem being solved:

Enemy damage taken multipliers (such as Enfeeble) should apply to max hit. Currently they do not.

### Steps taken to verify a working solution:
- Open pob
- Enable enfeeble
- See max hit change

### Link to a build that showcases this PR:

https://pobb.in/_vySTol7cCuS

### Before screenshot:

![image](https://user-images.githubusercontent.com/5115805/208863396-e3f0a207-dc88-4e6c-b756-379817fa3291.png)

### After screenshot:

![image](https://user-images.githubusercontent.com/5115805/208863081-0652feaf-e79c-448e-94b6-e3cc3fce1903.png)

