### PR TITLE
Add support for search input to Configuration tab

### DIFF
--- a/src/Classes/ConfigTab.lua
+++ b/src/Classes/ConfigTab.lua
@@ -31,7 +31,7 @@ local ConfigTabClass = newClass("ConfigTab", "UndoHandler", "ControlHost", "Cont
 
 	self.controls.search = new("EditControl", { "TOPLEFT", self, "TOPLEFT" }, 8, 5, 360, 20, "", "Search", "%c", 100, function()
 		self:UpdateControls()
-	end)
+	end, nil, nil, true)
 	self.controls.sectionAnchor = new("LabelControl", { "TOPLEFT", self.controls.search, "TOPLEFT" }, -10, 15, 0, 0, "")
 
 	local function searchMatch(varData)
@@ -655,6 +655,8 @@ function ConfigTabClass:Draw(viewPort, inputEvents)
 			elseif event.key == "y" and IsKeyDown("CTRL") then
 				self:Redo()
 				self.build.buildFlag = true
+			elseif event.key == "f" and IsKeyDown("CTRL") then
+				self:SelectControl(self.controls.search)
 			end
 		end
 	end


### PR DESCRIPTION
### Description of the problem being solved:

Sometimes its hard to find config option on big builds or builds with a lot of config options

### Steps taken to verify a working solution:
- Open a buid
- Try searching for something
- Only that thing should be visible

### Link to a build that showcases this PR:

https://pobb.in/dOdIJeTDPAfB

### Before screenshot:

![image](https://user-images.githubusercontent.com/5115805/235377795-f43d55ec-7684-41e6-a6bf-1f1882b177a2.png)

### After screenshot:

![image](https://user-images.githubusercontent.com/5115805/235378000-c439816c-6940-42b3-9d85-f979d292f39d.png)

![image](https://user-images.githubusercontent.com/5115805/235378005-93fc692d-5b86-4c37-913e-066d53daab54.png)

