### PR TITLE
Fix incorrect serialization of math.huge by writeLuaTable.

### DIFF
--- a/src/Modules/Common.lua
+++ b/src/Modules/Common.lua
@@ -342,7 +342,11 @@ function writeLuaTable(out, t, indent)
 		elseif type(v) == "string" then
 			out:write(qFmt(v))
 		else
-			out:write(tostring(v))
+			if v == math.huge then
+				out:write("math.huge")
+			else
+				out:write(tostring(v))
+			end
 		end
 		if i < #keyList then
 			out:write(',')


### PR DESCRIPTION
Fixes #5704 .

### Description of the problem being solved:
Due to the `writeLuaTable` function using `tostring` to serialize the values of mods `math.huge` is serialized to `inf` when saved to `ModCache.lua`. Setting a variable to `inf` is equivalent to settings it to `nil` in lua causing it to default to 0.

This is a sort of stop gap solution as this will be an issue with any values of mods that are not trivially serialized to string.

Mentioned issue contains some more discussion.