### PR TITLE
Fix multiple Mastery-related crashes

### DIFF
--- a/src/Classes/PassiveSpec.lua
+++ b/src/Classes/PassiveSpec.lua
@@ -8,7 +8,6 @@ local pairs = pairs
 local ipairs = ipairs
 local t_insert = table.insert
 local t_remove = table.remove
-local t_concat = table.concat
 local m_min = math.min
 local m_max = math.max
 local m_floor = math.floor

--- a/src/Classes/PassiveSpec.lua
+++ b/src/Classes/PassiveSpec.lua
@@ -931,8 +931,6 @@ function PassiveSpecClass:BuildAllDependsAndPaths()
 				else
 					self.nodes[id].alloc = false
 					self.allocNodes[id] = nil
-					-- grab the node of the spec being converted to display later to the user
-					-- self.ignoredNodes[id] = self.build.treeTab.specList[self.build.treeTab.activeSpec-1].nodes[id]
 					self.masterySelections[id] = nil
 				end
 			elseif node.type == "Mastery" then

--- a/src/Classes/PassiveSpec.lua
+++ b/src/Classes/PassiveSpec.lua
@@ -48,7 +48,6 @@ function PassiveSpecClass:Init(treeVersion, convert)
 	for id, node in pairs(self.nodes) do
 		-- if the node is allocated and between the old and new tree has the same ID but does not share the same name, add to list of nodes to be ignored
 		if convert and previousTreeNodes[id] and self.build.spec.allocNodes[id] and node.name ~= previousTreeNodes[id].name then
-			previousTreeNodes[id].incompatible = true
 			self.ignoredNodes[id] = previousTreeNodes[id]
 		end
 		for _, otherId in ipairs(node.linkedId) do
@@ -266,7 +265,6 @@ function PassiveSpecClass:AllocateMasteryEffects(masteryEffects, xml)
 				end
 			else
 				-- if there is no effect/selection on the latest tree then we do not want to allocate the mastery
-				self.ignoredNodes[id] = self.allocNodes[id]
 				self.allocNodes[id] = nil
 				self.nodes[id].alloc = false
 			end
@@ -914,9 +912,6 @@ function PassiveSpecClass:BuildAllDependsAndPaths()
 					node.reminderText = { "Tip: Right click to select a different effect" }
 					self.tree:ProcessStats(node)
 					self.allocatedMasteryCount = self.allocatedMasteryCount + 1
-					if node.name == "Life Mastery" then
-						self.allocatedLifeMasteryCount = self.allocatedLifeMasteryCount + 1
-					end
 					if not self.allocatedMasteryTypes[self.allocNodes[id].name] then
 						self.allocatedMasteryTypes[self.allocNodes[id].name] = 1
 						self.allocatedMasteryTypeCount = self.allocatedMasteryTypeCount + 1

