### PR TITLE
Add support for jewel limits

### DIFF
--- a/src/Classes/PassiveSpec.lua
+++ b/src/Classes/PassiveSpec.lua
@@ -651,7 +651,7 @@ function PassiveSpecClass:BuildAllDependsAndPaths()
 		if node.type ~= "ClassStart" and node.type ~= "Socket" and not node.ascendancyName then
 			for nodeId, itemId in pairs(self.jewels) do
 				local item = self.build.itemsTab.items[itemId]
-				if item and item.jewelRadiusIndex and self.allocNodes[nodeId] and item.jewelData then
+				if item and item.jewelRadiusIndex and self.allocNodes[nodeId] and item.jewelData and not item.jewelData.limitDisabled then
 					local radiusIndex = item.jewelRadiusIndex
 					if self.nodes[nodeId].nodesInRadius and self.nodes[nodeId].nodesInRadius[radiusIndex][node.id] then
 						if itemId ~= 0 then

--- a/src/Modules/CalcSetup.lua
+++ b/src/Modules/CalcSetup.lua
@@ -572,6 +572,7 @@ function calcs.initEnv(build, mode, override, specEnv)
 	-- Build and merge item modifiers, and create list of radius jewels
 	if not accelerate.requirementsItems then
 		local items = {}
+		local jewelLimits = {}
 		for _, slot in pairs(build.itemsTab.orderedSlots) do
 			local slotName = slot.slotName
 			local item
@@ -607,32 +608,59 @@ function calcs.initEnv(build, mode, override, specEnv)
 				-- Slot is a jewel socket, check if socket is allocated
 				if not env.allocNodes[slot.nodeId] then
 					item = nil
-				elseif item and item.jewelRadiusIndex then
-					-- Jewel has a radius, add it to the list
-					local funcList = item.jewelData.funcList or { { type = "Self", func = function(node, out, data)
-						-- Default function just tallies all stats in radius
-						if node then
-							for _, stat in pairs({"Str","Dex","Int"}) do
-								data[stat] = (data[stat] or 0) + out:Sum("BASE", nil, stat)
+				elseif item then
+					item.jewelData.limitDisabled = nil
+					if item.limit and not env.configInput.ignoreJewelLimits then
+						if jewelLimits[item.title] and jewelLimits[item.title] >= item.limit then
+							item.jewelData.limitDisabled = true
+							item = nil
+						else
+							jewelLimits[item.title] = (jewelLimits[item.title] or 0) + 1
+						end
+					-- Handle historic jewels
+					elseif item.type == "Jewel" and item.base.subType == "Timeless" and not env.configInput.ignoreJewelLimits then
+						local isHistoric = false
+						for _, mod in ipairs(item.modList) do
+							if mod.name == "Historic" then
+								isHistoric = true
+								break
 							end
 						end
-					end } }
-					for _, func in ipairs(funcList) do
-						local node = env.spec.nodes[slot.nodeId]
-						t_insert(env.radiusJewelList, {
-							nodes = node.nodesInRadius and node.nodesInRadius[item.jewelRadiusIndex] or { },
-							func = func.func,
-							type = func.type,
-							item = item,
-							nodeId = slot.nodeId,
-							attributes = node.attributesInRadius and node.attributesInRadius[item.jewelRadiusIndex] or { },
-							data = { }
-						})
-						if func.type ~= "Self" and node.nodesInRadius then
-							-- Add nearby unallocated nodes to the extra node list
-							for nodeId, node in pairs(node.nodesInRadius[item.jewelRadiusIndex]) do
-								if not env.allocNodes[nodeId] then
-									env.extraRadiusNodeList[nodeId] = env.spec.nodes[nodeId]
+						if isHistoric then
+							if jewelLimits["Historic"] then
+								item.jewelData.limitDisabled = true
+								item = nil
+							end
+							jewelLimits["Historic"] = 1
+						end
+					end
+					if item and item.jewelRadiusIndex then
+						-- Jewel has a radius, add it to the list
+						local funcList = item.jewelData.funcList or { { type = "Self", func = function(node, out, data)
+							-- Default function just tallies all stats in radius
+							if node then
+								for _, stat in pairs({"Str","Dex","Int"}) do
+									data[stat] = (data[stat] or 0) + out:Sum("BASE", nil, stat)
+								end
+							end
+						end } }
+						for _, func in ipairs(funcList) do
+							local node = env.spec.nodes[slot.nodeId]
+							t_insert(env.radiusJewelList, {
+								nodes = node.nodesInRadius and node.nodesInRadius[item.jewelRadiusIndex] or { },
+								func = func.func,
+								type = func.type,
+								item = item,
+								nodeId = slot.nodeId,
+								attributes = node.attributesInRadius and node.attributesInRadius[item.jewelRadiusIndex] or { },
+								data = { }
+							})
+							if func.type ~= "Self" and node.nodesInRadius then
+								-- Add nearby unallocated nodes to the extra node list
+								for nodeId, node in pairs(node.nodesInRadius[item.jewelRadiusIndex]) do
+									if not env.allocNodes[nodeId] then
+										env.extraRadiusNodeList[nodeId] = env.spec.nodes[nodeId]
+									end
 								end
 							end
 						end

