### PR TITLE
fix vaal auras incorrectly disabling other auras depending on order

### DIFF
--- a/src/Classes/PartyTab.lua
+++ b/src/Classes/PartyTab.lua
@@ -672,30 +672,59 @@ function PartyTabClass:ParseBuffs(list, buf, buffType, label)
 					if mod then
 						currentModType = modType
 						list[modType] = list[modType] or {}
-						if not list[modType][currentName] then
-							list[modType][currentName] = {
-								modList = new("ModList"),
-								effectMult = currentEffect
-							}
-							if isMark then
-								list[modType][currentName].isMark = true
+						if currentName:find("Vaal") then
+							list[modType]["Vaal"] = list[modType]["Vaal"] or {}
+							if not list[modType]["Vaal"][currentName] then
+								list[modType]["Vaal"][currentName] = {
+									modList = new("ModList"),
+									effectMult = currentEffect
+								}
+								if isMark then
+									list[modType]["Vaal"][currentName].isMark = true
+								end
+							elseif list[modType]["Vaal"][currentName].effectMult ~= currentEffect then
+								if list[modType]["Vaal"][currentName].effectMult < currentEffect then
+									list[modType]["Vaal"][currentName] = {
+										modList = new("ModList"),
+										effectMult = currentEffect
+									}
+								else
+									currentName = "SKIP"
+								end
 							end
-						elseif list[modType][currentName].effectMult ~= currentEffect then
-							if list[modType][currentName].effectMult < currentEffect then
+							if currentName ~= "SKIP" then
+								if mod.source:match("Item") then
+									_, mod.source = mod.source:match("Item:(%d+):(.+)")
+									mod.source = "Party - "..mod.source
+								end
+								list[modType]["Vaal"][currentName].modList:AddMod(mod)
+							end
+						else
+							if not list[modType][currentName] then
 								list[modType][currentName] = {
 									modList = new("ModList"),
 									effectMult = currentEffect
 								}
-							else
-								currentName = "SKIP"
+								if isMark then
+									list[modType][currentName].isMark = true
+								end
+							elseif list[modType][currentName].effectMult ~= currentEffect then
+								if list[modType][currentName].effectMult < currentEffect then
+									list[modType][currentName] = {
+										modList = new("ModList"),
+										effectMult = currentEffect
+									}
+								else
+									currentName = "SKIP"
+								end
 							end
-						end
-						if currentName ~= "SKIP" then
-							if mod.source:match("Item") then
-								_, mod.source = mod.source:match("Item:(%d+):(.+)")
-								mod.source = "Party - "..mod.source
+							if currentName ~= "SKIP" then
+								if mod.source:match("Item") then
+									_, mod.source = mod.source:match("Item:(%d+):(.+)")
+									mod.source = "Party - "..mod.source
+								end
+								list[modType][currentName].modList:AddMod(mod)
 							end
-							list[modType][currentName].modList:AddMod(mod)
 						end
 					end
 				end
@@ -706,12 +735,28 @@ function PartyTabClass:ParseBuffs(list, buf, buffType, label)
 				local count = 0
 				label.label = "^7---------------------------\n"
 				for aura, auraMod in pairs(list["Aura"] or {}) do
-					label.label = label.label..aura..": "..auraMod.effectMult.."%\n"
-					count = count + 1
+					if aura ~= "Vaal" then
+						label.label = label.label..aura..": "..auraMod.effectMult.."%\n"
+						count = count + 1
+					end
 				end
 				for aura, auraMod in pairs(list["AuraDebuff"] or {}) do
-					label.label = label.label..aura..": "..auraMod.effectMult.."%\n"
-					count = count + 1
+					if aura ~= "Vaal" then
+						label.label = label.label..aura..": "..auraMod.effectMult.."%\n"
+						count = count + 1
+					end
+				end
+				if list["Aura"] and list["Aura"]["Vaal"] then
+					for aura, auraMod in pairs(list["Aura"]["Vaal"]) do
+						label.label = label.label..aura..": "..auraMod.effectMult.."%\n"
+						count = count + 1
+					end
+				end
+				if list["AuraDebuff"] and list["AuraDebuff"]["Vaal"] then
+					for aura, auraMod in pairs(list["AuraDebuff"]["Vaal"]) do
+						label.label = label.label..aura..": "..auraMod.effectMult.."%\n"
+						count = count + 1
+					end
 				end
 				if list["extraAura"] and list["extraAura"]["extraAura"] then
 					label.label = label.label.."extraAuras:\n"

