### PR TITLE
FIX: Ancestral Bond - mirage interaction.

### DIFF
--- a/src/Modules/CalcOffence.lua
+++ b/src/Modules/CalcOffence.lua
@@ -1072,7 +1072,9 @@ function calcs.offence(env, actor, activeSkill)
 
 		if mirageActiveSkill then
 			local cooldown = calcSkillCooldown(mirageActiveSkill.skillModList, mirageActiveSkill.skillCfg, mirageActiveSkill.skillData)
-
+			
+			skillCfg.skillCond["usedByMirage"] = true
+			
 			-- Non-channelled skills only attack once, disregard attack rate
 			if not activeSkill.skillTypes[SkillType.Channel] then
 				skillData.timeOverride = 1
@@ -4481,7 +4483,9 @@ function calcs.offence(env, actor, activeSkill)
 			else
 				env.player.mainSkill.skillPartName = usedSkill.activeEffect.grantedEffect.name
 			end
-
+			
+			newSkill.skillCfg.skillCond["usedByMirage"] = true
+			
 			-- Recalculate the offensive/defensive aspects of this new skill
 			newEnv.player.mainSkill = newSkill
 			calcs.perform(newEnv)

--- a/src/Modules/CalcPerform.lua
+++ b/src/Modules/CalcPerform.lua
@@ -2635,11 +2635,12 @@ function calcs.perform(env, avoidCache)
 
 			-- Make a copy of this skill so we can add new modifiers to the copy affected by Mirage Archers
 			local newSkill, newEnv = calcs.copyActiveSkill(env, calcMode, usedSkill)
