### PR TITLE
3.21/minion accuracy equals accuracy

### DIFF
--- a/src/Modules/CalcPerform.lua
+++ b/src/Modules/CalcPerform.lua
@@ -1184,7 +1184,11 @@ function calcs.perform(env, avoidCache)
 			env.minion.modDB:NewMod("Armour", "BASE", m_floor((10 + env.minion.level * 2) * env.minion.minionData.armour * 1.038 ^ env.minion.level), "Base")
 		end
 		env.minion.modDB:NewMod("Evasion", "BASE", round((30 + env.minion.level * 5) * 1.03 ^ env.minion.level), "Base")
-		env.minion.modDB:NewMod("Accuracy", "BASE", round((17 + env.minion.level / 2) * (env.minion.minionData.accuracy or 1) * 1.03 ^ env.minion.level), "Base")
+		if modDB:Flag(nil, "MinionAccuracyEqualsAccuracy") then
+			env.minion.modDB:NewMod("Accuracy", "BASE", round(calcLib.val(modDB, "Accuracy")), "Player")
+		else
+			env.minion.modDB:NewMod("Accuracy", "BASE", round((17 + env.minion.level / 2) * (env.minion.minionData.accuracy or 1) * 1.03 ^ env.minion.level), "Base")
+		end
 		env.minion.modDB:NewMod("CritMultiplier", "BASE", 30, "Base")
 		env.minion.modDB:NewMod("CritDegenMultiplier", "BASE", 30, "Base")
 		env.minion.modDB:NewMod("FireResist", "BASE", env.minion.minionData.fireResist, "Base")

--- a/src/Modules/CalcPerform.lua
+++ b/src/Modules/CalcPerform.lua
@@ -1185,7 +1185,7 @@ function calcs.perform(env, avoidCache)
 		end
 		env.minion.modDB:NewMod("Evasion", "BASE", round((30 + env.minion.level * 5) * 1.03 ^ env.minion.level), "Base")
 		if modDB:Flag(nil, "MinionAccuracyEqualsAccuracy") then
-			env.minion.modDB:NewMod("Accuracy", "BASE", round(calcLib.val(modDB, "Accuracy")), "Player")
+			env.minion.modDB:NewMod("Accuracy", "BASE", calcLib.val(modDB, "Accuracy") + calcLib.val(modDB, "Dex") * (modDB:Override(nil, "DexAccBonusOverride") or data.misc.AccuracyPerDexBase), "Player")
 		else
 			env.minion.modDB:NewMod("Accuracy", "BASE", round((17 + env.minion.level / 2) * (env.minion.minionData.accuracy or 1) * 1.03 ^ env.minion.level), "Base")
 		end

--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -3034,6 +3034,7 @@ local specialModList = {
 	-- Minions
 	["your strength is added to your minions"] = { flag("HalfStrengthAddedToMinions") },
 	["half of your strength is added to your minions"] = { flag("HalfStrengthAddedToMinions") },
+	["minion's accuracy rating is equal to yours"] = { flag("MinionAccuracyEqualsAccuracy") },
 	["minions created recently have (%d+)%% increased attack and cast speed"] = function(num) return { mod("MinionModifier", "LIST", { mod = mod("Speed", "INC", num) }, { type = "Condition", var = "MinionsCreatedRecently" }) } end,
 	["minions created recently have (%d+)%% increased movement speed"] = function(num) return { mod("MinionModifier", "LIST", { mod = mod("MovementSpeed", "INC", num) }, { type = "Condition", var = "MinionsCreatedRecently" }) } end,
 	["minions poison enemies on hit"] = { mod("MinionModifier", "LIST", { mod = mod("PoisonChance", "BASE", 100) }) },


### PR DESCRIPTION
…mastery

### Description of the problem being solved:
- Added support for the new "Minion's accuracy rating is equal to yours" mod that is added in 3.21.
- _Screenshots show this is a nerf to minion accuracy if you don't have enough player accuracy_

### Steps taken to verify a working solution:
- Added Raise Zombie skill
- Added +1000 accuracy rating in custom modifiers
- Added minion's accuracy rating is equal to yours
- Zombie's MH Accuracy is 1040 (1000 flat + 40 from dex)

### Link to a build that showcases this PR:
[https://pobb.in/bSRGKIGq9tCB](https://pobb.in/bSRGKIGq9tCB)

### Before screenshot:
![3 21-minion-accuracy-equal-yours_before](https://user-images.githubusercontent.com/62115140/229030736-965c90a1-1535-410c-be75-6f59d4d31dfe.PNG)

### After screenshot:
![3 21-minion-accuracy-equal-yours_after](https://user-images.githubusercontent.com/62115140/229030750-7d6c20a2-6fbf-4c98-b559-fec4d6c757ed.PNG)
