### PR TITLE
Allow for custom mod dps multiplier

### DIFF
--- a/src/Modules/CalcSections.lua
+++ b/src/Modules/CalcSections.lua
@@ -333,12 +333,13 @@ return {
 		{ label = "Tvalue Override (ms)", modName = "MultiplierPvpTvalueOverride" }, 
 		{ label = "PvP Multiplier", modName = "MultiplierPvpDamage" }, 
 	}, },
-	{ label = "Skill DPS", flag = "notAverage", notFlag = "triggered", { format = "{1:output:TotalDPS}", { breakdown = "TotalDPS" }, }, },
+	{ label = "Skill DPS", flag = "notAverage", notFlag = "triggered", { format = "{1:output:TotalDPS}", { breakdown = "TotalDPS" }, { label = "DPS Multiplier", modName = "DPS" }, }, },
 	{ label = "Skill PvP DPS", flag = "notAveragePvP", { format = "{1:output:PvpTotalDPS}", { breakdown = "PvpTotalDPS" }, 
 		{ label = "Tvalue Override (ms)", modName = "MultiplierPvpTvalueOverride" }, 
-		{ label = "PvP Multiplier", modName = "MultiplierPvpDamage" }, 
+		{ label = "PvP Multiplier", modName = "MultiplierPvpDamage" },  
+		{ label = "DPS Multiplier", modName = "DPS" }, 
 	}, },
-	{ label = "Skill DPS", flag = "triggered", { format = "{1:output:TotalDPS}", { breakdown = "TotalDPS" }, }, },
+	{ label = "Skill DPS", flag = "triggered", { format = "{1:output:TotalDPS}", { breakdown = "TotalDPS" }, { label = "DPS Multiplier", modName = "DPS" }, }, },
 } }
 } },
 { 3, "Warcries", 1, colorCodes.OFFENCE, {{ defaultCollapsed = false, label = "Exerting Warcries", data = {

--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -595,6 +595,7 @@ local modNameList = {
 	["cast speed"] = { "Speed", flags = ModFlag.Cast },
 	["warcry speed"] = { "WarcrySpeed", keywordFlags = KeywordFlag.Warcry },
 	["attack and cast speed"] = "Speed",
+	["dps"] = "DPS",
 	-- Elemental ailments
 	["to shock"] = "EnemyShockChance",
 	["shock chance"] = "EnemyShockChance",


### PR DESCRIPTION
This just allows PoB to parse "%inc dps" or "%more dps", mainly for use in custom mods, common practice is to add a custom mod as "more damage" but that incorrectly messes with certain ailment calculations, so just allowing the user to straight input dps