### PR TITLE
remove byte order mark

### DIFF
--- a/src/Data/Uniques/Special/New.lua
+++ b/src/Data/Uniques/Special/New.lua
@@ -1,4 +1,4 @@
-﻿--
+--
 -- Upcoming uniques will live here until their mods/rolls are finalised
 --
 

--- a/src/Data/Uniques/amulet.lua
+++ b/src/Data/Uniques/amulet.lua
@@ -1,4 +1,4 @@
-﻿-- Item data (c) Grinding Gear Games
+-- Item data (c) Grinding Gear Games
 
 return {
 -- Amulet

--- a/src/Data/Uniques/axe.lua
+++ b/src/Data/Uniques/axe.lua
@@ -1,4 +1,4 @@
-﻿-- Item data (c) Grinding Gear Games
+-- Item data (c) Grinding Gear Games
 
 return {
 -- Weapon: One Handed Axe

--- a/src/Data/Uniques/belt.lua
+++ b/src/Data/Uniques/belt.lua
@@ -1,4 +1,4 @@
-﻿-- Item data (c) Grinding Gear Games
+-- Item data (c) Grinding Gear Games
 
 return {
 -- Belt

--- a/src/Data/Uniques/body.lua
+++ b/src/Data/Uniques/body.lua
@@ -1,4 +1,4 @@
-﻿-- Item data (c) Grinding Gear Games
+-- Item data (c) Grinding Gear Games
 
 return {
 -- Body: Armour

--- a/src/Data/Uniques/boots.lua
+++ b/src/Data/Uniques/boots.lua
@@ -1,4 +1,4 @@
-﻿-- Item data (c) Grinding Gear Games
+-- Item data (c) Grinding Gear Games
 
 return {
 -- Boots: Armour

--- a/src/Data/Uniques/bow.lua
+++ b/src/Data/Uniques/bow.lua
@@ -1,4 +1,4 @@
-﻿-- Item data (c) Grinding Gear Games
+-- Item data (c) Grinding Gear Games
 
 return {
 -- Weapon: Bow

--- a/src/Data/Uniques/claw.lua
+++ b/src/Data/Uniques/claw.lua
@@ -1,4 +1,4 @@
-﻿-- Item data (c) Grinding Gear Games
+-- Item data (c) Grinding Gear Games
 
 return {
 -- Weapon: Claw

--- a/src/Data/Uniques/dagger.lua
+++ b/src/Data/Uniques/dagger.lua
@@ -1,4 +1,4 @@
-﻿	-- Item data (c) Grinding Gear Games
+-- Item data (c) Grinding Gear Games
 
 return {
 -- Weapon: Dagger

--- a/src/Data/Uniques/fishing.lua
+++ b/src/Data/Uniques/fishing.lua
@@ -1,4 +1,4 @@
-﻿-- Item data (c) Grinding Gear Games
+-- Item data (c) Grinding Gear Games
 
 return {
 -- Weapon: Fishing Rod

--- a/src/Data/Uniques/flask.lua
+++ b/src/Data/Uniques/flask.lua
@@ -1,4 +1,4 @@
-﻿-- Item data (c) Grinding Gear Games
+-- Item data (c) Grinding Gear Games
 
 return {
 -- Flask: Life

--- a/src/Data/Uniques/gloves.lua
+++ b/src/Data/Uniques/gloves.lua
@@ -1,4 +1,4 @@
-﻿-- Item data (c) Grinding Gear Games
+-- Item data (c) Grinding Gear Games
 
 return {
 -- Gloves: Armour

--- a/src/Data/Uniques/helmet.lua
+++ b/src/Data/Uniques/helmet.lua
@@ -1,4 +1,5 @@
-﻿-- Item data (c) Grinding Gear Games
+-- Item data (c) Grinding Gear Games
+
 return {
 -- Helmet: Armour
 [[

--- a/src/Data/Uniques/mace.lua
+++ b/src/Data/Uniques/mace.lua
@@ -1,4 +1,4 @@
-﻿-- Item data (c) Grinding Gear Games
+-- Item data (c) Grinding Gear Games
 
 return {
 -- Weapon: One Handed Mace

--- a/src/Data/Uniques/quiver.lua
+++ b/src/Data/Uniques/quiver.lua
@@ -1,4 +1,4 @@
-﻿-- Item data (c) Grinding Gear Games
+-- Item data (c) Grinding Gear Games
 
 return {
 -- Quiver

--- a/src/Data/Uniques/shield.lua
+++ b/src/Data/Uniques/shield.lua
@@ -1,4 +1,4 @@
-﻿-- Item data (c) Grinding Gear Games
+-- Item data (c) Grinding Gear Games
 
 return {
 -- Shield: Armour

--- a/src/Data/Uniques/staff.lua
+++ b/src/Data/Uniques/staff.lua
@@ -1,4 +1,4 @@
-﻿-- Item data (c) Grinding Gear Games
+-- Item data (c) Grinding Gear Games
 
 return {
 -- Weapon: Staff

--- a/src/Data/Uniques/wand.lua
+++ b/src/Data/Uniques/wand.lua
@@ -1,4 +1,4 @@
-﻿-- Item data (c) Grinding Gear Games
+-- Item data (c) Grinding Gear Games
 
 return {
 -- Weapon: Wand


### PR DESCRIPTION
### Description of the problem being solved:

Currently, running HeadlessWrapper with 'vanilla' (non-JIT) Lua 5.1 fails because the interpreter can't handle the [byte order mark](https://en.wikipedia.org/wiki/Byte_order_mark) present at the beginning of some source files:

```
^0Error loading main script: .\HeadlessWrapper.lua:121: LoadModule() error loading 'Data/Uniques/axe.lua': Data/Uniques/axe.lua:1: unexpected symbol near '∩'
```

This change removes the BOM from every file that contains it (all of them are in Data/Uniques), converting them to regular UTF-8/ASCII. Note that since the BOM is a non-printing character, this change is invisible to diffs.

### Steps taken to verify a working solution:

- run HeadlessWrapper from a lua terminal and observe that PoB now starts correctly
- run Path of Building in developer mode and see that it still starts correctly