### PR TITLE
Fix crash caused by missing EnemyMod missing source.

### DIFF
--- a/src/Modules/CalcPerform.lua
+++ b/src/Modules/CalcPerform.lua
@@ -911,8 +911,8 @@ local function doActorMisc(env, actor)
 	modDB.multipliers["BloodCharge"] = output.BloodCharges
 
 	-- Process enemy modifiers 
-	for _, value in ipairs(modDB:List(nil, "EnemyModifier")) do
-		enemyDB:AddMod(value.mod)
+	for _, value in ipairs(modDB:Tabulate(nil, nil, "EnemyModifier")) do
+		enemyDB:AddMod(modLib.setSource(value.value.mod, value.value.mod.source or value.mod.source))
 	end
 
 	-- Add misc buffs/debuffs


### PR DESCRIPTION
Fixes #5729.

### Description of the problem being solved:
The source of the enemy mod was not being set in the pantheon code. This pr sets the source of the enemy mod to the source of the EnemyModifier mod from player.modDB if source is missing on the mod that is supposed to go into enemyDB.