### PR TITLE
Remove the auto application of full pool

### DIFF
--- a/src/Modules/CalcPerform.lua
+++ b/src/Modules/CalcPerform.lua
@@ -762,9 +762,6 @@ local function doActorLifeManaReservation(actor)
 			if (max - reserved) / max <= (lowPerc > 0 and lowPerc or data.misc.LowPoolThreshold) then
 				condList["Low"..pool] = true
 			end
-			if (max - reserved) / max >= (fullPerc > 0 and fullPerc or 1.0) then
-				condList["Full"..pool] = true
-			end
 		else
 			reserved = 0
 		end


### PR DESCRIPTION
Theres a reason this did not automatically apply before, you cant be sure on the state of the life pool unless its forced (eg lowlife if you reserve enough), so its up to the user to configure it

This breaks things like agnostic and overvalues "while on full life" things

incorrectly added by #5904
