### PR TITLE
Updated support for mace/scepter all damage will chill

### DIFF
--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -2564,7 +2564,12 @@ local specialModList = {
 	["your elemental damage can shock"] = { flag("ColdCanShock"), flag("FireCanShock") },
 	["your fire damage can shock"] = { flag("FireCanShock") },
 	["all y?o?u?r? ?damage can freeze"] = { flag("PhysicalCanFreeze"), flag("LightningCanFreeze"), flag("FireCanFreeze"), flag("ChaosCanFreeze") },
-	["all damage with maces and sceptres inflicts chill"] =  { mod("EnemyModifier", "LIST", { mod = flag("Condition:Chilled") }, { type = "Condition", var = "UsingMace" }) },
+	["all damage with maces and sceptres inflicts chill"] =  { 
+		flag("PhysicalCanChill", { type = "Condition", var = "UsingMace" }),
+		flag("LightningCanChill", { type = "Condition", var = "UsingMace" }),
+		flag("FireCanChill", { type = "Condition", var = "UsingMace" }),
+		flag("ChaosCanChill", { type = "Condition", var = "UsingMace" })
+	},
 	["your cold damage can ignite"] = { flag("ColdCanIgnite") },
 	["your lightning damage can ignite"] = { flag("LightningCanIgnite") },
 	["your fire damage can shock but not ignite"] = { flag("FireCanShock"), flag("FireCannotIgnite") },


### PR DESCRIPTION


Fixes #5771 .

### Description of the problem being solved:
The mace mastery that was for all damage will chill was not actually applying to all damage when using a mace. This is now fixed

### Steps taken to verify a working solution:
- Made a build that had that notable, and saw no chilling effect was occuring
- Made code changes
- Pulled up the same build and saw that the chill was occuring

### Link to a build that showcases this PR:
The link in the build was a 404, so made [a very small build](https://pastebin.com/h6LWwngz). 

### Before and after screenshot:
![image](https://user-images.githubusercontent.com/51249961/228954469-d22b8ca2-35be-45eb-82d6-42bb24cac5aa.png)

