### PR TITLE
Fix kaom's spirit rage regen calculation behaviour

### DIFF
--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -4013,7 +4013,7 @@ local specialModList = {
 		flag("Condition:CanGainRage", { type = "Condition", varList = { "UsingAxe", "UsingSword" } }),
 	},
 	["regenerate (%d+) rage per second for every (%d+) life recovery per second from regeneration"] = function(num, _, div) return { 
-		mod("RageRegen", "BASE", num, {type = "PerStat", stat = "LifeRegen", div = tonumber(div) }),
+		mod("RageRegen", "BASE", num, {type = "PercentStat", stat = "LifeRegen", percent = tonumber(num/div*100) }),
 		flag("Condition:CanGainRage"),
 	} end,
 	["when you lose temporal chains you gain maximum rage"] = { flag("Condition:CanGainRage") },


### PR DESCRIPTION
Fixes #5949 .

### Description of the problem being solved:
[Kaom's spirit](https://www.poewiki.net/wiki/Kaom%27s_Spirit) rage regen was calculated as a "PerStat" mod type making it only possible to have integer values of rage regen for every 100 life regen on the character. This goes against the in-game behaviour which lets you have a real number rage regen even with less than 100 life regen. This PR updates the mod type to "PercentStat"
### Steps taken to verify a working solution:
- equip kaom's spirit
- equip lvl 15 vitality
- check life regen in calcs
- check rage regen in calcs

### Link to a build that showcases this PR:
https://pobb.in/kEo6M0wLcbiV
### Before screenshot:
![image](https://user-images.githubusercontent.com/50706266/230463141-9be8551e-4af0-49b0-9c00-4d8c3155733c.png)
![image](https://user-images.githubusercontent.com/50706266/230463192-b7d30bd3-62f4-4b1e-8fa7-1ed2a056c314.png)

### After screenshot:
![image](https://user-images.githubusercontent.com/50706266/230462913-91e4bea7-20df-4c95-8ad5-ea2461b660e2.png)
![image](https://user-images.githubusercontent.com/50706266/230462971-6f32ffdb-ee07-4db2-a3bb-20c619c20540.png)
