### PR TITLE
Fix Energy Blade not working with socketed Abyssal jewels

### DIFF
--- a/src/Modules/CalcSetup.lua
+++ b/src/Modules/CalcSetup.lua
@@ -712,7 +712,8 @@ function calcs.initEnv(build, mode, override, specEnv)
 						end
 					end
 				elseif (slotName == "Weapon 1" or slotName == "Weapon 2") and modDB.conditions["AffectedByEnergyBlade"] then
-					local type = env.player.itemList[slotName] and env.player.itemList[slotName].weaponData and env.player.itemList[slotName].weaponData[1].type
+					local previousItem = env.player.itemList[slotName]
+					local type = previousItem and previousItem.weaponData and previousItem.weaponData[1].type
 					local info = env.data.weaponTypeInfo[type]
 					if info and type ~= "Bow" then
 						local name = info.oneHand and "Energy Blade One Handed" or "Energy Blade Two Handed"
@@ -738,6 +739,8 @@ function calcs.initEnv(build, mode, override, specEnv)
 						end
 						item:NormaliseQuality()
 						item:BuildAndParseRaw()
+						item.sockets = previousItem.sockets
+						item.abyssalSocketCount = previousItem.abyssalSocketCount
 						env.player.itemList[slotName] = item
 					else
 						env.itemModDB:ScaleAddList(srcList, scale)


### PR DESCRIPTION
Fixes https://github.com/PathOfBuildingCommunity/PathOfBuilding/issues/5132

### Description of the problem being solved:
Abyssal sockets were wiped when making an energy blade

### Link to a build that showcases this PR:
https://pobb.in/r7rTJXeFmpcy

### Before screenshot:
![image](https://user-images.githubusercontent.com/31533893/213162042-ac5e2c39-9185-466c-a351-27de61f362c1.png)

### After screenshot:
![image](https://user-images.githubusercontent.com/31533893/213162086-78b1b10a-9791-4390-ad04-96047c174742.png)
