### PR TITLE
Prompt for saving after altering the passive search string

### DIFF
--- a/src/Classes/PassiveTreeView.lua
+++ b/src/Classes/PassiveTreeView.lua
@@ -57,6 +57,7 @@ local PassiveTreeViewClass = newClass("PassiveTreeView", function(self)
 	self.zoomY = 0
 
 	self.searchStr = ""
+	self.searchStrSaved = ""
 	self.searchStrCached = ""
 	self.searchStrResults = {}
 	self.showStatDifferences = true
@@ -74,6 +75,7 @@ function PassiveTreeViewClass:Load(xml, fileName)
 	end
 	if xml.attrib.searchStr then
 		self.searchStr = xml.attrib.searchStr
+		self.searchStrSaved = xml.attrib.searchStrSaved
 	end
 	if xml.attrib.showHeatMap then
 		self.showHeatMap = xml.attrib.showHeatMap == "true"
@@ -84,6 +86,7 @@ function PassiveTreeViewClass:Load(xml, fileName)
 end
 
 function PassiveTreeViewClass:Save(xml)
+	self.searchStrSaved = self.searchStr
 	xml.attrib = {
 		zoomLevel = tostring(self.zoomLevel),
 		zoomX = tostring(self.zoomX),

--- a/src/Classes/PassiveTreeView.lua
+++ b/src/Classes/PassiveTreeView.lua
@@ -75,7 +75,7 @@ function PassiveTreeViewClass:Load(xml, fileName)
 	end
 	if xml.attrib.searchStr then
 		self.searchStr = xml.attrib.searchStr
-		self.searchStrSaved = xml.attrib.searchStrSaved
+		self.searchStrSaved = xml.attrib.searchStr
 	end
 	if xml.attrib.showHeatMap then
 		self.showHeatMap = xml.attrib.showHeatMap == "true"

--- a/src/Classes/TreeTab.lua
+++ b/src/Classes/TreeTab.lua
@@ -120,6 +120,7 @@ local TreeTabClass = newClass("TreeTab", "ControlHost", function(self, build)
 	end)
 	self.controls.treeSearch = new("EditControl", { "LEFT", self.controls.export, "RIGHT" }, 8, 0, main.portraitMode and 200 or 300, 20, "", "Search", "%c%(%)", 100, function(buf)
 		self.viewer.searchStr = buf
+		self.searchFlag = buf ~= self.viewer.searchStrSaved
 	end)
 	self.controls.treeSearch.tooltipText = "Uses Lua pattern matching for complex searches"
 	self.controls.findTimelessJewel = new("ButtonControl", { "LEFT", self.controls.treeSearch, "RIGHT" }, 8, 0, 150, 20, "Find Timeless Jewel", function()

--- a/src/Modules/Build.lua
+++ b/src/Modules/Build.lua
@@ -931,6 +931,7 @@ function buildMode:ResetModFlags()
 	self.notesTab.modFlag = false
 	self.configTab.modFlag = false
 	self.treeTab.modFlag = false
+	self.treeTab.searchFlag = false
 	self.spec.modFlag = false
 	self.skillsTab.modFlag = false
 	self.itemsTab.modFlag = false
@@ -1048,7 +1049,7 @@ function buildMode:OnFrame(inputEvents)
 		self.calcsTab:Draw(tabViewPort, inputEvents)
 	end
 
-	self.unsaved = self.modFlag or self.notesTab.modFlag or self.configTab.modFlag or self.treeTab.modFlag or self.spec.modFlag or self.skillsTab.modFlag or self.itemsTab.modFlag or self.calcsTab.modFlag
+	self.unsaved = self.modFlag or self.notesTab.modFlag or self.configTab.modFlag or self.treeTab.modFlag or self.treeTab.searchFlag or self.spec.modFlag or self.skillsTab.modFlag or self.itemsTab.modFlag or self.calcsTab.modFlag
 
 	SetDrawLayer(5)
 


### PR DESCRIPTION
Previously, PoB did not prompt the user to save if they modified the search string, despite the fact that the search string is stored in the save.

This PR causes that prompt to happen, allowing users to remove/adjust a search and then save that change without making other changes too.