### PR TITLE
Fix colour codes leaking into formated numbers

### DIFF
--- a/src/Modules/Common.lua
+++ b/src/Modules/Common.lua
@@ -571,7 +571,7 @@ end
 function formatNumSep(str)
 	return string.gsub(str, "(%^?x?%x?%x?%x?%x?%x?%x?-?%d+%.?%d+)", function(m)
 		local colour = m:match("(^x%x%x%x%x%x%x)") or m:match("(%^%d)") or ""
-		local str = m:gsub("(^x%x%x%x%x%x%x)", "") or m:gsub("(%^%d)", "")
+		local str = m:gsub("(^x%x%x%x%x%x%x)", ""):gsub("(%^%d)", "")
 		if str == "" or (colour == "" and m:match("%^")) then  -- return if we have an invalid color code or a completely stripped number.
 			return m
 		end


### PR DESCRIPTION
### Description of the problem being solved:
Regular colour codes weren't being stripped as gsub always returns something and hence the other gsub is never called this calls both.

### Link to a build that showcases this PR:
https://pobb.in/_Q--BVUhrgXZ

### Before screenshot:
![image](https://user-images.githubusercontent.com/31533893/232513196-b382b486-1ee6-42a1-9215-f509593213bb.png)

### After screenshot:
![image](https://user-images.githubusercontent.com/31533893/232512999-d1a95527-bfcd-43a6-9c26-fc77c092cfa2.png)
