### PR TITLE
Allow Trade to weight by multiple stats

### DIFF
--- a/src/Classes/TradeQuery.lua
+++ b/src/Classes/TradeQuery.lua
@@ -27,7 +27,7 @@ local TradeQueryClass = newClass("TradeQuery", function(self, itemsTab)
 	self.resultTbl = { }
 	self.sortedResultTbl = { }
 	self.itemIndexTbl = { }
-	
+
 	-- default set of trade item sort selection
 	self.pbItemSortSelectionIndex = 1
 	self.pbCurrencyConversion = { }
@@ -420,10 +420,8 @@ on trade site to work on other leagues and realms)]]
 	main:OpenPopup(pane_width, pane_height, "Trader", self.controls)
 end
 
--- Method to SetStatWeights
+-- Popup to set stat weight multipliers for sorting
 function TradeQueryClass:SetStatWeights()
-	--self.requesterCallback = callback
-    --self.requesterContext = context
 
     local controls = { }
     local statList = { }

--- a/src/Classes/TradeQuery.lua
+++ b/src/Classes/TradeQuery.lua
@@ -269,6 +269,18 @@ function TradeQueryClass:PriceItem()
 	self.controls.poesessidButton.tooltipText = [[
 The Trader feature supports two modes of operation depending on the POESESSID availability.
 You can click this button to enter your POESESSID.
+
+^2Session Mode^7
+- Requires POESESSID.
+- You can search, compare, and quickly import items without leaving Path of Building.
+- You can generate and perform searches for the private leagues you are participating.
+
+^xFF9922No Session Mode^7
+- Doesn't require POESESSID.
+- You cannot search and compare items in Path of Building.
+- You can generate weighted search URLs but have to visit the trade site and manually import items.
+- You can only generate weighted searches for public leagues. (Generated searches can be modified
+on trade site to work on other leagues and realms)]]
 	
 	-- Stat sort popup button
 	self.statSortSelectionList = { }
@@ -282,7 +294,7 @@ You can click this button to enter your POESESSID.
 		stat = "TotalEHP",
 		weightMult = 0.5,
 	})
