### PR TITLE
Split calc defence and only run ehp calcs on first pass of full dps

### DIFF
--- a/src/Modules/CalcDefence.lua
+++ b/src/Modules/CalcDefence.lua
@@ -230,7 +230,7 @@ function calcs.reducePoolsByDamage(poolTable, damageTable, actor)
 	}
 end
 
--- Performs all defensive calculations
+-- Performs all ingame and related defensive calculations
 function calcs.defence(env, actor)
 	local modDB = actor.modDB
 	local enemyDB = actor.enemy.modDB
@@ -1132,6 +1132,16 @@ function calcs.defence(env, actor)
 	for _, ailment in ipairs(data.ailmentTypeList) do
 		output["Self"..ailment.."Effect"] = calcLib.mod(modDB, nil, "Self"..ailment.."Effect") * (modDB:Flag(nil, "Condition:"..ailment.."edSelf") and calcLib.mod(modDB, nil, "Enemy"..ailment.."Effect") or calcLib.mod(enemyDB, nil, "Enemy"..ailment.."Effect")) * 100
 	end
+end
+
+-- Performs all extra defensive calculations ( eg EHP, maxHit )
+function calcs.buildDefenceEstimations(env, actor)
+	local modDB = actor.modDB
+	local enemyDB = actor.enemy.modDB
+	local output = actor.output
+	local breakdown = actor.breakdown
+
+	local condList = modDB.conditions
 
 	--Enemy damage input and modifications
 	do

--- a/src/Modules/CalcPerform.lua
+++ b/src/Modules/CalcPerform.lua
@@ -608,9 +608,9 @@ local function doActorAttribsPoolsConditions(env, actor)
 			if breakdown then
 				breakdown["Omni"] = breakdown.simple(nil, nil, output["Omni"], "Omni")
 			end
-      
-      local stats = { output.Str, output.Dex, output.Int }
-      table.sort(stats)
+
+			local stats = { output.Str, output.Dex, output.Int }
+			table.sort(stats)
 			output.LowestAttribute = stats[1]
 			condList["TwoHighestAttributesEqual"] = stats[2] == stats[3]
 		
@@ -3419,7 +3419,7 @@ function calcs.perform(env, avoidCache, fullDPSSkipEHP)
 		local effect = 1 + modDB:Sum("INC", nil, "ConsecratedGroundEffect") / 100
 		enemyDB:NewMod("DamageTaken", "INC", enemyDB:Sum("INC", nil, "DamageTakenConsecratedGround") * effect, "Consecrated Ground")
 	end
-	
+
 	-- Defence/offence calculations
 	calcs.defence(env, env.player)
 	if not fullDPSSkipEHP then

--- a/src/Modules/Calcs.lua
+++ b/src/Modules/Calcs.lua
@@ -217,7 +217,7 @@ function calcs.calcFullDPS(build, mode, override, specEnv)
 						GlobalCache.noCache = nil
 					end
 					fullEnv.player.mainSkill = activeSkill
-					calcs.perform(fullEnv, true)
+					calcs.perform(fullEnv, true, (GlobalCache.numActiveSkillInFullDPS ~= 1))
 					usedEnv = fullEnv
 					GlobalCache.noCache = forceCache
 				end

--- a/src/Modules/Calcs.lua
+++ b/src/Modules/Calcs.lua
@@ -203,9 +203,9 @@ function calcs.calcFullDPS(build, mode, override, specEnv)
 	GlobalCache.numActiveSkillInFullDPS = 0
 	for _, activeSkill in ipairs(fullEnv.player.activeSkillList) do
 		if activeSkill.socketGroup and activeSkill.socketGroup.includeInFullDPS and not isExcludedFromFullDps(activeSkill) then
-			GlobalCache.numActiveSkillInFullDPS = GlobalCache.numActiveSkillInFullDPS + 1
 			local activeSkillCount, enabled = getActiveSkillCount(activeSkill)
 			if enabled then
+				GlobalCache.numActiveSkillInFullDPS = GlobalCache.numActiveSkillInFullDPS + 1
 				local cachedData = getCachedData(activeSkill, mode)
 				if cachedData and next(override) == nil and not GlobalCache.noCache then
 					usedEnv = cachedData.Env


### PR DESCRIPTION
Minor speed improvement with full dps, but skipping EHP/maxhit calcs where unnecessary
This results in around a 2% speedup per skill in fulldps after the first, a similar thing could be done for minions
(eg with 5 skills total you get around an 8-9% speedup doing something like node power or item sorting)
