### PR TITLE
High precision handling for more multipliers

### DIFF
--- a/src/Classes/ModDB.lua
+++ b/src/Classes/ModDB.lua
@@ -122,6 +122,7 @@ end
 
 function ModDBClass:MoreInternal(context, cfg, flags, keywordFlags, source, ...)
 	local result = 1
+	local modPrecision = nil
 	for i = 1, select('#', ...) do
 		local modList = self.mods[select(i, ...)]
 		local modResult = 1 --The more multipliers for each mod are computed to the nearest percent then applied.
@@ -134,10 +135,20 @@ function ModDBClass:MoreInternal(context, cfg, flags, keywordFlags, source, ...)
 					else
 						modResult = modResult * (1 + mod.value / 100)
 					end
+					if modPrecision then
+						modPrecision = m_max(modPrecision, (data.highPrecisionMods[mod.name] and data.highPrecisionMods[mod.name][mod.type]) or modPrecision)
+					else
+						modPrecision = (data.highPrecisionMods[mod.name] and data.highPrecisionMods[mod.name][mod.type]) or nil
+					end
 				end
 			end
 		end
-		result = result * round(modResult,2)
+		if modPrecision then
+			local power = 10 ^ modPrecision
+			result = math.floor(result * modResult * power) / power
+		else
+			result = result * round(modResult, 2)
+		end
 	end
 	if self.parent then
 		result = result * self.parent:MoreInternal(context, cfg, flags, keywordFlags, source, ...)

--- a/src/Classes/ModList.lua
+++ b/src/Classes/ModList.lua
@@ -94,6 +94,7 @@ end
 
 function ModListClass:MoreInternal(context, cfg, flags, keywordFlags, source, ...)
 	local result = 1
+	local modPrecision = nil
 	for i = 1, select('#', ...) do
 		local modResult = 1 --The more multipliers for each mod are computed to the nearest percent then applied.
 		local modName = select(i, ...)
@@ -105,9 +106,19 @@ function ModListClass:MoreInternal(context, cfg, flags, keywordFlags, source, ..
 				else
 					modResult = modResult * (1 + mod.value / 100)
 				end
+				if modPrecision then
+					modPrecision = m_max(modPrecision, (data.highPrecisionMods[mod.name] and data.highPrecisionMods[mod.name][mod.type]) or modPrecision)
+				else
+					modPrecision = (data.highPrecisionMods[mod.name] and data.highPrecisionMods[mod.name][mod.type]) or nil
+				end
 			end
 		end
-		result = result * round(modResult,2)
+		if modPrecision then
+			local power = 10 ^ modPrecision
+			result = math.floor(result * modResult * power) / power
+		else
+			result = result * round(modResult, 2)
+		end
 	end
 	if self.parent then
 		result = result * self.parent:MoreInternal(context, cfg, flags, keywordFlags, source, ...)

--- a/src/Modules/Data.lua
+++ b/src/Modules/Data.lua
@@ -436,6 +436,9 @@ data.highPrecisionMods = {
 	["ChaosDamageEnergyShieldLeech"] = {
 		["BASE"] = 2,
 	},
+	["SupportManaMultiplier"] = {
+		["MORE"] = 4,
+	}
 }
 
 data.misc = { -- magic numbers


### PR DESCRIPTION
Fixes #5665.

### Description of the problem being solved:
#4641 introduced rounding for more multipliers and while most likely correct for some mods it causes issues for others like `SupportManaMultiplier` as mentioned the linked issue.  This pr implements support for mod specific precision based on code from #4640 .

Note the values are still slightly off due to rounding in calcPerform but should be close enough to give correct unreserved mana numbers.