### PR TITLE
Update Trader, Item weight and sorting to use percentage change rather than absolute

### DIFF
--- a/src/Classes/TradeQuery.lua
+++ b/src/Classes/TradeQuery.lua
@@ -626,15 +626,16 @@ function TradeQueryClass:SortFetchResults(slotTbl, trade_index, mode)
 		local storedFullDPS = GlobalCache.useFullDPS
 		GlobalCache.useFullDPS = GlobalCache.numActiveSkillInFullDPS > 0
 		local calcFunc, calcBase = self.itemsTab.build.calcsTab:GetMiscCalculator()
+		local baseItemOutput = calcFunc({ })
 		for index, tbl in pairs(self.resultTbl[trade_index]) do
 			local item = new("Item", tbl.item_string)
 			local output = calcFunc({ repSlotName = slotName, repItem = item }, {})
 			local newStatValue = 0
 			for _, statTable in ipairs(self.statSortSelectionList) do
 				if statTable.stat == "FullDPS" and not GlobalCache.useFullDPS then
-					newStatValue = newStatValue + m_max(output.TotalDPS or 0, m_max(output.TotalDot or 0, output.CombinedAvg or 0)) * statTable.weightMult
+					newStatValue = newStatValue + m_max((output.TotalDPS or 0) / (baseItemOutput.TotalDPS or 0), m_max((output.TotalDotDPS or 0) / (baseItemOutput.TotalDotDPS or 0), (output.CombinedDPS or 0) / (baseItemOutput.CombinedDPS or 0))) * statTable.weightMult
 				else
-					newStatValue = newStatValue + ( output[statTable.stat] or 0 ) * statTable.weightMult
+					newStatValue = newStatValue + ( output[statTable.stat] or 0 ) / ( baseItemOutput[statTable.stat] or 0 ) * statTable.weightMult
 				end
 			end
 			out[index] = newStatValue

--- a/src/Classes/TradeQuery.lua
+++ b/src/Classes/TradeQuery.lua
@@ -627,27 +627,10 @@ function TradeQueryClass:SortFetchResults(slotTbl, trade_index, mode)
 		GlobalCache.useFullDPS = GlobalCache.numActiveSkillInFullDPS > 0
 		local calcFunc, calcBase = self.itemsTab.build.calcsTab:GetMiscCalculator()
 		local baseItemOutput = calcFunc({ })
-		local function ratioModSums(...)
-			local baseModSum = 0
-			local newModSum = 0
-			for _, mod in ipairs({ ... }) do
-				baseModSum = baseModSum + baseOutput[mod] or 0
-				newModSum = newModSum + newOutput[mod] or 0
-			end
-			return newModSum / ((baseModSum ~= 0) and baseModSum or 1)
-		end
 		for index, tbl in pairs(self.resultTbl[trade_index]) do
 			local item = new("Item", tbl.item_string)
 			local output = calcFunc({ repSlotName = slotName, repItem = item }, {})
-			local newStatValue = 0
-			for _, statTable in ipairs(self.statSortSelectionList) do
-				if statTable.stat == "FullDPS" and not GlobalCache.useFullDPS then
-					newStatValue = newStatValue + ratioModSums("TotalDPS", "TotalDotDPS", "CombinedDPS") * statTable.weightMult
-				else
-					newStatValue = newStatValue + ratioModSums(statTable.stat) * statTable.weightMult
-				end
-			end
-			out[index] = newStatValue
+			out[index] = self.TradeQueryGeneratorClass.WeightedRatioOutputs(baseItemOutput, output, self.statSortSelectionList)
 		end
 		GlobalCache.useFullDPS = storedFullDPS
 		return out

--- a/src/Classes/TradeQuery.lua
+++ b/src/Classes/TradeQuery.lua
@@ -634,7 +634,7 @@ function TradeQueryClass:SortFetchResults(slotTbl, trade_index, mode)
 				baseModSum = baseModSum + baseOutput[mod] or 0
 				newModSum = newModSum + newOutput[mod] or 0
 			end
-			return newModSum / (baseModSum ~= 0 and baseModSum or 1)
+			return newModSum / ((baseModSum ~= 0) and baseModSum or 1)
 		end
 		for index, tbl in pairs(self.resultTbl[trade_index]) do
 			local item = new("Item", tbl.item_string)

