### PR TITLE
Correct base for Saemus' gift

### DIFF
--- a/src/Data/Uniques/quiver.lua
+++ b/src/Data/Uniques/quiver.lua
@@ -241,9 +241,10 @@ Gain 7 Life per Enemy Hit with Attacks
 Saemus' Gift
 {variant:1}Spike-Point Arrow Quiver
 {variant:2}Feathered Arrow Quiver
-{variant:1}Requires Level 45
-{variant:2}Requires Level 20
-Implicits: 1
+Variant: Pre 3.17.0
+Variant: Current
+Requires Level 20
+Implicits: 2
 {variant:1}(20-30)% increased Critical Strike Chance with Bows
 {variant:2}(20-30)% increased Projectile Speed
 +(30-40) to Dexterity

--- a/src/Data/Uniques/quiver.lua
+++ b/src/Data/Uniques/quiver.lua
@@ -243,7 +243,7 @@ Saemus' Gift
 {variant:2}Feathered Arrow Quiver
 Variant: Pre 3.17.0
 Variant: Current
-Requires Level 20
+Requires Level 45
 Implicits: 2
 {variant:1}(20-30)% increased Critical Strike Chance with Bows
 {variant:2}(20-30)% increased Projectile Speed

--- a/src/Data/Uniques/quiver.lua
+++ b/src/Data/Uniques/quiver.lua
@@ -239,10 +239,13 @@ Gain 7 Life per Enemy Hit with Attacks
 {variant:2}Arrows Fork
 ]],[[
 Saemus' Gift
-Spike-Point Arrow Quiver
-Requires Level 45
+{variant:1}Spike-Point Arrow Quiver
+{variant:2}Feathered Arrow Quiver
+{variant:1}Requires Level 45
+{variant:2}Requires Level 20
 Implicits: 1
-(20-30)% increased Critical Strike Chance with Bows
+{variant:1}(20-30)% increased Critical Strike Chance with Bows
+{variant:2}(20-30)% increased Projectile Speed
 +(30-40) to Dexterity
 (8-12)% increased Cast Speed
 +(30-60) to maximum Life


### PR DESCRIPTION
### Description of the problem being solved:
Saemus' Gift changed base in 3.17. This corrects the base by adding a new variant.
### Steps taken to verify a working solution:
- Checked the item in the item tab
