### PR TITLE
Fix Explosive Arrow Full DPS

### DIFF
--- a/src/Data/Skills/act_dex.lua
+++ b/src/Data/Skills/act_dex.lua
@@ -3744,6 +3744,55 @@ skills["ExplosiveArrow"] = {
 			area = false,
 		},
 	},
+	explosiveArrowFunc = function(activeSkill, output, globalOutput, env)
+		if activeSkill.skillPart ~= 1 and activeSkill.skillPart ~= 2 then
+			-- This doesn't apply to the "Arrow" skill part. That works like a normal skill.
+			return
+		end
+
+		local modDB = env.modDB
+		local enemyDB = activeSkill.actor.enemy.modDB
+		local skillModList = activeSkill.skillModList
+		local duration = calcSkillDuration(skillModList, activeSkill.skillCfg, activeSkill.skillData, env, enemyDB)
+		local fuseLimit = skillModList:Sum("BASE", activeSkill.skillCfg, "ExplosiveArrowMaxFuseCount")
+		local activeTotems
+		if activeSkill.skillFlags.totem then
+			activeTotems = modDB:Override(nil, "TotemsSummoned") or skillModList:Sum("BASE", activeSkill.skillCfg, "ActiveTotemLimit", "ActiveBallistaLimit")
+		end
+
+		local barrageProjectiles = nil
+		if skillModList:Flag(nil, "SequentialProjectiles") and not skillModList:Flag(nil, "OneShotProj") and not skillModList:Flag(nil,"NoAdditionalProjectiles") and not skillModList:Flag(nil, "TriggeredBySnipe") then
+			barrageProjectiles = skillModList:Sum("BASE", skillCfg, "ProjectileCount")
+			activeSkill.skillData.dpsMultiplier = activeSkill.skillData.dpsMultiplier / barrageProjectiles  -- cancel out the normal dps multiplier from barrage that applies to most other skills
+		end
+
+		local fuseApplicationRate = (output.HitChance / 100) * globalOutput.Speed * globalOutput.ActionSpeedMod * activeSkill.skillData.dpsMultiplier * (barrageProjectiles or 1)
+		if activeSkill.skillFlags.totem then
+			fuseApplicationRate = fuseApplicationRate * activeTotems
+		end
+
+		-- Calculate the max number of fuses you can sustain
+		-- Does not take into account mines or traps
+		if activeSkill.skillPart == 2 then
+			local maximum = math.min(math.floor(fuseApplicationRate * duration) + 1, fuseLimit)
+			skillModList:NewMod("Multiplier:ExplosiveArrowStage", "BASE", maximum, "Base")
+			skillModList:NewMod("Multiplier:ExplosiveArrowStageAfterFirst", "BASE", maximum - 1, "Base")
+			globalOutput.MaxExplosiveArrowFuseCalculated = maximum
+		else
+			globalOutput.MaxExplosiveArrowFuseCalculated = nil
+		end
+		
+		-- Calculate explosion rate
+		local timeToMaxFuses = fuseLimit / fuseApplicationRate
+		if activeSkill.skillPart == 2 or (activeSkill.skillPart == 1 and (activeSkill.activeStageCount or 0) + 1 >= fuseLimit) then
+			globalOutput.HitTime = math.min(duration, timeToMaxFuses)
+		else
+			-- Number of fuses is less than the limit, so the entire fuse duration applies
+			globalOutput.HitTime = duration
+		end
+
+		globalOutput.HitSpeed = 1 / globalOutput.HitTime
+	end,
 	statMap = {
 		["explosive_arrow_explosion_minimum_added_fire_damage"] = {
 			mod("FireMin", "BASE", nil, 0, 0, { type = "SkillPart", skillPartList = { 1, 2 } }),

--- a/src/Export/Skills/act_dex.txt
+++ b/src/Export/Skills/act_dex.txt
@@ -684,6 +684,55 @@ local skills, mod, flag, skill = ...
 			area = false,
 		},
 	},
