### PR TITLE
Minor improvements to trade tool stat weights

### DIFF
--- a/src/Classes/TradeQuery.lua
+++ b/src/Classes/TradeQuery.lua
@@ -294,7 +294,7 @@ on trade site to work on other leagues and realms)]]
 		stat = "TotalEHP",
 		weightMult = 0.5,
 	})
-	self.controls.StatWeightMultipliersButton = new("ButtonControl", {"TOPRIGHT", nil, "TOPRIGHT"}, -12, 19, 100, 18, "^7Sort Calc By:", function()
+	self.controls.StatWeightMultipliersButton = new("ButtonControl", {"TOPRIGHT", nil, "TOPRIGHT"}, -12, 19, 150, 18, "^7Adjust search weights:", function()
 		self:SetStatWeights()
 	end)
 	self.controls.StatWeightMultipliersButton.tooltipFunc = function(tooltip)

--- a/src/Classes/TradeQueryGenerator.lua
+++ b/src/Classes/TradeQueryGenerator.lua
@@ -803,7 +803,7 @@ function TradeQueryGeneratorClass:RequestQuery(slot, context, statWeights, callb
 		if i == 1 then
 			controls.sortStatLabel = new("LabelControl", {"RIGHT",lastItemAnchor,"LEFT"}, -5, 0, 0, 16, "Stat to Sort By:")
 		elseif i == 5 then
-			-- tooltips dont actualy work for labels
+			-- tooltips do not actually work for labels
 			lastItemAnchor.tooltipFunc = function(tooltip)
 				tooltip:Clear()
 				tooltip:AddLine(16, "Sorts the weights by the stats selected multiplied by a value")

--- a/src/Classes/TradeQueryGenerator.lua
+++ b/src/Classes/TradeQueryGenerator.lua
@@ -7,6 +7,7 @@
 local dkjson = require "dkjson"
 local curl = require("lcurl.safe")
 local m_max = math.max
+local s_format = string.format
 
 -- TODO generate these from data files
 local itemCategoryTags = {
@@ -795,17 +796,28 @@ function TradeQueryGeneratorClass:RequestQuery(slot, context, statWeights, callb
 	lastItemAnchor = controls.maxPrice
 	popupHeight = popupHeight + 23
 	
-    controls.sortStatType = new("LabelControl", {"TOPLEFT",lastItemAnchor,"BOTTOMLEFT"}, 0, 5, 70, 18, #statWeights < 2 and statWeights[1].label or "Multiple Stats")
-    controls.sortStatLabel = new("LabelControl", {"RIGHT",controls.sortStatType,"LEFT"}, -5, 0, 0, 16, "Stat to Sort By:")
-	controls.sortStatType.tooltipFunc = function(tooltip)
-		tooltip:Clear()
-		tooltip:AddLine(16, "Sorts the weights by the stats selected multiplied by a value")
-		tooltip:AddLine(16, "Currently sorting by:")
-		for _, stat in ipairs(statWeights) do
-			tooltip:AddLine(16, s_format("%s: %.2f", stat.label, stat.weightMult))
+	for i, stat in ipairs(statWeights) do
+		controls["sortStatType"..tostring(i)] = new("LabelControl", {"TOPLEFT",lastItemAnchor,"BOTTOMLEFT"}, 0, i == 1 and 5 or 3, 70, 16, i < (#statWeights < 6 and 10 or 5) and s_format("%.2f: %s", stat.weightMult, stat.label) or ("+ "..tostring(#statWeights - 4).." Additional Stats"))
+		lastItemAnchor = controls["sortStatType"..tostring(i)]
+		popupHeight = popupHeight + 19
+		if i == 1 then
+			controls.sortStatLabel = new("LabelControl", {"RIGHT",lastItemAnchor,"LEFT"}, -5, 0, 0, 16, "Stat to Sort By:")
+		elseif i == 5 then
+			-- tooltips dont actualy work for labels
+			lastItemAnchor.tooltipFunc = function(tooltip)
+				tooltip:Clear()
+				tooltip:AddLine(16, "Sorts the weights by the stats selected multiplied by a value")
+				tooltip:AddLine(16, "Currently sorting by:")
+				for i, stat in ipairs(statWeights) do
+					if i > 4 then
+						tooltip:AddLine(16, s_format("%s: %.2f", stat.label, stat.weightMult))
+					end
+				end
+			end
+			break
 		end
 	end
-    popupHeight = popupHeight + 23
+	popupHeight = popupHeight + 4
 
 	controls.generateQuery = new("ButtonControl", { "BOTTOM", nil, "BOTTOM" }, -45, -10, 80, 20, "Execute", function()
 		main:ClosePopup()

--- a/src/Classes/TradeStatWeightMultiplierListControl.lua
+++ b/src/Classes/TradeStatWeightMultiplierListControl.lua
@@ -30,7 +30,7 @@ function TradeStatWeightMultiplierListControlClass:AddValueTooltip(tooltip, inde
 end
 
 function TradeStatWeightMultiplierListControlClass:OnSelClick(index, data, doubleClick)
-	if doubleClick and self.indexController.index ~= index then
+	if self.indexController.index ~= index then
 		self.indexController.index = index
 		self.indexController.SliderLabel.label = self.list[index].stat.label
 		self.indexController.Slider:SetVal(self.list[index].stat.weightMult == 1 and 1 or self.list[index].stat.weightMult - 0.01)


### PR DESCRIPTION
This removes the need to double click to change what stat weight you are changing, and also shows more stats in the "find best"

![image](https://user-images.githubusercontent.com/49933620/222057657-74e2921c-650c-4db8-991d-2bb0f2d45965.png)

the tooltip to list the rest of the stats are still broken