### PR TITLE
Support magic utility flask effect for silver flasks

### DIFF
--- a/src/Modules/CalcPerform.lua
+++ b/src/Modules/CalcPerform.lua
@@ -937,15 +937,22 @@ local function doActorMisc(env, actor)
 			for item in pairs(env.flasks) do
 				if item.baseName:match("Silver Flask") then
 					onslaughtFromFlask = true
-					if flaskEffectInc < (item.flaskData.effectInc + modDB:Sum("INC", nil, "FlaskEffect")) / 100 then 
-						flaskEffectInc =  (item.flaskData.effectInc + modDB:Sum("INC", nil, "FlaskEffect")) / 100
+
+					local curFlaskEffectInc = item.flaskData.effectInc + modDB:Sum("INC", nil, "FlaskEffect")
+					if item.rarity == "MAGIC" then
+						curFlaskEffectInc = curFlaskEffectInc + modDB:Sum("INC", nil, "MagicUtilityFlaskEffect")
+					end
+
+					if flaskEffectInc < curFlaskEffectInc / 100 then 
+						flaskEffectInc = curFlaskEffectInc / 100
 					end
 				end
 			end
+			local onslaughtEffectInc = modDB:Sum("INC", nil, "OnslaughtEffect", "BuffEffectOnSelf") / 100
 			if onslaughtFromFlask then
-				effect = m_floor(20 * (1 + flaskEffectInc + modDB:Sum("INC", nil, "OnslaughtEffect", "BuffEffectOnSelf") / 100))
+				effect = m_floor(20 * (1 + flaskEffectInc + onslaughtEffectInc))
 			else
-				effect = m_floor(20 * (1 + modDB:Sum("INC", nil, "OnslaughtEffect", "BuffEffectOnSelf") / 100))
+				effect = m_floor(20 * (1 + onslaughtEffectInc))
 			end
 			modDB:NewMod("Speed", "INC", effect, "Onslaught", ModFlag.Attack)
 			modDB:NewMod("Speed", "INC", effect, "Onslaught", ModFlag.Cast)


### PR DESCRIPTION
Signed-off-by: Tomas Slusny <slusnucky@gmail.com>

### Description of the problem being solved:

Based on this comment the effect is not being applied (and it indeed isnt). If flask is magic it should apply.

https://github.com/PathOfBuildingCommunity/PathOfBuilding/pull/5407#issuecomment-1369218523

### Steps taken to verify a working solution:
- Allocate master alchemist
- Verify onslaught effect is increased

### Link to a build that showcases this PR:

https://pobb.in/u/thedeathbeam/pf-poison-scourge-arrow

### Before screenshot:

![image](https://user-images.githubusercontent.com/5115805/210279670-44f4f190-9d87-4946-8296-d9e0cd14de28.png)

### After screenshot:

![image](https://user-images.githubusercontent.com/5115805/210279650-38c22ff4-7576-48dd-a042-6769d3df51c3.png)

