### PR TITLE
Fix flask conditions for using Life and Mana flasks

### DIFF
--- a/src/Modules/CalcPerform.lua
+++ b/src/Modules/CalcPerform.lua
@@ -1571,12 +1571,13 @@ function calcs.perform(env, avoidCache)
 			flaskBuffsPerBase[item.baseName] = flaskBuffsPerBase[item.baseName] or {}
 			flaskBuffsPerBaseNonPlayer[item.baseName] = flaskBuffsPerBaseNonPlayer[item.baseName] or {}
 			flaskConditions["UsingFlask"] = true
-			if item.baseName:match("Hybrid Flask") then
+			if item.base.flask.life then
 				flaskConditions["UsingLifeFlask"] = true
-				flaskConditions["UsingManaFlask"] = true
-			else
-				flaskConditions["Using"..item.baseName:gsub("%s+", "")] = true
 			end
+			if item.base.flask.mana then
+				flaskConditions["UsingManaFlask"] = true
+			end
+			flaskConditions["Using"..item.baseName:gsub("%s+", "")] = true
 
 			local flaskEffectInc = item.flaskData.effectInc
 			local flaskEffectIncNonPlayer = flaskEffectInc


### PR DESCRIPTION
### Description of the problem being solved:

The current parsing for life/mana flasks was wrong as it was adding conditions like UsingDivineLifeFlask insead of simply adding UsingLifeFlask etc.

### Steps taken to verify a working solution:
- Enable life flask
- Check if heart of oak is giving you regen

### Link to a build that showcases this PR:

https://pobb.in/1GG8yuGg_pUw

### Before screenshot:

![image](https://user-images.githubusercontent.com/5115805/229357931-d8d9cb09-3268-4bae-9af5-fc5428cfc874.png)


### After screenshot:

![image](https://user-images.githubusercontent.com/5115805/229357959-256e0356-382e-47b3-aba1-925d34d63568.png)

