### PR TITLE
Add support for potential alt primal aegis wording

### DIFF
--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -2089,6 +2089,7 @@ local specialModList = {
 		flag("EnableSkill", { type = "SkillName", skillId = "Primal Aegis" }),
 	},
 	["primal aegis can take (%d+) elemental damage per allocated notable passive skill"] = function(num) return { mod("ElementalAegisValue", "MAX", num, 0, 0, { type = "Multiplier", var = "AllocatedNotable" }, { type = "GlobalEffect", effectType = "Buff", unscalable = true }) } end,
+	["primal aegis can take (%d+) elemental damage per player level"] = function(num) return { mod("ElementalAegisValue", "MAX", num, 0, 0, { type = "Multiplier", var = "Level" }, { type = "GlobalEffect", effectType = "Buff", unscalable = true }) } end,
 	-- Gladiator
 	["chance to block spell damage is equal to chance to block attack damage"] = { flag("SpellBlockChanceIsBlockChance") },
 	["maximum chance to block spell damage is equal to maximum chance to block attack damage"] = { flag("SpellBlockChanceMaxIsBlockChanceMax") },


### PR DESCRIPTION
### Description of the problem being solved:
Primal Aegis can take 20 Elemental Damage per Player Level is on 3.21 tree

![image](https://user-images.githubusercontent.com/31533893/229067760-a5738f98-8a1b-4591-a703-15c9661cda16.png)
![image](https://user-images.githubusercontent.com/31533893/229067799-2e5713bd-249c-43ee-b97d-9984763883cf.png)
