### PR TITLE
PoB Trader: No Session Mode, private leagues support and some more

### DIFF
--- a/src/Classes/TradeQuery.lua
+++ b/src/Classes/TradeQuery.lua
@@ -38,7 +38,7 @@ local TradeQueryClass = newClass("TradeQuery", function(self, itemsTab)
 	self.pbRealmIndex = 1
 	self.pbLeagueIndex = 1
 
-	self.tradeQueryRequests = new("TradeQueryRequests", self)
+	self.tradeQueryRequests = new("TradeQueryRequests")
 	main.onFrameFuncs["TradeQueryRequests"] = function()
 		self.tradeQueryRequests:ProcessQueue()
 	end
@@ -480,7 +480,7 @@ function TradeQueryClass:PriceItemRowDisplay(str_cnt, slotTbl, top_pane_alignmen
 			end
 			self.pbSortSelectionIndex = 1
 			context.controls["priceButton"..context.str_cnt].label = "Searching..."
-			self.tradeQueryRequests:SearchWithQuery(self.pbLeague, query, 
+			self.tradeQueryRequests:SearchWithQuery(self.pbRealm, self.pbLeague, query, 
 				function(items, errMsg)
 					if errMsg then
 						self:SetNotice(context.controls.pbNotice, colorCodes.NEGATIVE .. errMsg)

--- a/src/Classes/TradeQuery.lua
+++ b/src/Classes/TradeQuery.lua
@@ -336,7 +336,7 @@ on trade site to work on other leagues and realms)]]
 	end)
 	self.controls.realm:SetSel(self.pbRealmIndex)
 	self.controls.realm.enabled = function()
-		return self.realmDropList and #self.realmDropList > 1
+		return #self.controls.realm.list > 1
 	end
 
 	-- League selection
@@ -348,7 +348,7 @@ on trade site to work on other leagues and realms)]]
 	end)
 	self.controls.league:SetSel(self.pbLeagueIndex)
 	self.controls.league.enabled = function()
-		return #self.itemsTab.leagueDropList > 1
+		return #self.controls.league.list > 1
 	end
 
 	if  self.pbRealm == "" then

