### PR TITLE
Help section improvements

### DIFF
--- a/help.txt
+++ b/help.txt
@@ -1,21 +1,12 @@
----[Help File][1]
+---[Help File Introduction]
 
-This file contains a list of shortcuts, and other misc things PoB has
+This file contains a list of shortcuts, and other misc information about PoB functionality
 
----[Contents][2]
+---[Contents]
 
-1. Intro
-2. Contents
-3. FAQ
-4. Hotkeys
-5. Other Notable Things
-6. Timeless Jewels
-7. Party Tab
-8. Items Tab
+---[FAQ]
 
----[FAQ][3]
-
----[Hotkeys][4]
+---[Hotkeys]
 
 General Shortcuts:
 
@@ -35,7 +26,8 @@ Ctrl + N	New build (in build selection menu)
 Ctrl + S	Save build to file
 Ctrl + U	Check for update
 Ctrl + V or RMB	Paste
-Ctrl + W or Mouse 4	Close Build (gives save prompt if unsaved)
+Ctrl + W or	
+Mouse 4	Close Build (gives save prompt if unsaved)
 Ctrl + X	Cut
 Ctrl + Y	Redo
 Ctrl + Z	Undo
@@ -80,11 +72,11 @@ DEV[F5	Restart]
 DEV[F6	Run garbage collector]
 DEV[Shift	Copy export xml to clipboard (hold key during export)]
 
----[Other Notable Things][5]
+---[Other Notable Things]
 
 Adding ^ and then a number or hex code before text will change the colour of the text, eg ^^77 will make the following text white until the next colour marker is set.
 
----[Timeless Jewels][6]
+---[Timeless Jewels]
 
 Timeless jewels modify nodes in a radius based off their seed, the same seed will apply the same changes to the same small/notable nodes so that is the number you look for. The Conqueror (name on the jewel) only affects the keystone.
 
@@ -118,7 +110,7 @@ Militant Faith jewels also have the option to select the other mods on the jewel
 Advanced tricks:
     For Militant Faith, if you don't want any nodes to change, you can just sort by devotion. As unchanged nodes add devotion, the ones with the most devotion will be the ones with unchanged nodes
 	
----[Party Tab][7]
+---[Party Tab]
 
 The Party tab Allows you to import support characters and have their auras and curses apply
 

--- a/help.txt
+++ b/help.txt
@@ -33,7 +33,7 @@ Ctrl + Y	Redo
 Ctrl + Z	Undo
 Ctrl + BSP / DEL	Faster text delete
 Ctrl + + /-/0	Zoom in / Out / Reset
-F1	Open item/gem/etc in poewiki.net
+F1	Open item/gem/etc in poewiki.net, or if nothing to open, opens help file
 F2	Rename item, set, etc.
 E	On an equipped item will open it on the edit menu on the right.
 Ctrl + LMB	Enable / disable gems

--- a/help.txt
+++ b/help.txt
@@ -127,7 +127,7 @@ Your curses will take priority over a support's
 For now Enemy conditions and Modifiers are not exported but can be imported if its saved in the XML, and Links skills are not exported or parsed
 Some auras like Mines which use a stack value for their effect will not apply as their stack value is missing
 
----[Items Tab][8]
+---[Items Tab]
 
 The Item Tab in Path of Building allows you to plan out the gear you will use for your character. To access the Item Tab, click on the "Items" tab located at the top of the screen.
 

--- a/help.txt
+++ b/help.txt
@@ -1,6 +1,7 @@
 ---[Help File Introduction]
 
 This file contains a list of shortcuts, and other misc information about PoB functionality
+While holding shift scroll bars in help section and version history will jump to the previous/next section while scrolling
 
 ---[Contents]
 
@@ -42,6 +43,7 @@ Mouse 4/5	Undo / Redo path respectively (in build selection menu)
 Shift	While scrolling on a slider makes it 5* times faster
 Ctrl	While scrolling on a slider makes it 5* times slower
 * default of 5, some scroll bars have more or less extreme modifiers to scroll speed
+  and scroll bars in help section and version history will jump to the previous/next section
 
 When creating an item either through item creator or adding an item pressing ctrl will add it to the first slot
     and ctrl+shift will add it to the second slot e.g. offhand for a weapon.

