### PR TITLE
Fix Implicit mods on Kalandra's Touch not applying.

### DIFF
--- a/src/Modules/CalcSetup.lua
+++ b/src/Modules/CalcSetup.lua
@@ -779,7 +779,7 @@ function calcs.initEnv(build, mode, override, specEnv)
 					end
 				elseif item.name:match("Kalandra's Touch") then
 					local otherRing = (slotName == "Ring 1" and build.itemsTab.items[build.itemsTab.orderedSlots[59].selItemId]) or (slotName == "Ring 2" and build.itemsTab.items[build.itemsTab.orderedSlots[58].selItemId])
-					if not otherRing.name:match("Kalandra's Touch") then
+					if otherRing and not otherRing.name:match("Kalandra's Touch") then
 						local otherRingList = otherRing and copyTable(otherRing.modList or otherRing.slotModList[slot.slotNum]) or {}
 						for index, mod in ipairs(otherRingList) do
 							modLib.setSource(mod, item.modSource)

--- a/src/Modules/CalcSetup.lua
+++ b/src/Modules/CalcSetup.lua
@@ -777,24 +777,26 @@ function calcs.initEnv(build, mode, override, specEnv)
 							env.itemModDB:ScaleAddMod(mod, scale)
 						end
 					end
-				elseif item.name == "Kalandra's Touch, Iron Ring" then
+				elseif item.name:match("Kalandra's Touch") then
+					local otherRingList = {}
 					if slotName == "Ring 1" and build.itemsTab.items[build.itemsTab.orderedSlots[59].selItemId] then
 						local item = build.itemsTab.items[build.itemsTab.orderedSlots[59].selItemId]
-						srcList = copyTable(item.modList or item.slotModList[slot.slotNum])
+						otherRingList = copyTable(item.modList or item.slotModList[slot.slotNum])
 					elseif slotName == "Ring 2" and build.itemsTab.items[build.itemsTab.orderedSlots[58].selItemId] then
 						local item = build.itemsTab.items[build.itemsTab.orderedSlots[58].selItemId]
-						srcList = copyTable(item.modList or item.slotModList[slot.slotNum])
+						otherRingList = copyTable(item.modList or item.slotModList[slot.slotNum])
 					end
-					for index, mod in ipairs(srcList) do
+					for index, mod in ipairs(otherRingList) do
 						modLib.setSource(mod, item.modSource)
 						for _, tag in ipairs(mod) do
 							if tag.type == "SocketedIn" then
-								srcList[index] = nil
+								otherRingList[index] = nil
 								break
 							end
 						end
 					end
 					env.itemModDB:ScaleAddList(srcList, scale)
+					env.itemModDB:ScaleAddList(otherRingList, scale)
 				else
 					env.itemModDB:ScaleAddList(srcList, scale)
 				end

--- a/src/Modules/CalcSetup.lua
+++ b/src/Modules/CalcSetup.lua
@@ -778,25 +778,21 @@ function calcs.initEnv(build, mode, override, specEnv)
 						end
 					end
 				elseif item.name:match("Kalandra's Touch") then
-					local otherRingList = {}
-					if slotName == "Ring 1" and build.itemsTab.items[build.itemsTab.orderedSlots[59].selItemId] then
-						local item = build.itemsTab.items[build.itemsTab.orderedSlots[59].selItemId]
-						otherRingList = copyTable(item.modList or item.slotModList[slot.slotNum])
-					elseif slotName == "Ring 2" and build.itemsTab.items[build.itemsTab.orderedSlots[58].selItemId] then
-						local item = build.itemsTab.items[build.itemsTab.orderedSlots[58].selItemId]
-						otherRingList = copyTable(item.modList or item.slotModList[slot.slotNum])
-					end
-					for index, mod in ipairs(otherRingList) do
-						modLib.setSource(mod, item.modSource)
-						for _, tag in ipairs(mod) do
-							if tag.type == "SocketedIn" then
-								otherRingList[index] = nil
-								break
+					local otherRing = (slotName == "Ring 1" and build.itemsTab.items[build.itemsTab.orderedSlots[59].selItemId]) or (slotName == "Ring 2" and build.itemsTab.items[build.itemsTab.orderedSlots[58].selItemId])
+					if not otherRing.name:match("Kalandra's Touch") then
+						local otherRingList = otherRing and copyTable(otherRing.modList or otherRing.slotModList[slot.slotNum])
+						for index, mod in ipairs(otherRingList) do
+							modLib.setSource(mod, item.modSource)
+							for _, tag in ipairs(mod) do
+								if tag.type == "SocketedIn" then
+									otherRingList[index] = nil
+									break
+								end
 							end
 						end
+						env.itemModDB:ScaleAddList(otherRingList, scale)
 					end
 					env.itemModDB:ScaleAddList(srcList, scale)
-					env.itemModDB:ScaleAddList(otherRingList, scale)
 				else
 					env.itemModDB:ScaleAddList(srcList, scale)
 				end

--- a/src/Modules/ConfigOptions.lua
+++ b/src/Modules/ConfigOptions.lua
@@ -483,12 +483,6 @@ Huge sets the radius to 11.
 			enemyModList:NewMod("CurseEffectOnSelf", "MORE", -val, "Config")
 		end
 	end },
-	{ var = "enemyCanAvoidPoisonBlindBleed", type = "list", label = "Enemy avoid Poison / Blind / Bleed:", tooltip = "'Impervious'", list = {{val=0,label="None"},{val=25,label="25% (Low tier)"},{val=45,label="45% (Mid tier)"},{val=65,label="65% (High tier)"}}, apply = function(val, modList, enemyModList)
-		if val ~= 0 then
-			enemyModList:NewMod("AvoidPoison", "BASE", val, "Config")
-			enemyModList:NewMod("AvoidBleed", "BASE", val, "Config")
-		end
-	end },
 	{ var = "enemyHasResistances", type = "list", label = "Enemy has Elemental / ^xD02090Chaos ^7Resist:", tooltip = "'Resistant'", list = {{val=0,label="None"},{val="LOW",label="20% / 15% (Low tier)"},{val="MID",label="30% / 20% (Mid tier)"},{val="HIGH",label="40% / 25% (High tier)"}}, apply = function(val, modList, enemyModList)
 		local map = { ["LOW"] = {20,15}, ["MID"] = {30,20}, ["HIGH"] = {40,25} }
 		if map[val] then


### PR DESCRIPTION
Fixes #5443 .

### Description of the problem being solved:
Kalandra's touch ignored it's own mods causing  implicit mods to not apply. Also prevents from reflecting the other ring if it's also Kalandra's touch.