### PR TITLE
Fix active skill mods applying to support gems

### DIFF
--- a/src/Modules/CalcActiveSkill.lua
+++ b/src/Modules/CalcActiveSkill.lua
@@ -468,7 +468,7 @@ function calcs.buildActiveSkillModList(env, activeSkill)
 
 	-- Apply gem/quality modifiers from support gems
 	for _, value in ipairs(skillModList:List(activeSkill.skillCfg, "SupportedGemProperty")) do
-		if value.keyword == "grants_active_skill" and activeSkill.activeEffect.gemData then
+		if value.keyword == "grants_active_skill" and activeSkill.activeEffect.gemData and not activeSkill.activeEffect.gemData.tags.support  then
 			activeEffect[value.key] = activeEffect[value.key] + value.value
 		end
 	end

--- a/src/Modules/CalcTools.lua
+++ b/src/Modules/CalcTools.lua
@@ -101,10 +101,10 @@ function calcLib.gemIsType(gem, type)
 			(type == "elemental" and (gem.tags.fire or gem.tags.cold or gem.tags.lightning)) or 
 			(type == "aoe" and gem.tags.area) or
 			(type == "trap or mine" and (gem.tags.trap or gem.tags.mine)) or
-			(type == "active skill" and gem.tags.active_skill) or
+			((type == "active skill" or type == "grants_active_skill") and gem.tags.grants_active_skill and not gem.tags.support) or
 			(type == "non-vaal" and not gem.tags.vaal) or
 			(type == gem.name:lower()) or
-			gem.tags[type])
+			((type ~= "active skill" and type ~= "grants_active_skill") and gem.tags[type]))
 end
 
 -- From PyPoE's formula.py


### PR DESCRIPTION
Fixes https://github.com/PathOfBuildingCommunity/PathOfBuilding/issues/4684 https://github.com/PathOfBuildingCommunity/PathOfBuilding/issues/2719 https://github.com/PathOfBuildingCommunity/PathOfBuilding/issues/2295

### Description of the problem being solved:
Active skill gem mods cannot apply if the skill has the support gem tag this includes a fix added in https://github.com/PathOfBuildingCommunity/PathOfBuilding/pull/5530 along with one for the item mods to hopefully get it merged faster.

### Link to a build that showcases this PR:
https://pobb.in/iH6RqTU-zfT0

### Before screenshot:
![image](https://user-images.githubusercontent.com/31533893/231071728-ddf04cad-ebc3-43db-8805-5bb99de9c21b.png)
![image](https://user-images.githubusercontent.com/31533893/231071743-eba23094-061d-4e6e-a5b0-6bcee2964a63.png)

### After screenshot:
![image](https://user-images.githubusercontent.com/31533893/231071776-2702b34f-ec68-4595-b75f-69b5030f420a.png)
![image](https://user-images.githubusercontent.com/31533893/231071814-475d210c-942b-4987-8cf5-382768f3b6b9.png)