--- a/src/Modules/CalcSetup.lua
+++ b/src/Modules/CalcSetup.lua
@@ -611,27 +611,12 @@ function calcs.initEnv(build, mode, override, specEnv)
 				elseif item then
 					item.jewelData.limitDisabled = nil
 					if item.limit and not env.configInput.ignoreJewelLimits then
-						if jewelLimits[item.title] and jewelLimits[item.title] >= item.limit then
+						local limitKey = item.base.subType == "Timeless" and "Historic" or item.title
+						if jewelLimits[limitKey] and jewelLimits[limitKey] >= item.limit then
 							item.jewelData.limitDisabled = true
 							item = nil
 						else
-							jewelLimits[item.title] = (jewelLimits[item.title] or 0) + 1
-						end
-					-- Handle historic jewels
-					elseif item.type == "Jewel" and item.base.subType == "Timeless" and not env.configInput.ignoreJewelLimits then
-						local isHistoric = false
-						for _, mod in ipairs(item.modList) do
-							if mod.name == "Historic" then
-								isHistoric = true
-								break
-							end
-						end
-						if isHistoric then
-							if jewelLimits["Historic"] then
-								item.jewelData.limitDisabled = true
-								item = nil
-							end
-							jewelLimits["Historic"] = 1
+							jewelLimits[limitKey] = (jewelLimits[limitKey] or 0) + 1
 						end
 					end
 					if item and item.jewelRadiusIndex then

--- a/src/Modules/ConfigOptions.lua
+++ b/src/Modules/ConfigOptions.lua
@@ -156,6 +156,7 @@ return {
 		modList:NewMod("Condition:EVBypass", "FLAG", true, "Config")
 	end },
 	{ var = "ignoreItemDisablers", type = "check", label = "Don't disable items", tooltip = "Ignore the effects of things which disable items, like Bringer of Rain" },
+	{ var = "ignoreJewelLimits", type = "check", label = "Ignore Jewel Limits", tooltip = "Ignore the limits on jewels" },
 
 	-- Section: Skill-specific options
 	{ section = "Skill Options", col = 2 },

--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -4061,14 +4061,6 @@ local specialModList = {
 	["grants %+(%d+)%% to lightning resistance per (%d+)%% quality"] = function(num, _, div) return { mod("LightningResist", "BASE", num, { type = "Multiplier", var = "QualityOn{SlotName}", div = tonumber(div) }) } end,
 	["%+(%d+)%% to quality"] = function(num) return { mod("Quality", "BASE", num) } end,
 	["infernal blow debuff deals an additional (%d+)%% of damage per charge"] = function(num) return { mod("DebuffEffect", "BASE", num, { type = "SkillName", skillName = "Infernal Blow" }) } end,
-	-- Display-only modifiers
-	["extra gore"] = { },
-	["prefixes:"] = { },
-	["suffixes:"] = { },
-	["while your passive skill tree connects to a class' starting location, you gain:"] = { },
-	["socketed lightning spells [hd][ae][va][el] (%d+)%% increased spell damage if triggered"] = { },
-	["manifeste?d? dancing dervishe?s? disables both weapon slots"] = { },
-	["manifeste?d? dancing dervishe?s? dies? when rampage ends"] = { },
 	-- Legion modifiers
 	["bathed in the blood of (%d+) sacrificed in the name of (.+)"] =  function(num, _, name)
 		return { mod("JewelData", "LIST",
@@ -4086,7 +4078,15 @@ local specialModList = {
 		return { mod("JewelData", "LIST",
 				{ key = "conqueredBy", value = { id = num, conqueror = conquerorList[name:lower()] } }) } end,
 	["passives in radius are conquered by the (%D+)"] = { },
-	["historic"] = { },
+	["historic"] = { mod("Historic", "Flag", 1) },
+	-- Display-only modifiers
+	["extra gore"] = { },
+	["prefixes:"] = { },
+	["suffixes:"] = { },
+	["while your passive skill tree connects to a class' starting location, you gain:"] = { },
+	["socketed lightning spells [hd][ae][va][el] (%d+)%% increased spell damage if triggered"] = { },
+	["manifeste?d? dancing dervishe?s? disables both weapon slots"] = { },
+	["manifeste?d? dancing dervishe?s? dies? when rampage ends"] = { },
 	["survival"] = { },
 	["you can have two different banners at the same time"] = { },
 	["can have a second enchantment modifier"] = { },

--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -4078,7 +4078,7 @@ local specialModList = {
 		return { mod("JewelData", "LIST",
 				{ key = "conqueredBy", value = { id = num, conqueror = conquerorList[name:lower()] } }) } end,
 	["passives in radius are conquered by the (%D+)"] = { },
-	["historic"] = { mod("Historic", "Flag", 1) },
+	["historic"] = { },
 	-- Display-only modifiers
 	["extra gore"] = { },
 	["prefixes:"] = { },


### PR DESCRIPTION
Built ontop of #5664 (So that one should be merged first)

Implements limits for jewels as well as an option to ignore the limits

This correctly limits most types of limits, including basic ones (like anima stone), radius jewels (like unnatural instinct), grand spectrums (limit of 3 across all grand spectrums), impossible escape (though this is a little buggy as it doesn't unallocate nodes that are allocated)

This is broken for historic jewels atm though