### PR TITLE
Add button to open build folder in explorer

### DIFF
--- a/src/Modules/Main.lua
+++ b/src/Modules/Main.lua
@@ -702,7 +702,8 @@ function main:OpenOptionsPopup()
 	end
 	controls.buildPath.tooltipText = "Overrides the default save location for builds.\nThe default location is: '"..self.defaultBuildPath.."'"
 	controls.buildPathButton = new("ButtonControl", { "LEFT", controls.buildPath, "RIGHT" }, -defaultLabelSpacingPx, 0, 40, 18, "Open", function()
-		os.execute('explorer '..controls.buildPath.buf:gsub("/","\\"))
+		local path = controls.buildPath.buf ~= '' and controls.buildPath.buf:gsub("/","\\") or self.defaultBuildPath:gsub("/","\\")
+		os.execute('explorer '..path)
 	end)
 
 	nextRow()

--- a/src/Modules/Main.lua
+++ b/src/Modules/Main.lua
@@ -701,6 +701,9 @@ function main:OpenOptionsPopup()
 		controls.buildPath:SetText(self.buildPath)
 	end
 	controls.buildPath.tooltipText = "Overrides the default save location for builds.\nThe default location is: '"..self.defaultBuildPath.."'"
+	controls.buildPathButton = new("ButtonControl", { "LEFT", controls.buildPath, "RIGHT" }, -defaultLabelSpacingPx, 0, 40, 18, "Open", function()
+		os.execute('explorer '..controls.buildPath.buf:gsub("/","\\"))
+	end)
 
 	nextRow()
 	controls.nodePowerTheme = new("DropDownControl", { "TOPLEFT", nil, "TOPLEFT" }, defaultLabelPlacementX, currentY, 100, 18, {


### PR DESCRIPTION
Adds a button to open the build save path in explorer. I have no way to test other operating systems so I've opted not to even attempt making it work for systems other than windows.

If no custom build path is provided, it opens the default build folder.

### Before screenshot:
![image](https://user-images.githubusercontent.com/5985728/230598564-89a55aeb-9f31-4495-b016-53b33a6d501b.png)

### After screenshot:
![image](https://user-images.githubusercontent.com/5985728/230598541-e8791796-14af-4f5b-a51d-762fa1566eab.png)