+	explosiveArrowFunc = function(activeSkill, output, globalOutput, env)
+		if activeSkill.skillPart ~= 1 and activeSkill.skillPart ~= 2 then
+			-- This doesn't apply to the "Arrow" skill part. That works like a normal skill.
+			return
+		end
+
+		local modDB = env.modDB
+		local enemyDB = activeSkill.actor.enemy.modDB
+		local skillModList = activeSkill.skillModList
+		local duration = calcSkillDuration(skillModList, activeSkill.skillCfg, activeSkill.skillData, env, enemyDB)
+		local fuseLimit = skillModList:Sum("BASE", activeSkill.skillCfg, "ExplosiveArrowMaxFuseCount")
+		local activeTotems
+		if activeSkill.skillFlags.totem then
+			activeTotems = modDB:Override(nil, "TotemsSummoned") or skillModList:Sum("BASE", activeSkill.skillCfg, "ActiveTotemLimit", "ActiveBallistaLimit")
+		end
+
+		local barrageProjectiles = nil
+		if skillModList:Flag(nil, "SequentialProjectiles") and not skillModList:Flag(nil, "OneShotProj") and not skillModList:Flag(nil,"NoAdditionalProjectiles") and not skillModList:Flag(nil, "TriggeredBySnipe") then
+			barrageProjectiles = skillModList:Sum("BASE", skillCfg, "ProjectileCount")
+			activeSkill.skillData.dpsMultiplier = activeSkill.skillData.dpsMultiplier / barrageProjectiles  -- cancel out the normal dps multiplier from barrage that applies to most other skills
+		end
+
+		local fuseApplicationRate = (output.HitChance / 100) * globalOutput.Speed * globalOutput.ActionSpeedMod * activeSkill.skillData.dpsMultiplier * (barrageProjectiles or 1)
+		if activeSkill.skillFlags.totem then
+			fuseApplicationRate = fuseApplicationRate * activeTotems
+		end
+
+		-- Calculate the max number of fuses you can sustain
+		-- Does not take into account mines or traps
+		if activeSkill.skillPart == 2 then
+			local maximum = math.min(math.floor(fuseApplicationRate * duration) + 1, fuseLimit)
+			skillModList:NewMod("Multiplier:ExplosiveArrowStage", "BASE", maximum, "Base")
+			skillModList:NewMod("Multiplier:ExplosiveArrowStageAfterFirst", "BASE", maximum - 1, "Base")
+			globalOutput.MaxExplosiveArrowFuseCalculated = maximum
+		else
+			globalOutput.MaxExplosiveArrowFuseCalculated = nil
+		end
+		
+		-- Calculate explosion rate
+		local timeToMaxFuses = fuseLimit / fuseApplicationRate
+		if activeSkill.skillPart == 2 or (activeSkill.skillPart == 1 and (activeSkill.activeStageCount or 0) + 1 >= fuseLimit) then
+			globalOutput.HitTime = math.min(duration, timeToMaxFuses)
+		else
+			-- Number of fuses is less than the limit, so the entire fuse duration applies
+			globalOutput.HitTime = duration
+		end
+
+		globalOutput.HitSpeed = 1 / globalOutput.HitTime
+	end,
 	statMap = {
 		["explosive_arrow_explosion_minimum_added_fire_damage"] = {
 			mod("FireMin", "BASE", nil, 0, 0, { type = "SkillPart", skillPartList = { 1, 2 } }),

--- a/src/Modules/CalcOffence.lua
+++ b/src/Modules/CalcOffence.lua
@@ -2095,7 +2095,6 @@ function calcs.offence(env, actor, activeSkill)
 		globalOutput.TheoreticalMaxOffensiveWarcryEffect = 1
 		globalOutput.RallyingHitEffect = 1
 		globalOutput.AilmentWarcryEffect = 1
-		globalOutput.MaxExplosiveArrowFuseCalculated = 1
 
 		if env.mode_buffs then
 			-- Iterative over all the active skills to account for exerted attacks provided by warcries
@@ -2419,22 +2418,10 @@ function calcs.offence(env, actor, activeSkill)
 			end
 		end
 
-		--Calculates the max number of fuses you can sustain
-		--Does not take into account mines or traps
-		if activeSkill.activeEffect.grantedEffect.name == "Explosive Arrow" and activeSkill.skillPart == 2 then
-			local hitRate = output.HitChance / 100 * globalOutput.Speed * globalOutput.ActionSpeedMod * skillData.dpsMultiplier
-			if skillFlags.totem then
-				local activeTotems = env.modDB:Override(nil, "TotemsSummoned") or skillModList:Sum("BASE", skillCfg, "ActiveTotemLimit", "ActiveBallistaLimit")
-				hitRate = hitRate * activeTotems
-			end
-			local duration = calcSkillDuration(activeSkill.skillModList, activeSkill.skillCfg, activeSkill.skillData, env, enemyDB)
-			local skillMax = activeSkill.skillModList:Sum("BASE", env.player.mainSkill.skillCfg, "ExplosiveArrowMaxFuseCount")
-			local maximum = m_min(m_floor(hitRate * duration) + 1, skillMax)
-			skillModList:NewMod("Multiplier:ExplosiveArrowStage", "BASE", maximum, "Base")
-			skillModList:NewMod("Multiplier:ExplosiveArrowStageAfterFirst", "BASE", maximum - 1, "Base")
-			globalOutput.MaxExplosiveArrowFuseCalculated = maximum
-		else
-			globalOutput.MaxExplosiveArrowFuseCalculated = nil
+		-- Calculate maximum sustainable fuses and explosion rate for Explosive Arrow
+		-- Does not take into account mines or traps
+		if activeSkill.activeEffect.grantedEffect.name == "Explosive Arrow" then
+			activeSkill.activeEffect.grantedEffect.explosiveArrowFunc(activeSkill, output, globalOutput, env)
 		end
 
 		-- Calculate crit chance, crit multiplier, and their combined effect


### PR DESCRIPTION
Fixes #2486

### Description of the problem being solved:

When "Include in Full DPS" is checked for Explosive Arrow, currently PoB doesn't give it any special treatment and simply takes the "Average Damage" (of an explosion) times Attack Rate (the rate that you apply *fuses*) to get DPS. The correct calculation is Average Damage times Explosion Rate. This change implements a calculation for Explosion Rate, shown as "Hit Rate" in PoB.

The time between explosions (HitTime) is either the skill duration, or the time it take to reach the fuse limit, whichever is lower. The time to max fuses is:

    timeToMaxFuses = fuseLimit / (hitChance * attackSpeed * totemLimit * barrageProjectiles)

The calculation is done in `explosiveArrowFunc()`, which lives on the skill itself and kinda looks like a preFunc, but it needs access to information that's not available to the preFuncs. I also pulled the Maximum Sustainable Fuses calculation into this new function.

### Screenshots

![dps](https://user-images.githubusercontent.com/5018804/209177722-4b5a64fc-c823-456b-ba30-6bc062a5d026.png)

### Link to a build that showcases this PR:

This is the build used in the above screenshots: https://pobb.in/m4qGXNAjPT89