### PR TITLE
Update Tree version to latest upon import

### DIFF
--- a/src/Classes/ImportTab.lua
+++ b/src/Classes/ImportTab.lua
@@ -580,7 +580,7 @@ function ImportTabClass:ImportPassiveTreeAndJewels(json, charData)
 	end
 	self.build.itemsTab:PopulateSlots()
 	self.build.itemsTab:AddUndoState()
-	self.build.spec:ImportFromNodeList(charData.classId, charData.ascendancyClass, charPassiveData.hashes, charPassiveData.mastery_effects or {})
+	self.build.spec:ImportFromNodeList(charData.classId, charData.ascendancyClass, charPassiveData.hashes, charPassiveData.mastery_effects or {}, latestTreeVersion)
 	self.build.spec:AddUndoState()
 	self.build.characterLevel = charData.level
 	self.build.configTab:UpdateLevel()

--- a/src/Classes/PassiveSpec.lua
+++ b/src/Classes/PassiveSpec.lua
@@ -17,6 +17,14 @@ local PassiveSpecClass = newClass("PassiveSpec", "UndoHandler", function(self, b
 	self.UndoHandler()
 
 	self.build = build
+
+	-- Initialise and build all tables
+	self:Init(treeVersion)
+
+	self:SelectClass(0)
+end)
+
+function PassiveSpecClass:Init(treeVersion)
 	self.treeVersion = treeVersion
 	self.tree = main:LoadTree(treeVersion)
 
@@ -57,9 +65,7 @@ local PassiveSpecClass = newClass("PassiveSpec", "UndoHandler", function(self, b
 
 	-- Keys are mastery node IDs, values are mastery effect IDs
 	self.masterySelections = { }
-
-	self:SelectClass(0)
-end)
+end
 
 function PassiveSpecClass:Load(xml, dbFileName)
 	self.title = xml.attrib.title
@@ -165,7 +171,11 @@ function PassiveSpecClass:PostLoad()
 end
 
 -- Import passive spec from the provided class IDs and node hash list
-function PassiveSpecClass:ImportFromNodeList(classId, ascendClassId, hashList, masteryEffects)
+function PassiveSpecClass:ImportFromNodeList(classId, ascendClassId, hashList, masteryEffects, treeVersion)
+	if treeVersion and treeVersion ~= self.treeVersion then
+		self:Init(treeVersion)
+		self.build.treeTab.showConvert = self.treeVersion ~= latestTreeVersion
+	end
 	self:ResetNodes()
 	self:SelectClass(classId)
 	for _, id in pairs(hashList) do
@@ -1525,12 +1535,13 @@ function PassiveSpecClass:CreateUndoState()
 		classId = self.curClassId,
 		ascendClassId = self.curAscendClassId,
 		hashList = allocNodeIdList,
-		masteryEffects = selections
+		masteryEffects = selections,
+		treeVersion = self.treeVersion
 	}
 end
 
 function PassiveSpecClass:RestoreUndoState(state)
-	self:ImportFromNodeList(state.classId, state.ascendClassId, state.hashList, state.masteryEffects)
+	self:ImportFromNodeList(state.classId, state.ascendClassId, state.hashList, state.masteryEffects, state.treeVersion)
 	self:SetWindowTitleWithBuildClass()
 end
 


### PR DESCRIPTION
Fixes https://github.com/PathOfBuildingCommunity/PathOfBuilding/issues/5767

### Description of the problem being solved:
If you imported into an old tree some nodes wouldn't be allocated.

### Steps taken to verify a working solution:
- Convert Prompt disappears and version updates
- Undo still works
- All tree nodes now allocated.

### Link to a build that showcases this PR:
https://pastebin.com/0sVa0vDb
Import [Kaatseyes](https://github.com/Kaatseyes) Sabo
### Before screenshot:
![image](https://user-images.githubusercontent.com/31533893/224600976-75637bfb-deee-4707-88af-0c8b9b2e9827.png)

### After screenshot:
![image](https://user-images.githubusercontent.com/31533893/224600995-ccf9a626-b7b9-42ef-ad85-ce22a447e944.png)
