### PR TITLE
Add support for regex OR to tree and item search

### DIFF
--- a/src/Classes/ItemDBControl.lua
+++ b/src/Classes/ItemDBControl.lua
@@ -142,25 +142,29 @@ function ItemDBClass:DoesItemMatchFilters(item)
 		local found = false
 		local mode = self.controls.searchMode.selIndex
 		if mode == 1 or mode == 2 then
-			if item.name:lower():matchOrPattern(searchStr) then
+			local err, match = PCall(string.matchOrPattern, item.name:lower(), searchStr)
+			if not err and match then
 				found = true
 			end
 		end
 		if mode == 1 or mode == 3 then
 			for _, line in pairs(item.enchantModLines) do
-				if line.line:lower():matchOrPattern(searchStr) then
+				local err, match = PCall(string.matchOrPattern, line.line:lower(), searchStr)
+				if not err and match then
 					found = true
 					break
 				end
 			end
 			for _, line in pairs(item.implicitModLines) do
-				if line.line:lower():matchOrPattern(searchStr) then
+				local err, match = PCall(string.matchOrPattern, line.line:lower(), searchStr)
+				if not err and match then
 					found = true
 					break
 				end
 			end
 			for _, line in pairs(item.explicitModLines) do
-				if line.line:lower():matchOrPattern(searchStr) then
+				local err, match = PCall(string.matchOrPattern, line.line:lower(), searchStr)
+				if not err and match then
 					found = true
 					break
 				end
@@ -168,7 +172,8 @@ function ItemDBClass:DoesItemMatchFilters(item)
 			if not found then
 				searchStr = searchStr:gsub(" ","")
 				for i, mod in ipairs(item.baseModList) do
-					if mod.name:lower():matchOrPattern(searchStr) then
+					local err, match = PCall(string.matchOrPattern, mod.name:lower(), searchStr)
+					if not err and match then
 						found = true
 						break
 					end

--- a/src/Classes/ItemDBControl.lua
+++ b/src/Classes/ItemDBControl.lua
@@ -137,7 +137,7 @@ function ItemDBClass:DoesItemMatchFilters(item)
 			return false
 		end
 	end
-	local searchStr = self.controls.search.buf:lower()
+	local searchStr = self.controls.search.buf:lower():gsub("[%-%.%+%[%]%$%^%%%?%*]", "%%%0")
 	if searchStr:match("%S") then
 		local found = false
 		local mode = self.controls.searchMode.selIndex

--- a/src/Classes/ItemDBControl.lua
+++ b/src/Classes/ItemDBControl.lua
@@ -142,25 +142,25 @@ function ItemDBClass:DoesItemMatchFilters(item)
 		local found = false
 		local mode = self.controls.searchMode.selIndex
 		if mode == 1 or mode == 2 then
-			if item.name:lower():find(searchStr, 1, true) then
+			if item.name:lower():matchOrPattern(searchStr) then
 				found = true
 			end
 		end
 		if mode == 1 or mode == 3 then
 			for _, line in pairs(item.enchantModLines) do
-				if line.line:lower():find(searchStr, 1, true) then
+				if line.line:lower():matchOrPattern(searchStr) then
 					found = true
 					break
 				end
 			end
 			for _, line in pairs(item.implicitModLines) do
-				if line.line:lower():find(searchStr, 1, true) then
+				if line.line:lower():matchOrPattern(searchStr) then
 					found = true
 					break
 				end
 			end
 			for _, line in pairs(item.explicitModLines) do
-				if line.line:lower():find(searchStr, 1, true) then
+				if line.line:lower():matchOrPattern(searchStr) then
 					found = true
 					break
 				end
@@ -168,7 +168,7 @@ function ItemDBClass:DoesItemMatchFilters(item)
 			if not found then
 				searchStr = searchStr:gsub(" ","")
 				for i, mod in ipairs(item.baseModList) do
