### PR TITLE
Do not strip colors when rendering dropdowns

### DIFF
--- a/src/Classes/DropDownControl.lua
+++ b/src/Classes/DropDownControl.lua
@@ -336,7 +336,7 @@ function DropDownClass:Draw(viewPort, noTooltip)
 				local y = (dropIndex - 1) * lineHeight - scrollBar.offset
 				-- highlight background if hovered
 				if index == self.hoverSel then
-					SetDrawColor(0.5, 0.4, 0.3)
+					SetDrawColor(0.33, 0.33, 0.33)
 					DrawImage(nil, 0, y, width - 4, lineHeight)
 				end
 				-- highlight font color if hovered or selected
@@ -346,7 +346,7 @@ function DropDownClass:Draw(viewPort, noTooltip)
 					SetDrawColor(0.66, 0.66, 0.66)
 				end
 				-- draw actual item label with search match highlight if available
-				local label = StripEscapes(type(listVal) == "table" and listVal.label or listVal)
+				local label = type(listVal) == "table" and listVal.label or listVal
 				DrawString(0, y, "LEFT", lineHeight, "VAR", label)
 				self:DrawSearchHighlights(label, searchInfo, 0, y, width - 4, lineHeight)
 			end


### PR DESCRIPTION
The coloring is pretty useful for build guides to distringuish different variations.

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>

### Description of the problem being solved:

Colors from dropdowns are stripped and only shown for current selection.

### Steps taken to verify a working solution:
- Have colored dropdown
- Click it see colors

### Link to a build that showcases this PR:

https://pobb.in/nnNpYgb5o2CD

### Before screenshot:

![image](https://user-images.githubusercontent.com/5115805/218507786-9e4192f2-ee4d-430a-a5a8-af9385dce167.png)

### After screenshot:

![image](https://user-images.githubusercontent.com/5115805/218779493-4e0a153a-7cf7-4393-8d01-7c631c0f0ee7.png)

