### PR TITLE
Change foil search to correctly assign foil to voidborn uniques

### DIFF
--- a/src/Classes/Item.lua
+++ b/src/Classes/Item.lua
@@ -95,7 +95,7 @@ function ItemClass:ParseRaw(raw)
 			if self.rarity == "UNIQUE" then
 				-- Hack for relics
 				for _, line in ipairs(self.rawLines) do
-					if line == "Foil Unique" then
+					if line:find("Foil Unique") then
 						self.rarity = "RELIC"
 						break
 					end


### PR DESCRIPTION
Fixes  #5580.

Does not save foil colour type, but does assign foil to the item