### PR TITLE
Fix discontinuous mod values occuring with range tier slider

### DIFF
--- a/src/Classes/ItemsTab.lua
+++ b/src/Classes/ItemsTab.lua
@@ -620,20 +620,21 @@ holding Shift will put it in the second.]])
 	for i = 1, 6 do
 		local prev = self.controls["displayItemAffix"..(i-1)] or self.controls.displayItemSectionAffix
 		local drop, slider
-		local function verifyRange(range, index, drop)
+		local function verifyRange(range, index, drop) -- flips range if it will form discontinuous values
 			local priorMod = index - 1 > 0 and self.displayItem.affixes[drop.list[drop.selIndex].modList[index - 1]] or nil
 			local nextMod = index + 1 < #drop.list[drop.selIndex].modList and self.displayItem.affixes[drop.list[drop.selIndex].modList[index + 1]] or nil
-			local function flipRange(modA, modB) -- assume all pairs are incorrectly orientated.
-				local function getMinMax(mod) -- gets first range pair
+			local function flipRange(modA, modB) -- assumes all pairs are ordered the same
+				local function getMinMax(mod) -- gets first valid range from a mod
 					for _, line in ipairs(mod) do
 						local min, max = line:match("%((%d[%d%.]*)%-(%d[%d%.]*)%)")
 						if min and max then return tonumber(min), tonumber(max)	end
 					end
 				end
+
 				local minA, maxA = getMinMax(modA)
 				local minB, maxB = getMinMax(modB)
 				
-				if(minA and minB and maxA and maxB) then
+				if (minA and minB and maxA and maxB) then
 					if (minA < minB) then -- ascending
 						return minA + 1 == maxB
 					else -- descending
@@ -642,6 +643,7 @@ holding Shift will put it in the second.]])
 				end
 				return false
 			end
+			
 			if priorMod then
 				if flipRange(priorMod, self.displayItem.affixes[drop.list[drop.selIndex].modList[index]]) then
 					range = 1 - range


### PR DESCRIPTION
Fixes https://github.com/PathOfBuildingCommunity/PathOfBuilding/issues/6054

### Description of the problem being solved:
Some mods are ordered as descending but have their value pairs in ascending order.
This inverts the range if it won't be continuous this has a few assumptions 
- We only need to look at first range with a valid min max.
- The min-max pairs will be orientated the same way and will always be strictly ascending / descending.

### Link to a build that showcases this PR:
https://pobb.in/5JWKpx3ekvUd

### Steps taken to verify a working solution:
![image](https://user-images.githubusercontent.com/31533893/232062297-2640bcc7-3390-4bcd-9507-d459f2129c79.png)
![image](https://user-images.githubusercontent.com/31533893/232062255-a6d1e641-0eb2-45a5-9736-ff7a6343caa2.png)
![image](https://user-images.githubusercontent.com/31533893/232062907-99740e78-9428-4da4-a408-18c8fe33a3e1.png)
![image](https://user-images.githubusercontent.com/31533893/232062412-8a28ea21-3761-47ec-93ca-a196e79f60af.png)
![image](https://user-images.githubusercontent.com/31533893/232062669-d7b6ac76-2d49-41ee-8248-cdcfc97afc2e.png)
![image](https://user-images.githubusercontent.com/31533893/232062466-c663c088-593a-48e2-a379-71ea24872129.png)
