### PR TITLE
Fix max-hit with 100% taken as conversion

### DIFF
--- a/spec/System/TestDefence_spec.lua
+++ b/spec/System/TestDefence_spec.lua
@@ -430,6 +430,33 @@ describe("TestDefence", function()
         runCallback("OnFrame")
         assert.is.not_false(withinTenPercent(1000, takenHitFromTypeMaxHit("Physical")))
         assert.is.not_false(withinTenPercent(1000, takenHitFromTypeMaxHit("Cold")))
+        
+        build.configTab.input.customMods = "\z
+        +940 to maximum life\n\z
+        +10000 to armour\n\z
+        +110% to fire resistance\n\z
+        Armour applies to Fire, Cold and Lightning Damage taken from Hits instead of Physical Damage\n\z
+        100% of cold damage taken as fire\n\z
+        50% of lightning damage taken as fire\n\z
+        50% less fire damage taken\n\z
+        "
+        build.configTab:BuildModList()
+        runCallback("OnFrame")
+        assert.is.not_false(withinTenPercent(1000, takenHitFromTypeMaxHit("Physical")))
+        assert.is.not_false(withinTenPercent(1000, takenHitFromTypeMaxHit("Cold")))
+    
+        build.configTab.input.customMods = "\z
+        +99 to energy shield\n\z
+        100% less attributes\n\z
+        +60% to all elemental resistances\n\z
+        25% of Elemental Damage from Hits taken as Chaos Damage\n\z
+        Chaos Inoculation\n\z
+        "
+        build.configTab:BuildModList()
+        runCallback("OnFrame")
+        local _, takenDamages = takenHitFromTypeMaxHit("Cold")
+        local poolsRemaining = build.calcsTab.calcs.reducePoolsByDamage(nil, takenDamages, build.calcsTab.calcsEnv.player)
+        assert.are.equals(0, round(poolsRemaining.Life))
     end)
     
     it("damage conversion to different size pools", function()

--- a/src/Modules/CalcDefence.lua
+++ b/src/Modules/CalcDefence.lua
@@ -2564,7 +2564,7 @@ function calcs.defence(env, actor)
 				local totalTakenMulti = output[damageConvertedType.."AfterReductionTakenHitMulti"]
 
 				if effectiveAppliedArmour == 0 and convertPercent == 100 then	-- use a simpler calculation for no armour DR
-					local drMulti = output[damageType.."ResistTakenHitMulti"] * (1 - output[damageType.."DamageReduction"] / 100)
+					local drMulti = output[damageConvertedType.."ResistTakenHitMulti"] * (1 - output[damageConvertedType.."DamageReduction"] / 100)
 					hitTaken = m_max(totalHitPool / damageConvertedMulti / drMulti - takenFlat, 0) / totalTakenMulti
 				else
 					-- get relevant raw reductions and reduction modifiers


### PR DESCRIPTION
Fixes #5864 .

### Description of the problem being solved:
One more spot had wrong variable in damage taken as conversion calculation

### Link to a build that showcases this PR:
https://pobb.in/JMHXRIQ-wt0h

### Before screenshot:
![image](https://user-images.githubusercontent.com/36479307/229395836-08ce11fe-b2b6-4311-9b75-1cf733f9dc13.png)

### After screenshot:
![image](https://user-images.githubusercontent.com/36479307/229395855-9b349087-aef7-4781-9132-4fd748b485a7.png)
