### PR TITLE
Update wording on sandstorm visage

### DIFF
--- a/src/Data/Uniques/helmet.lua
+++ b/src/Data/Uniques/helmet.lua
@@ -497,7 +497,7 @@ Source: Drops from unique{Lycia, Herald of the Scourge} in normal{The Beyond}
 (8-10)% increased Cast Speed
 (200-250)% increased Energy Shield
 Avoid interruption from Stuns while Casting
-Base Critical Strike Chance of Spells is the Critical Strike Chance of your Main Hand Weapon
+Base Critical Strike Chance of Spells is the Critical Strike Chance of Main Hand Weapon
 Cannot deal Critical Strikes with Attacks
 ]],[[
 Flamesight

--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -3670,7 +3670,7 @@ local specialModList = {
 	["when you lose temporal chains you gain maximum rage"] = { flag("Condition:CanGainRage") },
 	["your critical strike multiplier is (%d+)%%"] = function(num) return { mod("CritMultiplier", "OVERRIDE", num) } end,
 	["base critical strike chance for attacks with weapons is ([%d%.]+)%%"] = function(num) return { mod("WeaponBaseCritChance", "OVERRIDE", num) } end,
-	["base critical strike chance of spells is the critical strike chance of your main hand weapon"] = { flag("BaseCritFromMainHand", nil, ModFlag.Spell) },
+	["base critical strike chance of spells is the critical strike chance of y?o?u?r? ?main hand weapon"] = { flag("BaseCritFromMainHand", nil, ModFlag.Spell) },
 	["critical strike chance is (%d+)%% for hits with this weapon"] = function(num) return { mod("CritChance", "OVERRIDE", num, nil, ModFlag.Hit, { type = "Condition", var = "{Hand}Attack" }, { type = "SkillType", skillType = SkillType.Attack }) } end, 
 	["maximum critical strike chance is (%d+)%%"] = function(num) return {
 		mod("CritChanceCap", "OVERRIDE", num),


### PR DESCRIPTION
### Description of the problem being solved:
3.20.1 updated the wording

https://www.pathofexile.com/trade/search/Sanctum/eaawnewtL
![image](https://user-images.githubusercontent.com/31533893/208888679-3ca668ca-0c08-476b-81d2-bcc0b542f6d2.png)

