### PR TITLE
Fix mastery choices overlapping when they had multiple lines

### DIFF
--- a/src/Classes/PassiveMasteryControl.lua
+++ b/src/Classes/PassiveMasteryControl.lua
@@ -14,7 +14,6 @@ local PassiveMasteryControlClass = newClass("PassiveMasteryControl", "ListContro
 	self.list = list or { }
 	-- automagical width
 	for j=1,#list do
-		list[j].label = list[j].label:gsub("\n", " ")
 		width = m_max(width, DrawStringWidth(16, "VAR", list[j].label) + 5)
 	end
 	self.ListControl(anchor, x, y, width, height, 16, false, false, self.list)

--- a/src/Classes/PassiveMasteryControl.lua
+++ b/src/Classes/PassiveMasteryControl.lua
@@ -14,6 +14,7 @@ local PassiveMasteryControlClass = newClass("PassiveMasteryControl", "ListContro
 	self.list = list or { }
 	-- automagical width
 	for j=1,#list do
+		list[j].label = list[j].label:gsub("\n", " ")
 		width = m_max(width, DrawStringWidth(16, "VAR", list[j].label) + 5)
 	end
 	self.ListControl(anchor, x, y, width, height, 16, false, false, self.list)

--- a/src/Classes/PassiveTree.lua
+++ b/src/Classes/PassiveTree.lua
@@ -327,6 +327,10 @@ local PassiveTreeClass = newClass("PassiveTree", function(self, treeVersion)
 					if not self.masteryEffects[effect.effect] then
 						self.masteryEffects[effect.effect] = { id = effect.effect, sd = effect.stats }
 						self:ProcessStats(self.masteryEffects[effect.effect])
+
+					else
+						-- Copy multiline stats from an earlier ProcessStats call
+						effect.stats = self.masteryEffects[effect.effect].sd
 					end
 				end
 			end

--- a/src/Classes/PassiveTree.lua
+++ b/src/Classes/PassiveTree.lua
@@ -327,7 +327,6 @@ local PassiveTreeClass = newClass("PassiveTree", function(self, treeVersion)
 					if not self.masteryEffects[effect.effect] then
 						self.masteryEffects[effect.effect] = { id = effect.effect, sd = effect.stats }
 						self:ProcessStats(self.masteryEffects[effect.effect])
-
 					else
 						-- Copy multiline stats from an earlier ProcessStats call
 						effect.stats = self.masteryEffects[effect.effect].sd


### PR DESCRIPTION
Fixes #5872 

### Description of the problem being solved:
Some mastery descriptions had a line break in them.  Our standard list box doesn't support multiline selections, so I simply removed the line break from any masteries that had them.

### After screenshot:
![image](https://user-images.githubusercontent.com/1209372/229406060-e2aebca3-4db2-4c62-9b90-2b90246cf931.png)
