### PR TITLE
Bugfix: Strength adding to minions at half value

### DIFF
--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -3032,7 +3032,7 @@ local specialModList = {
 	["totems gain %+(%d+)%% to (%w+) resistance"] = function(_, num, resistance) return { mod("Totem"..firstToUpper(resistance).."Resist", "BASE", num) } end,
 	["totems gain %+(%d+)%% to all elemental resistances"] = function(_, num) return { mod("TotemElementalResist", "BASE", num) } end,
 	-- Minions
-	["your strength is added to your minions"] = { flag("HalfStrengthAddedToMinions") },
+	["your strength is added to your minions"] = { flag("StrengthAddedToMinions") },
 	["half of your strength is added to your minions"] = { flag("HalfStrengthAddedToMinions") },
 	["minions created recently have (%d+)%% increased attack and cast speed"] = function(num) return { mod("MinionModifier", "LIST", { mod = mod("Speed", "INC", num) }, { type = "Condition", var = "MinionsCreatedRecently" }) } end,
 	["minions created recently have (%d+)%% increased movement speed"] = function(num) return { mod("MinionModifier", "LIST", { mod = mod("MovementSpeed", "INC", num) }, { type = "Condition", var = "MinionsCreatedRecently" }) } end,


### PR DESCRIPTION
 Fixes a bug where strength adding to minions was only applying at half value.

### Description of the problem being solved:
"Your strength is added to your minions" was only applying at half value due to a miss-flag.

### Steps taken to verify a working solution:
- Added raise zombie gem
- Custom modifier +1000 strength
- Custom modifier your strength is added to your minions
- In calcs toggle on "Show minion stats"
- Zombies are now getting the full 1020 strength that the player has

### Link to a build that showcases this PR:
[https://pobb.in/mUR8tBJ1boJd](https://pobb.in/mUR8tBJ1boJd)

### Before screenshot:
![fix-strength-to-minions_before](https://user-images.githubusercontent.com/62115140/229016774-d8c3743e-e622-44ce-928e-5eb6d3fb3326.PNG)

### After screenshot:
![fix-strength-to-minions_after](https://user-images.githubusercontent.com/62115140/229016785-e2704724-0199-42fd-84f2-426df9fa1502.PNG)
