### PR TITLE
PoB Trader: add self adjusting weighted search to prevent result clipping

### DIFF
--- a/src/Classes/TradeQuery.lua
+++ b/src/Classes/TradeQuery.lua
@@ -740,7 +740,7 @@ function TradeQueryClass:UpdateRealms()
 		ConPrintf("Fetching realms and leagues using POESESSID")
 		self.tradeQueryRequests:FetchRealmsAndLeaguesHTML(function(data, errMsg)
 			if errMsg then
-				self:SetNotice("Error while fetching league list: "..errMsg)
+				self:SetNotice(self.controls.pbNotice, "Error while fetching league list: "..errMsg)
 				return
 			end
 			local leagues = data.leagues

--- a/src/Classes/TradeQuery.lua
+++ b/src/Classes/TradeQuery.lua
@@ -544,7 +544,7 @@ function TradeQueryClass:PriceItemRowDisplay(str_cnt, slotTbl, top_pane_alignmen
 			end
 			self.pbSortSelectionIndex = 1
 			context.controls["priceButton"..context.str_cnt].label = "Searching..."
-			self.tradeQueryRequests:SearchWithQuery(self.pbRealm, self.pbLeague, query, 
+			self.tradeQueryRequests:SearchWithQueryWeightAdjusted(self.pbRealm, self.pbLeague, query, 
 				function(items, errMsg)
 					if errMsg then
 						self:SetNotice(context.controls.pbNotice, colorCodes.NEGATIVE .. errMsg)

--- a/src/Classes/TradeQueryRequests.lua
+++ b/src/Classes/TradeQueryRequests.lua
@@ -154,7 +154,7 @@ function TradeQueryRequestsClass:SearchWithQueryWeightAdjusted(realm, league, qu
 				previousSearchItems = items
 				local highestWeight = items[1].weight
 				local queryJson = dkjson.decode(query)
-				queryJson.query.stats[1].value.min = highestWeight
+				queryJson.query.stats[1].value.min = (tonumber(highestWeight) + queryJson.query.stats[1].value.min) / 2
 				query = dkjson.encode(queryJson)
 				self:PerformSearch(realm, league, query, performSearchCallback)
 			end)


### PR DESCRIPTION
Current PoE trade API returns at most 10k results per search which are not guaranteed to include the highest-scored items.
There were attempts to improve the situation by calculating a better min weight limit but that doesn't guarantee a solution.

This PR proposes an iterative approach to solve the issue. The new method keeps repeating the search as long as the results come out capped. Each time, the weight of the highest-rated item of the previous search is used as the new min weight limit.

During my tests, these recursive searches are usually completed within 2 steps. So I added an arbitrary limit of 5 max recursions to prevent any potential runaways.

The new method is only utilized in the search triggered by the query generator for now. Didn't want to make it default for URL-based searches as it changes the behavior.