### PR TITLE
Fix Cremation explosion part skill types

### DIFF
--- a/src/Data/Skills/act_dex.lua
+++ b/src/Data/Skills/act_dex.lua
@@ -2296,6 +2296,7 @@ skills["CorpseEruption"] = {
 			name = "Corpse Explosion",
 			spell = false,
 			cast =  true,
+			projectile = false,
 		},
 	},
 	statMap = {

--- a/src/Export/Skills/act_dex.txt
+++ b/src/Export/Skills/act_dex.txt
@@ -428,6 +428,7 @@ local skills, mod, flag, skill = ...
 			name = "Corpse Explosion",
 			spell = false,
 			cast =  true,
+			projectile = false,
 		},
 	},
 	statMap = {


### PR DESCRIPTION
Fixes #5764

### Description of the problem being solved:

Projectile modifiers apply to Cremation Corpse Explosion part, whereas only Spell part should be affected.

### Before screenshot:
![kép](https://user-images.githubusercontent.com/57040965/227477792-4e613d9b-0f15-40ce-b987-329d2d291623.png)
### After screenshot:
![kép](https://user-images.githubusercontent.com/57040965/227478054-23007c5e-e62c-4d78-8312-9fc926af38df.png)
