### PR TITLE
Add support for Vaal Absolution + Vaal Domination

### DIFF
--- a/src/Data/Minions.lua
+++ b/src/Data/Minions.lua
@@ -550,6 +550,33 @@ minions["AxisEliteSoldierDominatingBlow"] = {
 	},
 }
 
+minions["AxisEliteSoldierDominatingBlowVaal"] = {
+	name = "Ascended Sentinel of Dominance",
+	life = 4,
+	armour = 0.5,
+	fireResist = 40,
+	coldResist = 40,
+	lightningResist = 40,
+	chaosResist = 20,
+	damage = 2.8,
+	damageSpread = 0.2,
+	attackTime = 0.83,
+	attackRange = 28,
+	accuracy = 3.4,
+	skillList = {
+		"TeleportVaalDomination",
+		"GAVaalDominationTeleportSlam",
+		"VaalDominationSunderMelee",
+		"VaalDominationSunder",
+		"GAVaalDominationLargeSlam",
+		"VaalDominationMelee",
+	},
+	modList = {
+		mod("Damage", "MORE", 200),
+		mod("DamageTaken", "MORE", -70),
+	},
+}
+
 minions["AbsolutionTemplarJudge"] = {
 	name = "Sentinel of Absolution",
 	life = 4,
@@ -571,6 +598,33 @@ minions["AbsolutionTemplarJudge"] = {
 		"AbsolutionMinionEmpowered",
 	},
 	modList = {
+	},
+}
+
+minions["AbsolutionTemplarJudgeVaal"] = {
+	name = "Ascended Sentinel of Absolution",
+	life = 4,
+	energyShield = 0.2,
+	armour = 0.5,
+	fireResist = 40,
+	coldResist = 40,
+	lightningResist = 40,
+	chaosResist = 20,
+	damage = 2.8,
+	damageSpread = 0.2,
+	attackTime = 1.17,
+	attackRange = 9,
+	accuracy = 1,
+	skillList = {
+		"AbsolutionMinionVaal",
+		"AbsolutionMinionVaalCascade",
+		"GTVaalAbsolutionLarge",
+		"VaalAbsolutionDelayedBlast",
+		"GSVaalAbsolutionEmerge",
+	},
+	modList = {
+		mod("Damage", "MORE", 200),
+		mod("DamageTaken", "MORE", -70),
 	},
 }
 

