### PR TITLE
3.21 attack and lightning masteries

### DIFF
--- a/src/Modules/CalcOffence.lua
+++ b/src/Modules/CalcOffence.lua
@@ -1631,6 +1631,10 @@ function calcs.offence(env, actor, activeSkill)
 		end
 		--enemy block chance
 		output.enemyBlockChance = m_max(m_min((enemyDB:Sum("BASE", cfg, "BlockChance") or 0), 100) - skillModList:Sum("BASE", cfg, "reduceEnemyBlock"), 0)
+		if enemyDB:Flag(nil, "CannotBlockAttacks") and isAttack then
+			output.enemyBlockChance = 0
+		end
+
 		output.HitChance = output.AccuracyHitChance * (1 - output.enemyBlockChance / 100)
 		if output.enemyBlockChance > 0 and not isAttack then
 			globalOutput.enemyHasSpellBlock = true

--- a/src/Modules/CalcPerform.lua
+++ b/src/Modules/CalcPerform.lua
@@ -3404,6 +3404,7 @@ function calcs.perform(env, avoidCache)
 				for _, mod in ipairs(modDB:Tabulate("BASE", nil, "ExtraExposure", "Extra"..element.."Exposure")) do
 					min = min + mod.value
 				end
+				enemyDB:NewMod("Condition:Has"..element.."Exposure", "FLAG", true, "")
 				enemyDB:NewMod(element.."Resist", "BASE", m_min(min, modDB:Override(nil, "ExposureMin")), source)
 				modDB:NewMod("Condition:AppliedExposureRecently", "FLAG", true, "")
 			end

