### PR TITLE
Fix hex codes with number formatting

### DIFF
--- a/src/Modules/Common.lua
+++ b/src/Modules/Common.lua
@@ -569,9 +569,9 @@ end
 
 -- Formats "1234.56" -> "1,234.5"
 function formatNumSep(str)
-	return string.gsub(str, "(%^?%d?-?%d+%.?%d+)", function(m)
-		local colour = m:match("(%^%d)") or ""
-		local str = string.gsub(m, "(%^%d)", "")
+	return string.gsub(str, "(%^?x?%x?%x?%x?%x?%x?%x?-?%d+%.?%d+)", function(m)
+		local colour = m:match("(%^%d)") or m:match("(^x%x%x%x%x%x%x)") or ""
+		local str = m:gsub("(%^%d)", ""):gsub("(^x%x%x%x%x%x%x)", "")
 		local x, y, minus, integer, fraction = str:find("(-?)(%d+)(%.?%d*)")
 		if main.showThousandsSeparators then
 			integer = integer:reverse():gsub("(%d%d%d)", "%1"..main.thousandsSeparator):reverse()


### PR DESCRIPTION
### Description of the problem being solved:
Hex codes also exhibit issue seen in https://github.com/PathOfBuildingCommunity/PathOfBuilding/pull/5733 but no examples currently exist. This updates the implementation to also handle them appropriately.

Example uses ^xA0A080 comma could also get added inside hex codes breaking them e.g. ^xBB6600
### Before screenshot:
![image](https://user-images.githubusercontent.com/31533893/222290569-0dcb0644-53be-4ef9-b300-0e65466e69fc.png)

### After screenshot:
![image](https://user-images.githubusercontent.com/31533893/222290476-9e077d1e-4632-4750-9fa6-a43b03e13e0d.png)
