### PR TITLE
Add support for Momentum support

### DIFF
--- a/src/Data/Skills/sup_dex.lua
+++ b/src/Data/Skills/sup_dex.lua
@@ -4474,7 +4474,7 @@ skills["SupportMomentum"] = {
 			mod("Speed", "INC", nil, ModFlag.Attack, 0, { type = "Multiplier", var = "MomentumStacks" }),
 		},
 		["support_momentum_movement_speed_+%_per_stack_removed"] = {
-			mod("MovementSpeed", "INC", nil, 0, 0, { type = "Multiplier", var = "MomentumStacksRemoved" }),
+			mod("MovementSpeed", "INC", nil, 0, 0, { type = "Multiplier", var = "MomentumStacksRemoved" }, { type = "GlobalEffect", effectType = "Buff" }),
 		},
 	},
 	qualityStats = {

--- a/src/Data/Skills/sup_dex.lua
+++ b/src/Data/Skills/sup_dex.lua
@@ -4463,6 +4463,20 @@ skills["SupportMomentum"] = {
 	addSkillTypes = { SkillType.Duration, SkillType.Buff, },
 	excludeSkillTypes = { SkillType.Triggered, },
 	statDescriptionScope = "gem_stat_descriptions",
+	statMap = {
+		["support_momentum_max_stacks"] = {
+			mod("MomentumStacksMax", "BASE", nil, 0, 0),
+		},
+		["count_as_momentum_+_if_not_channelled"] = {
+			mod("MomentumStacksExtra", "BASE", nil, 0, 0),
+		},
+		["support_momentum_attack_speed_+%_per_stack"] = {
+			mod("Speed", "INC", nil, ModFlag.Attack, 0, { type = "Multiplier", var = "MomentumStacks" }),
+		},
+		["support_momentum_movement_speed_+%_per_stack_removed"] = {
+			mod("MovementSpeed", "INC", nil, 0, 0, { type = "Multiplier", var = "MomentumStacksRemoved" }),
+		},
+	},
 	qualityStats = {
 		Default = {
 			{ "support_momentum_base_buff_duration_ms", 25 },

--- a/src/Data/Skills/sup_dex.lua
+++ b/src/Data/Skills/sup_dex.lua
@@ -4477,6 +4477,9 @@ skills["SupportMomentum"] = {
 			mod("MovementSpeed", "INC", nil, 0, 0, { type = "Multiplier", var = "MomentumStacksRemoved" }, { type = "GlobalEffect", effectType = "Buff" }),
 		},
 	},
+	baseMods = {
+		flag("SupportedByMomentum"),
+	},
 	qualityStats = {
 		Default = {
 			{ "support_momentum_base_buff_duration_ms", 25 },

--- a/src/Export/Skills/sup_dex.txt
+++ b/src/Export/Skills/sup_dex.txt
@@ -567,7 +567,7 @@ local skills, mod, flag, skill = ...
 			mod("Speed", "INC", nil, ModFlag.Attack, 0, { type = "Multiplier", var = "MomentumStacks" }),
 		},
 		["support_momentum_movement_speed_+%_per_stack_removed"] = {
-			mod("MovementSpeed", "INC", nil, 0, 0, { type = "Multiplier", var = "MomentumStacksRemoved" }),
+			mod("MovementSpeed", "INC", nil, 0, 0, { type = "Multiplier", var = "MomentumStacksRemoved" }, { type = "GlobalEffect", effectType = "Buff" }),
 		},
 	},
 #mods

--- a/src/Export/Skills/sup_dex.txt
+++ b/src/Export/Skills/sup_dex.txt
@@ -570,4 +570,5 @@ local skills, mod, flag, skill = ...
 			mod("MovementSpeed", "INC", nil, 0, 0, { type = "Multiplier", var = "MomentumStacksRemoved" }, { type = "GlobalEffect", effectType = "Buff" }),
 		},
 	},
+#baseMod flag("SupportedByMomentum")
 #mods

--- a/src/Export/Skills/sup_dex.txt
+++ b/src/Export/Skills/sup_dex.txt
@@ -556,4 +556,18 @@ local skills, mod, flag, skill = ...
 #mods
 
 #skill SupportMomentum
+	statMap = {
+		["support_momentum_max_stacks"] = {
+			mod("MomentumStacksMax", "BASE", nil, 0, 0),
+		},
+		["count_as_momentum_+_if_not_channelled"] = {
+			mod("MomentumStacksExtra", "BASE", nil, 0, 0),
+		},
+		["support_momentum_attack_speed_+%_per_stack"] = {
+			mod("Speed", "INC", nil, ModFlag.Attack, 0, { type = "Multiplier", var = "MomentumStacks" }),
+		},
+		["support_momentum_movement_speed_+%_per_stack_removed"] = {
+			mod("MovementSpeed", "INC", nil, 0, 0, { type = "Multiplier", var = "MomentumStacksRemoved" }),
+		},
+	},
 #mods

--- a/src/Modules/CalcOffence.lua
+++ b/src/Modules/CalcOffence.lua
@@ -855,6 +855,20 @@ function calcs.offence(env, actor, activeSkill)
 			end
 		end
 	end
+	-- momentum stacks
+	do
+		local maxMomentumStacks = skillModList:Sum("BASE", skillCfg, "MomentumStacksMax")
+		local extraMomentumStacks = skillModList:Sum("BASE", skillCfg, "MomentumStacksExtra")
+		if maxMomentumStacks > 0 then
+			if not modDB:HasMod("BASE", nil, "Multiplier:MomentumStacks") then
+				modDB:NewMod("Multiplier:MomentumStacks", "BASE", m_min((maxMomentumStacks + extraMomentumStacks) / 2, maxMomentumStacks), "Config", { type = "Condition", var = "Combat" })
+			elseif modDB:Sum("BASE", nil, "Multiplier:MomentumStacks") > maxMomentumStacks then
+				modDB:ReplaceMod("Multiplier:MomentumStacks", "BASE", maxMomentumStacks, "Config", { type = "Condition", var = "Combat" })
+			end
+		elseif modDB:HasMod("BASE", nil, "Multiplier:MomentumStacks") then
+			modDB:ReplaceMod("Multiplier:MomentumStacks", "BASE", 0, "Config")
+		end
+	end
 
 	local isAttack = skillFlags.attack
 

--- a/src/Modules/CalcOffence.lua
+++ b/src/Modules/CalcOffence.lua
@@ -856,7 +856,7 @@ function calcs.offence(env, actor, activeSkill)
 		end
 	end
 	-- momentum stacks
-	do
+	if skillModList:Flag(nil, "SupportedByMomentum") then
 		local maxMomentumStacks = skillModList:Sum("BASE", skillCfg, "MomentumStacksMax")
 		local extraMomentumStacks = skillModList:Sum("BASE", skillCfg, "MomentumStacksExtra")
 		if maxMomentumStacks > 0 then

--- a/src/Modules/ConfigOptions.lua
+++ b/src/Modules/ConfigOptions.lua
@@ -323,6 +323,13 @@ return {
 	{ var = "meatShieldEnemyNearYou", type = "check", label = "Is the enemy near you?", ifSkill = "Meat Shield", apply = function(val, modList, enemyModList)
 		modList:NewMod("Condition:MeatShieldEnemyNearYou", "FLAG", true, "Config")
 	end },
+	{ label = "Momentum:", ifSkill = { "Momentum" } },
+	{ var = "MomentumStacks", type = "count", label = "# of Momentum (if not average):", ifSkill = { "Momentum" }, apply = function(val, modList, enemyModList)
+		modList:NewMod("Multiplier:MomentumStacks", "BASE", val, "Config", { type = "Condition", var = "Combat" })
+	end },
+	{ var = "MomentumSwiftnessStacks", type = "count", label = "Swiftness # of Momentum Removed:", ifSkill = { "Momentum" }, apply = function(val, modList, enemyModList)
+		modList:NewMod("Multiplier:MomentumStacksRemoved", "BASE", val, "Config")
+	end },
 	{ label = "Plague Bearer:", ifSkill = "Plague Bearer"},
 	{ var = "plagueBearerState", type = "list", label = "State:", ifSkill = "Plague Bearer", list = {{val="INC",label="Incubating"},{val="INF",label="Infecting"}}, apply = function(val, modList, enemyModList)
 		if val == "INC" then


### PR DESCRIPTION
Adds config options for amount of momentum (if not average)

If not set it correctly gives you the correct average amount of momentum, taking into account the extra from +1 
(though both the average and the +1 are incorrect if channeling skill)

also grants movement speed per removed momentum charge, (though this is missing a cap)