### PR TITLE
Set character level to level requirement for allocated passives

### DIFF
--- a/src/Classes/ImportTab.lua
+++ b/src/Classes/ImportTab.lua
@@ -583,7 +583,7 @@ function ImportTabClass:ImportPassiveTreeAndJewels(json, charData)
 	self.build.spec:ImportFromNodeList(charData.classId, charData.ascendancyClass, charPassiveData.hashes, charPassiveData.mastery_effects or {}, latestTreeVersion)
 	self.build.spec:AddUndoState()
 	self.build.characterLevel = charData.level
-	self.build.placeholder = false
+	self.build.characterLevelAutoMode = false
 	self.build.configTab:UpdateLevel()
 	self.build.controls.characterLevel:SetText(charData.level)
 	self.build:EstimatePlayerProgress()

--- a/src/Classes/ImportTab.lua
+++ b/src/Classes/ImportTab.lua
@@ -583,6 +583,7 @@ function ImportTabClass:ImportPassiveTreeAndJewels(json, charData)
 	self.build.spec:ImportFromNodeList(charData.classId, charData.ascendancyClass, charPassiveData.hashes, charPassiveData.mastery_effects or {}, latestTreeVersion)
 	self.build.spec:AddUndoState()
 	self.build.characterLevel = charData.level
+	self.build.placeholder = false
 	self.build.configTab:UpdateLevel()
 	self.build.controls.characterLevel:SetText(charData.level)
 	self.build:EstimatePlayerProgress()

--- a/src/Modules/Build.lua
+++ b/src/Modules/Build.lua
@@ -45,6 +45,7 @@ function buildMode:Init(dbFileName, buildName, buildXML, convertBuild)
 	self.bandit = "None"
 	self.pantheonMajorGod = "None"
 	self.pantheonMinorGod = "None"
+	self.placeholder = true
 	if buildXML then
 		if self:LoadDB(buildXML, "Unnamed build") then
 			self:CloseBuild()
@@ -164,6 +165,7 @@ function buildMode:Init(dbFileName, buildName, buildXML, convertBuild)
 		self.configTab:BuildModList()
 		self.modFlag = true
 		self.buildFlag = true
+		self.placeholder = buf == ''
 	end)
 	self.controls.characterLevel:SetText(tostring(self.characterLevel))
 	self.controls.characterLevel.tooltipFunc = function(tooltip)
@@ -739,6 +741,15 @@ function buildMode:EstimatePlayerProgress()
 	-- to prevent a negative level at a blank sheet the level requirement will be set dependent on points invested until caught up with quest skillpoints 
 	levelreq = math.max(PointsUsed - acts[currentAct].questPoints + 1, acts[currentAct].level)
 	
+	self.lastAllocated = self.lastAllocated or -1
+	
+	if (self.placeholder or self.placeholder == nil) and self.lastAllocated ~= PointsUsed then
+		self.characterLevel = levelreq
+		self.controls.characterLevel:SetText(tostring(self.characterLevel))
+	end
+	
+	self.lastAllocated = PointsUsed
+
 	-- Ascendency points for lab
 	-- this is a recommendation for beginners who are using Path of Building for the first time and trying to map out progress in PoB
 	local labstr = {"\nLabyrinth: Normal Lab", "\nLabyrinth: Cruel Lab", "\nLabyrinth: Merciless Lab", "\nLabyrinth: Uber Lab"}
@@ -795,6 +806,7 @@ function buildMode:Load(xml, fileName)
 		self.viewMode = xml.attrib.viewMode
 	end
 	self.characterLevel = tonumber(xml.attrib.level) or 1
+	self.placeholder = xml.attrib.placeholder == "true"
 	for _, diff in pairs({ "bandit", "pantheonMajorGod", "pantheonMinorGod" }) do
 		self[diff] = xml.attrib[diff] or "None"
 	end
@@ -838,6 +850,7 @@ function buildMode:Save(xml)
 		pantheonMajorGod = self.configTab.input.pantheonMajorGod,
 		pantheonMinorGod = self.configTab.input.pantheonMinorGod,
 		mainSocketGroup = tostring(self.mainSocketGroup),
+		placeholder = tostring(self.placeholder)
 	}
 	for _, id in ipairs(self.spectreList) do
 		t_insert(xml, { elem = "Spectre", attrib = { id = id } })

--- a/src/Modules/Build.lua
+++ b/src/Modules/Build.lua
@@ -813,7 +813,7 @@ function buildMode:Load(xml, fileName)
 		self.viewMode = xml.attrib.viewMode
 	end
 	self.characterLevel = tonumber(xml.attrib.level) or 1
