### PR TITLE
Fix cluster jewel notable compare tooltip when crafting a cluster

### DIFF
--- a/src/Classes/ItemsTab.lua
+++ b/src/Classes/ItemsTab.lua
@@ -592,6 +592,7 @@ holding Shift will put it in the second.]])
 			return self.displayItem and self.displayItem.crafted and self.displayItem.clusterJewel
 		end
 	}
+	
 	self.controls.displayItemClusterJewelNodeCountLabel = new("LabelControl", {"TOPLEFT",self.controls.displayItemClusterJewelSkill,"BOTTOMLEFT"}, 0, 7, 0, 14, "^7Added Passives:")
 	self.controls.displayItemClusterJewelNodeCount = new("SliderControl", {"LEFT",self.controls.displayItemClusterJewelNodeCountLabel,"RIGHT"}, 2, 0, 150, 20, function(val)
 		local divVal = self.controls.displayItemClusterJewelNodeCount:GetDivVal()
@@ -710,7 +711,7 @@ holding Shift will put it in the second.]])
 
 					-- Comparison
 					tooltip:AddSeparator(14)
-					self:AppendAnointTooltip(tooltip, node, "Allocating")
+					self:AppendAddedNotableTooltip(tooltip, node)
 
 					-- Information of for this notable appears
 					local clusterInfo = self.build.data.clusterJewelInfoForNotable[notableName]
@@ -2130,6 +2131,21 @@ function ItemsTabClass:AppendAnointTooltip(tooltip, node, actionText)
 	local numChanges = self.build:AddStatComparesToTooltip(tooltip, outputBase, outputNew, header)
 	if node and numChanges == 0 then
 		tooltip:AddLine(14, "^7"..actionText.." "..node.dn.." changes nothing.")
+	end
+end
+
+---Appends tooltip with information about added notable passive node if it would be allocated.
+---@param tooltip table @The tooltip to append into
+---@param node table @The passive tree node that will be added
+function ItemsTabClass:AppendAddedNotableTooltip(tooltip, node)
+	local storedGlobalCacheDPSView = GlobalCache.useFullDPS
+	GlobalCache.useFullDPS = GlobalCache.numActiveSkillInFullDPS > 0
+	local calcFunc, calcBase = self.build.calcsTab:GetMiscCalculator()
+	local outputNew = calcFunc({ addNodes = { [node] = true } }, { requirementsItems = true, requirementsGems = true, skills = true })
+	GlobalCache.useFullDPS = storedGlobalCacheDPSView
+	local numChanges = self.build:AddStatComparesToTooltip(tooltip, calcBase, outputNew, "^7Allocating "..node.dn.." will give you: ")
+	if numChanges == 0 then
+		tooltip:AddLine(14, "^7Allocating "..node.dn.." changes nothing.")
 	end
 end
 


### PR DESCRIPTION
### Description of the problem being solved:
When creating cluster jewels in pob, the tooltips for notables would often mismatch between tree (correct tooltip) and crafting view (incorrect). Sometimes the differences were small but other times the crafting view would show complete nonsense.

### Link to a build that showcases this PR:
https://pobb.in/F8rBJoJDXFpB

### Tooltip when hovering on an unallocated cluster node on tree:
![image](https://user-images.githubusercontent.com/36479307/227063994-4fc6a628-fced-4e04-a27b-e921bb33c695.png)

### Tooltip when hovering on the same node in crafting mode before:
![image](https://user-images.githubusercontent.com/36479307/227064233-39f25a6d-c895-46cc-ac7e-0bfd51702dda.png)

### Tooltip when hovering on the same node in crafting mode after:
![image](https://user-images.githubusercontent.com/36479307/227064307-55c117e5-0521-481c-9d0b-3f411f5938ca.png)
