### PR TITLE
Prevent pathing through class starts for Split Personality

### DIFF
--- a/src/Classes/PassiveSpec.lua
+++ b/src/Classes/PassiveSpec.lua
@@ -595,7 +595,7 @@ function PassiveSpecClass:SetNodeDistanceToClassStart(root)
 			end
 
 			-- Otherwise, record the distance to this node if it hasn't already been visited
-			if other.alloc and not nodeDistanceToRoot[other.id] then
+			if other.alloc and node.type ~= "Mastery" and other.type ~= "ClassStart" and other.type ~= "AscendClassStart" and not nodeDistanceToRoot[other.id] then
 				nodeDistanceToRoot[other.id] = curDist;
 
 				-- Add the other node to the end of the queue


### PR DESCRIPTION
Fixes #5626 .

### Description of the problem being solved:
The `SetNodeDistanceToClassStart` function is currently allowed to path through class start nodes as well as other types of not relevant nodes. This pr prevents that from happening.