--- a/src/Modules/CalcPerform.lua
+++ b/src/Modules/CalcPerform.lua
@@ -2317,8 +2317,8 @@ function calcs.perform(env, avoidCache, fullDPSSkipEHP)
 	end
 	if allyBuffs["Aura"] then
 		for auraName, aura in pairs(allyBuffs["Aura"]) do
-			local auraNameCompressed = auraName:gsub(" ","")
-			if not (auraName:sub(1,4) == "Vaal") then
+			if auraName ~= "Vaal" then
+				local auraNameCompressed = auraName:gsub(" ","")
 				if not modDB:Flag(nil, "AlliesAurasCannotAffectSelf") and not modDB.conditions["AffectedBy"..auraNameCompressed] then
 					modDB.conditions["AffectedByAura"] = true
 					if auraName:sub(1,4) == "Vaal" then
@@ -2338,9 +2338,9 @@ function calcs.perform(env, avoidCache, fullDPSSkipEHP)
 				end
 			end
 		end
-		for auraName, aura in pairs(allyBuffs["Aura"]) do
-			local auraNameCompressed = auraName:gsub(" ","")
-			if auraName:sub(1,4) == "Vaal" then
+		if allyBuffs["Aura"]["Vaal"] then
+			for auraName, aura in pairs(allyBuffs["Aura"]["Vaal"]) do
+				local auraNameCompressed = auraName:gsub(" ","")
 				if not modDB:Flag(nil, "AlliesAurasCannotAffectSelf") and not modDB.conditions["AffectedBy"..auraNameCompressed] then
 					modDB.conditions["AffectedByAura"] = true
 					if auraName:sub(1,4) == "Vaal" then
@@ -2363,12 +2363,25 @@ function calcs.perform(env, avoidCache, fullDPSSkipEHP)
 	end
 	if allyBuffs["AuraDebuff"] and env.mode_effective then
 		for auraName, aura in pairs(allyBuffs["AuraDebuff"]) do
-			local auraNameCompressed = auraName:gsub(" ","")
-			if not modDB.conditions["AffectedBy"..auraNameCompressed] then
-				modDB.conditions["AffectedBy"..auraNameCompressed] = true
-				local srcList = new("ModList")
-				srcList:ScaleAddList(aura.modList, aura.effectMult / 100)
-				mergeBuff(srcList, debuffs, auraName)
+			if auraName ~= "Vaal" then
+				local auraNameCompressed = auraName:gsub(" ","")
+				if not modDB.conditions["AffectedBy"..auraNameCompressed] then
+					modDB.conditions["AffectedBy"..auraNameCompressed] = true
+					local srcList = new("ModList")
+					srcList:ScaleAddList(aura.modList, aura.effectMult / 100)
+					mergeBuff(srcList, debuffs, auraName)
+				end
+			end
+		end
+		if allyBuffs["AuraDebuff"]["Vaal"] then
+			for auraName, aura in pairs(allyBuffs["AuraDebuff"]["Vaal"]) do
+				local auraNameCompressed = auraName:gsub(" ","")
+				if not modDB.conditions["AffectedBy"..auraNameCompressed] then
+					modDB.conditions["AffectedBy"..auraNameCompressed] = true
+					local srcList = new("ModList")
+					srcList:ScaleAddList(aura.modList, aura.effectMult / 100)
+					mergeBuff(srcList, debuffs, auraName)
+				end
 			end
 		end
 	end

