### PR TITLE
Support excluding tags in GetModSpawnWeight

### DIFF
--- a/src/Classes/Item.lua
+++ b/src/Classes/Item.lua
@@ -881,7 +881,7 @@ function ItemClass:NormaliseQuality()
 	end	
 end
 
-function ItemClass:GetModSpawnWeight(mod, extraTags)
+function ItemClass:GetModSpawnWeight(mod, includeTags, excludeTags)
 	local weight = 0
 	if self.base then
 		local function HasInfluenceTag(key)
@@ -904,13 +904,13 @@ function ItemClass:GetModSpawnWeight(mod, extraTags)
 		end
 
 		for i, key in ipairs(mod.weightKey) do
-			if self.base.tags[key] or (extraTags and extraTags[key]) or HasInfluenceTag(key) then
+			if (self.base.tags[key] or (includeTags and includeTags[key]) or HasInfluenceTag(key)) and not (excludeTags and excludeTags[key]) then
 				weight = (HasInfluenceTag(key) and HasMavenInfluence(mod.affix)) and 1000 or mod.weightVal[i]
 				break
 			end
 		end
 		for i, key in ipairs(mod.weightMultiplierKey) do
-			if self.base.tags[key] or (extraTags and extraTags[key]) or HasInfluenceTag(key) then
+			if (self.base.tags[key] or (includeTags and includeTags[key]) or HasInfluenceTag(key)) and not (excludeTags and excludeTags[key]) then
 				weight = weight * mod.weightMultiplierVal[i] / 100
 				break
 			end

--- a/src/Classes/ItemsTab.lua
+++ b/src/Classes/ItemsTab.lua
@@ -2616,12 +2616,10 @@ function ItemsTabClass:AddCrucibleModifierToDisplayItem()
 		end
 		if self.displayItem.canHaveOnlySupportSkillsCrucibleTree then
 			 return keyMap["crucible_unique_staff"] and mod.weightVal[keyMap["crucible_unique_staff"]] ~= 0
-		end
-		if self.displayItem.canHaveShieldCrucibleTree then
+		elseif self.displayItem.canHaveShieldCrucibleTree then
 			return self.displayItem:GetModSpawnWeight(mod, { ["crucible_unique_helmet"] = true, ["shield"] = true }) > 0
 		elseif self.displayItem.canHaveTwoHandedSwordCrucibleTree then
-			self.displayItem.base.tags["one_hand_weapon"] = nil
-			return self.displayItem:GetModSpawnWeight(mod, { ["two_hand_weapon"] = true }) > 0
+			return self.displayItem:GetModSpawnWeight(mod, { ["two_hand_weapon"] = true }, { ["one_hand_weapon"] = true }) > 0
 		end
 		return self.displayItem:GetModSpawnWeight(mod) > 0
 	end


### PR DESCRIPTION
### Description of the problem being solved:
Adding excludeTags param to GetModSpawnWeight so we don't need to modify an item's base tags to remove/ignore a type when checking for applicable mods in special cases, like Crucible.
