### PR TITLE
Fix colour codes and number formating

### DIFF
--- a/src/Modules/Common.lua
+++ b/src/Modules/Common.lua
@@ -569,8 +569,10 @@ end
 
 -- Formats "1234.56" -> "1,234.5"
 function formatNumSep(str)
-	return string.gsub(str, "(-?%d+%.?%d+)", function(m)
-	    local x, y, minus, integer, fraction = m:find("(-?)(%d+)(%.?%d*)")
+	return string.gsub(str, "(%^?%d?-?%d+%.?%d+)", function(m)
+		local colour = m:match("(%^%d)") or ""
+		local str = string.gsub(m, "(%^%d)", "")
+	    local x, y, minus, integer, fraction = str:find("(-?)(%d+)(%.?%d*)")
         if main.showThousandsSeparators then
             integer = integer:reverse():gsub("(%d%d%d)", "%1"..main.thousandsSeparator):reverse()
             -- There will be leading separators if the number of digits are divisible by 3
@@ -585,7 +587,7 @@ function formatNumSep(str)
         else
             integer = integer:reverse():gsub("(%d%d%d)", "%1"):reverse()
         end
-        return minus..integer..fraction:gsub("%.", main.decimalSeparator)
+        return colour..minus..integer..fraction:gsub("%.", main.decimalSeparator)
     end)
 end
 

--- a/src/Modules/Common.lua
+++ b/src/Modules/Common.lua
@@ -28,9 +28,9 @@ common.sha1 = require("sha1")
 
 -- Try to load a library return nil if failed. https://stackoverflow.com/questions/34965863/lua-require-fallback-error-handling
 function prerequire(...)
-    local status, lib = pcall(require, ...)
-    if(status) then return lib end
-    return nil
+	local status, lib = pcall(require, ...)
+	if(status) then return lib end
+	return nil
 end
 
 profiler = prerequire("lua-profiler")
@@ -495,12 +495,12 @@ end
 function tableConcat(t1,t2)
 	local t3 = {}
 	for i=1,#t1 do
-        t3[#t3+1] = t1[i]
-    end
-    for i=1,#t2 do
-        t3[#t3+1] = t2[i]
-    end
-    return t3
+		t3[#t3+1] = t1[i]
+	end
+	for i=1,#t2 do
+		t3[#t3+1] = t2[i]
+	end
+	return t3
 end
 
 -- Natural sort comparator
@@ -572,23 +572,23 @@ function formatNumSep(str)
 	return string.gsub(str, "(%^?%d?-?%d+%.?%d+)", function(m)
 		local colour = m:match("(%^%d)") or ""
 		local str = string.gsub(m, "(%^%d)", "")
-	    local x, y, minus, integer, fraction = str:find("(-?)(%d+)(%.?%d*)")
-        if main.showThousandsSeparators then
-            integer = integer:reverse():gsub("(%d%d%d)", "%1"..main.thousandsSeparator):reverse()
-            -- There will be leading separators if the number of digits are divisible by 3
-            -- This checks for their presence and removes them
-            -- Don't use patterns here because thousandsSeparator can be a pattern control character, and will crash if used
-            if main.thousandsSeparator ~= "" then
-                local thousandsSeparator = string.find(integer, main.thousandsSeparator, 1, 2)
-                if thousandsSeparator and thousandsSeparator == 1 then
-                    integer = integer:sub(2)
-                end
-            end
-        else
-            integer = integer:reverse():gsub("(%d%d%d)", "%1"):reverse()
-        end
-        return colour..minus..integer..fraction:gsub("%.", main.decimalSeparator)
-    end)
+		local x, y, minus, integer, fraction = str:find("(-?)(%d+)(%.?%d*)")
+		if main.showThousandsSeparators then
+			integer = integer:reverse():gsub("(%d%d%d)", "%1"..main.thousandsSeparator):reverse()
+			-- There will be leading separators if the number of digits are divisible by 3
+			-- This checks for their presence and removes them
+			-- Don't use patterns here because thousandsSeparator can be a pattern control character, and will crash if used
+			if main.thousandsSeparator ~= "" then
+				local thousandsSeparator = string.find(integer, main.thousandsSeparator, 1, 2)
+				if thousandsSeparator and thousandsSeparator == 1 then
+					integer = integer:sub(2)
+				end
+			end
+		else
+			integer = integer:reverse():gsub("(%d%d%d)", "%1"):reverse()
+		end
+		return colour..minus..integer..fraction:gsub("%.", main.decimalSeparator)
+	end)
 end
 
 function getFormatNumSep(dec)
@@ -650,11 +650,11 @@ function copyFile(srcName, dstName)
 end
 
 function zip(a, b)
-    local zipped = { }
+	local zipped = { }
 	for i, _ in pairs(a) do
 		table.insert(zipped, { a[i], b[i] })
-    end
-    return zipped
+	end
+	return zipped
 end
 
 -- Generate a UUID for a skill


### PR DESCRIPTION
### Description of the problem being solved:
Colour codes at start of numbers were treated as part of the integer to be formatted.
This strips the colours codes at the start of numbers and readds it to the start of the number after formatting this will still be broken / not apply proper formatting of numbers with colour codes inside them e.g. ^12^26^73^37.
### Link to a build that showcases this PR:
https://pobb.in/jcUg9zwq0DjB

### Before screenshot:
![image](https://user-images.githubusercontent.com/31533893/222050635-3d6d18ca-ae5d-47e2-aac9-c2e8f9c36ccd.png)

### After screenshot:
![image](https://user-images.githubusercontent.com/31533893/222050649-75ba9de2-91ea-4817-ba46-ac7bc2068f8e.png)
