### PR TITLE
Fix export of skills with different amounts of stats

### DIFF
--- a/src/Data/Skills/other.lua
+++ b/src/Data/Skills/other.lua
@@ -3055,7 +3055,7 @@ skills["SummonRigwaldsPack"] = {
 	},
 	levels = {
 		[10] = { 100, 3, 6, levelRequirement = 55, statInterpolation = { 1, 1, 1, }, },
-		[25] = { 100, 8, 16, levelRequirement = 78, statInterpolation = { 1, 1, 1, }, },
+		[25] = { 0, 8, 16, levelRequirement = 78, statInterpolation = { 0, 1, 1, }, },
 	},
 }
 skills["SummonTauntingContraption"] = {

--- a/src/Export/Scripts/skills.lua
+++ b/src/Export/Scripts/skills.lua
@@ -318,6 +318,7 @@ directiveTable.skill = function(state, args, out)
 		end
 	end
 	local statsPerLevel = dat("GrantedEffectStatSetsPerLevel"):GetRowList("GrantedEffectStatSets", granted.GrantedEffectStatSets)
+	local statMapOrder = {}
 	for indx, levelRow in ipairs(dat("GrantedEffectsPerLevel"):GetRowList("GrantedEffect", granted)) do
 		local statRow = statsPerLevel[indx]
 		local level = { extra = { }, statInterpolation = { }, cost = { } }
@@ -380,14 +381,30 @@ directiveTable.skill = function(state, args, out)
 		level.statInterpolation = statRow.StatInterpolations
 		local resolveInterpolation = false
 		local injectConstantValuesIntoEachLevel = false
+		local statMapOrderIndex = 1
 		for i, stat in ipairs(statRow.FloatStats) do
 			if not statMap[stat.Id] then
 				statMap[stat.Id] = #skill.stats + 1
 				table.insert(skill.stats, { id = stat.Id })
+				if indx == 1 then
+					table.insert(statMapOrder, stat.Id)
+				else
+					print(displayName .. ": stat missing from earlier levels: ".. stat.Id)
+				end
+			elseif statMapOrder[statMapOrderIndex] ~= stat.Id then
+				-- add missing stats
+				while statMapOrderIndex < #statMapOrder and statMapOrder[statMapOrderIndex] ~= stat.Id do
+					table.insert(level, 0)
+					if #level.statInterpolation < #statMapOrder then
+						table.insert(level.statInterpolation, statMapOrderIndex, "0")
+					end
+					statMapOrderIndex = statMapOrderIndex + 1
+				end
 			end
+			statMapOrderIndex = statMapOrderIndex + 1
 			if resolveInterpolation then
 				table.insert(level, statRow.BaseResolvedValues[i])
-				level.statInterpolation[i] = 1
+				level.statInterpolation[statMapOrderIndex] = 1
 			else
 				table.insert(level, statRow.FloatStatsValues[i] / math.max(statRow.InterpolationBases[i].Value, 0.00001) )
 			end
@@ -397,7 +414,22 @@ directiveTable.skill = function(state, args, out)
 				if not statMap[stat.Id] then
 					statMap[stat.Id] = #skill.stats + #skill.constantStats + 1
 					table.insert(skill.stats, { id = stat.Id })
+					if indx == 1 then
+						table.insert(statMapOrder, stat.Id)
+					else
+						print(displayName .. ": stat missing from earlier levels: ".. stat.Id)
+					end
+				elseif statMapOrder[statMapOrderIndex] ~= stat.Id then
+					-- add missing stats
+					while statMapOrderIndex < #statMapOrder and statMapOrder[statMapOrderIndex] ~= stat.Id do
+						table.insert(level, 0)
+						if #level.statInterpolation < #statMapOrder then
+							table.insert(level.statInterpolation, statMapOrderIndex, "0")
+						end
+						statMapOrderIndex = statMapOrderIndex + 1
+					end
 				end
+				statMapOrderIndex = statMapOrderIndex + 1
 				table.insert(level, granted.GrantedEffectStatSets.ConstantStatsValues[i])
 				table.insert(level.statInterpolation, #statRow.FloatStats + 1, 1)
 			end
@@ -406,7 +438,22 @@ directiveTable.skill = function(state, args, out)
 			if not statMap[stat.Id] then
 				statMap[stat.Id] = #skill.stats + 1
 				table.insert(skill.stats, { id = stat.Id })
+				if indx == 1 then
+					table.insert(statMapOrder, stat.Id)
+				else
+					print(displayName .. ": stat missing from earlier levels: ".. stat.Id)
+				end
+			elseif statMapOrder[statMapOrderIndex] ~= stat.Id then
+				-- add missing stats
+				while statMapOrderIndex < #statMapOrder and statMapOrder[statMapOrderIndex] ~= stat.Id do
+					table.insert(level, 0)
+					if #level.statInterpolation < #statMapOrder then
+						table.insert(level.statInterpolation, statMapOrderIndex, "0")
+					end
+					statMapOrderIndex = statMapOrderIndex + 1
+				end
 			end
+			statMapOrderIndex = statMapOrderIndex + 1
 			table.insert(level, statRow.AdditionalStatsValues[i])
 		end
 		for i, stat in ipairs(statRow.AdditionalBooleanStats) do


### PR DESCRIPTION
fixes rigwalds export needing to be fixed manually every time and gives warnings if stat is missing from earlier levels


check that its fine for the unused stat to have a value/statInterpolation of 0

also maybe disable the warnings as they arnt needed for any current stuff?