### PR TITLE
Fix helmet enchant script

### DIFF
--- a/src/Data/EnchantmentHelmet.lua
+++ b/src/Data/EnchantmentHelmet.lua
@@ -270,11 +270,13 @@ return {
 			"25% increased Blade Vortex Spell Damage",
 			"20% increased Blade Vortex Duration",
 			"16% increased Blade Vortex Area of Effect",
+			"Blade Vortex has +2% to Critical Strike Multiplier for each blade",
 		},
 		["ENDGAME"] = {
 			"40% increased Blade Vortex Spell Damage",
 			"30% increased Blade Vortex Duration",
 			"24% increased Blade Vortex Area of Effect",
+			"Blade Vortex has +3% to Critical Strike Multiplier for each blade",
 		},
 	},
 	["Bladefall"] = {
@@ -2722,14 +2724,6 @@ return {
 			"Unearth Spawns corpses with +5 Level",
 			"40% increased Unearth Damage",
 			"12% increased Unearth Cast Speed",
-		},
-	},
-	["Vaal Blade Vortex"] = {
-		["MERCILESS"] = {
-			"Blade Vortex has +2% to Critical Strike Multiplier for each blade",
-		},
-		["ENDGAME"] = {
-			"Blade Vortex has +3% to Critical Strike Multiplier for each blade",
 		},
 	},
 	["Vampiric Link"] = {

--- a/src/Export/Scripts/enchant.lua
+++ b/src/Export/Scripts/enchant.lua
@@ -203,9 +203,11 @@ local skillMap = {
 	["SpectralHelix"] = "Spectral Helix",
 	["DefianceBanner"] = "Defiance Banner",
 	["EnergyBlade"] = "Energy Blade",
-	["Tornado"] = "Tornado",
 	["TornadoShot"] = "Tornado Shot",
+	["Tornado"] = "Tornado",
 	["VolcanicFissure"] = "Volcanic Fissure",
+	["Table Charge"] = "Shield Charge",
+	["Flame Dash"] = "Flame Dash",
 }
 
 local bySkill = { }
@@ -222,20 +224,31 @@ for _, mod in ipairs(dat("Mods"):GetRowList("GenerationType", 10)) do
 						break
 					end
 				end
+				if activeSkill.Id:match("vaal") then -- Vaal Blade Vortex missing the vaal tag
+					isVaal = true
+				end
 				if not isVaal and activeSkill.DisplayName ~= "" then
 					skill = activeSkill.DisplayName
 					break
 				end
 			end
 		end
-		if not skill then
-			for id, name in pairs(skillMap) do
-				if mod.Id:match(id) then
+		if skill == nil then
+			skill = ""
+		end
+		for id, name in pairs(skillMap) do
+			local i, j = string.find(mod.Id, id)
+			if(j ~= nil) then
+				if string.len(skill) < (j - i) then
 					skill = name
-					break
 				end
 			end
 		end
+		
+		if skillMap[skill] ~= nil then
+			skill = skillMap[skill]
+		end
+
 		local stats, orders = describeMod(mod)
 		if not skill or not stats[1] then
 			printf("%s\n%s", mod.Id, stats[1])


### PR DESCRIPTION
This PR fixes known issues in the enchantment export script, notably:
- Modifying the skillMap table resulted in an enchant incorrectly getting exported under Tornado instead of Tornado Shot
- Shield Charge enchants got exported under the name Table Charge
- Blade Vortex missed an enchant, instead it got exported under Vaal Blade Vortex

These issues should be fixed now, closing #5553.