### PR TITLE
Fix modCache not being used during startup causing long loading times

### DIFF
--- a/src/Modules/Main.lua
+++ b/src/Modules/Main.lua
@@ -55,6 +55,13 @@ function main:Init()
 	self.buildPath = self.defaultBuildPath
 	MakeDir(self.buildPath)
 
+	if launch.devMode and IsKeyDown("CTRL") then
+		self.rebuildModCache = true
+	elseif not launch.headlessMode then
+		-- Load mod cache
+		LoadModule("Data/ModCache", modLib.parseModCache)
+	end
+
 	if launch.devMode and IsKeyDown("CTRL") and IsKeyDown("SHIFT") then
 		self.allowTreeDownload = true
 	end
@@ -97,11 +104,8 @@ function main:Init()
 		end
 	end
 
-	if launch.devMode and IsKeyDown("CTRL") then
+	if self.rebuildModCache then
 		self:RebuildModCache()
-	elseif not launch.headlessMode then
-		-- Load mod cache
-		LoadModule("Data/ModCache", modLib.parseModCache)
 	end
 
 	self.sharedItemList = { }


### PR DESCRIPTION
Introduced in https://github.com/PathOfBuildingCommunity/PathOfBuilding/commit/8c0ba3e2ef08b0c1e301cfff1e26fdd8ba2cfa27

### Description of the problem being solved:
Mod Cache was not used for tree and item database loading.