### PR TITLE
Fix skillType tags for maximum Ballista Totem mods

### DIFF
--- a/src/Data/SkillStatMap.lua
+++ b/src/Data/SkillStatMap.lua
@@ -1473,7 +1473,7 @@ return {
 	mod("ActiveTotemLimit", "BASE", nil),
 },
 ["attack_skills_additional_ballista_totems_allowed"] = {
-	mod("ActiveTotemLimit", "BASE", nil, 0, 0, { type = "SkillType", skillType = SkillType.RangedAttack }),
+	mod("ActiveTotemLimit", "BASE", nil, 0, 0, { type = "SkillType", skillType = SkillType.TotemsAreBallistae }),
 },
 ["base_number_of_totems_allowed"] = {
 	mod("ActiveTotemLimit", "BASE", nil),

--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -478,7 +478,7 @@ local modNameList = {
 	["totem duration"] = "TotemDuration",
 	["maximum number of summoned totems"] = "ActiveTotemLimit",
 	["maximum number of summoned totems."] = "ActiveTotemLimit", -- Mark plz
-	["maximum number of summoned ballista totems"] = { "ActiveBallistaLimit", tag = { type = "SkillType", skillType = SkillType.RangedAttack } },
+	["maximum number of summoned ballista totems"] = { "ActiveBallistaLimit", tag = { type = "SkillType", skillType = SkillType.TotemsAreBallistae } },
 	["trap throwing speed"] = "TrapThrowingSpeed",
 	["trap and mine throwing speed"] = { "TrapThrowingSpeed", "MineLayingSpeed" },
 	["trap trigger area of effect"] = "TrapTriggerAreaOfEffect",


### PR DESCRIPTION
Fixes #5488  .

### Description of the problem being solved:
Volcanic Fissure supported by Earthbreaker incorrectly gets +1 totem limit from "Attack Skills have +1 to maximum number of Summoned Ballista Totems" mods such as from Panopticon and Watchtowers.

### Steps taken to verify a working solution:
- Make a build with the skill gems Volcanic Fissure supported by Earthbreaker.
- Allocate Panopticon and Watchtowers.
- Check that the Active Totem Limit under the "Calcs" tab still shows 1.
- As a sanity check, make a build with a bow and a bow attack skill gem supported by Ballista Support with the same passives allocated, and confirm that those still increase active totem limit.

### Link to a build that showcases this PR:
https://pastebin.com/yzzh77Gp

### Before screenshot:
![image](https://user-images.githubusercontent.com/67874326/211733640-b0925efa-6206-49d9-ae0a-031341e60ead.png)

### After screenshot:
![image](https://user-images.githubusercontent.com/67874326/211733719-d73bac18-c117-4b36-9351-932ae0741b52.png)
