### PR TITLE
Fix Widowhail increased bonuses calculation

### DIFF
--- a/src/Modules/CalcSetup.lua
+++ b/src/Modules/CalcSetup.lua
@@ -883,7 +883,7 @@ function calcs.initEnv(build, mode, override, specEnv)
 				elseif item.type == "Quiver" and ((not slot.slotName:match("Swap") and build.itemsTab.items[build.itemsTab.slots["Weapon 1"].selItemId] and build.itemsTab.items[build.itemsTab.slots["Weapon 1"].selItemId].name:match("Widowhail"))
 													or (build.itemsTab.items[build.itemsTab.slots["Weapon 1 Swap"].selItemId] and build.itemsTab.items[build.itemsTab.slots["Weapon 1 Swap"].selItemId].name:match("Widowhail"))) then
 					local WidowHailBaseMods = not slot.slotName:match("Swap") and build.itemsTab.items[build.itemsTab.slots["Weapon 1"].selItemId].baseModList or build.itemsTab.items[build.itemsTab.slots["Weapon 1 Swap"].selItemId].baseModList
-					scale = scale * (WidowHailBaseMods:Sum("INC", nil, "EffectOfBonusesFromQuiver") or 100) / 100
+					scale = scale * (1 + (WidowHailBaseMods:Sum("INC", nil, "EffectOfBonusesFromQuiver") or 100) / 100)
 					env.itemModDB:ScaleAddList(srcList, scale)
 				else
 					env.itemModDB:ScaleAddList(srcList, scale)


### PR DESCRIPTION
### Description of the problem being solved:
Quiver bonuses were multiplied by increase instead of 1 + increase

### Before screenshot:
![image](https://user-images.githubusercontent.com/36479307/229390471-1fa86c3c-fb00-4659-a13b-c844e082c519.png)

### After screenshot:
![image](https://user-images.githubusercontent.com/36479307/229390485-8c9f31ad-ff81-4eda-9cd1-523dcb2fb420.png)
