### PR TITLE
Parse the modifier for less damage on subsequent hits on lancing steel

### DIFF
--- a/src/Data/Skills/act_dex.lua
+++ b/src/Data/Skills/act_dex.lua
@@ -5649,7 +5649,7 @@ skills["LancingSteel"] = {
 	},
 	preDamageFunc = function(activeSkill, output)
 		if activeSkill.skillPart == 2 then
-			activeSkill.skillData.dpsMultiplier = 1 + 0.4 * (output.ProjectileCount - 1)
+			activeSkill.skillData.dpsMultiplier = 1 + activeSkill.skillModList:More(activeSkill.skillCfg, "LancingSteelSubsequentDamage") * (output.ProjectileCount - 1)
 		end
 	end,
 	statMap = {
@@ -5658,6 +5658,9 @@ skills["LancingSteel"] = {
 		},
 		["lancing_steel_damage_+%_at_close_range"] = {
 			mod("Damage", "INC", nil, 0, bit.bor(KeywordFlag.Hit, KeywordFlag.Ailment), { type = "DistanceRamp", ramp = {{10,1},{70,0}} }),
+		},
+		["lancing_steel_damage_+%_final_after_first_hit_on_target"] = {
+			mod("LancingSteelSubsequentDamage", "MORE", nil, 0, 0, { type = "SkillPart", skillPart = 2 } ),
 		},
 	},
 	baseFlags = {

--- a/src/Export/Skills/act_dex.txt
+++ b/src/Export/Skills/act_dex.txt
@@ -1133,7 +1133,7 @@ local skills, mod, flag, skill = ...
 	},
 	preDamageFunc = function(activeSkill, output)
 		if activeSkill.skillPart == 2 then
-			activeSkill.skillData.dpsMultiplier = 1 + 0.4 * (output.ProjectileCount - 1)
+			activeSkill.skillData.dpsMultiplier = 1 + activeSkill.skillModList:More(activeSkill.skillCfg, "LancingSteelSubsequentDamage") * (output.ProjectileCount - 1)
 		end
 	end,
 	statMap = {
@@ -1142,6 +1142,9 @@ local skills, mod, flag, skill = ...
 		},
 		["lancing_steel_damage_+%_at_close_range"] = {
 			mod("Damage", "INC", nil, 0, bit.bor(KeywordFlag.Hit, KeywordFlag.Ailment), { type = "DistanceRamp", ramp = {{10,1},{70,0}} }),
+		},
+		["lancing_steel_damage_+%_final_after_first_hit_on_target"] = {
+			mod("LancingSteelSubsequentDamage", "MORE", nil, 0, 0, { type = "SkillPart", skillPart = 2 } ),
 		},
 	},
 #mods


### PR DESCRIPTION
### Description of the problem being solved:
The modifier "Hits after the first on each Enemy deal 60% less Damage" was already supported through a preDamageFunc, but since we used a static value instead of a proper parse, the modifier still showed as unsupported.

This adds a mapping to the stat in question and uses said stat in the preDamageFunc, not only making it show as parsed, but also allowing it to be automatically parsed in case that number ever changes.

### Steps taken to verify a working solution:
- Compared damage values before and after change, noted they were identical

### Before screenshot:
![image](https://user-images.githubusercontent.com/5985728/230582724-49606cd8-2fb6-407b-91fb-0ea8040980b2.png)

### After screenshot:
![image](https://user-images.githubusercontent.com/5985728/230582774-bb96a6ad-5921-4acf-bc36-3f885bbc1793.png)
