### PR TITLE
Fix Fanaticism applying to triggered skills

### DIFF
--- a/src/Modules/CalcActiveSkill.lua
+++ b/src/Modules/CalcActiveSkill.lua
@@ -368,7 +368,7 @@ function calcs.buildActiveSkillModList(env, activeSkill)
 		skillKeywordFlags = bor(skillKeywordFlags, KeywordFlag.Trap)
 	elseif skillFlags.mine then
 		skillKeywordFlags = bor(skillKeywordFlags, KeywordFlag.Mine)
-	else
+	elseif not skillTypes[SkillType.Triggered] then
 		skillFlags.selfCast = true
 	end
 	if skillTypes[SkillType.Attack] then


### PR DESCRIPTION
The self cast flag was only checking to make sure that a skill was not supported by totems, mines or traps when it should also be checking to make sure it isn't triggered
Fixes #6100