-	self.controls.StatWeightMultipliersButton = new("ButtonControl", {"TOPRIGHT", nil, "TOPRIGHT"}, -12, 15, 100, 18, "^7Sort Calc By:", function()
+	self.controls.StatWeightMultipliersButton = new("ButtonControl", {"TOPRIGHT", nil, "TOPRIGHT"}, -12, 19, 100, 18, "^7Sort Calc By:", function()
 		self:SetStatWeights()
 	end)
 	self.controls.StatWeightMultipliersButton.tooltipFunc = function(tooltip)

--- a/src/Classes/TradeQuery.lua
+++ b/src/Classes/TradeQuery.lua
@@ -272,9 +272,27 @@ You can click this button to enter your POESESSID.
 	
 	-- Stat sort popup button
 	self.statSortSelectionList = { }
+	t_insert(self.statSortSelectionList,  {
+		label = "Full DPS",
+		stat = "FullDPS",
+		weightMult = 1.0,
+	})
+	t_insert(self.statSortSelectionList,  {
+		label = "Effective Hit Pool",
+		stat = "TotalEHP",
+		weightMult = 0.5,
+	})
 	self.controls.StatWeightMultipliersButton = new("ButtonControl", {"TOPRIGHT", nil, "TOPRIGHT"}, -12, 15, 100, 18, "^7Sort Calc By:", function()
 		self:SetStatWeights()
 	end)
+	self.controls.StatWeightMultipliersButton.tooltipFunc = function(tooltip)
+		tooltip:Clear()
+		tooltip:AddLine(16, "Sorts the weights by the stats selected multiplied by a value")
+		tooltip:AddLine(16, "Currently sorting by:")
+		for _, stat in ipairs(self.statSortSelectionList) do
+			tooltip:AddLine(16, s_format("%s: %.2f", stat.label, stat.weightMult))
+		end
+	end
 
 ^2Session Mode^7
 - Requires POESESSID.
@@ -441,29 +459,30 @@ function TradeQueryClass:SetStatWeights()
 				end
 				return controls[stat.label.."Slider"].tooltip.realDraw(self, x, y, width, height, viewPort)
 			end
-			if stat.label == "Full DPS" then
-				controls[stat.label.."Slider"]:SetVal(1.0)
-				statList[stat.stat].weightMult = 1.0
-			elseif stat.label == "Effective Hit Pool" then
-				controls[stat.label.."Slider"]:SetVal(0.49)
-				statList[stat.stat].weightMult = 0.49
-			end
 			lastItemAnchor = { controls[stat.label.."SliderLabel"], controls[stat.label.."Slider"], controls[stat.label.."SliderValue"] }
 			popupHeight = popupHeight + 21
 		end
+	end
+	
+	for _, stat in ipairs(self.statSortSelectionList) do
+		controls[stat.label.."Slider"]:SetVal(stat.weightMult == 1 and 1 or stat.weightMult - 0.01)
+		statList[stat.stat].weightMult = stat.weightMult
 	end
 
 	controls.finalise = new("ButtonControl", { "BOTTOM", nil, "BOTTOM" }, -45, -10, 80, 20, "Save", function()
 		main:ClosePopup()
 		
-		-- this needs to save the weights somewhere, maybe the XML?
+		-- this needs to save the weights somewhere, maybe the XML? its not nessesary but possibly useful QoL
 		local statSortSelectionList = {}
 		for stat, statTable in pairs(statList) do
 			if statTable.weightMult > 0 then
 				t_insert(statSortSelectionList, statTable)
 			end
 		end
-		self.statSortSelectionList = statSortSelectionList
+		if (#statSortSelectionList) > 0 then
+			--THIS SHOULD REALLY GIVE A WARNING NOT JUST USE PREVIOUS
+			self.statSortSelectionList = statSortSelectionList
+		end
     end)
 	controls.cancel = new("ButtonControl", { "BOTTOM", nil, "BOTTOM" }, 45, -10, 80, 20, "Cancel", function()
 		main:ClosePopup()

--- a/src/Classes/TradeQuery.lua
+++ b/src/Classes/TradeQuery.lua
@@ -439,7 +439,7 @@ function TradeQueryClass:SetStatWeights()
 	for id, stat in pairs(data.powerStatList) do
 		if not stat.ignoreForItems and stat.label ~= "Name" then
 			t_insert(statList, { 
-				label = stat.label.." :        ".."0", 
+				label = "0      :  "..stat.label, 
 				stat = {
 					label = stat.label,
 					stat = stat.stat,
@@ -455,11 +455,11 @@ function TradeQueryClass:SetStatWeights()
 		if value == 0 then
 			controls.SliderValue.label = "^7Disabled"
 			statList[sliderController.index].stat.weightMult = 0
-			statList[sliderController.index].label = statList[sliderController.index].stat.label.." :        "..s_format("%d", 0)
+			statList[sliderController.index].label = s_format("%d      :  ", 0)..statList[sliderController.index].stat.label
 		else
 			controls.SliderValue.label = s_format("^7%.2f", 0.01 + value * 0.99)
 			statList[sliderController.index].stat.weightMult = 0.01 + value * 0.99
-			statList[sliderController.index].label = statList[sliderController.index].stat.label.." :        "..s_format("%.2f", 0.01 + value * 0.99)
+			statList[sliderController.index].label = s_format("%.2f :  ", 0.01 + value * 0.99)..statList[sliderController.index].stat.label
 		end
 	end)
 	controls.SliderValue = new("LabelControl", { "TOPLEFT", controls.Slider, "TOPRIGHT" }, 20, 0, 0, 16, "^7Disabled")
@@ -481,7 +481,7 @@ function TradeQueryClass:SetStatWeights()
 		for _, stat in ipairs(statList) do
 			if stat.stat.stat == statBase.stat then
 				stat.stat.weightMult = statBase.weightMult
-				stat.label = statBase.label.." :        "..s_format("%.2f", statBase.weightMult)
+				stat.label = s_format("%.2f :  ", statBase.weightMult)..statBase.label
 				if statList[sliderController.index].stat.stat == statBase.stat then
 					controls.Slider:SetVal(statBase.weightMult == 1 and 1 or statBase.weightMult - 0.01)	
 				end

--- a/src/Classes/TradeQuery.lua
+++ b/src/Classes/TradeQuery.lua
@@ -324,7 +324,13 @@ on trade site to work on other leagues and realms)]]
 			self:UpdateControlsWithItems(slotTables[index], index)
 		end
 	end)
-	self.controls.itemSortSelection.tooltipText = "Weighted Sum searches will always sort\nusing descending weighted sum."
+	self.controls.itemSortSelection.tooltipText = 
+[[Weighted Sum searches will always sort using descending weighted sum
+Additional post filtering options can be done these include:
+Highest Stat Value - Sort from highest to lowest Stat Value change of equipping item
+Highest Stat Value / Price - Sorts from highest to lowest Stat Value per currency
+Lowest Price - Sorts from lowest to highest price of retrieved items
+Highest Weight - Displays the order retrieved from trade]]
 	self.controls.itemSortSelection:SetSel(self.pbItemSortSelectionIndex)
 	self.controls.itemSortSelectionLabel = new("LabelControl", {"TOPRIGHT", self.controls.itemSortSelection, "TOPLEFT"}, -4, 0, 100, 16, "^7Sort Items By:")
 
@@ -612,17 +618,18 @@ function TradeQueryClass:SetFetchResultReturn(slotIndex, index)
 end
 
 -- Method to sort the fetched results
+-- 1 Highest Stat Value
+-- 2 Stat Value / Price
+-- 3 Lowest Price
+-- 4 Highest Trade Weight
 function TradeQueryClass:SortFetchResults(slotTbl, trade_index)
 	local newTbl = {}
-	if self.pbItemSortSelectionIndex == 1 then
-		for index, tbl in pairs(self.resultTbl[trade_index]) do
-			t_insert(newTbl, { outputAttr = index, index = index })
-		end
-		return newTbl
-	end
-	if self.pbItemSortSelectionIndex > 2 then
+	-- Stat Value
+	if self.pbSortSelectionIndex <= 2 then
 		local slot = slotTbl.ref and self.itemsTab.sockets[slotTbl.ref] or self.itemsTab.slots[slotTbl.name]
 		local slotName = slotTbl.ref and "Jewel " .. tostring(slotTbl.ref) or slotTbl.name
+		local storedFullDPS = GlobalCache.useFullDPS
+		GlobalCache.useFullDPS = GlobalCache.numActiveSkillInFullDPS > 0
 		local calcFunc, calcBase = self.itemsTab.build.calcsTab:GetMiscCalculator()
 		for index, tbl in pairs(self.resultTbl[trade_index]) do
 			local item = new("Item", tbl.item_string)
@@ -635,9 +642,9 @@ function TradeQueryClass:SortFetchResults(slotTbl, trade_index)
 					newStatValue = newStatValue + ( output[statTable.stat] or 0 ) * statTable.weightMult
 				end
 			end
-			if self.pbItemSortSelectionIndex == 4 then
+			-- Stat Value / Price
+			if self.pbItemSortSelectionIndex == 2 then
 				local chaosAmount = self:ConvertCurrencyToChaos(tbl.currency, tbl.amount)
-				--print(tbl.amount, tbl.currency, item.name)
 				if chaosAmount > 0 then
 					t_insert(newTbl, { outputAttr = newStatValue / chaosAmount, index = index })
 				end

--- a/src/Classes/TradeQuery.lua
+++ b/src/Classes/TradeQuery.lua
@@ -492,7 +492,7 @@ function TradeQueryClass:SetStatWeights()
 	controls.finalise = new("ButtonControl", { "BOTTOM", nil, "BOTTOM" }, -45, -10, 80, 20, "Save", function()
 		main:ClosePopup()
 		
-		-- this needs to save the weights somewhere, maybe the XML? its not nessesary but possibly useful QoL
+		-- this needs to save the weights somewhere, maybe the XML? its not necessary but possibly useful QoL
 		local statSortSelectionList = {}
 		for stat, statTable in pairs(statList) do
 			if statTable.stat.weightMult > 0 then

--- a/src/Classes/TradeQuery.lua
+++ b/src/Classes/TradeQuery.lua
@@ -625,7 +625,7 @@ end
 function TradeQueryClass:SortFetchResults(slotTbl, trade_index)
 	local newTbl = {}
 	-- Stat Value
-	if self.pbSortSelectionIndex <= 2 then
+	if self.pbItemSortSelectionIndex <= 2 then
 		local slot = slotTbl.ref and self.itemsTab.sockets[slotTbl.ref] or self.itemsTab.slots[slotTbl.name]
 		local slotName = slotTbl.ref and "Jewel " .. tostring(slotTbl.ref) or slotTbl.name
 		local storedFullDPS = GlobalCache.useFullDPS

--- a/src/Classes/TradeQuery.lua
+++ b/src/Classes/TradeQuery.lua
@@ -305,29 +305,17 @@ on trade site to work on other leagues and realms)]]
 			tooltip:AddLine(16, s_format("%s: %.2f", stat.label, stat.weightMult))
 		end
 	end
-
-^2Session Mode^7
-- Requires POESESSID.
-- You can search, compare, and quickly import items without leaving Path of Building.
-- You can generate and perform searches for the private leagues you are participating.
-
-^xFF9922No Session Mode^7
-- Doesn't require POESESSID.
-- You cannot search and compare items in Path of Building.
-- You can generate weighted search URLs but have to visit the trade site and manually import items.
-- You can only generate weighted searches for public leagues. (Generated searches can be modified
-on trade site to work on other leagues and realms)]]
 	self.sortModes = {
-		DPS = "DPS",
-		DPS_PRICE = "DPS / Price",
-		PRICE_ASCENDING = "Price (Lowest)",
-		WEIGHT = "Weighted Sum",
+		StatValue = "(Highest) Stat Value",
+		StatValuePRICE = "Stat Value / Price",
+		PRICE = "(Lowest) Price",
+		WEIGHT = "(Highest) Weighted Sum",
 	}
 	-- Item sort dropdown
