### PR TITLE
Fix low life recoverable calculation

### DIFF
--- a/src/Modules/CalcDefence.lua
+++ b/src/Modules/CalcDefence.lua
@@ -1628,7 +1628,7 @@ function calcs.buildDefenceEstimations(env, actor)
 	-- Life Recoverable
 	output.LifeRecoverable = output.LifeUnreserved
 	if env.configInput["conditionLowLife"] then
-		output.LifeRecoverable = m_min(output.Life * data.misc.configurable.LowLifePercentage, output.LifeUnreserved)
+		output.LifeRecoverable = m_min(output.Life * data.misc.configurable.LowLifePercentage / 100, output.LifeUnreserved)
 		if output.LifeRecoverable < output.LifeUnreserved then
 			output.CappingLife = true
 		end


### PR DESCRIPTION
Fixes #6000 introduced in https://github.com/PathOfBuildingCommunity/PathOfBuilding/pull/5904

### Description of the problem being solved:
The number was being multiplied by 50/55 instead of 0.5/0.55

### Steps taken to verify a working solution:
![image](https://user-images.githubusercontent.com/31533893/230805550-8ee24c08-be67-4f00-b3c4-7ae491fc9822.png)
![image](https://user-images.githubusercontent.com/31533893/230805563-fa9a8f6a-8f66-4f0e-9848-4fb7ec54c090.png)

### Link to a build that showcases this PR:
https://pobb.in/qQ5kRuWBCLBG