### PR TITLE
Add shaper influce to entropic devastion

### DIFF
--- a/src/Data/Uniques/gloves.lua
+++ b/src/Data/Uniques/gloves.lua
@@ -994,6 +994,7 @@ Requires Level 67, 51 Dex, 51 Int
 Entropic Devastation
 Assassin's Mitts
 Source: Drops from unique{The Shaper} (Uber)
+Shaper Item
 Grants Call of Steel
 (100-150)% increased Evasion and Energy Shield
 (30-50)% increased Effect of Impales inflicted with Spells


### PR DESCRIPTION
>Fixed a bug where the Entropic Devastation Unique did not have Shaper-influence.