--- a/src/Data/Skills/act_str.lua
+++ b/src/Data/Skills/act_str.lua
@@ -17,6 +17,7 @@ skills["Absolution"] = {
 	castTime = 0.75,
 	minionList = {
 		"AbsolutionTemplarJudge",
+		"AbsolutionTemplarJudgeVaal",
 	},
 	statMap = {
 		["sentinel_minion_cooldown_speed_+%"] = {
@@ -116,6 +117,14 @@ skills["VaalAbsolution"] = {
 	skillTypes = { [SkillType.Spell] = true, [SkillType.Minion] = true, [SkillType.Duration] = true, [SkillType.Physical] = true, [SkillType.Lightning] = true, [SkillType.Vaal] = true, },
 	statDescriptionScope = "skill_stat_descriptions",
 	castTime = 0.5,
+	statMap = {
+		["vaal_upgrade_minion_damage_+%_final"] = {
+		-- Stat is handled directly on minion
+		},
+		["vaal_upgrade_minion_damage_taken_+%_final"] = {
+		-- Stat is handled directly on minion
+		},
+	},
 	baseFlags = {
 		spell = true,
 		minion = true,
@@ -2495,6 +2504,7 @@ skills["DominatingBlow"] = {
 	castTime = 1,
 	minionList = {
 		"AxisEliteSoldierDominatingBlow",
+		"AxisEliteSoldierDominatingBlowVaal",
 	},
 	statMap = {
 		["sentinel_minion_cooldown_speed_+%"] = {
@@ -2586,6 +2596,14 @@ skills["VaalDomination"] = {
 	skillTypes = { [SkillType.Spell] = true, [SkillType.Minion] = true, [SkillType.Duration] = true, [SkillType.Vaal] = true, },
 	statDescriptionScope = "skill_stat_descriptions",
 	castTime = 0.5,
+	statMap = {
+		["vaal_upgrade_minion_damage_+%_final"] = {
+		-- Stat is handled directly on minion
+		},
+		["vaal_upgrade_minion_damage_taken_+%_final"] = {
+		-- Stat is handled directly on minion
+		},
+	},
 	baseFlags = {
 		attack = true,
 		melee = true,

--- a/src/Data/Skills/minion.lua
+++ b/src/Data/Skills/minion.lua
@@ -911,6 +911,70 @@ skills["DominatingBlowMinionCharge"] = {
 		[1] = { storedUses = 1, levelRequirement = 1, cooldown = 4, },
 	},
 }
+skills["VaalDominationMelee"] = {
+	name = "Default Attack",
+	hidden = true,
+	color = 4,
+	baseEffectiveness = 0,
+	description = "Strike your foes down with a powerful blow.",
+	skillTypes = { [SkillType.Attack] = true, [SkillType.RangedAttack] = true, [SkillType.MirageArcherCanUse] = true, [SkillType.Projectile] = true, [SkillType.MeleeSingleTarget] = true, [SkillType.Multistrikeable] = true, [SkillType.Melee] = true, [SkillType.ProjectilesFromUser] = true, },
+	statDescriptionScope = "skill_stat_descriptions",
+	castTime = 1,
+	baseFlags = {
+		attack = true,
+		melee = true,
+		projectile = true,
+	},
+	stats = {
+	},
+	levels = {
+		[1] = { damageEffectiveness = 3, attackSpeedMultiplier = -72, baseMultiplier = 3, levelRequirement = 1, },
+	},
+}
+skills["VaalDominationSunder"] = {
+	name = "Sunder",
+	hidden = true,
+	color = 4,
+	skillTypes = { [SkillType.Attack] = true, [SkillType.Area] = true, [SkillType.Multistrikeable] = true, [SkillType.Melee] = true, [SkillType.Triggerable] = true, },
+	statDescriptionScope = "skill_stat_descriptions",
+	castTime = 1,
+	baseFlags = {
+		attack = true,
+		melee = true,
+		area = true,
+	},
+	constantStats = {
+		{ "shockwave_slam_explosion_damage_+%_final", -60 },
+		{ "old_sunder_additional_width_per_stage", 1 },
+	},
+	stats = {
+		"is_area_damage",
+	},
+	levels = {
+		[1] = { damageEffectiveness = 2.7, baseMultiplier = 2.7, levelRequirement = 1, },
+	},
+}
+skills["GAVaalDominationLargeSlam"] = {
+	name = "AoE Slam",
+	hidden = true,
+	color = 4,
+	skillTypes = { [SkillType.Triggerable] = true, [SkillType.Attack] = true, },
+	statDescriptionScope = "skill_stat_descriptions",
+	castTime = 1,
+	baseFlags = {
+		attack = true,
+		area = true,
+	},
+	constantStats = {
+		{ "melee_range_+", 15 },
+	},
+	stats = {
+		"is_area_damage",
+	},
+	levels = {
+		[1] = { attackSpeedMultiplier = -77, cooldown = 7, damageEffectiveness = 3.5, storedUses = 1, baseMultiplier = 3.5, levelRequirement = 0, },
+	},
+}
 skills["AbsolutionMinion"] = {
 	name = "Absolution",
 	hidden = true,
@@ -940,7 +1004,7 @@ skills["AbsolutionMinion"] = {
 	},
 }
 skills["AbsolutionMinionEmpowered"] = {
-	name = "Absolution",
+	name = "Empowered Absolution",
 	hidden = true,
 	color = 1,
 	baseEffectiveness = 1.4865000247955,
@@ -966,6 +1030,87 @@ skills["AbsolutionMinionEmpowered"] = {
 	},
 	levels = {
 		[1] = { 0.80000001192093, 1.2000000476837, critChance = 6, cooldown = 6, damageEffectiveness = 1.3, storedUses = 1, levelRequirement = 0, statInterpolation = { 3, 3, }, },
+	},
+}
+skills["AbsolutionMinionVaal"] = {
+	name = "Absolution",
+	hidden = true,
+	color = 1,
+	baseEffectiveness = 0.92720001935959,
+	incrementalEffectiveness = 0.045299999415874,
+	description = "Damages enemies in an area, applying a debuff for a short duration. If a non-unique enemy dies while affected by the debuff, the enemy's corpse will be consumed to summon a Sentinel of Absolution for a longer secondary duration, or to refresh the duration and life of an existing one instead if you have the maximum number of them.",
+	skillTypes = { [SkillType.Spell] = true, [SkillType.Minion] = true, [SkillType.Duration] = true, [SkillType.Physical] = true, [SkillType.Lightning] = true, [SkillType.MinionsCanExplode] = true, [SkillType.CreatesMinion] = true, [SkillType.Damage] = true, [SkillType.Area] = true, [SkillType.Multicastable] = true, [SkillType.Cascadable] = true, [SkillType.Triggerable] = true, [SkillType.Totemable] = true, [SkillType.Trappable] = true, [SkillType.Mineable] = true, [SkillType.CanRapidFire] = true, },
+	statDescriptionScope = "minion_spell_damage_skill_stat_descriptions",
+	castTime = 1.5,
+	baseFlags = {
+		area = true,
+		spell = true,
+		duration = true,
+	},
+	constantStats = {
+		{ "active_skill_area_of_effect_radius_+%_final", -35 },
+	},
+	stats = {
+		"spell_minimum_base_physical_damage",
+		"spell_maximum_base_physical_damage",
+		"is_area_damage",
+	},
+	levels = {
+		[1] = { 0.80000001192093, 1.2000000476837, damageEffectiveness = 1.8, critChance = 6, levelRequirement = 0, statInterpolation = { 3, 3, }, },
+	},
+}
+skills["AbsolutionMinionVaalCascade"] = {
+	name = "Absolution Cascade",
+	hidden = true,
+	color = 1,
+	baseEffectiveness = 1.4026999473572,
+	incrementalEffectiveness = 0.045299999415874,
+	description = "Damages enemies in an area, applying a debuff for a short duration. If a non-unique enemy dies while affected by the debuff, the enemy's corpse will be consumed to summon a Sentinel of Absolution for a longer secondary duration, or to refresh the duration and life of an existing one instead if you have the maximum number of them.",
+	skillTypes = { [SkillType.Spell] = true, [SkillType.Minion] = true, [SkillType.Duration] = true, [SkillType.Physical] = true, [SkillType.Lightning] = true, [SkillType.MinionsCanExplode] = true, [SkillType.CreatesMinion] = true, [SkillType.Damage] = true, [SkillType.Area] = true, [SkillType.Multicastable] = true, [SkillType.Cascadable] = true, [SkillType.Triggerable] = true, [SkillType.Totemable] = true, [SkillType.Trappable] = true, [SkillType.Mineable] = true, [SkillType.CanRapidFire] = true, },
+	statDescriptionScope = "minion_spell_damage_skill_stat_descriptions",
+	castTime = 1.5,
+	baseFlags = {
+		area = true,
+		spell = true,
+		duration = true,
+	},
+	constantStats = {
+		{ "support_spell_cascade_number_of_cascades_per_side", 1 },
+		{ "active_skill_area_of_effect_radius_+%_final", -25 },
+	},
+	stats = {
+		"spell_minimum_base_physical_damage",
+		"spell_maximum_base_physical_damage",
+		"support_spell_cascade_sideways",
+		"is_area_damage",
+	},
+	levels = {
+		[1] = { 0.80000001192093, 1.2000000476837, damageEffectiveness = 2.4, critChance = 6, levelRequirement = 0, statInterpolation = { 3, 3, }, },
+	},
+}
+skills["VaalAbsolutionDelayedBlast"] = {
+	name = "AoE Blast",
+	hidden = true,
+	color = 4,
+	baseEffectiveness = 3.1199998855591,
+	incrementalEffectiveness = 0.045299999415874,
+	skillTypes = { [SkillType.Spell] = true, [SkillType.Damage] = true, [SkillType.Area] = true, [SkillType.Triggerable] = true, [SkillType.AreaSpell] = true, },
+	statDescriptionScope = "skill_stat_descriptions",
+	castTime = 1.33,
+	baseFlags = {
+		area = true,
+		spell = true,
+	},
+	constantStats = {
+		{ "active_skill_area_of_effect_+%_final", 300 },
+	},
+	stats = {
+		"spell_minimum_base_physical_damage",
+		"spell_maximum_base_physical_damage",
+		"is_area_damage",
+	},
+	levels = {
+		[1] = { 0.80000001192093, 1.2000000476837, critChance = 6, cooldown = 6, damageEffectiveness = 3.2, storedUses = 1, levelRequirement = 0, statInterpolation = { 3, 3, }, },
 	},
 }
 skills["SummonedRhoaShieldCharge"] = {

--- a/src/Export/Minions/Minions.txt
+++ b/src/Export/Minions/Minions.txt
@@ -95,7 +95,17 @@ local minions, mod = ...
 #monster Metadata/Monsters/Axis/AxisEliteSoldierDominatingBlow AxisEliteSoldierDominatingBlow
 #emit
 
+#monster Metadata/Monsters/Axis/AxisEliteSoldierDominatingBlowVaal AxisEliteSoldierDominatingBlowVaal
+#mod mod("Damage", "MORE", 200)
+#mod mod("DamageTaken", "MORE", -70)
+#emit
+
 #monster Metadata/Monsters/TemplarJudge/AbsolutionTemplarJudge AbsolutionTemplarJudge
+#emit
+
+#monster Metadata/Monsters/TemplarJudge/AbsolutionTemplarJudgeVaal AbsolutionTemplarJudgeVaal
+#mod mod("Damage", "MORE", 200)
+#mod mod("DamageTaken", "MORE", -70)
 #emit
 
 #monster Metadata/Monsters/Rhoas/RhoaUniqueSummoned RhoaUniqueSummoned

--- a/src/Export/Skills/act_str.txt
+++ b/src/Export/Skills/act_str.txt
@@ -9,6 +9,7 @@ local skills, mod, flag, skill = ...
 #flags spell minion duration area
 	minionList = {
 		"AbsolutionTemplarJudge",
+		"AbsolutionTemplarJudgeVaal",
 	},
 	statMap = {
 		["sentinel_minion_cooldown_speed_+%"] = {
@@ -27,6 +28,14 @@ local skills, mod, flag, skill = ...
 
 #skill VaalAbsolution
 #flags spell minion duration area
+	statMap = {
+		["vaal_upgrade_minion_damage_+%_final"] = {
+		-- Stat is handled directly on minion
+		},
+		["vaal_upgrade_minion_damage_taken_+%_final"] = {
+		-- Stat is handled directly on minion
+		},
+	},
 #mods
 
 #skill AbyssalCry
@@ -470,6 +479,7 @@ local skills, mod, flag, skill = ...
 #flags attack melee duration minion
 	minionList = {
 		"AxisEliteSoldierDominatingBlow",
+		"AxisEliteSoldierDominatingBlowVaal",
 	},
 	statMap = {
 		["sentinel_minion_cooldown_speed_+%"] = {
@@ -483,6 +493,14 @@ local skills, mod, flag, skill = ...
 
 #skill VaalDomination
 #flags attack melee duration minion
+	statMap = {
+		["vaal_upgrade_minion_damage_+%_final"] = {
+		-- Stat is handled directly on minion
+		},
+		["vaal_upgrade_minion_damage_taken_+%_final"] = {
+		-- Stat is handled directly on minion
+		},
+	},
 #mods
 
 #skill PuresteelBanner

--- a/src/Export/Skills/minion.txt
+++ b/src/Export/Skills/minion.txt
@@ -141,12 +141,36 @@ local skills, mod, flag, skill = ...
 #flags attack melee
 #mods
 
+#skill VaalDominationMelee Default Attack
+#flags attack melee projectile
+#mods
+
+#skill VaalDominationSunder Sunder
+#flags attack melee area
+#mods
+
+#skill GAVaalDominationLargeSlam AoE Slam
+#flags attack  area
+#mods
+
 #skill AbsolutionMinion
 #flags area spell duration
 #mods
 
-#skill AbsolutionMinionEmpowered
+#skill AbsolutionMinionEmpowered Empowered Absolution
 #flags area spell duration
+#mods
+
+#skill AbsolutionMinionVaal
+#flags area spell duration
+#mods
+
+#skill AbsolutionMinionVaalCascade Absolution Cascade
+#flags area spell duration
+#mods
+
+#skill VaalAbsolutionDelayedBlast AoE Blast
+#flags area spell
 #mods
 
 #skill SummonedRhoaShieldCharge


### PR DESCRIPTION
The minions needed to be added to the base skill instead of the Vaal version for supports to work on them