### PR TITLE
FIX crash on import if abyss jewel socketed in weapon swap weapon

### DIFF
--- a/src/Classes/ItemsTab.lua
+++ b/src/Classes/ItemsTab.lua
@@ -121,7 +121,7 @@ local ItemsTabClass = newClass("ItemsTab", "UndoHandler", "ControlHost", "Contro
 				return self.activeItemSet.useSecondWeaponSet
 			end
 			for i = 1, 6 do
-				local abyssal = new("ItemSlotControl", {"TOPLEFT",prevSlot,"BOTTOMLEFT"}, 0, 2, self, slotName.."Swap Abyssal Socket "..i, "Abyssal #"..i)			
+				local abyssal = new("ItemSlotControl", {"TOPLEFT",prevSlot,"BOTTOMLEFT"}, 0, 2, self, slotName.." Swap Abyssal Socket "..i, "Abyssal #"..i)			
 				addSlot(abyssal)
 				abyssal.parentSlot = swapSlot
 				abyssal.weaponSet = 2


### PR DESCRIPTION
Fixes #5592 .

### Description of the problem being solved:
Missing space caused a mismatch of socket names. 
https://github.com/PathOfBuildingCommunity/PathOfBuilding/blob/92f13a5d2b23cc2c14fff67c0a2cfd349cc1371d/src/Classes/ImportTab.lua#L916
https://github.com/PathOfBuildingCommunity/PathOfBuilding/blob/92f13a5d2b23cc2c14fff67c0a2cfd349cc1371d/src/Classes/ItemsTab.lua#L124
Items Tab:      `Weapon 2Swap Abyssal Socket 1`
Import code:  `Weapon 2 Swap Abyssal Socket 1`

Adding the space in ItemsTab makes the naming more in line with the names of other slots.

Note that this change may cause issues when loading some builds saved with the space-less slot naming but i was not able to create such a build.