### PR TITLE
Recolor custom mods like items based on mod being parsed or not

### DIFF
--- a/src/Classes/ConfigTab.lua
+++ b/src/Classes/ConfigTab.lua
@@ -136,6 +136,10 @@ local ConfigTabClass = newClass("ConfigTab", "UndoHandler", "ControlHost", "Cont
 				control = new("Control", {"TOPLEFT",lastSection,"TOPLEFT"}, 234, 0, 16, 16)
 			end
 
+			if varData.inactiveText then
+				control.inactiveText = varData.inactiveText
+			end
+
 			local shownFuncs = {}
 			control.shown = function()
 				for _, shownFunc in ipairs(shownFuncs) do
@@ -150,7 +154,7 @@ local ConfigTabClass = newClass("ConfigTab", "UndoHandler", "ControlHost", "Cont
 			control.tooltipText = function()
 				local out
 				for i, tooltipFunc in ipairs(tooltipFuncs) do
-					local curTooltipText = type(tooltipFunc) == "string" and tooltipFunc or tooltipFunc()
+					local curTooltipText = type(tooltipFunc) == "string" and tooltipFunc or tooltipFunc(self.modList)
 					if curTooltipText then
 						out = (out and out .. "\n" or "") .. curTooltipText
 					end

--- a/src/Classes/EditControl.lua
+++ b/src/Classes/EditControl.lua
@@ -287,7 +287,10 @@ function EditClass:Draw(viewPort, noTooltip)
 			DrawString(-self.controls.scrollBarH.offset, -self.controls.scrollBarV.offset, "LEFT", textHeight, self.font, self.placeholder)
 		else
 			SetDrawColor(self.inactiveCol)
-			if self.protected then
+			if self.inactiveText then
+				local inactiveText = type(inactiveText) == "string" and self.inactiveText or self.inactiveText(self.buf)
+				DrawString(-self.controls.scrollBarH.offset, -self.controls.scrollBarV.offset, "LEFT", textHeight, self.font, inactiveText)
+			elseif self.protected then
 				DrawString(-self.controls.scrollBarH.offset, -self.controls.scrollBarV.offset, "LEFT", textHeight, self.font, string.rep(protected_replace, #self.buf))
 			else
 				DrawString(-self.controls.scrollBarH.offset, -self.controls.scrollBarV.offset, "LEFT", textHeight, self.font, self.buf)

--- a/src/HeadlessWrapper.lua
+++ b/src/HeadlessWrapper.lua
@@ -62,7 +62,7 @@ function DrawStringCursorIndex(height, font, text, cursorX, cursorY)
 	return 0
 end
 function StripEscapes(text)
-	return text:gsub("^%d",""):gsub("^x%x%x%x%x%x%x","")
+	return text:gsub("%^%d",""):gsub("%^x%x%x%x%x%x%x","")
 end
 function GetAsyncCount()
 	return 0

--- a/src/Modules/ConfigOptions.lua
+++ b/src/Modules/ConfigOptions.lua
@@ -1792,21 +1792,45 @@ Huge sets the radius to 11.
 	
 	-- Section: Custom mods
 	{ section = "Custom Modifiers", col = 1 },
-	{ var = "customMods", type = "text", label = "", apply = function(val, modList, enemyModList)
-		for line in val:gmatch("([^\n]*)\n?") do
-			local mods, extra = modLib.parseMod(line)
+	{ var = "customMods", type = "text", label = "",
+		apply = function(val, modList, enemyModList, build)
+			for line in val:gmatch("([^\n]*)\n?") do
+				local strippedLine = StripEscapes(line):gsub("^[%s?]+", ""):gsub("[%s?]+$", "")
+				local mods, extra = modLib.parseMod(strippedLine)
 
-			if mods then
-				local source = "Custom"
-				for i = 1, #mods do
-					local mod = mods[i]
+				if mods and not extra then
+					local source = "Custom"
+					for i = 1, #mods do
+						local mod = mods[i]
 
-					if mod then
-						mod = modLib.setSource(mod, source)
-						modList:AddMod(mod)
+						if mod then
+							mod = modLib.setSource(mod, source)
+							modList:AddMod(mod)
+						end
 					end
 				end
 			end
-		end
-	end },
+		end,
+		inactiveText = function(val)
+			local inactiveText = ""
+			for line in val:gmatch("([^\n]*)\n?") do
+				local strippedLine = StripEscapes(line):gsub("^[%s?]+", ""):gsub("[%s?]+$", "")
+				local mods, extra = modLib.parseMod(strippedLine)
+				inactiveText = inactiveText .. ((mods and not extra) and colorCodes.MAGIC or colorCodes.UNSUPPORTED).. (IsKeyDown("ALT") and strippedLine or line) .. "\n"
+			end
+			return inactiveText
+		end,
+		tooltip = function(modList)
+			if not launch.devModeAlt then
+				return
+			end
+
+			local out
+			for _, mod in ipairs(modList) do
+				if mod.source == "Custom" then
+					out = (out and out.."\n" or "") .. modLib.formatMod(mod) .. "|" .. mod.source
+				end
+			end
+			return out
+		end},
 }


### PR DESCRIPTION
Depends on/built on top/closes https://github.com/PathOfBuildingCommunity/PathOfBuilding/pull/5712
Closes https://github.com/PathOfBuildingCommunity/PathOfBuilding/issues/5744

### Description of the problem being solved:

Currently in custom mods its hard to tell if I typed the mod correctly or not. With this change the mods are recolored like on items when the input field loses focus.

### Steps taken to verify a working solution:
- Enter properly parsed mod
- Unfocus custom mods input
- See it turn blue
- Same for invalid mod turning red

### Link to a build that showcases this PR:

https://pobb.in/5fQaEhtVLtYj

### Before screenshot:
![image](https://user-images.githubusercontent.com/5115805/221614869-a530a37e-3ebc-4a08-a697-4c86c8e7a2a7.png)

### After screenshot:
![image](https://user-images.githubusercontent.com/5115805/221614906-ff535ab1-b696-4a01-89cf-591a55395cc6.png)
