### PR TITLE
Estimate resistance penalty on import

### DIFF
--- a/src/Classes/ImportTab.lua
+++ b/src/Classes/ImportTab.lua
@@ -590,7 +590,8 @@ function ImportTabClass:ImportPassiveTreeAndJewels(json, charData)
 		if type(self.build.Act) == "string" and self.build.Act == "Endgame" then resistancePenaltyIndex = 3
 		elseif type(self.build.Act) == "number" then 
 			if self.build.Act < 5 then resistancePenaltyIndex = 1
-			elseif self.build.Act > 5 and self.build.Act < 11 then resistancePenaltyIndex = 2 end
+			elseif self.build.Act > 5 and self.build.Act < 11 then resistancePenaltyIndex = 2
+			elseif self.build.Act > 10 then resistancePenaltyIndex = 3 end
 		end
 	end
 	self.build.configTab.varControls["resistancePenalty"]:SetSel(resistancePenaltyIndex)

--- a/src/Classes/ImportTab.lua
+++ b/src/Classes/ImportTab.lua
@@ -584,6 +584,16 @@ function ImportTabClass:ImportPassiveTreeAndJewels(json, charData)
 	self.build.spec:AddUndoState()
 	self.build.characterLevel = charData.level
 	self.build.controls.characterLevel:SetText(charData.level)
+	self.build:EstimatePlayerProgress()
+	local resistancePenaltyIndex = 3
+	if self.build.Act then -- Estimate resistance penalty setting based on act progression estimate
+		if type(self.build.Act) == "string" and self.build.Act == "Endgame" then resistancePenaltyIndex = 3
+		elseif type(self.build.Act) == "number" then 
+			if self.build.Act < 5 then resistancePenaltyIndex = 1
+			elseif self.build.Act > 5 and self.build.Act < 11 then resistancePenaltyIndex = 2 end
+		end
+	end
+	self.build.configTab.varControls["resistancePenalty"]:SetSel(resistancePenaltyIndex)
 	self.build.buildFlag = true
 	main:SetWindowTitleSubtext(string.format("%s (%s, %s, %s)", self.build.buildName, charData.name, charData.class, charData.league))
 end

--- a/src/Modules/Build.lua
+++ b/src/Modules/Build.lua
@@ -139,51 +139,7 @@ function buildMode:Init(dbFileName, buildName, buildXML, convertBuild)
 		end
 	end
 	self.controls.pointDisplay.width = function(control)
-		local PointsUsed, AscUsed = self.spec:CountAllocNodes()
-		local bandit = self.calcsTab.mainOutput.ExtraPoints or 0 
-		local usedMax, ascMax, levelreq, currentAct, banditStr, labSuggest = 99 + 22 + bandit, 8, 1, 1, "", ""
-		local acts = { 
-			[1] = { level = 1, questPoints = 0 }, 
-			[2] = { level = 12, questPoints = 2 }, 
-			[3] = { level = 22, questPoints = 3 + bandit }, 
-			[4] = { level = 32, questPoints = 5 + bandit },
-			[5] = { level = 40, questPoints = 6 + bandit },
-			[6] = { level = 44, questPoints = 8 + bandit },
-			[7] = { level = 50, questPoints = 11 + bandit },
-			[8] = { level = 54, questPoints = 14 + bandit },
-			[9] = { level = 60, questPoints = 17 + bandit },
-			[10] = { level = 64, questPoints = 19 + bandit },
-			[11] = { level = 67, questPoints = 22 + bandit }
-		}
-				
-		-- loop for how much quest skillpoints are used with the progress
-		while currentAct < 11 and PointsUsed + 1 - acts[currentAct].questPoints > acts[currentAct + 1].level do
-			currentAct = currentAct + 1
-		end
-
-		-- bandits notification; when considered and in calculation after act 2
-		if currentAct <= 2 and bandit ~= 0 then
-			bandit = 0
-		end
-		
-		-- to prevent a negative level at a blank sheet the level requirement will be set dependent on points invested until caught up with quest skillpoints 
-		levelreq = math.max(PointsUsed - acts[currentAct].questPoints + 1, acts[currentAct].level)
-		
-		-- Ascendency points for lab
-		-- this is a recommendation for beginners who are using Path of Building for the first time and trying to map out progress in PoB
-		local labstr = {"\nLabyrinth: Normal Lab", "\nLabyrinth: Cruel Lab", "\nLabyrinth: Merciless Lab", "\nLabyrinth: Uber Lab"}
-		local strAct = "Endgame"
-		if levelreq >= 33 and levelreq < 55 then labSuggest = labstr[1]
-		elseif levelreq >= 55 and levelreq < 68 then labSuggest = labstr[2]
-		elseif levelreq >= 68 and levelreq < 75 then labSuggest = labstr[3]
-		elseif levelreq >= 75 and levelreq < 90 then labSuggest = labstr[4] end
-		if levelreq < 90 and currentAct <= 10 then strAct = currentAct end
-		
-		control.str = string.format("%s%3d / %3d   %s%d / %d", PointsUsed > usedMax and "^1" or "^7", PointsUsed, usedMax, AscUsed > ascMax and "^1" or "^7", AscUsed, ascMax)
-		control.req = "Required Level: ".. levelreq .. "\nEstimated Progress:\nAct: ".. strAct .. "\nQuestpoints: " .. acts[currentAct].questPoints - bandit .. "\nBandits Skillpoints: " .. bandit .. labSuggest
-		
-		if PointsUsed > usedMax then InsertIfNew(self.controls.warnings.lines, "You have too many passive points allocated") end
-		if AscUsed > ascMax then InsertIfNew(self.controls.warnings.lines, "You have too many ascendancy points allocated") end
+		control.str, control.req = self:EstimatePlayerProgress()
 		return DrawStringWidth(16, "FIXED", control.str) + 8
 	end
 	self.controls.pointDisplay.Draw = function(control)