-					if mod.name:lower():find(searchStr, 1, true) then
+					if mod.name:lower():matchOrPattern(searchStr) then
 						found = true
 						break
 					end

--- a/src/Classes/NotableDBControl.lua
+++ b/src/Classes/NotableDBControl.lua
@@ -52,18 +52,20 @@ function NotableDBClass:DoesNotableMatchFilters(node)
 		return false
 	end
 
-	local searchStr = self.controls.search.buf:lower()
+	local searchStr = self.controls.search.buf:lower():gsub("[%-%.%+%[%]%$%^%%%?%*]", "%%%0")
 	if searchStr:match("%S") then
 		local found = false
 		local mode = self.controls.searchMode.selIndex
 		if mode == 1 or mode == 2 then
-			if node.dn:lower():find(searchStr, 1, true) then
+			local err, match = PCall(string.matchOrPattern, node.dn:lower(), searchStr)
+			if not err and match then
 				found = true
 			end
 		end
 		if mode == 1 or mode == 3 then
 			for _, line in ipairs(node.sd) do
-				if line:lower():find(searchStr, 1, true) then
+				local err, match = PCall(string.matchOrPattern, line:lower(), searchStr)
+				if not err and match then
 					found = true
 					break
 				end

--- a/src/Classes/PassiveTreeView.lua
+++ b/src/Classes/PassiveTreeView.lua
@@ -440,7 +440,7 @@ function PassiveTreeViewClass:Draw(build, viewPort, inputEvents)
 			local searchWords = {}
 			for matchstring, v in search:gmatch('"([^"]*)"') do
 				searchWords[#searchWords+1] = matchstring
-				search = search:gsub('"'..matchstring..'"', "")
+				search = search:gsub('"'..matchstring:gsub("([%(%)])", "%%%1")..'"', "")
 			end
 			for matchstring, v in search:gmatch("(%S*)") do
 				if matchstring:match("%S") ~= nil then

--- a/src/Classes/PassiveTreeView.lua
+++ b/src/Classes/PassiveTreeView.lua
@@ -805,7 +805,7 @@ function PassiveTreeViewClass:DoesNodeMatchSearchParams(node)
 
 	local function search(haystack, need)
 		for i=#need, 1, -1 do
-			if haystack:match(need[i]) then
+			if haystack:matchOrPattern(need[i]) then
 				table.remove(need, i)
 			end
 		end

--- a/src/Classes/TreeTab.lua
+++ b/src/Classes/TreeTab.lua
@@ -118,7 +118,7 @@ local TreeTabClass = newClass("TreeTab", "ControlHost", function(self, build)
 	self.controls.export = new("ButtonControl", { "LEFT", self.controls.import, "RIGHT" }, 8, 0, 90, 20, "Export Tree", function()
 		self:OpenExportPopup()
 	end)
-	self.controls.treeSearch = new("EditControl", { "LEFT", self.controls.export, "RIGHT" }, 8, 0, main.portraitMode and 200 or 300, 20, "", "Search", "%c%(%)", 100, function(buf)
+	self.controls.treeSearch = new("EditControl", { "LEFT", self.controls.export, "RIGHT" }, 8, 0, main.portraitMode and 200 or 300, 20, "", "Search", "%c", 100, function(buf)
 		self.viewer.searchStr = buf
 	end)
 	self.controls.treeSearch.tooltipText = "Uses Lua pattern matching for complex searches"

--- a/src/Modules/Common.lua
+++ b/src/Modules/Common.lua
@@ -839,11 +839,6 @@ end
 
 function string:matchOrPattern(pattern)
 	local function generateOrPatterns(pattern)
-		local _, leftBracketCount = pattern:gsub("%(","")
-		local _, rightBracketCount = pattern:gsub("%)","")
-		if leftBracketCount ~= rightBracketCount then
-			return { }
-		end
 		local subGroups = {}
 		local index = 1
 		for subGroup in pattern:gmatch("%b()") do

--- a/src/Modules/Common.lua
+++ b/src/Modules/Common.lua
@@ -872,10 +872,10 @@ function string:matchOrPattern(pattern)
 		return finalPatterns
 	end
 	local patterns = generateOrPatterns(pattern)
-    for pattern, _ in pairs(patterns) do
-        if self:match(pattern) then
-            return true
-        end
-    end
+	for pattern, _ in pairs(patterns) do
+		if self:match(pattern) then
+			return true
+		end
+	end
 	return false
 end

--- a/src/Modules/Common.lua
+++ b/src/Modules/Common.lua
@@ -836,3 +836,46 @@ function urlDecode(str)
 	end
 	return str:gsub("%%(%x%x)", hexToChar)
 end
+
+function string:matchOrPattern(pattern)
+	local function generateOrPatterns(pattern)
+		local subGroups = {}
+		local index = 1
+		for subGroup in pattern:gmatch("%b()") do
+			local subGroupDetails = { }
+			local open, close = pattern:find(subGroup, (subGroups[index] and subGroups[index].close or 1), true)
+			subGroupDetails.open = open
+			subGroupDetails.close = close
+			subGroupDetails.patterns = generateOrPatterns(subGroup:sub(2,-2))
+			t_insert(subGroups, subGroupDetails)
+			index = index + 1
+		end
+
+		local patterns = { pattern:sub(1, (subGroups[1] and subGroups[1].open or 0) - 1) }
+		for i, subGroup in ipairs(subGroups) do
+			local regularNextString = pattern:sub(subGroup.close + 1, (subGroups[i+1] and subGroups[i+1].open or 0) - 1)
+			local tempPatterns = {}
+			for _, subPattern in ipairs(patterns) do
+				for subGroupPattern, _ in pairs(subGroup.patterns) do
+					t_insert(tempPatterns, subPattern..subGroupPattern..regularNextString)
+				end
+			end
+			patterns = tempPatterns
+		end
+
+		local finalPatterns = { }
+		for _, generatedPattern in ipairs(patterns) do
+			for subPattern in generatedPattern:gmatch("[^|]+") do
+				finalPatterns[subPattern] = true -- store string as key to avoid duplicates.
+			end
+		end
+		return finalPatterns
+	end
+	local patterns = generateOrPatterns(pattern)
+    for pattern, _ in pairs(patterns) do
+        if self:match(pattern) then
+            return true
+        end
+    end
+	return false
+end

--- a/src/Modules/Common.lua
+++ b/src/Modules/Common.lua
@@ -839,6 +839,11 @@ end
 
 function string:matchOrPattern(pattern)
 	local function generateOrPatterns(pattern)
+		local _, leftBracketCount = pattern:gsub("%(","")
+		local _, rightBracketCount = pattern:gsub("%)","")
+		if leftBracketCount ~= rightBracketCount then
+			return { }
+		end
 		local subGroups = {}
 		local index = 1
 		for subGroup in pattern:gmatch("%b()") do


### PR DESCRIPTION
Fixes https://github.com/PathOfBuildingCommunity/PathOfBuilding/issues/5221

### Description of the problem being solved:
This has capture groups support. 
~~It could likely be used to refactor ModParser~~(too slow https://github.com/QuickStick123/PathOfBuilding/tree/mod-parser-refactor partially working solution is like 10x slower) and applied in other places.

### Steps taken to verify a working solution:
Tree: "life|mana"
![image](https://user-images.githubusercontent.com/31533893/224527628-39501031-0ad5-4e75-bd00-47ec2c77bb68.png)

Uniques: "increased (fire|cold|lightning) damage"
![image](https://user-images.githubusercontent.com/31533893/224529410-e832e26c-db1a-4510-91f1-916303b62dbb.png)

Anoints: "critical strike (multiplier|chance)"
![image](https://user-images.githubusercontent.com/31533893/227081532-91a8ed1f-3505-40c4-8a75-1278a584b5ef.png)

