### PR TITLE
Fix Reverberation Rod to add back Controlled Destruction

### DIFF
--- a/src/Data/Uniques/wand.lua
+++ b/src/Data/Uniques/wand.lua
@@ -238,7 +238,7 @@ Implicits: 3
 {variant:3,4,5}+2 to Level of Socketed Gems
 {variant:4,5}Socketed Gems are Supported by Level 10 Arcane Surge
 Socketed Gems are Supported by Level 10 Spell Echo
-{variant:4}Socketed Gems are Supported by Level 10 Controlled Destruction
+{variant:4,5}Socketed Gems are Supported by Level 10 Controlled Destruction
 +(10-30) to Intelligence
 ]],[[
 Relic of the Pact


### PR DESCRIPTION
Fixes # .

### Description of the problem being solved:

I checked https://www.pathofexile.com/forum/view-thread/3361403 poedb and poewiki and nothing indicates Reverberation Rod losing Controlled Destruction.

### Steps taken to verify a working solution:
-
-
-

### Link to a build that showcases this PR:

### Before screenshot:

### After screenshot:
