### PR TITLE
Avoid Collison of weapon melee and fishing rod.

### DIFF
--- a/src/Data/Global.lua
+++ b/src/Data/Global.lua
@@ -94,11 +94,11 @@ ModFlag.Wand =		 0x00800000
 ModFlag.Unarmed =	 0x01000000
 ModFlag.Fishing =	 0x02000000
 -- Weapon classes
-ModFlag.WeaponMelee =0x02000000
-ModFlag.WeaponRanged=0x04000000
-ModFlag.Weapon1H =	 0x08000000
-ModFlag.Weapon2H =	 0x10000000
-ModFlag.WeaponMask = 0x1FFF0000
+ModFlag.WeaponMelee =0x04000000
+ModFlag.WeaponRanged=0x08000000
+ModFlag.Weapon1H =	 0x10000000
+ModFlag.Weapon2H =	 0x20000000
+ModFlag.WeaponMask = 0x2FFF0000
 
 KeywordFlag = { }
 -- Skill keywords


### PR DESCRIPTION
Fixes https://www.reddit.com/r/pathofexile/comments/114iwvv/comment/j8wtil6/?utm_source=share&utm_medium=web2x&context=3

### Description of the problem being solved:
Strong Arm had fishing tag when it shouldn't
![image](https://user-images.githubusercontent.com/31533893/219816327-0c50cb87-88a5-49f9-9710-6f2693078df3.png)


### Steps taken to verify a working solution:
![image](https://user-images.githubusercontent.com/31533893/219816352-1951f1fc-f3bd-4d38-9d9a-d77b94b03a0b.png)


### Link to a build that showcases this PR:
https://pobb.in/rGt2T3q_9b7j