### PR TITLE
Use nearest keystone for timeless jewel search name

### DIFF
--- a/src/Classes/TreeTab.lua
+++ b/src/Classes/TreeTab.lua
@@ -867,7 +867,7 @@ function TreeTabClass:FindTimelessJewel()
 				for _, nodeInRadius in pairs(treeData.nodes[socketId].nodesInRadius[3]) do
 					if nodeInRadius.isKeystone then
 						local distance = math.sqrt((nodeInRadius.x - socketData.x) ^ 2 + (nodeInRadius.y - socketData.y) ^ 2)
-						if (distance < minDistance) then
+						if distance < minDistance then
 							keystone = nodeInRadius.name
 							minDistance = distance
 						end

--- a/src/Classes/TreeTab.lua
+++ b/src/Classes/TreeTab.lua
@@ -863,10 +863,14 @@ function TreeTabClass:FindTimelessJewel()
 			elseif socketId == 54127 then
 				keystone = "Duelist"
 			else
+				local minDistance = math.huge
 				for _, nodeInRadius in pairs(treeData.nodes[socketId].nodesInRadius[3]) do
 					if nodeInRadius.isKeystone then
-						keystone = nodeInRadius.name
-						break
+						local distance = math.sqrt((nodeInRadius.x - socketData.x) ^ 2 + (nodeInRadius.y - socketData.y) ^ 2)
+						if (distance < minDistance) then
+							keystone = nodeInRadius.name
+							minDistance = distance
+						end
 					end
 				end
 			end


### PR DESCRIPTION
Fixes https://github.com/PathOfBuildingCommunity/PathOfBuilding/issues/6083

### Description of the problem being solved:
Confusion around by assuming the jewel socket next to acrobatics was called acrobatics when it was in fact called wind dancer.

This fixes this by instead using the closest keystone for the name.

### Before screenshot:
![image](https://user-images.githubusercontent.com/31533893/233284285-abbfe0f9-6a06-4a01-b4bd-221cfefbe6e3.png)

### After screenshot:
![image](https://user-images.githubusercontent.com/31533893/233284356-ce7f211e-ff82-4935-84fd-c4c7aa16a95c.png)
