### PR TITLE
Fix group disable not disabling support gems and two part skills not applying support part to linked groups

### DIFF
--- a/src/Modules/CalcSetup.lua
+++ b/src/Modules/CalcSetup.lua
@@ -944,10 +944,10 @@ function calcs.initEnv(build, mode, override, specEnv)
 				else
 					for _, socketGroup in pairs(build.skillsTab.socketGroupList) do
 						-- Look for other groups that are socketed in the item
-						if socketGroup.slot == grantedSkill.slotName and not socketGroup.source then
+						if socketGroup.slot == grantedSkill.slotName and not socketGroup.source and socketGroup.enabled then
 							-- Add all support gems to the skill's group
 							for _, gemInstance in ipairs(socketGroup.gemList) do
-								if gemInstance.gemData and gemInstance.gemData.grantedEffect.support then
+								if gemInstance.gemData and (gemInstance.gemData.grantedEffect.support or (gemInstance.gemData.secondaryGrantedEffect and gemInstance.gemData.secondaryGrantedEffect.support)) then
 									t_insert(group.gemList, gemInstance)
 								end
 							end


### PR DESCRIPTION
Fixes #5482 , https://github.com/PathOfBuildingCommunity/PathOfBuilding/issues/1065 .

### Description of the problem being solved:
#5482 Currently there is no check whether a group is enabled or not when groups are linked together based on the item they're socketed in. This pr adds it.

#1065 Two parts skills (Active and Support in one) such as Arcanist brand currently do not have their support parts applied to linked groups (in the same item). This pr adds a check for the case where `secondaryGrantedEffect` is a support.

### Before screenshot:
![obraz](https://user-images.githubusercontent.com/91493239/221563481-92abb1e5-4fca-4ae9-880f-895ad44d9b37.png)
### After screenshot:
![obraz](https://user-images.githubusercontent.com/91493239/221563531-51d57c35-3b5a-4269-a3b5-bb54d6e41105.png)

### Before screenshot:
![obraz](https://user-images.githubusercontent.com/91493239/221563595-fe48f2d1-1969-43ac-963f-f06e22159d30.png)
### After screenshot:
![obraz](https://user-images.githubusercontent.com/91493239/221563612-2a111bff-fd15-4007-9e10-ab0670089406.png)
