### PR TITLE
Militant Faith update skill cost to mana cost

### DIFF
--- a/src/Data/Uniques/jewel.lua
+++ b/src/Data/Uniques/jewel.lua
@@ -1994,7 +1994,7 @@ Implicits: 0
 {variant:14}1% increased Minion Attack and Cast Speed per 10 Devotion
 {variant:15}Minions have +60 to Accuracy Rating per 10 Devotion
 {variant:16}Regenerate 0.6 Mana per Second per 10 Devotion
-{variant:17}1% reduced Cost of Skills per 10 Devotion
+{variant:17}1% reduced Mana Cost of Skills per 10 Devotion
 {variant:18}1% increased effect of Non-Curse Auras per 10 Devotion
 {variant:19}3% increased Defences from Equipped Shield per 10 Devotion
 Passives in radius are Conquered by the Templars


### PR DESCRIPTION
3.15: The modifier on the Militant Faith Timeless Jewel that  grants 1% reduced Cost of Skills per 10 Devotion can no longer roll.  Existing items with this modifier have had this replaced with a modifier that grants 1% reduced Mana Cost of Skills per 10 Devotion.