### PR TITLE
add support for `extra-en-dict.txt`

### DIFF
--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -28,7 +28,8 @@ jobs:
             ${{ env.CONFIG_URL }}/cspell.json \
             ${{ env.CONFIG_URL }}/pob-dict.txt \
             ${{ env.CONFIG_URL }}/poe-dict.txt \
-            ${{ env.CONFIG_URL }}/ignore-dict.txt
+            ${{ env.CONFIG_URL }}/ignore-dict.txt \
+            ${{ env.CONFIG_URL }}/extra-en-dict.txt
 
       - name: Run cspell
         uses: streetsidesoftware/cspell-action@v2.4.0


### PR DESCRIPTION
(Spell checker workflow change)
`extra-en-dict.txt` will include English words not found in CSpell's dictionaries and not specific to PoE or PoB.