### PR TITLE
Fix error on disabling node power mid-generation

### DIFF
--- a/src/Classes/TreeTab.lua
+++ b/src/Classes/TreeTab.lua
@@ -712,7 +712,7 @@ function TreeTabClass:BuildPowerReportList(currentStat)
 	for nodeName, node in pairs(self.build.spec.tree.clusterNodeMap) do
 		local isAlloc = node.alloc
 		if not isAlloc then			
-			local nodePower = (node.power.singleStat or 0) * ((displayStat.pc or displayStat.mod) and 100 or 1)
+			local nodePower = (node.power and node.power.singleStat or 0) * ((displayStat.pc or displayStat.mod) and 100 or 1)
 			local nodePowerStr = s_format("%"..displayStat.fmt, nodePower)
 
 			nodePowerStr = formatNumSep(nodePowerStr)


### PR DESCRIPTION
### Description of the problem being solved:
When disabling show node power partway through a calculations, nodes would lose their power property. This caused a crash unless the disabling happened at precisely the right point to not run into the code I changed. Simply checking that node power exists before using the singleStat of it solved the issue.

### Steps taken to verify a working solution:
- Open build
- Enable show node power
- Switch to full DPS
- Disable show node power

Without this change an error should appear. With it, no error should occur.

### Link to a build that showcases this PR:
https://pobb.in/2xvFigGrZNrL