### PR TITLE
Fix inconsistent display of additional quality and gem levels in skill group tooltip for inactive gems

### DIFF
--- a/src/Classes/SkillsTab.lua
+++ b/src/Classes/SkillsTab.lua
@@ -1205,9 +1205,9 @@ function SkillsTabClass:AddSocketGroupTooltip(tooltip, socketGroup)
 			tooltip:AddLine(20, string.format("%s%s ^7%d%s/%d%s %s",
 				gemInstance.color,
 				(gemInstance.grantedEffect and gemInstance.grantedEffect.name) or (gemInstance.gemData and gemInstance.gemData.name) or gemInstance.nameSpec,
-				displayEffect.level,
+				activeEffect.srcInstance and activeEffect.srcInstance.level or activeEffect.level,
 				displayEffect.level > gemInstance.level and colorCodes.MAGIC .. "+" .. (displayEffect.level - gemInstance.level) .. "^7" or "",
-				displayEffect.quality,
+				activeEffect.srcInstance and activeEffect.srcInstance.quality or activeEffect.quality,
 				displayEffect.quality > gemInstance.quality and colorCodes.MAGIC .. "+" .. (displayEffect.quality - gemInstance.quality) .. "^7" or "",
 				reason
 			))


### PR DESCRIPTION
### Description of the problem being solved:
#5181 But i forgot to apply the fix to inactive gems tooltip as well,