### PR TITLE
Fix infinite recursion issue with Manaforged arrows

### DIFF
--- a/src/Modules/CalcPerform.lua
+++ b/src/Modules/CalcPerform.lua
@@ -3211,7 +3211,7 @@ function calcs.perform(env, avoidCache, fullDPSSkipEHP)
 			if not skill.skillTypes[SkillType.Triggered] and skill ~= env.player.mainSkill and not skill.skillData.triggeredByManaPercentSpent and band(skill.skillCfg.flags, ModFlag.Bow) > 0 then
 				local uuid = cacheSkillUUID(skill)
 				if not GlobalCache.cachedData["CACHE"][uuid] or GlobalCache.noCache then
-					calcs.buildActiveSkill(env, "CACHE", skill)
+					calcs.buildActiveSkill(env, "CACHE", skill, true)
 				end
 
 				if GlobalCache.cachedData["CACHE"][uuid] then


### PR DESCRIPTION
Fixes #6040 .

### Description of the problem being solved:
The marked status was not set for the self skill pre-calculation in Manafroged implementation causing infinite recursion stack overflow.