### PR TITLE
fix misc spelling issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/accuracy_bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/accuracy_bug_report.yaml
@@ -24,10 +24,10 @@ body:
   - type: textarea
     id: expected
     attributes:
-      label: What is the wording ingame?
+      label: What is the wording in-game?
       description: Please write a clear and concise description of what should happen.
       placeholder: |
-        E.g. when I look at the unique [...] ingame it says [...].
+        E.g. when I look at the unique [...] in-game it says [...].
         [screenshot].
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/behaviour_bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/behaviour_bug_report.yaml
@@ -31,9 +31,9 @@ body:
   - type: textarea
     id: expected
     attributes:
-      label: What is the behaviour ingame?
+      label: What is the behaviour in-game?
       description: Please write a clear and concise description of what should happen.
-      placeholder: E.g. Ingame something behaves in a certain way. e.g. curse priority, auras disabled by mod, skills triggered in a certain way, etc.
+      placeholder: E.g. In-game something behaves in a certain way. e.g. curse priority, auras disabled by mod, skills triggered in a certain way, etc.
     validations:
       required: true
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/calculation_bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/calculation_bug_report.yaml
@@ -31,9 +31,9 @@ body:
   - type: textarea
     id: expected
     attributes:
-      label: What is the value from the calculation ingame?
+      label: What is the value from the calculation in-game?
       description: Please write a clear and concise description of what should happen.
