### PR TITLE
3.21: 100% increased Armour and Energy Shield from Equipped Body Armour if equipped...

### DIFF
--- a/src/Modules/CalcDefence.lua
+++ b/src/Modules/CalcDefence.lua
@@ -160,7 +160,7 @@ function calcs.defence(env, actor)
 		local gearArmour = 0
 		local gearEvasion = 0
 		local slotCfg = wipeTable(tempTable1)
-		for _, slot in pairs({"Helmet","Body Armour","Gloves","Boots","Weapon 2","Weapon 3"}) do
+		for _, slot in pairs({"Helmet","Gloves","Boots","Body Armour","Weapon 2","Weapon 3"}) do
 			local armourData = actor.itemList[slot] and actor.itemList[slot].armourData
 			if armourData then
 				slotCfg.slotName = slot
@@ -207,7 +207,11 @@ function calcs.defence(env, actor)
 							})
 						end
 					else
-						energyShield = energyShield + energyShieldBase * calcLib.mod(modDB, slotCfg, "EnergyShield", "Defences")
+						if slot == "Body Armour" then
+							energyShield = energyShield + energyShieldBase * calcLib.mod(modDB, slotCfg, "EnergyShield", "Defences", "Body ArmourESAndArmour")
+						else	
+							energyShield = energyShield + energyShieldBase * calcLib.mod(modDB, slotCfg, "EnergyShield", "Defences")
+						end
 						gearEnergyShield = gearEnergyShield + energyShieldBase
 						if breakdown then
 							breakdown.slot(slot, nil, slotCfg, energyShieldBase, nil, "EnergyShield", "Defences")
@@ -220,7 +224,11 @@ function calcs.defence(env, actor)
 					if slot == "Body Armour" and modDB:Flag(nil, "Unbreakable") then
 						armourBase = armourBase * 2
 					end
-					armour = armour + armourBase * calcLib.mod(modDB, slotCfg, "Armour", "ArmourAndEvasion", "Defences")
+					if slot == "Body Armour" then
+						armour = armour + armourBase * calcLib.mod(modDB, slotCfg, "Armour", "ArmourAndEvasion", "Defences", "Body ArmourESAndArmour")
+					else
+						armour = armour + armourBase * calcLib.mod(modDB, slotCfg, "Armour", "ArmourAndEvasion", "Defences")
+					end
 					gearArmour = gearArmour + armourBase
 					if breakdown then
 						breakdown.slot(slot, nil, slotCfg, armourBase, nil, "Armour", "ArmourAndEvasion", "Defences")

--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -1895,6 +1895,16 @@ local specialModList = {
 	["defend with (%d+)%% of armour while not on low energy shield"] = function(num) return {
 		mod("ArmourDefense", "MAX", num - 100, "Armour and Energy Shield Mastery", { type = "Condition", var = "LowEnergyShield", neg = true }),
 	} end,
+	["(%d+)%% increased armour and energy shield from equipped body armour if equipped gloves, helmet and boots all have armour and energy shield"] = function(num) return {
+		mod("Body ArmourESAndArmour", "INC", num,  
+			{ type = "StatThreshold", stat = "ArmourOnGloves", threshold = 1},
+			{ type = "StatThreshold", stat = "EnergyShieldOnGloves", threshold = 1},
+			{ type = "StatThreshold", stat = "ArmourOnHelmet", threshold = 1},
+			{ type = "StatThreshold", stat = "EnergyShieldOnHelmet", threshold = 1},
+			{ type = "StatThreshold", stat = "ArmourOnBoots", threshold = 1},
+			{ type = "StatThreshold", stat = "EnergyShieldOnBoots", threshold = 1}
+		)
+	} end,
 	-- Exerted Attacks
 	["exerted attacks deal (%d+)%% increased damage"] = function(num) return { mod("ExertIncrease", "INC", num, nil, ModFlag.Attack, 0) } end,
 	["exerted attacks have (%d+)%% chance to deal double damage"] = function(num) return { mod("ExertDoubleDamageChance", "BASE", num, nil, ModFlag.Attack, 0) } end,


### PR DESCRIPTION
…body armour if equipped gloves, helmet and boots all have armour and energy shield mastery

### Description of the problem being solved:
- Added support for the new 3.21 mastery "100% increased Armour and Energy Shield from Equipped Body Armour if Equipped Gloves, Helmet and Boots all have Armour and Energy Shield"

### Steps taken to verify a working solution:
- Added full whites armour/es ( low level items outside of the body armour for extra clarity )
- Added the new mastery point
- Armour/ES jumps from 764/228 to 1317/360
- Unequip helm/gloves/boots - the massive gain is lost

### Link to a build that showcases this PR:
[https://pobb.in/hWyPwKNr3RdZ](https://pobb.in/hWyPwKNr3RdZ)

### Before screenshot:
![3 21-body-armour-esarmour_before](https://user-images.githubusercontent.com/62115140/229270122-d46d9173-ae22-4177-ae60-116351157d56.PNG)

### After screenshot:
![3 21-body-armour-esarmour_after](https://user-images.githubusercontent.com/62115140/229270132-0377b70b-0ebb-43c1-a2db-d6a7d176112b.PNG)
