### PR TITLE
Fix tree conversion

### DIFF
--- a/src/Classes/PassiveSpec.lua
+++ b/src/Classes/PassiveSpec.lua
@@ -1540,8 +1540,8 @@ function PassiveSpecClass:CreateUndoState()
 	}
 end
 
-function PassiveSpecClass:RestoreUndoState(state)
-	self:ImportFromNodeList(state.classId, state.ascendClassId, state.hashList, state.masteryEffects, state.treeVersion)
+function PassiveSpecClass:RestoreUndoState(state, treeVersion)
+	self:ImportFromNodeList(state.classId, state.ascendClassId, state.hashList, state.masteryEffects, treeVersion or state.treeVersion)
 	self:SetWindowTitleWithBuildClass()
 end
 

--- a/src/Classes/TreeTab.lua
+++ b/src/Classes/TreeTab.lua
@@ -168,7 +168,7 @@ local TreeTabClass = newClass("TreeTab", "ControlHost", function(self, build)
 		local newSpec = new("PassiveSpec", self.build, latestTreeVersion)
 		newSpec.title = self.build.spec.title
 		newSpec.jewels = copyTable(self.build.spec.jewels)
-		newSpec:RestoreUndoState(self.build.spec:CreateUndoState())
+		newSpec:RestoreUndoState(self.build.spec:CreateUndoState(), latestTreeVersion)
 		newSpec:BuildClusterJewelGraphs()
 		t_insert(self.specList, self.activeSpec + 1, newSpec)
 		self:SetActiveSpec(self.activeSpec + 1)


### PR DESCRIPTION
### Description of the problem being solved:
https://github.com/PathOfBuildingCommunity/PathOfBuilding/pull/5768 introduced a bug where due to now supporting undo across tree versions and conversion using a restore on the latest version it now stopped working as it would simply undo to the old version. This now adds an optional parameter to override this. 