### PR TITLE
Fix crash related to uninitalised srcInstance

### DIFF
--- a/src/Modules/Build.lua
+++ b/src/Modules/Build.lua
@@ -1223,7 +1223,7 @@ function buildMode:RefreshSkillSelectControls(controls, mainGroup, suffix)
 						t_insert(controls.mainSkillPart.list, { val = i, label = part.name })
 					end
 					controls.mainSkillPart.selIndex = activeEffect.srcInstance["skillPart"..suffix] or 1
-					if activeEffect.grantedEffect.parts[activeEffect.srcInstance["skillPart"..suffix]].stages then
+					if activeEffect.grantedEffect.parts[controls.mainSkillPart.selIndex].stages then
 						controls.mainSkillStageCount.shown = true
 						controls.mainSkillStageCount.buf = tostring(activeEffect.srcInstance["skillStageCount"..suffix] or activeEffect.grantedEffect.parts[activeEffect.srcInstance["skillPart"..suffix]].stagesMin or 1)
 					end

--- a/src/Modules/Build.lua
+++ b/src/Modules/Build.lua
@@ -1225,7 +1225,7 @@ function buildMode:RefreshSkillSelectControls(controls, mainGroup, suffix)
 					controls.mainSkillPart.selIndex = activeEffect.srcInstance["skillPart"..suffix] or 1
 					if activeEffect.grantedEffect.parts[controls.mainSkillPart.selIndex].stages then
 						controls.mainSkillStageCount.shown = true
-						controls.mainSkillStageCount.buf = tostring(activeEffect.srcInstance["skillStageCount"..suffix] or activeEffect.grantedEffect.parts[activeEffect.srcInstance["skillPart"..suffix]].stagesMin or 1)
+						controls.mainSkillStageCount.buf = tostring(activeEffect.srcInstance["skillStageCount"..suffix] or activeEffect.grantedEffect.parts[controls.mainSkillPart.selIndex].stagesMin or 1)
 					end
 				end
 				if activeSkill.skillFlags.mine then

--- a/src/Modules/CalcActiveSkill.lua
+++ b/src/Modules/CalcActiveSkill.lua
@@ -216,7 +216,7 @@ function calcs.buildActiveSkillModList(env, activeSkill)
 
 	-- Handle multipart skills
 	local activeGemParts = activeGrantedEffect.parts
