### PR TITLE
Remove incorrect tooltip from "Have you Suppressed Recently"

### DIFF
--- a/src/Modules/ConfigOptions.lua
+++ b/src/Modules/ConfigOptions.lua
@@ -1125,7 +1125,7 @@ Huge sets the radius to 11.
 	{ var = "multiplierCastLast8Seconds", type = "count", label = "How many spells cast in the last 8 seconds?", ifMult = "CastLast8Seconds", tooltip = "Only non-instant spells you cast count", apply = function(val, modList, enemyModList)
 		modList:NewMod("Multiplier:CastLast8Seconds", "BASE", val, "Config", { type = "Condition", var = "Combat" })
 	end },
-	{ var = "conditionSuppressedRecently", type = "check", label = "Have you Suppressed Recently?", ifCond = "SuppressedRecently", tooltip = "This applies -10% ^xB97123Fire^7, ^x3F6DB3Cold^7, and ^xADAA47Lightning ^7Resistance to the enemy.", apply = function(val, modList, enemyModList)
+	{ var = "conditionSuppressedRecently", type = "check", label = "Have you Suppressed Recently?", ifCond = "SuppressedRecently", apply = function(val, modList, enemyModList)
 		modList:NewMod("Condition:SuppressedRecently", "FLAG", true, "Config", { type = "Condition", var = "Combat" })
 	end },
 	{ var = "multiplierHitsSuppressedRecently", type = "count", label = "# of Hits Suppressed Recently:", ifMult = "HitsSuppressedRecently", implyCond = "SuppressedRecently", tooltip = "This also implies that you have Suppressed Recently.", apply = function(val, modList, enemyModList)


### PR DESCRIPTION
This do not applies -10% to elemental resistances

### Description of the problem being solved:

### Steps taken to verify a working solution:
- Get source of suppressed recently condition
- Check tooltip

### Link to a build that showcases this PR:

https://pobb.in/FmELVkDrp3VP

### Before screenshot:

![image](https://user-images.githubusercontent.com/5115805/229327563-7945c19d-4205-463c-946d-1accf47f556b.png)


### After screenshot:

Tooltip gone