### PR TITLE
Allow Vaal auras to work as well with Sublime Vision

### DIFF
--- a/src/Classes/ModStore.lua
+++ b/src/Classes/ModStore.lua
@@ -601,16 +601,17 @@ function ModStoreClass:EvalMod(mod, cfg)
 			end
 		elseif tag.type == "SkillName" then
 			local match = false
-			local matchName = tag.summonSkill and (cfg and cfg.summonSkillName or "") or (cfg and cfg.skillName)
+			local matchName = tag.summonSkill and (cfg and cfg.summonSkillName or "") or (cfg and cfg.skillName or "")
+			matchName = matchName:lower()
 			if tag.skillNameList then
 				for _, name in pairs(tag.skillNameList) do
-					if name == matchName then
+					if name:lower() == matchName then
 						match = true
 						break
 					end
 				end
 			else
-				match = (tag.skillName == matchName)
+				match = (tag.skillName and tag.skillName:lower() == matchName)
 			end
 			if tag.neg then
 				match = not match

--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -4021,7 +4021,7 @@ local specialModList = {
 	["your travel skills are disabled"] = { flag("DisableSkill", { type = "SkillType", skillType = SkillType.Travel }) },
 	["aura skills other than ([%a%s]+) are disabled"] = function(_, name) return {
 		flag("DisableSkill", { type = "SkillType", skillType = SkillType.Aura }),
-		flag("EnableSkill", { type = "SkillId", skillId = gemIdLookup[name] }),
+		flag("EnableSkill", { type = "SkillName", skillName = name }),
 	} end,
 	["travel skills other than ([%a%s]+) are disabled"] = function(_, name) return {
 		flag("DisableSkill", { type = "SkillType", skillType = SkillType.Travel }),


### PR DESCRIPTION
Sublime Vision do not disables Vaal auras.

Closes #6073

### Description of the problem being solved:

Sublime Vision do not disables Vaal counterparts of the aura in game. PoB atm does.

### Steps taken to verify a working solution:
- Grab Vaal Haste
- Grab Haste Sublime Vision
- See that both Vaal Haste and Haste work
- See that other auras are properly disabled

### Link to a build that showcases this PR:

https://pobb.in/HpG-8yknh7lS

### Before screenshot:

![image](https://user-images.githubusercontent.com/5115805/234654701-dcdf8c95-1524-4688-9525-9739806a75da.png)

### After screenshot:

![image](https://user-images.githubusercontent.com/5115805/234654568-e89c5f46-3326-44f8-b1d3-2f0ad27d8ce3.png)