--- a/src/Modules/CalcPerform.lua
+++ b/src/Modules/CalcPerform.lua
@@ -2318,22 +2318,46 @@ function calcs.perform(env, avoidCache, fullDPSSkipEHP)
 	if allyBuffs["Aura"] then
 		for auraName, aura in pairs(allyBuffs["Aura"]) do
 			local auraNameCompressed = auraName:gsub(" ","")
-			if not modDB:Flag(nil, "AlliesAurasCannotAffectSelf") and not modDB.conditions["AffectedBy"..auraNameCompressed] then
-				modDB.conditions["AffectedByAura"] = true
-				if auraName:sub(1,4) == "Vaal" then
-					modDB.conditions["AffectedBy"..auraName:sub(6):gsub(" ","")] = true
+			if not (auraName:sub(1,4) == "Vaal") then
+				if not modDB:Flag(nil, "AlliesAurasCannotAffectSelf") and not modDB.conditions["AffectedBy"..auraNameCompressed] then
+					modDB.conditions["AffectedByAura"] = true
+					if auraName:sub(1,4) == "Vaal" then
+						modDB.conditions["AffectedBy"..auraName:sub(6):gsub(" ","")] = true
+					end
+					modDB.conditions["AffectedBy"..auraNameCompressed] = true
+					local srcList = new("ModList")
+					srcList:ScaleAddList(aura.modList, aura.effectMult / 100)
+					mergeBuff(srcList, buffs, auraName)
 				end
-				modDB.conditions["AffectedBy"..auraNameCompressed] = true
-				local srcList = new("ModList")
-				srcList:ScaleAddList(aura.modList, aura.effectMult / 100)
-				mergeBuff(srcList, buffs, auraName)
+				if env.minion and not env.minion.modDB.conditions["AffectedBy"..auraNameCompressed] then
+					env.minion.modDB.conditions["AffectedByAura"] = true
+					env.minion.modDB.conditions["AffectedBy"..auraNameCompressed] = true
+					local srcList = new("ModList")
+					srcList:ScaleAddList(aura.modList, aura.effectMult / 100)
+					mergeBuff(srcList, minionBuffs, auraName)
+				end
 			end
-			if env.minion and not env.minion.modDB.conditions["AffectedBy"..auraNameCompressed] then
-				env.minion.modDB.conditions["AffectedByAura"] = true
-				env.minion.modDB.conditions["AffectedBy"..auraNameCompressed] = true
-				local srcList = new("ModList")
-				srcList:ScaleAddList(aura.modList, aura.effectMult / 100)
-				mergeBuff(srcList, minionBuffs, auraName)
+		end
+		for auraName, aura in pairs(allyBuffs["Aura"]) do
+			local auraNameCompressed = auraName:gsub(" ","")
+			if auraName:sub(1,4) == "Vaal" then
+				if not modDB:Flag(nil, "AlliesAurasCannotAffectSelf") and not modDB.conditions["AffectedBy"..auraNameCompressed] then
+					modDB.conditions["AffectedByAura"] = true
+					if auraName:sub(1,4) == "Vaal" then
+						modDB.conditions["AffectedBy"..auraName:sub(6):gsub(" ","")] = true
+					end
+					modDB.conditions["AffectedBy"..auraNameCompressed] = true
+					local srcList = new("ModList")
+					srcList:ScaleAddList(aura.modList, aura.effectMult / 100)
+					mergeBuff(srcList, buffs, auraName)
+				end
+				if env.minion and not env.minion.modDB.conditions["AffectedBy"..auraNameCompressed] then
+					env.minion.modDB.conditions["AffectedByAura"] = true
+					env.minion.modDB.conditions["AffectedBy"..auraNameCompressed] = true
+					local srcList = new("ModList")
+					srcList:ScaleAddList(aura.modList, aura.effectMult / 100)
+					mergeBuff(srcList, minionBuffs, auraName)
+				end
 			end
 		end
 	end


### PR DESCRIPTION
This was due to the vaal aura also giving the "affected by" condition which prevents the non-vaal from being added, 
~~would like a better fix in future, but this is fine for a hotfix while the tab gets upgraded~~

_edit:_ better fix, tag vaal auras at import time, this prevents having to loop over the list of auras twice, though is only a minor improvement