### PR TITLE
Fix Life Mastery item condition to include Enchants

### DIFF
--- a/src/Classes/Item.lua
+++ b/src/Classes/Item.lua
@@ -224,12 +224,11 @@ function ItemClass:FindModifierSubstring(substring, itemSlotName)
 	--getTagBasedModifiers(substring, itemSlotName)
 
 	-- merge various modifier lines into one table
-	for k,v in pairs(self.enchantModLines) do modLines[k] = v end
-	for k,v in pairs(self.scourgeModLines) do modLines[k] = v end
-	for k,v in pairs(self.implicitModLines) do modLines[k] = v end
-	for k,v in pairs(self.explicitModLines) do modLines[k] = v end
-	for k,v in pairs(self.enchantModLines) do modLines[k] = v end
-	for k,v in pairs(self.crucibleModLines) do modLines[k] = v end
+	for _,v in pairs(self.enchantModLines) do t_insert(modLines, v) end
+	for _,v in pairs(self.scourgeModLines) do t_insert(modLines, v) end
+	for _,v in pairs(self.implicitModLines) do t_insert(modLines, v) end
+	for _,v in pairs(self.explicitModLines) do t_insert(modLines, v) end
+	for _,v in pairs(self.crucibleModLines) do t_insert(modLines, v) end
 
 	for _,v in pairs(modLines) do
 		if v.line:lower():find(substring) and not v.line:lower():find(substring .. " modifier") then

--- a/src/Classes/Item.lua
+++ b/src/Classes/Item.lua
@@ -228,6 +228,7 @@ function ItemClass:FindModifierSubstring(substring, itemSlotName)
 	for k,v in pairs(self.scourgeModLines) do modLines[k] = v end
 	for k,v in pairs(self.implicitModLines) do modLines[k] = v end
 	for k,v in pairs(self.explicitModLines) do modLines[k] = v end
+	for k,v in pairs(self.enchantModLines) do modLines[k] = v end
 	for k,v in pairs(self.crucibleModLines) do modLines[k] = v end
 
 	for _,v in pairs(modLines) do


### PR DESCRIPTION
Fixes #6064 

### Description of the problem being solved:
Adds crafted enchantment conditions to modifiers being considered in item conditionals.

### Steps taken to verify a working solution:
- Follow step described in issue #6064 and see problem is solved.


### Link to a build that showcases this PR:
Same as in Issue

### Before screenshot:
![Before](https://user-images.githubusercontent.com/1735956/232332312-e5ae567b-e6fb-46da-8382-60ea292d355e.png)

### After screenshot:
![After](https://user-images.githubusercontent.com/1735956/232332273-38eec251-18f1-4b89-9344-7ef61536a20c.png)
