### PR TITLE
Only show # of poisons on enemy config if needed

### DIFF
--- a/src/Modules/ConfigOptions.lua
+++ b/src/Modules/ConfigOptions.lua
@@ -1275,7 +1275,7 @@ Huge sets the radius to 11.
 	{ var = "conditionEnemyPoisoned", type = "check", label = "Is the enemy Poisoned?", ifEnemyCond = "Poisoned", apply = function(val, modList, enemyModList)
 		enemyModList:NewMod("Condition:Poisoned", "FLAG", true, "Config", { type = "Condition", var = "Effective" })
 	end },
-	{ var = "multiplierPoisonOnEnemy", type = "count", label = "# of Poison on enemy:", implyCond = "Poisoned", apply = function(val, modList, enemyModList)
+	{ var = "multiplierPoisonOnEnemy", type = "count", label = "# of Poison on enemy:", ifEnemyMult = "PoisonStack", implyCond = "Poisoned", apply = function(val, modList, enemyModList)
 		enemyModList:NewMod("Multiplier:PoisonStack", "BASE", val, "Config", { type = "Condition", var = "Effective" })
 	end },
 	{ var = "conditionSinglePoison", type = "check", label = "Cap to Single Poison on enemy?", ifCond = "SinglePoison", tooltip = "This is for low tolerance, but will limit you to only applying a single poison on the enemy", apply = function(val, modList, enemyModList)


### PR DESCRIPTION
Lock showing # of poison on enemy config option behind ifEnemyMult PoisonStack just like # of poisons on self.

### Description of the problem being solved:
Config options should not be shown by default when they do nothing. The  poison stack config option should only appear when there is relevant multiplier or condition it will fulfill.

### Steps taken to verify a working solution:
- See that config option is hidden
- Equip wasp nest or use dagger mastery (or vile toxins)
- See the config option appear

### Link to a build that showcases this PR:

https://pobb.in/UrCgykdZKTSz