-	self.sortSelectionList = {
-		self.sortModes.DPS,
-		self.sortModes.DPS_PRICE,
-		self.sortModes.PRICE_ASCENDING,
+	self.itemSortSelectionList = {
+		self.sortModes.StatValue,
+		self.sortModes.StatValuePRICE,
+		self.sortModes.PRICE,
 		self.sortModes.WEIGHT,
 	}
 	self.controls.itemSortSelection = new("DropDownControl", {"TOPRIGHT",self.controls.StatWeightMultipliersButton,"BOTTOMRIGHT"}, 0, 4, 154, 18, self.itemSortSelectionList, function(index, value)
@@ -587,12 +575,13 @@ end
 
 -- Method to update controls after a search is completed
 function TradeQueryClass:UpdateControlsWithItems(slotTbl, index)
-	local sortMode = self.sortSelectionList[self.pbSortSelectionIndex]
+	local sortMode = self.itemSortSelectionList[self.pbItemSortSelectionIndex]
 	local sortedItems, errMsg = self:SortFetchResults(slotTbl, index, sortMode)
 	if errMsg == "MissingConversionRates" then
-		self:SetNotice(self.controls.pbNotice, "^4Price sorting is not available, falling back to DPS sort.")
-		sortedItems, errMsg = self:SortFetchResults(slotTbl, index, self.sortModes.DPS)
-	elseif errMsg then
+		self:SetNotice(self.controls.pbNotice, "^4Price sorting is not available, falling back to Stat Value sort.")
+		sortedItems, errMsg = self:SortFetchResults(slotTbl, index, self.sortModes.StatValue)
+	end
+	if errMsg then
 		self:SetNotice(self.controls.pbNotice, "Error: " .. errMsg)
 		return
 	else
@@ -630,15 +619,9 @@ function TradeQueryClass:SetFetchResultReturn(slotIndex, index)
 end
 
 -- Method to sort the fetched results
--- 1 Highest Stat Value
--- 2 Stat Value / Price
--- 3 Lowest Price
--- 4 Highest Trade Weight
-function TradeQueryClass:SortFetchResults(slotTbl, trade_index)
-	local newTbl = {}
-	-- Stat Value
-	if self.pbItemSortSelectionIndex <= 2 then
-		local slot = slotTbl.ref and self.itemsTab.sockets[slotTbl.ref] or self.itemsTab.slots[slotTbl.name]
+function TradeQueryClass:SortFetchResults(slotTbl, trade_index, mode)
+	local function getStatValueTable()
+		local out = {}
 		local slotName = slotTbl.ref and "Jewel " .. tostring(slotTbl.ref) or slotTbl.name
 		local storedFullDPS = GlobalCache.useFullDPS
 		GlobalCache.useFullDPS = GlobalCache.numActiveSkillInFullDPS > 0
@@ -649,23 +632,14 @@ function TradeQueryClass:SortFetchResults(slotTbl, trade_index)
 			local newStatValue = 0
 			for _, statTable in ipairs(self.statSortSelectionList) do
 				if statTable.stat == "FullDPS" and not GlobalCache.useFullDPS then
-					newStatValue = newStatValue + m_max(output.TotalDPS or 0, m_max(output.TotalDotDPS or 0, output.CombinedDPS or 0)) * statTable.weightMult
+					newStatValue = newStatValue + m_max(output.TotalDPS or 0, m_max(output.TotalDot or 0, output.CombinedAvg or 0)) * statTable.weightMult
 				else
 					newStatValue = newStatValue + ( output[statTable.stat] or 0 ) * statTable.weightMult
 				end
 			end
-			-- Stat Value / Price
-			if self.pbItemSortSelectionIndex == 2 then
-				local chaosAmount = self:ConvertCurrencyToChaos(tbl.currency, tbl.amount)
-				if chaosAmount > 0 then
-					t_insert(newTbl, { outputAttr = newStatValue / chaosAmount, index = index })
-				end
-			else
-				if tbl.amount > 0 then
-					t_insert(newTbl, { outputAttr = newStatValue, index = index })
-				end
-			end
+			out[index] = newStatValue
 		end
+		GlobalCache.useFullDPS = storedFullDPS
 		return out
 	end
 	local function getPriceTable()
@@ -688,23 +662,23 @@ function TradeQueryClass:SortFetchResults(slotTbl, trade_index)
 			t_insert(newTbl, { outputAttr = index, index = index })
 		end
 		return newTbl
-	elseif mode == self.sortModes.DPS  then
-		local dpsTable = getDpsTable()
-		for index, dps in pairs(dpsTable) do
-			t_insert(newTbl, { outputAttr = dps, index = index })
+	elseif mode == self.sortModes.StatValue  then
+		local StatValueTable = getStatValueTable()
+		for index, statValue in pairs(StatValueTable) do
+			t_insert(newTbl, { outputAttr = statValue, index = index })
 		end
 		table.sort(newTbl, function(a,b) return a.outputAttr > b.outputAttr end)
-	elseif mode == self.sortModes.DPS_PRICE then
-		local dpsTable = getDpsTable()
+	elseif mode == self.sortModes.StatValuePRICE then
+		local StatValueTable = getStatValueTable()
 		local priceTable = getPriceTable()
 		if priceTable == nil then
 			return nil, "MissingConversionRates"
 		end
-		for index, dps in pairs(dpsTable) do
-			t_insert(newTbl, { outputAttr = dps / priceTable[index], index = index })
+		for index, statValue in pairs(StatValueTable) do
+			t_insert(newTbl, { outputAttr = statValue / priceTable[index], index = index })
 		end
 		table.sort(newTbl, function(a,b) return a.outputAttr > b.outputAttr end)
-	elseif mode == self.sortModes.PRICE_ASCENDING then
+	elseif mode == self.sortModes.PRICE then
 		local priceTable = getPriceTable()
 		if priceTable == nil then
 			return nil, "MissingConversionRates"
@@ -777,7 +751,7 @@ function TradeQueryClass:PriceItemRowDisplay(str_cnt, slotTbl, top_pane_alignmen
 		end)
 	end)
 	controls["bestButton"..str_cnt].shown = function() return not self.resultTbl[str_cnt] end
-	controls["bestButton"..str_cnt].tooltipText = "Creates a weighted search to find the highest DPS items for this slot."
+	controls["bestButton"..str_cnt].tooltipText = "Creates a weighted search to find the highest Stat Value items for this slot."
 	controls["uri"..str_cnt] = new("EditControl", {"TOPLEFT",controls["bestButton"..str_cnt],"TOPRIGHT"}, 8, 0, 518, row_height, nil, nil, "^%C\t\n", nil, function(buf)
 		local subpath = buf:match("https://www.pathofexile.com/trade/search/(.+)$") or ""
 		local paths = {}

--- a/src/Classes/TradeQuery.lua
+++ b/src/Classes/TradeQuery.lua
@@ -649,7 +649,7 @@ function TradeQueryClass:SortFetchResults(slotTbl, trade_index)
 			local newStatValue = 0
 			for _, statTable in ipairs(self.statSortSelectionList) do
 				if statTable.stat == "FullDPS" and not GlobalCache.useFullDPS then
-					newStatValue = newStatValue + m_max(output.TotalDPS or 0, m_max(output.TotalDot or 0, output.CombinedAvg or 0)) * statTable.weightMult
+					newStatValue = newStatValue + m_max(output.TotalDPS or 0, m_max(output.TotalDotDPS or 0, output.CombinedDPS or 0)) * statTable.weightMult
 				else
 					newStatValue = newStatValue + ( output[statTable.stat] or 0 ) * statTable.weightMult
 				end

--- a/src/Classes/TradeQuery.lua
+++ b/src/Classes/TradeQuery.lua
@@ -27,8 +27,11 @@ local TradeQueryClass = newClass("TradeQuery", function(self, itemsTab)
 	self.sortedResultTbl = { }
 	self.itemIndexTbl = { }
 
+	-- default set of calc sort selection
+	self.pbCalcSortSelectionIndex = 1
+	
 	-- default set of trade item sort selection
-	self.pbSortSelectionIndex = 1
+	self.pbItemSortSelectionIndex = 1
 	self.pbCurrencyConversion = { }
 	self.currencyConversionTradeMap = { }
 	self.lastCurrencyConversionRequest = 0
@@ -268,6 +271,25 @@ function TradeQueryClass:PriceItem()
 	self.controls.poesessidButton.tooltipText = [[
 The Trader feature supports two modes of operation depending on the POESESSID availability.
 You can click this button to enter your POESESSID.
+	
+	-- Calc sort dropdown
+	self.calcSortSelectionList = { }
+	for id, stat in pairs(data.powerStatList) do
+		if not stat.ignoreForItems and stat.label ~= "Name" then
+			t_insert(self.calcSortSelectionList, {
+				label = stat.label,
+				stat = stat.stat,
+				transform = stat.transform,
+			})
+		end
+	end
+	self.controls.calcSortSelection = new("DropDownControl", {"TOPRIGHT", nil, "TOPRIGHT"}, -12, 15, 100, 18, self.calcSortSelectionList, function(index, value)
+		self.pbCalcSortSelectionIndex = index
+	end)
+	self.controls.calcSortSelection.tooltipText = "Type of calc to sort by"
+	self.controls.calcSortSelection:SetSel(self.pbCalcSortSelectionIndex)
+	self.controls.calcSortSelectionLabel = new("LabelControl", {"TOPRIGHT", self.controls.calcSortSelection, "TOPLEFT"}, -4, 0, 100, 16, "^7Sort Calc By:")
+	
 
 ^2Session Mode^7
 - Requires POESESSID.
@@ -293,18 +315,18 @@ on trade site to work on other leagues and realms)]]
 		self.sortModes.PRICE_ASCENDING,
 		self.sortModes.WEIGHT,
 	}
-	self.controls.itemSortSelection = new("DropDownControl", {"TOPRIGHT", nil, "TOPRIGHT"}, -12, 19, 100, 18, self.sortSelectionList, function(index, value)
-		self.pbSortSelectionIndex = index
+	self.controls.itemSortSelection = new("DropDownControl", {"TOPRIGHT",self.controls.calcSortSelection,"BOTTOMRIGHT"}, 0, 4, 154, 18, self.itemSortSelectionList, function(index, value)
+		self.pbItemSortSelectionIndex = index
 		for index, _ in pairs(self.resultTbl) do
 			self:UpdateControlsWithItems(slotTables[index], index)
 		end
 	end)
 	self.controls.itemSortSelection.tooltipText = "Weighted Sum searches will always sort\nusing descending weighted sum."
-	self.controls.itemSortSelection:SetSel(self.pbSortSelectionIndex)
-	self.controls.itemSortSelectionLabel = new("LabelControl", {"TOPRIGHT", self.controls.itemSortSelection, "TOPLEFT"}, -4, 0, 60, 16, "^7Sort By:")
+	self.controls.itemSortSelection:SetSel(self.pbItemSortSelectionIndex)
+	self.controls.itemSortSelectionLabel = new("LabelControl", {"TOPRIGHT", self.controls.itemSortSelection, "TOPLEFT"}, -4, 0, 100, 16, "^7Sort Items By:")
 
 	self.maxFetchPerSearchDefault = 2
-	self.controls.fetchCountEdit = new("EditControl", {"TOPRIGHT",self.controls.itemSortSelection,"BOTTOMRIGHT"}, 0, 4, 154, row_height, "", "Fetch Pages", "%D", 3, function(buf)
+	self.controls.fetchCountEdit = new("EditControl", {"TOPRIGHT", self.controls.itemSortSelectionLabel, "TOPLEFT"}, -8, 0, 150, row_height, "", "Fetch Pages", "%D", 3, function(buf)
 		self.maxFetchPages = m_min(m_max(tonumber(buf) or self.maxFetchPerSearchDefault, 1), 10)
 		self.tradeQueryRequests.maxFetchPerSearch = 10 * self.maxFetchPages
 		self.controls.fetchCountEdit.focusValue = self.maxFetchPages
@@ -473,7 +495,7 @@ function TradeQueryClass:UpdateControlsWithItems(slotTbl, index)
 
 	self.sortedResultTbl[index] = sortedItems
 	self.itemIndexTbl[index] = self.sortedResultTbl[index][1].index
-	self.controls["priceButton"..index].tooltipText = "Sorted by " .. self.sortSelectionList[self.pbSortSelectionIndex]
+	self.controls["priceButton"..index].tooltipText = "Sorted by " .. self.itemSortSelectionList[self.pbItemSortSelectionIndex]
 	local pb_index = self.sortedResultTbl[index][1].index
 	self.totalPrice[index] = {
 		currency = self.resultTbl[index][pb_index].currency,
@@ -501,16 +523,40 @@ function TradeQueryClass:SetFetchResultReturn(slotIndex, index)
 	end
 end
 
-function TradeQueryClass:SortFetchResults(slotTbl, trade_index, mode)
-	local function getDpsTable()
-		local out = {}
+-- Method to sort the fetched results
+function TradeQueryClass:SortFetchResults(slotTbl, trade_index)
+	local newTbl = {}
+	if self.pbItemSortSelectionIndex == 1 then
+		for index, tbl in pairs(self.resultTbl[trade_index]) do
+			t_insert(newTbl, { outputAttr = index, index = index })
+		end
+		return newTbl
+	end
+	if self.pbItemSortSelectionIndex > 2 then
+		local slot = slotTbl.ref and self.itemsTab.sockets[slotTbl.ref] or self.itemsTab.slots[slotTbl.name]
 		local slotName = slotTbl.ref and "Jewel " .. tostring(slotTbl.ref) or slotTbl.name
-		local calcFunc, _ = self.itemsTab.build.calcsTab:GetMiscCalculator()
+		local calcFunc, calcBase = self.itemsTab.build.calcsTab:GetMiscCalculator()
+		local newCalcedType = self.calcSortSelectionList[self.pbCalcSortSelectionIndex].stat
 		for index, tbl in pairs(self.resultTbl[trade_index]) do
 			local item = new("Item", tbl.item_string)
 			local output = calcFunc({ repSlotName = slotName, repItem = item }, {})
-			local newDPS = GlobalCache.useFullDPS and output.FullDPS or m_max(output.TotalDPS, m_max(output.TotalDot, output.CombinedAvg))
-			out[index] = newDPS
+			local newStatValue = 0
+			if newCalcedType == "FullDPS" and not GlobalCache.useFullDPS then
+				newStatValue = m_max(output.TotalDPS, m_max(output.TotalDot, output.CombinedAvg))
+			else
+				newStatValue = output[newCalcedType]
+			end
+			if self.pbItemSortSelectionIndex == 4 then
+				local chaosAmount = self:ConvertCurrencyToChaos(tbl.currency, tbl.amount)
+				--print(tbl.amount, tbl.currency, item.name)
+				if chaosAmount > 0 then
+					t_insert(newTbl, { outputAttr = newStatValue / chaosAmount, index = index })
+				end
+			else
+				if tbl.amount > 0 then
+					t_insert(newTbl, { outputAttr = newStatValue, index = index })
+				end
+			end
 		end
 		return out
 	end
@@ -585,7 +631,7 @@ function TradeQueryClass:PriceItemRowDisplay(str_cnt, slotTbl, top_pane_alignmen
 	local activeSlotRef = slotTbl.ref and self.itemsTab.activeItemSet[slotTbl.ref] or self.itemsTab.activeItemSet[slotTbl.name]
 	controls["name"..str_cnt] = new("LabelControl", top_pane_alignment_ref, top_pane_alignment_width, top_pane_alignment_height, 100, row_height-4, "^7"..slotTbl.name)
 	controls["bestButton"..str_cnt] = new("ButtonControl", {"TOPLEFT",controls["name"..str_cnt],"TOPLEFT"}, 100 + 8, 0, 80, row_height, "Find best", function()
-		self.tradeQueryGenerator:RequestQuery(slotTbl.ref and self.itemsTab.sockets[slotTbl.ref] or self.itemsTab.slots[slotTbl.name], { slotTbl = slotTbl, controls = controls, str_cnt = str_cnt }, function(context, query, errMsg)
+		self.tradeQueryGenerator:RequestQuery(slotTbl.ref and self.itemsTab.sockets[slotTbl.ref] or self.itemsTab.slots[slotTbl.name], { slotTbl = slotTbl, controls = controls, str_cnt = str_cnt }, { { stat = self.calcSortSelectionList[self.pbCalcSortSelectionIndex], weight = 1 } }, function(context, query)
 			if errMsg then
 				self:SetNotice(context.controls.pbNotice, colorCodes.NEGATIVE .. errMsg)
 				return
@@ -598,7 +644,7 @@ function TradeQueryClass:PriceItemRowDisplay(str_cnt, slotTbl, top_pane_alignmen
 				controls["uri"..context.str_cnt]:SetText(url, true)
 				return
 			end
-			self.pbSortSelectionIndex = 1
+			self.pbItemSortSelectionIndex = 1
 			context.controls["priceButton"..context.str_cnt].label = "Searching..."
 			self.tradeQueryRequests:SearchWithQueryWeightAdjusted(self.pbRealm, self.pbLeague, query, 
 				function(items, errMsg)

--- a/src/Classes/TradeQuery.lua
+++ b/src/Classes/TradeQuery.lua
@@ -687,7 +687,7 @@ function TradeQueryClass:PriceItemRowDisplay(str_cnt, slotTbl, top_pane_alignmen
 	local activeSlotRef = slotTbl.ref and self.itemsTab.activeItemSet[slotTbl.ref] or self.itemsTab.activeItemSet[slotTbl.name]
 	controls["name"..str_cnt] = new("LabelControl", top_pane_alignment_ref, top_pane_alignment_width, top_pane_alignment_height, 100, row_height-4, "^7"..slotTbl.name)
 	controls["bestButton"..str_cnt] = new("ButtonControl", {"TOPLEFT",controls["name"..str_cnt],"TOPLEFT"}, 100 + 8, 0, 80, row_height, "Find best", function()
-		self.tradeQueryGenerator:RequestQuery(slotTbl.ref and self.itemsTab.sockets[slotTbl.ref] or self.itemsTab.slots[slotTbl.name], { slotTbl = slotTbl, controls = controls, str_cnt = str_cnt }, self.statSortSelectionList, function(context, query)
+		self.tradeQueryGenerator:RequestQuery(slotTbl.ref and self.itemsTab.sockets[slotTbl.ref] or self.itemsTab.slots[slotTbl.name], { slotTbl = slotTbl, controls = controls, str_cnt = str_cnt }, self.statSortSelectionList, function(context, query, errMsg)
 			if errMsg then
 				self:SetNotice(context.controls.pbNotice, colorCodes.NEGATIVE .. errMsg)
 				return

--- a/src/Classes/TradeQuery.lua
+++ b/src/Classes/TradeQuery.lua
@@ -28,7 +28,7 @@ local TradeQueryClass = newClass("TradeQuery", function(self, itemsTab)
 	self.itemIndexTbl = { }
 
 	-- default set of calc sort selection
-	self.pbCalcSortSelectionIndex = 1
+	self.pbStatSortSelectionIndex = 1
 	
 	-- default set of trade item sort selection
 	self.pbItemSortSelectionIndex = 1
@@ -273,22 +273,22 @@ The Trader feature supports two modes of operation depending on the POESESSID av
 You can click this button to enter your POESESSID.
 	
 	-- Calc sort dropdown
-	self.calcSortSelectionList = { }
+	self.statSortSelectionList = { }
 	for id, stat in pairs(data.powerStatList) do
 		if not stat.ignoreForItems and stat.label ~= "Name" then
-			t_insert(self.calcSortSelectionList, {
+			t_insert(self.statSortSelectionList, {
 				label = stat.label,
 				stat = stat.stat,
 				transform = stat.transform,
 			})
 		end
 	end
-	self.controls.calcSortSelection = new("DropDownControl", {"TOPRIGHT", nil, "TOPRIGHT"}, -12, 15, 100, 18, self.calcSortSelectionList, function(index, value)
-		self.pbCalcSortSelectionIndex = index
+	self.controls.statSortSelection = new("DropDownControl", {"TOPRIGHT", nil, "TOPRIGHT"}, -12, 15, 100, 18, self.statSortSelectionList, function(index, value)
+		self.pbStatSortSelectionIndex = index
 	end)
-	self.controls.calcSortSelection.tooltipText = "Type of calc to sort by"
-	self.controls.calcSortSelection:SetSel(self.pbCalcSortSelectionIndex)
-	self.controls.calcSortSelectionLabel = new("LabelControl", {"TOPRIGHT", self.controls.calcSortSelection, "TOPLEFT"}, -4, 0, 100, 16, "^7Sort Calc By:")
+	self.controls.statSortSelection.tooltipText = "Type of calc to sort by"
+	self.controls.statSortSelection:SetSel(self.pbStatSortSelectionIndex)
+	self.controls.statSortSelectionLabel = new("LabelControl", {"TOPRIGHT", self.controls.statSortSelection, "TOPLEFT"}, -4, 0, 100, 16, "^7Sort Calc By:")
 	
 
 ^2Session Mode^7
@@ -315,7 +315,7 @@ on trade site to work on other leagues and realms)]]
 		self.sortModes.PRICE_ASCENDING,
 		self.sortModes.WEIGHT,
 	}
-	self.controls.itemSortSelection = new("DropDownControl", {"TOPRIGHT",self.controls.calcSortSelection,"BOTTOMRIGHT"}, 0, 4, 154, 18, self.itemSortSelectionList, function(index, value)
+	self.controls.itemSortSelection = new("DropDownControl", {"TOPRIGHT",self.controls.statSortSelection,"BOTTOMRIGHT"}, 0, 4, 154, 18, self.itemSortSelectionList, function(index, value)
 		self.pbItemSortSelectionIndex = index
 		for index, _ in pairs(self.resultTbl) do
 			self:UpdateControlsWithItems(slotTables[index], index)
@@ -536,15 +536,15 @@ function TradeQueryClass:SortFetchResults(slotTbl, trade_index)
 		local slot = slotTbl.ref and self.itemsTab.sockets[slotTbl.ref] or self.itemsTab.slots[slotTbl.name]
 		local slotName = slotTbl.ref and "Jewel " .. tostring(slotTbl.ref) or slotTbl.name
 		local calcFunc, calcBase = self.itemsTab.build.calcsTab:GetMiscCalculator()
-		local newCalcedType = self.calcSortSelectionList[self.pbCalcSortSelectionIndex].stat
+		local newCalcedType = self.statSortSelectionList[self.pbStatSortSelectionIndex].stat
 		for index, tbl in pairs(self.resultTbl[trade_index]) do
 			local item = new("Item", tbl.item_string)
 			local output = calcFunc({ repSlotName = slotName, repItem = item }, {})
 			local newStatValue = 0
 			if newCalcedType == "FullDPS" and not GlobalCache.useFullDPS then
-				newStatValue = m_max(output.TotalDPS, m_max(output.TotalDot, output.CombinedAvg))
+				newStatValue = m_max(output.TotalDPS or 0, m_max(output.TotalDot or 0, output.CombinedAvg or 0))
 			else
-				newStatValue = output[newCalcedType]
+				newStatValue = output[newCalcedType] or 0
 			end
 			if self.pbItemSortSelectionIndex == 4 then
 				local chaosAmount = self:ConvertCurrencyToChaos(tbl.currency, tbl.amount)
@@ -631,7 +631,7 @@ function TradeQueryClass:PriceItemRowDisplay(str_cnt, slotTbl, top_pane_alignmen
 	local activeSlotRef = slotTbl.ref and self.itemsTab.activeItemSet[slotTbl.ref] or self.itemsTab.activeItemSet[slotTbl.name]
 	controls["name"..str_cnt] = new("LabelControl", top_pane_alignment_ref, top_pane_alignment_width, top_pane_alignment_height, 100, row_height-4, "^7"..slotTbl.name)
 	controls["bestButton"..str_cnt] = new("ButtonControl", {"TOPLEFT",controls["name"..str_cnt],"TOPLEFT"}, 100 + 8, 0, 80, row_height, "Find best", function()
-		self.tradeQueryGenerator:RequestQuery(slotTbl.ref and self.itemsTab.sockets[slotTbl.ref] or self.itemsTab.slots[slotTbl.name], { slotTbl = slotTbl, controls = controls, str_cnt = str_cnt }, { { stat = self.calcSortSelectionList[self.pbCalcSortSelectionIndex], weight = 1 } }, function(context, query)
+		self.tradeQueryGenerator:RequestQuery(slotTbl.ref and self.itemsTab.sockets[slotTbl.ref] or self.itemsTab.slots[slotTbl.name], { slotTbl = slotTbl, controls = controls, str_cnt = str_cnt }, { { stat = self.statSortSelectionList[self.pbStatSortSelectionIndex], weight = 1 } }, function(context, query)
 			if errMsg then
 				self:SetNotice(context.controls.pbNotice, colorCodes.NEGATIVE .. errMsg)
 				return

--- a/src/Classes/TradeQueryGenerator.lua
+++ b/src/Classes/TradeQueryGenerator.lua
@@ -406,7 +406,7 @@ function TradeQueryGeneratorClass:GenerateModWeights(modsToTest)
 			local meanStatDiff = 0
 			for _, statTable in ipairs(self.calcContext.options.statWeights) do
 				if statTable.stat == "FullDPS" and not GlobalCache.useFullDPS then
-					meanStatDiff = meanStatDiff + m_max(output.TotalDPS or 0, m_max(output.TotalDot or 0, output.CombinedAvg or 0)) * statTable.weightMult
+					meanStatDiff = meanStatDiff + m_max(output.TotalDPS or 0, m_max(output.TotalDotDPS or 0, output.CombinedDPS or 0)) * statTable.weightMult
 				else
 					meanStatDiff = meanStatDiff + ( output[statTable.stat] or 0 ) * statTable.weightMult
 				end
@@ -534,7 +534,7 @@ function TradeQueryGeneratorClass:StartQuery(slot, options)
 	local compStatValue = 0
 	for _, statTable in ipairs(options.statWeights) do
 		if statTable.stat == "FullDPS" and not GlobalCache.useFullDPS then
-			compStatValue = compStatValue + m_max(baseOutput.TotalDPS or 0, m_max(baseOutput.TotalDot or 0, baseOutput.CombinedAvg or 0)) * statTable.weightMult
+			compStatValue = compStatValue + m_max(baseOutput.TotalDPS or 0, m_max(baseOutput.TotalDotDPS or 0, baseOutput.CombinedDPS or 0)) * statTable.weightMult
 		else
 			compStatValue = compStatValue + (baseOutput[statTable.stat] or 0) * statTable.weightMult
 		end
@@ -603,7 +603,7 @@ function TradeQueryGeneratorClass:FinishQuery()
 	local currentStatDiff = 0
 	for _, statTable in ipairs(self.calcContext.options.statWeights) do
 		if statTable.stat == "FullDPS" and not GlobalCache.useFullDPS then
-			currentStatDiff = currentStatDiff + m_max(originalOutput.TotalDPS or 0, m_max(originalOutput.TotalDot or 0, originalOutput.CombinedAvg or 0)) * statTable.weightMult
+			currentStatDiff = currentStatDiff + m_max(originalOutput.TotalDPS or 0, m_max(originalOutput.TotalDotDPS or 0, originalOutput.CombinedDPS or 0)) * statTable.weightMult
 		else
 			currentStatDiff = currentStatDiff + ( originalOutput[statTable.stat] or 0 ) * statTable.weightMult
 		end

--- a/src/Classes/TradeQueryGenerator.lua
+++ b/src/Classes/TradeQueryGenerator.lua
@@ -793,6 +793,10 @@ function TradeQueryGeneratorClass:RequestQuery(slot, context, statWeights, callb
 	controls.maxPriceType = new("DropDownControl", {"LEFT",controls.maxPrice,"RIGHT"}, 5, 0, 150, 18, currencyDropdownNames, function(index, value) end)
 	controls.maxPriceLabel = new("LabelControl", {"RIGHT",controls.maxPrice,"LEFT"}, -5, 0, 0, 16, "Max Price:")
 	popupHeight = popupHeight + 23
+	
+    controls.sortStatType = new("LabelControl", {"TOPLEFT",lastItemAnchor,"BOTTOMLEFT"}, 0, 5, 70, 18, statWeights[1].label)
+    controls.sortStatLabel = new("LabelControl", {"RIGHT",controls.sortStatType,"LEFT"}, -5, 0, 0, 16, "Stat to Sort By:")
+    popupHeight = popupHeight + 23
 
 	controls.generateQuery = new("ButtonControl", { "BOTTOM", nil, "BOTTOM" }, -45, -10, 80, 20, "Execute", function()
 		main:ClosePopup()

--- a/src/Classes/TradeQueryGenerator.lua
+++ b/src/Classes/TradeQueryGenerator.lua
@@ -402,7 +402,7 @@ function TradeQueryGeneratorClass:GenerateModWeights(modsToTest)
 				logToFile("Failed to test %s mod: %s", self.calcContext.itemCategory, modLine)
 			end
 
-            local output = self.calcContext.calcFunc({ repSlotName = self.calcContext.slot.slotName, repItem = self.calcContext.testItem }, {})
+			local output = self.calcContext.calcFunc({ repSlotName = self.calcContext.slot.slotName, repItem = self.calcContext.testItem }, {})
 			local meanStatDiff = 0
 			for _, statTable in ipairs(self.calcContext.options.statWeights) do
 				if statTable.stat == "FullDPS" and not GlobalCache.useFullDPS then
@@ -412,10 +412,10 @@ function TradeQueryGeneratorClass:GenerateModWeights(modsToTest)
 				end
 			end
 			meanStatDiff = meanStatDiff - (self.calcContext.baseStatValue or 0)
-            if meanStatDiff > 0.01 then
-                table.insert(self.modWeights, { tradeModId = entry.tradeMod.id, weight = meanStatDiff / modValue, meanStatDiff = meanStatDiff, invert = entry.sign == "-" and true or false })
-                self.alreadyWeightedMods[entry.tradeMod.id] = true
-            end
+			if meanStatDiff > 0.01 then
+				table.insert(self.modWeights, { tradeModId = entry.tradeMod.id, weight = meanStatDiff / modValue, meanStatDiff = meanStatDiff, invert = entry.sign == "-" and true or false })
+				self.alreadyWeightedMods[entry.tradeMod.id] = true
+			end
 
 			local now = GetTime()
 			if now - start > 50 then
@@ -528,9 +528,9 @@ function TradeQueryGeneratorClass:StartQuery(slot, options)
 	local storedGlobalCacheDPSView = GlobalCache.useFullDPS
 	GlobalCache.useFullDPS = GlobalCache.numActiveSkillInFullDPS > 0
 
-    -- Calculate base output with a blank item
-    local calcFunc, _ = self.itemsTab.build.calcsTab:GetMiscCalculator()
-    local baseOutput = calcFunc({ repSlotName = slot.slotName, repItem = testItem }, {})
+	-- Calculate base output with a blank item
+	local calcFunc, _ = self.itemsTab.build.calcsTab:GetMiscCalculator()
+	local baseOutput = calcFunc({ repSlotName = slot.slotName, repItem = testItem }, {})
 	local compStatValue = 0
 	for _, statTable in ipairs(options.statWeights) do
 		if statTable.stat == "FullDPS" and not GlobalCache.useFullDPS then
@@ -541,19 +541,19 @@ function TradeQueryGeneratorClass:StartQuery(slot, options)
 	end
 
 	-- Test each mod one at a time and cache the normalized Stat (configured earlier) diff to use as weight
-    self.modWeights = { }
-    self.alreadyWeightedMods = { }
+	self.modWeights = { }
+	self.alreadyWeightedMods = { }
 
-    self.calcContext = {
-        itemCategoryQueryStr = itemCategoryQueryStr,
-        itemCategory = itemCategory,
-        testItem = testItem,
-        baseStatValue = compStatValue,
-        calcFunc = calcFunc,
-        options = options,
-        slot = slot,
-        globalCacheUseFullDPS = storedGlobalCacheDPSView
-    }
+	self.calcContext = {
+		itemCategoryQueryStr = itemCategoryQueryStr,
+		itemCategory = itemCategory,
+		testItem = testItem,
+		baseStatValue = compStatValue,
+		calcFunc = calcFunc,
+		options = options,
+		slot = slot,
+		globalCacheUseFullDPS = storedGlobalCacheDPSView
+	}
 
 	-- OnFrame will pick this up and begin the work
 	self.calcContext.co = coroutine.create(self.ExecuteQuery)
@@ -583,23 +583,23 @@ function TradeQueryGeneratorClass:ExecuteQuery()
 end
 
 function TradeQueryGeneratorClass:FinishQuery()
-    -- Calc original item Stats without anoint or enchant, and use that diff as a basis for default min sum.
-    local originalItem = self.itemsTab.items[self.calcContext.slot.selItemId]
-    self.calcContext.testItem.explicitModLines = { }
-    if originalItem then
-        for _, modLine in ipairs(originalItem.explicitModLines) do
-            table.insert(self.calcContext.testItem.explicitModLines, modLine)
-        end
-        for _, modLine in ipairs(originalItem.scourgeModLines) do
-            table.insert(self.calcContext.testItem.explicitModLines, modLine)
-        end
-        for _, modLine in ipairs(originalItem.implicitModLines) do
-            table.insert(self.calcContext.testItem.explicitModLines, modLine)
-        end
-    end
-    self.calcContext.testItem:BuildAndParseRaw()
+	-- Calc original item Stats without anoint or enchant, and use that diff as a basis for default min sum.
+	local originalItem = self.itemsTab.items[self.calcContext.slot.selItemId]
+	self.calcContext.testItem.explicitModLines = { }
+	if originalItem then
+		for _, modLine in ipairs(originalItem.explicitModLines) do
+			table.insert(self.calcContext.testItem.explicitModLines, modLine)
+		end
+		for _, modLine in ipairs(originalItem.scourgeModLines) do
+			table.insert(self.calcContext.testItem.explicitModLines, modLine)
+		end
+		for _, modLine in ipairs(originalItem.implicitModLines) do
+			table.insert(self.calcContext.testItem.explicitModLines, modLine)
+		end
+	end
+	self.calcContext.testItem:BuildAndParseRaw()
 
-    local originalOutput = self.calcContext.calcFunc({ repSlotName = self.calcContext.slot.slotName, repItem = self.calcContext.testItem }, {})
+	local originalOutput = self.calcContext.calcFunc({ repSlotName = self.calcContext.slot.slotName, repItem = self.calcContext.testItem }, {})
 	local currentStatDiff = 0
 	for _, statTable in ipairs(self.calcContext.options.statWeights) do
 		if statTable.stat == "FullDPS" and not GlobalCache.useFullDPS then
@@ -613,14 +613,14 @@ function TradeQueryGeneratorClass:FinishQuery()
 	-- Restore global cache full DPS
 	GlobalCache.useFullDPS = self.calcContext.globalCacheUseFullDPS
 
-    -- This Stat diff value will generally be higher than the weighted sum of the same item, because the stats are all applied at once and can thus multiply off each other.
-    -- So apply a modifier to get a reasonable min and hopefully approximate that the query will start out with small upgrades.
-    local minWeight = currentStatDiff * 0.7
+	-- This Stat diff value will generally be higher than the weighted sum of the same item, because the stats are all applied at once and can thus multiply off each other.
+	-- So apply a modifier to get a reasonable min and hopefully approximate that the query will start out with small upgrades.
+	local minWeight = currentStatDiff * 0.7
 
-    -- Sort by mean Stat diff rather than weight to more accurately prioritize stats that can contribute more
-    table.sort(self.modWeights, function(a, b)
-        return a.meanStatDiff > b.meanStatDiff
-    end)
+	-- Sort by mean Stat diff rather than weight to more accurately prioritize stats that can contribute more
+	table.sort(self.modWeights, function(a, b)
+		return a.meanStatDiff > b.meanStatDiff
+	end)
 
 	-- Generate trade query str and open in browser
 	local filters = 0
@@ -699,8 +699,8 @@ function TradeQueryGeneratorClass:FinishQuery()
 end
 
 function TradeQueryGeneratorClass:RequestQuery(slot, context, statWeights, callback)
-    self.requesterCallback = callback
-    self.requesterContext = context
+	self.requesterCallback = callback
+	self.requesterContext = context
 
 	local controls = { }
 	local options = { }

--- a/src/Classes/TradeQueryGenerator.lua
+++ b/src/Classes/TradeQueryGenerator.lua
@@ -764,9 +764,6 @@ function TradeQueryGeneratorClass:RequestQuery(slot, context, statWeights, callb
 		lastItemAnchor = controls.influence2
 		popupHeight = popupHeight + 46
 	end
-    controls.sortStatType = new("LabelControl", {"TOPLEFT",lastItemAnchor,"BOTTOMLEFT"}, 0, 5, 70, 18, statWeights[1].label)
-    controls.sortStatLabel = new("LabelControl", {"RIGHT",controls.sortStatType,"LEFT"}, -5, 0, 0, 16, "Stat to Sort By:")
-    popupHeight = popupHeight + 23
 
 	-- Add max price limit selection dropbox
 	local currencyTable = {

--- a/src/Classes/TradeQueryGenerator.lua
+++ b/src/Classes/TradeQueryGenerator.lua
@@ -792,10 +792,19 @@ function TradeQueryGeneratorClass:RequestQuery(slot, context, statWeights, callb
 	controls.maxPrice = new("EditControl", {"TOPLEFT",lastItemAnchor,"BOTTOMLEFT"}, 0, 5, 70, 18, nil, nil, "%D", nil, function(buf) end)
 	controls.maxPriceType = new("DropDownControl", {"LEFT",controls.maxPrice,"RIGHT"}, 5, 0, 150, 18, currencyDropdownNames, function(index, value) end)
 	controls.maxPriceLabel = new("LabelControl", {"RIGHT",controls.maxPrice,"LEFT"}, -5, 0, 0, 16, "Max Price:")
+	lastItemAnchor = controls.maxPrice
 	popupHeight = popupHeight + 23
 	
-    controls.sortStatType = new("LabelControl", {"TOPLEFT",lastItemAnchor,"BOTTOMLEFT"}, 0, 5, 70, 18, statWeights[1].label)
+    controls.sortStatType = new("LabelControl", {"TOPLEFT",lastItemAnchor,"BOTTOMLEFT"}, 0, 5, 70, 18, #statWeights < 2 and statWeights[1].label or "Multiple Stats")
     controls.sortStatLabel = new("LabelControl", {"RIGHT",controls.sortStatType,"LEFT"}, -5, 0, 0, 16, "Stat to Sort By:")
+	controls.sortStatType.tooltipFunc = function(tooltip)
+		tooltip:Clear()
+		tooltip:AddLine(16, "Sorts the weights by the stats selected multiplied by a value")
+		tooltip:AddLine(16, "Currently sorting by:")
+		for _, stat in ipairs(statWeights) do
+			tooltip:AddLine(16, s_format("%s: %.2f", stat.label, stat.weightMult))
+		end
+	end
     popupHeight = popupHeight + 23
 
 	controls.generateQuery = new("ButtonControl", { "BOTTOM", nil, "BOTTOM" }, -45, -10, 80, 20, "Execute", function()

--- a/src/Classes/TradeStatWeightMultiplierListControl.lua
+++ b/src/Classes/TradeStatWeightMultiplierListControl.lua
@@ -1,0 +1,38 @@
+-- Path of Building
+--
+-- Class: Trade Stat Weight Multiplier List Control
+-- Specialized UI element for listing and modifing Trade Stat Weight Multipliers.
+--
+
+local TradeStatWeightMultiplierListControlClass = newClass("TradeStatWeightMultiplierListControl", "ListControl", function(self, anchor, x, y, width, height, list, indexController)
+	self.list = list
+	self.indexController = indexController
+	self.ListControl(anchor, x, y, width, height, 16, true, false, self.list)
+	self.selIndex = nil
+end)
+
+function TradeStatWeightMultiplierListControlClass:Draw(viewPort, noTooltip)
+	self.noTooltip = noTooltip
+	self.ListControl.Draw(self, viewPort)
+end
+
+function TradeStatWeightMultiplierListControlClass:GetRowValue(column, index, data)
+	if column == 1 then
+		return data.label
+	end
+end
+
+function TradeStatWeightMultiplierListControlClass:AddValueTooltip(tooltip, index, data)
+	tooltip:Clear()
+	if not self.noTooltip then
+		tooltip:AddLine(16, "^7Double click to modify this stats weight multiplier.")
+	end
+end
+
+function TradeStatWeightMultiplierListControlClass:OnSelClick(index, data, doubleClick)
+	if doubleClick and self.indexController.index ~= index then
+		self.indexController.index = index
+		self.indexController.SliderLabel.label = self.list[index].stat.label
+		self.indexController.Slider:SetVal(self.list[index].stat.weightMult == 1 and 1 or self.list[index].stat.weightMult - 0.01)
+	end
+end

--- a/src/Classes/TradeStatWeightMultiplierListControl.lua
+++ b/src/Classes/TradeStatWeightMultiplierListControl.lua
@@ -1,7 +1,7 @@
 -- Path of Building
 --
 -- Class: Trade Stat Weight Multiplier List Control
--- Specialized UI element for listing and modifing Trade Stat Weight Multipliers.
+-- Specialized UI element for listing and modifying Trade Stat Weight Multipliers.
 --
 
 local TradeStatWeightMultiplierListControlClass = newClass("TradeStatWeightMultiplierListControl", "ListControl", function(self, anchor, x, y, width, height, list, indexController)


### PR DESCRIPTION
Allow user to change what stat(s) trade "find best" weights by, default is still fullDPS but also some EHP, and also allows for dots, defences like max hit, or other misc stats like movement speed

![image](https://user-images.githubusercontent.com/49933620/210168842-16690e17-1b8a-4678-9b75-0ba12ed56995.png)

![image](https://user-images.githubusercontent.com/49933620/210168837-4dc63484-cc2b-4bf2-8459-018876d2e416.png)

supersedes #5376

Has a few minor formatting issues but should be fine to merge and fix later