--- a/src/Classes/PassiveSpec.lua
+++ b/src/Classes/PassiveSpec.lua
@@ -202,8 +202,6 @@ function PassiveSpecClass:ImportFromNodeList(classId, ascendClassId, hashList, m
 			if node.type ~= "Mastery" or (node.type == "Mastery" and self.masterySelections[id]) then
 				node.alloc = true
 				self.allocNodes[id] = node
-			else
-				self.ignoredNodes[id] = node
 			end
 		else
 			t_insert(self.allocSubgraphNodes, id)

--- a/src/Classes/PassiveSpec.lua
+++ b/src/Classes/PassiveSpec.lua
@@ -1020,7 +1020,6 @@ function PassiveSpecClass:BuildAllDependsAndPaths()
 				end
 				if prune then
 					self:DeallocSingleNode(depNode)
-					self.ignoredNodes[depNode.id] = depNode
 				end
 			end
 		end

--- a/src/Classes/PassiveTree.lua
+++ b/src/Classes/PassiveTree.lua
@@ -56,32 +56,7 @@ local PassiveTreeClass = newClass("PassiveTree", function(self, treeVersion)
 	MakeDir("TreeData")
 
 	ConPrintf("Loading passive tree data for version '%s'...", treeVersions[treeVersion].display)
-	local treeText
-	local treeFile = io.open("TreeData/"..treeVersion.."/tree.lua", "r")
-	if treeFile then
-		treeText = treeFile:read("*a")
-		treeFile:close()
-	else
-		ConPrintf("Downloading passive tree data...")
-		local page
-		local pageFile = io.open("TreeData/"..treeVersion.."/data.json", "r")
-		if pageFile then
-			page = pageFile:read("*a")
-			pageFile:close()
-		else
-			page = getFile("https://www.pathofexile.com/passive-skill-tree")
-		end
-		local treeData = page:match("var passiveSkillTreeData = (%b{})")
-		if treeData then
-			treeText = "local tree=" .. jsonToLua(page:match("var passiveSkillTreeData = (%b{})"))
-			treeText = treeText .. "return tree"
-		else
-			treeText = "return " .. jsonToLua(page)
-		end
-		treeFile = io.open("TreeData/"..treeVersion.."/tree.lua", "w")
-		treeFile:write(treeText)
-		treeFile:close()
-	end
+	local treeText = self:GetTreeText(treeVersion)
 	for k, v in pairs(assert(loadstring(treeText))()) do
 		self[k] = v
 	end
@@ -499,6 +474,36 @@ local PassiveTreeClass = newClass("PassiveTree", function(self, treeVersion)
 	-- Late load the Generated data so we can take advantage of a tree existing
 	buildTreeDependentUniques(self)
 end)
+
+function PassiveTreeClass:GetTreeText(treeVersion)
+	local treeText
+	local treeFile = io.open("TreeData/"..treeVersion.."/tree.lua", "r")
+	if treeFile then
+		treeText = treeFile:read("*a")
+		treeFile:close()
+	else
+		ConPrintf("Downloading passive tree data...")
+		local page
+		local pageFile = io.open("TreeData/"..treeVersion.."/data.json", "r")
+		if pageFile then
+			page = pageFile:read("*a")
+			pageFile:close()
+		else
+			page = getFile("https://www.pathofexile.com/passive-skill-tree")
+		end
+		local treeData = page:match("var passiveSkillTreeData = (%b{})")
+		if treeData then
+			treeText = "local tree=" .. jsonToLua(page:match("var passiveSkillTreeData = (%b{})"))
+			treeText = treeText .. "return tree"
+		else
+			treeText = "return " .. jsonToLua(page)
+		end
+		treeFile = io.open("TreeData/"..treeVersion.."/tree.lua", "w")
+		treeFile:write(treeText)
+		treeFile:close()
+	end
+	return treeText
+end
 
 function PassiveTreeClass:ProcessStats(node)
 	node.modKey = ""

--- a/src/Classes/PassiveTree.lua
+++ b/src/Classes/PassiveTree.lua
@@ -56,7 +56,32 @@ local PassiveTreeClass = newClass("PassiveTree", function(self, treeVersion)
 	MakeDir("TreeData")
 
 	ConPrintf("Loading passive tree data for version '%s'...", treeVersions[treeVersion].display)
-	local treeText = self:GetTreeText(treeVersion)
+	local treeText
+	local treeFile = io.open("TreeData/"..treeVersion.."/tree.lua", "r")
+	if treeFile then
+		treeText = treeFile:read("*a")
+		treeFile:close()
+	else
+		ConPrintf("Downloading passive tree data...")
+		local page
+		local pageFile = io.open("TreeData/"..treeVersion.."/data.json", "r")
+		if pageFile then
+			page = pageFile:read("*a")
+			pageFile:close()
+		else
+			page = getFile("https://www.pathofexile.com/passive-skill-tree")
+		end
+		local treeData = page:match("var passiveSkillTreeData = (%b{})")
+		if treeData then
+			treeText = "local tree=" .. jsonToLua(page:match("var passiveSkillTreeData = (%b{})"))
+			treeText = treeText .. "return tree"
+		else
+			treeText = "return " .. jsonToLua(page)
+		end
+		treeFile = io.open("TreeData/"..treeVersion.."/tree.lua", "w")
+		treeFile:write(treeText)
+		treeFile:close()
+	end
 	for k, v in pairs(assert(loadstring(treeText))()) do
 		self[k] = v
 	end
@@ -474,36 +499,6 @@ local PassiveTreeClass = newClass("PassiveTree", function(self, treeVersion)
 	-- Late load the Generated data so we can take advantage of a tree existing
 	buildTreeDependentUniques(self)
 end)
-
-function PassiveTreeClass:GetTreeText(treeVersion)
-	local treeText
-	local treeFile = io.open("TreeData/"..treeVersion.."/tree.lua", "r")
-	if treeFile then
-		treeText = treeFile:read("*a")
-		treeFile:close()
-	else
-		ConPrintf("Downloading passive tree data...")
-		local page
-		local pageFile = io.open("TreeData/"..treeVersion.."/data.json", "r")
-		if pageFile then
-			page = pageFile:read("*a")
-			pageFile:close()
-		else
-			page = getFile("https://www.pathofexile.com/passive-skill-tree")
-		end
-		local treeData = page:match("var passiveSkillTreeData = (%b{})")
-		if treeData then
-			treeText = "local tree=" .. jsonToLua(page:match("var passiveSkillTreeData = (%b{})"))
-			treeText = treeText .. "return tree"
-		else
-			treeText = "return " .. jsonToLua(page)
-		end
-		treeFile = io.open("TreeData/"..treeVersion.."/tree.lua", "w")
-		treeFile:write(treeText)
-		treeFile:close()
-	end
-	return treeText
-end
 
 function PassiveTreeClass:ProcessStats(node)
 	node.modKey = ""

--- a/src/Classes/TreeTab.lua
+++ b/src/Classes/TreeTab.lua
@@ -18,31 +18,6 @@ local s_gsub = string.gsub
 local s_byte = string.byte
 local dkjson = require "dkjson"
 
--- on convert, add nodes that were deallocated to success popup
-local function addAffectedNodes(self, msg)
-	local sortedTable = { }
-	if self.build.spec.ignoredNodes and next(self.build.spec.ignoredNodes) then
-		for _, node in pairs(self.build.spec.ignoredNodes) do
-			if node.ascendancyName then
-				if node.incompatible then
-					t_insert(sortedTable, node.ascendancyName  .. ": " .. node.name .. " (incompatible)")
-				else
-					t_insert(sortedTable, node.ascendancyName  .. ": " .. node.name)
-				end
-			elseif node.incompatible then
-				t_insert(sortedTable, (node.name or node.dn) .. " (incompatible)")
-			elseif not node.allMasteryOptions then
-				t_insert(sortedTable, node.name)
-			else
-				t_insert(sortedTable, node.dn)
-			end
-		end
-		t_sort(sortedTable)
-		msg = msg .. "\n\n Total # of affected passives: " .. #sortedTable .. "\n\n" .. t_concat(sortedTable, "\n")
-	end
-	return msg
-end
-
 local TreeTabClass = newClass("TreeTab", "ControlHost", function(self, build)
 	self.ControlHost()
 
@@ -205,9 +180,7 @@ local TreeTabClass = newClass("TreeTab", "ControlHost", function(self, build)
 		t_insert(self.specList, self.activeSpec + 1, newSpec)
 		self:SetActiveSpec(self.activeSpec + 1)
 		self.modFlag = true
-		local msg = "The tree has been converted to "..treeVersions[latestTreeVersion].display..".\nNote that some or all of the passives may have been de-allocated due to changes in the tree.\n\nYou can switch back to the old tree using the tree selector at the bottom left."
-		msg = addAffectedNodes(self, msg)
-		main:OpenMessagePopup("Tree Converted", msg)
+		main:OpenMessagePopup("Tree Converted", "The tree has been converted to "..treeVersions[latestTreeVersion].display..".\nNote that some or all of the passives may have been de-allocated due to changes in the tree.\n\nYou can switch back to the old tree using the tree selector at the bottom left.")
 	end)
 	self.jumpToNode = false
 	self.jumpToX = 0

--- a/src/Classes/TreeTab.lua
+++ b/src/Classes/TreeTab.lua
@@ -38,7 +38,7 @@ local function addAffectedNodes(self, msg)
 			end
 		end
 		t_sort(sortedTable)
-		msg = msg .. "\n\n Affected passives from previous version: \n" .. t_concat(sortedTable, "\n")
+		msg = msg .. "\n\n Total # of affected passives: " .. #sortedTable .. "\n\n" .. t_concat(sortedTable, "\n")
 	end
 	return msg
 end

--- a/src/Classes/TreeTab.lua
+++ b/src/Classes/TreeTab.lua
@@ -171,7 +171,7 @@ local TreeTabClass = newClass("TreeTab", "ControlHost", function(self, build)
 		return self.showConvert
 	end
 	self.controls.specConvert = new("ButtonControl", { "LEFT", self.controls.specConvertText, "RIGHT" }, 8, 0, 120, 20, "^2Convert to "..treeVersions[latestTreeVersion].display, function()
-		local newSpec = new("PassiveSpec", self.build, latestTreeVersion)
+		local newSpec = new("PassiveSpec", self.build, latestTreeVersion, self.specList[self.activeSpec or 1].treeVersion)
 		newSpec.title = self.build.spec.title
 		newSpec.jewels = copyTable(self.build.spec.jewels)
 		newSpec:RestoreUndoState(self.build.spec:CreateUndoState(), latestTreeVersion)


### PR DESCRIPTION
Fixes #5882, #5489, #6024

### Description of the problem being solved:
Fixing multiple crashes related to masteries while hovering, on import, and when converting from older trees. Adding details to convert success popup to show if any nodes were deallocated during the process.

### Steps taken to verify a working solution:
### 5882 (convert Sabo 3.20 to 3.21)
- Load build, convert to 3.21, see no errors and confirm in the success popup the nodes that were deallocated
### 5489, 6024 (after import, allocation without selection, hover crashes)
- 5489 Load build, open 3.16 tree, hover over fortify/warcry masteries, confirm no crash
- 6024 Load build, validate not allocated, hover over any mastery (Cold Mastery 44179 breaks in live)

### Link to a build that showcases this PR:
5882 <pre>https://pobb.in/ly7av2QtcdVe</pre>

5489 <pre>https://pastebin.com/rCHGQTZ0</pre>

6024 <pre>https://pobb.in/BaVgVdTML0MQ</pre>

### Before screenshot:
### 5489
Hover over Warcry
![image](https://user-images.githubusercontent.com/92683202/232662942-fd540c45-5543-482f-b923-4857627462fe.png)

### 6024
Hover over Cold
![image](https://user-images.githubusercontent.com/92683202/232663163-1efb12ae-4808-4f66-89d7-cef8d62965e2.png)

### After screenshot:
### 5489
![image](https://user-images.githubusercontent.com/92683202/235071367-888ac035-33ac-4af5-ae3a-306af3877857.png)

### 6024
![image](https://user-images.githubusercontent.com/92683202/232663238-7ceb0a91-e09f-4db2-8937-0d0acab857b2.png)

### Extra credit: converting a 3.19 tree to 3.21 that was allocating 3.21 stun mastery from 3.19 resistance mastery (id same, name changed)
<pre>https://pobb.in/o75c5diy9XfI</pre>
3.19 section (Resistance Mastery):
![image](https://user-images.githubusercontent.com/92683202/235072264-93f7d702-a4e3-42bd-b4ed-81a263de7a0c.png)

Convert before fix (stun mastery):
![image](https://user-images.githubusercontent.com/92683202/235072114-138e907c-0030-492f-be63-ac4ad45618cb.png)

Convert after (no stun mastery):
![image](https://user-images.githubusercontent.com/92683202/235071883-5066891d-b250-440a-b71a-aa522f6f8655.png)