### PR TITLE
Fixing Missing Variant on replica hyrri's truth

### DIFF
--- a/src/Data/Uniques/amulet.lua
+++ b/src/Data/Uniques/amulet.lua
@@ -562,6 +562,7 @@ League: Heist
 Source: Steal from a unique{Curio Display} during a Grand Heist
 Variant: Pre 3.16.0
 Variant: Pre 3.19.0
+Variant: Current
 LevelReq: 64
 Implicits: 1
 {tags:jewellery_attribute}+(20-30) to Dexterity
@@ -672,7 +673,7 @@ Karui Charge
 Jade Amulet
 Source: No longer obtainable
 Variant: Pre 2.6.0
-Variant: Pre 3.17.0
+Variant: Current
 Requires Level 24
 Implicits: 1
 {tags:jewellery_attribute}+(20-30) to Dexterity

--- a/src/Data/Uniques/boots.lua
+++ b/src/Data/Uniques/boots.lua
@@ -496,7 +496,7 @@ Shavronne's Gambit
 Scholar Boots
 Source: No longer obtainable
 Variant: Pre 2.6.0
-Variant: Pre 3.17.0
+Variant: Current
 Requires Level 32, 54 Int
 +10 to Dexterity
 +(20-30) to Intelligence

--- a/src/Data/Uniques/helmet.lua
+++ b/src/Data/Uniques/helmet.lua
@@ -387,7 +387,7 @@ Martyr's Crown
 Vine Circlet
 Source: No longer obtainable
 Variant: Pre 3.0.0
-Variant: Pre 3.17.0
+Variant: Current
 Requires Level 52
 {variant:1}+(260-300) to maximum Energy Shield
 {variant:2}+(170-210) to maximum Energy Shield
@@ -757,7 +757,7 @@ Deidbellow
 Gilded Sallet
 Source: No longer obtainable
 Variant: Pre 2.6.0
-Variant: Pre 3.17.0
+Variant: Current
 Requires Level 33, 38 Str, 38 Dex
 +(20-30) to Strength
 +(20-30) to Dexterity

--- a/src/Data/Uniques/jewel.lua
+++ b/src/Data/Uniques/jewel.lua
@@ -853,7 +853,7 @@ Growing Agony
 Viridian Jewel
 Source: No longer obtainable
 Variant: Pre 2.6.0
-Variant: Pre 3.17.0
+Variant: Current
 Limited to: 1
 Radius: Medium
 {variant:1}(4-12)% increased Damage over Time
@@ -965,7 +965,7 @@ Crimson Jewel
 Source: No longer obtainable
 Variant: Pre 2.6.0
 Variant: Pre 3.3.0
-Variant: Pre 3.17.0
+Variant: Current
 Limited to: 2
 Radius: Medium
 {variant:1}(4-12)% increased Global Physical Damage
@@ -1056,7 +1056,7 @@ Steel Spirit
 Viridian Jewel
 Source: No longer obtainable
 Variant: Pre 2.6.0
-Variant: Pre 3.17.0
+Variant: Current
 Radius: Medium
 {variant:1}(6-10)% increased Projectile Damage
 {variant:2}(7-10)% increased Projectile Damage

--- a/src/Data/Uniques/mace.lua
+++ b/src/Data/Uniques/mace.lua
@@ -672,7 +672,7 @@ Hrimnor's Dirge
 Sledgehammer
 Source: No longer obtainable
 Variant: Pre 2.6.0
-Variant: Pre 3.17.0
+Variant: Current
 Requires Level 36, 62 Str
 Implicits: 2
 {variant:1}40% increased Stun Duration on Enemies

--- a/src/Data/Uniques/ring.lua
+++ b/src/Data/Uniques/ring.lua
@@ -144,7 +144,7 @@ Voidheart
 Iron Ring
 Source: No longer obtainable
 Variant: Pre 2.4.0
-Variant: Pre 3.17.0
+Variant: Current
 Requires Level 48
 Implicits: 1
 {tags:attack,physical}Adds 1 to 4 Physical Damage to Attacks
@@ -162,7 +162,7 @@ Bloodboil
 Coral Ring
 Source: No longer obtainable
 Variant: Pre 2.6.0
-Variant: Pre 3.17.0
+Variant: Current
 Requires Level 24
 Implicits: 1
 {tags:life}+(20-30) to maximum Life

--- a/src/Data/Uniques/shield.lua
+++ b/src/Data/Uniques/shield.lua
@@ -204,7 +204,7 @@ Golden Buckler
 Source: No longer obtainable
 Variant: Pre 2.0.0
 Variant: Pre 3.0.0