@@ -747,6 +703,54 @@ function buildMode:Init(dbFileName, buildName, buildXML, convertBuild)
 	--]]
 
 	self.abortSave = false
+end
+
+function buildMode:EstimatePlayerProgress()
+	local PointsUsed, AscUsed = self.spec:CountAllocNodes()
+	local bandit = self.calcsTab.mainOutput.ExtraPoints or 0 
+	local usedMax, ascMax, levelreq, currentAct, banditStr, labSuggest = 99 + 22 + bandit, 8, 1, 1, "", ""
+	local acts = { 
+		[1] = { level = 1, questPoints = 0 }, 
+		[2] = { level = 12, questPoints = 2 }, 
+		[3] = { level = 22, questPoints = 3 + bandit }, 
+		[4] = { level = 32, questPoints = 5 + bandit },
+		[5] = { level = 40, questPoints = 6 + bandit },
+		[6] = { level = 44, questPoints = 8 + bandit },
+		[7] = { level = 50, questPoints = 11 + bandit },
+		[8] = { level = 54, questPoints = 14 + bandit },
+		[9] = { level = 60, questPoints = 17 + bandit },
+		[10] = { level = 64, questPoints = 19 + bandit },
+		[11] = { level = 67, questPoints = 22 + bandit }
+	}
+			
+	-- loop for how much quest skillpoints are used with the progress
+	while currentAct < 11 and PointsUsed + 1 - acts[currentAct].questPoints > acts[currentAct + 1].level do
+		currentAct = currentAct + 1
+	end
+
+	-- bandits notification; when considered and in calculation after act 2
+	if currentAct <= 2 and bandit ~= 0 then
+		bandit = 0
+	end
+	
+	-- to prevent a negative level at a blank sheet the level requirement will be set dependent on points invested until caught up with quest skillpoints 
+	levelreq = math.max(PointsUsed - acts[currentAct].questPoints + 1, acts[currentAct].level)
+	
+	-- Ascendency points for lab
+	-- this is a recommendation for beginners who are using Path of Building for the first time and trying to map out progress in PoB
+	local labstr = {"\nLabyrinth: Normal Lab", "\nLabyrinth: Cruel Lab", "\nLabyrinth: Merciless Lab", "\nLabyrinth: Uber Lab"}
+	local strAct = "Endgame"
+	if levelreq >= 33 and levelreq < 55 then labSuggest = labstr[1]
+	elseif levelreq >= 55 and levelreq < 68 then labSuggest = labstr[2]
+	elseif levelreq >= 68 and levelreq < 75 then labSuggest = labstr[3]
+	elseif levelreq >= 75 and levelreq < 90 then labSuggest = labstr[4] end
+	if levelreq < 90 and currentAct <= 10 then strAct = currentAct end
+	
+	if PointsUsed > usedMax then InsertIfNew(self.controls.warnings.lines, "You have too many passive points allocated") end
+	if AscUsed > ascMax then InsertIfNew(self.controls.warnings.lines, "You have too many ascendancy points allocated") end
+	self.Act = strAct
+	
+	return string.format("%s%3d / %3d   %s%d / %d", PointsUsed > usedMax and "^1" or "^7", PointsUsed, usedMax, AscUsed > ascMax and "^1" or "^7", AscUsed, ascMax), "Required Level: ".. levelreq .. "\nEstimated Progress:\nAct: ".. strAct .. "\nQuestpoints: " .. acts[currentAct].questPoints - bandit .. "\nBandits Skillpoints: " .. bandit .. labSuggest
 end
 
 function buildMode:CanExit(mode)

--- a/src/Modules/ConfigOptions.lua
+++ b/src/Modules/ConfigOptions.lua
@@ -45,7 +45,7 @@ end
 return {
 	-- Section: General options
 	{ section = "General", col = 1 },
-	{ var = "resistancePenalty", type = "list", label = "Resistance penalty:", list = {{val=0,label="None"},{val=-30,label="Act 5 (-30%)"},{val=nil,label="Act 10 (-60%)"}} },
+	{ var = "resistancePenalty", type = "list", label = "Resistance penalty:", list = {{val=0,label="None"},{val=-30,label="Act 5 (-30%)"},{val=nil,label="Act 10 (-60%)"}}, defaultIndex = 3 },
 	{ var = "bandit", type = "list", label = "Bandit quest:", tooltipFunc = banditTooltip, list = {{val="None",label="Kill all"},{val="Oak",label="Help Oak"},{val="Kraityn",label="Help Kraityn"},{val="Alira",label="Help Alira"}} },
 	{ var = "pantheonMajorGod", type = "list", label = "Major God:", tooltipFunc = applyPantheonDescription, list = {
 		{ label = "Nothing", val = "None" },


### PR DESCRIPTION
Fixes #5587 .

### Description of the problem being solved:
When importing a new character act 10 resistance penalty was applied but the selector in config tab was still set to "none". This pr implements estimation of the resistance penalty on import based on existing player progression estimation code and changes the selector to default to act 10 penalty to better reflect the default applied values. 