### PR TITLE
Hide the power report on loading a build and unchecking "Show node power"

### DIFF
--- a/src/Classes/PassiveTreeView.lua
+++ b/src/Classes/PassiveTreeView.lua
@@ -75,9 +75,6 @@ function PassiveTreeViewClass:Load(xml, fileName)
 	if xml.attrib.searchStr then
 		self.searchStr = xml.attrib.searchStr
 	end
-	if xml.attrib.showHeatMap then
-		self.showHeatMap = xml.attrib.showHeatMap == "true"
-	end
 	if xml.attrib.showStatDifferences then
 		self.showStatDifferences = xml.attrib.showStatDifferences == "true"
 	end
@@ -89,7 +86,6 @@ function PassiveTreeViewClass:Save(xml)
 		zoomX = tostring(self.zoomX),
 		zoomY = tostring(self.zoomY),
 		searchStr = self.searchStr,
-		showHeatMap = tostring(self.showHeatMap),
 		showStatDifferences = tostring(self.showStatDifferences),
 	}
 end

--- a/src/Classes/TreeTab.lua
+++ b/src/Classes/TreeTab.lua
@@ -128,6 +128,11 @@ local TreeTabClass = newClass("TreeTab", "ControlHost", function(self, build)
 	self.controls.treeHeatMap = new("CheckBoxControl", { "LEFT", self.controls.findTimelessJewel, "RIGHT" }, 130, 0, 20, "Show Node Power:", function(state)
 		self.viewer.showHeatMap = state
 		self.controls.treeHeatMapStatSelect.shown = state
+		
+		if state == false then 
+			self.showPowerReport = false 
+			self:TogglePowerReport()
+		end
 	end)
 	self.controls.treeHeatMapStatSelect = new("DropDownControl", { "LEFT", self.controls.treeHeatMap, "RIGHT" }, 8, 0, 150, 20, nil, function(index, value)
 		self:SetPowerCalc(value)


### PR DESCRIPTION
Fixes #5903

### Description of the problem being solved:
Show node power causes severe lag. For almost all usecases, it should not enable on load. In addition, if show node power is disabled while power report is showing, it would hide the hide power report button, but keep the report open. 

This PR removes show node power (showHeatMap) from saves and loads. In addition, it hides the power report when the show node power checkbox is toggled to false.