### PR TITLE
Fix ailment conditionals not being preemptively enabled when an ailment can be applied.

### DIFF
--- a/src/Modules/Calcs.lua
+++ b/src/Modules/Calcs.lua
@@ -506,6 +506,17 @@ function calcs.buildOutput(build, mode)
 		end
 		local function addModTags(actor, mod)
 			addTo(env.modsUsed, mod.name, mod)
+			
+			-- Imply enemy conditionals based on damage type
+			-- Needed to preemptively show config options for elemental ailments
+			for dmgType, conditions in pairs({["[fi][ig][rn][ei]t?e?"] = {"Ignited", "Burning"}, ["[cf][or][le][de]z?e?"] = {"Frozen"}}) do
+				if mod.name:lower():match(dmgType) then
+					for _, var in ipairs(conditions) do
+						addTo(env.enemyConditionsUsed, var, mod)
+					end
+				end
+			end
+			
 			for _, tag in ipairs(mod) do
 				addTo(env.tagTypesUsed, tag.type, mod)
 				if tag.type == "IgnoreCond" then


### PR DESCRIPTION
Fixes #5895, #5944.

### Description of the problem being solved:
Ailment config options did not show up even though current build was capable of inflicting them, causing annoyances when trying to use item/gem sorting to optimize for their effect.

This pr attempts to preemptively enable config options for related enemy conditionals based on used mods to fix this.

This may not be the best way of doing this and may be missing handling for some other situations where a similar issue occurs, but does fix the mentioned issues.