### PR TITLE
Fix MoM and Prevented Life loss effect interaction

### DIFF
--- a/spec/System/TestDefence_spec.lua
+++ b/spec/System/TestDefence_spec.lua
@@ -272,6 +272,49 @@ describe("TestDefence", function()
         assert.are.equals(0, poolsRemaining.Life)
         assert.are.equals(120, poolsRemaining.LifeLossLostOverTime)
         assert.are.equals(20, poolsRemaining.LifeBelowHalfLossLostOverTime)
+        
+        build.skillsTab:PasteSocketGroup("\z
+        Label: 50% petrified\n\z
+        Petrified Blood 20/40 Alternate1  1\n\z
+        ")
+        build.skillsTab:ProcessSocketGroup(build.skillsTab.socketGroupList[1])
+        build.configTab.input.customMods = "\z
+        +1950 to life\n\z
+        +2960 to mana\n\z
+        +3000 to energy shield\n\z
+        100% less attributes\n\z
+        100% less mana reserved\n\z
+        +60% to all resistances\n\z
+        chaos damage does not bypass energy shield\n\z
+        mind over matter\n\z
+        eldritch battery\n\z
+        10% of lightning damage is taken from mana before life\n\z
+        chaos damage is taken from mana before life\n\z
+        When Hit during effect, 50% of Life loss from Damage taken occurs over 4 seconds instead\n\z
+        "
+        build.configTab.input.conditionUsingFlask = true
+        build.configTab:BuildModList()
+        runCallback("OnFrame")
+        
+        _, takenDamages = takenHitFromTypeMaxHit("Fire")
+        poolsRemaining = build.calcsTab.calcs.reducePoolsByDamage(nil, takenDamages, build.calcsTab.calcsEnv.player)
+        assert.are.equals(0, poolsRemaining.Life)
+        assert.are.equals(0, poolsRemaining.EnergyShield)
+        assert.is.not_false(poolsRemaining.Mana > 0)
+        
+        _, takenDamages = takenHitFromTypeMaxHit("Lightning")
+        poolsRemaining = build.calcsTab.calcs.reducePoolsByDamage(nil, takenDamages, build.calcsTab.calcsEnv.player)
+        assert.are.equals(0, poolsRemaining.Life)
+        assert.are.equals(0, poolsRemaining.EnergyShield)
+        assert.are.equals(0, poolsRemaining.Mana)
+        
+        _, takenDamages = takenHitFromTypeMaxHit("Chaos")
+        poolsRemaining = build.calcsTab.calcs.reducePoolsByDamage(nil, takenDamages, build.calcsTab.calcsEnv.player)
+        assert.are.equals(0, poolsRemaining.Life)
+        assert.are.equals(0, poolsRemaining.EnergyShield)
+        assert.are.equals(0, poolsRemaining.Mana)
+        
+        build.skillsTab.socketGroupList = {}
     end)
 
     -- fun part

--- a/src/Modules/CalcDefence.lua
+++ b/src/Modules/CalcDefence.lua
@@ -1617,17 +1617,23 @@ function calcs.defence(env, actor)
 	
 	-- Prevented life loss taken over 4 seconds (and Petrified Blood)
 	do
-		output["preventedLifeLoss"] = modDB:Sum("BASE", nil, "LifeLossPrevented")
+		local halfLife = output.Life * 0.5
+		local recoverable = output.LifeRecoverable
+		local aboveLow = m_max(recoverable - halfLife, 0)
+		local preventedLifeLoss = modDB:Sum("BASE", nil, "LifeLossPrevented")
+		output["preventedLifeLoss"] = preventedLifeLoss
 		local initialLifeLossBelowHalfPrevented = modDB:Sum("BASE", nil, "LifeLossBelowHalfPrevented")
 		output["preventedLifeLossBelowHalf"] = (1 - output["preventedLifeLoss"] / 100) * initialLifeLossBelowHalfPrevented
 		local portionLife = 1
 		if not env.configInput["conditionLowLife"] then
 			--portion of life that is lowlife
-			portionLife = m_min(output.Life * 0.5 / output.LifeRecoverable, 1)
+			portionLife = m_min(halfLife / recoverable, 1)
 			output["preventedLifeLossTotal"] = output["preventedLifeLoss"] + output["preventedLifeLossBelowHalf"] * portionLife
 		else
 			output["preventedLifeLossTotal"] = output["preventedLifeLoss"] + output["preventedLifeLossBelowHalf"]
 		end
+		output.LifeHitPool = aboveLow / (1 - preventedLifeLoss / 100) + m_min(recoverable, halfLife) / (1 - initialLifeLossBelowHalfPrevented / 100) / (1 - preventedLifeLoss / 100)
+		
 		if breakdown then
 			breakdown["preventedLifeLossTotal"] = {
 				s_format("Total life protected:"),
@@ -1691,22 +1697,28 @@ function calcs.defence(env, actor)
 	if output["sharedMindOverMatter"] > 0 then
 		output.OnlySharedMindOverMatter = true
 		local sourcePool = m_max(output.ManaUnreserved or 0, 0)
+		local sourceHitPool = sourcePool
 		local manatext = "unreserved mana"
 		if modDB:Flag(nil, "EnergyShieldProtectsMana") and output.MinimumBypass < 100 then
 			manatext = manatext.." + non-bypassed energy shield"
 			if output.MinimumBypass > 0 then
 				local manaProtected = output.EnergyShieldRecoveryCap / (1 - output.MinimumBypass / 100) * (output.MinimumBypass / 100)
 				sourcePool = m_max(sourcePool - manaProtected, -output.LifeRecoverable) + m_min(sourcePool + output.LifeRecoverable, manaProtected) / (output.MinimumBypass / 100)
-			else 
+				sourceHitPool = m_max(sourceHitPool - manaProtected, -output.LifeHitPool) + m_min(sourceHitPool + output.LifeHitPool, manaProtected) / (output.MinimumBypass / 100)
+			else
 				sourcePool = sourcePool + output.EnergyShieldRecoveryCap
+				sourceHitPool = sourcePool
 			end
 		end
 		local poolProtected = sourcePool / (output["sharedMindOverMatter"] / 100) * (1 - output["sharedMindOverMatter"] / 100)
+		local hitPoolProtected = sourceHitPool / (output["sharedMindOverMatter"] / 100) * (1 - output["sharedMindOverMatter"] / 100)
 		if output["sharedMindOverMatter"] >= 100 then
 			poolProtected = m_huge
 			output["sharedManaEffectiveLife"] = output.LifeRecoverable + sourcePool
+			output["sharedMoMHitPool"] = output.LifeHitPool + sourceHitPool
 		else
 			output["sharedManaEffectiveLife"] = m_max(output.LifeRecoverable - poolProtected, 0) + m_min(output.LifeRecoverable, poolProtected) / (1 - output["sharedMindOverMatter"] / 100)
+			output["sharedMoMHitPool"] = m_max(output.LifeHitPool - hitPoolProtected, 0) + m_min(output.LifeHitPool, hitPoolProtected) / (1 - output["sharedMindOverMatter"] / 100)
 		end
 		if breakdown then
 			if output["sharedMindOverMatter"] then
@@ -1722,6 +1734,7 @@ function calcs.defence(env, actor)
 		end
 	else
 		output["sharedManaEffectiveLife"] = output.LifeRecoverable
+		output["sharedMoMHitPool"] = output.LifeHitPool
 	end
 	for _, damageType in ipairs(dmgTypeList) do
 		output[damageType.."MindOverMatter"] = m_min(modDB:Sum("BASE", nil, damageType.."DamageTakenFromManaBeforeLife"), 100 - output["sharedMindOverMatter"])
@@ -1731,22 +1744,28 @@ function calcs.defence(env, actor)
 			output.AnySpecificMindOverMatter = true
 			output.OnlySharedMindOverMatter = false
 			local sourcePool = m_max(output.ManaUnreserved or 0, 0)
+			local sourceHitPool = sourcePool
 			local manatext = "unreserved mana"
 			if modDB:Flag(nil, "EnergyShieldProtectsMana") and output[damageType.."EnergyShieldBypass"] < 100 then
 				manatext = manatext.." + non-bypassed energy shield"
 				if output[damageType.."EnergyShieldBypass"] > 0 then
 					local manaProtected = output.EnergyShieldRecoveryCap / (1 - output[damageType.."EnergyShieldBypass"] / 100) * (output[damageType.."EnergyShieldBypass"] / 100)
 					sourcePool = m_max(sourcePool - manaProtected, -output.LifeRecoverable) + m_min(sourcePool + output.LifeRecoverable, manaProtected) / (output[damageType.."EnergyShieldBypass"] / 100)
-				else 
+					sourceHitPool = m_max(sourceHitPool - manaProtected, -output.LifeHitPool) + m_min(sourceHitPool + output.LifeHitPool, manaProtected) / (output[damageType.."EnergyShieldBypass"] / 100)
+				else
 					sourcePool = sourcePool + output.EnergyShieldRecoveryCap
+					sourceHitPool = sourcePool
 				end
 			end
 			local poolProtected = sourcePool / (MindOverMatter / 100) * (1 - MindOverMatter / 100)
+			local hitPoolProtected = sourceHitPool / (MindOverMatter / 100) * (1 - MindOverMatter / 100)
 			if MindOverMatter >= 100 then
 				poolProtected = m_huge
 				output[damageType.."ManaEffectiveLife"] = output.LifeRecoverable + sourcePool
+				output[damageType.."MoMHitPool"] = output.LifeHitPool + sourceHitPool
 			else
 				output[damageType.."ManaEffectiveLife"] = m_max(output.LifeRecoverable - poolProtected, 0) + m_min(output.LifeRecoverable, poolProtected) / (1 - MindOverMatter / 100)
+				output[damageType.."MoMHitPool"] = m_max(output.LifeHitPool - hitPoolProtected, 0) + m_min(output.LifeHitPool, hitPoolProtected) / (1 - MindOverMatter / 100)
 			end
 			if breakdown then
 				if output[damageType.."MindOverMatter"] then
@@ -1762,6 +1781,7 @@ function calcs.defence(env, actor)
 			end
 		else
 			output[damageType.."ManaEffectiveLife"] = output["sharedManaEffectiveLife"]
+			output[damageType.."MoMHitPool"] = output["sharedMoMHitPool"]
 		end
 	end
 
@@ -1847,6 +1867,7 @@ function calcs.defence(env, actor)
 	--total pool
 	for _, damageType in ipairs(dmgTypeList) do
 		output[damageType.."TotalPool"] = output[damageType.."ManaEffectiveLife"]
+		output[damageType.."TotalHitPool"] = output[damageType.."MoMHitPool"]
 		local manatext = "Mana"
 		if output[damageType.."EnergyShieldBypass"] < 100 then 
 			if modDB:Flag(nil, "EnergyShieldProtectsMana") then
@@ -1855,8 +1876,10 @@ function calcs.defence(env, actor)
 				if output[damageType.."EnergyShieldBypass"] > 0 then
 					local poolProtected = output.EnergyShieldRecoveryCap / (1 - output[damageType.."EnergyShieldBypass"] / 100) * (output[damageType.."EnergyShieldBypass"] / 100)
 					output[damageType.."TotalPool"] = m_max(output[damageType.."TotalPool"] - poolProtected, 0) + m_min(output[damageType.."TotalPool"], poolProtected) / (output[damageType.."EnergyShieldBypass"] / 100)
+					output[damageType.."TotalHitPool"] = m_max(output[damageType.."TotalHitPool"] - poolProtected, 0) + m_min(output[damageType.."TotalHitPool"], poolProtected) / (output[damageType.."EnergyShieldBypass"] / 100)
 				else
 					output[damageType.."TotalPool"] = output[damageType.."TotalPool"] + output.EnergyShieldRecoveryCap
+					output[damageType.."TotalHitPool"] = output[damageType.."TotalHitPool"] + output.EnergyShieldRecoveryCap
 				end
 			end
 		end
@@ -2519,30 +2542,18 @@ function calcs.defence(env, actor)
 	-- maximum hit taken
 	-- fix total pools, as they aren't used anymore
 	for _, damageType in ipairs(dmgTypeList) do
-		-- base + petrified blood
-		if output.preventedLifeLossTotal > 0 then
-			local halfLife = output.Life * 0.5
-			local recoverable = output.LifeRecoverable
-			if not env.configInput.conditionLowLife then
-				local belowHalf = modDB:Sum("BASE", nil, "LifeLossBelowHalfPrevented") / 100
-				local aboveLow = m_max(recoverable - halfLife, 0)
-				output[damageType.."TotalPool"] = output[damageType.."TotalPool"] - recoverable + aboveLow / (1 - output.preventedLifeLoss / 100) + m_min(recoverable, halfLife) / (1 - belowHalf) / (1 - output.preventedLifeLoss / 100)
-			else
-				output[damageType.."TotalPool"] = output[damageType.."TotalPool"] - recoverable + recoverable / (1 - output.preventedLifeLossTotal / 100)
-			end
-		end
 		-- ward
 		local wardBypass = modDB:Sum("BASE", nil, "WardBypass") or 0
 		if wardBypass > 0 then
 			local poolProtected = output.Ward / (1 - wardBypass / 100) * (wardBypass / 100)
-			local sourcePool = output[damageType.."TotalPool"]
+			local sourcePool = output[damageType.."TotalHitPool"]
 			sourcePool = m_max(sourcePool - poolProtected, 0) + m_min(sourcePool, poolProtected) / (wardBypass / 100)
-			output[damageType.."TotalPool"] = sourcePool
+			output[damageType.."TotalHitPool"] = sourcePool
 		else
-			output[damageType.."TotalPool"] = output[damageType.."TotalPool"] + output.Ward or 0
+			output[damageType.."TotalHitPool"] = output[damageType.."TotalHitPool"] + output.Ward or 0
 		end
 		-- aegis
-		output[damageType.."TotalHitPool"] = output[damageType.."TotalPool"] + m_max(m_max(output[damageType.."Aegis"], output["sharedAegis"]), isElemental[damageType] and output[damageType.."AegisDisplay"] or 0)
+		output[damageType.."TotalHitPool"] = output[damageType.."TotalHitPool"] + m_max(m_max(output[damageType.."Aegis"], output["sharedAegis"]), isElemental[damageType] and output[damageType.."AegisDisplay"] or 0)
 		-- guard skill
 		local GuardAbsorbRate = output["sharedGuardAbsorbRate"] or 0 + output[damageType.."GuardAbsorbRate"] or 0
 		if GuardAbsorbRate > 0 then


### PR DESCRIPTION
### Description of the problem being solved:
Prevented life loss (petrified blood / progenesis) + MoM was calculating the effective mana hit pool from a life pool that was not effectively multiplied by prevented life loss effects.

### Link to a build that showcases this PR:
https://pobb.in/uywtG_MOvl8T

### Before screenshot:
![image](https://user-images.githubusercontent.com/36479307/229677040-b2bdc8a3-14bd-4739-919b-ae001a5c61a3.png)

### After screenshot:
![image](https://user-images.githubusercontent.com/36479307/229676875-9d96bd5c-72ec-44d0-addc-70ef8cf4894f.png)
