### PR TITLE
Added support for Doom Blast (from Impending Doom)

### DIFF
--- a/src/Data/SkillStatMap.lua
+++ b/src/Data/SkillStatMap.lua
@@ -1633,6 +1633,10 @@ return {
 ["curse_maximum_doom"] = {
 	mod("MaxDoom", "BASE", nil),
 },
+["triggered_vicious_hex_explosion"] = {
+	skill("triggeredWhenHexEnds", true, { type = "SkillType", skillType = SkillType.Triggerable }, { type = "SkillType", skillType = SkillType.Spell }),
+},
+
 -- Aura
 ["non_curse_aura_effect_+%"] = {
 	mod("AuraEffect", "INC", nil, 0, 0, { type = "SkillType", skillType = SkillType.AppliesCurse, neg = true }),

--- a/src/Data/Skills/sup_int.lua
+++ b/src/Data/Skills/sup_int.lua
@@ -2805,13 +2805,23 @@ skills["ViciousHexExplosion"] = {
 	skillTypes = { [SkillType.Spell] = true, [SkillType.Area] = true, [SkillType.Damage] = true, [SkillType.Triggerable] = true, [SkillType.Triggered] = true, [SkillType.AreaSpell] = true, [SkillType.Chaos] = true, [SkillType.Cooldown] = true, [SkillType.InbuiltTrigger] = true, },
 	statDescriptionScope = "skill_stat_descriptions",
 	castTime = 1,
+	parts = {
+		{
+			name = "No Overlap",
+		},
+		{
+			name = "1 Overlap",
+		},
+		{
+			name = "2 Overlaps",
+		},
+	},
 	baseFlags = {
 		spell = true,
 		area = true,
 	},
 	baseMods = {
 		skill("radius", 20),
-		skill("showAverage", true),
 	},
 	qualityStats = {
 		Default = {

--- a/src/Export/Skills/sup_int.txt
+++ b/src/Export/Skills/sup_int.txt
@@ -356,8 +356,18 @@ local skills, mod, flag, skill = ...
 
 #skill ViciousHexExplosion
 #flags spell area
+	parts = {
+		{
+			name = "No Overlap",
+		},
+		{
+			name = "1 Overlap",
+		},
+		{
+			name = "2 Overlaps",
+		},
+	},
 #baseMod skill("radius", 20)
-#baseMod skill("showAverage", true)
 #mods
 
 #skill SupportIncreasedAreaOfEffect

--- a/src/Modules/CalcActiveSkill.lua
+++ b/src/Modules/CalcActiveSkill.lua
@@ -456,7 +456,7 @@ function calcs.buildActiveSkillModList(env, activeSkill)
 
 	-- Apply gem/quality modifiers from support gems
 	for _, value in ipairs(skillModList:List(activeSkill.skillCfg, "SupportedGemProperty")) do
-		if value.keyword == "active_skill" and activeSkill.activeEffect.gemData then
+		if value.keyword == "active_skill" and activeSkill.activeEffect.gemData and not activeSkill.activeEffect.gemData.tags.support then
 			activeEffect[value.key] = activeEffect[value.key] + value.value
 		end
 	end

--- a/src/Modules/ConfigOptions.lua
+++ b/src/Modules/ConfigOptions.lua
@@ -1209,6 +1209,9 @@ Huge sets the radius to 11.
 	{ var = "conditionHaveManaStorm", type = "check", label = "Do you have Manastorm's ^xADAA47Lightning ^7Buff?", ifFlag = "Condition:HaveManaStorm", tooltip = "This option enables Manastorm's ^xADAA47Lightning ^7Damage Buff.\n(When you cast a Spell, Sacrifice all ^x7070FFMana ^7to gain Added Maximum ^xADAA47Lightning ^7Damage\nequal to 25% of Sacrificed ^x7070FFMana ^7for 4 seconds)", apply = function(val, modList, enemyModList)
 		modList:NewMod("Condition:SacrificeManaForLightning", "FLAG", true, "Config", { type = "Condition", var = "Combat" })
 	end },
+	{ var = "conditionHaveVixensEntrapment", type = "check", label = "Use Vixen's Entrapment cooldown?", ifFlag = "Condition:HaveVixensEntrapment", tooltip = "Causes Impending Doom calculations to take the cooldown of Vixen's Entrapment into account,\nlowering DPS if cast rate is higher than the gloves' trigger cooldown.", apply = function(val, modList, enemyModList)
+		modList:NewMod("VixenTriggerCap", "FLAG", true, "Config", { type = "Condition", var = "Combat" })
+	end },
 	{ var = "buffFanaticism", type = "check", label = "Do you have Fanaticism?", ifFlag = "Condition:CanGainFanaticism", tooltip = "This will enable the Fanaticism buff itself. (Grants 75% more cast speed, reduced skill cost, and increased area of effect)", apply = function(val, modList, enemyModList)
 		modList:NewMod("Condition:Fanaticism", "FLAG", true, "Config", { type = "Condition", var = "Combat" }, { type = "Condition", var = "CanGainFanaticism" })
 	end },

--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -3643,6 +3643,9 @@ local specialModList = {
 	["every 8 seconds, gain avatar of fire for 4 seconds"] = {
 		flag("Condition:HaveVulconus"),
 	},
+	["trigger socketed curse spell when you cast a curse spell, with a ([%d%.]+) second cooldown"] = {
+		flag("Condition:HaveVixensEntrapment"),
+	},
 	["modifiers to attributes instead apply to omniscience"] = { flag("Omniscience") },
 	["attribute requirements can be satisfied by (%d+)%% of omniscience"] = function(num) return {
 		mod("OmniAttributeRequirements", "INC", num),


### PR DESCRIPTION
* Now shows DPS instead of average damage
* You can now pick overlap count (for spell cascade)
* Support gems no longer get levels from "+# to Level of Active Skill Gems" and similar
* getTriggerActionTriggerRate() no longer adjusts to tick rate for skills that can store several uses (which Doom Blast can)
* Added a config checkbox for Vixen's Entrapment to cap Doom Blast trigger rate when cast speed is too high

### Description of the problem being solved:
Impending Doom was working incorrectly in several aspects.


### Steps taken to verify a working solution:
Moderate ad hoc testing while developing.

### Link to a build that showcases this PR:
https://pastebin.com/8ZHzwwGb

### Before and after screenshots:
https://imgur.com/a/z9h2U6E
