### PR TITLE
Fix socket group linking not working on weapon swap and generalize socket group linking code.

### DIFF
--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -2420,9 +2420,7 @@ local specialModList = {
 		if itemSlotName == "main hand" then
 			targetItemSlotName = "Weapon 1"
 		end
-		return {
-			mod("LinkedSupport", "LIST", { targetSlotName = targetItemSlotName }, { type = "SocketedIn", slotName = "{SlotName}" }),
-		}
+		return { mod("LinkedSupport", "LIST", { targetSlotName = targetItemSlotName }) }
 	end,
 	["socketed hex curse skills are triggered by doedre's effigy when summoned"] = { mod("ExtraSupport", "LIST", { skillId = "SupportCursePillarTriggerCurses", level = 20 }, { type = "SocketedIn", slotName = "{SlotName}" }) },
 	["trigger level (%d+) (.+) every (%d+) seconds"] = function(num, _, skill) return triggerExtraSkill(skill, num) end,


### PR DESCRIPTION
Fixes #5584 .

### Description of the problem being solved:
The old code used hard coded slot names which did not take into account the "swap" suffix that weapon slots have.

### Steps taken to verify a working solution:
- Test [The Squire](https://www.poewiki.net/wiki/The_Squire)
- Test [Uul-Netol's Vow](https://www.poewiki.net/wiki/Uul-Netol%27s_Vow)

### Link to a build that showcases this PR:
`https://pobb.in/hAVkORH1aWmN`
