### PR TITLE
Fix wither on hit from balance of terror

### DIFF
--- a/src/Modules/CalcPerform.lua
+++ b/src/Modules/CalcPerform.lua
@@ -1293,10 +1293,6 @@ function calcs.perform(env, avoidCache)
 				hasGuaranteedBonechill = true
 			end
 		end
-		if activeSkill.skillModList:Flag(nil, "Condition:CanWither") then
-			local effect = activeSkill.minion and 6 or m_floor(6 * (1 + modDB:Sum("INC", nil, "WitherEffect") / 100))
-			modDB:NewMod("WitherEffectStack", "MAX", effect)
-		end
 		if activeSkill.skillFlags.warcry and not modDB:Flag(nil, "AlreadyGlobalWarcryCooldown") then
 			local cooldown = calcSkillCooldown(activeSkill.skillModList, activeSkill.skillCfg, activeSkill.skillData)
 			local warcryList = { }
@@ -2030,6 +2026,10 @@ function calcs.perform(env, avoidCache)
 					t_insert(curses, curse)	
 				end
 			end
+		end
+		if activeSkill.skillModList:Flag(nil, "Condition:CanWither") then
+			local effect = activeSkill.minion and 6 or m_floor(6 * (1 + modDB:Sum("INC", nil, "WitherEffect") / 100))
+			modDB:NewMod("WitherEffectStack", "MAX", effect)
 		end
 		if activeSkill.minion and activeSkill.minion.activeSkillList then
 			local castingMinion = activeSkill.minion

--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -2851,7 +2851,7 @@ local specialModList = {
 	["warcries have infinite power"] = { flag("WarcryInfinitePower") },
 	["(%d+)%% chance to inflict corrosion on hit with attacks"] = { flag("Condition:CanCorrode") },
 	["(%d+)%% chance to inflict withered for (%d+) seconds on hit"] = { flag("Condition:CanWither") },
-	["inflict withered for (%d+) seconds on hit if you've cast (.+) in the past (%d+) seconds"] = function (_, _, curse) return { flag("Condition:CanWither", nil, ModFlag.Hit, { type = "Condition", var = "SelfCast"..curse:gsub("^%l", string.upper):gsub(" %l", string.upper):gsub(" ", "") }) } end,
+	["inflict withered for (%d+) seconds on hit if you've cast (.+) in the past (%d+) seconds"] = function (_, _, curse) return { flag("Condition:CanWither", { type = "Condition", var = "SelfCast"..curse:gsub("^%l", string.upper):gsub(" %l", string.upper):gsub(" ", "") }) } end,
 	["(%d+)%% chance to inflict withered for (%d+) seconds on hit with this weapon"] = { flag("Condition:CanWither") },
 	["(%d+)%% chance to inflict withered for two seconds on hit if there are (%d+) or fewer withered debuffs on enemy"] = { flag("Condition:CanWither") },
 	["inflict withered for (%d+) seconds on hit with this weapon"] = { flag("Condition:CanWither") },


### PR DESCRIPTION
- Move wither effect check after self cast curse condition is set so it properly applies
- Remove the hit flag from parsed mod

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>

### Description of the problem being solved:

Balance of Terror wither on hit is not working currently because the condition is checked too late and the hit flag prevents the config option from showing.

### Steps taken to verify a working solution:
- Open pob using balance of terror
- Check if wither config is present
- Check if wither stacks change damage
- Check if removing balance of terror removes wither config and stacks

### Link to a build that showcases this PR:

https://pobb.in/3P0Ms0CMxrvo

### Before screenshot:

![image](https://user-images.githubusercontent.com/5115805/210204932-21f06f3d-c3e8-4b83-b3dc-ed890e0a5c41.png)

### After screenshot:

![image](https://user-images.githubusercontent.com/5115805/210204853-ad17de33-1382-4c02-80c9-f8db064cdb17.png)
