### PR TITLE
Generalise count types

### DIFF
--- a/src/Classes/PassiveSpec.lua
+++ b/src/Classes/PassiveSpec.lua
@@ -230,9 +230,6 @@ function PassiveSpecClass:AllocateMasteryEffects(masteryEffects)
 		self.tree:ProcessStats(self.allocNodes[id])
 		self.masterySelections[id] = effectId
 		self.allocatedMasteryCount = self.allocatedMasteryCount + 1
-		if self.allocNodes[id].name == "Life Mastery" then
-			self.allocatedLifeMasteryCount = self.allocatedLifeMasteryCount + 1
-		end
 		if not self.allocatedMasteryTypes[self.allocNodes[id].name] then
 			self.allocatedMasteryTypes[self.allocNodes[id].name] = 1
 			self.allocatedMasteryTypeCount = self.allocatedMasteryTypeCount + 1
@@ -873,7 +870,6 @@ function PassiveSpecClass:BuildAllDependsAndPaths()
 	self.allocatedNotableCount = 0
 	self.allocatedMasteryTypes = { }
 	self.allocatedMasteryTypeCount = 0
-	self.allocatedLifeMasteryCount = 0
 	for id, node in pairs(self.nodes) do
 		if node.type == "Mastery" and self.masterySelections[id] then
 			local effect = self.tree.masteryEffects[self.masterySelections[id]]
@@ -883,9 +879,6 @@ function PassiveSpecClass:BuildAllDependsAndPaths()
 				node.reminderText = { "Tip: Right click to select a different effect" }
 				self.tree:ProcessStats(node)
 				self.allocatedMasteryCount = self.allocatedMasteryCount + 1
-				if node.name == "Life Mastery" then
-					self.allocatedLifeMasteryCount = self.allocatedLifeMasteryCount + 1
-				end
 				if not self.allocatedMasteryTypes[self.allocNodes[id].name] then
 					self.allocatedMasteryTypes[self.allocNodes[id].name] = 1
 					self.allocatedMasteryTypeCount = self.allocatedMasteryTypeCount + 1

--- a/src/Modules/CalcSetup.lua
+++ b/src/Modules/CalcSetup.lua
@@ -518,7 +518,6 @@ function calcs.initEnv(build, mode, override, specEnv)
 	local allocatedMasteryCount = env.spec.allocatedMasteryCount
 	local allocatedMasteryTypeCount = env.spec.allocatedMasteryTypeCount
 	local allocatedMasteryTypes = copyTable(env.spec.allocatedMasteryTypes)
-	local allocatedLifeMasteryCount = env.spec.allocatedLifeMasteryCount
 	if not accelerate.nodeAlloc then
 		-- Build list of passive nodes
 		local nodes
@@ -529,9 +528,6 @@ function calcs.initEnv(build, mode, override, specEnv)
 					nodes[node.id] = node
 					if node.type == "Mastery" then
 						allocatedMasteryCount = allocatedMasteryCount + 1
-						if node.name == "Life" then
-							allocatedLifeMasteryCount = allocatedLifeMasteryCount + 1
-						end
 
 						if not allocatedMasteryTypes[node.name] then
 							allocatedMasteryTypes[node.name] = 1
@@ -554,9 +550,6 @@ function calcs.initEnv(build, mode, override, specEnv)
 				elseif override.removeNodes[node] then
 					if node.type == "Mastery" then
 						allocatedMasteryCount = allocatedMasteryCount - 1
-						if node.name == "Life" then
-							allocatedLifeMasteryCount = allocatedLifeMasteryCount + 1
-						end
 
 						allocatedMasteryTypes[node.name] = allocatedMasteryTypes[node.name] - 1
 						if allocatedMasteryTypes[node.name] == 0 then
@@ -576,7 +569,7 @@ function calcs.initEnv(build, mode, override, specEnv)
 	modDB:NewMod("Multiplier:AllocatedNotable", "BASE", allocatedNotableCount, "")
 	modDB:NewMod("Multiplier:AllocatedMastery", "BASE", allocatedMasteryCount, "")
 	modDB:NewMod("Multiplier:AllocatedMasteryType", "BASE", allocatedMasteryTypeCount, "")
-	modDB:NewMod("Multiplier:AllocatedLifeMastery", "BASE", allocatedLifeMasteryCount)
+	modDB:NewMod("Multiplier:AllocatedLifeMastery", "BASE", allocatedMasteryTypes["Life Mastery"])
 	
 	-- Build and merge item modifiers, and create list of radius jewels
 	if not accelerate.requirementsItems then


### PR DESCRIPTION
Fixes #5965 .

### Description of the problem being solved:
Life masteries were redundantly being counted

### Steps taken to verify a working solution:
- Allocating 6 life masteries, and confirming the 10% More Life is still in effect.

### Link to a build that showcases this PR:
https://pobb.in/4eIZutKXOS1h

### Before screenshot:
![image](https://user-images.githubusercontent.com/48551928/231714763-ef866b21-2c75-4862-b57b-2b97eca2fd41.png)

### After screenshot:
![image](https://user-images.githubusercontent.com/48551928/231714491-1a11a717-41d3-41b8-b0e8-73eec676cd08.png)
