### PR TITLE
Fix draw layers for a new version of SimpleGraphic

### DIFF
--- a/src/Classes/ButtonControl.lua
+++ b/src/Classes/ButtonControl.lua
@@ -76,6 +76,7 @@ function ButtonClass:Draw(viewPort, noTooltip)
 		SetDrawColor(0.33, 0.33, 0.33)
 	end
 	local label = self:GetProperty("label")
+	SetDrawLayer(nil, GetDrawLayer() + 1)
 	if label == "+" then
 		DrawImage(nil, x + width * 0.2, y + height * 0.45, width * 0.6, height * 0.1)
 		DrawImage(nil, x + width * 0.45, y + height * 0.2, width * 0.1, height * 0.6)
@@ -88,6 +89,7 @@ function ButtonClass:Draw(viewPort, noTooltip)
 		local overSize = self.overSizeText or 0
 		DrawString(x + width / 2, y + 2 - overSize, "CENTER_X", height - 4 + overSize * 2, "VAR", label)
 	end
+	SetDrawLayer(nil, GetDrawLayer() - 1)
 	if mOver then
 		if not noTooltip or self.forceTooltip then
 			SetDrawLayer(nil, 100)

--- a/src/Classes/DropDownControl.lua
+++ b/src/Classes/DropDownControl.lua
@@ -350,7 +350,9 @@ function DropDownClass:Draw(viewPort, noTooltip)
 				end
 				-- draw actual item label with search match highlight if available
 				local label = type(listVal) == "table" and listVal.label or listVal
+				SetDrawLayer(nil, 6)
 				DrawString(0, y, "LEFT", lineHeight, "VAR", label)
+				SetDrawLayer(nil, 5)
 				self:DrawSearchHighlights(label, searchInfo, 0, y, width - 4, lineHeight)
 			end
 		end

--- a/src/Classes/ListControl.lua
+++ b/src/Classes/ListControl.lua
@@ -263,7 +263,9 @@ function ListClass:Draw(viewPort, noTooltip)
 			if not self.SetHighlightColor or not self:SetHighlightColor(index, value) then
 				SetDrawColor(1, 1, 1)
 			end
+			SetDrawLayer(nil, GetDrawLayer() + 1)
 			DrawString(colOffset, lineY + textOffsetY, "LEFT", textHeight, colFont, text)
+			SetDrawLayer(nil, GetDrawLayer() - 1)
 		end
 		if self.colLabels then
 			local mOver = relX >= colOffset and relX <= colOffset + colWidth and relY >= 0 and relY <= 18


### PR DESCRIPTION
### Description of the problem being solved:
Some buttons, dropdowns, and list text was getting rendered behind the background, as they didn't set their draw layers appropriately.  Switching to batched draws in the ANGLE branch of SimpleGraphic made this apparent.