### PR TITLE
Fix max res Armour Mastery incorrectly applying to max Chaos res

### DIFF
--- a/src/Data/StatDescriptions/stat_descriptions.lua
+++ b/src/Data/StatDescriptions/stat_descriptions.lua
@@ -105510,7 +105510,7 @@ return {
 							[2]="#"
 						}
 					},
-					text="{0:+d}% to all maximum Resistances if Equipped Helmet, Body Armour, Gloves, and Boots all have Armour"
+					text="{0:+d}% to all maximum Elemental Resistances if Equipped Helmet, Body Armour, Gloves, and Boots all have Armour"
 				}
 			}
 		},


### PR DESCRIPTION
Confirmed by Novynn that the mastery is meant to say elemental on it. Fixing it before GGG make the change to reflect the current state of the game