-
+			
 			-- Add new modifiers to new skill (which already has all the old skill's modifiers)
 			newSkill.skillModList:NewMod("Damage", "MORE", moreDamage, "Mirage Archer", env.player.mainSkill.ModFlags, env.player.mainSkill.KeywordFlags)
 			newSkill.skillModList:NewMod("Speed", "MORE", moreAttackSpeed, "Mirage Archer", env.player.mainSkill.ModFlags, env.player.mainSkill.KeywordFlags)
-
+			newSkill.skillCfg.skillCond["usedByMirage"] = true
+			
 			env.player.mainSkill.mirage = { }
 			env.player.mainSkill.mirage.count = mirageCount
 			env.player.mainSkill.mirage.name = usedSkill.activeEffect.grantedEffect.name

--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -3544,11 +3544,11 @@ local specialModList = {
 	["deal no chaos damage"] = { flag("DealNoChaos") },
 	["deal no damage"] = { flag("DealNoLightning"), flag("DealNoCold"), flag("DealNoFire"), flag("DealNoChaos"), flag("DealNoPhysical") },
 	["you can't deal damage with skills yourself"] = {
-		flag("DealNoLightning", { type = "SkillType", skillTypeList = {SkillType.Minion, SkillType.SummonsTotem, SkillType.RemoteMined, SkillType.Trapped}, neg = true }, {type = "Condition", var="usedByMirage", neg = true}),
-		flag("DealNoCold", 		{ type = "SkillType", skillTypeList = {SkillType.Minion, SkillType.SummonsTotem, SkillType.RemoteMined, SkillType.Trapped}, neg = true }, {type = "Condition", var="usedByMirage", neg = true}),
-		flag("DealNoFire", 		{ type = "SkillType", skillTypeList = {SkillType.Minion, SkillType.SummonsTotem, SkillType.RemoteMined, SkillType.Trapped}, neg = true }, {type = "Condition", var="usedByMirage", neg = true}),
-		flag("DealNoChaos", 	{ type = "SkillType", skillTypeList = {SkillType.Minion, SkillType.SummonsTotem, SkillType.RemoteMined, SkillType.Trapped}, neg = true }, {type = "Condition", var="usedByMirage", neg = true}),
-		flag("DealNoPhysical", 	{ type = "SkillType", skillTypeList = {SkillType.Minion, SkillType.SummonsTotem, SkillType.RemoteMined, SkillType.Trapped}, neg = true }, {type = "Condition", var="usedByMirage", neg = true})
+		flag("DealNoLightning", { type = "SkillType", skillTypeList = {SkillType.SummonsTotem, SkillType.RemoteMined, SkillType.Trapped}, neg = true }, {type = "Condition", var="usedByMirage", neg = true}),
+		flag("DealNoCold", 		{ type = "SkillType", skillTypeList = {SkillType.SummonsTotem, SkillType.RemoteMined, SkillType.Trapped}, neg = true }, {type = "Condition", var="usedByMirage", neg = true}),
+		flag("DealNoFire", 		{ type = "SkillType", skillTypeList = {SkillType.SummonsTotem, SkillType.RemoteMined, SkillType.Trapped}, neg = true }, {type = "Condition", var="usedByMirage", neg = true}),
+		flag("DealNoChaos", 	{ type = "SkillType", skillTypeList = {SkillType.SummonsTotem, SkillType.RemoteMined, SkillType.Trapped}, neg = true }, {type = "Condition", var="usedByMirage", neg = true}),
+		flag("DealNoPhysical", 	{ type = "SkillType", skillTypeList = {SkillType.SummonsTotem, SkillType.RemoteMined, SkillType.Trapped}, neg = true }, {type = "Condition", var="usedByMirage", neg = true})
 	},
 	["deal no non%-elemental damage"] = { flag("DealNoPhysical"), flag("DealNoChaos") },
 	["deal no non%-lightning damage"] = { flag("DealNoPhysical"), flag("DealNoCold"), flag("DealNoFire"), flag("DealNoChaos") },

--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -3544,11 +3544,11 @@ local specialModList = {
 	["deal no chaos damage"] = { flag("DealNoChaos") },
 	["deal no damage"] = { flag("DealNoLightning"), flag("DealNoCold"), flag("DealNoFire"), flag("DealNoChaos"), flag("DealNoPhysical") },
 	["you can't deal damage with skills yourself"] = {
-		flag("DealNoLightning", { type = "SkillType", skillTypeList = {SkillType.Minion, SkillType.SummonsTotem, SkillType.RemoteMined, SkillType.Trapped}, neg = true }),
-		flag("DealNoCold", 		{ type = "SkillType", skillTypeList = {SkillType.Minion, SkillType.SummonsTotem, SkillType.RemoteMined, SkillType.Trapped}, neg = true }),
-		flag("DealNoFire", 		{ type = "SkillType", skillTypeList = {SkillType.Minion, SkillType.SummonsTotem, SkillType.RemoteMined, SkillType.Trapped}, neg = true }),
-		flag("DealNoChaos", 	{ type = "SkillType", skillTypeList = {SkillType.Minion, SkillType.SummonsTotem, SkillType.RemoteMined, SkillType.Trapped}, neg = true }),
-		flag("DealNoPhysical", 	{ type = "SkillType", skillTypeList = {SkillType.Minion, SkillType.SummonsTotem, SkillType.RemoteMined, SkillType.Trapped}, neg = true })
+		flag("DealNoLightning", { type = "SkillType", skillTypeList = {SkillType.Minion, SkillType.SummonsTotem, SkillType.RemoteMined, SkillType.Trapped}, neg = true }, {type = "Condition", var="usedByMirage", neg = true}),
+		flag("DealNoCold", 		{ type = "SkillType", skillTypeList = {SkillType.Minion, SkillType.SummonsTotem, SkillType.RemoteMined, SkillType.Trapped}, neg = true }, {type = "Condition", var="usedByMirage", neg = true}),
+		flag("DealNoFire", 		{ type = "SkillType", skillTypeList = {SkillType.Minion, SkillType.SummonsTotem, SkillType.RemoteMined, SkillType.Trapped}, neg = true }, {type = "Condition", var="usedByMirage", neg = true}),
+		flag("DealNoChaos", 	{ type = "SkillType", skillTypeList = {SkillType.Minion, SkillType.SummonsTotem, SkillType.RemoteMined, SkillType.Trapped}, neg = true }, {type = "Condition", var="usedByMirage", neg = true}),
+		flag("DealNoPhysical", 	{ type = "SkillType", skillTypeList = {SkillType.Minion, SkillType.SummonsTotem, SkillType.RemoteMined, SkillType.Trapped}, neg = true }, {type = "Condition", var="usedByMirage", neg = true})
 	},
 	["deal no non%-elemental damage"] = { flag("DealNoPhysical"), flag("DealNoChaos") },
 	["deal no non%-lightning damage"] = { flag("DealNoPhysical"), flag("DealNoCold"), flag("DealNoFire"), flag("DealNoChaos") },


### PR DESCRIPTION
### Description of the problem being solved:
Mirages are not "you" and thus can deal damage even when Ancestral Bond is allocated. 

Note that i'm not sure if General's cry is handled correctly here. The damage values may be inflated due to not being handled like Mirage archer.