### PR TITLE
Exit updater out early if a file download fails

### DIFF
--- a/src/UpdateCheck.lua
+++ b/src/UpdateCheck.lua
@@ -252,6 +252,9 @@ for index, data in ipairs(updateFiles) do
 		end
 		file:close()
 	end
+	if failedFile then
+		break
+	end
 end
 for name, zip in pairs(zipFiles) do
 	zip:Close()


### PR DESCRIPTION
Exit updater out early if a file download fails, this is due to the update not applying anyway if a fail download fails

Other improvements that could be made are:
1) checking the download folder for files downloaded incase a previous download failed or was canceled
 or 2) having it automatically clearing the download folder instead of leaving files there to be overridden