### PR TITLE
Fix Damage taken conversion using wrong variable (#5859)

### DIFF
--- a/src/Modules/CalcDefence.lua
+++ b/src/Modules/CalcDefence.lua
@@ -72,7 +72,7 @@ function calcs.takenHitFromDamage(rawDamage, damageType, actor)
 		local takenFlat = output[damageConvertedType.."takenFlat"]
 		if convertPercent > 0 or takenFlat ~= 0 then
 			local convertedDamage = rawDamage * convertPercent / 100
-			local reducedDamage = round(m_max(convertedDamage * damageMitigationMultiplierForType(convertedDamage, damageConvertedType) + takenFlat, 0) * output[damageType .."AfterReductionTakenHitMulti"])
+			local reducedDamage = round(m_max(convertedDamage * damageMitigationMultiplierForType(convertedDamage, damageConvertedType) + takenFlat, 0) * output[damageConvertedType .."AfterReductionTakenHitMulti"])
 			receivedDamageSum = receivedDamageSum + reducedDamage
 			damages[damageConvertedType] = (reducedDamage > 0 or convertPercent > 0) and reducedDamage or nil
 		end


### PR DESCRIPTION
### Description of the problem being solved:
A wrong variable was used resulting in incorrect damage multipliers being used. Most notably with CI 0x multiplier.

### Link to a build that showcases this PR:
https://pobb.in/fUXT_CRhTkse

![image](https://user-images.githubusercontent.com/36479307/229384754-6e6a818c-0700-48f3-8090-f1c6066602a2.png)
