### PR TITLE
Support Uniques with Extra Crucible Mod Tags

### DIFF
--- a/src/Classes/ItemsTab.lua
+++ b/src/Classes/ItemsTab.lua
@@ -47,6 +47,50 @@ local catalystQualityFormat = {
 	"^x7F7F7FQuality (Critical Modifiers): "..colorCodes.MAGIC.."+%d%% (augmented)",
 }
 
+local casterTagCrucibleUniques = {
+	["Atziri's Rule"] = true,
+	["Cane of Kulemak"] = true,
+	["Cane of Unravelling"] = true,
+	["Cospri's Malice"] = true,
+	["Cybil's Paw"] = true,
+	["Disintegrator"] = true,
+	["Duskdawn"] = true,
+	["Geofri's Devotion"] = true,
+	["Mjolner"] = true,
+	["Pledge of Hands"] = true,
+	["Soulwrest"] = true,
+	["Taryn's Shiver"] = true,
+	["The Rippling Thoughts"] = true,
+	["The Surging Thoughts"] = true,
+	["The Whispering Ice"] = true,
+	["Tremor Rod"] = true,
+	["Xirgil's Crank"] = true,
+}
+local minionTagCrucibleUniques = {
+	["Arakaali's Fang"] = true,
+	["Ashcaller"] = true,
+	["Chaber Cairn"] = true,
+	["Chober Chaber"] = true,
+	["Clayshaper"] = true,
+	["Earendel's Embrace"] = true,
+	["Femurs of the Saints"] = true,
+	["Jorrhast's Blacksteel"] = true,
+	["Law of the Wilds"] = true,
+	["Midnight Bargain"] = true,
+	["Mon'tregul's Grasp"] = true,
+	["Null's Inclination"] = true,
+	["Queen's Decree"] = true,
+	["Queen's Escape"] = true,
+	["Replica Earendel's Embrace"] = true,
+	["Replica Midnight Bargain"] = true,
+	["Severed in Sleep"] = true,
+	["Soulwrest"] = true,
+	["The Black Cane"] = true,
+	["The Iron Mass"] = true,
+	["The Scourge"] = true,
+	["United in Dream"] = true,
+}
+
 local ItemsTabClass = newClass("ItemsTab", "UndoHandler", "ControlHost", "Control", function(self, build)
 	self.UndoHandler()
 	self.ControlHost()
@@ -2610,10 +2654,18 @@ function ItemsTabClass:AddCrucibleModifierToDisplayItem()
 		return table.concat(label, "/")
 	end
 	local function itemCanHaveMod(mod)
-		local keyMap = { }
+		local keyMap, includeTags = { }, { }
 		for index, key in ipairs(mod.weightKey) do
 			keyMap[key] = index
 		end
+		-- check for uniques with off-tag mods
+		if casterTagCrucibleUniques[self.displayItem.title] then
+			includeTags["caster_unique_weapon"] = true
+		end
+		if minionTagCrucibleUniques[self.displayItem.title] then
+			includeTags["minion_unique_weapon"] = true
+		end
+
 		if self.displayItem.canHaveOnlySupportSkillsCrucibleTree then
 			 return keyMap["crucible_unique_staff"] and mod.weightVal[keyMap["crucible_unique_staff"]] ~= 0
 		elseif self.displayItem.canHaveShieldCrucibleTree then
@@ -2621,7 +2673,7 @@ function ItemsTabClass:AddCrucibleModifierToDisplayItem()
 		elseif self.displayItem.canHaveTwoHandedSwordCrucibleTree then
 			return self.displayItem:GetModSpawnWeight(mod, { ["two_hand_weapon"] = true }, { ["one_hand_weapon"] = true }) > 0
 		end
-		return self.displayItem:GetModSpawnWeight(mod) > 0
+		return self.displayItem:GetModSpawnWeight(mod, includeTags) > 0
 	end
 	local function buildCrucibleMods()
 		for i, mod in pairs(self.build.data.crucible) do

--- a/src/Classes/ItemsTab.lua
+++ b/src/Classes/ItemsTab.lua
@@ -47,50 +47,6 @@ local catalystQualityFormat = {
 	"^x7F7F7FQuality (Critical Modifiers): "..colorCodes.MAGIC.."+%d%% (augmented)",
 }
 
-local casterTagCrucibleUniques = {
-	["Atziri's Rule"] = true,
-	["Cane of Kulemak"] = true,
-	["Cane of Unravelling"] = true,
-	["Cospri's Malice"] = true,
-	["Cybil's Paw"] = true,
-	["Disintegrator"] = true,
-	["Duskdawn"] = true,
-	["Geofri's Devotion"] = true,
-	["Mjolner"] = true,
-	["Pledge of Hands"] = true,
-	["Soulwrest"] = true,
-	["Taryn's Shiver"] = true,
-	["The Rippling Thoughts"] = true,
-	["The Surging Thoughts"] = true,
-	["The Whispering Ice"] = true,
-	["Tremor Rod"] = true,
-	["Xirgil's Crank"] = true,
-}
-local minionTagCrucibleUniques = {
-	["Arakaali's Fang"] = true,
-	["Ashcaller"] = true,
-	["Chaber Cairn"] = true,
-	["Chober Chaber"] = true,
-	["Clayshaper"] = true,
-	["Earendel's Embrace"] = true,
-	["Femurs of the Saints"] = true,
-	["Jorrhast's Blacksteel"] = true,
-	["Law of the Wilds"] = true,
-	["Midnight Bargain"] = true,
-	["Mon'tregul's Grasp"] = true,
-	["Null's Inclination"] = true,
-	["Queen's Decree"] = true,
-	["Queen's Escape"] = true,
-	["Replica Earendel's Embrace"] = true,
-	["Replica Midnight Bargain"] = true,
-	["Severed in Sleep"] = true,
-	["Soulwrest"] = true,
-	["The Black Cane"] = true,
-	["The Iron Mass"] = true,
-	["The Scourge"] = true,
-	["United in Dream"] = true,
-}
-
 local ItemsTabClass = newClass("ItemsTab", "UndoHandler", "ControlHost", "Control", function(self, build)
 	self.UndoHandler()
 	self.ControlHost()
@@ -2659,10 +2615,10 @@ function ItemsTabClass:AddCrucibleModifierToDisplayItem()
 			keyMap[key] = index
 		end
 		-- check for uniques with off-tag mods
-		if casterTagCrucibleUniques[self.displayItem.title] then
+		if self.build.data.casterTagCrucibleUniques[self.displayItem.title] then
 			includeTags["caster_unique_weapon"] = true
 		end
-		if minionTagCrucibleUniques[self.displayItem.title] then
+		if self.build.data.minionTagCrucibleUniques[self.displayItem.title] then
 			includeTags["minion_unique_weapon"] = true
 		end
 

--- a/src/Classes/ItemsTab.lua
+++ b/src/Classes/ItemsTab.lua
@@ -2615,13 +2615,12 @@ function ItemsTabClass:AddCrucibleModifierToDisplayItem()
 			keyMap[key] = index
 		end
 		-- check for uniques with off-tag mods
-		if self.build.data.casterTagCrucibleUniques[self.displayItem.title] then
+		if data.casterTagCrucibleUniques[self.displayItem.title] then
 			includeTags["caster_unique_weapon"] = true
 		end
-		if self.build.data.minionTagCrucibleUniques[self.displayItem.title] then
+		if data.minionTagCrucibleUniques[self.displayItem.title] then
 			includeTags["minion_unique_weapon"] = true
 		end
-
 		if self.displayItem.canHaveOnlySupportSkillsCrucibleTree then
 			 return keyMap["crucible_unique_staff"] and mod.weightVal[keyMap["crucible_unique_staff"]] ~= 0
 		elseif self.displayItem.canHaveShieldCrucibleTree then

--- a/src/Modules/Data.lua
+++ b/src/Modules/Data.lua
@@ -509,6 +509,50 @@ data.misc = { -- magic numbers
 	}
 }
 
+data.casterTagCrucibleUniques = {
+	["Atziri's Rule"] = true,
+	["Cane of Kulemak"] = true,
+	["Cane of Unravelling"] = true,
+	["Cospri's Malice"] = true,
+	["Cybil's Paw"] = true,
+	["Disintegrator"] = true,
+	["Duskdawn"] = true,
+	["Geofri's Devotion"] = true,
+	["Mjolner"] = true,
+	["Pledge of Hands"] = true,
+	["Soulwrest"] = true,
+	["Taryn's Shiver"] = true,
+	["The Rippling Thoughts"] = true,
+	["The Surging Thoughts"] = true,
+	["The Whispering Ice"] = true,
+	["Tremor Rod"] = true,
+	["Xirgil's Crank"] = true,
+}
+data.minionTagCrucibleUniques = {
+	["Arakaali's Fang"] = true,
+	["Ashcaller"] = true,
+	["Chaber Cairn"] = true,
+	["Chober Chaber"] = true,
+	["Clayshaper"] = true,
+	["Earendel's Embrace"] = true,
+	["Femurs of the Saints"] = true,
+	["Jorrhast's Blacksteel"] = true,
+	["Law of the Wilds"] = true,
+	["Midnight Bargain"] = true,
+	["Mon'tregul's Grasp"] = true,
+	["Null's Inclination"] = true,
+	["Queen's Decree"] = true,
+	["Queen's Escape"] = true,
+	["Replica Earendel's Embrace"] = true,
+	["Replica Midnight Bargain"] = true,
+	["Severed in Sleep"] = true,
+	["Soulwrest"] = true,
+	["The Black Cane"] = true,
+	["The Iron Mass"] = true,
+	["The Scourge"] = true,
+	["United in Dream"] = true,
+}
+
 -- Load bosses
 do 
 	data.bosses = { }


### PR DESCRIPTION
### Description of the problem being solved:
Added hard-coded list of uniques that have extra caster and/or minion tags that we reference in itemCanHaveMod to add "caster_unique_weapon" or "minion_unique_weapon" tag to the pool of possible crucible mods
