### PR TITLE
Fix default state validation for lists and color labels properly

### DIFF
--- a/src/Classes/ConfigTab.lua
+++ b/src/Classes/ConfigTab.lua
@@ -20,6 +20,7 @@ local ConfigTabClass = newClass("ConfigTab", "UndoHandler", "ControlHost", "Cont
 
 	self.input = { }
 	self.placeholder = { }
+	self.defaultState = { }
 	
 	self.enemyLevel = 1
 
@@ -424,8 +425,10 @@ local ConfigTabClass = newClass("ConfigTab", "UndoHandler", "ControlHost", "Cont
 			if varData.tooltipFunc then
 				control.tooltipFunc = varData.tooltipFunc
 			end
+			local labelControl = control
 			if varData.label and varData.type ~= "check" then
-				t_insert(self.controls, new("LabelControl", {"RIGHT",control,"LEFT"}, -4, 0, 0, DrawStringWidth(14, "VAR", varData.label) > 228 and 12 or 14, "^7"..varData.label))
+				labelControl = new("LabelControl", {"RIGHT",control,"LEFT"}, -4, 0, 0, DrawStringWidth(14, "VAR", varData.label) > 228 and 12 or 14, "^7"..varData.label)
+				t_insert(self.controls, labelControl)
 			end
 			if varData.var then
 				self.input[varData.var] = varData.defaultState
@@ -437,19 +440,34 @@ local ConfigTabClass = newClass("ConfigTab", "UndoHandler", "ControlHost", "Cont
 					self.input[varData.var] = varData.list[varData.defaultIndex].val
 					control.selIndex = varData.defaultIndex
 				end
+				if varData.type == "check" then
+					self.defaultState[varData.var] = varData.defaultState or false
+				elseif varData.type == "count" or varData.type == "integer" or varData.type == "countAllowZero" then
+					self.defaultState[varData.var] = varData.defaultState or 0
+				elseif varData.type == "list" then
+					self.defaultState[varData.var] = varData.list[varData.defaultIndex or 1].val
+				elseif varData.type == "text" then
+					self.defaultState[varData.var] = varData.defaultState or ""
+				else
+					self.defaultState[varData.var] = varData.defaultState
+				end
 			end
 
 			if not varData.hideIfInvalid then
 				local innerShown = control.shown
 				control.shown = function()
 					local shown = type(innerShown) == "boolean" and innerShown or innerShown()
-					return not shown and control.state ~= self:GetDefaultState(varData.var, type(control.state)) or shown
+					local cur = self.input[varData.var]
+					local def = self:GetDefaultState(varData.var, type(cur))
+					return not shown and cur ~= nil and cur ~= def or shown
 				end
-				local innerLabel = control.label
-				control.label = function()
+				local innerLabel = labelControl.label
+				labelControl.label = function()
 					local shown = type(innerShown) == "boolean" and innerShown or innerShown()
-					if not shown and control.state ~= self:GetDefaultState(varData.var, type(control.state)) then
-						return "^1"..innerLabel
+					local cur = self.input[varData.var]
+					local def = self:GetDefaultState(varData.var, type(cur))
+					if not shown and cur ~= nil and cur ~= def then
+						return "^1"..StripEscapes(innerLabel)
 					end
 					return innerLabel
 				end
@@ -467,7 +485,9 @@ local ConfigTabClass = newClass("ConfigTab", "UndoHandler", "ControlHost", "Cont
 					end
 
 					local shown = type(innerShown) == "boolean" and innerShown or innerShown()
-					if not shown and control.state ~= self:GetDefaultState(varData.var, type(control.state)) then
+					local cur = self.input[varData.var]
+					local def = self:GetDefaultState(varData.var, type(cur))
+					if not shown and cur ~= nil and cur ~= def then
 						tooltip:AddLine(14, "^1This config option is conditional with missing source and is invalid.")
 					end
 				end
@@ -527,21 +547,16 @@ function ConfigTabClass:GetDefaultState(var, varType)
 		return self.placeholder[var]
 	end
 
-	for i = 1, #varList do
-		if varList[i].var == var then
-			if varType == "number" then
-				return varList[i].defaultState or 0
-			elseif varType == "boolean" then
-				return varList[i].defaultState == true
-			else
-				return varList[i].defaultState
-			end
-		end
+	if self.defaultState[var] ~= nil then
+		return self.defaultState[var]
 	end
+
 	if varType == "number" then
 		return 0
 	elseif varType == "boolean" then
 		return false
+	elseif varType == "string" then
+		return ""
 	else
 		return nil
 	end


### PR DESCRIPTION
- Fix GetDefaultState to properly handle lists (this also saves saving of bunch of default list values to build XMLs)
- Fix control state checks for non-boolean type config options
- Fix coloring of config controls with separate labels

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>

### Description of the problem being solved:

### Steps taken to verify a working solution:
- Enable enduring cry
- Adjust warcry calculation mode
- Disable enduring cry

### Link to a build that showcases this PR:

https://pobb.in/zI8n1DDXYEeA

### Before screenshot:

![image](https://user-images.githubusercontent.com/5115805/213869487-19349381-88d2-4624-8e89-e27e9ece7fab.png)

### After screenshot:

![image](https://user-images.githubusercontent.com/5115805/213869456-8e68fd2f-0b32-4bde-97bb-4cf938001dab.png)

