### PR TITLE
Fix crucible item colour

### DIFF
--- a/src/Classes/ImportTab.lua
+++ b/src/Classes/ImportTab.lua
@@ -879,7 +879,7 @@ function ImportTabClass:ImportItem(itemData, slotName)
 		for _, line in ipairs(itemData.crucibleMods) do
 			for line in line:gmatch("[^\n]+") do
 				local modList, extra = modLib.parseMod(line)
-				t_insert(item.crucibleModLines, { line = line, extra = extra, mods = modList or { } })
+				t_insert(item.crucibleModLines, { line = line, extra = extra, mods = modList or { }, crucible = true })
 			end
 		end
 	end


### PR DESCRIPTION
Fixes https://github.com/PathOfBuildingCommunity/PathOfBuilding/issues/5986

### Description of the problem being solved:
Due to missing the crucible mod tag the mods weren't coloured.
This adds it so it works correctly.

### Link to a build that showcases this PR:
https://www.pathofexile.com/account/view-profile/johann_94/characters?characterName=elodeday

### Before screenshot:
![image](https://user-images.githubusercontent.com/31533893/230749696-9c2f61ed-cc30-4ba4-b049-891800d4e304.png)

### After screenshot:
![image](https://user-images.githubusercontent.com/31533893/230749699-bbd7077b-8467-4122-a119-21b49f483b07.png)
