### PR TITLE
Timelessjewel search improvements

### DIFF
--- a/src/Classes/TreeTab.lua
+++ b/src/Classes/TreeTab.lua
@@ -1751,7 +1751,7 @@ function TreeTabClass:FindTimelessJewel()
 				for nodeId in pairs(radiusNodes) do
 					allocatedNodes[nodeId] = self.build.calcsTab.mainEnv.grantedPassives[nodeId] ~= nil or self.build.spec.allocNodes[nodeId] ~= nil
 					if timelessData.socketFilterDistance > 0 then
-						unAllocatedNodesDistance[nodeId] = #self.build.spec.nodes[nodeId].path
+						unAllocatedNodesDistance[nodeId] = self.build.spec.nodes[nodeId].pathDist or 1000
 					end
 				end
 			end

--- a/src/Classes/TreeTab.lua
+++ b/src/Classes/TreeTab.lua
@@ -1106,7 +1106,7 @@ function TreeTabClass:FindTimelessJewel()
 	
 	local socketFilterAdditionalDistanceMAX = 10
 	controls.socketFilterAdditionalDistanceLabel = new("LabelControl", { "LEFT", controls.socketFilter, "RIGHT" }, 10, 0, 0, 16, "^7Node Distance:")
-	controls.socketFilterAdditionalDistance = new("SliderControl", { "LEFT", controls.socketFilterAdditionalDistanceLabel, "RIGHT" }, 10, 0, 90, 18, function(value)
+	controls.socketFilterAdditionalDistance = new("SliderControl", { "LEFT", controls.socketFilterAdditionalDistanceLabel, "RIGHT" }, 10, 0, 66, 18, function(value)
 		timelessData.socketFilterDistance = m_floor(value * socketFilterAdditionalDistanceMAX + 0.01)
 		controls.socketFilterAdditionalDistanceValue.label = s_format("^7%d", timelessData.socketFilterDistance)
 	end, { ["SHIFT"] = 1, ["CTRL"] = 1 / (socketFilterAdditionalDistanceMAX * 2), ["DEFAULT"] = 1 / socketFilterAdditionalDistanceMAX })
@@ -1504,14 +1504,12 @@ function TreeTabClass:FindTimelessJewel()
 		tooltip:AddLine(16, "^7Click this button to generate new fallback node weights, replacing your old ones.")
 	end
 
-	controls.searchListButton = new("ButtonControl", { "TOPLEFT", nil, "TOPLEFT" }, 12, 250, 106, 20, "^2Desired Nodes", function()
+	controls.searchListButton = new("ButtonControl", { "TOPLEFT", nil, "TOPLEFT" }, 12, 250, 106, 20, "^7Desired Nodes", function()
 		if controls.searchListFallback.shown then
 			controls.searchListFallback.shown = false
 			controls.searchListFallback.enabled = false
 			controls.searchList.shown = true
 			controls.searchList.enabled = true
-			controls.searchListButton.label = "^2Desired Nodes"
-			controls.searchListFallbackButton.label = "^7Fallback Nodes"
 		end
 	end)
 	controls.searchListButton.tooltipFunc = function(tooltip, mode, index, value)
@@ -1519,13 +1517,13 @@ function TreeTabClass:FindTimelessJewel()
 		tooltip:AddLine(16, "^7This contains a list of your desired nodes along with their primary, secondary, and minimum weights.")
 		tooltip:AddLine(16, "^7This list can be updated manually or by selecting the node you want to update via the search dropdown list and then moving the node weight sliders.")
 	end
+	controls.searchListButton.locked = function() return controls.searchList.shown end
 	controls.searchListFallbackButton = new("ButtonControl", { "LEFT", controls.searchListButton, "RIGHT" }, 5, 0, 110, 20, "^7Fallback Nodes", function()
 		controls.searchList.shown = false
 		controls.searchList.enabled = false
 		controls.searchListFallback.shown = true
 		controls.searchListFallback.enabled = true
-		controls.searchListButton.label = "^7Desired Nodes"
-		controls.searchListFallbackButton.label = "^2Fallback Nodes"
+		controls.searchListFallbackButton.label = "^7Fallback Nodes"
 	end)
 	controls.searchListFallbackButton.tooltipFunc = function(tooltip, mode, index, value)
 		tooltip:Clear()
@@ -1535,6 +1533,7 @@ function TreeTabClass:FindTimelessJewel()
 		tooltip:AddLine(16, "^7Fallback node weights typically contain automatically generated stat weights based on your current build.")
 		tooltip:AddLine(16, "^7Any manual changes made to your fallback nodes are lost when you click the generate button, as it completely replaces them.")
 	end
+	controls.searchListFallbackButton.locked = function() return controls.searchListFallback.shown end
 	controls.searchList = new("EditControl", { "TOPLEFT", nil, "TOPLEFT" }, 12, 275, 438, 200, timelessData.searchList, nil, "^%C\t\n", nil, function(value)
 		timelessData.searchList = value
 		parseSearchList(0, false)

--- a/src/Classes/TreeTab.lua
+++ b/src/Classes/TreeTab.lua
@@ -1495,28 +1495,37 @@ function TreeTabClass:FindTimelessJewel()
 		timelessData.fallbackWeightMode.idx = index
 	end)
 	controls.fallbackWeightsList.selIndex = timelessData.fallbackWeightMode.idx or 1
-	controls.fallbackWeightsButton = new("ButtonControl", { "LEFT", controls.fallbackWeightsList, "RIGHT" }, 5, 0, 66, 18, "Generate", setupFallbackWeights)
+	controls.fallbackWeightsButton = new("ButtonControl", { "LEFT", controls.fallbackWeightsList, "RIGHT" }, 5, 0, 66, 18, "Generate", function()
+		setupFallbackWeights()
+		controls.searchListFallbackButton.label = "^4Fallback Nodes"
+	end)
 	controls.fallbackWeightsButton.tooltipFunc = function(tooltip, mode, index, value)
 		tooltip:Clear()
 		tooltip:AddLine(16, "^7Click this button to generate new fallback node weights, replacing your old ones.")
 	end
 
-	controls.searchListButton = new("ButtonControl", { "TOPLEFT", nil, "TOPLEFT" }, 12, 250, 106, 20, "Desired Nodes", function()
-		controls.searchListFallback.shown = false
-		controls.searchListFallback.enabled = false
-		controls.searchList.shown = true
-		controls.searchList.enabled = true
+	controls.searchListButton = new("ButtonControl", { "TOPLEFT", nil, "TOPLEFT" }, 12, 250, 106, 20, "^2Desired Nodes", function()
+		if controls.searchListFallback.shown then
+			controls.searchListFallback.shown = false
+			controls.searchListFallback.enabled = false
+			controls.searchList.shown = true
+			controls.searchList.enabled = true
+			controls.searchListButton.label = "^2Desired Nodes"
+			controls.searchListFallbackButton.label = "^7Fallback Nodes"
+		end
 	end)
 	controls.searchListButton.tooltipFunc = function(tooltip, mode, index, value)
 		tooltip:Clear()
 		tooltip:AddLine(16, "^7This contains a list of your desired nodes along with their primary, secondary, and minimum weights.")
 		tooltip:AddLine(16, "^7This list can be updated manually or by selecting the node you want to update via the search dropdown list and then moving the node weight sliders.")
 	end
-	controls.searchListFallbackButton = new("ButtonControl", { "LEFT", controls.searchListButton, "RIGHT" }, 5, 0, 110, 20, "Fallback Nodes", function()
+	controls.searchListFallbackButton = new("ButtonControl", { "LEFT", controls.searchListButton, "RIGHT" }, 5, 0, 110, 20, "^7Fallback Nodes", function()
 		controls.searchList.shown = false
 		controls.searchList.enabled = false
 		controls.searchListFallback.shown = true
 		controls.searchListFallback.enabled = true
+		controls.searchListButton.label = "^7Desired Nodes"
+		controls.searchListFallbackButton.label = "^2Fallback Nodes"
 	end)
 	controls.searchListFallbackButton.tooltipFunc = function(tooltip, mode, index, value)
 		tooltip:Clear()

--- a/src/Modules/Build.lua
+++ b/src/Modules/Build.lua
@@ -818,6 +818,7 @@ function buildMode:Load(xml, fileName)
 				idx = tonumber(child.attrib.fallbackWeightModeIdx)
 			}
 			self.timelessData.socketFilter = child.attrib.socketFilter == "true"
+			self.timelessData.socketFilterDistance = tonumber(child.attrib.socketFilterDistance) or 0
 			self.timelessData.searchList = child.attrib.searchList
 			self.timelessData.searchListFallback = child.attrib.searchListFallback
 		end
@@ -893,6 +894,7 @@ function buildMode:Save(xml)
 			jewelSocketId = next(self.timelessData.jewelSocket) and tostring(self.timelessData.jewelSocket.id),
 			fallbackWeightModeIdx = next(self.timelessData.fallbackWeightMode) and tostring(self.timelessData.fallbackWeightMode.idx),
 			socketFilter = self.timelessData.socketFilter and "true",
+			socketFilterDistance = self.timelessData.socketFilterDistance and tostring(self.timelessData.socketFilterDistance),
 			searchList = self.timelessData.searchList and tostring(self.timelessData.searchList),
 			searchListFallback = self.timelessData.searchListFallback and tostring(self.timelessData.searchListFallback)
 		}


### PR DESCRIPTION
Adds an option to include unallocated nodes that are a selected distance away as if they were allocated (eg willing to spend x points for y effect)

eg node distance 0 (same as old filter)
![image](https://user-images.githubusercontent.com/49933620/222364110-d466c258-a45b-4f4b-aee5-f9441fe58cb8.png)
vs 2
![image](https://user-images.githubusercontent.com/49933620/222364208-d221246e-9bcb-4580-9be0-6899c20aec87.png)
vs off
![image](https://user-images.githubusercontent.com/49933620/222364289-95a2e3b6-9831-4084-bdf7-a8fdc4ba04ae.png)

This is currently capped at 10 but can be increased/decreased easily in future PR if needed
This will likely need further improvements, like minimum weight per point spent, or indicators for which nodes are allocated etc but for now this can help significantly in specific situations

This PR also colours the Desired nodes/fallback nodes selection buttons based on which is currently selected as well as colouring fallback yellow if you click generate to give feedback that something has changed there

eg 
![image](https://user-images.githubusercontent.com/49933620/222363815-e6582e59-1ea0-418d-a08e-4f194047dee0.png)
![image](https://user-images.githubusercontent.com/49933620/222363896-d1650c1f-ba6a-4913-a252-ac6f1f4048a1.png)
![image](https://user-images.githubusercontent.com/49933620/222363853-deb75c58-0556-4bec-8765-47f332089cbd.png)
