### PR TITLE
Fix lowlife and full life percent being global (in data)

### DIFF
--- a/src/Classes/ConfigTab.lua
+++ b/src/Classes/ConfigTab.lua
@@ -155,7 +155,7 @@ local ConfigTabClass = newClass("ConfigTab", "UndoHandler", "ControlHost", "Cont
 			control.tooltipText = function()
 				local out
 				for i, tooltipFunc in ipairs(tooltipFuncs) do
-					local curTooltipText = type(tooltipFunc) == "string" and tooltipFunc or tooltipFunc(self.modList)
+					local curTooltipText = type(tooltipFunc) == "string" and tooltipFunc or tooltipFunc(self.modList, self.build)
 					if curTooltipText then
 						out = (out and out .. "\n" or "") .. curTooltipText
 					end

--- a/src/Modules/CalcDefence.lua
+++ b/src/Modules/CalcDefence.lua
@@ -1656,7 +1656,7 @@ function calcs.buildDefenceEstimations(env, actor)
 	-- Life Recoverable
 	output.LifeRecoverable = output.LifeUnreserved
 	if env.configInput["conditionLowLife"] then
-		output.LifeRecoverable = m_min(output.Life * data.misc.configurable.LowLifePercentage / 100, output.LifeUnreserved)
+		output.LifeRecoverable = m_min(output.Life * (output.LowLifePercentage or data.misc.LowPoolThreshold) / 100, output.LifeUnreserved)
 		if output.LifeRecoverable < output.LifeUnreserved then
 			output.CappingLife = true
 		end

--- a/src/Modules/CalcPerform.lua
+++ b/src/Modules/CalcPerform.lua
@@ -391,9 +391,6 @@ local function doActorLifeMana(actor)
 	output.LowLifePercentage = 100.0 * (lowLifePerc > 0 and lowLifePerc or data.misc.LowPoolThreshold)
 	local fullLifePerc = modDB:Sum("BASE", nil, "FullLifePercentage")
 	output.FullLifePercentage = 100.0 * (fullLifePerc > 0 and fullLifePerc or 1.0)
-	-- This is hacky, but currently the only way to bring data into ConfigOptions for dynamically updated tooltips
-	data.tooltipValues.LowLifePercentage = output.LowLifePercentage
-	data.tooltipValues.FullLifePercentage = output.FullLifePercentage
 
 	output.ChaosInoculation = modDB:Flag(nil, "ChaosInoculation")
 	-- Life/mana pools

--- a/src/Modules/CalcPerform.lua
+++ b/src/Modules/CalcPerform.lua
@@ -387,11 +387,13 @@ local function doActorLifeMana(actor)
 	local breakdown = actor.breakdown
 	local condList = modDB.conditions
 
-	-- This is hacky, but currently the only way to bring data into ConfigOptions for dynamically updated tooltips
 	local lowLifePerc = modDB:Sum("BASE", nil, "LowLifePercentage")
-	data.misc.configurable.LowLifePercentage = 100.0 * (lowLifePerc > 0 and lowLifePerc or data.misc.LowPoolThreshold)
+	output.LowLifePercentage = 100.0 * (lowLifePerc > 0 and lowLifePerc or data.misc.LowPoolThreshold)
 	local fullLifePerc = modDB:Sum("BASE", nil, "FullLifePercentage")
-	data.misc.configurable.FullLifePercentage = 100.0 * (fullLifePerc > 0 and fullLifePerc or 1.0)
+	output.FullLifePercentage = 100.0 * (fullLifePerc > 0 and fullLifePerc or 1.0)
+	-- This is hacky, but currently the only way to bring data into ConfigOptions for dynamically updated tooltips
+	data.tooltipValues.LowLifePercentage = output.LowLifePercentage
+	data.tooltipValues.FullLifePercentage = output.FullLifePercentage
 
 	output.ChaosInoculation = modDB:Flag(nil, "ChaosInoculation")
 	-- Life/mana pools
@@ -753,7 +755,6 @@ local function doActorLifeManaReservation(actor)
 		local reserved
 		if max > 0 then
 			local lowPerc = modDB:Sum("BASE", nil, "Low" .. pool .. "Percentage")
-			local fullPerc = modDB:Sum("BASE", nil, "Full" .. pool .. "Percentage")
 			reserved = (actor["reserved_"..pool.."Base"] or 0) + m_ceil(max * (actor["reserved_"..pool.."Percent"] or 0) / 100)
 			output[pool.."Reserved"] = m_min(reserved, max)
 			output[pool.."ReservedPercent"] = m_min(reserved / max * 100, 100)

--- a/src/Modules/ConfigOptions.lua
+++ b/src/Modules/ConfigOptions.lua
@@ -57,17 +57,17 @@ Fill in the exact damage numbers if more precision is needed]])
 	end
 end
 