--- a/src/Classes/TradeQuery.lua
+++ b/src/Classes/TradeQuery.lua
@@ -627,15 +627,24 @@ function TradeQueryClass:SortFetchResults(slotTbl, trade_index, mode)
 		GlobalCache.useFullDPS = GlobalCache.numActiveSkillInFullDPS > 0
 		local calcFunc, calcBase = self.itemsTab.build.calcsTab:GetMiscCalculator()
 		local baseItemOutput = calcFunc({ })
+		local function ratioModSums(...)
+			local baseModSum = 0
+			local newModSum = 0
+			for _, mod in ipairs({ ... }) do
+				baseModSum = baseModSum + baseOutput[mod] or 0
+				newModSum = newModSum + newOutput[mod] or 0
+			end
+			return newModSum / (baseModSum ~= 0 and baseModSum or 1)
+		end
 		for index, tbl in pairs(self.resultTbl[trade_index]) do
 			local item = new("Item", tbl.item_string)
 			local output = calcFunc({ repSlotName = slotName, repItem = item }, {})
 			local newStatValue = 0
 			for _, statTable in ipairs(self.statSortSelectionList) do
 				if statTable.stat == "FullDPS" and not GlobalCache.useFullDPS then
-					newStatValue = newStatValue + m_max((output.TotalDPS or 0) / (baseItemOutput.TotalDPS or 0), m_max((output.TotalDotDPS or 0) / (baseItemOutput.TotalDotDPS or 0), (output.CombinedDPS or 0) / (baseItemOutput.CombinedDPS or 0))) * statTable.weightMult
+					newStatValue = newStatValue + ratioModSums("TotalDPS", "TotalDotDPS", "CombinedDPS") * statTable.weightMult
 				else
-					newStatValue = newStatValue + ( output[statTable.stat] or 0 ) / ( baseItemOutput[statTable.stat] or 0 ) * statTable.weightMult
+					newStatValue = newStatValue + ratioModSums(statTable.stat) * statTable.weightMult
 				end
 			end
 			out[index] = newStatValue

--- a/src/Classes/TradeQuery.lua
+++ b/src/Classes/TradeQuery.lua
@@ -630,7 +630,7 @@ function TradeQueryClass:SortFetchResults(slotTbl, trade_index, mode)
 		for index, tbl in pairs(self.resultTbl[trade_index]) do
 			local item = new("Item", tbl.item_string)
 			local output = calcFunc({ repSlotName = slotName, repItem = item }, {})
-			out[index] = self.TradeQueryGeneratorClass.WeightedRatioOutputs(baseItemOutput, output, self.statSortSelectionList)
+			out[index] = self.tradeQueryGenerator.WeightedRatioOutputs(baseItemOutput, output, self.statSortSelectionList)
 		end
 		GlobalCache.useFullDPS = storedFullDPS
 		return out

--- a/src/Classes/TradeQueryGenerator.lua
+++ b/src/Classes/TradeQueryGenerator.lua
@@ -125,7 +125,7 @@ local function canModSpawnForItemCategory(mod, tags)
 	return false
 end
 
-function TradeQueryGeneratorClass.WeightedRatioOutputs(baseOutput, newOutput, statWeights)
+local function WeightedRatioOutputs(baseOutput, newOutput, statWeights)
 	local meanStatDiff = 0
 	local function ratioModSums(...)
 		local baseModSum = 0
