### PR TITLE
Add support for parsing for poisoned by you

### DIFF
--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -1536,6 +1536,7 @@ local modTagList = {
 	["against poisoned enemies"] = { tag = { type = "ActorCondition", actor = "enemy", var = "Poisoned" } },
 	["you inflict on poisoned enemies"] = { tag = { type = "ActorCondition", actor = "enemy", var = "Poisoned" } },
 	["to poisoned enemies"] = { tag = { type = "ActorCondition", actor = "enemy", var = "Poisoned" } },
+	["poisoned by you"] = { tag = { type = "ActorCondition", actor = "enemy", var = "Poisoned" } },
 	["against enemies affected by (%d+) or more poisons"] = function(num) return { tag = { type = "MultiplierThreshold", actor = "enemy", var = "PoisonStack", threshold = num } } end,
 	["against enemies affected by at least (%d+) poisons"] = function(num) return { tag = { type = "MultiplierThreshold", actor = "enemy", var = "PoisonStack", threshold = num } } end,
 	["against hindered enemies"] = { tag = { type = "ActorCondition", actor = "enemy", var = "Hindered" } },


### PR DESCRIPTION
This adds support for parsing Serpentine Spellslinger after its wording changed.

### Link to a build that showcases this PR:

https://pobb.in/us9UeZkqbMGR

### After screenshot:

![image](https://user-images.githubusercontent.com/5115805/219121885-8a01f4d0-b411-4660-a569-12ed5366df50.png)