### PR TITLE
Fix enemy level getting out of sync due to updating later than expected

### DIFF
--- a/src/Classes/ConfigTab.lua
+++ b/src/Classes/ConfigTab.lua
@@ -478,14 +478,9 @@ function ConfigTabClass:Draw(viewPort, inputEvents)
 	self:DrawControls(viewPort)
 end
 
-function ConfigTabClass:BuildModList()
-	local modList = new("ModList")
-	self.modList = modList
-	local enemyModList = new("ModList")
-	self.enemyModList = enemyModList
+function ConfigTabClass:UpdateLevel()
 	local input = self.input
 	local placeholder = self.placeholder
-	--enemy level handled here because it's needed to correctly set boss stats
 	if input.enemyLevel and input.enemyLevel > 0 then
 		self.enemyLevel = m_min(data.misc.MaxEnemyLevel, input.enemyLevel)
 	elseif placeholder.enemyLevel and placeholder.enemyLevel > 0 then
@@ -493,6 +488,16 @@ function ConfigTabClass:BuildModList()
 	else
 		self.enemyLevel = m_min(data.misc.MaxEnemyLevel, self.build.characterLevel)
 	end
+end
+
+function ConfigTabClass:BuildModList()
+	local modList = new("ModList")
+	self.modList = modList
+	local enemyModList = new("ModList")
+	self.enemyModList = enemyModList
+	local input = self.input
+	local placeholder = self.placeholder
+	self:UpdateLevel() -- enemy level handled here because it's needed to correctly set boss stats
 	for _, varData in ipairs(varList) do
 		if varData.apply then
 			if varData.type == "check" then

--- a/src/Classes/ImportTab.lua
+++ b/src/Classes/ImportTab.lua
@@ -679,6 +679,7 @@ function ImportTabClass:ImportItemsAndSkills(json)
 	self.build.itemsTab:AddUndoState()
 	self.build.skillsTab:AddUndoState()
 	self.build.characterLevel = charItemData.character.level
+	self.build.configTab:UpdateLevel()
 	self.build.controls.characterLevel:SetText(charItemData.character.level)
 	self.build.buildFlag = true
 	return charItemData.character -- For the wrapper

--- a/src/Classes/ImportTab.lua
+++ b/src/Classes/ImportTab.lua
@@ -583,6 +583,7 @@ function ImportTabClass:ImportPassiveTreeAndJewels(json, charData)
 	self.build.spec:ImportFromNodeList(charData.classId, charData.ascendancyClass, charPassiveData.hashes, charPassiveData.mastery_effects or {})
 	self.build.spec:AddUndoState()
 	self.build.characterLevel = charData.level
+	self.build.configTab:UpdateLevel()
 	self.build.controls.characterLevel:SetText(charData.level)
 	self.build:EstimatePlayerProgress()
 	local resistancePenaltyIndex = 3

--- a/src/Modules/ConfigOptions.lua
+++ b/src/Modules/ConfigOptions.lua
@@ -1491,6 +1491,7 @@ Uber Pinnacle Boss adds the following modifiers:
 
 			local defaultLevel = 83
 			build.configTab.varControls['enemyLevel']:SetPlaceholder("", true)
+			build.configTab:UpdateLevel()
 			if build.configTab.enemyLevel then
 				defaultLevel = build.configTab.enemyLevel
 			end
@@ -1523,6 +1524,7 @@ Uber Pinnacle Boss adds the following modifiers:
 
 			local defaultLevel = 83
 			build.configTab.varControls['enemyLevel']:SetPlaceholder("", true)
+			build.configTab:UpdateLevel()
 			if build.configTab.enemyLevel then
 				defaultLevel = build.configTab.enemyLevel
 			end
@@ -1556,6 +1558,7 @@ Uber Pinnacle Boss adds the following modifiers:
 
 			local defaultLevel = 84
 			build.configTab.varControls['enemyLevel']:SetPlaceholder(defaultLevel, true)
+			build.configTab:UpdateLevel()
 			if build.configTab.enemyLevel then
 				defaultLevel = m_max(build.configTab.enemyLevel, defaultLevel)
 			end
@@ -1590,6 +1593,7 @@ Uber Pinnacle Boss adds the following modifiers:
 
 			local defaultLevel = 85
 			build.configTab.varControls['enemyLevel']:SetPlaceholder(defaultLevel, true)
+			build.configTab:UpdateLevel()
 			if build.configTab.enemyLevel then
 				defaultLevel = m_max(build.configTab.enemyLevel, defaultLevel)
 			end


### PR DESCRIPTION
Fixes https://github.com/PathOfBuildingCommunity/PathOfBuilding/issues/4991 https://github.com/PathOfBuildingCommunity/PathOfBuilding/issues/4847 https://github.com/PathOfBuildingCommunity/PathOfBuilding/issues/4949

### Description of the problem being solved:
Level being used for placeholders and other calculations could get out of sync causing confusing behaviour.