### PR TITLE
Support new Reservation Mastery (+1% max res)

### DIFF
--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -1361,6 +1361,10 @@ local modTagList = {
 	["wh[ie][ln]e? not on full energy shield"] = { tag = { type = "Condition", var = "FullEnergyShield", neg = true } },
 	["wh[ie][ln]e? you have energy shield"] = { tag = { type = "Condition", var = "HaveEnergyShield" } },
 	["wh[ie][ln]e? you have no energy shield"] = { tag = { type = "Condition", var = "HaveEnergyShield", neg = true } },
+	["if you have reserved life and mana"] = { tagList = {
+		{ type = "StatThreshold", stat = "LifeReserved", threshold = 0, upper = false },
+		{ type = "StatThreshold", stat = "ManaReserved", threshold = 0, upper = false },
+	} },
 	["if you have energy shield"] = { tag = { type = "Condition", var = "HaveEnergyShield" } },
 	["while stationary"] = { tag = { type = "Condition", var = "Stationary" } },
 	["while moving"] = { tag = { type = "Condition", var = "Moving" } },


### PR DESCRIPTION
### Description of the problem being solved:
Support the new Reservation mastery `+1% to all maximum Elemental Resistances if you have Reserved Life and Mana`

### Steps taken to verify a working solution:
- Equipped two auras, one on arrogance
- Added lots of elemental resistance in config
- Allocated the mastery at the Reservation wheel east of Scion's start

### Link to a build that showcases this PR:
- https://pobb.in/20Wvcf3RtNwt

### Before screenshot:
![image](https://user-images.githubusercontent.com/124351315/229281287-5b412ef1-fe5e-4a3e-acf4-73eac3c9b7e3.png)

### After screenshot:
![image](https://user-images.githubusercontent.com/124351315/229281241-beb5e111-a8a2-4296-8ae9-9ee0144c84b0.png)


