### PR TITLE
Fix crash caused by very long lines without spaces

### DIFF
--- a/src/Modules/Main.lua
+++ b/src/Modules/Main.lua
@@ -1222,13 +1222,13 @@ do
 				s = #str + 1
 				e = #str + 1
 			end
-			if DrawStringWidth(height, "VAR", str:sub(lineStart, s - 1)) > width then
-				t_insert(wrapTable, str:sub(lineStart, lastBreak))
-				lineStart = lastSpace
-			end
 			if s > #str then
 				t_insert(wrapTable, str:sub(lineStart, -1))
 				break
+			end
+			if DrawStringWidth(height, "VAR", str:sub(lineStart, s - 1)) > width then
+				t_insert(wrapTable, str:sub(lineStart, lastBreak))
+				lineStart = lastSpace
 			end
 			lastBreak = s - 1
 			lastSpace = e + 1

--- a/src/Modules/Main.lua
+++ b/src/Modules/Main.lua
@@ -1226,12 +1226,12 @@ do
 				t_insert(wrapTable, str:sub(lineStart, -1))
 				break
 			end
+			lastBreak = s - 1
+			lastSpace = e + 1
 			if DrawStringWidth(height, "VAR", str:sub(lineStart, s - 1)) > width then
 				t_insert(wrapTable, str:sub(lineStart, lastBreak))
 				lineStart = lastSpace
 			end
-			lastBreak = s - 1
-			lastSpace = e + 1
 		end
 		return wrapTable
 	end


### PR DESCRIPTION
Fixes crash mentioned in #5783

### Description of the problem being solved:
Long lines being fed into the WrapString that have no spaces cause crash due to `lastBreak` not being set.

Note that this fix may cause some things to wrap differently but should not cause incorrect wrapping.