### PR TITLE
Add missing skilltype tag to minion skill.

### DIFF
--- a/src/Data/Skills/minion.lua
+++ b/src/Data/Skills/minion.lua
@@ -275,7 +275,7 @@ skills["MonsterProjectileSpellLightningGolemSummoned"] = {
 	color = 4,
 	baseEffectiveness = 3.2934999465942,
 	incrementalEffectiveness = 0.036100000143051,
-	skillTypes = { [SkillType.Spell] = true, [SkillType.Projectile] = true, [SkillType.ProjectilesFromUser] = true, [SkillType.Triggerable] = true, [SkillType.Damage] = true, },
+	skillTypes = { [SkillType.Spell] = true, [SkillType.Projectile] = true, [SkillType.ProjectilesFromUser] = true, [SkillType.Triggerable] = true, [SkillType.Damage] = true, [SkillType.Multicastable] = true, },
 	statDescriptionScope = "skill_stat_descriptions",
 	castTime = 1,
 	baseFlags = {

--- a/src/Export/Skills/minion.txt
+++ b/src/Export/Skills/minion.txt
@@ -42,7 +42,7 @@ local skills, mod, flag, skill = ...
 #flags spell projectile duration
 #mods
 
-#addSkillTypes Damage
+#addSkillTypes Damage Multicastable 
 #skill MonsterProjectileSpellLightningGolemSummoned Lightning Projectile
 #flags spell projectile
 #mods


### PR DESCRIPTION
Fixes https://github.com/PathOfBuildingCommunity/PathOfBuilding/issues/5745.

### Description of the problem being solved:
SkillType tag was missing from the minion skill. It's also not there in the game files so not really sure what's going on with minions skills. Related: #4628