--- a/src/Classes/TradeQuery.lua
+++ b/src/Classes/TradeQuery.lua
@@ -568,6 +568,8 @@ function TradeQueryClass:PriceItemRowDisplay(str_cnt, slotTbl, top_pane_alignmen
 			local item = new("Item", self.resultTbl[str_cnt][pb_index].item_string)
 			tooltip:Clear()
 			self.itemsTab:AddItemTooltip(tooltip, item, self)
+			tooltip:AddSeparator(10)
+			tooltip:AddLine(16, string.format("^7Price: %s %s", self.resultTbl[str_cnt][pb_index].amount, self.resultTbl[str_cnt][pb_index].currency))
 		end
 	controls["importButton"..str_cnt] = new("ButtonControl", {"TOPLEFT",controls["resultDropdown"..str_cnt],"TOPRIGHT"}, 8, 0, 100, row_height, "Import Item", function()
 		self.itemsTab:CreateDisplayItemFromRaw(self.resultTbl[str_cnt][self.itemIndexTbl[str_cnt]].item_string)

--- a/src/Classes/TradeQuery.lua
+++ b/src/Classes/TradeQuery.lua
@@ -518,7 +518,7 @@ function TradeQueryClass:PriceItemRowDisplay(str_cnt, slotTbl, top_pane_alignmen
 	controls["priceButton"..str_cnt] = new("ButtonControl", {"TOPLEFT",controls["uri"..str_cnt],"TOPRIGHT"}, 8, 0, 100, row_height, "Price Item",
 		function()
 			controls["priceButton"..str_cnt].label = "Searching..."
-			self.tradeQueryRequests:SearchWithURL(controls["uri"..str_cnt], function(items, errMsg)
+			self.tradeQueryRequests:SearchWithURL(controls["uri"..str_cnt].buf, function(items, errMsg)
 				if errMsg then
 					self:SetNotice(controls.pbNotice, "Error: " .. errMsg)
 				else

--- a/src/Classes/TradeQuery.lua
+++ b/src/Classes/TradeQuery.lua
@@ -347,7 +347,7 @@ on trade site to work on other leagues and realms)]]
 		return #self.itemsTab.leagueDropList > 1
 	end
 
-if  self.pbRealm == "" then
+	if  self.pbRealm == "" then
 		self:UpdateRealms()
 	end
 

--- a/src/Classes/TradeQuery.lua
+++ b/src/Classes/TradeQuery.lua
@@ -589,7 +589,7 @@ function TradeQueryClass:PriceItemRowDisplay(str_cnt, slotTbl, top_pane_alignmen
 	controls["uri"..str_cnt].tooltipFunc = function(tooltip)
 		tooltip:Clear()
 		if controls["uri"..str_cnt].buf:find('^https://www.pathofexile.com/trade/search/') ~= nil then
-			tooltip:AddLine(16, "Control + click to open in web-browser or click 'Price Item' to do it in PoB")
+			tooltip:AddLine(16, "Control + click to open in web-browser")
 		end
 	end
 	controls["priceButton"..str_cnt] = new("ButtonControl", {"TOPLEFT",controls["uri"..str_cnt],"TOPRIGHT"}, 8, 0, 100, row_height, "Price Item",

--- a/src/Classes/TradeQuery.lua
+++ b/src/Classes/TradeQuery.lua
@@ -371,6 +371,19 @@ end
 function TradeQueryClass:SetCurrencyConversionButton()
 	local currencyLabel = "Update Currency Conversion Rates"
 	self.pbFileTimestampDiff[self.controls.league.selIndex] = nil
+	if self.pbLeague == nil then
+		return
+	end
+	if self.pbRealm ~= "pc" then
+		self.controls.updateCurrencyConversion.label = "Currency Rates are not available"
+		self.controls.updateCurrencyConversion.enabled = false
+		self.controls.updateCurrencyConversion.tooltipFunc = function(tooltip)
+			tooltip:Clear()
+			tooltip:AddLine(16, "Currency Conversion rates are pulled from PoE Ninja")
+			tooltip:AddLine(16, "The data is only available for the PC realm.")
+		end
+		return
+	end
 	local values_file = io.open("../"..self.pbLeague.."_currency_values.json", "r")
 	if values_file then
 		local lines = values_file:read "*a"

--- a/src/Classes/TradeQuery.lua
+++ b/src/Classes/TradeQuery.lua
@@ -243,6 +243,7 @@ function TradeQueryClass:PriceItem()
 			main.POESESSID = poesessid_controls.sessionInput.buf
 			main:ClosePopup()
 			main:SaveSettings()
+			self:UpdateRealms()
 		end)
 		poesessid_controls.save.enabled = function() return #poesessid_controls.sessionInput.buf == 32 or poesessid_controls.sessionInput.buf == "" end
 		poesessid_controls.cancel = new("ButtonControl", {"TOPLEFT", poesessid_controls.sessionInput, "TOP"}, 8, 24, 90, row_height, "Cancel", function()

--- a/src/Classes/TradeQuery.lua
+++ b/src/Classes/TradeQuery.lua
@@ -334,6 +334,10 @@ on trade site to work on other leagues and realms)]]
 			end)
 		end
 	end)
+	self.controls.realm:SetSel(self.pbRealmIndex)
+	self.controls.realm.enabled = function()
+		return self.realmDropList and #self.realmDropList > 1
+	end
 
 	-- League selection
 	self.controls.leagueLabel = new("LabelControl", {"TOPRIGHT", self.controls.realmLabel, "TOPRIGHT"}, 0, 24, 20, 16, "^7League:")

--- a/src/Classes/TradeQuery.lua
+++ b/src/Classes/TradeQuery.lua
@@ -562,7 +562,6 @@ function TradeQueryClass:PriceItemRowDisplay(str_cnt, slotTbl, top_pane_alignmen
 			)
 		end)
 	end)
