### PR TITLE
Scale Cane of Kulemak unveiled mods ranges by 60%-90%

### DIFF
--- a/src/Data/Uniques/Special/Generated.lua
+++ b/src/Data/Uniques/Special/Generated.lua
@@ -86,6 +86,7 @@ table.insert(paradoxica, "Attacks with this Weapon deal Double Damage")
 table.insert(data.uniques.generated, table.concat(paradoxica, "\n"))
 
 local caneOfKulemakMods = getVeiledMods("catarina", "weapon", "staff", "two_hand_weapon")
+local caneOfKulemakMinUnveiledModifierMagnitudes, caneOfKulemakMaxUnveiledModifierMagnitudes = 60, 90
 local caneOfKulemak = {
 	"Cane of Kulemak",
 	"Serpentine Staff",
@@ -103,10 +104,16 @@ end
 table.insert(caneOfKulemak, "Requires Level 68, 85 Str, 85 Int")
 table.insert(caneOfKulemak, "Implicits: 1")
 table.insert(caneOfKulemak, "+20% Chance to Block Attack Damage while wielding a Staff")
-table.insert(caneOfKulemak, "(60-90)% increased Unveiled Modifier magnitudes")
+table.insert(caneOfKulemak, "("..caneOfKulemakMinUnveiledModifierMagnitudes.."-"..caneOfKulemakMaxUnveiledModifierMagnitudes..")% increased Unveiled Modifier magnitudes")
 
 for index, mod in pairs(caneOfKulemakMods) do
 	for _, value in pairs(mod.veiledLines) do
+		local minValue, maxValue = value:match("%((%d+)%-(%d+)%)")
+		if minValue then
+			value = value:gsub("%(%d+%-%d+%)", "%("..tostring(math.floor(minValue*(100 + caneOfKulemakMinUnveiledModifierMagnitudes) / 100)).."%-"..tostring(math.floor(maxValue*(100 + caneOfKulemakMaxUnveiledModifierMagnitudes) / 100)).."%)")
+		elseif value == "+2 to Level of Socketed Support Gems" then
+			value = "+3 to Level of Socketed Support Gems"
+		end
 		table.insert(caneOfKulemak, "{variant:"..index.."}"..value.."")
 	end
 end


### PR DESCRIPTION
imported/copy pasted Cane of Kulemak already has the mods scaled up by its % increased Unveiled Modifier magnitudes

This then scales the values on the unique item in the itemDB to match, with the bottom of the range being scaled up by 60% and the top of the range by 90%
