### PR TITLE
Crucible League: Updated Uniques

### DIFF
--- a/src/Data/Uniques/amulet.lua
+++ b/src/Data/Uniques/amulet.lua
@@ -1069,7 +1069,7 @@ Implicits: 1
 {tags:mana}(10-20)% increased maximum Mana
 {variant:1}Critical Strike Chance is increased by Lightning Resistance
 {variant:2}Critical Strike Chance is increased by Overcapped Lightning Resistance
-{variant:3}50% increased Lightning Damage
+{variant:3}{tags:jewellery_elemental}50% increased Lightning Damage
 {variant:3}Lightning Damage with Non-Critical Strikes is Lucky
 ]],[[
 Choir of the Storm

--- a/src/Data/Uniques/amulet.lua
+++ b/src/Data/Uniques/amulet.lua
@@ -506,8 +506,8 @@ Implicits: 1
 {tags:jewellery_resistance}+(35-40)% to Cold Resistance
 30% increased Freeze Duration on Enemies
 10% chance to Freeze
-60% increased Damage if you've Frozen an Enemy Recently
 {variant:2}Freezes you inflict spread to other Enemies with a Radius of 12
+60% increased Damage if you've Frozen an Enemy Recently
 ]],[[
 The Pandemonius
 Jade Amulet

--- a/src/Data/Uniques/amulet.lua
+++ b/src/Data/Uniques/amulet.lua
@@ -494,17 +494,20 @@ Skills Chain +1 times
 ]],[[
 The Halcyon
 Jade Amulet
+Variant: Pre 3.21.0
+Variant: Current
 League: Breach
 Source: Drops in Tul Breach or from unique{Tul, Creeping Avalanche}
 Upgrade: Upgrades to unique{The Pandemonius} using currency{Blessing of Tul}
 Requires Level 35
 Implicits: 1
 {tags:jewellery_attribute}+(20-30) to Dexterity
-{tags:jewellery_elemental}(10-20)% increased Cold Damage
+{variant:1}{tags:jewellery_elemental}(10-20)% increased Cold Damage
 {tags:jewellery_resistance}+(35-40)% to Cold Resistance
 30% increased Freeze Duration on Enemies
 10% chance to Freeze
 60% increased Damage if you've Frozen an Enemy Recently
+{variant:2}Freezes you inflict spread to other Enemies with a Radius of 12
 ]],[[
 The Pandemonius
 Jade Amulet
@@ -1056,15 +1059,18 @@ League: Breach
 Source: Drops in Esh Breach or from unique{Esh, Forked Thought}
 Upgrade: Upgrades to unique{Choir of the Storm} using currency{Blessing of Esh}
 Variant: Pre 3.16.0
+Variant: Pre 3.21.0
 Variant: Current
 Requires Level 40
 Implicits: 1
 {tags:jewellery_attribute}+(20-30) to Intelligence
-Trigger Level 12 Lightning Bolt when you deal a Critical Strike
+{variant:1,2}Trigger Level 12 Lightning Bolt when you deal a Critical Strike
 {tags:jewellery_attribute}+(10-15) to all Attributes
 {tags:mana}(10-20)% increased maximum Mana
 {variant:1}Critical Strike Chance is increased by Lightning Resistance
 {variant:2}Critical Strike Chance is increased by Overcapped Lightning Resistance
+{variant:3}50% increased Lightning Damage
+{variant:3}Lightning Damage with Non-Critical Strikes is Lucky
 ]],[[
 Choir of the Storm
 Lapis Amulet
@@ -1072,16 +1078,18 @@ League: Breach
 Source: Upgraded from unique{Voice of the Storm} using currency{Blessing of Esh}
 Variant: Pre 3.0.0
 Variant: Pre 3.16.0
+Variant: Pre 3.21.0
 Variant: Current
 Requires Level 69
 Implicits: 1
 {tags:jewellery_attribute}+(20-30) to Intelligence
-Trigger Level 20 Lightning Bolt when you deal a Critical Strike
-{tags:jewellery_elemental}50% increased Lightning Damage
+{variant:1,2,3}Trigger Level 20 Lightning Bolt when you deal a Critical Strike
+{variant:4}Trigger Level 30 Lightning Bolt when you deal a Critical Strike
+{variant:1,2,3}{tags:jewellery_elemental}50% increased Lightning Damage
 {tags:mana}(10-20)% increased maximum Mana
 {variant:1,2}Critical Strike Chance is increased by Lightning Resistance
-{variant:1,3}{tags:jewellery_resistance}-30% to Lightning Resistance
-{variant:3}Critical Strike Chance is increased by Overcapped Lightning Resistance
+{variant:1,3,4}{tags:jewellery_resistance}-30% to Lightning Resistance
+{variant:3,4}Critical Strike Chance is increased by Overcapped Lightning Resistance
 ]],[[
 Voll's Devotion
 Agate Amulet
@@ -1162,6 +1170,8 @@ Unaffected by Shock
 ]],[[
 Xoph's Heart
 Amber Amulet
+Variant: Pre 3.21.0
+Variant: Current
 League: Breach
 Source: Drops in Xoph Breach or from unique{Xoph, Dark Embers}
 Upgrade: Upgrades to unique{Xoph's Blood} using currency{Blessing of Xoph}
@@ -1172,7 +1182,8 @@ Implicits: 1
 {tags:jewellery_elemental}25% increased Fire Damage
 {tags:life}+(25-35) to maximum Life
 {tags:jewellery_resistance}+(20-40)% to Fire Resistance
-Cover Enemies in Ash when they Hit you
+{variant:1}Cover Enemies in Ash when they Hit you
+{variant:2}Nearby Enemies are Covered in Ash
 ]],[[
 Xoph's Blood
 Amber Amulet

--- a/src/Data/Uniques/amulet.lua
+++ b/src/Data/Uniques/amulet.lua
@@ -1066,10 +1066,10 @@ Implicits: 1
 {tags:jewellery_attribute}+(20-30) to Intelligence
 {variant:1,2}Trigger Level 12 Lightning Bolt when you deal a Critical Strike
 {tags:jewellery_attribute}+(10-15) to all Attributes
+{variant:3}{tags:jewellery_elemental}50% increased Lightning Damage
 {tags:mana}(10-20)% increased maximum Mana
 {variant:1}Critical Strike Chance is increased by Lightning Resistance
 {variant:2}Critical Strike Chance is increased by Overcapped Lightning Resistance
-{variant:3}{tags:jewellery_elemental}50% increased Lightning Damage
 {variant:3}Lightning Damage with Non-Critical Strikes is Lucky
 ]],[[
 Choir of the Storm

--- a/src/Data/Uniques/axe.lua
+++ b/src/Data/Uniques/axe.lua
@@ -361,28 +361,38 @@ Gain a Frenzy Charge on every 50th Rampage Kill
 Rampage
 ]],[[
 Uul-Netol's Kiss
-Labrys
+{variant:1}Labrys
+{variant:2}Vaal Axe
+Variant: Pre 3.21.0
+Variant: Current
 League: Breach
 Source: Drops in Uul-Netol Breach or from unique{Uul-Netol, Unburdened Flesh}
 Upgrade: Upgrades to unique{Uul-Netol's Embrace} using currency{Blessing of Uul-Netol}
-Implicits: 0
-(140-170)% increased Physical Damage
+Implicits: 1
+{variant:2}25% chance to Maim on Hit
+{variant:1}(140-170)% increased Physical Damage
+{variant:2}(230-270)% increased Physical Damage
 15% reduced Attack Speed
-25% chance to Curse Enemies with Vulnerability on Hit
-Attacks have 25% chance to inflict Bleeding when Hitting Cursed Enemies
+{variant:1}25% chance to Curse Enemies with Vulnerability on Hit
+{variant:2}100% chance to Curse Enemies with Vulnerability on Hit
+{variant:1}Attacks have 25% chance to inflict Bleeding when Hitting Cursed Enemies
+{variant:2}Exerted Attacks deal 200% increased Damage
+{variant:2}Exerted Attacks always Knockback
 ]],[[
 Uul-Netol's Embrace
 Vaal Axe
 League: Breach
 Source: Upgraded from unique{Uul-Netol's Kiss} using currency{Blessing of Uul-Netol}
 Variant: Pre 3.11.0
+Variant: Pre 3.21.0
 Variant: Current
 Implicits: 1
-{variant:2}25% chance to Maim on Hit
+{variant:2,3}25% chance to Maim on Hit
 Trigger Level 20 Bone Nova when you Hit a Bleeding Enemy
 (280-320)% increased Physical Damage
 (30-25)% reduced Attack Speed
-Attacks have 25% chance to inflict Bleeding when Hitting Cursed Enemies
+{variant:1,2}Attacks have 25% chance to inflict Bleeding when Hitting Cursed Enemies
+{variant:3}Attacks have 25% chance to inflict Bleeding
 ]],[[
 Wideswing
 Poleaxe

--- a/src/Data/Uniques/belt.lua
+++ b/src/Data/Uniques/belt.lua
@@ -197,12 +197,14 @@ Stygian Vise
 League: Abyss
 Source: Drops from unique{Amanamu, Liege of the Lightless} or unique{Ulaman, Sovereign of the Well}
 Variant: Pre 3.11.0
+Variant: Pre 3.21.0
 Variant: Current
 Implicits: 1
 Has 1 Abyssal Socket
 Has 1 Abyssal Socket
 {variant:1}50% increased Effect of Socketed Abyss Jewels
 {variant:2}75% increased Effect of Socketed Abyss Jewels
+{variant:3}(50-100)% increased Effect of Socketed Abyss Jewels
 ]],[[
 Doryani's Invitation
 Heavy Belt

--- a/src/Data/Uniques/body.lua
+++ b/src/Data/Uniques/body.lua
@@ -1231,20 +1231,27 @@ League: Abyss
 Source: Drops from unique{Amanamu, Liege of the Lightless} or unique{Ulaman, Sovereign of the Well}
 Variant: Two Abyssal Sockets (Pre 3.12.0)
 Variant: One Abyssal Socket (Pre 3.12.0)
+Variant: Two Abyssal Sockets (Pre 3.21.0)
+Variant: One Abyssal Socket (Pre 3.21.0)
+Variant: Three Abyssal Sockets (Current)
 Variant: Two Abyssal Sockets (Current)
 Variant: One Abyssal Socket (Current)
 Implicits: 1
 +(20-25) to maximum Mana
-{variant:1,3}Has 2 Abyssal Sockets
-{variant:2,4}Has 1 Abyssal Socket
+{variant:5}Has 3 Abyssal Sockets
+{variant:1,3,6}Has 2 Abyssal Sockets
+{variant:2,4,7}Has 1 Abyssal Socket
 {variant:1,2}Socketed Gems are Supported by Level 20 Elemental Penetration
 {variant:3,4}Socketed Gems are Supported by Level 25 Elemental Penetration
 20% chance to Trigger Level 20 Shade Form when you Use a Socketed Skill
 (160-180)% increased Evasion and Energy Shield
-(6-10)% increased maximum Life
-(9-15)% increased maximum Mana
-1% increased Maximum Life per Abyss Jewel affecting you
-1% increased Maximum Mana per Abyss Jewel affecting you
+{variant:1,2,3,4}(6-10)% increased maximum Life
+{variant:1,2,3,4}(9-15)% increased maximum Mana
+{variant:1,2,3,4}1% increased Maximum Life per Abyss Jewel affecting you
+{variant:5,6,7}3% increased Maximum Life per Abyss Jewel affecting you
+{variant:1,2,3,4}1% increased Maximum Mana per Abyss Jewel affecting you
+{variant:5,6,7}3% increased Maximum Mana per Abyss Jewel affecting you
+{variant:5,6,7}Penetrate 4% Elemental Resistances per Abyss Jewel affecting you
 ]],[[
 Replica Shroud of the Lightless
 Carnal Armour

--- a/src/Data/Uniques/body.lua
+++ b/src/Data/Uniques/body.lua
@@ -368,20 +368,25 @@ Implicits: 0
 {variant:3}100% of Fire Damage from Hits taken as Physical Damage
 ]],[[
 The Snowblind Grace
-Coronal Leather
+{variant:1,2}Coronal Leather
+{variant:3}Zodiac Leather
 League: Breach
 Source: Drops in Tul Breach or from unique{Tul, Creeping Avalanche}
 Upgrade: Upgrades to unique{The Perfect Form} using currency{Blessing of Tul}
 Variant: Pre 3.16.0
+Variant: Pre 3.21.0
 Variant: Current
 Implicits: 0
 {variant:1}10% chance to Suppress Spell Damage
 {variant:2}20% chance to Suppress Spell Damage
-+(30-40) to Dexterity
+{variant:1,2}+(30-40) to Dexterity
+{variant:3}(10-15)% increased Dexterity
 {variant:1}(30-50)% increased Evasion Rating
-{variant:2}(80-100)% increased Evasion Rating
+{variant:2,3}(80-100)% increased Evasion Rating
 +(40-60) to maximum Life
-25% increased Arctic Armour Buff Effect
+{variant:1,2}25% increased Arctic Armour Buff Effect
+{variant:3}50% increased Arctic Armour Buff Effect
+{variant:3}Arctic Armour has no Reservation
 {variant:1}Evasion Rating is increased by Uncapped Cold Resistance
 {variant:2}Evasion Rating is increased by Overcapped Cold Resistance
 ]],[[
@@ -390,18 +395,21 @@ Zodiac Leather
 League: Breach
 Source: Upgraded from unique{The Snowblind Grace} using currency{Blessing of Tul}
 Variant: Pre 3.16.0
+Variant: Pre 3.21.0
 Variant: Current
 Implicits: 0
+{variant:3}+50% chance to Suppress Spell Damage
 {variant:1}(5-10)% increased Dexterity
 {variant:2}(10-15)% increased Dexterity
 {variant:1}(30-50)% increased Evasion Rating
 {variant:2}(80-100)% increased Evasion Rating
+{variant:3}(150-200)% increased Evasion Rating
 {variant:1}+(50-80) to maximum Life
 {variant:2}+(70-100) to maximum Life
 -30% to Cold Resistance
-Arctic Armour has no Reservation
+{variant:1,2}Arctic Armour has no Reservation
 {variant:1}Evasion Rating is increased by Uncapped Cold Resistance
-{variant:2}Evasion Rating is increased by Overcapped Cold Resistance
+{variant:2,3}Evasion Rating is increased by Overcapped Cold Resistance
 Acrobatics
 ]],[[
 Replica Perfect Form

--- a/src/Data/Uniques/boots.lua
+++ b/src/Data/Uniques/boots.lua
@@ -41,7 +41,7 @@ Requires Level 68, 120 Str
 ]],[[
 The Infinite Pursuit
 {variant:1}Goliath Greaves
-{variant:1}Titan Greaves
+{variant:2}Titan Greaves
 Variant: Pre 3.21.0
 Variant: Current
 League: Breach

--- a/src/Data/Uniques/boots.lua
+++ b/src/Data/Uniques/boots.lua
@@ -860,15 +860,20 @@ Bubonic Trail
 Murder Boots
 League: Abyss
 Source: Drops from unique{Amanamu, Liege of the Lightless} or unique{Ulaman, Sovereign of the Well}
-Variant: One Abyssal Socket
-Variant: Two Abyssal Sockets
+Variant: One Abyssal Socket (Pre 3.21.0)
+Variant: Two Abyssal Sockets (Pre 3.21.0)
+Variant: One Abyssal Socket (Current)
+Variant: Two Abyssal Sockets (Current)
 Requires Level 69, 82 Dex, 42 Int
-{variant:1}Has 1 Abyssal Socket
-{variant:2}Has 2 Abyssal Sockets
+{variant:1,3}Has 1 Abyssal Socket
+{variant:2,4}Has 2 Abyssal Sockets
 Triggers Level 20 Death Walk when Equipped
-(4-6)% increased maximum Life
-30% increased Movement Speed
-10% increased Damage for each type of Abyssal Jewel affecting you
+{variant:1,2}(4-6)% increased maximum Life
+{variant:1,2}30% increased Movement Speed
+{variant:3,4}(24-32)% increased Movement Speed while affected by a Magic Abyss Jewel
+{variant:1,2}10% increased Damage for each type of Abyssal Jewel affecting you
+{variant:3,4}(40-60)% reduced Duration of Elemental Ailments on You while affected by a Rare Abyss Jewel
+{variant:3,4}(16-24)% increased Reservation Efficiency while affected by a Unique Abyss Jewel
 ]],[[
 Corpsewalker
 Carnal Boots

--- a/src/Data/Uniques/boots.lua
+++ b/src/Data/Uniques/boots.lua
@@ -40,27 +40,39 @@ Requires Level 68, 120 Str
 30% increased Movement Speed
 ]],[[
 The Infinite Pursuit
-Goliath Greaves
+{variant:1}Goliath Greaves
+{variant:1}Titan Greaves
+Variant: Pre 3.21.0
+Variant: Current
 League: Breach
 Source: Drops in Uul-Netol Breach or from unique{Uul-Netol, Unburdened Flesh}
 Upgrade: Upgrades to unique{The Red Trail} using currency{Blessing of Uul-Netol}
 Requires Level 54, 95 Str
-+(30-60) to maximum Life
+{variant:1}+(30-60) to maximum Life
 20% increased Movement Speed
 Moving while Bleeding doesn't cause you to take extra Damage
-15% increased Movement Speed while Bleeding
+{variant:1}15% increased Movement Speed while Bleeding
+{variant:2}20% increased Movement Speed while Bleeding
+{variant:2}Bleeding on you expires 75% slower while Moving
+{variant:2}Cannot be Stunned while Bleeding
+{variant:2}Cannot be Poisoned while Bleeding
 50% chance to be inflicted with Bleeding when Hit by an Attack
 ]],[[
 The Red Trail
 Titan Greaves
+Variant: Pre 3.21.0
+Variant: Current
 League: Breach
 Source: Upgraded from unique{The Infinite Pursuit} using currency{Blessing of Uul-Netol}
 Requires Level 68, 120 Str
-(60-80)% increased Armour
-+(50-70) to maximum Life
+{variant:1}(60-80)% increased Armour
+{variant:2}(60-100)% increased Armour
+{variant:1}+(50-70) to maximum Life
+{variant:2}+(60-100) to maximum Life
 25% increased Movement Speed
 Gain a Frenzy Charge on Hit while Bleeding
-15% increased Movement Speed while Bleeding
+{variant:1}15% increased Movement Speed while Bleeding
+{variant:2}30% increased Movement Speed
 10% additional Physical Damage Reduction while stationary
 50% chance to be inflicted with Bleeding when Hit by an Attack
 Gore Footprints

--- a/src/Data/Uniques/bow.lua
+++ b/src/Data/Uniques/bow.lua
@@ -554,15 +554,22 @@ Enemies Frozen by you take 20% increased Damage
 +(90-120) Energy Shield gained on Killing a Shocked Enemy
 ]],[[
 Xoph's Inception
-Bone Bow
+{variant:1}Bone Bow
+{variant:2}Citadel Bow
+Variant: Pre 3.21.0
+Variant: Current
 League: Breach
 Source: Drops in Xoph Breach or from unique{Xoph, Dark Embers}
 Upgrade: Upgrades to unique{Xoph's Nurture} using currency{Blessing of Xoph}
 Requires Level 23, 80 Dex
-(70-90)% increased Physical Damage
-Gain (20-30) Life per Ignited Enemy Killed
+{variant:1}(70-90)% increased Physical Damage
+{variant:2}(160-190)% increased Physical Damage
+{variant:1}Gain (20-30) Life per Ignited Enemy Killed
+{variant:2}Gain (200-300) Life per Ignited Enemy Killed
 Gain 20% of Physical Damage as Extra Fire Damage
 10% chance to Ignite
+{variant:2}Projectiles Pierce all Burning Enemies
+{variant:2}Arrows deal 30 to 50 Added Fire Damage for each time they've Pierced
 ]],[[
 Xoph's Nurture
 Citadel Bow

--- a/src/Data/Uniques/claw.lua
+++ b/src/Data/Uniques/claw.lua
@@ -279,15 +279,17 @@ Ornament of the East
 Gut Ripper
 Variant: Pre 2.6.0
 Variant: Pre 3.0.0
+Variant: Pre 3.21.0
 Variant: Current
 Requires Level 46, 80 Dex, 80 Int
 Implicits: 2
 {variant:1}Grants 21 Life per Enemy Hit
-{variant:2,3}Grants 44 Life per Enemy Hit
+{variant:2,3,4}Grants 44 Life per Enemy Hit
 +1 to Level of Socketed Dexterity Gems
 {variant:3}Socketed Gems are Supported by Level 10 Faster Attacks
+{variant:4}Socketed Gems are Supported by Level 15 Faster Attacks
 {variant:1,2}(100-120)% increased Physical Damage
-{variant:3}(160-180)% increased Physical Damage
+{variant:3,4}(160-180)% increased Physical Damage
 (10-15)% increased Attack Speed
 25% increased Stun and Block Recovery
 Hits can't be Evaded

--- a/src/Data/Uniques/claw.lua
+++ b/src/Data/Uniques/claw.lua
@@ -172,11 +172,11 @@ Implicits: 3
 {variant:1,2,3}(10-15)% increased Attack Speed
 {variant:4}(8-12)% increased Dexterity
 {variant:4}(8-12)% increased Intelligence
+{variant:4}Recover 1% of Life on Kill
 {variant:1,2}Adds 1 to 3 Lightning Damage to Attacks with this Weapon per 10 Intelligence
 {variant:3}Adds 1 to 5 Lightning Damage to Attacks with this Weapon per 10 Intelligence
 {variant:4}Adds 1 to 10 Lightning Damage to Attacks with this Weapon per 10 Dexterity
 {variant:4}5% increased Critical Strike Chance per 25 Intelligence
-{variant:4}Recover 1% of Life on Kill
 ]],[[
 Hand of Wisdom and Action
 Imperial Claw

--- a/src/Data/Uniques/claw.lua
+++ b/src/Data/Uniques/claw.lua
@@ -153,22 +153,30 @@ Implicits: 3
 {variant:5,6}Ghost Reaver
 ]],[[
 Hand of Thought and Motion
-Blinder
+{variant:1,2,3}Blinder
+{variant:4}Imperial Claw
 League: Breach
 Source: Drops in Esh Breach or from unique{Esh, Forked Thought}
 Upgrade: Upgrades to unique{Hand of Wisdom and Action} using currency{Blessing of Esh}
 Variant: Pre 2.6.0
 Variant: Pre 3.0.0
+Variant: Pre 3.21.0
 Variant: Current
 Requires Level 22, 41 Dex, 41 Int
-Implicits: 2
+Implicits: 3
 {variant:1}Grants 10 Life per Enemy Hit
 {variant:2,3}Grants 12 Life per Enemy Hit
-(20-25)% increased Elemental Damage with Attack Skills
-Adds 1 to (50-60) Lightning Damage
-(10-15)% increased Attack Speed
+{variant:4}Grants 46 Life per Enemy Hit
+{variant:1,2,3}(20-25)% increased Elemental Damage with Attack Skills
+{variant:1,2,3}Adds 1 to (50-60) Lightning Damage
+{variant:1,2,3}(10-15)% increased Attack Speed
+{variant:4}(8-12)% increased Dexterity
+{variant:4}(8-12)% increased Intelligence
 {variant:1,2}Adds 1 to 3 Lightning Damage to Attacks with this Weapon per 10 Intelligence
 {variant:3}Adds 1 to 5 Lightning Damage to Attacks with this Weapon per 10 Intelligence
+{variant:4}Adds 1 to 10 Lightning Damage to Attacks with this Weapon per 10 Dexterity
+{variant:4}5% increased Critical Strike Chance per 25 Intelligence
+{variant:4}Recover 1% of Life on Kill
 ]],[[
 Hand of Wisdom and Action
 Imperial Claw
@@ -176,16 +184,18 @@ League: Breach
 Source: Upgraded from unique{Hand of Thought and Motion} using currency{Blessing of Esh}
 Variant: Pre 2.6.0
 Variant: Pre 3.0.0
+Variant: Pre 3.21.0
 Variant: Current
 Requires Level 68, 131 Dex, 95 Int
 Implicits: 2
 {variant:1}Grants 25 Life per Enemy Hit
-{variant:2,3}Grants 46 Life per Enemy Hit
-(20-25)% increased Elemental Damage with Attack Skills
+{variant:2,3,4}Grants 46 Life per Enemy Hit
+{variant:1,2,3}(20-25)% increased Elemental Damage with Attack Skills
+{variant:4}1% of Attack Damage Leeched as Life
 (8-12)% increased Dexterity
 (8-12)% increased Intelligence
 {variant:1,2}Adds 1 to 6 Lightning Damage to Attacks with this Weapon per 10 Intelligence
-{variant:3}Adds 1 to 10 Lightning Damage to Attacks with this Weapon per 10 Intelligence
+{variant:3,4}Adds 1 to 10 Lightning Damage to Attacks with this Weapon per 10 Intelligence
 1% increased Attack Speed per 25 Dexterity
 ]],[[
 Izaro's Dilemma

--- a/src/Data/Uniques/helmet.lua
+++ b/src/Data/Uniques/helmet.lua
@@ -79,8 +79,8 @@ Requires Level 48, 101 Str
 {variant:1,2}+(100-120) to Armour
 {variant:3}(80-120)% increased Armour
 {variant:1,2}+(40-50) to maximum Life
-{variant:1,2}-20 Fire Damage taken when Hit
-{variant:3}-(100-200) Fire Damage taken when Hit
+{variant:1,2}-20 Fire Damage taken from Hits
+{variant:3}-(100-200) Fire Damage taken from Hits
 {variant:1}Armour is increased by Uncapped Fire Resistance
 {variant:2,3}Armour is increased by Overcapped Fire Resistance
 {variant:3}-30% to Fire Resistance

--- a/src/Data/Uniques/helmet.lua
+++ b/src/Data/Uniques/helmet.lua
@@ -1011,15 +1011,19 @@ Lightpoacher
 Great Crown
 League: Abyss
 Source: Drops from unique{Amanamu, Liege of the Lightless} or unique{Ulaman, Sovereign of the Well}
-Variant: One Abyssal Socket
-Variant: Two Abyssal Sockets
-{variant:1}Has 1 Abyssal Socket
-{variant:2}Has 2 Abyssal Sockets
+Variant: One Abyssal Socket (Pre 3.21.0)
+Variant: Two Abyssal Sockets (Pre 3.21.0)
+Variant: One Abyssal Socket (Current)
+Variant: Two Abyssal Sockets (Current)
+{variant:1,3}Has 1 Abyssal Socket
+{variant:2,4}Has 2 Abyssal Sockets
 Trigger Level 20 Spirit Burst when you Use a Skill while you have a Spirit Charge
 +(10-15)% to all Elemental Resistances
-Recover (4-5)% of Life when a Spirit Charge expires or is consumed
-(15-20)% chance to gain a Spirit Charge on Kill
+{variant:1,2}Recover (4-5)% of Life when a Spirit Charge expires or is consumed
+{variant:1,2}(15-20)% chance to gain a Spirit Charge on Kill
+{variant:3,4}100% chance to gain a Spirit Charge on Kill
 +1 to Maximum Spirit Charges per Abyss Jewel affecting you
+{variant:3,4}Gain 5% of Physical Damage as Extra Damage of each Element per Spirit Charge
 ]],[[
 Malachai's Vision
 Praetor Crown

--- a/src/Data/Uniques/helmet.lua
+++ b/src/Data/Uniques/helmet.lua
@@ -67,32 +67,41 @@ Cannot Evade Enemy Attacks
 Cannot be Stunned
 ]],[[
 The Formless Flame
-Siege Helmet
+{variant:1,2}Siege Helmet
+{variant:3}Royal Burgonet 
 League: Breach
 Source: Drops in Xoph Breach or from unique{Xoph, Dark Embers}
 Upgrade: Upgrades to unique{The Formless Inferno} using currency{Blessing of Xoph}
 Variant: Pre 3.16.0
+Variant: Pre 3.21.0
 Variant: Current
 Requires Level 48, 101 Str
-+(100-120) to Armour
-+(40-50) to maximum Life
--20 Fire Damage taken when Hit
+{variant:1,2}+(100-120) to Armour
+{variant:3}(80-120)% increased Armour
+{variant:1,2}+(40-50) to maximum Life
+{variant:1,2}-20 Fire Damage taken when Hit
+{variant:3}-(100-200) Fire Damage taken from Hits
 {variant:1}Armour is increased by Uncapped Fire Resistance
-{variant:2}Armour is increased by Overcapped Fire Resistance
+{variant:2,3}Armour is increased by Overcapped Fire Resistance
+{variant:3}-30% to Fire Resistance
 ]],[[
 The Formless Inferno
 Royal Burgonet
 League: Breach
 Source: Upgraded from unique{The Formless Flame} using currency{Blessing of Xoph}
 Variant: Pre 3.16.0
+Variant: Pre 3.21.0
 Variant: Current
 Requires Level 65, 148 Str
-(80-120)% increased Armour
-+(40-50) to maximum Life
+{variant:1,2}(80-120)% increased Armour
+{variant:1,2}+(40-50) to maximum Life
+{variant:3}+(60-100) to maximum Life
 -30% to Fire Resistance
-8% of Physical Damage from Hits taken as Fire Damage
+{variant:1,2}8% of Physical Damage from Hits taken as Fire Damage
 {variant:1}Armour is increased by Uncapped Fire Resistance
 {variant:2}Armour is increased by Overcapped Fire Resistance
+{variant:3}Minion Life is increased by Overcapped Fire Resistance
+{variant:3}Socketed Skills are supported by level 30 Infernal Legion
 ]],[[
 Echoes of Creation
 Shaper Item

--- a/src/Data/Uniques/helmet.lua
+++ b/src/Data/Uniques/helmet.lua
@@ -79,11 +79,11 @@ Requires Level 48, 101 Str
 {variant:1,2}+(100-120) to Armour
 {variant:3}(80-120)% increased Armour
 {variant:1,2}+(40-50) to maximum Life
+{variant:3}-30% to Fire Resistance
 {variant:1,2}-20 Fire Damage taken from Hits
 {variant:3}-(100-200) Fire Damage taken from Hits
 {variant:1}Armour is increased by Uncapped Fire Resistance
 {variant:2,3}Armour is increased by Overcapped Fire Resistance
-{variant:3}-30% to Fire Resistance
 ]],[[
 The Formless Inferno
 Royal Burgonet
@@ -93,6 +93,7 @@ Variant: Pre 3.16.0
 Variant: Pre 3.21.0
 Variant: Current
 Requires Level 65, 148 Str
+{variant:3}Socketed Gems are supported by level 30 Infernal Legion
 {variant:1,2}(80-120)% increased Armour
 {variant:1,2}+(40-50) to maximum Life
 {variant:3}+(60-100) to maximum Life
@@ -101,7 +102,6 @@ Requires Level 65, 148 Str
 {variant:1}Armour is increased by Uncapped Fire Resistance
 {variant:2}Armour is increased by Overcapped Fire Resistance
 {variant:3}Minion Life is increased by Overcapped Fire Resistance
-{variant:3}Socketed Gems are supported by level 30 Infernal Legion
 ]],[[
 Echoes of Creation
 Shaper Item

--- a/src/Data/Uniques/helmet.lua
+++ b/src/Data/Uniques/helmet.lua
@@ -80,7 +80,7 @@ Requires Level 48, 101 Str
 {variant:3}(80-120)% increased Armour
 {variant:1,2}+(40-50) to maximum Life
 {variant:1,2}-20 Fire Damage taken when Hit
-{variant:3}-(100-200) Fire Damage taken from Hits
+{variant:3}-(100-200) Fire Damage taken when Hit
 {variant:1}Armour is increased by Uncapped Fire Resistance
 {variant:2,3}Armour is increased by Overcapped Fire Resistance
 {variant:3}-30% to Fire Resistance
@@ -101,7 +101,7 @@ Requires Level 65, 148 Str
 {variant:1}Armour is increased by Uncapped Fire Resistance
 {variant:2}Armour is increased by Overcapped Fire Resistance
 {variant:3}Minion Life is increased by Overcapped Fire Resistance
-{variant:3}Socketed Skills are supported by level 30 Infernal Legion
+{variant:3}Socketed Gems are supported by level 30 Infernal Legion
 ]],[[
 Echoes of Creation
 Shaper Item

--- a/src/Data/Uniques/jewel.lua
+++ b/src/Data/Uniques/jewel.lua
@@ -35,25 +35,33 @@ Minions have +(2-5)% chance to Suppress Spell Damage
 ]],[[
 The Blue Dream
 Cobalt Jewel
+Variant: Pre 3.21.0
+Variant: Current
 League: Breach
 Source: Drops in Chayula Breach or from unique{Chayula, Who Dreamt}
 Upgrade: Upgrades to unique{The Blue Nightmare} using currency{Blessing of Chayula}
 Radius: Large
-Gain 5% of Lightning Damage as Extra Chaos Damage
+{variant:1}Gain 5% of Lightning Damage as Extra Chaos Damage
+{variant:2}Gain (6-10)% of Lightning Damage as Extra Chaos Damage
 Passives granting Lightning Resistance or all Elemental Resistances in Radius
 also grant an equal chance to gain a Power Charge on Kill
 ]],[[
 The Blue Nightmare
 Cobalt Jewel
+Variant: Pre 3.21.0
+Variant: Current
 League: Breach
 Source: Upgraded from unique{The Blue Dream} using currency{Blessing of Chayula}
 Limited to: 1
 Radius: Large
-Gain 5% of Lightning Damage as Extra Chaos Damage
-Passives granting Lightning Resistance or all Elemental Resistances in Radius
-also grant Chance to Block Spell Damage at 35% of its value
-Passives granting Lightning Resistance or all Elemental Resistances in Radius
-also grant an equal chance to gain a Power Charge on Kill
+{variant:1}Gain 5% of Lightning Damage as Extra Chaos Damage
+{variant:2}Gain (6-10)% of Lightning Damage as Extra Chaos Damage
+{variant:1}Passives granting Lightning Resistance or all Elemental Resistances in Radius
+{variant:1}also grant Chance to Block Spell Damage at 35% of its value
+{variant:2}Passives granting Lightning Resistance or all Elemental Resistances in Radius
+{variant:2}also grant Chance to Block Spell Damage at 50% of its value
+{variant:1}Passives granting Lightning Resistance or all Elemental Resistances in Radius
+{variant:1}also grant an equal chance to gain a Power Charge on Kill
 ]],[[
 Brawn
 Crimson Jewel
@@ -242,29 +250,36 @@ Variant: Current - Min Frenzy Charge
 ]],[[
 The Green Dream
 Viridian Jewel
+Variant: Pre 3.21.0
+Variant: Current
 League: Breach
 Source: Drops in Chayula Breach or from unique{Chayula, Who Dreamt}
 Upgrade: Upgrades to unique{The Green Nightmare} using currency{Blessing of Chayula}
 Radius: Large
-Gain 5% of Cold Damage as Extra Chaos Damage
+{variant:1}Gain 5% of Cold Damage as Extra Chaos Damage
+{variant:2}Gain (6-10)% of Cold Damage as Extra Chaos Damage
 Passives granting Cold Resistance or all Elemental Resistances in Radius
 also grant an equal chance to gain a Frenzy Charge on Kill
 ]],[[
 The Green Nightmare
 Viridian Jewel
 Variant: Pre 3.16.0
+Variant: Pre 3.21.0
 Variant: Current
 League: Breach
 Source: Upgraded from unique{The Green Dream} using currency{Blessing of Chayula}
 Limited to: 1
 Radius: Large
-Gain 5% of Cold Damage as Extra Chaos Damage
+{variant:1}Gain 5% of Cold Damage as Extra Chaos Damage
+{variant:2}Gain (6-10)% of Cold Damage as Extra Chaos Damage
 {variant:1}Passives granting Cold Resistance or all Elemental Resistances in Radius
 {variant:1}also grant Chance to Suppress Spell Damage at 35% of its value
 {variant:2}Passives granting Cold Resistance or all Elemental Resistances in Radius
 {variant:2}also grant Chance to Suppress Spell Damage at 50% of its value
-Passives granting Cold Resistance or all Elemental Resistances in Radius
-also grant an equal chance to gain a Frenzy Charge on Kill
+{variant:3}Passives granting Cold Resistance or all Elemental Resistances in Radius
+{variant:3}also grant Chance to Suppress Spell Damage at 70% of its value
+{variant:1,2}Passives granting Cold Resistance or all Elemental Resistances in Radius
+{variant:1,2}also grant an equal chance to gain a Frenzy Charge on Kill
 ]],[[
 Hair Trigger
 Viridian Jewel
@@ -534,7 +549,10 @@ League: Breach
 Source: Drops in Chayula Breach or from unique{Chayula, Who Dreamt}
 Upgrade: Upgrades to unique{The Red Nightmare} using currency{Blessing of Chayula}
 Radius: Large
-Gain 5% of Fire Damage as Extra Chaos Damage
+Variant: Pre 3.21.0
+Variant: Current
+{variant:1}Gain 5% of Fire Damage as Extra Chaos Damage
+{variant:2}Gain (6-10)% of Fire Damage as Extra Chaos Damage
 Passives granting Fire Resistance or all Elemental Resistances in Radius
 also grant an equal chance to gain an Endurance Charge on Kill
 ]],[[
@@ -544,11 +562,16 @@ League: Breach
 Source: Upgraded from unique{The Red Dream} using currency{Blessing of Chayula}
 Limited to: 1
 Radius: Large
-Gain 5% of Fire Damage as Extra Chaos Damage
-Passives granting Fire Resistance or all Elemental Resistances in Radius
-also grant Chance to Block Attack Damage at 35% of its value
-Passives granting Fire Resistance or all Elemental Resistances in Radius
-also grant an equal chance to gain an Endurance Charge on Kill
+Variant: Pre 3.21.0
+Variant: Current
+{variant:1}Gain 5% of Fire Damage as Extra Chaos Damage
+{variant:2}Gain (6-10)% of Fire Damage as Extra Chaos Damage
+{variant:1}Passives granting Fire Resistance or all Elemental Resistances in Radius
+{variant:1}also grant Chance to Block Attack Damage at 35% of its value
+{variant:2}Passives granting Fire Resistance or all Elemental Resistances in Radius
+{variant:2}also grant Chance to Block Attack Damage at 50% of its value
+{variant:1}Passives granting Fire Resistance or all Elemental Resistances in Radius
+{variant:1}also grant an equal chance to gain an Endurance Charge on Kill
 ]],[[
 The Siege
 Small Cluster Jewel

--- a/src/Data/Uniques/jewel.lua
+++ b/src/Data/Uniques/jewel.lua
@@ -773,10 +773,14 @@ Hypnotic Eye Jewel
 ]],[[
 Tecrod's Gaze
 Murderous Eye Jewel
+Variant: Pre 3.21.0
+Variant: Current
 Requires Level 40
 +(10-20) to Strength
-20% increased Main Hand Critical Strike Chance per Murderous Eye Jewel affecting you, up to a maximum of 100%
-+10% to Off Hand Critical Strike Multiplier per Murderous Eye Jewel affecting you, up to a maximum of +50%
+{variant:1}20% increased Main Hand Critical Strike Chance per Murderous Eye Jewel affecting you, up to a maximum of 100%
+{variant:2}40% increased Main Hand Critical Strike Chance per Murderous Eye Jewel affecting you, up to a maximum of 200%
+{variant:1}+10% to Off Hand Critical Strike Multiplier per Murderous Eye Jewel affecting you, up to a maximum of +50%
+{variant:2}+20% to Off Hand Critical Strike Multiplier per Murderous Eye Jewel affecting you, up to a maximum of +100%
 ]],[[
 Ulaman's Gaze
 Searching Eye Jewel

--- a/src/Data/Uniques/jewel.lua
+++ b/src/Data/Uniques/jewel.lua
@@ -270,8 +270,8 @@ League: Breach
 Source: Upgraded from unique{The Green Dream} using currency{Blessing of Chayula}
 Limited to: 1
 Radius: Large
-{variant:1}Gain 5% of Cold Damage as Extra Chaos Damage
-{variant:2}Gain (6-10)% of Cold Damage as Extra Chaos Damage
+{variant:1,2}Gain 5% of Cold Damage as Extra Chaos Damage
+{variant:3}Gain (6-10)% of Cold Damage as Extra Chaos Damage
 {variant:1}Passives granting Cold Resistance or all Elemental Resistances in Radius
 {variant:1}also grant Chance to Suppress Spell Damage at 35% of its value
 {variant:2}Passives granting Cold Resistance or all Elemental Resistances in Radius

--- a/src/Data/Uniques/shield.lua
+++ b/src/Data/Uniques/shield.lua
@@ -489,9 +489,9 @@ Implicits: 1
 {variant:2}(170-230)% increased Energy Shield
 {variant:1}+(70-100) to maximum Life
 +(35-40)% to Lightning Resistance
+{variant:2}Shocks you inflict spread to other Enemies within a Radius of 12
 Adds 1 to 10 Lightning Damage for each Shocked Enemy you've Killed Recently
 {variant:1}Shock Reflection
-{variant:2}Shocks you inflict spread to other Enemies within a Radius of 12
 ]],[[
 Esh's Visage
 Vaal Spirit Shield

--- a/src/Data/Uniques/shield.lua
+++ b/src/Data/Uniques/shield.lua
@@ -25,13 +25,16 @@ League: Breach
 Source: Drops in Uul-Netol Breach or from unique{Uul-Netol, Unburdened Flesh}
 Upgrade: Upgrades to unique{The Surrender} using currency{Blessing of Uul-Netol}
 Variant: Pre 3.0.0
+Variant: Pre 3.21.0
 Variant: Current
 Implicits: 1
-{variant:2}+(30-40) to maximum Life
-(120-160)% increased Armour
+{variant:2,3}+(30-40) to maximum Life
+{variant:1,2}(120-160)% increased Armour
+{variant:3}100% increased Armour
 +(50-70) to maximum Life
 +6% Chance to Block
-+1000 Armour if you've Blocked Recently
+{variant:1,2}+1000 Armour if you've Blocked Recently
+{variant:3}+(1500-3000) Armour if you've Blocked Recently
 Permanently Intimidate Enemies on Block
 ]],[[
 The Surrender
@@ -39,15 +42,18 @@ Ezomyte Tower Shield
 League: Breach
 Source: Upgraded from unique{The Anticipation} using currency{Blessing of Uul-Netol}
 Variant: Pre 3.0.0
+Variant: Pre 3.21.0
 Variant: Current
 Implicits: 1
-{variant:2}+(30-40) to maximum Life
+{variant:2,3}+(30-40) to maximum Life
 Grants Level 30 Reckoning Skill
-(130-170)% increased Armour
+{variant:1,2}(130-170)% increased Armour
+{variant:3}(165-205)% increased Armour
 +(65-80) to maximum Life
-Recover 250 Life when you Block
+{variant:1,2}Recover 250 Life when you Block
+{variant:3}Recover (250-500) Life when you Block
 +6% Chance to Block
-+1500 Armour if you've Blocked Recently
+{variant:1,2}+1500 Armour if you've Blocked Recently
 ]],[[
 Chernobog's Pillar
 Ebony Tower Shield
@@ -469,17 +475,23 @@ Implicits: 2
 {variant:4}Warcries grant Arcane Surge to you and Allies, with 10% increased effect per 5 power, up to 50%
 ]],[[
 Esh's Mirror
-Thorium Spirit Shield
+{variant:1}Thorium Spirit Shield
+{variant:2}Vaal Spirit Shield
+Variant: Pre 3.21.0
+Variant: Current
 League: Breach
 Source: Drops in Esh Breach or from unique{Esh, Forked Thought}
 Upgrade: Upgrades to unique{Esh's Visage} using currency{Blessing of Esh}
-Implicits: 0
+Implicits: 1
+{variant:2}(5-10)% increased Spell Damage
 +(20-30) to Intelligence
-(80-100)% increased Energy Shield
-+(40-70) to maximum Life
+{variant:1}(80-100)% increased Energy Shield
+{variant:2}(170-230)% increased Energy Shield
+{variant:1}+(40-70) to maximum Life
 +(35-40)% to Lightning Resistance
 Adds 1 to 10 Lightning Damage for each Shocked Enemy you've Killed Recently
-Shock Reflection
+{variant:1}Shock Reflection
+{variant:2}Shocks you inflict spread to other Enemies within a Radius of 12
 ]],[[
 Esh's Visage
 Vaal Spirit Shield

--- a/src/Data/Uniques/shield.lua
+++ b/src/Data/Uniques/shield.lua
@@ -487,7 +487,7 @@ Implicits: 1
 +(20-30) to Intelligence
 {variant:1}(80-100)% increased Energy Shield
 {variant:2}(170-230)% increased Energy Shield
-{variant:1}+(40-70) to maximum Life
+{variant:1}+(70-100) to maximum Life
 +(35-40)% to Lightning Resistance
 Adds 1 to 10 Lightning Damage for each Shocked Enemy you've Killed Recently
 {variant:1}Shock Reflection

--- a/src/Data/Uniques/sword.lua
+++ b/src/Data/Uniques/sword.lua
@@ -429,17 +429,22 @@ Source: Drops in Chayula Breach or from unique{Chayula, Who Dreamt}
 Upgrade: Upgrades to unique{United in Dream} using currency{Blessing of Chayula}
 Variant: Pre 2.6.0
 Variant: Pre 3.0.0
+Variant: Pre 3.21.0
 Variant: Current
 League: Breach
 Implicits: 2
 {variant:1}18% increased Global Accuracy Rating
-{variant:2,3}40% increased Global Accuracy Rating
-+(10-20) to all Attributes
-Minions deal (20-30)% increased Damage
-Minions have +17% to Chaos Resistance
+{variant:2,3,4}40% increased Global Accuracy Rating
+{variant:1,2,3}+(10-20) to all Attributes
+{variant:1,2,3}Minions deal (20-30)% increased Damage
+{variant:4}Grants Level 25 Envy Skill
+{variant:1,2,3}Minions have +17% to Chaos Resistance
+{variant:4}Minions have +29% to Chaos Resistance
 {variant:1,2}Minions Poison Enemies on Hit
 {variant:3}Minions have 60% chance to Poison Enemies on Hit
-Minions Recover 20% of Life on Killing a Poisoned Enemy
+{variant:4}Minions have 60% chance to inflict Withered on Hit
+{variant:1,2,3}Minions Recover 20% of Life on Killing a Poisoned Enemy
+{variant:4}Minions have +5% to Critical Strike Multiplier per Withered Debuff on Enemy
 ]],[[
 United in Dream
 Cutlass
@@ -447,20 +452,22 @@ Source: Upgraded from unique{Severed in Sleep} using currency{Blessing of Chayul
 Variant: Pre 2.6.0
 Variant: Pre 3.0.0
 Variant: Pre 3.16.0
+Variant: Pre 3.21.0
 Variant: Current
 League: Breach
 LevelReq: 69
 Implicits: 2
 {variant:1}18% increased Global Accuracy Rating
-{variant:2,3,4}40% increased Global Accuracy Rating
+{variant:2,3,4,5}40% increased Global Accuracy Rating
 {variant:1,2,3}Grants Level 15 Envy Skill
-{variant:4}Grants Level 25 Envy Skill
+{variant:4,5}Grants Level 25 Envy Skill
 {variant:1,2,3}Minions deal (30-40)% increased Damage
 {variant:4}Minions deal (60-80)% increased Damage
 Minions have +29% to Chaos Resistance
 {variant:1,2}Minions Poison Enemies on Hit
-{variant:3,4}Minions have 60% chance to Poison Enemies on Hit
-Minions Leech 5% of Damage as Life against Poisoned Enemies
+{variant:3,4,5}Minions have 60% chance to Poison Enemies on Hit
+{variant:1,2,3,4}Minions Leech 5% of Damage as Life against Poisoned Enemies
+{variant:5}Minions Recover 10% of Life on Killing a Poisoned Enemy
 ]],[[
 Story of the Vaal
 {variant:1}Variscite Blade

--- a/src/Data/Uniques/sword.lua
+++ b/src/Data/Uniques/sword.lua
@@ -435,9 +435,9 @@ League: Breach
 Implicits: 2
 {variant:1}18% increased Global Accuracy Rating
 {variant:2,3,4}40% increased Global Accuracy Rating
+{variant:4}Grants Level 25 Envy Skill
 {variant:1,2,3}+(10-20) to all Attributes
 {variant:1,2,3}Minions deal (20-30)% increased Damage
-{variant:4}Grants Level 25 Envy Skill
 {variant:1,2,3}Minions have +17% to Chaos Resistance
 {variant:4}Minions have +29% to Chaos Resistance
 {variant:1,2}Minions Poison Enemies on Hit

--- a/src/Data/Uniques/wand.lua
+++ b/src/Data/Uniques/wand.lua
@@ -201,7 +201,7 @@ Variant: Pre 2.6.0
 Variant: Pre 3.21.0
 Variant: Current
 Requires Level 65, 212 Int
-Implicits: 2
+Implicits: 3
 {variant:1}(16-19)% increased Spell Damage
 {variant:2,3}(35-39)% increased Spell Damage
 {variant:4}(33-37)% increased Spell Damage
@@ -249,7 +249,7 @@ Variant: Current
 League: Ultimatum
 Source: Drops from unique{The Trialmaster}
 Requires Level 24, 83 Int
-Implicits: 1
+Implicits: 2
 {variant:1}(15-19)% increased Spell Damage
 {variant:2}(17-21)% increased Spell Damage
 Grants Level 1 Blood Sacrament Skill

--- a/src/Data/Uniques/wand.lua
+++ b/src/Data/Uniques/wand.lua
@@ -347,9 +347,9 @@ Variant: Current
 League: Breach
 Source: Upgraded from unique{Tulborn} using currency{Blessing of Tul}
 Requires Level 65, 212 Int
-Implicits: 1
-{variant:1}(35-39)% increased Spell Damage
-{variant:2}Adds (14-29) to (42-47) Cold Damage to Spells and Attacks
+Implicits: 2
+{variant:1,2}(35-39)% increased Spell Damage
+{variant:3}Adds (14-29) to (42-47) Cold Damage to Spells and Attacks
 {variant:1,2}(10-15)% increased Cast Speed
 {variant:3}(10-20)% increased Cast Speed
 {variant:1}50% chance to gain a Power Charge on Killing a Frozen Enemy
@@ -369,7 +369,7 @@ Variant: Current
 League: Heist
 Source: Steal from a unique{Curio Display} during a Grand Heist
 Requires Level 65, 212 Int
-Implicits: 1
+Implicits: 2
 {variant:1}(35-39)% increased Spell Damage
 {variant:2}Adds (14-29) to (42-47) Cold Damage to Spells and Attacks
 (15-25)% increased Cast Speed

--- a/src/Data/Uniques/wand.lua
+++ b/src/Data/Uniques/wand.lua
@@ -292,31 +292,42 @@ Adds 1 to (35-45) Lightning Damage
 (25-35)% chance to gain a Power Charge on Kill
 ]],[[
 Tulborn
-Spiraled Wand
+{variant:1}Spiraled Wand
+{variant:2}Opal Wand
+Variant: Pre 3.21.0
+Variant: Current
 League: Breach
 Source: Drops in Tul Breach or from unique{Tul, Creeping Avalanche}
 Upgrade: Upgrades to unique{Tulfall} using currency{Blessing of Tul}
 Requires Level 24, 83 Int
-Implicits: 1
-(15-19)% increased Spell Damage
-(10-15)% increased Cast Speed
+Implicits: 2
+{variant:1}(15-19)% increased Spell Damage
+{variant:2}(38-42)% increased Spell Damage
+{variant:1}(10-15)% increased Cast Speed
 50% chance to gain a Power Charge on Killing a Frozen Enemy
-Adds 10 to 20 Cold Damage to Spells per Power Charge
+{variant:1}Adds 10 to 20 Cold Damage to Spells per Power Charge
+{variant:2}Adds (120-140) to (150-170) Cold Damage to Spells
 +(20-25) Mana gained on Killing a Frozen Enemy
+{variant:2}Cold Exposure you inflict applies an extra -12% to Cold Resistance
 ]],[[
 Tulfall
-Tornado Wand
+{variant:1,2}Tornado Wand
+{variant:3}Opal Wand
 Variant: Pre 3.16.0
+Variant: Pre 3.21.0
 Variant: Current
 League: Breach
 Source: Upgraded from unique{Tulborn} using currency{Blessing of Tul}
 Requires Level 65, 212 Int
 Implicits: 1
-(35-39)% increased Spell Damage
-(10-15)% increased Cast Speed
+{variant:1}(35-39)% increased Spell Damage
+{variant:2}(38-42)% increased Spell Damage
+{variant:1,2}(10-15)% increased Cast Speed
+{variant:3}(10-20)% increased Cast Speed
 {variant:1}50% chance to gain a Power Charge on Killing a Frozen Enemy
-{variant:2}Gain a Power Charge on Killing a Frozen Enemy
-Adds 15 to 25 Cold Damage to Spells per Power Charge
+{variant:2,3}Gain a Power Charge on Killing a Frozen Enemy
+{variant:1,2}Adds 15 to 25 Cold Damage to Spells per Power Charge
+{variant:3}Adds 50 to 70 Cold Damage to Spells per Power Charge
 Lose all Power Charges on reaching Maximum Power Charges
 Gain a Frenzy Charge on reaching Maximum Power Charges
 {variant:1}(10-15)% increased Cold Damage per Frenzy Charge

--- a/src/Data/Uniques/wand.lua
+++ b/src/Data/Uniques/wand.lua
@@ -6,11 +6,13 @@ return {
 Abberath's Horn
 Goat's Horn
 Variant: Pre 2.3.0
+Variant: Pre 3.21.0
 Variant: Current
 Requires Level 6, 29 Int
-Implicits: 2
+Implicits: 3
 {variant:1}(9-12)% increased Spell Damage
 {variant:2}(10-14)% increased Spell Damage
+{variant:3}Adds (1-2) to (3-4) Fire Damage to Spells and Attacks
 (20-30)% increased Fire Damage
 Adds (4-6) to (8-12) Fire Damage to Spells
 (40-60)% increased Global Critical Strike Chance
@@ -225,14 +227,16 @@ Spiraled Wand
 Variant: Pre 2.3.0
 Variant: Pre 3.11.0
 Variant: Pre 3.19.0
+Variant: Pre 3.21.0
 Variant: Current
 Requires Level 24, 83 Int
-Implicits: 2
+Implicits: 3
 {variant:1}(10-14)% increased Spell Damage
 {variant:2,3,4}(15-19)% increased Spell Damage
+{variant:5}Adds (1-2) to (9-11) Lightning Damage to Spells and Attacks
 {variant:1,2}+1 to Level of Socketed Gems
-{variant:3,4}+2 to Level of Socketed Gems
-{variant:4}Socketed Gems are Supported by Level 10 Arcane Surge
+{variant:3,4,5}+2 to Level of Socketed Gems
+{variant:4,5}Socketed Gems are Supported by Level 10 Arcane Surge
 Socketed Gems are Supported by Level 10 Spell Echo
 {variant:4}Socketed Gems are Supported by Level 10 Controlled Destruction
 +(10-30) to Intelligence
@@ -283,10 +287,12 @@ Tornado Wand
 Elder Item
 Source: Drops from unique{The Elder}
 Variant: Pre 3.4.0
+Variant: Pre 3.21.0
 Variant: Current
 Requires Level 65, 212 Int
-Implicits: 1
-(35-39)% increased Spell Damage
+Implicits: 2
+{variant:1,2}(35-39)% increased Spell Damage
+{variant:3}Adds (3-5) to (70-82) Lightning Damage to Spells and Attacks
 (30-40)% increased Spell Damage
 Adds (26-35) to (95-105) Lightning Damage to Spells
 +(6-10)% to Critical Strike Multiplier per Power Charge
@@ -294,7 +300,7 @@ Adds (26-35) to (95-105) Lightning Damage to Spells
 +2% Chance to Block Spell Damage per Power Charge
 Adds 3 to 9 Lightning Damage to Spells per Power Charge
 {variant:1}400 Lightning Damage taken per second per Power Charge if you've dealt a Critical Strike Recently
-{variant:2}200 Lightning Damage taken per second per Power Charge if your Skills have dealt a Critical Strike Recently
+{variant:2,3}200 Lightning Damage taken per second per Power Charge if your Skills have dealt a Critical Strike Recently
 ]],[[
 Storm Prison
 {variant:1,2}Carved Wand
@@ -306,7 +312,7 @@ Requires Level 12, 47 Int
 Implicits: 3
 {variant:1}(9-13)% increased Spell Damage
 {variant:2}(11-15)% increased Spell Damage
-{variant:3}(15-19)% increased Spell Damage
+{variant:3}Adds (1-2) to (9-11) Lightning Damage to Spells and Attacks
 (40-60)% increased Physical Damage
 Adds 1 to (35-45) Lightning Damage
 (15-25)% increased Mana Regeneration Rate
@@ -324,7 +330,7 @@ Upgrade: Upgrades to unique{Tulfall} using currency{Blessing of Tul}
 Requires Level 24, 83 Int
 Implicits: 2
 {variant:1}(15-19)% increased Spell Damage
-{variant:2}(38-42)% increased Spell Damage
+{variant:2}Adds (14-29) to (42-47) Cold Damage to Spells and Attacks
 {variant:1}(10-15)% increased Cast Speed
 50% chance to gain a Power Charge on Killing a Frozen Enemy
 {variant:1}Adds 10 to 20 Cold Damage to Spells per Power Charge
@@ -343,7 +349,7 @@ Source: Upgraded from unique{Tulborn} using currency{Blessing of Tul}
 Requires Level 65, 212 Int
 Implicits: 1
 {variant:1}(35-39)% increased Spell Damage
-{variant:2}(38-42)% increased Spell Damage
+{variant:2}Adds (14-29) to (42-47) Cold Damage to Spells and Attacks
 {variant:1,2}(10-15)% increased Cast Speed
 {variant:3}(10-20)% increased Cast Speed
 {variant:1}50% chance to gain a Power Charge on Killing a Frozen Enemy
@@ -365,7 +371,7 @@ Source: Steal from a unique{Curio Display} during a Grand Heist
 Requires Level 65, 212 Int
 Implicits: 1
 {variant:1}(35-39)% increased Spell Damage
-{variant:2}(38-42)% increased Spell Damage
+{variant:2}Adds (14-29) to (42-47) Cold Damage to Spells and Attacks
 (15-25)% increased Cast Speed
 Lose all Power Charges on reaching Maximum Power Charges
 Gain a Frenzy Charge on reaching Maximum Power Charges

--- a/src/Data/Uniques/wand.lua
+++ b/src/Data/Uniques/wand.lua
@@ -18,60 +18,69 @@ Gain 10 Life per Ignited Enemy Killed
 25% reduced Ignite Duration on Enemies
 ]],[[
 Apep's Rage
-Opal Wand
+{variant:1,2,3,4,5}Opal Wand
+{variant:6}Omen wand
 Variant: Pre 2.3.0
 Variant: Pre 3.7.0
 Variant: Pre 3.11.0
 Variant: Pre 3.19.0
+Variant: Pre 3.21.0
 Variant: Current
 Requires Level 62, 212 Int
-Implicits: 2
+Implicits: 3
 {variant:1}(17-20)% increased Spell Damage
 {variant:2,3,4,5}(38-42)% increased Spell Damage
+{variant:6}(27-31)% increased Spell Damage
 {variant:1,2}Adds (50-65) to (90-105) Chaos Damage to Spells
-{variant:3,4,5}Adds (90-130) to (140-190) Chaos Damage to Spells
+{variant:3,4,5,6}Adds (90-130) to (140-190) Chaos Damage to Spells
 (25-30)% increased Cast Speed
 +(5-10)% to Chaos Resistance
 {variant:1,2,3}40% increased Mana Cost of Skills
 {variant:3,4}Poisons you inflict deal Damage 20% faster
-{variant:5}Poisons you inflict deal Damage (30-50)% faster
-{variant:4,5}Lose 40 Mana when you use a Skill
+{variant:5,6}Poisons you inflict deal Damage (30-50)% faster
+{variant:4,5,6}Lose 40 Mana when you use a Skill
 ]],[[
 Ashcaller
-Quartz Wand
+{variant:1,2,3}Quartz Wand
+{variant:4}Carved Wand
 Variant: Pre 3.8.0
 Variant: Pre 3.19.0
+Variant: Pre 3.21.0
 Variant: Current
 Requires Level 18, 65 Int
-Implicits: 1
-(18-22)% increased Spell Damage
+Implicits: 2
+{variant:1,2,3}(18-22)% increased Spell Damage
+{variant:4}(11-15)% increased Spell Damage
 {variant:1,2}10% chance to Trigger Level 8 Summon Raging Spirit on Kill
-{variant:3}25% chance to Trigger Level 10 Summon Raging Spirit on Kill
+{variant:3,4}25% chance to Trigger Level 10 Summon Raging Spirit on Kill
 {variant:1}Adds (10-14) to (18-22) Fire Damage
-{variant:3}Adds (20-24) to (38-46) Fire Damage
+{variant:3,4}Adds (20-24) to (38-46) Fire Damage
 {variant:2}+(15-25)% to Fire Damage over Time Multiplier
 {variant:1,2}Adds (4-6) to (7-9) Fire Damage to Spells
-{variant:3}Adds (20-24) to (36-46) Fire Damage to Spells
+{variant:3,4}Adds (20-24) to (36-46) Fire Damage to Spells
 {variant:1}(40-50)% increased Burning Damage
 {variant:2}(20-30)% increased Burning Damage
 {variant:1,2}(16-22)% chance to Ignite
-{variant:3}10% chance to Cover Enemies in Ash on Hit
+{variant:3,4}10% chance to Cover Enemies in Ash on Hit
 ]],[[
 Eclipse Solaris
-Crystal Wand
+{variant:1,2,3,4}Crystal Wand
+{variant:5}Engraved Wand
 Variant: Pre 2.2.0
 Variant: Pre 2.3.0
 Variant: Pre 3.10.0
+Variant: Pre 3.21.0
 Variant: Current
 Requires Level 45, 146 Int
-Implicits: 2
+Implicits: 3
 {variant:1,2}(14-18)% increased Spell Damage
 {variant:3,4}(29-33)% increased Spell Damage
+{variant:5}(22-26)% increased Spell Damage
 {variant:1,2,3}Adds (18-22) to (36-44) Physical Damage
-{variant:4}Adds (30-45) to (60-80) Fire Damage
-{variant:4}(6-10)% increased Attack Speed
+{variant:4,5}Adds (30-45) to (60-80) Fire Damage
+{variant:4,5}(6-10)% increased Attack Speed
 {variant:1}+(18-30)% to Global Critical Strike Multiplier
-{variant:2,3,4}+(27-33)% to Global Critical Strike Multiplier
+{variant:2,3,4,5}+(27-33)% to Global Critical Strike Multiplier
 20% increased Light Radius
 Nearby Enemies are Blinded
 (120-140)% increased Critical Strike Chance against Blinded Enemies
@@ -163,37 +172,43 @@ Implicits: 2
 10% chance to Blind Enemies on hit
 ]],[[
 Obliteration
-Demon's Horn
+{variant:1,2,3,4}Demon's Horn
+{variant:5}Imbued Wand
 Variant: Pre 2.3.0
 Variant: Pre 3.10.0
 Variant: Pre 3.19.0
+Variant: Pre 3.21.0
 Variant: Current
 Requires Level 56, 179 Int
-Implicits: 2
+Implicits: 3
 {variant:1}(15-18)% increased Spell Damage
 {variant:2,3,4}(31-35)% increased Spell Damage
+{variant:5}(33-37)% increased Spell Damage
 {variant:1,2}Adds (24-30) to (80-92) Physical Damage
 {variant:3}Adds (25-50) to (85-125) Physical Damage
 {variant:1,2,3}(26-32)% increased Critical Strike Chance
 {variant:1,2,3}Gain (13-15)% of Physical Damage as Extra Chaos Damage
-{variant:4}Gain (30-40)% of Physical Damage as Extra Chaos Damage
+{variant:4,5}Gain (30-40)% of Physical Damage as Extra Chaos Damage
 Enemies you Kill have a 20% chance to Explode, dealing a quarter of their maximum Life as Chaos Damage
 ]],[[
 Piscator's Vigil
-Tornado Wand
+{variant:1,2,3}Tornado Wand
+{variant:4}Imbued Wand
 Variant: Pre 2.3.0
 Variant: Pre 2.6.0
+Variant: Pre 3.21.0
 Variant: Current
 Requires Level 65, 212 Int
 Implicits: 2
 {variant:1}(16-19)% increased Spell Damage
 {variant:2,3}(35-39)% increased Spell Damage
+{variant:4}(33-37)% increased Spell Damage
 No Physical Damage
 (10-18)% increased Attack Speed
 +(340-400) to Accuracy Rating
 (20-30)% increased Critical Strike Chance
 Attacks with this Weapon have (100-115)% increased Elemental Damage
-{variant:3}Attacks with this Weapon Penetrate 5% Elemental Resistances
+{variant:3,4}Attacks with this Weapon Penetrate 5% Elemental Resistances
 ]],[[
 The Poet's Pen
 Carved Wand
@@ -223,12 +238,16 @@ Socketed Gems are Supported by Level 10 Spell Echo
 +(10-30) to Intelligence
 ]],[[
 Relic of the Pact
-Spiraled Wand
+{variant:1}Spiraled Wand
+{variant:2}Sage Wand
+Variant: Pre 3.21.0
+Variant: Current
 League: Ultimatum
 Source: Drops from unique{The Trialmaster}
 Requires Level 24, 83 Int
 Implicits: 1
-(15-19)% increased Spell Damage
+{variant:1}(15-19)% increased Spell Damage
+{variant:2}(17-21)% increased Spell Damage
 Grants Level 1 Blood Sacrament Skill
 Your Critical Strike Chance is Lucky while on Low Life
 ]],[[
@@ -278,13 +297,16 @@ Adds 3 to 9 Lightning Damage to Spells per Power Charge
 {variant:2}200 Lightning Damage taken per second per Power Charge if your Skills have dealt a Critical Strike Recently
 ]],[[
 Storm Prison
-Carved Wand
+{variant:1,2}Carved Wand
+{variant:3}Spiraled Wand
 Variant: Pre 2.3.0
+Variant: Pre 3.21.0
 Variant: Current
 Requires Level 12, 47 Int
-Implicits: 2
+Implicits: 3
 {variant:1}(9-13)% increased Spell Damage
 {variant:2}(11-15)% increased Spell Damage
+{variant:3}(15-19)% increased Spell Damage
 (40-60)% increased Physical Damage
 Adds 1 to (35-45) Lightning Damage
 (15-25)% increased Mana Regeneration Rate
@@ -334,12 +356,16 @@ Gain a Frenzy Charge on reaching Maximum Power Charges
 {variant:2}(15-20)% increased Cold Damage per Frenzy Charge
 ]],[[
 Replica Tulfall
-Tornado Wand
+{variant:1}Tornado Wand
+{variant:2}Opal Wand
+Variant: Pre 3.21.0
+Variant: Current
 League: Heist
 Source: Steal from a unique{Curio Display} during a Grand Heist
 Requires Level 65, 212 Int
 Implicits: 1
-(35-39)% increased Spell Damage
+{variant:1}(35-39)% increased Spell Damage
+{variant:2}(38-42)% increased Spell Damage
 (15-25)% increased Cast Speed
 Lose all Power Charges on reaching Maximum Power Charges
 Gain a Frenzy Charge on reaching Maximum Power Charges


### PR DESCRIPTION
### Description of the problem being solved:
Implements changes to unique items and their base types from the Crucible patch notes.

Known unsupported modifiers:
- Nightmare jewel node conversions
- Severed in Sleep wither on hit, crit scaling
- Infinite Pursuit bleed expiry, sun/poison immunity
- Xoph's Inception pierce against burning, damage per pierce
- Formless Flame fire damage from hits
- Formless Inferno minion life scaling
- Xoph's Heart covered in ash
- Lightpoacher spirit charges
- Bubonic Trail abyss jewel scaling

### Steps taken to verify a working solution:
- Manual verification in the item tab

### Link to a build that showcases this PR:
https://pobb.in/SEWlx50vzllT includes all uniques