@@ -134,7 +134,7 @@ function TradeQueryGeneratorClass.WeightedRatioOutputs(baseOutput, newOutput, st
 			baseModSum = baseModSum + baseOutput[mod] or 0
 			newModSum = newModSum + newOutput[mod] or 0
 		end
-		return newModSum / (baseModSum ~= 0 and baseModSum or 1)
+		return newModSum / ((baseModSum ~= 0) and baseModSum or 1)
 	end
 	for _, statTable in ipairs(statWeights) do
 		if statTable.stat == "FullDPS" and not GlobalCache.useFullDPS then
@@ -424,7 +424,7 @@ function TradeQueryGeneratorClass:GenerateModWeights(modsToTest)
 			end
 
 			local output = self.calcContext.calcFunc({ repSlotName = self.calcContext.slot.slotName, repItem = self.calcContext.testItem }, {})
-			local meanStatDiff = self:WeightedRatioOutputs(self.calcContext.baseOutput, output, self.calcContext.options.statWeights) * 1000 - (self.calcContext.baseStatValue or 0)
+			local meanStatDiff = WeightedRatioOutputs(self.calcContext.baseOutput, output, self.calcContext.options.statWeights) * 1000 - (self.calcContext.baseStatValue or 0)
 			if meanStatDiff > 0.01 then
 				table.insert(self.modWeights, { tradeModId = entry.tradeMod.id, weight = meanStatDiff / modValue, meanStatDiff = meanStatDiff, invert = entry.sign == "-" and true or false })
 				self.alreadyWeightedMods[entry.tradeMod.id] = true
@@ -546,7 +546,7 @@ function TradeQueryGeneratorClass:StartQuery(slot, options)
 	local baseOutput = calcFunc({ })
 	local baseItemOutput = calcFunc({ repSlotName = slot.slotName, repItem = testItem }, {})
 	-- make weights more human readable
-	local compStatValue = self:WeightedRatioOutputs(baseOutput, baseItemOutput, options.statWeights) * 1000
+	local compStatValue = WeightedRatioOutputs(baseOutput, baseItemOutput, options.statWeights) * 1000
 
 	-- Test each mod one at a time and cache the normalized Stat (configured earlier) diff to use as weight
 	self.modWeights = { }
@@ -609,7 +609,7 @@ function TradeQueryGeneratorClass:FinishQuery()
 	self.calcContext.testItem:BuildAndParseRaw()
 
 	local originalOutput = self.calcContext.calcFunc({ repSlotName = self.calcContext.slot.slotName, repItem = self.calcContext.testItem }, {})
-	local currentStatDiff = self:WeightedRatioOutputs(self.calcContext.baseOutput, originalOutput, self.calcContext.options.statWeights) * 1000 - (self.calcContext.baseStatValue or 0)
+	local currentStatDiff = WeightedRatioOutputs(self.calcContext.baseOutput, originalOutput, self.calcContext.options.statWeights) * 1000 - (self.calcContext.baseStatValue or 0)
 
 	-- Restore global cache full DPS
 	GlobalCache.useFullDPS = self.calcContext.globalCacheUseFullDPS

--- a/src/Classes/TradeQueryGenerator.lua
+++ b/src/Classes/TradeQueryGenerator.lua
@@ -125,6 +125,27 @@ local function canModSpawnForItemCategory(mod, tags)
 	return false
 end
 
+function TradeQueryGeneratorClass.WeightedRatioOutputs(baseOutput, newOutput, statWeights)
+	local meanStatDiff = 0
+	local function ratioModSums(...)
+		local baseModSum = 0
+		local newModSum = 0
+		for _, mod in ipairs({ ... }) do
+			baseModSum = baseModSum + baseOutput[mod] or 0
+			newModSum = newModSum + newOutput[mod] or 0
+		end
+		return newModSum / (baseModSum ~= 0 and baseModSum or 1)
+	end
+	for _, statTable in ipairs(statWeights) do
+		if statTable.stat == "FullDPS" and not GlobalCache.useFullDPS then
+			meanStatDiff = meanStatDiff + ratioModSums("TotalDPS", "TotalDotDPS", "CombinedDPS") * statTable.weightMult
+		else
+			meanStatDiff = meanStatDiff + ratioModSums(statTable.stat) * statTable.weightMult
+		end
+	end
+	return meanStatDiff
+end
+
 function TradeQueryGeneratorClass:GenerateModData(mods, tradeQueryStatsParsed)
 	for modId, mod in pairs(mods) do
 		if localOnlyModGroups[mod.group] == true or (modId:find("Local") ~= nil and modId:find("Socketed") == nil) then -- skip all local mods other than socket level mods
@@ -402,17 +423,8 @@ function TradeQueryGeneratorClass:GenerateModWeights(modsToTest)
 				logToFile("Failed to test %s mod: %s", self.calcContext.itemCategory, modLine)
 			end
 
-			local baseOutput = self.calcContext.baseOutput
 			local output = self.calcContext.calcFunc({ repSlotName = self.calcContext.slot.slotName, repItem = self.calcContext.testItem }, {})
-			local meanStatDiff = 0
-			for _, statTable in ipairs(self.calcContext.options.statWeights) do
-				if statTable.stat == "FullDPS" and not GlobalCache.useFullDPS then
-					meanStatDiff = meanStatDiff + m_max((output.TotalDPS or 0) / (baseOutput.TotalDPS or 0), m_max((output.TotalDotDPS or 0) / (baseOutput.TotalDotDPS or 0), (output.CombinedDPS or 0) / (baseOutput.CombinedDPS or 0))) * statTable.weightMult
-				else
-					meanStatDiff = meanStatDiff + ( output[statTable.stat] or 0 ) / ( baseOutput[statTable.stat] or 0 ) * statTable.weightMult
-				end
-			end
-			meanStatDiff = meanStatDiff * 1000 - (self.calcContext.baseStatValue or 0)
+			local meanStatDiff = self:WeightedRatioOutputs(self.calcContext.baseOutput, output, self.calcContext.options.statWeights) * 1000 - (self.calcContext.baseStatValue or 0)
 			if meanStatDiff > 0.01 then
 				table.insert(self.modWeights, { tradeModId = entry.tradeMod.id, weight = meanStatDiff / modValue, meanStatDiff = meanStatDiff, invert = entry.sign == "-" and true or false })
 				self.alreadyWeightedMods[entry.tradeMod.id] = true
@@ -533,16 +545,8 @@ function TradeQueryGeneratorClass:StartQuery(slot, options)
 	local calcFunc, _ = self.itemsTab.build.calcsTab:GetMiscCalculator()
 	local baseOutput = calcFunc({ })
 	local baseItemOutput = calcFunc({ repSlotName = slot.slotName, repItem = testItem }, {})
-	local compStatValue = 0
-	for _, statTable in ipairs(options.statWeights) do
-		if statTable.stat == "FullDPS" and not GlobalCache.useFullDPS then
-			compStatValue = compStatValue + m_max((baseItemOutput.TotalDPS or 0) / (baseOutput.TotalDPS or 0), m_max((baseItemOutput.TotalDotDPS or 0) / (baseOutput.TotalDotDPS or 0), (baseItemOutput.CombinedDPS or 0) / (baseOutput.CombinedDPS or 0))) * statTable.weightMult
-		else
-			compStatValue = compStatValue + (baseItemOutput[statTable.stat] or 0) / ( baseOutput[statTable.stat] or 0 ) * statTable.weightMult
-		end
-	end
 	-- make weights more human readable
-	compStatValue = compStatValue * 1000
+	local compStatValue = self:WeightedRatioOutputs(baseOutput, baseItemOutput, options.statWeights) * 1000
 
 	-- Test each mod one at a time and cache the normalized Stat (configured earlier) diff to use as weight
 	self.modWeights = { }
@@ -604,17 +608,8 @@ function TradeQueryGeneratorClass:FinishQuery()
 	end
 	self.calcContext.testItem:BuildAndParseRaw()
 
-	local baseOutput = self.calcContext.baseOutput
 	local originalOutput = self.calcContext.calcFunc({ repSlotName = self.calcContext.slot.slotName, repItem = self.calcContext.testItem }, {})
-	local currentStatDiff = 0
-	for _, statTable in ipairs(self.calcContext.options.statWeights) do
-		if statTable.stat == "FullDPS" and not GlobalCache.useFullDPS then
-			currentStatDiff = currentStatDiff + m_max((originalOutput.TotalDPS or 0) / (baseOutput.TotalDPS or 0), m_max((originalOutput.TotalDotDPS or 0) / (baseOutput.TotalDotDPS or 0), (originalOutput.CombinedDPS or 0) / (baseOutput.CombinedDPS or 0))) * statTable.weightMult
-		else
-			currentStatDiff = currentStatDiff + ( originalOutput[statTable.stat] or 0 ) / ( baseOutput[statTable.stat] or 0 ) * statTable.weightMult
-		end
-	end
-	currentStatDiff = currentStatDiff * 1000 - (self.calcContext.baseStatValue or 0)
+	local currentStatDiff = self:WeightedRatioOutputs(self.calcContext.baseOutput, originalOutput, self.calcContext.options.statWeights) * 1000 - (self.calcContext.baseStatValue or 0)
 
 	-- Restore global cache full DPS
 	GlobalCache.useFullDPS = self.calcContext.globalCacheUseFullDPS

--- a/src/Classes/TradeQueryGenerator.lua
+++ b/src/Classes/TradeQueryGenerator.lua
@@ -125,7 +125,7 @@ local function canModSpawnForItemCategory(mod, tags)
 	return false
 end
 
-local function WeightedRatioOutputs(baseOutput, newOutput, statWeights)
+function TradeQueryGeneratorClass.WeightedRatioOutputs(baseOutput, newOutput, statWeights)
 	local meanStatDiff = 0
 	local function ratioModSums(...)
 		local baseModSum = 0
@@ -424,7 +424,7 @@ function TradeQueryGeneratorClass:GenerateModWeights(modsToTest)
 			end
 
 			local output = self.calcContext.calcFunc({ repSlotName = self.calcContext.slot.slotName, repItem = self.calcContext.testItem }, {})
-			local meanStatDiff = WeightedRatioOutputs(self.calcContext.baseOutput, output, self.calcContext.options.statWeights) * 1000 - (self.calcContext.baseStatValue or 0)
+			local meanStatDiff = TradeQueryGeneratorClass.WeightedRatioOutputs(self.calcContext.baseOutput, output, self.calcContext.options.statWeights) * 1000 - (self.calcContext.baseStatValue or 0)
 			if meanStatDiff > 0.01 then
 				table.insert(self.modWeights, { tradeModId = entry.tradeMod.id, weight = meanStatDiff / modValue, meanStatDiff = meanStatDiff, invert = entry.sign == "-" and true or false })
 				self.alreadyWeightedMods[entry.tradeMod.id] = true
@@ -546,7 +546,7 @@ function TradeQueryGeneratorClass:StartQuery(slot, options)
 	local baseOutput = calcFunc({ })
 	local baseItemOutput = calcFunc({ repSlotName = slot.slotName, repItem = testItem }, {})
 	-- make weights more human readable
-	local compStatValue = WeightedRatioOutputs(baseOutput, baseItemOutput, options.statWeights) * 1000
+	local compStatValue = TradeQueryGeneratorClass.WeightedRatioOutputs(baseOutput, baseItemOutput, options.statWeights) * 1000
 
 	-- Test each mod one at a time and cache the normalized Stat (configured earlier) diff to use as weight
 	self.modWeights = { }
@@ -609,7 +609,7 @@ function TradeQueryGeneratorClass:FinishQuery()
 	self.calcContext.testItem:BuildAndParseRaw()
 
 	local originalOutput = self.calcContext.calcFunc({ repSlotName = self.calcContext.slot.slotName, repItem = self.calcContext.testItem }, {})
-	local currentStatDiff = WeightedRatioOutputs(self.calcContext.baseOutput, originalOutput, self.calcContext.options.statWeights) * 1000 - (self.calcContext.baseStatValue or 0)
+	local currentStatDiff = TradeQueryGeneratorClass.WeightedRatioOutputs(self.calcContext.baseOutput, originalOutput, self.calcContext.options.statWeights) * 1000 - (self.calcContext.baseStatValue or 0)
 
 	-- Restore global cache full DPS
 	GlobalCache.useFullDPS = self.calcContext.globalCacheUseFullDPS

--- a/src/Classes/TradeQueryGenerator.lua
+++ b/src/Classes/TradeQueryGenerator.lua
@@ -131,8 +131,8 @@ function TradeQueryGeneratorClass.WeightedRatioOutputs(baseOutput, newOutput, st
 		local baseModSum = 0
 		local newModSum = 0
 		for _, mod in ipairs({ ... }) do
-			baseModSum = baseModSum + baseOutput[mod] or 0
-			newModSum = newModSum + newOutput[mod] or 0
+			baseModSum = baseModSum + (baseOutput[mod] or 0)
+			newModSum = newModSum + (newOutput[mod] or 0)
 		end
 		return newModSum / ((baseModSum ~= 0) and baseModSum or 1)
 	end


### PR DESCRIPTION
This is built onetop of #5507 and doesnt make much sense for base to have

The purpose of this PR is that if sorting by multiple stats and you apply a weight multiplier to one it has little effect, eg fulldps 0.1 ehp 1.0 if my full dps is 100 times bigger itll almost always still just weight and sort by full dps because the change will be 10x bigger after the weight multiplier

by sorting by the percentage change instead it allows them to weight correctly, eg https://www.pathofexile.com/trade/search/Sanctum/LOJYnzGFn with "fulldps 1.0, EHP 0.5" it weights a 1% increased in dps the same as a 2% increase in EHP, rather than almost completely ignoring changes in ehp becouse the absolute difference was so much lower