### PR TITLE
Fix crash caused by item stuck on cursor when dragging

### DIFF
--- a/src/Classes/ControlHost.lua
+++ b/src/Classes/ControlHost.lua
@@ -13,6 +13,9 @@ function ControlHostClass:SelectControl(newSelControl)
 		return
 	end
 	if self.selControl then
+		if self.selControl.selDragActive and self.selControl.dragTargetList then
+			return
+		end
 		self.selControl:SetFocus(false)
 	end
 	self.selControl = newSelControl


### PR DESCRIPTION
Fixes #5540 .

### Description of the problem being solved:
When dragging an item it was possible to chance focus to a different control causing the item that was being dragged to get stuck to the cursor. 

The item being stuck to the cursor would cause a crash when the focus was switched back to the control from which the item was dragged from or if the item was dropped in to a slot or deleted.

This pr disables the ability to change focus to a different control when the original control is handling item dragging.