### PR TITLE
Correct display of max mana leech rate breakdown

### DIFF
--- a/src/Modules/CalcDefence.lua
+++ b/src/Modules/CalcDefence.lua
@@ -831,7 +831,7 @@ function calcs.defence(env, actor)
 	if breakdown then
 		breakdown.MaxManaLeechRate = {
 			s_format("%d ^8(maximum mana)", output.Mana),
-			s_format("x %d%% ^8(percentage of mana to maximum leech rate)", modDB:Sum("BASE", nil, "MaxManaLeechRate")),
+			s_format("x %d%% ^8(percentage of mana to maximum leech rate)", calcLib.val(modDB, "MaxManaLeechRate")),
 			s_format("= %.1f", output.MaxManaLeechRate)
 		}
 	end


### PR DESCRIPTION
### Description of the problem being solved:
Max mana leech rate was only base values, not including increased/more modifiers.

### Steps taken to verify a working solution:
- Checked mana leech before and after change

### Link to a build that showcases this PR:
https://pobb.in/Ni5SaBFkXDSY

### Before screenshot:
![image](https://user-images.githubusercontent.com/5985728/230295172-b9d7e18d-0539-472a-8659-14969e1b1d28.png)


### After screenshot:
![image](https://user-images.githubusercontent.com/5985728/230295234-5190081b-7cd8-4174-8247-4469fc0447f7.png)
