### PR TITLE
Fix issue calculating defences based on overcapped resistances

### DIFF
--- a/src/Modules/CalcDefence.lua
+++ b/src/Modules/CalcDefence.lua
@@ -241,6 +241,107 @@ function calcs.defence(env, actor)
 
 	-- Action Speed
 	output.ActionSpeedMod = calcs.actionSpeedMod(actor)
+	
+	-- Armour defence types for conditionals
+	for _, slot in pairs({"Helmet","Gloves","Boots","Body Armour","Weapon 2","Weapon 3"}) do
+		local armourData = actor.itemList[slot] and actor.itemList[slot].armourData
+		if armourData then
+			wardBase = armourData.Ward or 0
+			if wardBase > 0 then
+				output["WardOn"..slot] = wardBase
+			end
+			energyShieldBase = armourData.EnergyShield or 0
+			if energyShieldBase > 0 then
+				output["EnergyShieldOn"..slot] = energyShieldBase
+			end
+			armourBase = armourData.Armour or 0
+			if armourBase > 0 then
+				output["ArmourOn"..slot] = armourBase
+			end
+			evasionBase = armourData.Evasion or 0
+			if evasionBase > 0 then
+				output["EvasionOn"..slot] = evasionBase
+			end
+		end
+	end
+
+	-- Resistances
+	output["PhysicalResist"] = 0
+
+	-- Highest Maximum Elemental Resistance for Melding of the Flesh
+	if modDB:Flag(nil, "ElementalResistMaxIsHighestResistMax") then
+		local highestResistMax = 0;
+		local highestResistMaxType = "";
+		for _, elem in ipairs(resistTypeList) do
+			local resistMax = modDB:Override(nil, elem.."ResistMax") or m_min(data.misc.MaxResistCap, modDB:Sum("BASE", nil, elem.."ResistMax", isElemental[elem] and "ElementalResistMax"))
+			if resistMax > highestResistMax and isElemental[elem] then
+				highestResistMax = resistMax;
+				highestResistMaxType = elem;
+			end
+		end
+		for _, elem in ipairs(resistTypeList) do
+			if isElemental[elem] then
+				modDB:NewMod(elem.."ResistMax", "OVERRIDE", highestResistMax, highestResistMaxType.." Melding of the Flesh");
+			end
+		end
+	end
+	
+	for _, elem in ipairs(resistTypeList) do
+		local min, max, total, totemTotal, totemMax
+		min = data.misc.ResistFloor
+		max = modDB:Override(nil, elem.."ResistMax") or m_min(data.misc.MaxResistCap, modDB:Sum("BASE", nil, elem.."ResistMax", isElemental[elem] and "ElementalResistMax"))
+		total = modDB:Override(nil, elem.."Resist")
+		totemMax = modDB:Override(nil, "Totem"..elem.."ResistMax") or m_min(data.misc.MaxResistCap, modDB:Sum("BASE", nil, "Totem"..elem.."ResistMax", isElemental[elem] and "TotemElementalResistMax"))
+		totemTotal = modDB:Override(nil, "Totem"..elem.."Resist")
+		if not total then
+			local base = modDB:Sum("BASE", nil, elem.."Resist", isElemental[elem] and "ElementalResist")
+			total = base * m_max(calcLib.mod(modDB, nil, elem.."Resist", isElemental[elem] and "ElementalResist"), 0)
+		end
+		if not totemTotal then
+			local base = modDB:Sum("BASE", nil, "Totem"..elem.."Resist", isElemental[elem] and "TotemElementalResist")
+			totemTotal = base * m_max(calcLib.mod(modDB, nil, "Totem"..elem.."Resist", isElemental[elem] and "TotemElementalResist"), 0)
+		end
+		
+		-- Fractional resistances are truncated
+		total = m_modf(total)
+		totemTotal = m_modf(totemTotal)
+		min = m_modf(min)
+		max = m_modf(max)
+		totemMax = m_modf(totemMax)
+		
+		local final = m_max(m_min(total, max), min)
+		local totemFinal = m_max(m_min(totemTotal, totemMax), min)
+
+		output[elem.."Resist"] = final
+		output[elem.."ResistTotal"] = total
+		output[elem.."ResistOverCap"] = m_max(0, total - max)
+		output[elem.."ResistOver75"] = m_max(0, final - 75)
+		output["Missing"..elem.."Resist"] = m_max(0, max - final)
+		output["Totem"..elem.."Resist"] = totemFinal
+		output["Totem"..elem.."ResistTotal"] = totemTotal
+		output["Totem"..elem.."ResistOverCap"] = m_max(0, totemTotal - totemMax)
+		output["MissingTotem"..elem.."Resist"] = m_max(0, totemMax - totemFinal)
+		if breakdown then
+			breakdown[elem.."Resist"] = {
+				"Min: "..min.."%",
+				"Max: "..max.."%",
+				"Total: "..total.."%",
+			}
+			breakdown["Totem"..elem.."Resist"] = {
+				"Min: "..min.."%",
+				"Max: "..totemMax.."%",
+				"Total: "..totemTotal.."%",
+			}
+		end
+	end
+
+	-- Damage Reduction
+	output.DamageReductionMax = modDB:Override(nil, "DamageReductionMax") or data.misc.DamageReductionCap
+	modDB:NewMod("ArmourAppliesToPhysicalDamageTaken", "BASE", 100)
+	for _, damageType in ipairs(dmgTypeList) do
+		output["Base"..damageType.."DamageReduction"] = m_min(m_max(0, modDB:Sum("BASE", nil, damageType.."DamageReduction")), output.DamageReductionMax)
+		output["Base"..damageType.."DamageReductionWhenHit"] = m_min(m_max(0, output["Base"..damageType.."DamageReduction"] + modDB:Sum("BASE", nil, damageType.."DamageReductionWhenHit")), output.DamageReductionMax)
+	end
 
 	-- Block
 	output.BlockChanceMax = modDB:Sum("BASE", nil, "BlockChanceMax")
@@ -340,7 +441,6 @@ function calcs.defence(env, actor)
 				slotCfg.slotName = slot
 				wardBase = armourData.Ward or 0
 				if wardBase > 0 then
-					output["WardOn"..slot] = wardBase
 					if modDB:Flag(nil, "EnergyShieldToWard") then
 						local inc = modDB:Sum("INC", slotCfg, "Ward", "Defences", "EnergyShield")
 						local more = modDB:More(slotCfg, "Ward", "Defences")
@@ -366,7 +466,6 @@ function calcs.defence(env, actor)
 				end
 				energyShieldBase = armourData.EnergyShield or 0
 				if energyShieldBase > 0 then
-					output["EnergyShieldOn"..slot] = energyShieldBase
 					if modDB:Flag(nil, "EnergyShieldToWard") then
 						local more = modDB:More(slotCfg, "EnergyShield", "Defences")
 						energyShield = energyShield + energyShieldBase * more
@@ -394,7 +493,6 @@ function calcs.defence(env, actor)
 				end
 				armourBase = armourData.Armour or 0
 				if armourBase > 0 then
-					output["ArmourOn"..slot] = armourBase
 					if slot == "Body Armour" and modDB:Flag(nil, "Unbreakable") then
 						armourBase = armourBase * 2
 					end
@@ -410,7 +508,6 @@ function calcs.defence(env, actor)
 				end
 				evasionBase = armourData.Evasion or 0
 				if evasionBase > 0 then
-					output["EvasionOn"..slot] = evasionBase
 					gearEvasion = gearEvasion + evasionBase
 					if breakdown then
 						breakdown.slot(slot, nil, slotCfg, evasionBase, nil, "Evasion", "ArmourAndEvasion", "Defences")
@@ -602,84 +699,6 @@ function calcs.defence(env, actor)
 				}
 			end
 		end
