### PR TITLE
Stop life loss prevention occuring on overkill damage resulting in breakpointing behaviour

### DIFF
--- a/src/Modules/CalcDefence.lua
+++ b/src/Modules/CalcDefence.lua
@@ -192,7 +192,7 @@ function calcs.reducePoolsByDamage(poolTable, damageTable, actor)
 			local preventPercent = output.preventedLifeLoss / 100
 			local poolAboveLow = lifeOverHalfLife / (1 - preventPercent)
 			local preventBelowHalfPercent = modDB:Sum("BASE", nil, "LifeLossBelowHalfPrevented") / 100
-			local damageThatLifeCanStillTake = poolAboveLow + m_min(life, halfLife) / (1 - preventBelowHalfPercent) / (1 - output.preventedLifeLoss / 100)
+			local damageThatLifeCanStillTake = poolAboveLow + m_max(m_min(life, halfLife), 0) / (1 - preventBelowHalfPercent) / (1 - output.preventedLifeLoss / 100)
 			local overkillDamage = damageThatLifeCanStillTake < damageRemainder and damageRemainder - damageThatLifeCanStillTake or 0
 			if overkillDamage ~= 0 then
 				damageRemainder = damageThatLifeCanStillTake

--- a/src/Modules/CalcDefence.lua
+++ b/src/Modules/CalcDefence.lua
@@ -192,22 +192,26 @@ function calcs.reducePoolsByDamage(poolTable, damageTable, actor)
 				local preventPercent = output.preventedLifeLoss / 100
 				local poolAboveLow = lifeOverHalfLife / (1 - preventPercent)
 				local damageToSplit = m_min(damageRemainder, poolAboveLow)
-				local lostLife = damageToSplit * (1 - preventPercent)
-				local preventedLoss = damageToSplit * preventPercent
+				local maximumPrevent = preventPercent * life -- cap to avoid preventing negative life aka dead.
+				local preventedLoss = m_min(damageToSplit * preventPercent, maximumPrevent)
+				local lostLife = damageToSplit - preventedLoss
 				damageRemainder = damageRemainder - damageToSplit
 				LifeLossLostOverTime = LifeLossLostOverTime + preventedLoss
 				life = life - lostLife
 				
 				if life <= output.Life * 0.5 then
-					local unspecificallyLowLifePreventedDamage = damageRemainder * preventPercent
+					local maximumPrevent = preventPercent * life -- cap to avoid preventing negative life aka dead.
+					local unspecificallyLowLifePreventedDamage = m_min(damageRemainder * preventPercent, maximumPrevent)
 					LifeLossLostOverTime = LifeLossLostOverTime + unspecificallyLowLifePreventedDamage
 					damageRemainder = damageRemainder - unspecificallyLowLifePreventedDamage
-					local specificallyLowLifePreventedDamage = damageRemainder * modDB:Sum("BASE", nil, "LifeLossBelowHalfPrevented") / 100
+					local specificallyLowLifePreventedDamage = m_min(damageRemainder * modDB:Sum("BASE", nil, "LifeLossBelowHalfPrevented") / 100, maximumPrevent)
 					LifeBelowHalfLossLostOverTime = LifeBelowHalfLossLostOverTime + specificallyLowLifePreventedDamage
 					damageRemainder = damageRemainder - specificallyLowLifePreventedDamage
 				end
 			else
-				local tempDamage = damageRemainder * output.preventedLifeLoss / 100
+				local preventPercent = output.preventedLifeLoss / 100
+				local maximumPrevent = preventPercent * life -- cap to avoid preventing negative life aka dead.
+				local tempDamage = m_min(damageRemainder * preventPercent, maximumPrevent)
 				LifeLossLostOverTime = LifeLossLostOverTime + tempDamage
 				damageRemainder = damageRemainder - tempDamage
 			end


### PR DESCRIPTION
Fixes https://github.com/PathOfBuildingCommunity/PathOfBuilding/issues/5907

### Description of the problem being solved:
When a hit kills you with PB life loss prevention was being applied to the damage you were taking while dead. This lead to more being mitigated then it should resulting in weird breakpoint behaviours as we transition between 0-1 hit to just over 1 hit producing large amounts of life loss prevention.

### Steps taken to verify a working solution:
![image](https://user-images.githubusercontent.com/31533893/229692947-db920e68-b0a5-4c62-a98f-2a28ff8fd486.png)

### Link to a build that showcases this PR:
https://pobb.in/MrUkxpa_Q25d