-      placeholder: E.g. Ingame when I [...] and use [...] I believe it should be calculated as [...] and so the value is [...].
+      placeholder: E.g. In-game when I [...] and use [...] I believe it should be calculated as [...] and so the value is [...].
     validations:
       required: true
   - type: textarea

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -481,7 +481,7 @@
 - Force rebuild to initialise boss presets and remove phys fallback [\#4615](https://github.com/PathOfBuildingCommunity/PathOfBuilding/pull/4615) ([Regisle](https://github.com/Regisle))
 - Stop pretending Tawhoa is implemented [\#4732](https://github.com/PathOfBuildingCommunity/PathOfBuilding/pull/4732) ([Lilylicious](https://github.com/Lilylicious))
 - Selected Mastery Tree Upconversion Error [\#4765](https://github.com/PathOfBuildingCommunity/PathOfBuilding/pull/4765) ([Nostrademous](https://github.com/Nostrademous))
-- Set skillset to nil instead of removing it from table and reordering it [\#4772](https://github.com/PathOfBuildingCommunity/PathOfBuilding/pull/4772) ([deathbeam](https://github.com/deathbeam))
+- Set skillSet to nil instead of removing it from table and reordering it [\#4772](https://github.com/PathOfBuildingCommunity/PathOfBuilding/pull/4772) ([deathbeam](https://github.com/deathbeam))
 - Build did not save on generating a build code [\#4623](https://github.com/PathOfBuildingCommunity/PathOfBuilding/pull/4623) ([talkmill](https://github.com/talkmill))
 - Multistrike damage calculation with skills which have bow and melee Tag [\#4740](https://github.com/PathOfBuildingCommunity/PathOfBuilding/pull/4740) ([Sinured](https://github.com/Sinured))
 - Guaranteed ailments were not using correct values [\#4790](https://github.com/PathOfBuildingCommunity/PathOfBuilding/pull/4790) ([Lilylicious](https://github.com/Lilylicious))

--- a/changelog.txt
+++ b/changelog.txt
@@ -423,7 +423,7 @@ VERSION[2.20.0][2022/08/16]
 * Force rebuild to initialise boss presets and remove phys fallback (Regisle)
 * Remove parsing for Tawhoa, Forest's Strength as it is not implemented (Lilylicious)
 * Selected Mastery Tree Upconversion Error (Nostrademous)
-* Set skillset to nil instead of removing it from table and reordering it (deathbeam)
+* Set skillSet to nil instead of removing it from table and reordering it (deathbeam)
 * Build did not save on generating a build code (talkmill)
 * Multistrike damage calculation with skills which have bow and melee Tag (Sinured)
 * Guaranteed ailments were not using correct values (Lilylicious)

--- a/src/Classes/DropDownControl.lua
+++ b/src/Classes/DropDownControl.lua
@@ -139,12 +139,12 @@ function DropDownClass:GetSelValue(key)
 	return self.list[self.selIndex][key]
 end
 
-function DropDownClass:SetSel(newSel, dontCallSelFunc)
+function DropDownClass:SetSel(newSel, noCallSelFunc)
 	newSel = m_max(1, m_min(self:GetDropCount(), newSel))
 	newSel = self:DropIndexToListIndex(newSel)
 	if newSel and newSel ~= self.selIndex then
 		self.selIndex = newSel
-		if not dontCallSelFunc and self.selFunc then
+		if not noCallSelFunc and self.selFunc then
 			self.selFunc(newSel, self.list[newSel])
 		end
 	end

--- a/src/Modules/CalcDefence.lua
+++ b/src/Modules/CalcDefence.lua
@@ -468,7 +468,7 @@ function calcs.defence(env, actor)
 				output.splitEvade = true
 			else
 				output.EvadeChance = output.MeleeEvadeChance
-				output.dontSplitEvade = true
+				output.noSplitEvade = true
 			end
 			if breakdown then
 				breakdown.EvadeChance = {

--- a/src/Modules/CalcPerform.lua
+++ b/src/Modules/CalcPerform.lua
@@ -2853,7 +2853,7 @@ function calcs.perform(env, avoidCache)
 			env.player.mainSkill.skillData.triggerSource = source
 			env.player.mainSkill.infoMessage = "Weapon-Crafted Triggering Skill Found"
 			env.player.mainSkill.infoTrigger = triggerName
-			env.player.mainSkill.skillFlags.dontDisplay = true
+			env.player.mainSkill.skillFlags.noDisplay = true
 		end
 	end
 
@@ -2911,7 +2911,7 @@ function calcs.perform(env, avoidCache)
 			env.player.mainSkill.skillData.triggerSource = source
 			env.player.mainSkill.infoMessage = "Focus Triggering Skill Found"
 			env.player.mainSkill.infoTrigger = triggerName
-			env.player.mainSkill.skillFlags.dontDisplay = true
+			env.player.mainSkill.skillFlags.noDisplay = true
 		end
 	end
 
@@ -3124,7 +3124,7 @@ function calcs.perform(env, avoidCache)
 			env.player.mainSkill.infoMessage = "CwC Triggering Skill: " .. source.activeEffect.grantedEffect.name
 			env.player.mainSkill.infoTrigger = "CwC"
 
-			env.player.mainSkill.skillFlags.dontDisplay = true
+			env.player.mainSkill.skillFlags.noDisplay = true
 		end
 	end
 

--- a/src/Modules/CalcSections.lua
+++ b/src/Modules/CalcSections.lua
@@ -486,7 +486,7 @@ return {
 	{ label = "Skill Trigger Rate", flag = "triggered", notFlag = "focused", { format = "{2:output:SourceTriggerRate}", { breakdown = "SourceTriggerRate" }, { breakdown = "SimData" }, }, },
 	{ label = "Skill Trigger Rate", flagList = {"triggered", "focused"}, { format = "{2:output:SourceTriggerRate}", { breakdown = "SourceTriggerRate" }, { breakdown = "SimData" }, { modName = "FocusCooldownRecovery", modType = "INC", cfg = "skill", }, }, },
 	{ label = "Adj. Trigger Rate", flag = "triggered", { format = "{2:output:ServerTriggerRate}",  { breakdown = "ServerTriggerRate" }, }, },
-	{ label = "Eff. Trigger Rate", flag = "triggered", notFlag = "dontDisplay", { format = "{2:output:Speed}", { breakdown = "Speed" }, }, },
+	{ label = "Eff. Trigger Rate", flag = "triggered", notFlag = "noDisplay", { format = "{2:output:Speed}", { breakdown = "Speed" }, }, },
 	{ label = "Cast time", flag = "spell", notFlag = "triggered", { format = "{2:output:Time}s", }, },
 } }
 } },
@@ -1481,7 +1481,7 @@ return {
 	{ label = "Total Increased", { format = "{0:mod:1}%", { modName = { "Evasion", "ArmourAndEvasion", "Defences" }, modType = "INC" }, }, },
 	{ label = "Total More", { format = "{0:mod:1}%", { modName = { "Evasion", "ArmourAndEvasion", "Defences" }, modType = "MORE" }, }, },
 	{ label = "Total", { format = "{0:output:Evasion}", { breakdown = "Evasion" }, }, },
-	{ label = "Evade Chance", haveOutput = "dontSplitEvade", { format = "{0:output:EvadeChance}%", 
+	{ label = "Evade Chance", haveOutput = "noSplitEvade", { format = "{0:output:EvadeChance}%", 
 	  { breakdown = "EvadeChance" },
     { label = "Player modifiers", modName = { "CannotEvade", "EvadeChance", "MeleeEvadeChance", "ProjectileEvadeChance" } },
 	  { label = "Enemy modifiers", modName = { "Accuracy", "HitChance" }, enemy = true },

--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -942,7 +942,7 @@ local preFlagList = {
 	["^animated guardians? deals? "] = { addToMinion = true, addToMinionTag = { type = "SkillName", skillName = "Animate Guardian" } },
 	["^summoned holy relics [hd][ae][va][el] "] = { addToMinion = true, addToMinionTag = { type = "SkillName", skillName = "Summon Holy Relic" } },
 	["^summoned reaper [dh][ea][as]l?s? "] = { addToMinion = true, addToMinionTag = { type = "SkillName", skillName = "Summon Reaper" } },
-	["^summoned arbalists [hdgf][aei][vair][eln] "] = { addToMinion = true, addToMinionTag = { type = "SkillName", skillName = "Summon Arbalists" } },
+	["^summoned arbalists [hgdf][aei][vair][eln] "] = { addToMinion = true, addToMinionTag = { type = "SkillName", skillName = "Summon Arbalists" } },
 	["^summoned arbalists' attacks have "] = { addToMinion = true, addToMinionTag = { type = "SkillName", skillName = "Summon Arbalists" } },
 	["^herald skills [hd][ae][va][el] "] = { tag = { type = "SkillType", skillType = SkillType.Herald } },
 	["^agony crawler deals "] = { addToMinion = true, addToMinionTag = { type = "SkillName", skillName = "Herald of Agony" } },
@@ -1001,7 +1001,7 @@ local preFlagList = {
 	["^non%-curse aura skills have "] = { tagList = { { type = "SkillType", skillType = SkillType.Aura }, { type = "SkillType", skillType = SkillType.AppliesCurse, neg = true } } },
 	["^non%-channelling skills have "] = { tag = { type = "SkillType", skillType = SkillType.Channel, neg = true } },
 	["^non%-vaal skills deal "] = { tag = { type = "SkillType", skillType = SkillType.Vaal, neg = true } },
-	["^skills [hdfg][aei][vari][eln] "] = { },
+	["^skills [hgdf][aei][vari][eln] "] = { },
 	-- Slot specific
 	["^left ring slot: "] = { tag = { type = "SlotNumber", num = 1 } },
 	["^right ring slot: "] = { tag = { type = "SlotNumber", num = 2 } },


### PR DESCRIPTION
* Fixed some spelling issues that are currently ignored.  This will allow them to be removed from `ignore-dict.txt` in a future `pob-dict` update.
* The `ModParser.lua` changes are to support future simplification in the `pob-dict` "ignore" regexes.

Small change-set, shouldn't break anything, but someone might like to double-check my work as I'm having difficulty concentrating for more than a few minutes atm.