### PR TITLE
Allow setting Blood Charges to 0

### DIFF
--- a/src/Modules/ConfigOptions.lua
+++ b/src/Modules/ConfigOptions.lua
@@ -660,7 +660,7 @@ Huge sets the radius to 11.
 	{ var = "waitForMaxSeals", type = "check", label = "Do you wait for Max Unleash Seals?", ifFlag = "HasSeals", apply = function(val, modList, enemyModList)
 		modList:NewMod("UseMaxUnleash", "FLAG", true, "Config", { type = "Condition", var = "Combat" })
 	end },
-	{ var = "overrideBloodCharges", type = "count", label = "# of Blood Charges (if not maximum):", ifMult = "BloodCharge", apply = function(val, modList, enemyModList)
+	{ var = "overrideBloodCharges", type = "countAllowZero", label = "# of Blood Charges (if not maximum):", ifMult = "BloodCharge", apply = function(val, modList, enemyModList)
 		modList:NewMod("BloodCharges", "OVERRIDE", val, "Config", { type = "Condition", var = "Combat" })
 	end },
 	{ var = "minionsUsePowerCharges", type = "check", label = "Do your Minions use Power Charges?", ifFlag = "haveMinion", apply = function(val, modList, enemyModList)


### PR DESCRIPTION
Fixes #5657 .

### Description of the problem being solved:
Due the the `count` input being used for Blood Charges input box on the config tab setting the blood charge count to 0 resulted in defaulting to max blood charges.

There also seem to be some off by 1 issues with count boxes due to
https://github.com/PathOfBuildingCommunity/PathOfBuilding/blob/dec27c9472fc94965921c9662f7ff7d421fe4e9b/src/Classes/EditControl.lua#L692-L695

But not sure how to properly fix.