### PR TITLE
Fix more multipliers on skill damage being incorrectly rounded.

### DIFF
--- a/src/Modules/CalcOffence.lua
+++ b/src/Modules/CalcOffence.lua
@@ -104,7 +104,7 @@ local function calcDamage(activeSkill, output, cfg, breakdown, damageType, typeF
 	-- Combine modifiers
 	local modNames = damageStatsForTypes[typeFlags]
 	local inc = 1 + skillModList:Sum("INC", cfg, unpack(modNames)) / 100
-	local more = m_floor(skillModList:More(cfg, unpack(modNames)) * 100 + 0.50000001) / 100
+	local more = skillModList:More(cfg, unpack(modNames))
 	local moreMinDamage = skillModList:More(cfg, "Min"..damageType.."Damage")
 	local moreMaxDamage = skillModList:More(cfg, "Max"..damageType.."Damage")
 
@@ -4268,7 +4268,7 @@ function calcs.offence(env, actor, activeSkill)
 			end
 		end
 		local inc = skillModList:Sum("INC", dotCfg, "Damage", "ChaosDamage")
-		local more = round(skillModList:More(dotCfg, "Damage", "ChaosDamage"), 2)
+		local more = skillModList:More(dotCfg, "Damage", "ChaosDamage")
 		local mult = skillModList:Sum("BASE", dotTypeCfg, "DotMultiplier", "ChaosDotMultiplier")
 		output.DecayDPS = skillData.decay * (1 + inc/100) * more * (1 + mult/100) * effMult
 		output.DecayDuration = 8 * debuffDurationMult
@@ -4305,7 +4305,7 @@ function calcs.offence(env, actor, activeSkill)
 				effMult = (1 - resist / 100) * (1 + takenInc / 100) * takenMore
 			end
 			local inc = modDB:Sum("INC", dotTypeCfg, "Damage", "FireDamage", "ElementalDamage")
-			local more = round(modDB:More(dotTypeCfg, "Damage", "FireDamage", "ElementalDamage"), 2)
+			local more = modDB:More(dotTypeCfg, "Damage", "FireDamage", "ElementalDamage")
 			local mult = modDB:Sum("BASE", dotTypeCfg, "DotMultiplier", "FireDotMultiplier")
 			local total = baseDropsBurningGround * (1 + inc/100) * more * (1 + mult/100) * effMult
 			if not output.BurningGroundDPS or output.BurningGroundDPS < total then
@@ -4381,7 +4381,7 @@ function calcs.offence(env, actor, activeSkill)
 				end
 			end
 			local inc = skillModList:Sum("INC", dotTypeCfg, "Damage", damageType.."Damage", isElemental[damageType] and "ElementalDamage" or nil)
-			local more = round(skillModList:More(dotTypeCfg, "Damage", damageType.."Damage", isElemental[damageType] and "ElementalDamage" or nil), 2)
+			local more = skillModList:More(dotTypeCfg, "Damage", damageType.."Damage", isElemental[damageType] and "ElementalDamage" or nil)
 			local mult = skillModList:Sum("BASE", dotTypeCfg, "DotMultiplier", damageType.."DotMultiplier")
 			local aura = activeSkill.skillTypes[SkillType.Aura] and not activeSkill.skillTypes[SkillType.RemoteMined] and calcLib.mod(skillModList, dotTypeCfg, "AuraEffect")
 			local total = baseVal * (1 + inc/100) * more * (1 + mult/100) * (aura or 1) * effMult


### PR DESCRIPTION
Fixes https://github.com/PathOfBuildingCommunity/PathOfBuilding/issues/5757

### Description of the problem being solved:
Afaik GGG handles more multipliers in the following way
Compute each multiplier type to 2 d.p. then multiply them all so in this case it should be 0.96 * 1.4 with full precision as one is spell damage and other is cold.

This removes the rounding in the main section as it should be correctly handled in the MoreInternal function.