-	if activeGemParts then
+	if activeGemParts and #activeGemParts > 1 then
 		if env.mode == "CALCS" and activeSkill == env.player.mainSkill then
 			activeEffect.srcInstance.skillPartCalcs = m_min(#activeGemParts, activeEffect.srcInstance.skillPartCalcs or 1)
 			activeSkill.skillPart = activeEffect.srcInstance.skillPartCalcs

--- a/src/Modules/CalcActiveSkill.lua
+++ b/src/Modules/CalcActiveSkill.lua
@@ -234,7 +234,7 @@ function calcs.buildActiveSkillModList(env, activeSkill)
 		end
 		activeSkill.skillPartName = part.name
 		skillFlags.multiPart = #activeGemParts > 1
-	elseif activeEffect.srcInstance and not activeEffect.gemData.secondaryGrantedEffect then
+	elseif activeEffect.srcInstance and not (activeEffect.gemData and activeEffect.gemData.secondaryGrantedEffect) then
 		activeEffect.srcInstance.skillPart = nil
 		activeEffect.srcInstance.skillPartCalcs = nil
 	end
@@ -513,7 +513,7 @@ function calcs.buildActiveSkillModList(env, activeSkill)
 			skillModList:NewMod("Multiplier:ActiveMineCount", "BASE", activeSkill.activeMineCount, "Base")
 			env.enemy.modDB.multipliers["ActiveMineCount"] = m_max(activeSkill.activeMineCount or 0, env.enemy.modDB.multipliers["ActiveMineCount"] or 0)
 		end
-	elseif activeEffect.srcInstance and not activeEffect.gemData.secondaryGrantedEffect then
+	elseif activeEffect.srcInstance and not (activeEffect.gemData and activeEffect.gemData.secondaryGrantedEffect) then
 		activeEffect.srcInstance.skillMineCountCalcs = nil
 		activeEffect.srcInstance.skillMineCount = nil
 	end
@@ -529,7 +529,7 @@ function calcs.buildActiveSkillModList(env, activeSkill)
 				skillModList:NewMod("Multiplier:"..activeGrantedEffect.name:gsub("%s+", "").."StageAfterFirst", "BASE", m_min(limit - 1, activeSkill.activeStageCount), "Base")
 			end
 		end
-	elseif activeEffect.srcInstance and not activeEffect.gemData.secondaryGrantedEffect then
+	elseif activeEffect.srcInstance and not (activeEffect.gemData and activeEffect.gemData.secondaryGrantedEffect) then
 		activeEffect.srcInstance.skillStageCountCalcs = nil
 		activeEffect.srcInstance.skillStageCount = nil
 	end
@@ -601,7 +601,7 @@ function calcs.buildActiveSkillModList(env, activeSkill)
 					end
 					minion.itemSet = env.build.itemsTab.itemSets[activeEffect.srcInstance.skillMinionItemSet]
 				end
-			elseif activeEffect.srcInstance and not activeEffect.gemData.secondaryGrantedEffect then
+			elseif activeEffect.srcInstance and not (activeEffect.gemData and activeEffect.gemData.secondaryGrantedEffect) then
 				activeEffect.srcInstance.skillMinionItemSetCalcs = nil
 				activeEffect.srcInstance.skillMinionItemSet = nil
 			end
@@ -643,7 +643,7 @@ function calcs.buildActiveSkillModList(env, activeSkill)
 				end
 			end
 		end
-	elseif activeEffect.srcInstance and not activeEffect.gemData.secondaryGrantedEffect then
+	elseif activeEffect.srcInstance and not (activeEffect.gemData and activeEffect.gemData.secondaryGrantedEffect) then
 		activeEffect.srcInstance.skillMinionCalcs = nil
 		activeEffect.srcInstance.skillMinion = nil
 		activeEffect.srcInstance.skillMinionItemSetCalcs = nil

--- a/src/Modules/CalcActiveSkill.lua
+++ b/src/Modules/CalcActiveSkill.lua
@@ -234,7 +234,7 @@ function calcs.buildActiveSkillModList(env, activeSkill)
 		end
 		activeSkill.skillPartName = part.name
 		skillFlags.multiPart = #activeGemParts > 1
-	elseif activeEffect.srcInstance then
+	elseif activeEffect.srcInstance and not (activeEffect.gemData.secondaryGrantedEffect and activeEffect.gemData.secondaryGrantedEffect.parts and #activeEffect.gemData.secondaryGrantedEffect.parts > 1) then
 		activeEffect.srcInstance.skillPart = nil
 		activeEffect.srcInstance.skillPartCalcs = nil
 	end

--- a/src/Modules/CalcActiveSkill.lua
+++ b/src/Modules/CalcActiveSkill.lua
@@ -234,7 +234,7 @@ function calcs.buildActiveSkillModList(env, activeSkill)
 		end
 		activeSkill.skillPartName = part.name
 		skillFlags.multiPart = #activeGemParts > 1
-	elseif activeEffect.srcInstance and not (activeEffect.gemData.secondaryGrantedEffect and activeEffect.gemData.secondaryGrantedEffect.parts and #activeEffect.gemData.secondaryGrantedEffect.parts > 1) then
+	elseif activeEffect.srcInstance and not activeEffect.gemData.secondaryGrantedEffect then
 		activeEffect.srcInstance.skillPart = nil
 		activeEffect.srcInstance.skillPartCalcs = nil
 	end
@@ -513,7 +513,7 @@ function calcs.buildActiveSkillModList(env, activeSkill)
 			skillModList:NewMod("Multiplier:ActiveMineCount", "BASE", activeSkill.activeMineCount, "Base")
 			env.enemy.modDB.multipliers["ActiveMineCount"] = m_max(activeSkill.activeMineCount or 0, env.enemy.modDB.multipliers["ActiveMineCount"] or 0)
 		end
-	elseif activeEffect.srcInstance then
+	elseif activeEffect.srcInstance and not activeEffect.gemData.secondaryGrantedEffect then
 		activeEffect.srcInstance.skillMineCountCalcs = nil
 		activeEffect.srcInstance.skillMineCount = nil
 	end
@@ -529,7 +529,7 @@ function calcs.buildActiveSkillModList(env, activeSkill)
 				skillModList:NewMod("Multiplier:"..activeGrantedEffect.name:gsub("%s+", "").."StageAfterFirst", "BASE", m_min(limit - 1, activeSkill.activeStageCount), "Base")
 			end
 		end
-	elseif activeEffect.srcInstance then
+	elseif activeEffect.srcInstance and not activeEffect.gemData.secondaryGrantedEffect then
 		activeEffect.srcInstance.skillStageCountCalcs = nil
 		activeEffect.srcInstance.skillStageCount = nil
 	end
@@ -601,7 +601,7 @@ function calcs.buildActiveSkillModList(env, activeSkill)
 					end
 					minion.itemSet = env.build.itemsTab.itemSets[activeEffect.srcInstance.skillMinionItemSet]
 				end
-			elseif activeEffect.srcInstance then
+			elseif activeEffect.srcInstance and not activeEffect.gemData.secondaryGrantedEffect then
 				activeEffect.srcInstance.skillMinionItemSetCalcs = nil
 				activeEffect.srcInstance.skillMinionItemSet = nil
 			end
@@ -643,7 +643,7 @@ function calcs.buildActiveSkillModList(env, activeSkill)
 				end
 			end
 		end
-	elseif activeEffect.srcInstance then
+	elseif activeEffect.srcInstance and not activeEffect.gemData.secondaryGrantedEffect then
 		activeEffect.srcInstance.skillMinionCalcs = nil
 		activeEffect.srcInstance.skillMinion = nil
 		activeEffect.srcInstance.skillMinionItemSetCalcs = nil


### PR DESCRIPTION
Introduced in https://github.com/PathOfBuildingCommunity/PathOfBuilding/pull/5571

### Description of the problem being solved:
Multi skills primary parts were deleting relevant stuff off srcInstance for secondary effects e.g. blade vortex in vaal blade vortex.
This resolves it by not letting them be deleted and fixes a couple other dangerous indexing nil.

### Steps taken to verify a working solution:
- Add blade blast and observe no crash as well as being able to update stages.