### PR TITLE
Fix missing title for tree rename popup causing crash

### DIFF
--- a/src/Classes/PassiveSpecListControl.lua
+++ b/src/Classes/PassiveSpecListControl.lua
@@ -108,7 +108,7 @@ end
 
 function PassiveSpecListClass:OnSelKeyDown(index, spec, key)
 	if key == "F2" then
-		self:RenameSpec(spec)
+		self:RenameSpec(spec, "Rename Tree")
 	end
 end
 

--- a/src/Classes/SkillSetListControl.lua
+++ b/src/Classes/SkillSetListControl.lua
@@ -113,6 +113,6 @@ end
 
 function SkillSetListClass:OnSelKeyDown(index, skillSetId, key)
 	if key == "F2" then
-		self:RenameSet(skillSetId)
+		self:RenameSet(self.skillsTab.skillSets[skillSetId])
 	end
 end


### PR DESCRIPTION
Fixes #6052 .

### Description of the problem being solved:
Call to `RenameSpec` did not include title causing crash when trying to render the box containing the title.