-local function LowLifeTooltip(tooltip)
-	tooltip:Clear()
-	tooltip:AddLine(14, 'You will automatically be considered to be on Low ^xE05030Life ^7if you have at least '..100 - data.tooltipValues.LowLifePercentage..'% ^xE05030Life ^7reserved')
-	tooltip:AddLine(14, 'but you can use this option to force it if necessary.')
+local function LowLifeTooltip(modList, build)
+	local out = 'You will automatically be considered to be on Low ^xE05030Life ^7if you have at least '..100 - build.calcsTab.mainOuput.LowLifePercentage..'% ^xE05030Life ^7reserved'
+	out = out..'\nbut you can use this option to force it if necessary.'
+	return out
 end
 
-local function FullLifeTooltip(tooltip)
-	tooltip:Clear()
-	tooltip:AddLine(14, 'You can be considered to be on Full ^xE05030Life ^7if you have at least '..data.tooltipValues.FullLifePercentage..'% ^xE05030Life ^7unreserved.')
-	tooltip:AddLine(14, 'You will automatically be considered to be on Full ^xE05030Life ^7if you have Chaos Inoculation,')
-	tooltip:AddLine(14, 'but you can use this option to force it if necessary.')
+local function FullLifeTooltip(modList, build)
+	local out = 'You can be considered to be on Full ^xE05030Life ^7if you have at least '..build.calcsTab.mainOutput.FullLifePercentage..'% ^xE05030Life ^7unreserved.'
+	out = out..'\nYou will automatically be considered to be on Full ^xE05030Life ^7if you have Chaos Inoculation,'
+	out = out..'\nbut you can use this option to force it if necessary.'
+	return out
 end
 
 return {
@@ -115,10 +115,10 @@ return {
 	{ var = "conditionInsane", type = "check", label = "Are you insane?", ifCond = "Insane", apply = function(val, modList, enemyModList)
 		modList:NewMod("Condition:Insane", "FLAG", true, "Config")
 	end },
-	{ var = "conditionFullLife", type = "check", label = "Are you always on Full ^xE05030Life?", ifCond = "FullLife", tooltipFunc = FullLifeTooltip, apply = function(val, modList, enemyModList)
+	{ var = "conditionFullLife", type = "check", label = "Are you always on Full ^xE05030Life?", ifCond = "FullLife", tooltip = FullLifeTooltip, apply = function(val, modList, enemyModList)
 		modList:NewMod("Condition:FullLife", "FLAG", true, "Config")
 	end },
-	{ var = "conditionLowLife", type = "check", label = "Are you always on Low ^xE05030Life?", ifCond = "LowLife", tooltipFunc = LowLifeTooltip, apply = function(val, modList, enemyModList)
+	{ var = "conditionLowLife", type = "check", label = "Are you always on Low ^xE05030Life?", ifCond = "LowLife", tooltip = LowLifeTooltip, apply = function(val, modList, enemyModList)
 		modList:NewMod("Condition:LowLife", "FLAG", true, "Config")
 	end },
 	{ var = "conditionFullMana", type = "check", label = "Are you always on Full ^x7070FFMana?", ifCond = "FullMana", apply = function(val, modList, enemyModList)

--- a/src/Modules/ConfigOptions.lua
+++ b/src/Modules/ConfigOptions.lua
@@ -59,13 +59,13 @@ end
 
 local function LowLifeTooltip(tooltip)
 	tooltip:Clear()
-	tooltip:AddLine(14, 'You will automatically be considered to be on Low ^xE05030Life ^7if you have at least '..100 - data.misc.configurable.LowLifePercentage..'% ^xE05030Life ^7reserved')
+	tooltip:AddLine(14, 'You will automatically be considered to be on Low ^xE05030Life ^7if you have at least '..100 - data.tooltipValues.LowLifePercentage..'% ^xE05030Life ^7reserved')
 	tooltip:AddLine(14, 'but you can use this option to force it if necessary.')
 end
 
 local function FullLifeTooltip(tooltip)
 	tooltip:Clear()
-	tooltip:AddLine(14, 'You will automatically be considered to be on Full ^xE05030Life ^7if you have at least '..data.misc.configurable.FullLifePercentage..'% ^xE05030Life ^7unreserved.')
+	tooltip:AddLine(14, 'You can be considered to be on Full ^xE05030Life ^7if you have at least '..data.tooltipValues.FullLifePercentage..'% ^xE05030Life ^7unreserved.')
 	tooltip:AddLine(14, 'You will automatically be considered to be on Full ^xE05030Life ^7if you have Chaos Inoculation,')
 	tooltip:AddLine(14, 'but you can use this option to force it if necessary.')
 end

--- a/src/Modules/ConfigOptions.lua
+++ b/src/Modules/ConfigOptions.lua
@@ -58,13 +58,13 @@ Fill in the exact damage numbers if more precision is needed]])
 end
 
 local function LowLifeTooltip(modList, build)
-	local out = 'You will automatically be considered to be on Low ^xE05030Life ^7if you have at least '..100 - build.calcsTab.mainOuput.LowLifePercentage..'% ^xE05030Life ^7reserved'
+	local out = 'You will automatically be considered to be on Low ^xE05030Life ^7if you have at least '..100 - build.calcsTab.mainOutput.LowLifePercentage..'% ^xE05030Life ^7reserved'
 	out = out..'\nbut you can use this option to force it if necessary.'
 	return out
 end
 
 local function FullLifeTooltip(modList, build)
-	local out = 'You can be considered to be on Full ^xE05030Life ^7if you have at least '..build.calcsTab.mainOutput.FullLifePercentage..'% ^xE05030Life ^7unreserved.'
+	local out = 'You can be considered to be on Full ^xE05030Life ^7if you have at least '..build.calcsTab.mainOutput.FullLifePercentage..'% ^xE05030Life ^7left.'
 	out = out..'\nYou will automatically be considered to be on Full ^xE05030Life ^7if you have Chaos Inoculation,'
 	out = out..'\nbut you can use this option to force it if necessary.'
 	return out

--- a/src/Modules/Data.lua
+++ b/src/Modules/Data.lua
@@ -503,13 +503,6 @@ data.misc = { -- magic numbers
 	PvpNonElemental2 = 90,
 }
 
--- Some magic numbers can change, but need to be here in order to be used in ConfigOptions (e.g. in tooltips)
-data.tooltipValues = {
-	-- Life Scaling Mastery
-	LowLifePercentage = 0.5,
-	FullLifePercentage = 1.0,
-}
-
 data.casterTagCrucibleUniques = {
 	["Atziri's Rule"] = true,
 	["Cane of Kulemak"] = true,

--- a/src/Modules/Data.lua
+++ b/src/Modules/Data.lua
@@ -501,12 +501,13 @@ data.misc = { -- magic numbers
 	PvpElemental2 = 150,
 	PvpNonElemental1 = 0.57,
 	PvpNonElemental2 = 90,
-	-- Some magic numbers can change, but need to be here in order to be used in ConfigOptions (e.g. in tooltips)
-	configurable = {
-		-- Life Scaling Mastery
-		LowLifePercentage = 0.5,
-		FullLifePercentage = 1.0,
-	}
+}
+
+-- Some magic numbers can change, but need to be here in order to be used in ConfigOptions (e.g. in tooltips)
+data.tooltipValues = {
+	-- Life Scaling Mastery
+	LowLifePercentage = 0.5,
+	FullLifePercentage = 1.0,
 }
 
 data.casterTagCrucibleUniques = {


### PR DESCRIPTION
This moves the values to output, though they are still in data for the tooltip funcs

This also improves the tooltip for full life, as you are not automatically considered full life above a threshold due to issues that causes, but the tooltip likely needs further fixes