### PR TITLE
Fix energy blade not importing on copy paste

### DIFF
--- a/src/Classes/Item.lua
+++ b/src/Classes/Item.lua
@@ -82,8 +82,10 @@ function ItemClass:ParseRaw(raw)
 	end
 	local mode = "WIKI"
 	local l = 1
+	local itemClass
 	if self.rawLines[l] then
 		if self.rawLines[l]:match("^Item Class:") then
+			itemClass = self.rawLines[l]:gsub("^Item Class: %s+", "%1")
 			l = l + 1 -- Item class is already determined by the base type
 		end
 		local rarity = self.rawLines[l]:match("^Rarity: (%a+)")
@@ -116,7 +118,7 @@ function ItemClass:ParseRaw(raw)
 		end
 
 		-- Found the name for a rare or unique, but let's parse it if it's a magic or normal or Unidentified item to get the base
-		if not (self.rarity == "NORMAL" or self.rarity == "MAGIC" or unidentified) then
+		if not (self.rarity == "NORMAL" or self.rarity == "MAGIC" or unidentified) or self.name:match("Energy Blade") then
 			l = l + 1
 		end
 	end
@@ -395,6 +397,9 @@ function ItemClass:ParseRaw(raw)
 				local baseName
 				if self.rarity == "NORMAL" or self.rarity == "MAGIC" then
 					-- Exact match (affix-less magic and normal items)
+					if self.name:match("Energy Blade") then -- Special handling for energy blade base.
+						self.name = itemClass:match("One Hand") and "Energy Blade One Handed" or "Energy Blade Two Handed"
+					end
 					if data.itemBases[self.name] then
 						baseName = self.name
 					else

--- a/src/Classes/Item.lua
+++ b/src/Classes/Item.lua
@@ -397,7 +397,7 @@ function ItemClass:ParseRaw(raw)
 				local baseName
 				if self.rarity == "NORMAL" or self.rarity == "MAGIC" then
 					-- Exact match (affix-less magic and normal items)
-					if self.name:match("Energy Blade") then -- Special handling for energy blade base.
+					if self.name:match("Energy Blade") and itemClass then -- Special handling for energy blade base.
 						self.name = itemClass:match("One Hand") and "Energy Blade One Handed" or "Energy Blade Two Handed"
 					end
 					if data.itemBases[self.name] then


### PR DESCRIPTION
### Description of the problem being solved:
Empty handed profiles from poe.ninja this is caused by us not being able to parse an energy blade item.
https://github.com/PathOfBuildingCommunity/PathOfBuilding/pull/5016#issuecomment-1386661695 / Prior discussion on discord.

```
Item Class: One Hand Swords
Rarity: Normal
Energy Blade
--------
One Handed Sword
Elemental Damage: 13-265 (augmented)
Critical Strike Chance: 7.00%
Attacks per Second: 1.70
Weapon Range: 11
--------
Requirements:
Level: 72
Str: 100
Dex: 100
Int: 98
--------
Sockets: R-B-G 
--------
Item Level: 60
--------
Adds 13 to 265 Lightning Damage (implicit)

```

### After screenshot:
![image](https://user-images.githubusercontent.com/31533893/213153299-38070df4-1975-4c48-82d5-6042767b23cb.png)
![image](https://user-images.githubusercontent.com/31533893/213131243-e2e788bc-8dba-4888-ac44-186f9a25bdef.png)
