### PR TITLE
Fix Enabled and FullDPS checkboxes not updating when mouse shortcuts are used

### DIFF
--- a/src/Classes/SkillListControl.lua
+++ b/src/Classes/SkillListControl.lua
@@ -151,6 +151,9 @@ function SkillListClass:OnHoverKeyUp(key)
 		elseif key == "RIGHTBUTTON" then
 			if IsKeyDown("CTRL") then
 				item.includeInFullDPS = not item.includeInFullDPS
+				if item == self.skillsTab.displayGroup then
+					self.skillsTab:SetDisplayGroup(item)
+				end
 				self.skillsTab:AddUndoState()
 				self.skillsTab.build.buildFlag = true
 			else
@@ -163,6 +166,9 @@ function SkillListClass:OnHoverKeyUp(key)
 			end
 		elseif key == "LEFTBUTTON" and IsKeyDown("CTRL") then
 			item.enabled = not item.enabled
+			if item == self.skillsTab.displayGroup then
+				self.skillsTab:SetDisplayGroup(item)
+			end
 			self.skillsTab:AddUndoState()
 			self.skillsTab.build.buildFlag = true
 		end


### PR DESCRIPTION
### Description of the problem being solved:
Enabled and FullDPS checkboxes don't update when the underlying values are changed using mouse shortcuts.

https://user-images.githubusercontent.com/5316261/212365483-f0c56052-a4dd-4336-a682-84e329e37348.mp4

Added a check to force update UI if the active item is modified.