--- a/src/Classes/TextListControl.lua
+++ b/src/Classes/TextListControl.lua
@@ -3,7 +3,7 @@
 -- Class: Text List
 -- Simple list control for displaying a block of text
 --
-local TextListClass = newClass("TextListControl", "Control", "ControlHost", function(self, anchor, x, y, width, height, columns, list)
+local TextListClass = newClass("TextListControl", "Control", "ControlHost", function(self, anchor, x, y, width, height, columns, list, sectionHeights)
 	self.Control(anchor, x, y, width, height)
 	self.ControlHost()
 	self.controls.scrollBar = new("ScrollBarControl", {"RIGHT",self,"RIGHT"}, -1, 0, 18, 0, 40)
@@ -13,6 +13,7 @@ local TextListClass = newClass("TextListControl", "Control", "ControlHost", func
 	end
 	self.columns = columns or { { x = 0, align = "LEFT" } }
 	self.list = list or { }
+	self.sectionHeights = sectionHeights
 end)
 
 function TextListClass:IsMouseOver()
@@ -63,11 +64,27 @@ function TextListClass:OnKeyUp(key)
 	if not self:IsShown() or not self:IsEnabled() then
 		return
 	end
+	local scrollBar = self.controls.scrollBar
+	if IsKeyDown("SHIFT") and self.sectionHeights then
+		for i, height in ipairs(self.sectionHeights) do
+			if height >= scrollBar.offset then
+				if key == "WHEELDOWN" then
+					scrollBar:SetOffset((i==#self.sectionHeights and self.sectionHeights[i] or self.sectionHeights[i + 1]))
+					return self
+				elseif key == "WHEELUP" then
+					scrollBar:SetOffset(i==1 and self.sectionHeights[i] or self.sectionHeights[i - 1])
+					return self
+				end
+			end
+		end
+		scrollBar.offset = scrollBar.offsetMax
+		return self
+	end
 	if key == "WHEELDOWN" then
-		self.controls.scrollBar:Scroll(1)
+		scrollBar:Scroll(1)
 		return self
 	elseif key == "WHEELUP" then
-		self.controls.scrollBar:Scroll(-1)
+		scrollBar:Scroll(-1)
 		return self
 	end
 end

--- a/src/Modules/ItemTools.lua
+++ b/src/Modules/ItemTools.lua
@@ -178,8 +178,10 @@ itemLib.wiki = {
 		local route = string.gsub(name, " ", "_")
 
 		OpenURL("https://www.poewiki.net/wiki/" .. route)
+		itemLib.wiki.triggered = true
 	end,
 	matchesKey = function(key)
 		return key == itemLib.wiki.key
-	end
+	end,
+	triggered = false
 }

--- a/src/Modules/Main.lua
+++ b/src/Modules/Main.lua
@@ -988,6 +988,7 @@ function main:OpenAboutPopup(helpSectionIndex)
 	end
 	local helpList = { }
 	local helpSections = { }
+	local helpSectionHeights = { }
 	do
 		local helpName = launch.devMode and "../help.txt" or "help.txt"
 		local helpFile = io.open(helpName, "r")
@@ -1033,6 +1034,7 @@ function main:OpenAboutPopup(helpSectionIndex)
 					end
 				end
 				helpSections[sectionIndex].height = helpSections[sectionIndex].height + (contentsDone and (#helpSections + 1) or 0)
+				helpSectionHeights[sectionIndex] = helpSections[sectionIndex].height * textSize
 				if sectionValues.title == "Contents" then
 					contentsDone = true
 				end
@@ -1061,11 +1063,13 @@ function main:OpenAboutPopup(helpSectionIndex)
 	end)
 	controls.verLabel = new("ButtonControl", { "TOPLEFT", nil, "TOPLEFT" }, 10, 85, 100, 18, "^7Version history:", function()
 		controls.changelog.list = changeList
+		controls.changelog.sectionHeights = nil
 	end)
 	controls.helpLabel = new("ButtonControl", { "TOPRIGHT", nil, "TOPRIGHT" }, -10, 85, 40, 18, "^7Help:", function()
 		controls.changelog.list = helpList
+		controls.changelog.sectionHeights = helpSectionHeights
 	end)
-	controls.changelog = new("TextListControl", nil, 0, 103, popupWidth - 20, 515, {{ x = 1, align = "LEFT" }, { x = 110, align = "LEFT" }}, helpSectionIndex and helpList or changeList)
+	controls.changelog = new("TextListControl", nil, 0, 103, popupWidth - 20, 515, {{ x = 1, align = "LEFT" }, { x = 110, align = "LEFT" }}, helpSectionIndex and helpList or changeList, helpSectionIndex and helpSectionHeights or nil)
 	if helpSectionIndex then
 		controls.changelog.controls.scrollBar.offset = helpSections[helpSectionIndex].height * textSize
 	end

--- a/src/Modules/Main.lua
+++ b/src/Modules/Main.lua
@@ -1019,7 +1019,7 @@ function main:OpenAboutPopup(helpSectionIndex)
 								t_insert(helpList, { height = textSize, "^7"..outdent, "^7"..indent })
 							end
 						else
-							local Lines = self:WrapString(line, textSize, popupWidth - 110)
+							local Lines = self:WrapString(line, textSize, popupWidth - 135)
 							for i, line2 in ipairs(Lines) do
 								t_insert(helpList, { height = textSize, "^7"..(i > 1 and "    " or "")..line2 })
 							end
@@ -1071,7 +1071,7 @@ function main:OpenAboutPopup(helpSectionIndex)
 		controls.changelog.list = helpList
 		controls.changelog.sectionHeights = helpSectionHeights
 	end)
-	controls.changelog = new("TextListControl", nil, 0, 103, popupWidth - 20, 515, {{ x = 1, align = "LEFT" }, { x = 110, align = "LEFT" }}, helpSectionIndex and helpList or changeList, helpSectionIndex and helpSectionHeights or changeVersionHeights)
+	controls.changelog = new("TextListControl", nil, 0, 103, popupWidth - 20, 515, {{ x = 1, align = "LEFT" }, { x = 135, align = "LEFT" }}, helpSectionIndex and helpList or changeList, helpSectionIndex and helpSectionHeights or changeVersionHeights)
 	if helpSectionIndex then
 		controls.changelog.controls.scrollBar.offset = helpSections[helpSectionIndex].height * textSize
 	end

--- a/src/Modules/Main.lua
+++ b/src/Modules/Main.lua
@@ -958,6 +958,7 @@ function main:OpenUpdatePopup()
 end
 
 function main:OpenAboutPopup()
+	local textSize, titleSize, popupWidth = 16, 24, 810
 	local changeList = { }
 	local changelogName = launch.devMode and "../changelog.txt" or "changelog.txt"
 	local changelogFile = io.open(changelogName, "r")
@@ -967,11 +968,11 @@ function main:OpenAboutPopup()
 			local ver, date = line:match("^VERSION%[(.+)%]%[(.+)%]$")
 			if ver then
 				if #changeList > 0 then
-					t_insert(changeList, { height = 10 })
+					t_insert(changeList, { height = titleSize / 2 })
 				end
-				t_insert(changeList, { height = 18, "^7Version "..ver.." ("..date..")" })
+				t_insert(changeList, { height = titleSize, "^7Version "..ver.." ("..date..")" })
 			else
-				t_insert(changeList, { height = 12, "^7"..line })
+				t_insert(changeList, { height = textSize, "^7"..line })
 			end
 		end
 	end
@@ -994,18 +995,18 @@ function main:OpenAboutPopup()
 						line = (dev or line)
 						local outdent, indent = line:match("(.*)\t+(.*)")
 						if outdent then
-							local indentLines = self:WrapString(indent, 12, 500)
+							local indentLines = self:WrapString(indent, textSize, popupWidth - 190)
 							if #indentLines > 1 then
 								for i, indentLine in ipairs(indentLines) do
-									t_insert(helpList, { height = 12, (i == 1 and outdent or " "), "^7"..indentLine })
+									t_insert(helpList, { height = textSize, (i == 1 and outdent or " "), "^7"..indentLine })
 								end
 							else
-								t_insert(helpList, { height = 12, "^7"..outdent, "^7"..indent })
+								t_insert(helpList, { height = textSize, "^7"..outdent, "^7"..indent })
 							end
 						else
-							local Lines = self:WrapString(line, 12, 560)
+							local Lines = self:WrapString(line, textSize, popupWidth - 110)
 							for i, line2 in ipairs(Lines) do
-								t_insert(helpList, { height = 12, "^7"..(i > 1 and "    " or "")..line2 })
+								t_insert(helpList, { height = textSize, "^7"..(i > 1 and "    " or "")..line2 })
 							end
 						end
 					end
@@ -1025,11 +1026,12 @@ function main:OpenAboutPopup()
 	controls.verLabel = new("ButtonControl", { "TOPLEFT", nil, "TOPLEFT" }, 10, 85, 100, 18, "^7Version history:", function()
 		controls.changelog.list = changeList
 	end)
-	controls.helpLabel = new("ButtonControl", { "TOPLEFT", nil, "TOPLEFT" }, 600, 85, 40, 18, "^7Help:", function()
+	controls.helpLabel = new("ButtonControl", { "TOPRIGHT", nil, "TOPRIGHT" }, -10, 85, 40, 18, "^7Help:", function()
 		controls.changelog.list = helpList
 	end)
-	controls.changelog = new("TextListControl", nil, 0, 103, 630, 387, {{ x = 1, align = "LEFT" }, { x = 110, align = "LEFT" }}, changeList)
+	controls.changelog = new("TextListControl", nil, 0, 103, popupWidth - 20, 515, {{ x = 1, align = "LEFT" }, { x = 110, align = "LEFT" }}, changeList)
 	self:OpenPopup(650, 500, "About", controls)
+	self:OpenPopup(popupWidth, 628, "About", controls)
 end
 
 function main:DrawBackground(viewPort)

--- a/src/Modules/Main.lua
+++ b/src/Modules/Main.lua
@@ -970,6 +970,7 @@ end
 function main:OpenAboutPopup(helpSectionIndex)
 	local textSize, titleSize, popupWidth = 16, 24, 810
 	local changeList = { }
+	local changeVersionHeights = { }
 	local changelogName = launch.devMode and "../changelog.txt" or "changelog.txt"
 	local changelogFile = io.open(changelogName, "r")
 	if changelogFile then
@@ -978,8 +979,9 @@ function main:OpenAboutPopup(helpSectionIndex)
 			local ver, date = line:match("^VERSION%[(.+)%]%[(.+)%]$")
 			if ver then
 				if #changeList > 0 then
-					t_insert(changeList, { height = titleSize / 2 })
+					t_insert(changeList, { height = textSize / 2 })
 				end
+				t_insert(changeVersionHeights, #changeList * textSize)
 				t_insert(changeList, { height = titleSize, "^7Version "..ver.." ("..date..")" })
 			else
 				t_insert(changeList, { height = textSize, "^7"..line })
@@ -1063,13 +1065,13 @@ function main:OpenAboutPopup(helpSectionIndex)
 	end)
 	controls.verLabel = new("ButtonControl", { "TOPLEFT", nil, "TOPLEFT" }, 10, 85, 100, 18, "^7Version history:", function()
 		controls.changelog.list = changeList
-		controls.changelog.sectionHeights = nil
+		controls.changelog.sectionHeights = changeVersionHeights
 	end)
 	controls.helpLabel = new("ButtonControl", { "TOPRIGHT", nil, "TOPRIGHT" }, -10, 85, 40, 18, "^7Help:", function()
 		controls.changelog.list = helpList
 		controls.changelog.sectionHeights = helpSectionHeights
 	end)
-	controls.changelog = new("TextListControl", nil, 0, 103, popupWidth - 20, 515, {{ x = 1, align = "LEFT" }, { x = 110, align = "LEFT" }}, helpSectionIndex and helpList or changeList, helpSectionIndex and helpSectionHeights or nil)
+	controls.changelog = new("TextListControl", nil, 0, 103, popupWidth - 20, 515, {{ x = 1, align = "LEFT" }, { x = 110, align = "LEFT" }}, helpSectionIndex and helpList or changeList, helpSectionIndex and helpSectionHeights or changeVersionHeights)
 	if helpSectionIndex then
 		controls.changelog.controls.scrollBar.offset = helpSections[helpSectionIndex].height * textSize
 	end


### PR DESCRIPTION
This PR has a few minor tweaks to the help section,

1. making the text size and content box bigger
2. removing section numbers and content of help file and having those autogenerate
3. adding in a hotkey to open it automatically (this can open it to any arbitrary section but currently only to the top, does it if f1 is pressed and no link to wiki is opened)
4. adding fast scroll to help sections and changelog

I am not very happy with the implementation of the hotkey, also would like it to open to a relevant section instead of just the start, and wonder if a should cache the help/version history