### PR TITLE
Fix brainstorm trees not being saveable

### DIFF
--- a/src/Classes/PassiveSpec.lua
+++ b/src/Classes/PassiveSpec.lua
@@ -301,7 +301,7 @@ function PassiveSpecClass:EncodeURL(prefix)
 	local masteryNodeIds = {}
 
 	for id, node in pairs(self.allocNodes) do
-		if node.type ~= "ClassStart" and node.type ~= "AscendClassStart" and id < 65536 then
+		if node.type ~= "ClassStart" and node.type ~= "AscendClassStart" and id < 65536 and nodeCount < 255 then
 			t_insert(a, m_floor(id / 256))
 			t_insert(a, id % 256)
 			nodeCount = nodeCount + 1


### PR DESCRIPTION
Fixes https://github.com/PathOfBuildingCommunity/PathOfBuilding/issues/4781

### Description of the problem being solved:
When we try to generate a url the encoding breaks if there are more than 254 nodes this changes it so they are only added up until this number. As we save a tree url to build file this is also generated making the regular data unsavable as well.

### Steps taken to verify a working solution:
- Having more than 254 nodes allocated testing around with clusters and masteries as well to not observe crash.

### Link to a build that showcases this PR:
https://pobb.in/pvUFgxNk6v1P