### PR TITLE
Fix Trader memoryleak caused by OnFrame functions

### DIFF
--- a/src/Classes/TradeQuery.lua
+++ b/src/Classes/TradeQuery.lua
@@ -39,9 +39,9 @@ local TradeQueryClass = newClass("TradeQuery", function(self, itemsTab)
 	self.pbLeagueIndex = 1
 
 	self.tradeQueryRequests = new("TradeQueryRequests", self)
-	table.insert(main.onFrameFuncs, function()
+	main.onFrameFuncs["TradeQueryRequests"] = function()
 		self.tradeQueryRequests:ProcessQueue()
-	end)
+	end
 
     -- set 
     self.storedGlobalCacheDPSView = GlobalCache.useFullDPS
@@ -185,7 +185,9 @@ end
 -- Opens the item pricing popup
 function TradeQueryClass:PriceItem()
 	self.tradeQueryGenerator = new("TradeQueryGenerator", self)
-
+	main.onFrameFuncs["TradeQueryGenerator"] = function()
+        self.tradeQueryGenerator:OnFrame()
+    end
 	-- Count number of rows to render
 	local row_count = 3 + #baseSlots
 	-- Count sockets

--- a/src/Classes/TradeQuery.lua
+++ b/src/Classes/TradeQuery.lua
@@ -43,8 +43,8 @@ local TradeQueryClass = newClass("TradeQuery", function(self, itemsTab)
 		self.tradeQueryRequests:ProcessQueue()
 	end
 
-    -- set 
-    self.storedGlobalCacheDPSView = GlobalCache.useFullDPS
+	-- set 
+	self.storedGlobalCacheDPSView = GlobalCache.useFullDPS
 	GlobalCache.useFullDPS = GlobalCache.numActiveSkillInFullDPS > 0
 end)
 
@@ -186,8 +186,8 @@ end
 function TradeQueryClass:PriceItem()
 	self.tradeQueryGenerator = new("TradeQueryGenerator", self)
 	main.onFrameFuncs["TradeQueryGenerator"] = function()
-        self.tradeQueryGenerator:OnFrame()
-    end
+		self.tradeQueryGenerator:OnFrame()
+	end
 	-- Count number of rows to render
 	local row_count = 3 + #baseSlots
 	-- Count sockets

--- a/src/Classes/TradeQueryGenerator.lua
+++ b/src/Classes/TradeQueryGenerator.lua
@@ -77,9 +77,6 @@ local TradeQueryGeneratorClass = newClass("TradeQueryGenerator", function(self, 
     self.itemsTab = queryTab.itemsTab
     self.calcContext = { }
 
-    table.insert(main.onFrameFuncs, function()
-        self:OnFrame()
-    end)
 end)
 
 local function fetchStats()

--- a/src/Classes/TradeQueryRequests.lua
+++ b/src/Classes/TradeQueryRequests.lua
@@ -10,8 +10,8 @@ local dkjson = require "dkjson"
 local TradeQueryRequestsClass = newClass("TradeQueryRequests", function(self, tradeQuery, rateLimiter)
 	self.maxFetchPerSearch = 10
 	self.tradeQuery = tradeQuery
-    self.rateLimiter = rateLimiter or new("TradeQueryRateLimiter")
-    self.requestQueue = {
+	self.rateLimiter = rateLimiter or new("TradeQueryRateLimiter")
+	self.requestQueue = {
 		["search"] = {},
 		["fetch"] = {},
 	}


### PR DESCRIPTION
Fixes #5472 

Some PoB Trader modules are causing memory leaks by leaving OnFrame references behind in the main module.
This fix converts OnFrame subscription to be named, allowing the new class instantiation to replace the old OnFrame reference.

This doesn't solve the dangling reference problem altogether, we still hold one reference each to these classes which potentially prevents GC. Still, reserving memory for only one object is better than a growing memory leak.

Feel free to override if you implement proper lifecycle management.