--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -1646,6 +1646,7 @@ local modTagList = {
 	["against enemies affected by (%d+) spider's webs"] = function(num) return { tag = { type = "MultiplierThreshold", actor = "enemy", var = "Spider's WebStack", threshold = num } } end,
 	["against enemies on consecrated ground"] = { tag = { type = "ActorCondition", actor = "enemy", var = "OnConsecratedGround" } },
 	["if (%d+)%% of curse duration expired"] = function(num) return { tag = { type = "MultiplierThreshold", actor = "enemy", var = "CurseExpired", threshold = num } } end,
+	["against enemies with (%w+) exposure"] = function(element) return { tag = { type = "ActorCondition", actor = "enemy", var = "Has"..(firstToUpper(element).."Exposure") } } end,
 	-- Enemy multipliers
 	["per freeze, shock [ao][nr]d? ignite on enemy"] = { tag = { type = "Multiplier", var = "FreezeShockIgniteOnEnemy" } },
 	["per poison affecting enemy"] = { tag = { type = "Multiplier", actor = "enemy", var = "PoisonStack" } },

--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -1178,6 +1178,7 @@ local modTagList = {
 	["for each time you've blocked in the past 10 seconds"] = { tag = { type = "Multiplier", var =  "BlockedPast10Sec" } },
 	["per enemy killed by you or your totems recently"] = { tag = { type = "Multiplier", varList = { "EnemyKilledRecently","EnemyKilledByTotemsRecently" } } },
 	["per nearby enemy, up to %+?(%d+)%%"] = function(num) return { tag = { type = "Multiplier", var = "NearbyEnemies", limit = num, limitTotal = true } } end,
+	["per enemy in close range"] = { tagList = { { type = "Condition", var = "AtCloseRange" }, { type = "Multiplier", var = "NearbyEnemies" } } },
 	["to you and allies"] = { },
 	["per red socket"] = { tag = { type = "Multiplier", var = "RedSocketIn{SlotName}" } },
 	["per green socket on main hand weapon"] = { tag = { type = "Multiplier", var = "GreenSocketInWeapon 1" } },

--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -3598,6 +3598,10 @@ local specialModList = {
 	["intimidate enemies for (%d+) seconds on hit with attacks while at maximum endurance charges"] = { 
 		mod("EnemyModifier", "LIST", { mod = flag("Condition:Intimidated") }, { type = "StatThreshold", stat = "EnduranceCharges", thresholdStat = "EnduranceChargesMax" }, { type = "Condition", var = "HitRecently" })
 	},
+	["nearby enemies are intimidated while you have rage"] = {
+		-- MultiplierThreshold is on RageStacks because Rage is only set in CalcPerform if Condition:CanGainRage is true, Bear's Girdle does not flag CanGainRage
+		mod("EnemyModifier", "LIST", { mod = flag("Condition:Intimidated") }, { type = "MultiplierThreshold", var = "RageStack", threshold = 1 })
+	},
 	-- Flasks
 	["flasks do not apply to you"] = { flag("FlasksDoNotApplyToPlayer") },
 	["flasks apply to your zombies and spectres"] = { flag("FlasksApplyToMinion", { type = "SkillName", skillNameList = { "Raise Zombie", "Raise Spectre" } }) },

--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -3373,6 +3373,7 @@ local specialModList = {
 	["cannot block while you have no energy shield"] = { flag("CannotBlockAttacks", { type = "Condition", var = "HaveEnergyShield", neg = true }), flag("CannotBlockSpells", { type = "Condition", var = "HaveEnergyShield", neg = true }) },
 	["cannot block attacks"] = { flag("CannotBlockAttacks") },
 	["cannot block spells"] = { flag("CannotBlockSpells") },
+	["monsters cannot block your attacks"] = { mod("EnemyModifier", "LIST", { mod = flag("CannotBlockAttacks") }) },
 	["damage from blocked hits cannot bypass energy shield"] = { flag("BlockedDamageDoesntBypassES", { type = "Condition", var = "EVBypass", neg = true }) },
 	["damage from unblocked hits always bypasses energy shield"] = { flag("UnblockedDamageDoesBypassES", { type = "Condition", var = "EVBypass", neg = true }) },
 	["recover (%d+) life when you block"] = function(num) return { mod("LifeOnBlock", "BASE", num) } end,


### PR DESCRIPTION
### Description of the problem being solved:

Implements the following attack and lightning masteries:

* Monsters cannot Block your Attacks
* 5% increased Attack Speed per Enemy in Close Range
  * This requires setting *both* # of nearby enemies config and "at close range" config to apply
* Nearby Enemies are Intimidated while you have Rage
  * Followed the existing example from `"nearby enemies are crushed while you have ?a?t? least (%d+) rage"`
  * I originally tried to implement this using a more general `"while you have rage"` entry, but didn't end up getting this to work (I suspect my naive attempt might have been ending up trying to apply while the *enemy* had rage)
* 60% increased Critical Strike Chance against enemies with Lightning Exposure
  * In order to handle EE correctly, I created a new Condition applied after the EE applicability calculation and based the new mod on that condition, rather than attempting to use a threshold on the base LightningExposure value

### Steps taken to verify a working solution:

(using the showcase PR linked below)

1. For Monsters cannot Block your Attacks, the provided build has some monster block configured and the mastery selected; verify that checking and unchecking the mastery impacts double strike damage but not the spells' damage accordingly, and verify that with the mastery checked, double strike's damage does not change when modifying monster block chance config
2. For attack speed per enemy in close range: verify that double strike attack speed is updated when # nearby enemies config is modified *and* "is close range" config box is ticked, but not otherwise, and that the spells' damage is not modified
3. For Nearby Enemies are Intimidated while you have Rage, verify that ticking and unticking the mastery affects damage appropriately if-and-only-if rage is configured as non-zero
4. For crit chance against lightning exposed enemies, verify that with the mastery allocated, crit chance increases *either* upon setting WoC exposure config to lightning *or* allocating EE (but only if an appropriate combination of "Enemy was Hit by X Damage?" config boxes are ticked)

### Link to a build that showcases this PR:

https://pobb.in/A-izFWEEUewD

### Before screenshot:

![screenshot demonstrating which attack masteries are supported before this PR](https://user-images.githubusercontent.com/376284/229321222-0aa5047b-d4d5-4911-9e71-f9f34a0e154e.png)
![screenshot demonstrating which lightning masteries are supported before this PR](https://user-images.githubusercontent.com/376284/229321184-72d130b9-ac13-4399-9b41-da5554c59583.png)

### After screenshot:

![screenshot demonstrating which attack masteries are supported after this PR](https://user-images.githubusercontent.com/376284/229320932-f0e0c8f8-2d64-4925-aa39-381788d0f94e.png)
![screenshot demonstrating which lightning masteries are supported after this PR](https://user-images.githubusercontent.com/376284/229321008-109c326e-f5a0-4c9a-a1f5-b272f14d70b1.png)

