### PR TITLE
Fix missing nameSpec for skills granted by items on export

### DIFF
--- a/src/Modules/CalcSetup.lua
+++ b/src/Modules/CalcSetup.lua
@@ -590,7 +590,9 @@ function calcs.initEnv(build, mode, override, specEnv)
 			if item and item.grantedSkills then
 				-- Find skills granted by this item
 				for _, skill in ipairs(item.grantedSkills) do
+					local skillData = env.data.skills[skill.skillId]
 					local grantedSkill = copyTable(skill)
+					grantedSkill.nameSpec = skillData and skillData.name or nil
 					grantedSkill.sourceItem = item
 					grantedSkill.slotName = slotName
 					t_insert(env.grantedSkillsItems, grantedSkill)
@@ -924,6 +926,7 @@ function calcs.initEnv(build, mode, override, specEnv)
 				group.sourceNode = grantedSkill.sourceNode
 				local activeGemInstance = group.gemList[1] or {
 					skillId = grantedSkill.skillId,
+					nameSpec = grantedSkill.nameSpec,
 					quality = 0,
 					enabled = true,
 				}


### PR DESCRIPTION
Fixes #3173.

### Description of the problem being solved:

When creating a new build and adding an item which grants a skill, the `nameSpec` of said skill (gem) in the XML will be empty.

### Steps taken to verify a working solution:

Create such a said build by adding `Abberath's Hooves` or `Whispering Ice` and export it, after decoding the build code the gem has a `nameSpec`:

```xml
				<Gem skillId="RepeatingShockwave" enabled="true" enableGlobal2="nil" quality="0" nameSpec="Abberath&apos;s Fury" enableGlobal1="true" count="nil" level="7"/>
```
