### PR TITLE
Fix Prismatic Burst not choosing 1 damage type for DPS

### DIFF
--- a/src/Data/Skills/sup_int.lua
+++ b/src/Data/Skills/sup_int.lua
@@ -5499,7 +5499,8 @@ skills["PrismaticBurst"] = {
 		["prismatic_burst_unchosen_type_damage_-100%_final"] = {
 			mod("FireDamage", "MORE", nil, 0, 0, { type = "SkillPart", skillPartList = { 2, 3 } }),
 			mod("ColdDamage", "MORE", nil, 0, 0, { type = "SkillPart", skillPartList = { 1, 3 } }),
-			mod("LightningDamage", "MORE", nil, 0, 0, { type = "SkillPart", skillPartList = { 1, 2 } })
+			mod("LightningDamage", "MORE", nil, 0, 0, { type = "SkillPart", skillPartList = { 1, 2 } }),
+			mult = -100,
 		},
 		["spell_damage_+%_per_10_int"] = {
 			skill("Damage", nil, { type = "PerStat", stat = "Int", div = 10 }),

--- a/src/Export/Skills/sup_int.txt
+++ b/src/Export/Skills/sup_int.txt
@@ -783,7 +783,8 @@ local skills, mod, flag, skill = ...
 		["prismatic_burst_unchosen_type_damage_-100%_final"] = {
 			mod("FireDamage", "MORE", nil, 0, 0, { type = "SkillPart", skillPartList = { 2, 3 } }),
 			mod("ColdDamage", "MORE", nil, 0, 0, { type = "SkillPart", skillPartList = { 1, 3 } }),
-			mod("LightningDamage", "MORE", nil, 0, 0, { type = "SkillPart", skillPartList = { 1, 2 } })
+			mod("LightningDamage", "MORE", nil, 0, 0, { type = "SkillPart", skillPartList = { 1, 2 } }),
+			mult = -100,
 		},
 		["spell_damage_+%_per_10_int"] = {
 			skill("Damage", nil, { type = "PerStat", stat = "Int", div = 10 }),


### PR DESCRIPTION
Since the stat being mapped is a bool, it automatically take the value of 1 if mapped into a mod. This fixes it by applying a multiplier of -100