-	end
-
-	-- Resistances
-	output["PhysicalResist"] = 0
-
-	-- Highest Maximum Elemental Resistance for Melding of the Flesh
-	if modDB:Flag(nil, "ElementalResistMaxIsHighestResistMax") then
-		local highestResistMax = 0;
-		local highestResistMaxType = "";
-		for _, elem in ipairs(resistTypeList) do
-			local resistMax = modDB:Override(nil, elem.."ResistMax") or m_min(data.misc.MaxResistCap, modDB:Sum("BASE", nil, elem.."ResistMax", isElemental[elem] and "ElementalResistMax"))
-			if resistMax > highestResistMax and isElemental[elem] then
-				highestResistMax = resistMax;
-				highestResistMaxType = elem;
-			end
-		end
-		for _, elem in ipairs(resistTypeList) do
-			if isElemental[elem] then
-				modDB:NewMod(elem.."ResistMax", "OVERRIDE", highestResistMax, highestResistMaxType.." Melding of the Flesh");
-			end
-		end
-	end
-	
-	for _, elem in ipairs(resistTypeList) do
-		local min, max, total, totemTotal, totemMax
-		min = data.misc.ResistFloor
-		max = modDB:Override(nil, elem.."ResistMax") or m_min(data.misc.MaxResistCap, modDB:Sum("BASE", nil, elem.."ResistMax", isElemental[elem] and "ElementalResistMax"))
-		total = modDB:Override(nil, elem.."Resist")
-		totemMax = modDB:Override(nil, "Totem"..elem.."ResistMax") or m_min(data.misc.MaxResistCap, modDB:Sum("BASE", nil, "Totem"..elem.."ResistMax", isElemental[elem] and "TotemElementalResistMax"))
-		totemTotal = modDB:Override(nil, "Totem"..elem.."Resist")
-		if not total then
-			local base = modDB:Sum("BASE", nil, elem.."Resist", isElemental[elem] and "ElementalResist")
-			total = base * m_max(calcLib.mod(modDB, nil, elem.."Resist", isElemental[elem] and "ElementalResist"), 0)
-		end
-		if not totemTotal then
-			local base = modDB:Sum("BASE", nil, "Totem"..elem.."Resist", isElemental[elem] and "TotemElementalResist")
-			totemTotal = base * m_max(calcLib.mod(modDB, nil, "Totem"..elem.."Resist", isElemental[elem] and "TotemElementalResist"), 0)
-		end
-		
-		-- Fractional resistances are truncated
-		total = m_modf(total)
-		totemTotal = m_modf(totemTotal)
-		min = m_modf(min)
-		max = m_modf(max)
-		totemMax = m_modf(totemMax)
-		
-		local final = m_max(m_min(total, max), min)
-		local totemFinal = m_max(m_min(totemTotal, totemMax), min)
-
-		output[elem.."Resist"] = final
-		output[elem.."ResistTotal"] = total
-		output[elem.."ResistOverCap"] = m_max(0, total - max)
-		output[elem.."ResistOver75"] = m_max(0, final - 75)
-		output["Missing"..elem.."Resist"] = m_max(0, max - final)
-		output["Totem"..elem.."Resist"] = totemFinal
-		output["Totem"..elem.."ResistTotal"] = totemTotal
-		output["Totem"..elem.."ResistOverCap"] = m_max(0, totemTotal - totemMax)
-		output["MissingTotem"..elem.."Resist"] = m_max(0, totemMax - totemFinal)
-		if breakdown then
-			breakdown[elem.."Resist"] = {
-				"Min: "..min.."%",
-				"Max: "..max.."%",
-				"Total: "..total.."%",
-			}
-			breakdown["Totem"..elem.."Resist"] = {
-				"Min: "..min.."%",
-				"Max: "..totemMax.."%",
-				"Total: "..totemTotal.."%",
-			}
-		end
-	end
-
-	-- Damage Reduction
-	output.DamageReductionMax = modDB:Override(nil, "DamageReductionMax") or data.misc.DamageReductionCap
-	modDB:NewMod("ArmourAppliesToPhysicalDamageTaken", "BASE", 100)
-	for _, damageType in ipairs(dmgTypeList) do
-		output["Base"..damageType.."DamageReduction"] = m_min(m_max(0, modDB:Sum("BASE", nil, damageType.."DamageReduction")), output.DamageReductionMax)
-		output["Base"..damageType.."DamageReductionWhenHit"] = m_min(m_max(0, output["Base"..damageType.."DamageReduction"] + modDB:Sum("BASE", nil, damageType.."DamageReductionWhenHit")), output.DamageReductionMax)
 	end
 
 	-- Spell Suppression


### PR DESCRIPTION
resistance and damage reduction were incorrectly moved causing multiple issues, this moves them back but checks the conditionals earlier

The order of armours was changed as well, this should probs be changed back now that the conditionals are checked earlier