### PR TITLE
Do not modify env.configInput.conditionLeching directly

### DIFF
--- a/src/Modules/CalcPerform.lua
+++ b/src/Modules/CalcPerform.lua
@@ -1103,12 +1103,10 @@ local function doActorMisc(env, actor)
 		if modDB:Flag(nil, "CanLeechLifeOnFullLife") then
 			condList["Leeching"] = true
 			condList["LeechingLife"] = true
-			env.configInput.conditionLeeching = true
 		end
 		if modDB:Flag(nil, "CanLeechEnergyShieldOnFullEnergyShield") then
 			condList["Leeching"] = true
 			condList["LeechingEnergyShield"] = true
-			env.configInput.conditionLeeching = true
 		end
 		if modDB:Flag(nil, "Condition:InfusionActive") then
 			local effect = 1 + modDB:Sum("INC", nil, "InfusionEffect", "BuffEffectOnSelf") / 100


### PR DESCRIPTION
Currently with overleech env.configInput.conditionLeeching is modified directly resulting in default value checks failing on it as it was changed to non-default value not by user input. This force adjustment of configInput is unnecessary and it looks like just modifying condList is enough.

### Steps taken to verify a working solution:
- Allocate any overleech source
- Allocate anything that depends on leeching
- Are you leeching should not have any border (or red circle or option being red like in #6125 )

### Link to a build that showcases this PR:

https://pobb.in/883kGHg1K54F

### Before screenshot:

![image](https://user-images.githubusercontent.com/5115805/234147410-ef91ac68-d966-48c9-8b9e-b300df6cd211.png)

### After screenshot:

![image](https://user-images.githubusercontent.com/5115805/234147518-61f2ee6a-44b9-4453-b3b9-8e9e77bf6517.png)

