### PR TITLE
Add name to elemental damage Grand Spectrum variant

### DIFF
--- a/src/Data/Uniques/jewel.lua
+++ b/src/Data/Uniques/jewel.lua
@@ -230,7 +230,7 @@ Limited to: 3
 Variant: Pre 2.5.0
 Variant: Pre 3.0.0
 Variant: Pre 3.10.0
-Variant: Current
+Variant: Current - Elemental Damage
 Variant: Current - Chance to avoid Ailments
 Variant: Current - Min Frenzy Charge
 {variant:1}5% increased Elemental Damage per Grand Spectrum


### PR DESCRIPTION
Every other variant is properly named.

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>

### Before screenshot:

![image](https://user-images.githubusercontent.com/5115805/209837717-3b1ca2f2-d2ce-41e2-9b9f-3db0ec460862.png)

### After screenshot:

![image](https://user-images.githubusercontent.com/5115805/209837627-6382c991-93e9-425d-b182-8b7bab3c45b4.png)