-	-- controls["bestButton"..str_cnt].enabled = function() return main.POESESSID ~= "" end
 	controls["bestButton"..str_cnt].shown = function() return not self.resultTbl[str_cnt] end
 	controls["bestButton"..str_cnt].tooltipText = "Creates a weighted search to find the highest DPS items for this slot."
 	controls["uri"..str_cnt] = new("EditControl", {"TOPLEFT",controls["bestButton"..str_cnt],"TOPRIGHT"}, 8, 0, 518, row_height, nil, nil, "^%C\t\n", nil, function(buf)

--- a/src/Classes/TradeQueryRequests.lua
+++ b/src/Classes/TradeQueryRequests.lua
@@ -178,9 +178,22 @@ function TradeQueryRequestsClass:FetchResultBlock(url, callback)
 end
 
 ---@param callback fun(items:table, errMsg:string)
-function TradeQueryRequestsClass:SearchWithURL(urlEditControl, callback)
-	local _, queryId = urlEditControl.buf:match("https://www.pathofexile.com/trade/search/(.+)/(.+)$")
-	self:FetchSearchQueryHTML(queryId, function(query, errMsg)
+function TradeQueryRequestsClass:SearchWithURL(url, callback)
+	local subpath = url:match("https://www.pathofexile.com/trade/search/(.+)$")
+	local paths = {}
+	for path in subpath:gmatch("[^/]+") do
+		table.insert(paths, path)
+	end
+	if #paths < 2 or #paths > 3 then
+		return callback(nil, "Invalid URL")
+	end
+	local realm, league, queryId
+	if #paths == 3 then
+		realm = paths[1]
+	end
+	league = paths[#paths-1]
+	queryId = paths[#paths]
+	self:FetchSearchQueryHTML(realm, league, queryId, function(query, errMsg)
 		if errMsg then
 			return callback(nil, errMsg)
 		end

--- a/src/Classes/TradeQueryRequests.lua
+++ b/src/Classes/TradeQueryRequests.lua
@@ -7,7 +7,7 @@
 local dkjson = require "dkjson"
 
 ---@class TradeQueryRequests
-local TradeQueryRequestsClass = newClass("TradeQueryRequests", function(self, tradeQuery, rateLimiter)
+local TradeQueryRequestsClass = newClass("TradeQueryRequests", function(self, rateLimiter)
 	self.maxFetchPerSearch = 10
 	self.tradeQuery = tradeQuery
 	self.rateLimiter = rateLimiter or new("TradeQueryRateLimiter")
@@ -57,10 +57,10 @@ end
 ---@param query string
 ---@param callback fun(items:table, errMsg:string)
 ---@param params table @ params = { callbackQueryId = fun(queryId:string) }
-function TradeQueryRequestsClass:SearchWithQuery(league, query, callback, params)
+function TradeQueryRequestsClass:SearchWithQuery(realm, league, query, callback, params)
 	params = params or {}
 	--ConPrintf("Query json: %s", query)
-	self:PerformSearch(league, query, function(response, errMsg)
+	self:PerformSearch(realm, league, query, function(response, errMsg)
 		if params.callbackQueryId and response and response.id then
 			params.callbackQueryId(response.id)
 		end
@@ -76,7 +76,7 @@ end
 ---@param league string
 ---@param query string
 ---@param callback fun(response:table, errMsg:string)
-function TradeQueryRequestsClass:PerformSearch(league, query, callback)
+function TradeQueryRequestsClass:PerformSearch(realm, league, query, callback)
 	table.insert(self.requestQueue["search"], {
 		url = "https://www.pathofexile.com/api/trade/search/"..league:gsub(" ", "+"),
 		body = query,
@@ -184,8 +184,7 @@ function TradeQueryRequestsClass:SearchWithURL(urlEditControl, callback)
 		if errMsg then
 			return callback(nil, errMsg)
 		end
-		urlEditControl:SetText("https://www.pathofexile.com/trade/search/" .. self.tradeQuery.pbRealm .. self.tradeQuery.pbLeague:gsub(" ", "+") .. "/" .. queryId)
-		self:SearchWithQuery(self.tradeQuery.pbLeague, query, callback)
+		self:SearchWithQuery(realm, league, query, callback)
 	end)
 end
 
@@ -193,7 +192,7 @@ end
 ---@param queryId string
 ---@param league string
 ---@param callback fun(query:string, errMsg:string)
-function TradeQueryRequestsClass:FetchSearchQuery(queryId, callback)
+function TradeQueryRequestsClass:FetchSearchQuery(realm, league, queryId, callback)
 	local url = "https://www.pathofexile.com/api/trade/search/" .. self.tradeQuery.pbRealm .. self.tradeQuery.pbLeague:gsub(" ", "+") .. "/" .. queryId
 	table.insert(self.requestQueue["search"], {
 		url = url,
@@ -216,7 +215,7 @@ end
 ---@param queryId string
 ---@param callback fun(query:string, errMsg:string)
 ---@see TradeQueryRequests#FetchSearchQuery
-function TradeQueryRequestsClass:FetchSearchQueryHTML(queryId, callback)
+function TradeQueryRequestsClass:FetchSearchQueryHTML(realm, league, queryId, callback)
 	if main.POESESSID == "" then
 		return callback(nil, "Please provide your POESESSID")
 	end

--- a/src/Classes/TradeQueryRequests.lua
+++ b/src/Classes/TradeQueryRequests.lua
@@ -78,7 +78,7 @@ end
 ---@param callback fun(response:table, errMsg:string)
 function TradeQueryRequestsClass:PerformSearch(realm, league, query, callback)
 	table.insert(self.requestQueue["search"], {
-		url = "https://www.pathofexile.com/api/trade/search/"..league:gsub(" ", "+"),
+		url = self:buildUrl("https://www.pathofexile.com/api/trade/search", realm, league),
 		body = query,
 		callback = function(response, errMsg)
 			if errMsg and not errMsg:find("Response code: 400") then
@@ -206,7 +206,7 @@ end
 ---@param league string
 ---@param callback fun(query:string, errMsg:string)
 function TradeQueryRequestsClass:FetchSearchQuery(realm, league, queryId, callback)
-	local url = "https://www.pathofexile.com/api/trade/search/" .. self.tradeQuery.pbRealm .. self.tradeQuery.pbLeague:gsub(" ", "+") .. "/" .. queryId
+	local url = self:buildUrl("https://www.pathofexile.com/api/trade/search", realm, league, queryId)
 	table.insert(self.requestQueue["search"], {
 		url = url,
 		callback = function(response, errMsg)
@@ -233,8 +233,7 @@ function TradeQueryRequestsClass:FetchSearchQueryHTML(realm, league, queryId, ca
 		return callback(nil, "Please provide your POESESSID")
 	end
 	local header = "Cookie: POESESSID=" .. main.POESESSID
-	-- the league doesn't affect query so we set it to Standard as it doesn't change
-	launch:DownloadPage("https://www.pathofexile.com/trade/search/" .. self.tradeQuery.pbRealm .. self.tradeQuery.pbLeague:gsub(" ", "+") .. "/" .. queryId,
+	launch:DownloadPage(self:buildUrl("https://www.pathofexile.com/trade/search", realm, league, queryId),
 		function(response, errMsg)
 			if errMsg then
 				return callback(nil, errMsg)
@@ -337,3 +336,19 @@ function TradeQueryRequestsClass:FetchLeagues(realm, callback)
 	)
 end
 
+--- Build search and trade URLs with proper encoding
+---@param root string
+---@param realm string
+---@param league string
+---@param queryId string
+function TradeQueryRequestsClass:buildUrl(root, realm, league, queryId)
+	local result = root
+	if realm and realm ~='pc' then
+		result = result .. "/" .. realm
+	end	
+	result = result .. "/" .. league
+	if queryId then
+		result = result .. "/" .. queryId
+	end
+	return result	
+end

--- a/src/Modules/Common.lua
+++ b/src/Modules/Common.lua
@@ -816,3 +816,17 @@ function string:split(sep)
 	return fields
 end
 
+
+function urlEncode(str)
+	local charToHex = function(c)
+		return s_format("%%%02X", string.byte(c))
+	end
+	return str:gsub("([^%w_%-.~])", charToHex)
+end
+
+function urlDecode(str)
+	local hexToChar = function(x)
+		return s_char(tonumber(x, 16))
+	end
+	return str:gsub("%%(%x%x)", hexToChar)
+end


### PR DESCRIPTION
## No Session Mode
This PR adds a new working mode called "No Session Mode" to offer features that don't depend on POESESSID availability such as weighted search generation.
Current implementation uses trade API to create the search URL from the generated weighted search query. This step makes POESESSID mandatory. The new implementation creates search URLs with generated query passed as URL parameter (like `/search?q={query:...`) when POESESSID is not available.
This should allow people who don't want to provide their POESESSID to still use the search generation feature.

Feel free to suggest improvements over the current description/title.

![image](https://user-images.githubusercontent.com/5316261/210177632-98040928-64a3-42f6-bd42-db023b348472.png)

## Private Leagues Support
Added an alternative league fetch method to get available leagues including the private ones but require POESESSID.
This method is only available in "Session Mode" and we fall back to API fetch when POESESSID is not present.

## Price Info on Item Tooltip
Currently, the selected item price is only visible on the whisper button. Included the price info in the tooltips to make item browsing easier.
![image](https://user-images.githubusercontent.com/5316261/210178566-a962c43a-d0e5-4ebf-8895-073cd059f8de.png)

### Summary of Changes
- Add a "No Session Mode" with reduced capabilities to offer an alternative to the current implementation.
- Add private leagues support
- Add price info to item dropdown tooltips
- Two minor refactors to reduce coupling
- Add common functions for URL encoding and decoding 