### PR TITLE
3.21 - X% more max life if you have at least X life masteries allocated

### DIFF
--- a/src/Classes/PassiveSpec.lua
+++ b/src/Classes/PassiveSpec.lua
@@ -230,6 +230,9 @@ function PassiveSpecClass:AllocateMasteryEffects(masteryEffects)
 		self.tree:ProcessStats(self.allocNodes[id])
 		self.masterySelections[id] = effectId
 		self.allocatedMasteryCount = self.allocatedMasteryCount + 1
+		if self.allocNodes[id].name == "Life Mastery" then
+			self.allocatedLifeMasteryCount = self.allocatedLifeMasteryCount + 1
+		end
 		if not self.allocatedMasteryTypes[self.allocNodes[id].name] then
 			self.allocatedMasteryTypes[self.allocNodes[id].name] = 1
 			self.allocatedMasteryTypeCount = self.allocatedMasteryTypeCount + 1
@@ -870,6 +873,7 @@ function PassiveSpecClass:BuildAllDependsAndPaths()
 	self.allocatedNotableCount = 0
 	self.allocatedMasteryTypes = { }
 	self.allocatedMasteryTypeCount = 0
+	self.allocatedLifeMasteryCount = 0
 	for id, node in pairs(self.nodes) do
 		if node.type == "Mastery" and self.masterySelections[id] then
 			local effect = self.tree.masteryEffects[self.masterySelections[id]]
@@ -879,6 +883,9 @@ function PassiveSpecClass:BuildAllDependsAndPaths()
 				node.reminderText = { "Tip: Right click to select a different effect" }
 				self.tree:ProcessStats(node)
 				self.allocatedMasteryCount = self.allocatedMasteryCount + 1
+				if node.name == "Life Mastery" then
+					self.allocatedLifeMasteryCount = self.allocatedLifeMasteryCount + 1
+				end
 				if not self.allocatedMasteryTypes[self.allocNodes[id].name] then
 					self.allocatedMasteryTypes[self.allocNodes[id].name] = 1
 					self.allocatedMasteryTypeCount = self.allocatedMasteryTypeCount + 1

--- a/src/Modules/CalcSetup.lua
+++ b/src/Modules/CalcSetup.lua
@@ -517,6 +517,7 @@ function calcs.initEnv(build, mode, override, specEnv)
 	local allocatedMasteryCount = env.spec.allocatedMasteryCount
 	local allocatedMasteryTypeCount = env.spec.allocatedMasteryTypeCount
 	local allocatedMasteryTypes = copyTable(env.spec.allocatedMasteryTypes)
+	local allocatedLifeMasteryCount = env.spec.allocatedLifeMasteryCount
 	if not accelerate.nodeAlloc then
 		-- Build list of passive nodes
 		local nodes
@@ -527,6 +528,9 @@ function calcs.initEnv(build, mode, override, specEnv)
 					nodes[node.id] = node
 					if node.type == "Mastery" then
 						allocatedMasteryCount = allocatedMasteryCount + 1
+						if node.name == "Life" then
+							allocatedLifeMasteryCount = allocatedLifeMasteryCount + 1
+						end
 
 						if not allocatedMasteryTypes[node.name] then
 							allocatedMasteryTypes[node.name] = 1
@@ -549,6 +553,9 @@ function calcs.initEnv(build, mode, override, specEnv)
 				elseif override.removeNodes[node] then
 					if node.type == "Mastery" then
 						allocatedMasteryCount = allocatedMasteryCount - 1
+						if node.name == "Life" then
+							allocatedLifeMasteryCount = allocatedLifeMasteryCount + 1
+						end
 
 						allocatedMasteryTypes[node.name] = allocatedMasteryTypes[node.name] - 1
 						if allocatedMasteryTypes[node.name] == 0 then
@@ -568,6 +575,7 @@ function calcs.initEnv(build, mode, override, specEnv)
 	modDB:NewMod("Multiplier:AllocatedNotable", "BASE", allocatedNotableCount, "")
 	modDB:NewMod("Multiplier:AllocatedMastery", "BASE", allocatedMasteryCount, "")
 	modDB:NewMod("Multiplier:AllocatedMasteryType", "BASE", allocatedMasteryTypeCount, "")
+	modDB:NewMod("Multiplier:AllocatedLifeMastery", "BASE", allocatedLifeMasteryCount)
 	
 	-- Build and merge item modifiers, and create list of radius jewels
 	if not accelerate.requirementsItems then

--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -3129,6 +3129,10 @@ local specialModList = {
 		mod("ShrineBuff", "LIST", { mod = mod("Life", "INC", 20) }),
 		mod("ShrineBuff", "LIST", { mod = mod("AreaOfEffect", "INC", 20) })
 	},
+	-- 
+	["(%d+)%% more maximum life if you have at least (%d+) life masteries allocated"] = function(num, _, thresh) return {
+		mod("Life", "MORE", num, { type = "MultiplierThreshold", var = "AllocatedLifeMastery", threshold = tonumber(thresh) }),
+	} end,
 	["(%d+)%% increased effect of shrine buffs on you"] = function(num) return { mod("ShrineBuffEffect", "INC", num) } end,
 	["left ring slot: cover enemies in ash for 5 seconds when you ignite them"] = { mod("CoveredInAshEffect", "BASE", 20, { type = "SlotNumber", num = 1 }, { type = "ActorCondition", actor = "enemy", var = "Ignited" }) },
 	["right ring slot: cover enemies in frost for 5 seconds when you freeze them"] = { mod("CoveredInFrostEffect", "BASE", 20, { type = "SlotNumber", num = 2 }, { type = "ActorCondition", actor = "enemy", var = "Frozen" }) },


### PR DESCRIPTION
### Description of the problem being solved:
- Added support for the new 3.21 mastery `10% more Maximum Life if you have at least 6 Life Masteries allocated`

### Steps taken to verify a working solution:
- Allocated the other 5 life masteries
- Looked at life amount
- Allocated the last mastery `10% more Maximum Life if you have at least 6 Life Masteries allocated`
- Life incremented the expected amount

### Link to a build that showcases this PR:
[https://pobb.in/zHi7uOahPbS3](https://pobb.in/zHi7uOahPbS3)

### Before screenshot:
![3 21-more-life-6-mast_before](https://user-images.githubusercontent.com/62115140/229321689-90d2e864-617a-496f-b7b7-5afe8ccbae47.PNG)

### After screenshot:
![3 21-more-life-6-mast_after](https://user-images.githubusercontent.com/62115140/229321705-2f6dbded-238c-4c3d-b719-6e0ae6a37ff4.PNG)