-	self.characterLevelAutoMode = xml.attrib.placeholder == "true"
+	self.characterLevelAutoMode = xml.attrib.characterLevelAutoMode == "true"
 	for _, diff in pairs({ "bandit", "pantheonMajorGod", "pantheonMinorGod" }) do
 		self[diff] = xml.attrib[diff] or "None"
 	end
@@ -857,7 +857,7 @@ function buildMode:Save(xml)
 		pantheonMajorGod = self.configTab.input.pantheonMajorGod,
 		pantheonMinorGod = self.configTab.input.pantheonMinorGod,
 		mainSocketGroup = tostring(self.mainSocketGroup),
-		placeholder = tostring(self.characterLevelAutoMode)
+		characterLevelAutoMode = tostring(self.characterLevelAutoMode)
 	}
 	for _, id in ipairs(self.spectreList) do
 		t_insert(xml, { elem = "Spectre", attrib = { id = id } })

--- a/src/Modules/Build.lua
+++ b/src/Modules/Build.lua
@@ -743,7 +743,7 @@ function buildMode:EstimatePlayerProgress()
 	
 	self.lastAllocated = self.lastAllocated or -1
 	
-	if (self.placeholder or self.placeholder == nil) and self.lastAllocated ~= PointsUsed then
+	if self.placeholder and self.lastAllocated ~= PointsUsed then
 		self.characterLevel = levelreq
 		self.controls.characterLevel:SetText(tostring(self.characterLevel))
 	end

--- a/src/Modules/Build.lua
+++ b/src/Modules/Build.lua
@@ -160,12 +160,18 @@ function buildMode:Init(dbFileName, buildName, buildXML, convertBuild)
 			SetDrawLayer(nil, 0)
 		end
 	end
