### PR TITLE
Config tab map mod improvements

### DIFF
--- a/src/Data/ModMap.lua
+++ b/src/Data/ModMap.lua
@@ -6,126 +6,123 @@ return {
 		-- defensive prefixes
 		["Armoured"] = { 
 			type = "list",
-			tooltip = "'Armoured'",
-			apply = function(val, modList, enemyModList, mapModEffect)
-				local map = {20, 30, 40}
-				enemyModList:NewMod("PhysicalDamageReduction", "BASE", map[val] * mapModEffect, "Map mod Armoured")
+			label = "Enemy Physical Damage reduction:",
+			tooltipLines = { "+%d%% Monster Physical Damage Reduction" },
+			values = {20, 30, 40},
+			apply = function(val, mapModEffect, values, modList, enemyModList)
+				enemyModList:NewMod("PhysicalDamageReduction", "BASE", values[val] * mapModEffect, "Map mod Armoured")
 			end 
 		},
 		["Hexproof"] = {
 			type = "check",
-			tooltip = "'Hexproof'",
-			apply = function(val, modList, enemyModList, mapModEffect)
+			label = "Enemy is Hexproof?",
+			tooltipLines = { "Monsters are Hexproof" },
+			apply = function(val, mapModEffect, modList, enemyModList)
 				enemyModList:NewMod("Hexproof", "FLAG", true, "Map mod Hexproof")
 			end 
 		},
 		["Hexwarded"] = {
 			type = "list",
-			tooltip = "'Hexwarded'",
-			apply = function(val, modList, enemyModList, mapModEffect)
-				local map = {25, 40, 60}
-				enemyModList:NewMod("CurseEffectOnSelf", "MORE", -map[val] * mapModEffect, "Map mod Hexwarded")
+			label = "Less effect of Curses on enemy:",
+			tooltipLines = { "%d%% less effect of Curses on Monsters" },
+			values = {25, 40, 60},
+			apply = function(val, mapModEffect, values, modList, enemyModList)
+				enemyModList:NewMod("CurseEffectOnSelf", "MORE", -values[val] * mapModEffect, "Map mod Hexwarded")
 			end
 		},
 		["Resistant"] = {
 			type = "list",
-			tooltip = "'Resistant'",
-			apply = function(val, modList, enemyModList, mapModEffect)
-				local map = { {20, 15},  {30, 20}, {40, 25} }
-				enemyModList:NewMod("ElementalResist", "BASE", map[val][1] * mapModEffect, "Map mod Resistant")
-				enemyModList:NewMod("ChaosResist", "BASE", map[val][2] * mapModEffect, "Map mod Resistant")
+			label = "Enemy has Elemental / ^xD02090Chaos ^7Resist:",
+			tooltipLines = { "+%d%% Monster Elemental Resistances", "+%d%% Monster Chaos Resistance" },
+			values = { {20, 15}, {30, 20}, {40, 25} },
+			apply = function(val, mapModEffect, values, modList, enemyModList)
+				enemyModList:NewMod("ElementalResist", "BASE", values[val][1] * mapModEffect, "Map mod Resistant")
+				enemyModList:NewMod("ChaosResist", "BASE", values[val][2] * mapModEffect, "Map mod Resistant")
 			end
 		},
 		["Unwavering"] = {
 			type = "count",
-			tooltip = "'Unwavering'",
-			apply = function(val, modList, enemyModList, mapModEffect)
-				local map = { {15, 19}, {20, 24}, {25, 30} }
-				-- Low tier: 15–19% / Mid tier: 20–24% / High tier: 25–30%"
+			tooltipLines = { "(%d to %d)%% more Monster Life", "Monsters cannot be Stunned" },
+			values = { { {15, 19} }, { {20, 24} }, { {25, 30} } },
+			apply = function(val, rollRange, mapModEffect, values, modList, enemyModList)
 				enemyModList:NewMod("AvoidStun", "BASE", 100, "Map mod Unwavering")
-				enemyModList:NewMod("Life", "MORE", map[val][2] * mapModEffect, "Map mod Unwavering")
+				enemyModList:NewMod("Life", "MORE", (values[val][1][1] + (values[val][1][2] - values[val][1][1]) * rollRange / 100) * mapModEffect, "Map mod Unwavering")
 			end
 		},
 		["Fecund"] = {
 			type = "count",
-			tooltip = "'Fecund'",
-			apply = function(val, modList, enemyModList, mapModEffect)
-				local map = { {20, 29}, {30, 39}, {40, 49} }
-				-- Low tier: 20–29% / Mid tier: 30–39% / High tier: 40–49%"
-				enemyModList:NewMod("Life", "MORE", map[val][2] * mapModEffect, "Map mod Fecund")
+			tooltipLines = { "(%d to %d)%% more Monster Life" },
+			values = { {20, 29}, {30, 39}, {40, 49} },
+			apply = function(val, rollRange, mapModEffect, values, modList, enemyModList)
+				enemyModList:NewMod("Life", "MORE", (values[val][1] + (values[val][2] - values[val][1]) * rollRange / 100) * mapModEffect, "Map mod Fecund")
 			end
 		},
 		["Unstoppable"] = {
 			type = "check",
-			tooltip = "'Unstoppable'",
-			apply = function(val, modList, enemyModList, mapModEffect)
+			tooltipLines = { "Monsters cannot be Taunted", "Monsters' Action Speed cannot be modified to below base value" },
+			apply = function(val, mapModEffect, modList, enemyModList)
 				-- MISSING: Monsters cannot be Taunted
 				enemyModList:NewMod("MinimumActionSpeed", "MAX", 100, "Map mod Unstoppable")
 			end 
 		},
 		["Impervious"] = {
 			type = "list",
-			tooltip = "'Impervious'",
-			apply = function(val, modList, enemyModList, mapModEffect)
-				local map = { 20, 35, 50 }
-				enemyModList:NewMod("AvoidPoison", "BASE", map[val] * mapModEffect, "Map mod Impervious")
-				enemyModList:NewMod("AvoidImpale", "BASE", map[val] * mapModEffect, "Map mod Impervious")
-				enemyModList:NewMod("AvoidBleed", "BASE", map[val] * mapModEffect, "Map mod Impervious")
+			tooltipLines = { "Monsters have a %d%% chance to avoid Poison, Impale, and Bleeding" },
+			values = { 20, 35, 50 },
+			apply = function(val, mapModEffect, values, modList, enemyModList)
+				enemyModList:NewMod("AvoidPoison", "BASE", values[val] * mapModEffect, "Map mod Impervious")
+				enemyModList:NewMod("AvoidImpale", "BASE", values[val] * mapModEffect, "Map mod Impervious")
+				enemyModList:NewMod("AvoidBleed", "BASE", values[val] * mapModEffect, "Map mod Impervious")
 			end
 		},
 		["Oppressive"] = {
 			type = "list",
-			tooltip = "'Oppressive'",
-			apply = function(val, modList, enemyModList, mapModEffect)
-				local map = { 30, 45, 60 }
-				enemyModList:NewMod("SpellSuppressionChance", "BASE", map[val] * mapModEffect, "Map mod Oppressive")
+			tooltipLines = { },
+			values = { 30, 45, 60 },
+			apply = function(val, mapModEffect, values, modList, enemyModList)
+				enemyModList:NewMod("SpellSuppressionChance", "BASE", values[val] * mapModEffect, "Map mod Oppressive")
 			end
 		},
 		["Buffered"] = {
 			type = "count",
-			tooltip = "'Buffered'",
-			apply = function(val, modList, enemyModList, mapModEffect)
-				local map = { {20, 29}, {30, 39}, {40, 49} }
-				-- Low tier: 20–29% / Mid tier: 30–39% / High tier: 40–49%"
-				enemyModList:NewMod("LifeGainAsEnergyShield", "BASE", map[val][2] * mapModEffect, "Map mod Buffered")
+			tooltipLines = { },
+			values = { {20, 29}, {30, 39}, {40, 49} },
+			apply = function(val, rollRange, mapModEffect, values, modList, enemyModList)
+				enemyModList:NewMod("LifeGainAsEnergyShield", "BASE", (values[val][1] + (values[val][2] - values[val][1]) * rollRange / 100) * mapModEffect, "Map mod Buffered")
 			end
 		},
 		["Titan's"] = {}, -- Unique Boss has 25|30|35% increased Life / Unique Boss has 45|55|70% increased Area of Effect
 		-- offensive prefixes
 		["Savage"] = {
 			type = "count",
-			tooltip = "'Savage'",
-			apply = function(val, modList, enemyModList, mapModEffect)
-				local map = { {14, 17}, {18, 21}, {22, 25} }
-				-- Low tier: 14–17% / Mid tier: 18–21% / High tier: 22–25%"
-				enemyModList:NewMod("Damage", "INC", map[val][2] * mapModEffect, "Map mod Savage")
+			tooltipLines = { "(%d to %d)%% increased Monster Damage" },
+			values = { {14, 17}, {18, 21}, {22, 25} },
+			apply = function(val, rollRange, mapModEffect, values, modList, enemyModList)
+				enemyModList:NewMod("Damage", "INC", (values[val][1] + (values[val][2] - values[val][1]) * rollRange / 100) * mapModEffect, "Map mod Savage")
 			end
 		},
 		["Burning"] = {
 			type = "count",
-			tooltip = "'Burning'",
-			apply = function(val, modList, enemyModList, mapModEffect)
-				local map = { {50, 69}, {70, 89}, {90, 110} } 
-				-- Low tier: 50–69% / Mid tier: 70–89% / High tier: 90–110%"
-				enemyModList:NewMod("PhysicalDamageGainAsFire", "BASE", map[val][2] * mapModEffect, "Map mod Burning")
+			tooltipLines = { "Monsters deal (%d to %d)%% extra Physical Damage as Fire" },
+			values = { {50, 69}, {70, 89}, {90, 110} },
+			apply = function(val, rollRange, mapModEffect, values, modList, enemyModList)
+				enemyModList:NewMod("PhysicalDamageGainAsFire", "BASE", (values[val][1] + (values[val][2] - values[val][1]) * rollRange / 100) * mapModEffect, "Map mod Burning")
 			end
 		},
 		["Freezing"] = {
 			type = "count",
-			tooltip = "'Freezing'",
-			apply = function(val, modList, enemyModList, mapModEffect)
-				local map = { {50, 69}, {70, 89}, {90, 110} } 
-				-- Low tier: 50–69% / Mid tier: 70–89% / High tier: 90–110%"
-				enemyModList:NewMod("PhysicalDamageGainAsCold", "BASE", map[val][2] * mapModEffect, "Map mod Freezing")
+			tooltipLines = { "Monsters deal (%d to %d)%% extra Physical Damage as Cold" },
+			values = { {50, 69}, {70, 89}, {90, 110} },
+			apply = function(val, rollRange, mapModEffect, values, modList, enemyModList)
+				enemyModList:NewMod("PhysicalDamageGainAsCold", "BASE", (values[val][1] + (values[val][2] - values[val][1]) * rollRange / 100) * mapModEffect, "Map mod Freezing")
 			end
 		},
 		["Shocking"] = {
 			type = "count",
-			tooltip = "'Shocking'",
-			apply = function(val, modList, enemyModList, mapModEffect)
-				local map = { {50, 69}, {70, 89}, {90, 110} } 
-				-- Low tier: 50–69% / Mid tier: 70–89% / High tier: 90–110%"
-				enemyModList:NewMod("PhysicalDamageGainAsLightning", "BASE", map[val][2] * mapModEffect, "Map mod Shocking")
+			tooltipLines = { "Monsters deal (%d to %d)%% extra Physical Damage as Lightning" },
+			values = { {50, 69}, {70, 89}, {90, 110} },
+			apply = function(val, rollRange, mapModEffect, values, modList, enemyModList)
+				enemyModList:NewMod("PhysicalDamageGainAsLightning", "BASE", (values[val][1] + (values[val][2] - values[val][1]) * rollRange / 100) * mapModEffect, "Map mod Shocking")
 			end
 		},
 		["Fleet"] = {}, --(15–20)|(20–25)|(25–30)% increased Monster Movement Speed / (20–25)|(25–35)|(35–45)% increased Monster Attack Speed / 0% increased Monster Cast Speed
@@ -139,108 +136,109 @@ return {
 		-- suffixes
 		["of Balance"] = {
 			type = "check",
-			tooltip = "'of Balance'",
-			apply = function(val, modList, enemyModList, mapModEffect)
+			label = "Player has Elemental Equilibrium?",
+			tooltipLines = { },
+			apply = function(val, mapModEffect, modList, enemyModList)
 				-- Players cannot inflict Exposure
 				-- modList:NewMod("Keystone", "LIST", "Elemental Equilibrium", "Map mod of Balance") -- OLD MOD
 			end
 		},
 		["of Congealment"] = {
 			type = "check",
-			tooltip = "'of Congealment'",
-			apply = function(val, modList, enemyModList, mapModEffect)
+			label = "Cannot Leech ^xE05030Life ^7/ ^x7070FFMana?",
+			tooltipLines = { "Cannot Leech from Monsters" },
+			apply = function(val, mapModEffect, modList, enemyModList)
 				enemyModList:NewMod("CannotLeechLifeFromSelf", "FLAG", true, "Map mod of Congealment")
 				enemyModList:NewMod("CannotLeechManaFromSelf", "FLAG", true, "Map mod of Congealment")
 			end
 		},
 		["of Drought"] = {
 			type = "list",
-			tooltip = "'of Drought'",
-			apply = function(val, modList, enemyModList, mapModEffect)
-				local map = {30, 40, 50}
-				modList:NewMod("FlaskChargesGained", "INC", -map[val] * mapModEffect, "Map mod of Drought")
+			label = "Gains reduced Flask Charges:",
+			tooltipLines = { "Players gain %d%% reduced Flask Charges" },
+			values = {30, 40, 50},
+			apply = function(val, mapModEffect, values, modList, enemyModList)
+				modList:NewMod("FlaskChargesGained", "INC", -values[val] * mapModEffect, "Map mod of Drought")
 			end
 		},
 		["of Exposure"] = {
 			type = "count",
-			tooltip = "'of Exposure'\nMid tier: 5-8%\nHigh tier: 9-12%",
-			apply = function(val, modList, enemyModList, mapModEffect)
-				local map = { {0, 0}, {5, 8}, {9, 12} }
-				-- Mid tier: 5-8% / High tier: 9-12%"
-				if map[val] ~= 0 then
-					modList:NewMod("FireResistMax", "BASE", -map[val][2] * mapModEffect, "Map mod of Exposure")
-					modList:NewMod("ColdResistMax", "BASE", -map[val][2] * mapModEffect, "Map mod of Exposure")
-					modList:NewMod("LightningResistMax", "BASE", -map[val][2] * mapModEffect, "Map mod of Exposure")
-					modList:NewMod("ChaosResistMax", "BASE", -map[val][2] * mapModEffect, "Map mod of Exposure")
+			label = "-X% maximum Resistances:",
+			tooltip = "Mid tier: 5-8%\nHigh tier: 9-12%",
+			tooltipLines = { "minus (%d to %d)%% maximum Player Resistances" },
+			values = { {0, 0}, {5, 8}, {9, 12} },
+			apply = function(val, rollRange, mapModEffect, values, modList, enemyModList)
+				if map[val][2] ~= 0 then
+					local roll = (values[val][1] + (values[val][2] - values[val][1]) * rollRange / 100) * mapModEffect
+					modList:NewMod("FireResistMax", "BASE", -roll, "Map mod of Exposure")
+					modList:NewMod("ColdResistMax", "BASE", -roll, "Map mod of Exposure")
+					modList:NewMod("LightningResistMax", "BASE", -roll, "Map mod of Exposure")
+					modList:NewMod("ChaosResistMax", "BASE", -roll, "Map mod of Exposure")
 				end
 			end
 		},
 		["of Impotence"] = {
 			type = "list",
-			tooltip = "'of Impotence'",
-			apply = function(val, modList, enemyModList, mapModEffect)
-				local map = {15, 20, 25}
-				modList:NewMod("AreaOfEffect", "MORE", -map[val] * mapModEffect, "Map mod of Impotence")
+			label = "Less Area of Effect:",
+			tooltipLines = { "Players have %d%% less Area of Effect" },
+			values = {15, 20, 25},
+			apply = function(val, mapModEffect, values, modList, enemyModList)
+				modList:NewMod("AreaOfEffect", "MORE", -values[val] * mapModEffect, "Map mod of Impotence")
 			end
 		},
 		["of Insulation"] = {
 			type = "list",
-			tooltip = "'of Insulation'",
-			apply = function(val, modList, enemyModList, mapModEffect)
-				local map = {30, 50, 70}
-				enemyModList:NewMod("AvoidElementalAilments", "BASE", map[val] * mapModEffect, "Map mod of Insulation")
-			end
-		},
-		["Impervious"] = {
-			type = "list",
-			tooltip = "'Impervious'",
-			apply = function(val, modList, enemyModList, mapModEffect)
-				local map = {20, 35, 50}
-				enemyModList:NewMod("AvoidPoison", "BASE", map[val] * mapModEffect, "Map mod Impervious")
-				enemyModList:NewMod("AvoidBleed", "BASE", map[val] * mapModEffect, "Map mod Impervious")
+			label = "Enemy avoid Elemental Ailments:",
+			tooltipLines = { "Monsters have %d%% chance to Avoid Elemental Ailments" },
+			values = {30, 50, 70},
+			apply = function(val, mapModEffect, values, modList, enemyModList)
+				enemyModList:NewMod("AvoidElementalAilments", "BASE", values[val] * mapModEffect, "Map mod of Insulation")
 			end
 		},
 		["of Miring"] = {
 			type = "list",
-			tooltip = "'of Miring'",
-			apply = function(val, modList, enemyModList, mapModEffect)
-				local map = {30, 40, 50}
+			label = "Unlucky Dodge / Enemy has inc. Accuracy:",
+			tooltipLines = { "Monsters have %d%% increased Accuracy Rating", "Players have minus %d%% to amount of Suppressed Spell Damage Prevented" },
+			values = { {10, 30}, {15, 40}, {20, 50} },
+			apply = function(val, mapModEffect, values, modList, enemyModList)
 				-- modList:NewMod("DodgeChanceIsUnlucky", "FLAG", true, "Map mod of Miring") -- OLD MOD
 				-- Players have -10|15|20% to amount of Suppressed Spell Damage Prevented
-				enemyModList:NewMod("Accuracy", "INC", map[val] * mapModEffect, "Map mod of Miring")
+				enemyModList:NewMod("Accuracy", "INC", values[val][2] * mapModEffect, "Map mod of Miring")
 			end
 		},
 		["of Rust"] = {
 			type = "list",
-			tooltip = "'of Rust'",
-			apply = function(val, modList, enemyModList, mapModEffect)
-				local map = { {20, 20}, {30, 25}, {40, 30} }
-				modList:NewMod("BlockChance", "INC", -map[val][1] * mapModEffect, "Map mod of Rust")
-				modList:NewMod("Armour", "MORE", -map[val][2] * mapModEffect, "Map mod of Rust")
+			label = "Reduced Block Chance / less Armour:",
+			tooltipLines = { "Players have %d%% less Armour", "Players have %d%% reduced Chance to Block" },
+			values = { {20, 20}, {30, 25}, {40, 30} },
+			apply = function(val, mapModEffect, values, modList, enemyModList)
+				modList:NewMod("BlockChance", "INC", -values[val][1] * mapModEffect, "Map mod of Rust")
+				modList:NewMod("Armour", "MORE", -values[val][2] * mapModEffect, "Map mod of Rust")
 			end
 		},
 		["of Skirmishing"] = {
 			-- old map mod, doesnt exist anymore?
 			type = "check",
-			tooltip = "'of Skirmishing'", 
-			apply = function(val, modList, enemyModList, mapModEffect)
+			tooltipLines = { },
+			apply = function(val, mapModEffect, modList, enemyModList)
 				modList:NewMod("Keystone", "LIST", "Point Blank", "Map mod of Skirmishing")
 			end
 		},
 		["of Smothering"] = {
 			type = "list",
-			tooltip = "'of Smothering'",
-			apply = function(val, modList, enemyModList, mapModEffect)
-				local map = {20, 40, 60}
-				modList:NewMod("LifeRecoveryRate", "MORE", -map[val] * mapModEffect, "Map mod of Smothering")
-				modList:NewMod("EnergyShieldRecoveryRate", "MORE", -map[val] * mapModEffect, "Map mod of Smothering")
+			label = "Less Recovery Rate of ^xE05030Life ^7and ^x88FFFFEnergy Shield:",
+			tooltipLines = { "Players have %d%% less Recovery Rate of Life and Energy Shield" },
+			values = {20, 40, 60},
+			apply = function(val, mapModEffect, values, modList, enemyModList)
+				modList:NewMod("LifeRecoveryRate", "MORE", -values[val] * mapModEffect, "Map mod of Smothering")
+				modList:NewMod("EnergyShieldRecoveryRate", "MORE", -values[val] * mapModEffect, "Map mod of Smothering")
 			end
 		},
 		["of Stasis"] = {
 			type = "check",
 			label = "Cannot Regen ^xE05030Life^7, ^x7070FFMana ^7or ^x88FFFFES?", 
-			tooltip = "'of Stasis'", 
-			apply = function(val, modList, enemyModList, mapModEffect)
+			tooltipLines = { "Players cannot Regenerate Life, Mana or Energy Shield" },
+			apply = function(val, mapModEffect, modList, enemyModList)
 				modList:NewMod("NoLifeRegen", "FLAG", true, "Map mod of Stasis")
 				modList:NewMod("NoEnergyShieldRegen", "FLAG", true, "Map mod of Stasis")
 				modList:NewMod("NoManaRegen", "FLAG", true, "Map mod of Stasis")
@@ -248,11 +246,10 @@ return {
 		},
 		["of Toughness"] = {
 			type = "count",
-			tooltip = "'of Toughness'\nLow tier: 25-30%\nMid tier: 31-35%\nHigh tier: 36-40%",
-			apply = function(val, modList, enemyModList, mapModEffect)
-				local map = { {25, 30}, {31, 35}, {36, 40} } 
-				-- Low tier: 25-30% / Mid tier: 31-35% / High tier: 36-40%"
-				enemyModList:NewMod("SelfCritMultiplier", "INC", -map[val][2] * mapModEffect, "Map mod of Toughness")
+			tooltipLines = { "Monsters take (%d to %d)%% reduced Extra Damage from Critical Strikes" },
+			values = { {25, 30}, {31, 35}, {36, 40} },
+			apply = function(val, rollRange, mapModEffect, values, modList, enemyModList)
+				enemyModList:NewMod("SelfCritMultiplier", "INC", -(values[val][1] + (values[val][2] - values[val][1]) * rollRange / 100) * mapModEffect, "Map mod of Toughness")
 			end
 		},
 		["of Fatigue"] = {}, -- Players have 20|30|40% less Cooldown Recovery Rate
@@ -302,25 +299,24 @@ return {
 	},
 	Prefix = {
 		{ val = "NONE", label = "None" },
-		{ val = "Armoured", label = "Enemy Physical Damage reduction:" },
-		{ val = "Hexproof", label = "Enemy is Hexproof?" },
-		{ val = "Hexwarded", label = "Less effect of Curses on enemy:" },
-		{ val = "Resistant", label = "Enemy has Elemental / ^xD02090Chaos ^7Resist:" },
-		{ val = "Savage", label = "Enemy has increased Damage" },
+		{ val = "Armoured", label = "Enemy Phys D R" .. "                                Physical Damage reduction".."Armoured" },
+		{ val = "Hexproof", label = "Enemy is Hexproof?" .. "                                ".."Hexproof" },
+		{ val = "Hexwarded", label = "Less Curse effect" .. "                                of Curses on enemy".."Hexwarded" },
+		{ val = "Resistant", label = "Enemy Resist" .. "                                has Elemental / Chaos".."Resistant" },
+		{ val = "Impervious", label = "avoid Poison and Bleed:" .. "                                Enemy ".."Impervious" },
+		{ val = "Savage", label = "Enemy Inc Damage" .. "                                has increased Damage".."Savage" },
 	},
 	Suffix = {
 		{ val = "NONE", label = "None" },
-		{ val = "of Balance", label = "Player has Elemental Equilibrium?" }, 
-		{ val = "of Congealment", label = "Cannot Leech ^xE05030Life ^7/ ^x7070FFMana?" },
-		{ val = "of Drought", label = "Gains reduced Flask Charges:" },
-		{ val = "of Exposure", label = "-X% maximum Resistances:" },
-		{ val = "of Impotence", label = "Less Area of Effect:" },
-		{ val = "of Insulation", label = "Enemy avoid Elemental Ailments:" },
-		{ val = "Impervious", label = "Enemy avoid Poison and Bleed:" },
-		{ val = "of Miring", label = "Unlucky Dodge / Enemy has inc. Accuracy:" },
-		{ val = "of Rust", label = "Reduced Block Chance / less Armour:" },
-		{ val = "of Smothering", label = "Less Recovery Rate of ^xE05030Life ^7and ^x88FFFFEnergy Shield:" },
-		{ val = "of Stasis", label = "Cannot Regen ^xE05030Life^7, ^x7070FFMana ^7or ^x88FFFFES?" },
-		{ val = "of Toughness", label = "Enemy takes red. Extra Crit Damage:" },
+		{ val = "of Congealment", label = "Cannot Leech" .."                                Life / Mana".."of Congealment" },
+		{ val = "of Drought", label = "reduced Flask Charges" .. "                                Gains".."of Drought" },
+		{ val = "of Exposure", label = "-X% maximum Res" .. "                                Resistances".."of Exposure" },
+		{ val = "of Impotence", label = "Less Area of Effect:" .. "                                ".."of Impotence" },
+		{ val = "of Insulation", label = "avoid Elemental Ailments:" .. "                                Enemy".."of Impotence" },
+		{ val = "of Miring", label = "Enemy has inc. Accuracy: / Players have to amount of Suppressed Spell Damage Prevented" .. "                                ".."of Miring" },
+		{ val = "of Rust", label = "Reduced Block Chance / less Armour:" .. "                                ".."of Rust" },
+		{ val = "of Smothering", label = "Less Recovery Rate of ^xE05030Life ^7and ^x88FFFFEnergy Shield:" .. "                                ".."of Smothering" },
+		{ val = "of Stasis", label = "Cannot Regen" .. "                                Life, Mana or ES".."of Stasis" },
+		{ val = "of Toughness", label = "Enemy takes red. Extra Crit Damage:" .. "                                ".."of Toughness" },
 	},
 }

--- a/src/Data/ModMap.lua
+++ b/src/Data/ModMap.lua
@@ -2,31 +2,9 @@
 -- Item data (c) Grinding Gear Games
 
 return {
-	Prefix = {
-		{ val = "NONE", label = "None" },
-		{ val = "enemyHasPhysicalReduction", label = "Enemy Physical Damage reduction:" },
-		{ val = "enemyIsHexproof", label = "Enemy is Hexproof?" },
-		{ val = "enemyHasLessCurseEffectOnSelf", label = "Less effect of Curses on enemy:" },
-		{ val = "enemyHasResistances", label = "Enemy has Elemental / ^xD02090Chaos ^7Resist:" },
-	},
-	Suffix = {
-		{ val = "NONE", label = "None" },
-		{ val = "playerHasElementalEquilibrium", label = "Player has Elemental Equilibrium?" }, 
-		{ val = "playerCannotLeech", label = "Cannot Leech ^xE05030Life ^7/ ^x7070FFMana?" },
-		{ val = "playerGainsReducedFlaskCharges", label = "Gains reduced Flask Charges:" },
-		{ val = "playerHasMinusMaxResist", label = "-X% maximum Resistances:" },
-		{ val = "playerHasLessAreaOfEffect", label = "Less Area of Effect:" },
-		{ val = "enemyCanAvoidElementalAilment", label = "Enemy avoid Elemental Ailments:" },
-		{ val = "enemyCanAvoidNonElementalAilment", label = "Enemy avoid Poison and Bleed:" },
-		{ val = "enemyHasIncreasedAccuracy", label = "Unlucky Dodge / Enemy has inc. Accuracy:" },
-		{ val = "playerHasLessArmourAndBlock", label = "Reduced Block Chance / less Armour:" },
-		{ val = "playerHasPointBlank", label = "Player has Point Blank?" },
-		{ val = "playerHasLessLifeESRecovery", label = "Less Recovery Rate of ^xE05030Life ^7and ^x88FFFFEnergy Shield:" },
-		{ val = "playerCannotRegenLifeManaEnergyShield", label = "Cannot Regen ^xE05030Life^7, ^x7070FFMana ^7or ^x88FFFFES?" },
-		{ val = "enemyTakesReducedExtraCritDamage", label = "Enemy takes red. Extra Crit Damage:" },
-	},
 	AffixData = {
-		["enemyHasPhysicalReduction"] = { 
+		-- defensive prefixes
+		["Armoured"] = { 
 			type = "list",
 			tooltip = "'Armoured'",
 			apply = function(val, modList, enemyModList, mapModEffect)
@@ -34,14 +12,14 @@ return {
 				enemyModList:NewMod("PhysicalDamageReduction", "BASE", map[val] * mapModEffect, "Map mod Armoured")
 			end 
 		},
-		["enemyIsHexproof"] = {
+		["Hexproof"] = {
 			type = "check",
 			tooltip = "'Hexproof'",
 			apply = function(val, modList, enemyModList, mapModEffect)
 				enemyModList:NewMod("Hexproof", "FLAG", true, "Map mod Hexproof")
 			end 
 		},
-		["enemyHasLessCurseEffectOnSelf"] = {
+		["Hexwarded"] = {
 			type = "list",
 			tooltip = "'Hexwarded'",
 			apply = function(val, modList, enemyModList, mapModEffect)
@@ -49,7 +27,7 @@ return {
 				enemyModList:NewMod("CurseEffectOnSelf", "MORE", -map[val] * mapModEffect, "Map mod Hexwarded")
 			end
 		},
-		["enemyHasResistances"] = {
+		["Resistant"] = {
 			type = "list",
 			tooltip = "'Resistant'",
 			apply = function(val, modList, enemyModList, mapModEffect)
@@ -58,14 +36,116 @@ return {
 				enemyModList:NewMod("ChaosResist", "BASE", map[val][2] * mapModEffect, "Map mod Resistant")
 			end
 		},
-		["playerHasElementalEquilibrium"] = {
+		["Unwavering"] = {
+			type = "count",
+			tooltip = "'Unwavering'",
+			apply = function(val, modList, enemyModList, mapModEffect)
+				local map = { {15, 19}, {20, 24}, {25, 30} }
+				-- Low tier: 15–19% / Mid tier: 20–24% / High tier: 25–30%"
+				enemyModList:NewMod("AvoidStun", "BASE", 100, "Map mod Unwavering")
+				enemyModList:NewMod("Life", "MORE", map[val][2] * mapModEffect, "Map mod Unwavering")
+			end
+		},
+		["Fecund"] = {
+			type = "count",
+			tooltip = "'Fecund'",
+			apply = function(val, modList, enemyModList, mapModEffect)
+				local map = { {20, 29}, {30, 39}, {40, 49} }
+				-- Low tier: 20–29% / Mid tier: 30–39% / High tier: 40–49%"
+				enemyModList:NewMod("Life", "MORE", map[val][2] * mapModEffect, "Map mod Fecund")
+			end
+		},
+		["Unstoppable"] = {
+			type = "check",
+			tooltip = "'Unstoppable'",
+			apply = function(val, modList, enemyModList, mapModEffect)
+				-- MISSING: Monsters cannot be Taunted
+				enemyModList:NewMod("MinimumActionSpeed", "MAX", 100, "Map mod Unstoppable")
+			end 
+		},
+		["Impervious"] = {
+			type = "list",
+			tooltip = "'Impervious'",
+			apply = function(val, modList, enemyModList, mapModEffect)
+				local map = { 20, 35, 50 }
+				enemyModList:NewMod("AvoidPoison", "BASE", map[val] * mapModEffect, "Map mod Impervious")
+				enemyModList:NewMod("AvoidImpale", "BASE", map[val] * mapModEffect, "Map mod Impervious")
+				enemyModList:NewMod("AvoidBleed", "BASE", map[val] * mapModEffect, "Map mod Impervious")
+			end
+		},
+		["Oppressive"] = {
+			type = "list",
+			tooltip = "'Oppressive'",
+			apply = function(val, modList, enemyModList, mapModEffect)
+				local map = { 30, 45, 60 }
+				enemyModList:NewMod("SpellSuppressionChance", "BASE", map[val] * mapModEffect, "Map mod Oppressive")
+			end
+		},
+		["Buffered"] = {
+			type = "count",
+			tooltip = "'Buffered'",
+			apply = function(val, modList, enemyModList, mapModEffect)
+				local map = { {20, 29}, {30, 39}, {40, 49} }
+				-- Low tier: 20–29% / Mid tier: 30–39% / High tier: 40–49%"
+				enemyModList:NewMod("LifeGainAsEnergyShield", "BASE", map[val][2] * mapModEffect, "Map mod Buffered")
+			end
+		},
+		["Titan's"] = {}, -- Unique Boss has 25|30|35% increased Life / Unique Boss has 45|55|70% increased Area of Effect
+		-- offensive prefixes
+		["Savage"] = {
+			type = "count",
+			tooltip = "'Savage'",
+			apply = function(val, modList, enemyModList, mapModEffect)
+				local map = { {14, 17}, {18, 21}, {22, 25} }
+				-- Low tier: 14–17% / Mid tier: 18–21% / High tier: 22–25%"
+				enemyModList:NewMod("Damage", "INC", map[val][2] * mapModEffect, "Map mod Savage")
+			end
+		},
+		["Burning"] = {
+			type = "count",
+			tooltip = "'Burning'",
+			apply = function(val, modList, enemyModList, mapModEffect)
+				local map = { {50, 69}, {70, 89}, {90, 110} } 
+				-- Low tier: 50–69% / Mid tier: 70–89% / High tier: 90–110%"
+				enemyModList:NewMod("PhysicalDamageGainAsFire", "BASE", map[val][2] * mapModEffect, "Map mod Burning")
+			end
+		},
+		["Freezing"] = {
+			type = "count",
+			tooltip = "'Freezing'",
+			apply = function(val, modList, enemyModList, mapModEffect)
+				local map = { {50, 69}, {70, 89}, {90, 110} } 
+				-- Low tier: 50–69% / Mid tier: 70–89% / High tier: 90–110%"
+				enemyModList:NewMod("PhysicalDamageGainAsCold", "BASE", map[val][2] * mapModEffect, "Map mod Freezing")
+			end
+		},
+		["Shocking"] = {
+			type = "count",
+			tooltip = "'Shocking'",
+			apply = function(val, modList, enemyModList, mapModEffect)
+				local map = { {50, 69}, {70, 89}, {90, 110} } 
+				-- Low tier: 50–69% / Mid tier: 70–89% / High tier: 90–110%"
+				enemyModList:NewMod("PhysicalDamageGainAsLightning", "BASE", map[val][2] * mapModEffect, "Map mod Shocking")
+			end
+		},
+		["Fleet"] = {}, --(15–20)|(20–25)|(25–30)% increased Monster Movement Speed / (20–25)|(25–35)|(35–45)% increased Monster Attack Speed / 0% increased Monster Cast Speed
+		["Conflagrating"] = {}, -- All Monster Damage from Hits always Ignites
+		["Impaling"] = {}, -- Monsters have 25|40|60% chance to Impale with Attacks
+		["Empowered"] = {}, -- Monsters have a 0|15|20% chance to cause Elemental Ailments on Hit
+		["Overlord's"] = {}, -- Unique Boss deals 15|20|25% increased Damage / Unique Boss has 20|25|30% increased Attack and Cast Speed
+		-- reflect prefixes
+		["Punishing"] = {}, -- Monsters reflect 13|15|18% of Physical Damage
+		["Mirrored"] = {}, -- Monsters reflect 13|15|18% of Elemental Damage
+		-- suffixes
+		["of Balance"] = {
 			type = "check",
 			tooltip = "'of Balance'",
 			apply = function(val, modList, enemyModList, mapModEffect)
-				modList:NewMod("Keystone", "LIST", "Elemental Equilibrium", "Map mod of Balance")
+				-- Players cannot inflict Exposure
+				-- modList:NewMod("Keystone", "LIST", "Elemental Equilibrium", "Map mod of Balance") -- OLD MOD
 			end
 		},
-		["playerCannotLeech"] = {
+		["of Congealment"] = {
 			type = "check",
 			tooltip = "'of Congealment'",
 			apply = function(val, modList, enemyModList, mapModEffect)
@@ -73,7 +153,7 @@ return {
 				enemyModList:NewMod("CannotLeechManaFromSelf", "FLAG", true, "Map mod of Congealment")
 			end
 		},
-		["playerGainsReducedFlaskCharges"] = {
+		["of Drought"] = {
 			type = "list",
 			tooltip = "'of Drought'",
 			apply = function(val, modList, enemyModList, mapModEffect)
@@ -81,20 +161,21 @@ return {
 				modList:NewMod("FlaskChargesGained", "INC", -map[val] * mapModEffect, "Map mod of Drought")
 			end
 		},
-		["playerHasMinusMaxResist"] = {
+		["of Exposure"] = {
 			type = "count",
 			tooltip = "'of Exposure'\nMid tier: 5-8%\nHigh tier: 9-12%",
 			apply = function(val, modList, enemyModList, mapModEffect)
-				local map = {0, 8, 12} -- Mid tier: 5-8% / High tier: 9-12%"
+				local map = { {0, 0}, {5, 8}, {9, 12} }
+				-- Mid tier: 5-8% / High tier: 9-12%"
 				if map[val] ~= 0 then
-					modList:NewMod("FireResistMax", "BASE", -map[val] * mapModEffect, "Map mod of Exposure")
-					modList:NewMod("ColdResistMax", "BASE", -map[val] * mapModEffect, "Map mod of Exposure")
-					modList:NewMod("LightningResistMax", "BASE", -map[val] * mapModEffect, "Map mod of Exposure")
-					modList:NewMod("ChaosResistMax", "BASE", -map[val] * mapModEffect, "Map mod of Exposure")
+					modList:NewMod("FireResistMax", "BASE", -map[val][2] * mapModEffect, "Map mod of Exposure")
+					modList:NewMod("ColdResistMax", "BASE", -map[val][2] * mapModEffect, "Map mod of Exposure")
+					modList:NewMod("LightningResistMax", "BASE", -map[val][2] * mapModEffect, "Map mod of Exposure")
+					modList:NewMod("ChaosResistMax", "BASE", -map[val][2] * mapModEffect, "Map mod of Exposure")
 				end
 			end
 		},
-		["playerHasLessAreaOfEffect"] = {
+		["of Impotence"] = {
 			type = "list",
 			tooltip = "'of Impotence'",
 			apply = function(val, modList, enemyModList, mapModEffect)
@@ -102,7 +183,7 @@ return {
 				modList:NewMod("AreaOfEffect", "MORE", -map[val] * mapModEffect, "Map mod of Impotence")
 			end
 		},
-		["enemyCanAvoidElementalAilment"] = {
+		["of Insulation"] = {
 			type = "list",
 			tooltip = "'of Insulation'",
 			apply = function(val, modList, enemyModList, mapModEffect)
@@ -110,7 +191,7 @@ return {
 				enemyModList:NewMod("AvoidElementalAilments", "BASE", map[val] * mapModEffect, "Map mod of Insulation")
 			end
 		},
-		["enemyCanAvoidNonElementalAilment"] = {
+		["Impervious"] = {
 			type = "list",
 			tooltip = "'Impervious'",
 			apply = function(val, modList, enemyModList, mapModEffect)
@@ -119,16 +200,17 @@ return {
 				enemyModList:NewMod("AvoidBleed", "BASE", map[val] * mapModEffect, "Map mod Impervious")
 			end
 		},
-		["enemyHasIncreasedAccuracy"] = {
+		["of Miring"] = {
 			type = "list",
 			tooltip = "'of Miring'",
 			apply = function(val, modList, enemyModList, mapModEffect)
 				local map = {30, 40, 50}
-				modList:NewMod("DodgeChanceIsUnlucky", "FLAG", true, "Map mod of Miring")
+				-- modList:NewMod("DodgeChanceIsUnlucky", "FLAG", true, "Map mod of Miring") -- OLD MOD
+				-- Players have -10|15|20% to amount of Suppressed Spell Damage Prevented
 				enemyModList:NewMod("Accuracy", "INC", map[val] * mapModEffect, "Map mod of Miring")
 			end
 		},
-		["playerHasLessArmourAndBlock"] = {
+		["of Rust"] = {
 			type = "list",
 			tooltip = "'of Rust'",
 			apply = function(val, modList, enemyModList, mapModEffect)
@@ -137,14 +219,15 @@ return {
 				modList:NewMod("Armour", "MORE", -map[val][2] * mapModEffect, "Map mod of Rust")
 			end
 		},
-		["playerHasPointBlank"] = {
+		["of Skirmishing"] = {
+			-- old map mod, doesnt exist anymore?
 			type = "check",
 			tooltip = "'of Skirmishing'", 
 			apply = function(val, modList, enemyModList, mapModEffect)
 				modList:NewMod("Keystone", "LIST", "Point Blank", "Map mod of Skirmishing")
 			end
 		},
-		["playerHasLessLifeESRecovery"] = {
+		["of Smothering"] = {
 			type = "list",
 			tooltip = "'of Smothering'",
 			apply = function(val, modList, enemyModList, mapModEffect)
@@ -153,7 +236,7 @@ return {
 				modList:NewMod("EnergyShieldRecoveryRate", "MORE", -map[val] * mapModEffect, "Map mod of Smothering")
 			end
 		},
-		["playerCannotRegenLifeManaEnergyShield"] = {
+		["of Stasis"] = {
 			type = "check",
 			label = "Cannot Regen ^xE05030Life^7, ^x7070FFMana ^7or ^x88FFFFES?", 
 			tooltip = "'of Stasis'", 
@@ -163,13 +246,81 @@ return {
 				modList:NewMod("NoManaRegen", "FLAG", true, "Map mod of Stasis")
 			end
 		},
-		["enemyTakesReducedExtraCritDamage"] = {
+		["of Toughness"] = {
 			type = "count",
 			tooltip = "'of Toughness'\nLow tier: 25-30%\nMid tier: 31-35%\nHigh tier: 36-40%",
 			apply = function(val, modList, enemyModList, mapModEffect)
-				local map = {30, 35, 40} -- Low tier: 25-30% / Mid tier: 31-35% / High tier: 36-40%"
-				enemyModList:NewMod("SelfCritMultiplier", "INC", -map[val] * mapModEffect, "Map mod of Toughness")
+				local map = { {25, 30}, {31, 35}, {36, 40} } 
+				-- Low tier: 25-30% / Mid tier: 31-35% / High tier: 36-40%"
+				enemyModList:NewMod("SelfCritMultiplier", "INC", -map[val][2] * mapModEffect, "Map mod of Toughness")
 			end
 		},
+		["of Fatigue"] = {}, -- Players have 20|30|40% less Cooldown Recovery Rate
+		["of Transience"] = {}, --  Buffs on Players expire 30|50|70% faster
+		["of Doubt"] = {}, -- Players have 25|40|60% reduced effect of Non-Curse Auras from Skills
+		["of Imprecision"] = {}, -- Players have 15|20|25% less Accuracy Rating
+		["of Blinding"] = {}, -- Monsters Blind on Hit --SHOULD THIS BE SUPPORTED? (as a flag to make "are you blinded" show on config?)
+		["of Venom"] = {}, -- Monsters Poison on Hit
+		["of Deadliness"] = {}, -- Monsters have (160–200)|(260–300)|(360–400)% increased Critical Strike Chance / +(30–35)|(36–40)|(41–45)% to Monster Critical Strike Multiplier
+		-- other prefixes
+		["Antagonist's"] = {}, -- (20–30)% increased number of Rare Monsters
+		["Anarchic"] = {}, -- Area is inhabited by 2 additional Rogue Exiles
+		["Ceremonial"] = {}, -- Area contains many Totems
+		["Skeletal"] = {}, -- Area is inhabited by Skeletons
+		["Capricious"] = {}, -- Area is inhabited by Goatmen
+		["Slithering"] = {}, -- Area is inhabited by Sea Witches and their Spawn
+		["Undead"] = {}, -- Area is inhabited by Undead
+		["Emanant"] = {}, -- Area is inhabited by ranged monsters
+		["Feral"] = {}, -- Area is inhabited by Animals
+		["Demonic"] = {}, -- Area is inhabited by Demons
+		["Bipedal"] = {}, -- Area is inhabited by Humanoids
+		["Solar"] = {}, -- Area is inhabited by Solaris fanatics
+		["Lunar"] = {}, -- Area is inhabited by Lunaris fanatics
+		["Haunting"] = {}, -- Area is inhabited by Ghosts
+		["Feasting"] = {}, -- Area is inhabited by Cultists of Kitava
+		["Multifarious"] = {}, -- Area has increased monster variety
+		["Abhorrent"] = {}, -- Area is inhabited by Abominations
+		["Otherworldly"] = {}, -- Slaying Enemies close together can attract monsters from Beyond this realm
+		["Twinned"] = {}, -- Area contains two Unique Bosses
+		["Enthralled"] = {}, -- Unique Bosses are Possessed
+		["Chaining"] = {}, -- Monsters' skills Chain 2 additional times
+		["Splitting"] = {}, -- Monsters fire 2 additional Projectiles
+		-- other suffixes
+		["of Bloodlines"] = {}, -- (20–30)% more Magic Monsters
+		["of Giants"] = {}, --  Monsters have 45|70|100% increased Area of Effect
+		["of Flames"] = {}, -- Area has patches of Burning Ground
+		["of Ice"] = {}, -- Area has patches of Chilled Ground
+		["of Lightning"] = {}, -- Area has patches of Shocked Ground which increase Damage taken by 20|35|50%
+		["of Desecration"] = {}, -- Area has patches of desecrated ground
+		["of Consecration"] = {}, -- Area has patches of Consecrated Ground
+		["of Frenzy"] = {}, -- Monsters gain a Frenzy Charge on Hit
+		["of Endurance"] = {}, -- Monsters gain an Endurance Charge on Hit
+		["of Power"] = {}, -- Monsters gain a Power Charge on Hit
+		["of Carnage"] = {}, -- Monsters Maim on Hit with Attacks
+		["of Impedance"] = {}, -- Monsters Hinder on Hit with Spells
+		["of Enervation"] = {}, -- Monsters steal Power, Frenzy and Endurance charges on Hit
+	},
+	Prefix = {
+		{ val = "NONE", label = "None" },
+		{ val = "Armoured", label = "Enemy Physical Damage reduction:" },
+		{ val = "Hexproof", label = "Enemy is Hexproof?" },
+		{ val = "Hexwarded", label = "Less effect of Curses on enemy:" },
+		{ val = "Resistant", label = "Enemy has Elemental / ^xD02090Chaos ^7Resist:" },
+		{ val = "Savage", label = "Enemy has increased Damage" },
+	},
+	Suffix = {
+		{ val = "NONE", label = "None" },
+		{ val = "of Balance", label = "Player has Elemental Equilibrium?" }, 
+		{ val = "of Congealment", label = "Cannot Leech ^xE05030Life ^7/ ^x7070FFMana?" },
+		{ val = "of Drought", label = "Gains reduced Flask Charges:" },
+		{ val = "of Exposure", label = "-X% maximum Resistances:" },
+		{ val = "of Impotence", label = "Less Area of Effect:" },
+		{ val = "of Insulation", label = "Enemy avoid Elemental Ailments:" },
+		{ val = "Impervious", label = "Enemy avoid Poison and Bleed:" },
+		{ val = "of Miring", label = "Unlucky Dodge / Enemy has inc. Accuracy:" },
+		{ val = "of Rust", label = "Reduced Block Chance / less Armour:" },
+		{ val = "of Smothering", label = "Less Recovery Rate of ^xE05030Life ^7and ^x88FFFFEnergy Shield:" },
+		{ val = "of Stasis", label = "Cannot Regen ^xE05030Life^7, ^x7070FFMana ^7or ^x88FFFFES?" },
+		{ val = "of Toughness", label = "Enemy takes red. Extra Crit Damage:" },
 	},
 }

--- a/src/Data/ModMap.lua
+++ b/src/Data/ModMap.lua
@@ -4,94 +4,172 @@
 return {
 	Prefix = {
 		{ val = "NONE", label = "None" },
-		{ val = { var = "enemyHasPhysicalReduction", type = "list", tooltip = "'Armoured'", label = "Enemy Physical Damage reduction:", list = {{val=0,label="None"},{val=20,label="20% (Low tier)"},{val=30,label="30% (Mid tier)"},{val=40,label="40% (High tier)"}}, apply = function(val, modList, enemyModList, mapModEffect)
-			enemyModList:NewMod("PhysicalDamageReduction", "BASE", val * mapModEffect, "Config")
-		end }, label = "Enemy Physical Damage reduction:" },
-		{ val = { var = "enemyIsHexproof", type = "check", tooltip = "'Hexproof'", apply = function(val, modList, enemyModList, mapModEffect)
-			enemyModList:NewMod("Hexproof", "FLAG", true, "Config")
-		end }, label = "Enemy is Hexproof?" },
-		{ val = { var = "enemyHasLessCurseEffectOnSelf", type = "list", tooltip = "'Hexwarded'", label = "Less effect of Curses on enemy:", list = {{val=0,label="None"},{val=25,label="25% (Low tier)"},{val=40,label="40% (Mid tier)"},{val=60,label="60% (High tier)"}}, apply = function(val, modList, enemyModList, mapModEffect)	
-			if val ~= 0 then
-				enemyModList:NewMod("CurseEffectOnSelf", "MORE", -val * mapModEffect, "Config")
-			end
-		end }, label = "Less effect of Curses on enemy:" },
-		{ val = { var = "enemyHasResistances", type = "list", tooltip = "'Resistant'", label = "Enemy has Elemental / ^xD02090Chaos ^7Resist:", list = {{val=0,label="None"},{val="LOW",label="20% / 15% (Low tier)"},{val="MID",label="30% / 20% (Mid tier)"},{val="HIGH",label="40% / 25% (High tier)"}}, apply = function(val, modList, enemyModList, mapModEffect)
-			local map = { ["LOW"] = {20,15}, ["MID"] = {30,20}, ["HIGH"] = {40,25} }
-			if map[val] then
-				enemyModList:NewMod("ElementalResist", "BASE", map[val][1] * mapModEffect, "Config")
-				enemyModList:NewMod("ChaosResist", "BASE", map[val][2] * mapModEffect, "Config")
-			end
-		end }, label = "Enemy has Elemental / ^xD02090Chaos ^7Resist:" },
+		{ val = "enemyHasPhysicalReduction", label = "Enemy Physical Damage reduction:" },
+		{ val = "enemyIsHexproof", label = "Enemy is Hexproof?" },
+		{ val = "enemyHasLessCurseEffectOnSelf", label = "Less effect of Curses on enemy:" },
+		{ val = "enemyHasResistances", label = "Enemy has Elemental / ^xD02090Chaos ^7Resist:" },
 	},
 	Suffix = {
 		{ val = "NONE", label = "None" },
-		{ val = { var = "playerHasElementalEquilibrium", type = "check", label = "Player has Elemental Equilibrium?", tooltip = "'of Balance'", apply = function(val, modList, enemyModList, mapModEffect)
-			modList:NewMod("Keystone", "LIST", "Elemental Equilibrium", "Config")
-		end }, label = "Player has Elemental Equilibrium?" }, 
-		{ val = { var = "playerCannotLeech", type = "check", label = "Cannot Leech ^xE05030Life ^7/ ^x7070FFMana?", tooltip = "'of Congealment'", apply = function(val, modList, enemyModList, mapModEffect)
-			enemyModList:NewMod("CannotLeechLifeFromSelf", "FLAG", true, "Config")
-			enemyModList:NewMod("CannotLeechManaFromSelf", "FLAG", true, "Config")
-		end }, label = "Cannot Leech ^xE05030Life ^7/ ^x7070FFMana?" },
-		{ val = { var = "playerGainsReducedFlaskCharges", type = "list", label = "Gains reduced Flask Charges:", tooltip = "'of Drought'", list = {{val=0,label="None"},{val=30,label="30% (Low tier)"},{val=40,label="40% (Mid tier)"},{val=50,label="50% (High tier)"}}, apply = function(val, modList, enemyModList, mapModEffect)
-			if val ~= 0 then
-				modList:NewMod("FlaskChargesGained", "INC", -val * mapModEffect, "Config")
+		{ val = "playerHasElementalEquilibrium", label = "Player has Elemental Equilibrium?" }, 
+		{ val = "playerCannotLeech", label = "Cannot Leech ^xE05030Life ^7/ ^x7070FFMana?" },
+		{ val = "playerGainsReducedFlaskCharges", label = "Gains reduced Flask Charges:" },
+		{ val = "playerHasMinusMaxResist", label = "-X% maximum Resistances:" },
+		{ val = "playerHasLessAreaOfEffect", label = "Less Area of Effect:" },
+		{ val = "enemyCanAvoidElementalAilment", label = "Enemy avoid Elemental Ailments:" },
+		{ val = "enemyCanAvoidNonElementalAilment", label = "Enemy avoid Poison and Bleed:" },
+		{ val = "enemyHasIncreasedAccuracy", label = "Unlucky Dodge / Enemy has inc. Accuracy:" },
+		{ val = "playerHasLessArmourAndBlock", label = "Reduced Block Chance / less Armour:" },
+		{ val = "playerHasPointBlank", label = "Player has Point Blank?" },
+		{ val = "playerHasLessLifeESRecovery", label = "Less Recovery Rate of ^xE05030Life ^7and ^x88FFFFEnergy Shield:" },
+		{ val = "playerCannotRegenLifeManaEnergyShield", label = "Cannot Regen ^xE05030Life^7, ^x7070FFMana ^7or ^x88FFFFES?" },
+		{ val = "enemyTakesReducedExtraCritDamage", label = "Enemy takes red. Extra Crit Damage:" },
+	},
+	AffixData = {
+		["enemyHasPhysicalReduction"] = { 
+			type = "list",
+			tooltip = "'Armoured'",
+			apply = function(val, modList, enemyModList, mapModEffect)
+				local map = {20, 30, 40}
+				enemyModList:NewMod("PhysicalDamageReduction", "BASE", map[val] * mapModEffect, "Map mod Armoured")
+			end 
+		},
+		["enemyIsHexproof"] = {
+			type = "check",
+			tooltip = "'Hexproof'",
+			apply = function(val, modList, enemyModList, mapModEffect)
+				enemyModList:NewMod("Hexproof", "FLAG", true, "Map mod Hexproof")
+			end 
+		},
+		["enemyHasLessCurseEffectOnSelf"] = {
+			type = "list",
+			tooltip = "'Hexwarded'",
+			apply = function(val, modList, enemyModList, mapModEffect)
+				local map = {25, 40, 60}
+				enemyModList:NewMod("CurseEffectOnSelf", "MORE", -map[val] * mapModEffect, "Map mod Hexwarded")
 			end
-		end }, label = "Gains reduced Flask Charges:" },
-		{ val = { var = "playerHasMinusMaxResist", type = "count", label = "-X% maximum Resistances:", tooltip = "'of Exposure'\nMid tier: 5-8%\nHigh tier: 9-12%", apply = function(val, modList, enemyModList, mapModEffect)
-			if val ~= 0 then
-				modList:NewMod("FireResistMax", "BASE", -val * mapModEffect, "Config")
-				modList:NewMod("ColdResistMax", "BASE", -val * mapModEffect, "Config")
-				modList:NewMod("LightningResistMax", "BASE", -val * mapModEffect, "Config")
-				modList:NewMod("ChaosResistMax", "BASE", -val * mapModEffect, "Config")
+		},
+		["enemyHasResistances"] = {
+			type = "list",
+			tooltip = "'Resistant'",
+			apply = function(val, modList, enemyModList, mapModEffect)
+				local map = { {20, 15},  {30, 20}, {40, 25} }
+				enemyModList:NewMod("ElementalResist", "BASE", map[val][1] * mapModEffect, "Map mod Resistant")
+				enemyModList:NewMod("ChaosResist", "BASE", map[val][2] * mapModEffect, "Map mod Resistant")
 			end
-		end }, label = "-X% maximum Resistances:" },
-		{ val = { var = "playerHasLessAreaOfEffect", type = "list", label = "Less Area of Effect:", tooltip = "'of Impotence'", list = {{val=0,label="None"},{val=15,label="15% (Low tier)"},{val=20,label="20% (Mid tier)"},{val=25,label="25% (High tier)"}}, apply = function(val, modList, enemyModList, mapModEffect)
-			if val ~= 0 then
-				modList:NewMod("AreaOfEffect", "MORE", -val * mapModEffect, "Config")
+		},
+		["playerHasElementalEquilibrium"] = {
+			type = "check",
+			tooltip = "'of Balance'",
+			apply = function(val, modList, enemyModList, mapModEffect)
+				modList:NewMod("Keystone", "LIST", "Elemental Equilibrium", "Map mod of Balance")
 			end
-		end }, label = "Less Area of Effect:" },
-		{ val = { var = "enemyCanAvoidElementalAilment", type = "list", label = "Enemy avoid Elemental Ailments:", tooltip = "'of Insulation'", list = {{val=0,label="None"},{val=30,label="30% (Low tier)"},{val=50,label="50% (Mid tier)"},{val=70,label="70% (High tier)"}}, apply = function(val, modList, enemyModList, mapModEffect)	
-			if val ~= 0 then
-				enemyModList:NewMod("AvoidElementalAilments", "BASE", val * mapModEffect, "Config")
+		},
+		["playerCannotLeech"] = {
+			type = "check",
+			tooltip = "'of Congealment'",
+			apply = function(val, modList, enemyModList, mapModEffect)
+				enemyModList:NewMod("CannotLeechLifeFromSelf", "FLAG", true, "Map mod of Congealment")
+				enemyModList:NewMod("CannotLeechManaFromSelf", "FLAG", true, "Map mod of Congealment")
 			end
-		end }, label = "Enemy avoid Elemental Ailments:" },
-		{ val = { var = "enemyCanAvoidNonElementalAilment", type = "list", label = "Enemy avoid Poison and Bleed:", tooltip = "'Impervious'", list = {{val=0,label="None"},{val=20,label="20% (Low tier)"},{val=35,label="35% (Mid tier)"},{val=50,label="50% (High tier)"}}, apply = function(val, modList, enemyModList, mapModEffect)	
-			if val ~= 0 then
-				enemyModList:NewMod("AvoidPoison", "BASE", val * mapModEffect, "Config")
-				enemyModList:NewMod("AvoidBleed", "BASE", val * mapModEffect, "Config")
+		},
+		["playerGainsReducedFlaskCharges"] = {
+			type = "list",
+			tooltip = "'of Drought'",
+			apply = function(val, modList, enemyModList, mapModEffect)
+				local map = {30, 40, 50}
+				modList:NewMod("FlaskChargesGained", "INC", -map[val] * mapModEffect, "Map mod of Drought")
 			end
-		end }, label = "Enemy avoid Poison and Bleed:" },
-		{ val = { var = "enemyHasIncreasedAccuracy", type = "list", label = "Unlucky Dodge / Enemy has inc. Accuracy:", tooltip = "'of Miring'", list = {{val=0,label="None"},{val=30,label="30% (Low tier)"},{val=40,label="40% (Mid tier)"},{val=50,label="50% (High tier)"}}, apply = function(val, modList, enemyModList, mapModEffect)
-			if val ~= 0 then
-				modList:NewMod("DodgeChanceIsUnlucky", "FLAG", true, "Config")
-				enemyModList:NewMod("Accuracy", "INC", val * mapModEffect, "Config")
+		},
+		["playerHasMinusMaxResist"] = {
+			type = "count",
+			tooltip = "'of Exposure'\nMid tier: 5-8%\nHigh tier: 9-12%",
+			apply = function(val, modList, enemyModList, mapModEffect)
+				local map = {0, 8, 12} -- Mid tier: 5-8% / High tier: 9-12%"
+				if map[val] ~= 0 then
+					modList:NewMod("FireResistMax", "BASE", -map[val] * mapModEffect, "Map mod of Exposure")
+					modList:NewMod("ColdResistMax", "BASE", -map[val] * mapModEffect, "Map mod of Exposure")
+					modList:NewMod("LightningResistMax", "BASE", -map[val] * mapModEffect, "Map mod of Exposure")
+					modList:NewMod("ChaosResistMax", "BASE", -map[val] * mapModEffect, "Map mod of Exposure")
+				end
 			end
-		end }, label = "Unlucky Dodge / Enemy has inc. Accuracy:" },
-		{ val = { var = "playerHasLessArmourAndBlock", type = "list", label = "Reduced Block Chance / less Armour:", tooltip = "'of Rust'", list = {{val=0,label="None"},{val="LOW",label="20% / 20% (Low tier)"},{val="MID",label="30% / 25% (Mid tier)"},{val="HIGH",label="40% / 30% (High tier)"}}, apply = function(val, modList, enemyModList, mapModEffect)
-			local map = { ["LOW"] = {20,20}, ["MID"] = {30,25}, ["HIGH"] = {40,30} }
-			if map[val] then
-				modList:NewMod("BlockChance", "INC", -map[val][1] * mapModEffect, "Config")
-				modList:NewMod("Armour", "MORE", -map[val][2] * mapModEffect, "Config")
+		},
+		["playerHasLessAreaOfEffect"] = {
+			type = "list",
+			tooltip = "'of Impotence'",
+			apply = function(val, modList, enemyModList, mapModEffect)
+				local map = {15, 20, 25}
+				modList:NewMod("AreaOfEffect", "MORE", -map[val] * mapModEffect, "Map mod of Impotence")
 			end
-		end }, label = "Reduced Block Chance / less Armour:" },
-		{ val = { var = "playerHasPointBlank", type = "check", label = "Player has Point Blank?", tooltip = "'of Skirmishing'", apply = function(val, modList, enemyModList, mapModEffect)
-			modList:NewMod("Keystone", "LIST", "Point Blank", "Config")
-		end }, label = "Player has Point Blank?" },
-		{ val = { var = "playerHasLessLifeESRecovery", type = "list", label = "Less Recovery Rate of ^xE05030Life ^7and ^x88FFFFEnergy Shield:", tooltip = "'of Smothering'", list = {{val=0,label="None"},{val=20,label="20% (Low tier)"},{val=40,label="40% (Mid tier)"},{val=60,label="60% (High tier)"}}, apply = function(val, modList, enemyModList, mapModEffect)
-			if val ~= 0 then
-				modList:NewMod("LifeRecoveryRate", "MORE", -val * mapModEffect, "Config")
-				modList:NewMod("EnergyShieldRecoveryRate", "MORE", -val * mapModEffect, "Config")
+		},
+		["enemyCanAvoidElementalAilment"] = {
+			type = "list",
+			tooltip = "'of Insulation'",
+			apply = function(val, modList, enemyModList, mapModEffect)
+				local map = {30, 50, 70}
+				enemyModList:NewMod("AvoidElementalAilments", "BASE", map[val] * mapModEffect, "Map mod of Insulation")
 			end
-		end }, label = "Less Recovery Rate of ^xE05030Life ^7and ^x88FFFFEnergy Shield:" },
-		{ val = { var = "playerCannotRegenLifeManaEnergyShield", type = "check", label = "Cannot Regen ^xE05030Life^7, ^x7070FFMana ^7or ^x88FFFFES?", tooltip = "'of Stasis'", apply = function(val, modList, enemyModList, mapModEffect)
-			modList:NewMod("NoLifeRegen", "FLAG", true, "Config")
-			modList:NewMod("NoEnergyShieldRegen", "FLAG", true, "Config")
-			modList:NewMod("NoManaRegen", "FLAG", true, "Config")
-		end }, label = "Cannot Regen ^xE05030Life^7, ^x7070FFMana ^7or ^x88FFFFES?" },
-		{ val = { var = "enemyTakesReducedExtraCritDamage", type = "count", label = "Enemy takes red. Extra Crit Damage:", tooltip = "'of Toughness'\nLow tier: 25-30%\nMid tier: 31-35%\nHigh tier: 36-40%" , apply = function(val, modList, enemyModList, mapModEffect)
-			if val ~= 0 then
-				enemyModList:NewMod("SelfCritMultiplier", "INC", -val * mapModEffect, "Config")
+		},
+		["enemyCanAvoidNonElementalAilment"] = {
+			type = "list",
+			tooltip = "'Impervious'",
+			apply = function(val, modList, enemyModList, mapModEffect)
+				local map = {20, 35, 50}
+				enemyModList:NewMod("AvoidPoison", "BASE", map[val] * mapModEffect, "Map mod Impervious")
+				enemyModList:NewMod("AvoidBleed", "BASE", map[val] * mapModEffect, "Map mod Impervious")
 			end
-		end }, label = "Enemy takes red. Extra Crit Damage:" },
-	}
+		},
+		["enemyHasIncreasedAccuracy"] = {
+			type = "list",
+			tooltip = "'of Miring'",
+			apply = function(val, modList, enemyModList, mapModEffect)
+				local map = {30, 40, 50}
+				modList:NewMod("DodgeChanceIsUnlucky", "FLAG", true, "Map mod of Miring")
+				enemyModList:NewMod("Accuracy", "INC", map[val] * mapModEffect, "Map mod of Miring")
+			end
+		},
+		["playerHasLessArmourAndBlock"] = {
+			type = "list",
+			tooltip = "'of Rust'",
+			apply = function(val, modList, enemyModList, mapModEffect)
+				local map = { {20, 20}, {30, 25}, {40, 30} }
+				modList:NewMod("BlockChance", "INC", -map[val][1] * mapModEffect, "Map mod of Rust")
+				modList:NewMod("Armour", "MORE", -map[val][2] * mapModEffect, "Map mod of Rust")
+			end
+		},
+		["playerHasPointBlank"] = {
+			type = "check",
+			tooltip = "'of Skirmishing'", 
+			apply = function(val, modList, enemyModList, mapModEffect)
+				modList:NewMod("Keystone", "LIST", "Point Blank", "Map mod of Skirmishing")
+			end
+		},
+		["playerHasLessLifeESRecovery"] = {
+			type = "list",
+			tooltip = "'of Smothering'",
+			apply = function(val, modList, enemyModList, mapModEffect)
+				local map = {20, 40, 60}
+				modList:NewMod("LifeRecoveryRate", "MORE", -map[val] * mapModEffect, "Map mod of Smothering")
+				modList:NewMod("EnergyShieldRecoveryRate", "MORE", -map[val] * mapModEffect, "Map mod of Smothering")
+			end
+		},
+		["playerCannotRegenLifeManaEnergyShield"] = {
+			type = "check",
+			label = "Cannot Regen ^xE05030Life^7, ^x7070FFMana ^7or ^x88FFFFES?", 
+			tooltip = "'of Stasis'", 
+			apply = function(val, modList, enemyModList, mapModEffect)
+				modList:NewMod("NoLifeRegen", "FLAG", true, "Map mod of Stasis")
+				modList:NewMod("NoEnergyShieldRegen", "FLAG", true, "Map mod of Stasis")
+				modList:NewMod("NoManaRegen", "FLAG", true, "Map mod of Stasis")
+			end
+		},
+		["enemyTakesReducedExtraCritDamage"] = {
+			type = "count",
+			tooltip = "'of Toughness'\nLow tier: 25-30%\nMid tier: 31-35%\nHigh tier: 36-40%",
+			apply = function(val, modList, enemyModList, mapModEffect)
+				local map = {30, 35, 40} -- Low tier: 25-30% / Mid tier: 31-35% / High tier: 36-40%"
+				enemyModList:NewMod("SelfCritMultiplier", "INC", -map[val] * mapModEffect, "Map mod of Toughness")
+			end
+		},
+	},
 }

--- a/src/Data/ModMap.lua
+++ b/src/Data/ModMap.lua
@@ -1,0 +1,97 @@
+-- This is currently made by hand but should be auto generated
+-- Item data (c) Grinding Gear Games
+
+return {
+	Prefix = {
+		{ val = "NONE", label = "None" },
+		{ val = { var = "enemyHasPhysicalReduction", type = "list", tooltip = "'Armoured'", label = "Enemy Physical Damage reduction:", list = {{val=0,label="None"},{val=20,label="20% (Low tier)"},{val=30,label="30% (Mid tier)"},{val=40,label="40% (High tier)"}}, apply = function(val, modList, enemyModList, mapModEffect)
+			enemyModList:NewMod("PhysicalDamageReduction", "BASE", val * mapModEffect, "Config")
+		end }, label = "Enemy Physical Damage reduction:" },
+		{ val = { var = "enemyIsHexproof", type = "check", tooltip = "'Hexproof'", apply = function(val, modList, enemyModList, mapModEffect)
+			enemyModList:NewMod("Hexproof", "FLAG", true, "Config")
+		end }, label = "Enemy is Hexproof?" },
+		{ val = { var = "enemyHasLessCurseEffectOnSelf", type = "list", tooltip = "'Hexwarded'", label = "Less effect of Curses on enemy:", list = {{val=0,label="None"},{val=25,label="25% (Low tier)"},{val=40,label="40% (Mid tier)"},{val=60,label="60% (High tier)"}}, apply = function(val, modList, enemyModList, mapModEffect)	
+			if val ~= 0 then
+				enemyModList:NewMod("CurseEffectOnSelf", "MORE", -val * mapModEffect, "Config")
+			end
+		end }, label = "Less effect of Curses on enemy:" },
+		{ val = { var = "enemyHasResistances", type = "list", tooltip = "'Resistant'", label = "Enemy has Elemental / ^xD02090Chaos ^7Resist:", list = {{val=0,label="None"},{val="LOW",label="20% / 15% (Low tier)"},{val="MID",label="30% / 20% (Mid tier)"},{val="HIGH",label="40% / 25% (High tier)"}}, apply = function(val, modList, enemyModList, mapModEffect)
+			local map = { ["LOW"] = {20,15}, ["MID"] = {30,20}, ["HIGH"] = {40,25} }
+			if map[val] then
+				enemyModList:NewMod("ElementalResist", "BASE", map[val][1] * mapModEffect, "Config")
+				enemyModList:NewMod("ChaosResist", "BASE", map[val][2] * mapModEffect, "Config")
+			end
+		end }, label = "Enemy has Elemental / ^xD02090Chaos ^7Resist:" },
+	},
+	Suffix = {
+		{ val = "NONE", label = "None" },
+		{ val = { var = "playerHasElementalEquilibrium", type = "check", label = "Player has Elemental Equilibrium?", tooltip = "'of Balance'", apply = function(val, modList, enemyModList, mapModEffect)
+			modList:NewMod("Keystone", "LIST", "Elemental Equilibrium", "Config")
+		end }, label = "Player has Elemental Equilibrium?" }, 
+		{ val = { var = "playerCannotLeech", type = "check", label = "Cannot Leech ^xE05030Life ^7/ ^x7070FFMana?", tooltip = "'of Congealment'", apply = function(val, modList, enemyModList, mapModEffect)
+			enemyModList:NewMod("CannotLeechLifeFromSelf", "FLAG", true, "Config")
+			enemyModList:NewMod("CannotLeechManaFromSelf", "FLAG", true, "Config")
+		end }, label = "Cannot Leech ^xE05030Life ^7/ ^x7070FFMana?" },
+		{ val = { var = "playerGainsReducedFlaskCharges", type = "list", label = "Gains reduced Flask Charges:", tooltip = "'of Drought'", list = {{val=0,label="None"},{val=30,label="30% (Low tier)"},{val=40,label="40% (Mid tier)"},{val=50,label="50% (High tier)"}}, apply = function(val, modList, enemyModList, mapModEffect)
+			if val ~= 0 then
+				modList:NewMod("FlaskChargesGained", "INC", -val * mapModEffect, "Config")
+			end
+		end }, label = "Gains reduced Flask Charges:" },
+		{ val = { var = "playerHasMinusMaxResist", type = "count", label = "-X% maximum Resistances:", tooltip = "'of Exposure'\nMid tier: 5-8%\nHigh tier: 9-12%", apply = function(val, modList, enemyModList, mapModEffect)
+			if val ~= 0 then
+				modList:NewMod("FireResistMax", "BASE", -val * mapModEffect, "Config")
+				modList:NewMod("ColdResistMax", "BASE", -val * mapModEffect, "Config")
+				modList:NewMod("LightningResistMax", "BASE", -val * mapModEffect, "Config")
+				modList:NewMod("ChaosResistMax", "BASE", -val * mapModEffect, "Config")
+			end
+		end }, label = "-X% maximum Resistances:" },
+		{ val = { var = "playerHasLessAreaOfEffect", type = "list", label = "Less Area of Effect:", tooltip = "'of Impotence'", list = {{val=0,label="None"},{val=15,label="15% (Low tier)"},{val=20,label="20% (Mid tier)"},{val=25,label="25% (High tier)"}}, apply = function(val, modList, enemyModList, mapModEffect)
+			if val ~= 0 then
+				modList:NewMod("AreaOfEffect", "MORE", -val * mapModEffect, "Config")
+			end
+		end }, label = "Less Area of Effect:" },
+		{ val = { var = "enemyCanAvoidElementalAilment", type = "list", label = "Enemy avoid Elemental Ailments:", tooltip = "'of Insulation'", list = {{val=0,label="None"},{val=30,label="30% (Low tier)"},{val=50,label="50% (Mid tier)"},{val=70,label="70% (High tier)"}}, apply = function(val, modList, enemyModList, mapModEffect)	
+			if val ~= 0 then
+				enemyModList:NewMod("AvoidElementalAilments", "BASE", val * mapModEffect, "Config")
+			end
+		end }, label = "Enemy avoid Elemental Ailments:" },
+		{ val = { var = "enemyCanAvoidNonElementalAilment", type = "list", label = "Enemy avoid Poison and Bleed:", tooltip = "'Impervious'", list = {{val=0,label="None"},{val=20,label="20% (Low tier)"},{val=35,label="35% (Mid tier)"},{val=50,label="50% (High tier)"}}, apply = function(val, modList, enemyModList, mapModEffect)	
+			if val ~= 0 then
+				enemyModList:NewMod("AvoidPoison", "BASE", val * mapModEffect, "Config")
+				enemyModList:NewMod("AvoidBleed", "BASE", val * mapModEffect, "Config")
+			end
+		end }, label = "Enemy avoid Poison and Bleed:" },
+		{ val = { var = "enemyHasIncreasedAccuracy", type = "list", label = "Unlucky Dodge / Enemy has inc. Accuracy:", tooltip = "'of Miring'", list = {{val=0,label="None"},{val=30,label="30% (Low tier)"},{val=40,label="40% (Mid tier)"},{val=50,label="50% (High tier)"}}, apply = function(val, modList, enemyModList, mapModEffect)
+			if val ~= 0 then
+				modList:NewMod("DodgeChanceIsUnlucky", "FLAG", true, "Config")
+				enemyModList:NewMod("Accuracy", "INC", val * mapModEffect, "Config")
+			end
+		end }, label = "Unlucky Dodge / Enemy has inc. Accuracy:" },
+		{ val = { var = "playerHasLessArmourAndBlock", type = "list", label = "Reduced Block Chance / less Armour:", tooltip = "'of Rust'", list = {{val=0,label="None"},{val="LOW",label="20% / 20% (Low tier)"},{val="MID",label="30% / 25% (Mid tier)"},{val="HIGH",label="40% / 30% (High tier)"}}, apply = function(val, modList, enemyModList, mapModEffect)
+			local map = { ["LOW"] = {20,20}, ["MID"] = {30,25}, ["HIGH"] = {40,30} }
+			if map[val] then
+				modList:NewMod("BlockChance", "INC", -map[val][1] * mapModEffect, "Config")
+				modList:NewMod("Armour", "MORE", -map[val][2] * mapModEffect, "Config")
+			end
+		end }, label = "Reduced Block Chance / less Armour:" },
+		{ val = { var = "playerHasPointBlank", type = "check", label = "Player has Point Blank?", tooltip = "'of Skirmishing'", apply = function(val, modList, enemyModList, mapModEffect)
+			modList:NewMod("Keystone", "LIST", "Point Blank", "Config")
+		end }, label = "Player has Point Blank?" },
+		{ val = { var = "playerHasLessLifeESRecovery", type = "list", label = "Less Recovery Rate of ^xE05030Life ^7and ^x88FFFFEnergy Shield:", tooltip = "'of Smothering'", list = {{val=0,label="None"},{val=20,label="20% (Low tier)"},{val=40,label="40% (Mid tier)"},{val=60,label="60% (High tier)"}}, apply = function(val, modList, enemyModList, mapModEffect)
+			if val ~= 0 then
+				modList:NewMod("LifeRecoveryRate", "MORE", -val * mapModEffect, "Config")
+				modList:NewMod("EnergyShieldRecoveryRate", "MORE", -val * mapModEffect, "Config")
+			end
+		end }, label = "Less Recovery Rate of ^xE05030Life ^7and ^x88FFFFEnergy Shield:" },
+		{ val = { var = "playerCannotRegenLifeManaEnergyShield", type = "check", label = "Cannot Regen ^xE05030Life^7, ^x7070FFMana ^7or ^x88FFFFES?", tooltip = "'of Stasis'", apply = function(val, modList, enemyModList, mapModEffect)
+			modList:NewMod("NoLifeRegen", "FLAG", true, "Config")
+			modList:NewMod("NoEnergyShieldRegen", "FLAG", true, "Config")
+			modList:NewMod("NoManaRegen", "FLAG", true, "Config")
+		end }, label = "Cannot Regen ^xE05030Life^7, ^x7070FFMana ^7or ^x88FFFFES?" },
+		{ val = { var = "enemyTakesReducedExtraCritDamage", type = "count", label = "Enemy takes red. Extra Crit Damage:", tooltip = "'of Toughness'\nLow tier: 25-30%\nMid tier: 31-35%\nHigh tier: 36-40%" , apply = function(val, modList, enemyModList, mapModEffect)
+			if val ~= 0 then
+				enemyModList:NewMod("SelfCritMultiplier", "INC", -val * mapModEffect, "Config")
+			end
+		end }, label = "Enemy takes red. Extra Crit Damage:" },
+	}
+}

--- a/src/Data/ModMap.lua
+++ b/src/Data/ModMap.lua
@@ -217,7 +217,7 @@ return {
 			end
 		},
 		["of Skirmishing"] = {
-			-- old map mod, doesnt exist anymore?
+			-- old map mod, doesn't exist anymore?
 			type = "check",
 			tooltipLines = { },
 			apply = function(val, mapModEffect, modList, enemyModList)

--- a/src/Modules/ConfigOptions.lua
+++ b/src/Modules/ConfigOptions.lua
@@ -57,33 +57,18 @@ Fill in the exact damage numbers if more precision is needed]])
 	end
 end
 
-local function mapAffixDropDownFunction(val, modList, enemyModList, build, dropDown, followingDropDown)
-	if val == "NONE" and followingDropDown and build.configTab.varControls[followingDropDown].list[build.configTab.varControls[followingDropDown].selIndex].val ~= "NONE" then
-		--[[ this is disabled becouse it causes weird things to happen
-		val = build.configTab.varControls[followingDropDown].list[build.configTab.varControls[followingDropDown].selIndex].val
-		build.configTab.varControls[dropDown].selIndex = build.configTab.varControls[followingDropDown].selIndex
-		build.configTab.varControls[followingDropDown].selIndex = 1
-		--]]
-		modList:NewMod("CONFIG_"..dropDown.."Active", "FLAG", true, "Config")
-	end
+local function mapAffixDropDownFunction(val, modList, enemyModList, build)
 	if val ~= "NONE" then
-		if val.type == "check" and val.apply then
-			val.apply(var, modList, enemyModList, (1 + (build.configTab.input['multiplierMapModEffect'] or 0)/100))
-		elseif val.type == "list" then
-			build.configTab.varControls[dropDown..'List'].list = val.list
-			build.configTab.varControls[dropDown..'List'].tooltipText = val.tooltip
-			if val.apply then
-				val.apply(build.configTab.varControls[dropDown..'List'].list[build.configTab.varControls[dropDown..'List'].selIndex].val, modList, enemyModList, (1 + (build.configTab.input['multiplierMapModEffect'] or 0)/100))
+		local affixData = data.mapMods.AffixData[val]
+		if affixData.apply then
+			if affixData.type == "check" then
+				affixData.apply(var, modList, enemyModList, (1 + (build.configTab.input['multiplierMapModEffect'] or 0)/100))
+			elseif affixData.type == "list" then
+				affixData.apply(4 - (build.configTab.varControls['multiplierMapModTier'].selIndex or 1), modList, enemyModList, (1 + (build.configTab.input['multiplierMapModEffect'] or 0)/100))
+			elseif affixData.type == "count" then
+				affixData.apply(4 - (build.configTab.varControls['multiplierMapModTier'].selIndex or 1), modList, enemyModList, (1 + (build.configTab.input['multiplierMapModEffect'] or 0)/100))
 			end
-			modList:NewMod("CONFIG_"..dropDown.."ListActive", "FLAG", true, "Config")
-		elseif val.type == "count" then
-			build.configTab.varControls[dropDown..'Count'].tooltipText = val.tooltip
-			if val.apply then
-				val.apply((build.configTab.input[dropDown..'Count'] or 0), modList, enemyModList, (1 + (build.configTab.input['multiplierMapModEffect'] or 0)/100))
-			end
-			modList:NewMod("CONFIG_"..dropDown.."CountActive", "FLAG", true, "Config")
 		end
-		modList:NewMod("CONFIG_"..dropDown.."Active", "FLAG", true, "Config")
 	end
 end
 
@@ -520,48 +505,17 @@ Huge sets the radius to 11.
 		modList:NewMod("Multiplier:Sextant", "BASE", m_min(val, 5), "Config")
 	end },
 	{ var = "multiplierMapModEffect", type = "count", label = "% increased effect of map mods" },
+	{ var = "multiplierMapModTier", type = "list", label = "Map Tier", list = { {val = "HIGH", label = "red"}, {val = "MED", label = "yellow"}, {val = "LOW", label = "white"} } },
 	{ label = "Map Prefix Modifiers:" },
-	{ var = "Prefix1", type = "list", label = "Prefix 1", list = data.mapMods.Prefix, apply = function(val, modList, enemyModList, build)
-		mapAffixDropDownFunction(val, modList, enemyModList, build, "Prefix1", "Prefix2")
-	end },
-	{ var = "Prefix1List", type = "list", label = "Prefix1List", ifFlag = "CONFIG_Prefix1ListActive", list = { {val = "NONE", label = "None"} } },
-	{ var = "Prefix1Count", type = "count", label = "Prefix1Count", ifFlag = "CONFIG_Prefix1CountActive" },
-	{ var = "Prefix2", type = "list", label = "Prefix 2", ifFlag = "CONFIG_Prefix1Active", list = data.mapMods.Prefix, apply = function(val, modList, enemyModList, build)
-		mapAffixDropDownFunction(val, modList, enemyModList, build, "Prefix2", "Prefix3")
-	end },
-	{ var = "Prefix2List", type = "list", label = "Prefix2List", ifFlag = "CONFIG_Prefix2ListActive", list = { {val = "NONE", label = "None"} } },
-	{ var = "Prefix2Count", type = "count", label = "Prefix2Count", ifFlag = "CONFIG_Prefix2CountActive" },
-	{ var = "Prefix3", type = "list", label = "Prefix 3", ifFlag = "CONFIG_Prefix2Active", list = data.mapMods.Prefix, apply = function(val, modList, enemyModList, build)
-		mapAffixDropDownFunction(val, modList, enemyModList, build, "Prefix3", "Prefix4")
-	end },
-	{ var = "Prefix3List", type = "list", label = "Prefix3List", ifFlag = "CONFIG_Prefix3ListActive", list = { {val = "NONE", label = "None"} } },
-	{ var = "Prefix3Count", type = "count", label = "Prefix3Count", ifFlag = "CONFIG_Prefix3CountActive" },
-	{ var = "Prefix4", type = "list", label = "Prefix 4", ifFlag = "CONFIG_Prefix3Active", list = data.mapMods.Prefix, apply = function(val, modList, enemyModList, build)
-		mapAffixDropDownFunction(val, modList, enemyModList, build, "Prefix4")
-	end },
-	{ var = "Prefix4List", type = "list", label = "Prefix4List", ifFlag = "CONFIG_Prefix4ListActive", list = { {val = "NONE", label = "None"} } },
-	{ var = "Prefix4Count", type = "count", label = "Prefix4Count", ifFlag = "CONFIG_Prefix4CountActive" },
+	{ var = "MapPrefix1", type = "list", label = "Prefix 1", list = data.mapMods.Prefix, apply = mapAffixDropDownFunction },
+	{ var = "MapPrefix2", type = "list", label = "Prefix 2", list = data.mapMods.Prefix, apply = mapAffixDropDownFunction },
+	{ var = "MapPrefix3", type = "list", label = "Prefix 3", list = data.mapMods.Prefix, apply = mapAffixDropDownFunction },
+	{ var = "MapPrefix4", type = "list", label = "Prefix 4", list = data.mapMods.Prefix, apply = mapAffixDropDownFunction },
 	{ label = "Map Suffix Modifiers:" },
-	{ var = "Suffix1", type = "list", label = "Suffix 1", list = data.mapMods.Suffix, apply = function(val, modList, enemyModList, build)
-		mapAffixDropDownFunction(val, modList, enemyModList, build, "Suffix1", "Suffix2")
-	end },
-	{ var = "Suffix1List", type = "list", label = "Suffix1List", ifFlag = "CONFIG_Suffix1ListActive", list = { {val = "NONE", label = "None"} } },
-	{ var = "Suffix1Count", type = "count", label = "Suffix1Count", ifFlag = "CONFIG_Suffix1CountActive" },
-	{ var = "Suffix2", type = "list", label = "Suffix 2", ifFlag = "CONFIG_Suffix1Active", list = data.mapMods.Suffix, apply = function(val, modList, enemyModList, build)
-		mapAffixDropDownFunction(val, modList, enemyModList, build, "Suffix2", "Suffix3")
-	end },
-	{ var = "Suffix2List", type = "list", label = "Suffix2List", ifFlag = "CONFIG_Suffix2ListActive", list = { {val = "NONE", label = "None"} } },
-	{ var = "Suffix2Count", type = "count", label = "Suffix2Count", ifFlag = "CONFIG_Suffix2CountActive" },
-	{ var = "Suffix3", type = "list", label = "Suffix 3", ifFlag = "CONFIG_Suffix2Active", list = data.mapMods.Suffix, apply = function(val, modList, enemyModList, build)
-		mapAffixDropDownFunction(val, modList, enemyModList, build, "Suffix3", "Suffix4")
-	end },
-	{ var = "Suffix3List", type = "list", label = "Suffix3List", ifFlag = "CONFIG_Suffix3ListActive", list = { {val = "NONE", label = "None"} } },
-	{ var = "Suffix3Count", type = "count", label = "Suffix3Count", ifFlag = "CONFIG_Suffix3CountActive" },
-	{ var = "Suffix4", type = "list", label = "Suffix 4", ifFlag = "CONFIG_Suffix3Active", list = data.mapMods.Suffix, apply = function(val, modList, enemyModList, build)
-		mapAffixDropDownFunction(val, modList, enemyModList, build, "Suffix4")
-	end },
-	{ var = "Suffix4List", type = "list", label = "Suffix4List", ifFlag = "CONFIG_Suffix4ListActive", list = { {val = "NONE", label = "None"} } },
-	{ var = "Suffix4Count", type = "count", label = "Suffix4Count", ifFlag = "CONFIG_Suffix4CountActive" },
+	{ var = "MapSuffix1", type = "list", label = "Suffix 1", list = data.mapMods.Suffix, apply = mapAffixDropDownFunction },
+	{ var = "MapSuffix2", type = "list", label = "Suffix 2", list = data.mapMods.Suffix, apply = mapAffixDropDownFunction },
+	{ var = "MapSuffix3", type = "list", label = "Suffix 3", list = data.mapMods.Suffix, apply = mapAffixDropDownFunction },
+	{ var = "MapSuffix4", type = "list", label = "Suffix 4", list = data.mapMods.Suffix, apply = mapAffixDropDownFunction },
 	{ label = "Unique Map Modifiers:" },
 	{ var = "PvpScaling", type = "check", label = "PvP damage scaling in effect", tooltip = "'Hall of Grandmasters'", apply = function(val, modList, enemyModList)
 		modList:NewMod("HasPvpScaling", "FLAG", true, "Config")

--- a/src/Modules/ConfigOptions.lua
+++ b/src/Modules/ConfigOptions.lua
@@ -57,6 +57,36 @@ Fill in the exact damage numbers if more precision is needed]])
 	end
 end
 
+local function mapAffixDropDownFunction(val, modList, enemyModList, build, dropDown, followingDropDown)
+	if val == "NONE" and followingDropDown and build.configTab.varControls[followingDropDown].list[build.configTab.varControls[followingDropDown].selIndex].val ~= "NONE" then
+		--[[ this is disabled becouse it causes weird things to happen
+		val = build.configTab.varControls[followingDropDown].list[build.configTab.varControls[followingDropDown].selIndex].val
+		build.configTab.varControls[dropDown].selIndex = build.configTab.varControls[followingDropDown].selIndex
+		build.configTab.varControls[followingDropDown].selIndex = 1
+		--]]
+		modList:NewMod("CONFIG_"..dropDown.."Active", "FLAG", true, "Config")
+	end
+	if val ~= "NONE" then
+		if val.type == "check" and val.apply then
+			val.apply(var, modList, enemyModList, (1 + (build.configTab.input['multiplierMapModEffect'] or 0)/100))
+		elseif val.type == "list" then
+			build.configTab.varControls[dropDown..'List'].list = val.list
+			build.configTab.varControls[dropDown..'List'].tooltipText = val.tooltip
+			if val.apply then
+				val.apply(build.configTab.varControls[dropDown..'List'].list[build.configTab.varControls[dropDown..'List'].selIndex].val, modList, enemyModList, (1 + (build.configTab.input['multiplierMapModEffect'] or 0)/100))
+			end
+			modList:NewMod("CONFIG_"..dropDown.."ListActive", "FLAG", true, "Config")
+		elseif val.type == "count" then
+			build.configTab.varControls[dropDown..'Count'].tooltipText = val.tooltip
+			if val.apply then
+				val.apply((build.configTab.input[dropDown..'Count'] or 0), modList, enemyModList, (1 + (build.configTab.input['multiplierMapModEffect'] or 0)/100))
+			end
+			modList:NewMod("CONFIG_"..dropDown.."CountActive", "FLAG", true, "Config")
+		end
+		modList:NewMod("CONFIG_"..dropDown.."Active", "FLAG", true, "Config")
+	end
+end
+
 return {
 	-- Section: General options
 	{ section = "General", col = 1 },
@@ -486,97 +516,52 @@ Huge sets the radius to 11.
 
 	-- Section: Map modifiers/curses
 	{ section = "Map Modifiers and Player Debuffs", col = 2 },
-	{ label = "Map Prefix Modifiers:" },
-	{ var = "enemyHasPhysicalReduction", type = "list", label = "Enemy Physical Damage reduction:", tooltip = "'Armoured'", list = {{val=0,label="None"},{val=20,label="20% (Low tier)"},{val=30,label="30% (Mid tier)"},{val=40,label="40% (High tier)"}}, apply = function(val, modList, enemyModList)	
-		enemyModList:NewMod("PhysicalDamageReduction", "BASE", val, "Config")
-	end },
-	{ var = "enemyIsHexproof", type = "check", label = "Enemy is Hexproof?", tooltip = "'Hexproof'", apply = function(val, modList, enemyModList)
-		enemyModList:NewMod("Hexproof", "FLAG", true, "Config")
-	end },
-	{ var = "enemyHasLessCurseEffectOnSelf", type = "list", label = "Less effect of Curses on enemy:", tooltip = "'Hexwarded'", list = {{val=0,label="None"},{val=25,label="25% (Low tier)"},{val=40,label="40% (Mid tier)"},{val=60,label="60% (High tier)"}}, apply = function(val, modList, enemyModList)	
-		if val ~= 0 then
-			enemyModList:NewMod("CurseEffectOnSelf", "MORE", -val, "Config")
-		end
-	end },
-	{ var = "enemyHasResistances", type = "list", label = "Enemy has Elemental / ^xD02090Chaos ^7Resist:", tooltip = "'Resistant'", list = {{val=0,label="None"},{val="LOW",label="20% / 15% (Low tier)"},{val="MID",label="30% / 20% (Mid tier)"},{val="HIGH",label="40% / 25% (High tier)"}}, apply = function(val, modList, enemyModList)
-		local map = { ["LOW"] = {20,15}, ["MID"] = {30,20}, ["HIGH"] = {40,25} }
-		if map[val] then
-			enemyModList:NewMod("ElementalResist", "BASE", map[val][1], "Config")
-			enemyModList:NewMod("ChaosResist", "BASE", map[val][2], "Config")
-		end
-	end },
-	{ label = "Map Suffix Modifiers:" },
-	{ var = "playerHasElementalEquilibrium", type = "check", label = "Player has Elemental Equilibrium?", tooltip = "'of Balance'", apply = function(val, modList, enemyModList)
-		modList:NewMod("Keystone", "LIST", "Elemental Equilibrium", "Config")
-	end },
-	{ var = "playerCannotLeech", type = "check", label = "Cannot Leech ^xE05030Life ^7/ ^x7070FFMana?", tooltip = "'of Congealment'", apply = function(val, modList, enemyModList)
-		enemyModList:NewMod("CannotLeechLifeFromSelf", "FLAG", true, "Config")
-		enemyModList:NewMod("CannotLeechManaFromSelf", "FLAG", true, "Config")
-	end },
-	{ var = "playerGainsReducedFlaskCharges", type = "list", label = "Gains reduced Flask Charges:", tooltip = "'of Drought'", list = {{val=0,label="None"},{val=30,label="30% (Low tier)"},{val=40,label="40% (Mid tier)"},{val=50,label="50% (High tier)"}}, apply = function(val, modList, enemyModList)
-		if val ~= 0 then
-			modList:NewMod("FlaskChargesGained", "INC", -val, "Config")
-		end
-	end },
-	{ var = "playerHasMinusMaxResist", type = "count", label = "-X% maximum Resistances:", tooltip = "'of Exposure'\nMid tier: 5-8%\nHigh tier: 9-12%", apply = function(val, modList, enemyModList)
-		if val ~= 0 then
-			modList:NewMod("FireResistMax", "BASE", -val, "Config")
-			modList:NewMod("ColdResistMax", "BASE", -val, "Config")
-			modList:NewMod("LightningResistMax", "BASE", -val, "Config")
-			modList:NewMod("ChaosResistMax", "BASE", -val, "Config")
-		end
-	end },
-	{ var = "playerHasLessAreaOfEffect", type = "list", label = "Less Area of Effect:", tooltip = "'of Impotence'", list = {{val=0,label="None"},{val=15,label="15% (Low tier)"},{val=20,label="20% (Mid tier)"},{val=25,label="25% (High tier)"}}, apply = function(val, modList, enemyModList)
-		if val ~= 0 then
-			modList:NewMod("AreaOfEffect", "MORE", -val, "Config")
-		end
-	end },
-	{ var = "enemyCanAvoidElementalAilment", type = "list", label = "Enemy avoid Elemental Ailments:", tooltip = "'of Insulation'", list = {{val=0,label="None"},{val=30,label="30% (Low tier)"},{val=50,label="50% (Mid tier)"},{val=70,label="70% (High tier)"}}, apply = function(val, modList, enemyModList)	
-		if val ~= 0 then
-			enemyModList:NewMod("AvoidElementalAilments", "BASE", val, "Config")
-		end
-	end },
-	{ var = "enemyCanAvoidNonElementalAilment", type = "list", label = "Enemy avoid Poison and Bleed:", tooltip = "'Impervious'", list = {{val=0,label="None"},{val=20,label="20% (Low tier)"},{val=35,label="35% (Mid tier)"},{val=50,label="50% (High tier)"}}, apply = function(val, modList, enemyModList)	
-		if val ~= 0 then
-			enemyModList:NewMod("AvoidPoison", "BASE", val, "Config")
-			enemyModList:NewMod("AvoidBleed", "BASE", val, "Config")
-		end
-	end },
-	{ var = "enemyHasIncreasedAccuracy", type = "list", label = "Unlucky Dodge / Enemy has inc. Accuracy:", tooltip = "'of Miring'", list = {{val=0,label="None"},{val=30,label="30% (Low tier)"},{val=40,label="40% (Mid tier)"},{val=50,label="50% (High tier)"}}, apply = function(val, modList, enemyModList)
-		if val ~= 0 then
-			modList:NewMod("DodgeChanceIsUnlucky", "FLAG", true, "Config")
-			enemyModList:NewMod("Accuracy", "INC", val, "Config")
-		end
-	end },
-	{ var = "playerHasLessArmourAndBlock", type = "list", label = "Reduced Block Chance / less Armour:", tooltip = "'of Rust'", list = {{val=0,label="None"},{val="LOW",label="20% / 20% (Low tier)"},{val="MID",label="30% / 25% (Mid tier)"},{val="HIGH",label="40% / 30% (High tier)"}}, apply = function(val, modList, enemyModList)
-		local map = { ["LOW"] = {20,20}, ["MID"] = {30,25}, ["HIGH"] = {40,30} }
-		if map[val] then
-			modList:NewMod("BlockChance", "INC", -map[val][1], "Config")
-			modList:NewMod("Armour", "MORE", -map[val][2], "Config")
-		end
-	end },
-	{ var = "playerHasPointBlank", type = "check", label = "Player has Point Blank?", tooltip = "'of Skirmishing'", apply = function(val, modList, enemyModList)
-		modList:NewMod("Keystone", "LIST", "Point Blank", "Config")
-	end },
-	{ var = "playerHasLessLifeESRecovery", type = "list", label = "Less Recovery Rate of ^xE05030Life ^7and ^x88FFFFEnergy Shield:", tooltip = "'of Smothering'", list = {{val=0,label="None"},{val=20,label="20% (Low tier)"},{val=40,label="40% (Mid tier)"},{val=60,label="60% (High tier)"}}, apply = function(val, modList, enemyModList)
-		if val ~= 0 then
-			modList:NewMod("LifeRecoveryRate", "MORE", -val, "Config")
-			modList:NewMod("EnergyShieldRecoveryRate", "MORE", -val, "Config")
-		end
-	end },
-	{ var = "playerCannotRegenLifeManaEnergyShield", type = "check", label = "Cannot Regen ^xE05030Life^7, ^x7070FFMana ^7or ^x88FFFFES?", tooltip = "'of Stasis'", apply = function(val, modList, enemyModList)
-		modList:NewMod("NoLifeRegen", "FLAG", true, "Config")
-		modList:NewMod("NoEnergyShieldRegen", "FLAG", true, "Config")
-		modList:NewMod("NoManaRegen", "FLAG", true, "Config")
-	end },
-	{ var = "enemyTakesReducedExtraCritDamage", type = "count", label = "Enemy takes red. Extra Crit Damage:", tooltip = "'of Toughness'\nLow tier: 25-30%\nMid tier: 31-35%\nHigh tier: 36-40%" , apply = function(val, modList, enemyModList)
-		if val ~= 0 then
-			enemyModList:NewMod("SelfCritMultiplier", "INC", -val, "Config")
-		end
-	end },
 	{ var = "multiplierSextant", type = "count", label = "# of Sextants affecting the area", ifMult = "Sextant", apply = function(val, modList, enemyModList)
 		modList:NewMod("Multiplier:Sextant", "BASE", m_min(val, 5), "Config")
 	end },
+	{ var = "multiplierMapModEffect", type = "count", label = "% increased effect of map mods" },
+	{ label = "Map Prefix Modifiers:" },
+	{ var = "Prefix1", type = "list", label = "Prefix 1", list = data.mapMods.Prefix, apply = function(val, modList, enemyModList, build)
+		mapAffixDropDownFunction(val, modList, enemyModList, build, "Prefix1", "Prefix2")
+	end },
+	{ var = "Prefix1List", type = "list", label = "Prefix1List", ifFlag = "CONFIG_Prefix1ListActive", list = { {val = "NONE", label = "None"} } },
+	{ var = "Prefix1Count", type = "count", label = "Prefix1Count", ifFlag = "CONFIG_Prefix1CountActive" },
+	{ var = "Prefix2", type = "list", label = "Prefix 2", ifFlag = "CONFIG_Prefix1Active", list = data.mapMods.Prefix, apply = function(val, modList, enemyModList, build)
+		mapAffixDropDownFunction(val, modList, enemyModList, build, "Prefix2", "Prefix3")
+	end },
+	{ var = "Prefix2List", type = "list", label = "Prefix2List", ifFlag = "CONFIG_Prefix2ListActive", list = { {val = "NONE", label = "None"} } },
+	{ var = "Prefix2Count", type = "count", label = "Prefix2Count", ifFlag = "CONFIG_Prefix2CountActive" },
+	{ var = "Prefix3", type = "list", label = "Prefix 3", ifFlag = "CONFIG_Prefix2Active", list = data.mapMods.Prefix, apply = function(val, modList, enemyModList, build)
+		mapAffixDropDownFunction(val, modList, enemyModList, build, "Prefix3", "Prefix4")
+	end },
+	{ var = "Prefix3List", type = "list", label = "Prefix3List", ifFlag = "CONFIG_Prefix3ListActive", list = { {val = "NONE", label = "None"} } },
+	{ var = "Prefix3Count", type = "count", label = "Prefix3Count", ifFlag = "CONFIG_Prefix3CountActive" },
+	{ var = "Prefix4", type = "list", label = "Prefix 4", ifFlag = "CONFIG_Prefix3Active", list = data.mapMods.Prefix, apply = function(val, modList, enemyModList, build)
+		mapAffixDropDownFunction(val, modList, enemyModList, build, "Prefix4")
+	end },
+	{ var = "Prefix4List", type = "list", label = "Prefix4List", ifFlag = "CONFIG_Prefix4ListActive", list = { {val = "NONE", label = "None"} } },
+	{ var = "Prefix4Count", type = "count", label = "Prefix4Count", ifFlag = "CONFIG_Prefix4CountActive" },
+	{ label = "Map Suffix Modifiers:" },
+	{ var = "Suffix1", type = "list", label = "Suffix 1", list = data.mapMods.Suffix, apply = function(val, modList, enemyModList, build)
+		mapAffixDropDownFunction(val, modList, enemyModList, build, "Suffix1", "Suffix2")
+	end },
+	{ var = "Suffix1List", type = "list", label = "Suffix1List", ifFlag = "CONFIG_Suffix1ListActive", list = { {val = "NONE", label = "None"} } },
+	{ var = "Suffix1Count", type = "count", label = "Suffix1Count", ifFlag = "CONFIG_Suffix1CountActive" },
+	{ var = "Suffix2", type = "list", label = "Suffix 2", ifFlag = "CONFIG_Suffix1Active", list = data.mapMods.Suffix, apply = function(val, modList, enemyModList, build)
+		mapAffixDropDownFunction(val, modList, enemyModList, build, "Suffix2", "Suffix3")
+	end },
+	{ var = "Suffix2List", type = "list", label = "Suffix2List", ifFlag = "CONFIG_Suffix2ListActive", list = { {val = "NONE", label = "None"} } },
+	{ var = "Suffix2Count", type = "count", label = "Suffix2Count", ifFlag = "CONFIG_Suffix2CountActive" },
+	{ var = "Suffix3", type = "list", label = "Suffix 3", ifFlag = "CONFIG_Suffix2Active", list = data.mapMods.Suffix, apply = function(val, modList, enemyModList, build)
+		mapAffixDropDownFunction(val, modList, enemyModList, build, "Suffix3", "Suffix4")
+	end },
+	{ var = "Suffix3List", type = "list", label = "Suffix3List", ifFlag = "CONFIG_Suffix3ListActive", list = { {val = "NONE", label = "None"} } },
+	{ var = "Suffix3Count", type = "count", label = "Suffix3Count", ifFlag = "CONFIG_Suffix3CountActive" },
+	{ var = "Suffix4", type = "list", label = "Suffix 4", ifFlag = "CONFIG_Suffix3Active", list = data.mapMods.Suffix, apply = function(val, modList, enemyModList, build)
+		mapAffixDropDownFunction(val, modList, enemyModList, build, "Suffix4")
+	end },
+	{ var = "Suffix4List", type = "list", label = "Suffix4List", ifFlag = "CONFIG_Suffix4ListActive", list = { {val = "NONE", label = "None"} } },
+	{ var = "Suffix4Count", type = "count", label = "Suffix4Count", ifFlag = "CONFIG_Suffix4CountActive" },
 	{ label = "Unique Map Modifiers:" },
 	{ var = "PvpScaling", type = "check", label = "PvP damage scaling in effect", tooltip = "'Hall of Grandmasters'", apply = function(val, modList, enemyModList)
 		modList:NewMod("HasPvpScaling", "FLAG", true, "Config")

--- a/src/Modules/ConfigOptions.lua
+++ b/src/Modules/ConfigOptions.lua
@@ -6,6 +6,7 @@
 
 local m_min = math.min
 local m_max = math.max
+local s_format = string.format
 
 local function applyPantheonDescription(tooltip, mode, index, value)
 	tooltip:Clear()
@@ -57,16 +58,59 @@ Fill in the exact damage numbers if more precision is needed]])
 	end
 end
 
+local function mapAffixTooltip(tooltip, mode, index, value)
+	tooltip:Clear()
+	if value.val == "NONE" then
+		return
+	end
+	local applyModes = { BODY = true, HOVER = true }
+	if applyModes[mode] then
+		tooltip:AddLine(14, '^7'..value.val)
+		local affixData = data.mapMods.AffixData[value.val] or {}
+		if #affixData.tooltipLines > 0 then
+			if affixData.type == "check" then
+				for _, line in ipairs(affixData.tooltipLines) do
+					tooltip:AddLine(14, '^7'..line)
+				end
+			elseif affixData.type == "list" then
+				for i, tier in ipairs({"Low", "Med", "High"}) do
+					tooltip:AddLine(16, '^7'..tier..": ")
+					for j, line in ipairs(affixData.tooltipLines) do
+						local modValue = (#affixData.tooltipLines > 1) and affixData.values[i][j] or affixData.values[i]
+						if modValue == nil then
+							tooltip:AddLine(14, '   ^7'..line)
+						elseif modValue ~= 0 then
+							tooltip:AddLine(14, '   ^7'..s_format(line, modValue))
+						end
+					end
+				end
+			elseif affixData.type == "count" then
+				for i, tier in ipairs({"Low", "Med", "High"}) do
+					tooltip:AddLine(16, '^7'..tier..": ")
+					for j, line in ipairs(affixData.tooltipLines) do
+						local modValue = {(#affixData.tooltipLines > 1) and (affixData.values[i][j] and affixData.values[i][j][1] or nil) or affixData.values[i][1], (#affixData.tooltipLines > 1) and (affixData.values[i][j] and affixData.values[i][j][2] or nil) or affixData.values[i][2]}
+						if modValue[2] == nil then
+							tooltip:AddLine(14, '   ^7'..line)
+						elseif modValue[2] ~= 0 then
+							tooltip:AddLine(14, '   ^7'..s_format(line, modValue[1], modValue[2]))
+						end
+					end
+				end
+			end
+		end
+	end
+end
+
 local function mapAffixDropDownFunction(val, modList, enemyModList, build)
 	if val ~= "NONE" then
 		local affixData = data.mapMods.AffixData[val] or {}
 		if affixData.apply then
 			if affixData.type == "check" then
-				affixData.apply(var, modList, enemyModList, (1 + (build.configTab.input['multiplierMapModEffect'] or 0)/100))
+				affixData.apply(var, (1 + (build.configTab.input['multiplierMapModEffect'] or 0)/100), modList, enemyModList)
 			elseif affixData.type == "list" then
-				affixData.apply(4 - (build.configTab.varControls['multiplierMapModTier'].selIndex or 1), modList, enemyModList, (1 + (build.configTab.input['multiplierMapModEffect'] or 0)/100))
+				affixData.apply(4 - (build.configTab.varControls['multiplierMapModTier'].selIndex or 1), (1 + (build.configTab.input['multiplierMapModEffect'] or 0)/100), affixData.values, modList, enemyModList)
 			elseif affixData.type == "count" then
-				affixData.apply(4 - (build.configTab.varControls['multiplierMapModTier'].selIndex or 1), modList, enemyModList, (1 + (build.configTab.input['multiplierMapModEffect'] or 0)/100))
+				affixData.apply(4 - (build.configTab.varControls['multiplierMapModTier'].selIndex or 1), 100, (1 + (build.configTab.input['multiplierMapModEffect'] or 0)/100), affixData.values, modList, enemyModList)
 			end
 		end
 	end
@@ -507,15 +551,15 @@ Huge sets the radius to 11.
 	{ var = "multiplierMapModEffect", type = "count", label = "% increased effect of map mods" },
 	{ var = "multiplierMapModTier", type = "list", label = "Map Tier", list = { {val = "HIGH", label = "red"}, {val = "MED", label = "yellow"}, {val = "LOW", label = "white"} } },
 	{ label = "Map Prefix Modifiers:" },
-	{ var = "MapPrefix1", type = "list", label = "Prefix 1", list = data.mapMods.Prefix, apply = mapAffixDropDownFunction },
-	{ var = "MapPrefix2", type = "list", label = "Prefix 2", list = data.mapMods.Prefix, apply = mapAffixDropDownFunction },
-	{ var = "MapPrefix3", type = "list", label = "Prefix 3", list = data.mapMods.Prefix, apply = mapAffixDropDownFunction },
-	{ var = "MapPrefix4", type = "list", label = "Prefix 4", list = data.mapMods.Prefix, apply = mapAffixDropDownFunction },
+	{ var = "MapPrefix1", type = "list", label = "Prefix 1", tooltipFunc = mapAffixTooltip, list = data.mapMods.Prefix, apply = mapAffixDropDownFunction },
+	{ var = "MapPrefix2", type = "list", label = "Prefix 2", tooltipFunc = mapAffixTooltip, list = data.mapMods.Prefix, apply = mapAffixDropDownFunction },
+	{ var = "MapPrefix3", type = "list", label = "Prefix 3", tooltipFunc = mapAffixTooltip, list = data.mapMods.Prefix, apply = mapAffixDropDownFunction },
+	{ var = "MapPrefix4", type = "list", label = "Prefix 4", tooltipFunc = mapAffixTooltip, list = data.mapMods.Prefix, apply = mapAffixDropDownFunction },
 	{ label = "Map Suffix Modifiers:" },
-	{ var = "MapSuffix1", type = "list", label = "Suffix 1", list = data.mapMods.Suffix, apply = mapAffixDropDownFunction },
-	{ var = "MapSuffix2", type = "list", label = "Suffix 2", list = data.mapMods.Suffix, apply = mapAffixDropDownFunction },
-	{ var = "MapSuffix3", type = "list", label = "Suffix 3", list = data.mapMods.Suffix, apply = mapAffixDropDownFunction },
-	{ var = "MapSuffix4", type = "list", label = "Suffix 4", list = data.mapMods.Suffix, apply = mapAffixDropDownFunction },
+	{ var = "MapSuffix1", type = "list", label = "Suffix 1", tooltipFunc = mapAffixTooltip, list = data.mapMods.Suffix, apply = mapAffixDropDownFunction },
+	{ var = "MapSuffix2", type = "list", label = "Suffix 2", tooltipFunc = mapAffixTooltip, list = data.mapMods.Suffix, apply = mapAffixDropDownFunction },
+	{ var = "MapSuffix3", type = "list", label = "Suffix 3", tooltipFunc = mapAffixTooltip, list = data.mapMods.Suffix, apply = mapAffixDropDownFunction },
+	{ var = "MapSuffix4", type = "list", label = "Suffix 4", tooltipFunc = mapAffixTooltip, list = data.mapMods.Suffix, apply = mapAffixDropDownFunction },
 	{ label = "Unique Map Modifiers:" },
 	{ var = "PvpScaling", type = "check", label = "PvP damage scaling in effect", tooltip = "'Hall of Grandmasters'", apply = function(val, modList, enemyModList)
 		modList:NewMod("HasPvpScaling", "FLAG", true, "Config")

--- a/src/Modules/ConfigOptions.lua
+++ b/src/Modules/ConfigOptions.lua
@@ -59,7 +59,7 @@ end
 
 local function mapAffixDropDownFunction(val, modList, enemyModList, build)
 	if val ~= "NONE" then
-		local affixData = data.mapMods.AffixData[val]
+		local affixData = data.mapMods.AffixData[val] or {}
 		if affixData.apply then
 			if affixData.type == "check" then
 				affixData.apply(var, modList, enemyModList, (1 + (build.configTab.input['multiplierMapModEffect'] or 0)/100))

--- a/src/Modules/Data.lua
+++ b/src/Modules/Data.lua
@@ -598,6 +598,7 @@ do
 	end
 	setmetatable(data.costs, { __index = function(t, k) return t[map[k]] end })
 end
+data.mapMods = LoadModule("Data/ModMap")
 
 -- Cluster jewel data
 data.clusterJewels = LoadModule("Data/ClusterJewels")


### PR DESCRIPTION
Instead of each mapmod having its own input, this allows you to select up to 4 prefixes and 4 suffixes, as well as what map tier the map is from, and the map mod effect (from atlas tree)

![image](https://user-images.githubusercontent.com/49933620/223970116-135acff8-af10-47aa-8458-6781a34acd09.png)


This also adds more map mods, 


future improvements may include:
- supporting more map mods, 
- exporting the map mods rather than being manually maintained,
- allowing the end user to input the rollrange of the mods that roll,
- hiding mods which cannot showup for a given tier,
- and maybe changing the labels of the prefixes/suffixes to be the label of the mod selected rather than the basic "prefix"/"suffix"