### PR TITLE
Fix profiler crashing

### DIFF
--- a/src/Launch.lua
+++ b/src/Launch.lua
@@ -138,7 +138,7 @@ function launch:OnKeyDown(key, doubleClick)
 		local before = collectgarbage("count")
 		collectgarbage("collect")
 		ConPrintf("%dkB => %dkB", before, collectgarbage("count"))
-	elseif key == "PAUSE" and self.devMode then
+	elseif key == "PAUSE" and self.devMode and profiler then
 		if profiling then
 			profiler.stop()
 			profiler.report("profiler.log")

--- a/src/Modules/Common.lua
+++ b/src/Modules/Common.lua
@@ -26,9 +26,19 @@ common.xml = require("xml")
 common.base64 = require("base64")
 common.sha1 = require("sha1")
 
--- Uncomment if you need to perform in-depth profiling
-profiler = require("lua-profiler")
+-- Try to load a library return nil if failed. https://stackoverflow.com/questions/34965863/lua-require-fallback-error-handling
+function prequire(...)
+    local status, lib = pcall(require, ...)
+    if(status) then return lib end
+    return nil
+end
+
+profiler = prequire("lua-profiler")
 profiling = false
+
+if launch.devMode and profiler == nil then
+	ConPrintf("Unable to Load Profiler")
+end
 
 -- Class library
 common.classes = { }


### PR DESCRIPTION
This fixes the profiler trying to be loaded if it is not present and provides warning in console if dev mode is setup.

![image](https://user-images.githubusercontent.com/31533893/209317038-d60d1ebb-61a8-4888-9f3a-e5b492b6d795.png)
