### PR TITLE
Fix skill sets sometimes being deleted after deleting first one

### DIFF
--- a/src/Classes/SkillsTab.lua
+++ b/src/Classes/SkillsTab.lua
@@ -369,13 +369,13 @@ function SkillsTabClass:Load(xml, fileName)
 	for _, node in ipairs(xml) do
 		if node.elem == "Skill" then
 			-- Old format, initialize skill sets if needed
-			if #self.skillSetOrderList == 0 or #self.skillSets == 0 then
-				self.skillSetOrderList = { 1 }
+			if not self.skillSetOrderList[1] then
+				self.skillSetOrderList[1] = 1
 				self:NewSkillSet(1)
 			end
+			self:LoadSkill(node, 1)
 		end
 
-		self:LoadSkill(node, 1)
 		if node.elem == "SkillSet" then
 			local skillSet = self:NewSkillSet(tonumber(node.attrib.id))
 			skillSet.title = node.attrib.title
@@ -1246,7 +1246,7 @@ function SkillsTabClass:RestoreUndoState(state)
 		self.skillSets[k] = v
 	end
 	wipeTable(self.skillSetOrderList)
-	for k, v in pairs(state.skillSetOrderList) do
+	for k, v in ipairs(state.skillSetOrderList) do
 		self.skillSetOrderList[k] = v
 	end
 	self:SetActiveSkillSet(state.activeSkillSetId)
@@ -1285,8 +1285,8 @@ end
 -- Changes the active skill set
 function SkillsTabClass:SetActiveSkillSet(skillSetId)
 	-- Initialize skill sets if needed
-	if #self.skillSetOrderList == 0 or #self.skillSets == 0 then
-		self.skillSetOrderList = { 1 }
+	if not self.skillSetOrderList[1] then
+		self.skillSetOrderList[1] = 1
 		self:NewSkillSet(1)
 	end
 


### PR DESCRIPTION
On load, if first active skill set did not had id 1 new empty skill set was created and data was lost. Then on save most/all skill sets could be wiped like this.

### Steps taken to verify a working solution:
- Load PoB with first skill set not having id 1
- The skill set should still be present with its name preserved
- Save pob, see that skill set id is still its original ID
- Load pob again, see it still being there

### Link to a build that showcases this PR:

https://pobb.in/VFyFoOxCXlrT
