### PR TITLE
Highlight borders for changed config options in config tab

### DIFF
--- a/src/Classes/CheckBoxControl.lua
+++ b/src/Classes/CheckBoxControl.lua
@@ -38,6 +38,9 @@ function CheckBoxClass:Draw(viewPort, noTooltip)
 		SetDrawColor(0.33, 0.33, 0.33)
 	elseif mOver then
 		SetDrawColor(1, 1, 1)
+	elseif self.borderFunc then
+		r, g, b = self.borderFunc()
+		SetDrawColor(r, g, b)
 	else
 		SetDrawColor(0.5, 0.5, 0.5)
 	end

--- a/src/Classes/ConfigTab.lua
+++ b/src/Classes/ConfigTab.lua
@@ -453,8 +453,23 @@ local ConfigTabClass = newClass("ConfigTab", "UndoHandler", "ControlHost", "Cont
 				end
 			end
 
+			local innerShown = control.shown
+			if not varData.doNotHighlight then
+				control.borderFunc = function()
+					local shown = type(innerShown) == "boolean" and innerShown or innerShown()
+					local cur = self.input[varData.var]
+					local def = self:GetDefaultState(varData.var, type(cur))
+					if cur ~= nil and cur ~= def then
+						if not shown then
+							return 	0.753, 0.502, 0.502
+						end
+						return 	0.451, 0.576, 0.702
+					end
+					return 0.5, 0.5, 0.5
+				end
+			end
+
 			if not varData.hideIfInvalid then
-				local innerShown = control.shown
 				control.shown = function()
 					local shown = type(innerShown) == "boolean" and innerShown or innerShown()
 					local cur = self.input[varData.var]

--- a/src/Classes/DropDownControl.lua
+++ b/src/Classes/DropDownControl.lua
@@ -235,6 +235,9 @@ function DropDownClass:Draw(viewPort, noTooltip)
 		SetDrawColor(0.33, 0.33, 0.33)
 	elseif mOver or self.dropped then
 		SetDrawColor(1, 1, 1)
+	elseif self.borderFunc then
+		r, g, b = self.borderFunc()
+		SetDrawColor(r, g, b)
 	else
 		SetDrawColor(0.5, 0.5, 0.5)
 	end

--- a/src/Classes/EditControl.lua
+++ b/src/Classes/EditControl.lua
@@ -241,6 +241,9 @@ function EditClass:Draw(viewPort, noTooltip)
 		SetDrawColor(0.33, 0.33, 0.33)
 	elseif mOver then
 		SetDrawColor(1, 1, 1)
+	elseif self.borderFunc then
+		r, g, b = self.borderFunc()
+		SetDrawColor(r, g, b)
 	else
 		SetDrawColor(0.5, 0.5, 0.5)
 	end

--- a/src/Modules/ConfigOptions.lua
+++ b/src/Modules/ConfigOptions.lua
@@ -1788,7 +1788,7 @@ Huge sets the radius to 11.
 			end
 			
 			modList:NewMod("BossSkillActive", "FLAG", true, "Config")
-			
+
 			-- boss specific mods
 			if val == "Atziri Flameblast" and isUber then
 				enemyModList:NewMod("Damage", "INC", 60, "Alluring Abyss Map Mod")
@@ -1817,7 +1817,7 @@ Huge sets the radius to 11.
 	
 	-- Section: Custom mods
 	{ section = "Custom Modifiers", col = 1 },
-	{ var = "customMods", type = "text", label = "",
+	{ var = "customMods", type = "text", label = "", doNotHighlight = true,
 		apply = function(val, modList, enemyModList, build)
 			for line in val:gmatch("([^\n]*)\n?") do
 				local strippedLine = StripEscapes(line):gsub("^[%s?]+", ""):gsub("[%s?]+$", "")


### PR DESCRIPTION
This highlights borders for controls for changed config options when
    they are in non-default state. Useful for quickly checking what options
    user configured and prevents forgetting about some config set by
    accident (dropdowns in non-default state are especially hard to spot).

### Description of the problem being solved:

Sometimes its pretty easy to configure something by accident (either via missclick or simply forgetting about configuring it before) and it can be hard to tell if the config is in non-default state or not. Also in bigger pobs it can be sometimes hard to see what is the exact config for the pob. This solves that by subtly highlighting borders of changed config controls.

### Steps taken to verify a working solution:
- Create new pob
- Set some control to non-default state
- See border color change

### Link to a build that showcases this PR:
https://pobb.in/5fQaEhtVLtYj

### Before screenshot:
![image](https://user-images.githubusercontent.com/5115805/221505645-eb08f742-480e-4055-86a0-c0d91dcf2c10.png)

### After screenshot:
![image](https://user-images.githubusercontent.com/5115805/221505564-7f2266fc-e0de-4649-ae00-c153a69ea158.png)
