### PR TITLE
Fix: Deleting gem level causing a crash

### DIFF
--- a/src/Classes/SkillsTab.lua
+++ b/src/Classes/SkillsTab.lua
@@ -665,7 +665,7 @@ function SkillsTabClass:CreateGemSlot(index)
 			slot.enableGlobal1.state = true
 			slot.count:SetText(gemInstance.count)
 		end
-		gemInstance.level = tonumber(buf) or self.displayGroup.gemList[index].defaultLevel or self.defaultGemLevel or 20
+		gemInstance.level = tonumber(buf) or self.displayGroup.gemList[index].defaultLevel or self:ProcessGemLevel(gemInstance.gemData) or 20
 		self:ProcessSocketGroup(self.displayGroup)
 		self:AddUndoState()
 		self.build.buildFlag = true


### PR DESCRIPTION
Fixes #5476.

### Description of the problem being solved:
https://github.com/PathOfBuildingCommunity/PathOfBuilding/pull/4724 changed the way default gem levels are handled. This caused gemInstance.level to be assigned a string (`self.defaultGemLevel`) instead of an int.