### PR TITLE
Improve blade blast using stages

### DIFF
--- a/src/Data/Skills/act_dex.lua
+++ b/src/Data/Skills/act_dex.lua
@@ -687,36 +687,28 @@ skills["BladeBlast"] = {
 	castTime = 0.5,
 	parts = {
 		{
-			name = "1 Blade",
+			name = "Blade Hits Per Cast",
+			stages = true,
 		},
 		{
-			name = "3 Blades",
-		},
-		{
-			name = "6 Blades",
-		},
-		{
-			name = "10 Blades",
-		},
-		{
-			name = "40 Blades",
-		},
-		{
-			name = "50 Blades",
+			name = "Blade Hits Per Sec",
+			stages = true,
 		},
 	},
+	preDamageFunc = function(activeSkill, output)
+		activeSkill.skillData.dpsMultiplier = (activeSkill.skillData.dpsMultiplier or 1) * activeSkill.skillData.dpsBaseMultiplier
+		if activeSkill.skillPart == 2 then
+			activeSkill.skillData.hitTimeOverride = 1
+		end
+	end,
 	baseFlags = {
 		spell = true,
 		area = true,
 	},
 	baseMods = {
 		skill("radius", 14),
-		skill("dpsMultiplier", 1, { type = "SkillPart", skillPart = 1 }),
-		skill("dpsMultiplier", 3, { type = "SkillPart", skillPart = 2 }),
-		skill("dpsMultiplier", 6, { type = "SkillPart", skillPart = 3 }),
-		skill("dpsMultiplier", 10, { type = "SkillPart", skillPart = 4 }),
-		skill("dpsMultiplier", 40, { type = "SkillPart", skillPart = 5 }),
-		skill("dpsMultiplier", 50, { type = "SkillPart", skillPart = 6 }),
+		mod("Multiplier:BladeBlastMaxStages", "BASE", 900, 0, 0),
+		skill("dpsBaseMultiplier", 1, { type = "Multiplier", var = "BladeBlastStage" }),
 	},
 	qualityStats = {
 		Default = {

--- a/src/Export/Skills/act_dex.txt
+++ b/src/Export/Skills/act_dex.txt
@@ -128,30 +128,22 @@ local skills, mod, flag, skill = ...
 #baseMod skill("radius", 14)
 	parts = {
 		{
-			name = "1 Blade",
+			name = "Blade Hits Per Cast",
+			stages = true,
 		},
 		{
-			name = "3 Blades",
-		},
-		{
-			name = "6 Blades",
-		},
-		{
-			name = "10 Blades",
-		},
-		{
-			name = "40 Blades",
-		},
-		{
-			name = "50 Blades",
+			name = "Blade Hits Per Sec",
+			stages = true,
 		},
 	},
-#baseMod skill("dpsMultiplier", 1, { type = "SkillPart", skillPart = 1 })
-#baseMod skill("dpsMultiplier", 3, { type = "SkillPart", skillPart = 2 })
-#baseMod skill("dpsMultiplier", 6, { type = "SkillPart", skillPart = 3 })
-#baseMod skill("dpsMultiplier", 10, { type = "SkillPart", skillPart = 4 })
-#baseMod skill("dpsMultiplier", 40, { type = "SkillPart", skillPart = 5 })
-#baseMod skill("dpsMultiplier", 50, { type = "SkillPart", skillPart = 6 })
+	preDamageFunc = function(activeSkill, output)
+		activeSkill.skillData.dpsMultiplier = (activeSkill.skillData.dpsMultiplier or 1) * activeSkill.skillData.dpsBaseMultiplier
+		if activeSkill.skillPart == 2 then
+			activeSkill.skillData.hitTimeOverride = 1
+		end
+	end,
+#baseMod mod("Multiplier:BladeBlastMaxStages", "BASE", 900, 0, 0)
+#baseMod skill("dpsBaseMultiplier", 1, { type = "Multiplier", var = "BladeBlastStage" })
 #mods
 
 #skill BladeTrap


### PR DESCRIPTION
swaps bladeblast to using stages, allowing for more granularity with the number of blades hitting, as well as implements a separation of "per cast" and "per second", so that it will stop suggesting cast speed like spell echo

This also fixes other dps multipliers working with it, allowing for things like unleash to be properly calculated
eg before 
![image](https://user-images.githubusercontent.com/49933620/228496191-9c220e07-0638-4c76-bd52-1a17085f9645.png)
was showing dps loss, 
after shows correct dps gain
![image](https://user-images.githubusercontent.com/49933620/228496301-7ce5186c-bdda-4855-b6b8-d512f0543a6e.png)

