### PR TITLE
Remove legacy Crystalised Omniscience that no longer exists

### DIFF
--- a/src/Data/Uniques/amulet.lua
+++ b/src/Data/Uniques/amulet.lua
@@ -284,17 +284,13 @@ Extra Gore
 ]],[[
 Crystallised Omniscience
 Onyx Amulet
-Variant: Pre 3.19.0
-Variant: Current
 Source: Drops from unique{The Searing Exarch}
 Requires Level 61
 Implicits: 1
 {tags:jewellery_attribute}+(10-16) to all Attributes
 Modifiers to Attributes instead Apply to Omniscience
-{variant:1}+1% to All Elemental Resistances per 10 Omniscience
-{variant:1}Penetrate 1% Elemental Resistances per 10 Omniscience
-{variant:2}+1% to All Elemental Resistances per 15 Omniscience
-{variant:2}Penetrate 1% Elemental Resistances per 15 Omniscience
++1% to All Elemental Resistances per 15 Omniscience
+Penetrate 1% Elemental Resistances per 15 Omniscience
 Attribute Requirements can be satisfied by (15-25)% of Omniscience
 ]],[[
 Daresso's Salute


### PR DESCRIPTION
### Description of the problem being solved:
Legacy variant doesn't exist so no longer worth having as 3.19 change affected existing items. https://www.poewiki.net/wiki/Crystallised_Omniscience
![image](https://user-images.githubusercontent.com/31533893/209424713-1c5c8f75-c774-41b5-a354-4dcc71e1a20a.png)