-Variant: Pre 3.17.0
+Variant: Current
 Implicits: 1
 {variant:3}6% increased Movement Speed
 +(40-60) to Intelligence
@@ -257,7 +257,7 @@ War Buckler
 Source: No longer obtainable
 Variant: Pre 2.6.0
 Variant: Pre 3.0.0
-Variant: Pre 3.17.0
+Variant: Current
 Implicits: 1
 {variant:3}9% increased Movement Speed
 +1 to Level of Socketed Curse Gems
@@ -315,7 +315,7 @@ Painted Buckler
 Source: No longer obtainable
 Variant: Pre 2.6.0
 Variant: Pre 3.0.0
-Variant: Pre 3.17.0
+Variant: Current
 Implicits: 1
 {variant:3}6% increased Movement Speed
 (60-100)% increased Evasion Rating
@@ -925,18 +925,23 @@ Implicits: 2
 The Oak
 Plank Kite Shield
 Source: No longer obtainable
+Variant: Pre 1.1.0
+Variant: Pre 2.0.0
 Variant: Pre 2.6.0
-Variant: Pre 3.17.0
+Variant: Pre 3.19.0
+Variant: Current
 LevelReq: 40
 Implicits: 1
 +4% to all Elemental Resistances
 (80-120)% increased Armour and Energy Shield
 +(100-150) to maximum Life
-50% reduced Freeze Duration on you
-{variant:1}Regenerate 1% of Life per Second 
-{variant:2}Regenerate 3% of Life per Second
-{variant:1}Regenerate 5% of Life per Second while on Low Life
-{variant:2}Regenerate 3% of Life per Second while on Low Life
+{variant:1,2,3,4}50% reduced Freeze Duration on you
+{variant:5}80% reduced Freeze Duration on you
+{variant:3}Regenerate 1% of Life per Second 
+{variant:4,5}Regenerate 3% of Life per Second
+{variant:1,2}Regenerate 6% of Life per Second while on Low Life
+{variant:3}Regenerate 5% of Life per Second while on Low Life
+{variant:4,5}Regenerate 3% of Life per Second while on Low Life
 ]],[[
 The Unshattered Will
 Archon Kite Shield

--- a/src/Data/Uniques/shield.lua
+++ b/src/Data/Uniques/shield.lua
@@ -931,8 +931,9 @@ Variant: Pre 2.6.0
 Variant: Pre 3.19.0
 Variant: Current
 LevelReq: 40
-Implicits: 1
-+4% to all Elemental Resistances
+Implicits: 2
+{variant:1}+8% to all Elemental Resistances
+{variant:2,3,4,5}+4% to all Elemental Resistances
 (80-120)% increased Armour and Energy Shield
 +(100-150) to maximum Life
 {variant:1,2,3,4}50% reduced Freeze Duration on you

--- a/src/Data/Uniques/staff.lua
+++ b/src/Data/Uniques/staff.lua
@@ -426,7 +426,7 @@ Realm Ender
 Iron Staff
 Source: No longer obtainable
 Variant: Pre 2.6.0
-Variant: Pre 3.17.0
+Variant: Current
 Requires Level 40, 35 Str, 35 Int
 Implicits: 2
 {variant:1}+12% Chance to Block Attack Damage while wielding a Staff

--- a/src/Data/Uniques/sword.lua
+++ b/src/Data/Uniques/sword.lua
@@ -679,7 +679,7 @@ The Dancing Duo
 Reaver Sword
 Source: No longer obtainable
 Variant: Pre 3.11.0
-Variant: Pre 3.17.0
+Variant: Current
 Implicits: 2
 {variant:1}40% increased Global Accuracy Rating
 {variant:2}60% increased Global Accuracy Rating

--- a/src/Data/Uniques/wand.lua
+++ b/src/Data/Uniques/wand.lua
@@ -80,7 +80,7 @@ Corona Solaris
 Crystal Wand
 Source: No longer obtainable
 Variant: Pre 3.10.0
-Variant: Pre 3.17.0
+Variant: Current
 Requires Level 63, 146 Int
 Implicits: 1
 (29-33)% increased Spell Damage


### PR DESCRIPTION
Fixes https://github.com/PathOfBuildingCommunity/PathOfBuilding/issues/5686

### Description of the problem being solved:
Replica Hyrri's Truth was missing the 3rd variant this adds that alongside update the last variant to always be "Variant: Current" and updating oak