### PR TITLE
Fix hex code crash

### DIFF
--- a/src/Modules/Common.lua
+++ b/src/Modules/Common.lua
@@ -569,9 +569,11 @@ end
 
 -- Formats "1234.56" -> "1,234.5"
 function formatNumSep(str)
+
 	return string.gsub(str, "(%^?x?%x?%x?%x?%x?%x?%x?-?%d+%.?%d+)", function(m)
-		local colour = m:match("(%^%d)") or m:match("(^x%x%x%x%x%x%x)") or ""
-		local str = m:gsub("(%^%d)", ""):gsub("(^x%x%x%x%x%x%x)", "")
+		local colour = m:match("(^x%x%x%x%x%x%x)") or m:match("(%^%d)") or ""
+		if string.len(m) > 0 and colour == "" and m:match("%^") then return m end -- return if we have an invalid color code
+		local str = m:gsub("(^x%x%x%x%x%x%x)", "") or m:gsub("(%^%d)", "")
 		local x, y, minus, integer, fraction = str:find("(-?)(%d+)(%.?%d*)")
 		if main.showThousandsSeparators then
 			integer = integer:reverse():gsub("(%d%d%d)", "%1"..main.thousandsSeparator):reverse()

--- a/src/Modules/Common.lua
+++ b/src/Modules/Common.lua
@@ -569,11 +569,12 @@ end
 
 -- Formats "1234.56" -> "1,234.5"
 function formatNumSep(str)
-
 	return string.gsub(str, "(%^?x?%x?%x?%x?%x?%x?%x?-?%d+%.?%d+)", function(m)
 		local colour = m:match("(^x%x%x%x%x%x%x)") or m:match("(%^%d)") or ""
-		if string.len(m) > 0 and colour == "" and m:match("%^") then return m end -- return if we have an invalid color code
 		local str = m:gsub("(^x%x%x%x%x%x%x)", "") or m:gsub("(%^%d)", "")
+		if str == "" or (colour == "" and m:match("%^")) then  -- return if we have an invalid color code or a completely stripped number.
+			return m
+		end
 		local x, y, minus, integer, fraction = str:find("(-?)(%d+)(%.?%d*)")
 		if main.showThousandsSeparators then
 			integer = integer:reverse():gsub("(%d%d%d)", "%1"..main.thousandsSeparator):reverse()


### PR DESCRIPTION
### Description of the problem being solved:
Hex codes were causing problems. This occured in two ways they were partially parsed producing partial codes making garbled text and they were the only part being parsed this caused a crash.

### Link to a build that showcases this PR:
https://pobb.in/2Hzt-5GshxyF

![image](https://user-images.githubusercontent.com/31533893/229382933-a2752259-0235-4691-8f42-286b35d6201e.png)