-	self.controls.characterLevel = new("EditControl", {"LEFT",self.controls.pointDisplay,"RIGHT"}, 12, 0, 106, 20, "", "Level", "%D", 3, function(buf)
+	self.controls.levelScalingButton = new("ButtonControl", {"LEFT",self.controls.pointDisplay,"RIGHT"}, 12, 0, 50, 20, self.placeholder and "Auto" or "Manual", function()
+		self.placeholder = not self.placeholder
+		self.controls.levelScalingButton.label = self.placeholder and "Auto" or "Manual"
+		self.recalcAdaptiveLevel = true
+	end)
+	self.controls.characterLevel = new("EditControl", {"LEFT",self.controls.levelScalingButton,"RIGHT"}, 8, 0, 106, 20, "", "Level", "%D", 3, function(buf)
 		self.characterLevel = m_min(m_max(tonumber(buf) or 1, 1), 100)
 		self.configTab:BuildModList()
 		self.modFlag = true
 		self.buildFlag = true
-		self.placeholder = buf == ''
+		self.placeholder = false
+		self.controls.levelScalingButton.label = "Manual"
 	end)
 	self.controls.characterLevel:SetText(tostring(self.characterLevel))
 	self.controls.characterLevel.tooltipFunc = function(tooltip)
@@ -743,9 +749,10 @@ function buildMode:EstimatePlayerProgress()
 	
 	self.lastAllocated = self.lastAllocated or -1
 	
-	if self.placeholder and self.lastAllocated ~= PointsUsed then
+	if self.placeholder and (self.lastAllocated ~= PointsUsed or self.recalcAdaptiveLevel) then
 		self.characterLevel = levelreq
 		self.controls.characterLevel:SetText(tostring(self.characterLevel))
+		self.recalcAdaptiveLevel = false
 	end
 	
 	self.lastAllocated = PointsUsed

--- a/src/Modules/Build.lua
+++ b/src/Modules/Build.lua
@@ -45,7 +45,7 @@ function buildMode:Init(dbFileName, buildName, buildXML, convertBuild)
 	self.bandit = "None"
 	self.pantheonMajorGod = "None"
 	self.pantheonMinorGod = "None"
-	self.placeholder = true
+	self.characterLevelAutoMode = true
 	if buildXML then
 		if self:LoadDB(buildXML, "Unnamed build") then
 			self:CloseBuild()
@@ -160,9 +160,9 @@ function buildMode:Init(dbFileName, buildName, buildXML, convertBuild)
 			SetDrawLayer(nil, 0)
 		end
 	end
-	self.controls.levelScalingButton = new("ButtonControl", {"LEFT",self.controls.pointDisplay,"RIGHT"}, 12, 0, 50, 20, self.placeholder and "Auto" or "Manual", function()
-		self.placeholder = not self.placeholder
-		self.controls.levelScalingButton.label = self.placeholder and "Auto" or "Manual"
+	self.controls.levelScalingButton = new("ButtonControl", {"LEFT",self.controls.pointDisplay,"RIGHT"}, 12, 0, 50, 20, self.characterLevelAutoMode and "Auto" or "Manual", function()
+		self.characterLevelAutoMode = not self.characterLevelAutoMode
+		self.controls.levelScalingButton.label = self.characterLevelAutoMode and "Auto" or "Manual"
 		self.recalcAdaptiveLevel = true
 	end)
 	self.controls.characterLevel = new("EditControl", {"LEFT",self.controls.levelScalingButton,"RIGHT"}, 8, 0, 106, 20, "", "Level", "%D", 3, function(buf)
@@ -170,10 +170,10 @@ function buildMode:Init(dbFileName, buildName, buildXML, convertBuild)
 		self.configTab:BuildModList()
 		self.modFlag = true
 		self.buildFlag = true
-		self.placeholder = false
+		self.characterLevelAutoMode = false
 		self.controls.levelScalingButton.label = "Manual"
 	end)
-	self.controls.characterLevel:SetText(tostring(self.characterLevel))
+	self.controls.characterLevel:SetText(self.characterLevel)
 	self.controls.characterLevel.tooltipFunc = function(tooltip)
 		if tooltip:CheckForUpdate(self.characterLevel) then
 			tooltip:AddLine(16, "Experience multiplier:")
@@ -745,13 +745,13 @@ function buildMode:EstimatePlayerProgress()
 	end
 	
 	-- to prevent a negative level at a blank sheet the level requirement will be set dependent on points invested until caught up with quest skillpoints 
-	levelreq = math.max(PointsUsed - acts[currentAct].questPoints + 1, acts[currentAct].level)
+	levelreq = m_min(math.max(PointsUsed - acts[currentAct].questPoints + 1, acts[currentAct].level), 100)
 	
 	self.lastAllocated = self.lastAllocated or -1
 	
-	if self.placeholder and (self.lastAllocated ~= PointsUsed or self.recalcAdaptiveLevel) then
+	if self.characterLevelAutoMode and (self.lastAllocated ~= PointsUsed or self.recalcAdaptiveLevel) then
 		self.characterLevel = levelreq
-		self.controls.characterLevel:SetText(tostring(self.characterLevel))
+		self.controls.characterLevel:SetText(self.characterLevel)
 		self.recalcAdaptiveLevel = false
 	end
 	
@@ -813,7 +813,7 @@ function buildMode:Load(xml, fileName)
 		self.viewMode = xml.attrib.viewMode
 	end
 	self.characterLevel = tonumber(xml.attrib.level) or 1
-	self.placeholder = xml.attrib.placeholder == "true"
+	self.characterLevelAutoMode = xml.attrib.placeholder == "true"
 	for _, diff in pairs({ "bandit", "pantheonMajorGod", "pantheonMinorGod" }) do
 		self[diff] = xml.attrib[diff] or "None"
 	end
@@ -857,7 +857,7 @@ function buildMode:Save(xml)
 		pantheonMajorGod = self.configTab.input.pantheonMajorGod,
 		pantheonMinorGod = self.configTab.input.pantheonMinorGod,
 		mainSocketGroup = tostring(self.mainSocketGroup),
-		placeholder = tostring(self.placeholder)
+		placeholder = tostring(self.characterLevelAutoMode)
 	}
 	for _, id in ipairs(self.spectreList) do
 		t_insert(xml, { elem = "Spectre", attrib = { id = id } })


### PR DESCRIPTION
This PR is an entirely new feature requested directly to me on discord.

### Description of the problem being solved:
When creating a new build, most people do one of two things:
1) Set the character level to a set value (100, 94, 80, etc) which is inaccurate
2) Check the level requirement for the amount of allocated passives and set their character level to that value

This PR automates the second case by using a placeholder system for the character level. 

### Scenarios
_New build button_
Character level follows allocated passives.

_Imported character_
Character level is set to the imported character's level and does not follow allocated passives.

_Loaded build from list_
Character level behaviour follows the same behaviour as when the build was saved.

_Manually setting character level_
Mode switches to manual.

_Emptying character level_
~~If there are no numbers in the character level, the next time you allocate a passive it will set the level requirement to the requirement for the number allocated passives.~~ This now does nothing.

_Pressing the mode button_
Swaps to the other mode. If it's swapping into Auto, it immediately resets the level to the levelreq without needing to change any nodes to do so.

### Steps taken to verify a working solution:
- Created new character
- Imported existing character
- Created, imported, saved, exited, loaded, changed, saved, exited, loaded, etc.
