### PR TITLE
Added support for defend with X% of armour against projectile attacks

### DIFF
--- a/src/Modules/Build.lua
+++ b/src/Modules/Build.lua
@@ -354,6 +354,7 @@ function buildMode:Init(dbFileName, buildName, buildXML, convertBuild)
 		{ stat = "ProjectileEvadeChance", label = "Projectile Evade Chance", fmt = "d%%", color = colorCodes.EVASION, condFunc = function(v,o) return v > 0 and o.MeleeEvadeChance ~= o.ProjectileEvadeChance end },
 		{ },
 		{ stat = "Armour", label = "Armour", fmt = "d", compPercent = true },
+		{ stat = "ProjectileArmour", label="Projectile Armour", fmt = "d", condFunc = function(v,o) return o.Armour ~= o.ProjectileArmour end },
 		{ stat = "Spec:ArmourInc", label = "%Inc Armour from Tree", fmt = "d%%" },
 		{ stat = "PhysicalDamageReduction", label = "Phys. Damage Reduction", fmt = "d%%", condFunc = function() return true end },
 		{ },

--- a/src/Modules/CalcDefence.lua
+++ b/src/Modules/CalcDefence.lua
@@ -362,6 +362,7 @@ function calcs.defence(env, actor)
 		end
 		output.EnergyShield = modDB:Override(nil, "EnergyShield") or m_max(round(energyShield), 0)
 		output.Armour = m_max(round(armour), 0)
+		output.ProjectileArmour = m_max(round(armour * calcLib.mod(modDB, nil, "ProjectileArmour")), 0)
 		output.ArmourDefense = (modDB:Max(nil, "ArmourDefense") or 0) / 100
 		output.RawArmourDefense = output.ArmourDefense > 0 and ((1 + output.ArmourDefense) * 100) or nil
 		output.Evasion = m_max(round(evasion), 0)

--- a/src/Modules/CalcSections.lua
+++ b/src/Modules/CalcSections.lua
@@ -1464,6 +1464,7 @@ return {
 	{ label = "Total Increased", { format = "{0:mod:1}%", { modName = { "Armour", "ArmourAndEvasion", "Defences" }, modType = "INC" }, }, },
 	{ label = "Total More", { format = "{0:mod:1}%", { modName = { "Armour", "ArmourAndEvasion", "Defences" }, modType = "MORE" }, }, },
 	{ label = "Total", { format = "{0:output:Armour}", { breakdown = "Armour" }, }, },
+	{ label = "Total for Proj", haveOutput = "ProjectileArmour", { format = "{0:output:ProjectileArmour}", { modName = "ProjectileArmour" }, }, },
 	{ label = "Armour Defense", haveOutput = "RawArmourDefense", { format = "{0:output:RawArmourDefense}%", { modName = "ArmourDefense" }, }, },
 	{ label = "Phys. Dmg. Reduct", { format = "{0:output:PhysicalDamageReduction}%",
 		{ breakdown = "PhysicalDamageReduction" },

--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -1895,6 +1895,9 @@ local specialModList = {
 	["defend with (%d+)%% of armour while not on low energy shield"] = function(num) return {
 		mod("ArmourDefense", "MAX", num - 100, "Armour and Energy Shield Mastery", { type = "Condition", var = "LowEnergyShield", neg = true }),
 	} end,
+	["defend with (%d+)%% of armour against projectile attacks"] = function(num) return {
+		mod("ProjectileArmour", "MORE", num - 100, "Armour and Evasion Mastery"),
+	} end,
 	["(%d+)%% increased armour and energy shield from equipped body armour if equipped gloves, helmet and boots all have armour and energy shield"] = function(num) return {
 		mod("Body ArmourESAndArmour", "INC", num,  
 			{ type = "StatThreshold", stat = "ArmourOnGloves", threshold = 1},


### PR DESCRIPTION
### Description of the problem being solved:
- Added support for the new 3.21 mastery "Defend with 120% of Armour against Projectile Attacks"

### Steps taken to verify a working solution:
- Added a random armour body armour
- Added custom modifier `defend with 120% of armour against projectile attacks`
- Noticed that new stat showed up in the left panel for `Projectile Armour` that is equal to Armour * 1.2
- Removed custom modifier and new stat dissapears

### Link to a build that showcases this PR:
[https://pobb.in/hjrxL6Nu9L0r](https://pobb.in/hjrxL6Nu9L0r)

### Before screenshot:
![3 21-extra-armour-proj_before](https://user-images.githubusercontent.com/62115140/229303283-13e8e3ee-d34f-4459-8baf-d7c8dc79c6c8.PNG)

### After screenshot:
![3 21-extra-armour-proj_after](https://user-images.githubusercontent.com/62115140/229303297-4cd2820b-a6a2-4bf7-9c5e-969b268540c1.PNG)

