### PR TITLE
Updated 3.21 implicit for Goat Horn.

### DIFF
--- a/src/Data/Bases/wand.lua
+++ b/src/Data/Bases/wand.lua
@@ -15,8 +15,8 @@ itemBases["Goat's Horn"] = {
 	type = "Wand",
 	socketLimit = 3,
 	tags = { onehand = true, wand = true, weapon = true, ranged = true, one_hand_weapon = true, default = true, },
-	implicit = "(10-14)% increased Spell Damage",
-	implicitModTypes = { { "caster_damage", "damage", "caster" }, },
+	implicit = "Adds (1-2) to (3-4) Fire Damage to Spells and Attacks",
+	implicitModTypes = { { "elemental_damage", "caster_damage", "damage", "elemental", "fire", "attack", "caster" }, },
 	weapon = { PhysicalMin = 9, PhysicalMax = 16, CritChanceBase = 7, AttackRateBase = 1.2, Range = 120, },
 	req = { level = 6, int = 29, },
 }


### PR DESCRIPTION
Fixes 3.21 updated implicit for Goat Horn.

### Description of the problem being solved:
3.21 swapped the implicit for Goat's Horn: Adds 1-2 to 3-4 Fire Damage to Spells and Attacks (previously 10-14% increased Spell Damage).

### Steps taken to verify a working solution:
- Opened Dev environment
- Crafted Goat's Horn
- Moved sliders for implicit value and made sure saving it affected build dps

### Link to a build that showcases this PR:
[https://pobb.in/D7dYabXq4Axr](https://pobb.in/D7dYabXq4Axr)
### Before screenshot:
![pre3 21-goatHorn](https://user-images.githubusercontent.com/62115140/229006077-018886fd-0eea-4d18-9d23-d2d7734050c9.PNG)
### After screenshot:
![goatHorn-after](https://user-images.githubusercontent.com/62115140/229006168-fedb9fa6-4ff0-4a62-a646-d5dc011e11e7.PNG)

