### PR TITLE
Additional nil check when loading Settings

### DIFF
--- a/src/Modules/Main.lua
+++ b/src/Modules/Main.lua
@@ -438,7 +438,7 @@ function main:LoadSettings(ignoreBuild)
 	local setXML, errMsg = common.xml.LoadXMLFile(self.userPath.."Settings.xml")
 	if not setXML then
 		return true
-	elseif setXML[1].elem ~= "PathOfBuilding" then
+	elseif not setXML[1] or setXML[1].elem ~= "PathOfBuilding" then
 		launch:ShowErrMsg("^1Error parsing 'Settings.xml': 'PathOfBuilding' root element missing")
 		return true
 	end
@@ -552,7 +552,7 @@ function main:LoadSharedItems()
 	local setXML, errMsg = common.xml.LoadXMLFile(self.userPath.."Settings.xml")
 	if not setXML then
 		return true
-	elseif setXML[1].elem ~= "PathOfBuilding" then
+	elseif not setXML[1] or setXML[1].elem ~= "PathOfBuilding" then
 		launch:ShowErrMsg("^1Error parsing 'Settings.xml': 'PathOfBuilding' root element missing")
 		return true
 	end


### PR DESCRIPTION
Avoid things like #6136 

### Description of the problem being solved:
Add an additional nil check when loading Settings.xml so we do not lock out users if the file exists but is empty/does not have at least one node. I put it in the elseif so we notify users _something_ went wrong but they can exit out and continue, whereas currently this would block them completely until they fix the file.

Maybe something in our code is corrupting the file but I don't have any proof of that and anyone could go in and manually edit this file too, so I think it could be difficult to troubleshoot. However, I don't think we should allow this scenario to deny access when we could easily ignore it and start with default settings.

### Steps taken to verify a working solution:
- PoB closed, clear settings.xml, open PoB, see error but accessible
- Change xml[1] to something else to verify second conditional still works (elem == "Path of Building")
