### PR TITLE
3.21 - % of Armour also applies to chaos damage from hits

### DIFF
--- a/src/Modules/CalcSections.lua
+++ b/src/Modules/CalcSections.lua
@@ -1478,6 +1478,10 @@ return {
 		{ breakdown = "LightningDamageReduction" },
 		{ modName = { "ArmourAppliesToLightningDamageTaken", "SelfIgnoreLightningResistance", "DamageReductionMax" } },
 	}, },
+	{ label = "Chaos. Dmg. Reduct", haveOutput = "ChaosDamageReduction", { format = "{0:output:ChaosDamageReduction}%",
+		{ breakdown = "ChaosDamageReduction" },
+		{ modName = { "ArmourAppliesToChaosDamageTaken", "DamageReductionMax" } },
+	}, },
 } }
 } },
 { 1, "Evasion", 3, colorCodes.EVASION, {{ defaultCollapsed = false, label = "Evasion", data = {

--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -1809,6 +1809,7 @@ local specialModList = {
 		mod("ArmourAppliesToColdDamageTaken", "BASE", num),
 		mod("ArmourAppliesToLightningDamageTaken", "BASE", num),
 	} end,
+	["(%d+)%% of armour also applies to chaos damage from hits"] = function(num) return { mod("ArmourAppliesToChaosDamageTaken", "BASE", num) } end,
 	["maximum damage reduction for any damage type is (%d+)%%"] = function(num) return { mod("DamageReductionMax", "OVERRIDE", num) } end,
 	["gain additional elemental damage reduction equal to half your chaos resistance"] = { 
 		mod("FireDamageReduction", "BASE", 1, { type = "PerStat", stat = "ChaosResist", div = 2 }),


### PR DESCRIPTION

### Description of the problem being solved:
- Added support for the new mastery - % of armour also applies to chaos damage from hits

### Steps taken to verify a working solution:
- Added 1000 armor as a custom modifier
- Added the new mod - 10% of armour also applies to chaos damage from hits as a custom modifier
- Added our existing mod - 10% of armour applies to fire, cold and lightning damage taken from hits as a custom modifier
- Verified that the Maximum hit taken matched across elemental and chaos damage

### Link to a build that showcases this PR:
[https://pobb.in/hS5ZhHGHEIG7](https://pobb.in/hS5ZhHGHEIG7)

### Before screenshot:
![armor-applies-chaos_before](https://user-images.githubusercontent.com/62115140/229148660-406e77d7-d164-4a10-92e3-fed1f619d978.PNG)

### After screenshot:
![armor-applies-chaos_after](https://user-images.githubusercontent.com/62115140/229148675-3691c27c-6e2e-4db3-bc79-ac41b75f5a3b.PNG)
