### PR TITLE
Fix kalandra's touch not working

### DIFF
--- a/spec/System/TestItemMods_spec.lua
+++ b/spec/System/TestItemMods_spec.lua
@@ -187,7 +187,7 @@ describe("TetsItemMods", function()
         local genericRingInt = build.calcsTab.mainOutput.Int
 
         build.itemsTab:CreateDisplayItemFromRaw([[Kalandra's Touch
-        Iron Ring
+        Ring
         League: Kalandra
         Implicits: 0
         Reflects your other Ring

--- a/src/Modules/CalcSetup.lua
+++ b/src/Modules/CalcSetup.lua
@@ -777,7 +777,7 @@ function calcs.initEnv(build, mode, override, specEnv)
 							env.itemModDB:ScaleAddMod(mod, scale)
 						end
 					end
-				elseif item.name == "Kalandra's Touch, Iron Ring" then
+				elseif item.name == "Kalandra's Touch, Ring" then
 					if slotName == "Ring 1" and build.itemsTab.items[build.itemsTab.orderedSlots[59].selItemId] then
 						local item = build.itemsTab.items[build.itemsTab.orderedSlots[59].selItemId]
 						srcList = copyTable(item.modList or item.slotModList[slot.slotNum])


### PR DESCRIPTION
### Description of the problem being solved:
Due to not having a access to ring base type it was set as an iron ring in the meantime. This mean it didn't work when it was updated to the "Ring" base type.