### PR TITLE
Added accuracy equal to int mod

### DIFF
--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -1839,7 +1839,6 @@ local specialModList = {
 	["defend with (%d+)%% of armour while not on low energy shield"] = function(num) return {
 		mod("ArmourDefense", "MAX", num - 100, "Armour and Energy Shield Mastery", { type = "Condition", var = "LowEnergyShield", neg = true }),
 	} end,
-	["gain accuracy rating equal to your intelligence"] = { mod("Accuracy", "BASE", 1, { type = "PerStat", stat = "Int" }) },
 	-- Exerted Attacks
 	["exerted attacks deal (%d+)%% increased damage"] = function(num) return { mod("ExertIncrease", "INC", num, nil, ModFlag.Attack, 0) } end,
 	["exerted attacks have (%d+)%% chance to deal double damage"] = function(num) return { mod("ExertDoubleDamageChance", "BASE", num, nil, ModFlag.Attack, 0) } end,
@@ -3591,6 +3590,7 @@ local specialModList = {
 	["marauder: melee skills have (%d+)%% increased area of effect"] = function(num) return { mod("AreaOfEffect", "INC", num, { type = "Condition", var = "ConnectedToMarauderStart" }, { type = "SkillType", skillType = SkillType.Melee }) } end,
 	["intelligence provides no bonus to energy shield"] = { flag("NoIntBonusToES") },
 	["intelligence provides no inherent bonus to energy shield"] = { flag("NoIntBonusToES") },
+	["gain accuracy rating equal to your intelligence"] = { mod("Accuracy", "BASE", 1, { type = "PerStat", stat = "Int" }) },
 	["intelligence is added to accuracy rating with wands"] = { mod("Accuracy", "BASE", 1, nil, ModFlag.Wand, { type = "PerStat", stat = "Int" }) },
 	["dexterity's accuracy bonus instead grants %+(%d+) to accuracy rating per dexterity"] = function(num) return { mod("DexAccBonusOverride", "OVERRIDE", num ) } end,
 	["cannot recover energy shield to above armour"] = { flag("ArmourESRecoveryCap") },

--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -1839,6 +1839,7 @@ local specialModList = {
 	["defend with (%d+)%% of armour while not on low energy shield"] = function(num) return {
 		mod("ArmourDefense", "MAX", num - 100, "Armour and Energy Shield Mastery", { type = "Condition", var = "LowEnergyShield", neg = true }),
 	} end,
+	["gain accuracy rating equal to your intelligence"] = { mod("Accuracy", "BASE", 1, { type = "PerStat", stat = "Int" }) },
 	-- Exerted Attacks
 	["exerted attacks deal (%d+)%% increased damage"] = function(num) return { mod("ExertIncrease", "INC", num, nil, ModFlag.Attack, 0) } end,
 	["exerted attacks have (%d+)%% chance to deal double damage"] = function(num) return { mod("ExertDoubleDamageChance", "BASE", num, nil, ModFlag.Attack, 0) } end,


### PR DESCRIPTION
Adds the 3.21 "Gain Accuracy Rating equal to your Intelligence" mod.

### Description of the problem being solved:
New mastery modifier added in 3.21, needed to be added to our ModParser

### Steps taken to verify a working solution:
- Added custom modifier for +1000 intelligence
- Set character level to 100 with a random bow on it
- Noticed MH accuracy was 238 (29% chance to hit)
- added custom modifier "gain accuracy rating equal to your intelligence"
- Noticed MH accuracy was 1258 (76% chance to hit)

### Link to a build that showcases this PR:
[https://pobb.in/XKDBavRRrvtb](https://pobb.in/XKDBavRRrvtb)

### Before screenshot:
![3 21-accuracy-equal-int_before](https://user-images.githubusercontent.com/62115140/229010920-fd96f42a-7ac6-46de-886c-4aa51e15af36.PNG)

### After screenshot:
![3 21-accuracy-equal-int_after](https://user-images.githubusercontent.com/62115140/229010934-d6b62afe-4b3f-4f20-9370-dbd88222ad7e.PNG)
