### PR TITLE
Fix export of tags for Sceptres and Fishing Rods

### DIFF
--- a/src/Data/Bases/dagger.lua
+++ b/src/Data/Bases/dagger.lua
@@ -5,7 +5,7 @@ local itemBases = ...
 itemBases["Glass Shank"] = {
 	type = "Dagger",
 	socketLimit = 3,
-	tags = { onehand = true, one_hand_weapon = true, dagger = true, weapon = true, attack_dagger = true, default = true, },
+	tags = { onehand = true, one_hand_weapon = true, attack_dagger = true, weapon = true, dagger = true, default = true, },
 	influenceTags = { shaper = "dagger_shaper", elder = "dagger_elder", adjudicator = "dagger_adjudicator", basilisk = "dagger_basilisk", crusader = "dagger_crusader", eyrie = "dagger_eyrie", cleansing = "dagger_cleansing", tangle = "dagger_tangle" },
 	implicit = "30% increased Global Critical Strike Chance",
 	implicitModTypes = { { "critical" }, },
@@ -15,7 +15,7 @@ itemBases["Glass Shank"] = {
 itemBases["Skinning Knife"] = {
 	type = "Dagger",
 	socketLimit = 3,
-	tags = { onehand = true, one_hand_weapon = true, dagger = true, weapon = true, attack_dagger = true, default = true, },
+	tags = { onehand = true, one_hand_weapon = true, attack_dagger = true, weapon = true, dagger = true, default = true, },
 	influenceTags = { shaper = "dagger_shaper", elder = "dagger_elder", adjudicator = "dagger_adjudicator", basilisk = "dagger_basilisk", crusader = "dagger_crusader", eyrie = "dagger_eyrie", cleansing = "dagger_cleansing", tangle = "dagger_tangle" },
 	implicit = "30% increased Global Critical Strike Chance",
 	implicitModTypes = { { "critical" }, },
@@ -25,7 +25,7 @@ itemBases["Skinning Knife"] = {
 itemBases["Stiletto"] = {
 	type = "Dagger",
 	socketLimit = 3,
-	tags = { onehand = true, one_hand_weapon = true, dagger = true, weapon = true, attack_dagger = true, default = true, },
+	tags = { onehand = true, one_hand_weapon = true, attack_dagger = true, weapon = true, dagger = true, default = true, },
 	influenceTags = { shaper = "dagger_shaper", elder = "dagger_elder", adjudicator = "dagger_adjudicator", basilisk = "dagger_basilisk", crusader = "dagger_crusader", eyrie = "dagger_eyrie", cleansing = "dagger_cleansing", tangle = "dagger_tangle" },
 	implicit = "30% increased Global Critical Strike Chance",
 	implicitModTypes = { { "critical" }, },
@@ -35,7 +35,7 @@ itemBases["Stiletto"] = {
 itemBases["Prong Dagger"] = {
 	type = "Dagger",
 	socketLimit = 3,
-	tags = { maraketh = true, one_hand_weapon = true, onehand = true, not_for_sale = true, dagger = true, weapon = true, attack_dagger = true, default = true, },
+	tags = { maraketh = true, one_hand_weapon = true, onehand = true, not_for_sale = true, attack_dagger = true, weapon = true, dagger = true, default = true, },
 	influenceTags = { shaper = "dagger_shaper", elder = "dagger_elder", adjudicator = "dagger_adjudicator", basilisk = "dagger_basilisk", crusader = "dagger_crusader", eyrie = "dagger_eyrie", cleansing = "dagger_cleansing", tangle = "dagger_tangle" },
 	implicit = "4% Chance to Block Attack Damage",
 	implicitModTypes = { { "block" }, },
@@ -45,7 +45,7 @@ itemBases["Prong Dagger"] = {
 itemBases["Flaying Knife"] = {
 	type = "Dagger",
 	socketLimit = 3,
-	tags = { onehand = true, one_hand_weapon = true, dagger = true, weapon = true, attack_dagger = true, default = true, },
+	tags = { onehand = true, one_hand_weapon = true, attack_dagger = true, weapon = true, dagger = true, default = true, },
 	influenceTags = { shaper = "dagger_shaper", elder = "dagger_elder", adjudicator = "dagger_adjudicator", basilisk = "dagger_basilisk", crusader = "dagger_crusader", eyrie = "dagger_eyrie", cleansing = "dagger_cleansing", tangle = "dagger_tangle" },
 	implicit = "30% increased Global Critical Strike Chance",
 	implicitModTypes = { { "critical" }, },
@@ -55,7 +55,7 @@ itemBases["Flaying Knife"] = {
 itemBases["Poignard"] = {
 	type = "Dagger",
 	socketLimit = 3,
-	tags = { onehand = true, one_hand_weapon = true, dagger = true, weapon = true, attack_dagger = true, default = true, },
+	tags = { onehand = true, one_hand_weapon = true, attack_dagger = true, weapon = true, dagger = true, default = true, },
 	influenceTags = { shaper = "dagger_shaper", elder = "dagger_elder", adjudicator = "dagger_adjudicator", basilisk = "dagger_basilisk", crusader = "dagger_crusader", eyrie = "dagger_eyrie", cleansing = "dagger_cleansing", tangle = "dagger_tangle" },
 	implicit = "30% increased Global Critical Strike Chance",
 	implicitModTypes = { { "critical" }, },
@@ -65,7 +65,7 @@ itemBases["Poignard"] = {
 itemBases["Trisula"] = {
 	type = "Dagger",
 	socketLimit = 3,
-	tags = { maraketh = true, one_hand_weapon = true, onehand = true, not_for_sale = true, dagger = true, weapon = true, attack_dagger = true, default = true, },
+	tags = { maraketh = true, one_hand_weapon = true, onehand = true, not_for_sale = true, attack_dagger = true, weapon = true, dagger = true, default = true, },
 	influenceTags = { shaper = "dagger_shaper", elder = "dagger_elder", adjudicator = "dagger_adjudicator", basilisk = "dagger_basilisk", crusader = "dagger_crusader", eyrie = "dagger_eyrie", cleansing = "dagger_cleansing", tangle = "dagger_tangle" },
 	implicit = "4% Chance to Block Attack Damage",
 	implicitModTypes = { { "block" }, },
@@ -75,7 +75,7 @@ itemBases["Trisula"] = {
 itemBases["Gutting Knife"] = {
 	type = "Dagger",
 	socketLimit = 3,
-	tags = { onehand = true, one_hand_weapon = true, dagger = true, weapon = true, attack_dagger = true, default = true, },
+	tags = { onehand = true, one_hand_weapon = true, attack_dagger = true, weapon = true, dagger = true, default = true, },
 	influenceTags = { shaper = "dagger_shaper", elder = "dagger_elder", adjudicator = "dagger_adjudicator", basilisk = "dagger_basilisk", crusader = "dagger_crusader", eyrie = "dagger_eyrie", cleansing = "dagger_cleansing", tangle = "dagger_tangle" },
 	implicit = "30% increased Global Critical Strike Chance",
 	implicitModTypes = { { "critical" }, },
@@ -85,7 +85,7 @@ itemBases["Gutting Knife"] = {
 itemBases["Ambusher"] = {
 	type = "Dagger",
 	socketLimit = 3,
-	tags = { onehand = true, one_hand_weapon = true, dagger = true, weapon = true, attack_dagger = true, default = true, },
+	tags = { onehand = true, one_hand_weapon = true, attack_dagger = true, weapon = true, dagger = true, default = true, },
 	influenceTags = { shaper = "dagger_shaper", elder = "dagger_elder", adjudicator = "dagger_adjudicator", basilisk = "dagger_basilisk", crusader = "dagger_crusader", eyrie = "dagger_eyrie", cleansing = "dagger_cleansing", tangle = "dagger_tangle" },
 	implicit = "30% increased Global Critical Strike Chance",
 	implicitModTypes = { { "critical" }, },
@@ -95,7 +95,7 @@ itemBases["Ambusher"] = {
 itemBases["Sai"] = {
 	type = "Dagger",
 	socketLimit = 3,
-	tags = { maraketh = true, one_hand_weapon = true, onehand = true, not_for_sale = true, dagger = true, weapon = true, attack_dagger = true, default = true, },
+	tags = { maraketh = true, one_hand_weapon = true, onehand = true, not_for_sale = true, attack_dagger = true, weapon = true, dagger = true, default = true, },
 	influenceTags = { shaper = "dagger_shaper", elder = "dagger_elder", adjudicator = "dagger_adjudicator", basilisk = "dagger_basilisk", crusader = "dagger_crusader", eyrie = "dagger_eyrie", cleansing = "dagger_cleansing", tangle = "dagger_tangle" },
 	implicit = "6% Chance to Block Attack Damage",
 	implicitModTypes = { { "block" }, },
@@ -105,7 +105,7 @@ itemBases["Sai"] = {
 itemBases["Hollowpoint Dagger"] = {
 	type = "Dagger",
 	socketLimit = 3,
-	tags = { weapon = true, one_hand_weapon = true, onehand = true, not_for_sale = true, dagger = true, experimental_base = true, attack_dagger = true, default = true, },
+	tags = { weapon = true, one_hand_weapon = true, onehand = true, not_for_sale = true, attack_dagger = true, experimental_base = true, dagger = true, default = true, },
 	influenceTags = { shaper = "dagger_shaper", elder = "dagger_elder", adjudicator = "dagger_adjudicator", basilisk = "dagger_basilisk", crusader = "dagger_crusader", eyrie = "dagger_eyrie", cleansing = "dagger_cleansing", tangle = "dagger_tangle" },
 	implicit = "All Damage from Hits with This Weapon can Poison",
 	implicitModTypes = { {  }, },
@@ -115,7 +115,7 @@ itemBases["Hollowpoint Dagger"] = {
 itemBases["Pressurised Dagger"] = {
 	type = "Dagger",
 	socketLimit = 3,
-	tags = { weapon = true, one_hand_weapon = true, onehand = true, not_for_sale = true, dagger = true, experimental_base = true, attack_dagger = true, default = true, },
+	tags = { weapon = true, one_hand_weapon = true, onehand = true, not_for_sale = true, attack_dagger = true, experimental_base = true, dagger = true, default = true, },
 	influenceTags = { shaper = "dagger_shaper", elder = "dagger_elder", adjudicator = "dagger_adjudicator", basilisk = "dagger_basilisk", crusader = "dagger_crusader", eyrie = "dagger_eyrie", cleansing = "dagger_cleansing", tangle = "dagger_tangle" },
 	implicit = "All Damage from Hits with This Weapon can Poison",
 	implicitModTypes = { {  }, },
@@ -125,7 +125,7 @@ itemBases["Pressurised Dagger"] = {
 itemBases["Pneumatic Dagger"] = {
 	type = "Dagger",
 	socketLimit = 3,
-	tags = { weapon = true, one_hand_weapon = true, onehand = true, not_for_sale = true, dagger = true, experimental_base = true, attack_dagger = true, default = true, },
+	tags = { weapon = true, one_hand_weapon = true, onehand = true, not_for_sale = true, attack_dagger = true, experimental_base = true, dagger = true, default = true, },
 	influenceTags = { shaper = "dagger_shaper", elder = "dagger_elder", adjudicator = "dagger_adjudicator", basilisk = "dagger_basilisk", crusader = "dagger_crusader", eyrie = "dagger_eyrie", cleansing = "dagger_cleansing", tangle = "dagger_tangle" },
 	implicit = "All Damage from Hits with This Weapon can Poison",
 	implicitModTypes = { {  }, },
@@ -136,7 +136,7 @@ itemBases["Ethereal Blade"] = {
 	type = "Dagger",
 	hidden = true,
 	socketLimit = 3,
-	tags = { one_hand_weapon = true, onehand = true, not_for_sale = true, dagger = true, weapon = true, attack_dagger = true, default = true, },
+	tags = { one_hand_weapon = true, onehand = true, not_for_sale = true, attack_dagger = true, weapon = true, dagger = true, default = true, },
 	influenceTags = { shaper = "dagger_shaper", elder = "dagger_elder", adjudicator = "dagger_adjudicator", basilisk = "dagger_basilisk", crusader = "dagger_crusader", eyrie = "dagger_eyrie", cleansing = "dagger_cleansing", tangle = "dagger_tangle" },
 	implicitModTypes = { },
 	weapon = { PhysicalMin = 4, PhysicalMax = 8, CritChanceBase = 6, AttackRateBase = 1.5, Range = 10, },

--- a/src/Data/Bases/fishing.lua
+++ b/src/Data/Bases/fishing.lua
@@ -5,7 +5,7 @@ local itemBases = ...
 itemBases["Fishing Rod"] = {
 	type = "Fishing Rod",
 	socketLimit = 4,
-	tags = { two_hand_weapon = true, not_for_sale = true, weapon = true, twohand = true, fishing_rod = true, default = true, },
+	tags = { not_for_sale = true, fishing_rod = true, twohand = true, default = true, },
 	implicitModTypes = { },
 	weapon = { PhysicalMin = 8, PhysicalMax = 15, CritChanceBase = 5, AttackRateBase = 1.2, Range = 13, },
 	req = { str = 8, dex = 8, },

--- a/src/Data/Bases/mace.lua
+++ b/src/Data/Bases/mace.lua
@@ -286,7 +286,7 @@ itemBases["Boom Mace"] = {
 itemBases["Driftwood Sceptre"] = {
 	type = "Sceptre",
 	socketLimit = 3,
-	tags = { onehand = true, sceptre = true, mace = true, weapon = true, one_hand_weapon = true, default = true, },
+	tags = { onehand = true, sceptre = true, weapon = true, one_hand_weapon = true, default = true, },
 	influenceTags = { shaper = "sceptre_shaper", elder = "sceptre_elder", adjudicator = "sceptre_adjudicator", basilisk = "sceptre_basilisk", crusader = "sceptre_crusader", eyrie = "sceptre_eyrie", cleansing = "sceptre_cleansing", tangle = "sceptre_tangle" },
 	implicit = "10% increased Elemental Damage",
 	implicitModTypes = { { "elemental_damage", "damage", "elemental" }, },
@@ -296,7 +296,7 @@ itemBases["Driftwood Sceptre"] = {
 itemBases["Darkwood Sceptre"] = {
 	type = "Sceptre",
 	socketLimit = 3,
-	tags = { onehand = true, sceptre = true, mace = true, weapon = true, one_hand_weapon = true, default = true, },
+	tags = { onehand = true, sceptre = true, weapon = true, one_hand_weapon = true, default = true, },
 	influenceTags = { shaper = "sceptre_shaper", elder = "sceptre_elder", adjudicator = "sceptre_adjudicator", basilisk = "sceptre_basilisk", crusader = "sceptre_crusader", eyrie = "sceptre_eyrie", cleansing = "sceptre_cleansing", tangle = "sceptre_tangle" },
 	implicit = "12% increased Elemental Damage",
 	implicitModTypes = { { "elemental_damage", "damage", "elemental" }, },
@@ -306,7 +306,7 @@ itemBases["Darkwood Sceptre"] = {
 itemBases["Bronze Sceptre"] = {
 	type = "Sceptre",
 	socketLimit = 3,
-	tags = { onehand = true, sceptre = true, mace = true, weapon = true, one_hand_weapon = true, default = true, },
+	tags = { onehand = true, sceptre = true, weapon = true, one_hand_weapon = true, default = true, },
 	influenceTags = { shaper = "sceptre_shaper", elder = "sceptre_elder", adjudicator = "sceptre_adjudicator", basilisk = "sceptre_basilisk", crusader = "sceptre_crusader", eyrie = "sceptre_eyrie", cleansing = "sceptre_cleansing", tangle = "sceptre_tangle" },
 	implicit = "12% increased Elemental Damage",
 	implicitModTypes = { { "elemental_damage", "damage", "elemental" }, },
@@ -316,7 +316,7 @@ itemBases["Bronze Sceptre"] = {
 itemBases["Quartz Sceptre"] = {
 	type = "Sceptre",
 	socketLimit = 3,
-	tags = { onehand = true, sceptre = true, mace = true, weapon = true, one_hand_weapon = true, default = true, },
+	tags = { onehand = true, sceptre = true, weapon = true, one_hand_weapon = true, default = true, },
 	influenceTags = { shaper = "sceptre_shaper", elder = "sceptre_elder", adjudicator = "sceptre_adjudicator", basilisk = "sceptre_basilisk", crusader = "sceptre_crusader", eyrie = "sceptre_eyrie", cleansing = "sceptre_cleansing", tangle = "sceptre_tangle" },
 	implicit = "20% increased Elemental Damage",
 	implicitModTypes = { { "elemental_damage", "damage", "elemental" }, },
@@ -326,7 +326,7 @@ itemBases["Quartz Sceptre"] = {
 itemBases["Iron Sceptre"] = {
 	type = "Sceptre",
 	socketLimit = 3,
-	tags = { onehand = true, sceptre = true, mace = true, weapon = true, one_hand_weapon = true, default = true, },
+	tags = { onehand = true, sceptre = true, weapon = true, one_hand_weapon = true, default = true, },
 	influenceTags = { shaper = "sceptre_shaper", elder = "sceptre_elder", adjudicator = "sceptre_adjudicator", basilisk = "sceptre_basilisk", crusader = "sceptre_crusader", eyrie = "sceptre_eyrie", cleansing = "sceptre_cleansing", tangle = "sceptre_tangle" },
 	implicit = "14% increased Elemental Damage",
 	implicitModTypes = { { "elemental_damage", "damage", "elemental" }, },
@@ -336,7 +336,7 @@ itemBases["Iron Sceptre"] = {
 itemBases["Ochre Sceptre"] = {
 	type = "Sceptre",
 	socketLimit = 3,
-	tags = { onehand = true, sceptre = true, mace = true, weapon = true, one_hand_weapon = true, default = true, },
+	tags = { onehand = true, sceptre = true, weapon = true, one_hand_weapon = true, default = true, },
 	influenceTags = { shaper = "sceptre_shaper", elder = "sceptre_elder", adjudicator = "sceptre_adjudicator", basilisk = "sceptre_basilisk", crusader = "sceptre_crusader", eyrie = "sceptre_eyrie", cleansing = "sceptre_cleansing", tangle = "sceptre_tangle" },
 	implicit = "16% increased Elemental Damage",
 	implicitModTypes = { { "elemental_damage", "damage", "elemental" }, },
@@ -346,7 +346,7 @@ itemBases["Ochre Sceptre"] = {
 itemBases["Ritual Sceptre"] = {
 	type = "Sceptre",
 	socketLimit = 3,
-	tags = { onehand = true, sceptre = true, mace = true, weapon = true, one_hand_weapon = true, default = true, },
+	tags = { onehand = true, sceptre = true, weapon = true, one_hand_weapon = true, default = true, },
 	influenceTags = { shaper = "sceptre_shaper", elder = "sceptre_elder", adjudicator = "sceptre_adjudicator", basilisk = "sceptre_basilisk", crusader = "sceptre_crusader", eyrie = "sceptre_eyrie", cleansing = "sceptre_cleansing", tangle = "sceptre_tangle" },
 	implicit = "16% increased Elemental Damage",
 	implicitModTypes = { { "elemental_damage", "damage", "elemental" }, },
@@ -356,7 +356,7 @@ itemBases["Ritual Sceptre"] = {
 itemBases["Shadow Sceptre"] = {
 	type = "Sceptre",
 	socketLimit = 3,
-	tags = { onehand = true, sceptre = true, mace = true, weapon = true, one_hand_weapon = true, default = true, },
+	tags = { onehand = true, sceptre = true, weapon = true, one_hand_weapon = true, default = true, },
 	influenceTags = { shaper = "sceptre_shaper", elder = "sceptre_elder", adjudicator = "sceptre_adjudicator", basilisk = "sceptre_basilisk", crusader = "sceptre_crusader", eyrie = "sceptre_eyrie", cleansing = "sceptre_cleansing", tangle = "sceptre_tangle" },
 	implicit = "22% increased Elemental Damage",
 	implicitModTypes = { { "elemental_damage", "damage", "elemental" }, },
@@ -366,7 +366,7 @@ itemBases["Shadow Sceptre"] = {
 itemBases["Horned Sceptre"] = {
 	type = "Sceptre",
 	socketLimit = 3,
-	tags = { maraketh = true, not_for_sale = true, onehand = true, sceptre = true, mace = true, weapon = true, one_hand_weapon = true, default = true, },
+	tags = { maraketh = true, onehand = true, sceptre = true, not_for_sale = true, weapon = true, one_hand_weapon = true, default = true, },
 	influenceTags = { shaper = "sceptre_shaper", elder = "sceptre_elder", adjudicator = "sceptre_adjudicator", basilisk = "sceptre_basilisk", crusader = "sceptre_crusader", eyrie = "sceptre_eyrie", cleansing = "sceptre_cleansing", tangle = "sceptre_tangle" },
 	implicit = "Damage Penetrates 4% Elemental Resistances",
 	implicitModTypes = { { "elemental_damage", "damage", "elemental" }, },
@@ -376,7 +376,7 @@ itemBases["Horned Sceptre"] = {
 itemBases["Grinning Fetish"] = {
 	type = "Sceptre",
 	socketLimit = 3,
-	tags = { onehand = true, sceptre = true, mace = true, weapon = true, one_hand_weapon = true, default = true, },
+	tags = { onehand = true, sceptre = true, weapon = true, one_hand_weapon = true, default = true, },
 	influenceTags = { shaper = "sceptre_shaper", elder = "sceptre_elder", adjudicator = "sceptre_adjudicator", basilisk = "sceptre_basilisk", crusader = "sceptre_crusader", eyrie = "sceptre_eyrie", cleansing = "sceptre_cleansing", tangle = "sceptre_tangle" },
 	implicit = "18% increased Elemental Damage",
 	implicitModTypes = { { "elemental_damage", "damage", "elemental" }, },
@@ -386,7 +386,7 @@ itemBases["Grinning Fetish"] = {
 itemBases["Sekhem"] = {
 	type = "Sceptre",
 	socketLimit = 3,
-	tags = { onehand = true, sceptre = true, mace = true, weapon = true, one_hand_weapon = true, default = true, },
+	tags = { onehand = true, sceptre = true, weapon = true, one_hand_weapon = true, default = true, },
 	influenceTags = { shaper = "sceptre_shaper", elder = "sceptre_elder", adjudicator = "sceptre_adjudicator", basilisk = "sceptre_basilisk", crusader = "sceptre_crusader", eyrie = "sceptre_eyrie", cleansing = "sceptre_cleansing", tangle = "sceptre_tangle" },
 	implicit = "18% increased Elemental Damage",
 	implicitModTypes = { { "elemental_damage", "damage", "elemental" }, },
@@ -396,7 +396,7 @@ itemBases["Sekhem"] = {
 itemBases["Crystal Sceptre"] = {
 	type = "Sceptre",
 	socketLimit = 3,
-	tags = { onehand = true, sceptre = true, mace = true, weapon = true, one_hand_weapon = true, default = true, },
+	tags = { onehand = true, sceptre = true, weapon = true, one_hand_weapon = true, default = true, },
 	influenceTags = { shaper = "sceptre_shaper", elder = "sceptre_elder", adjudicator = "sceptre_adjudicator", basilisk = "sceptre_basilisk", crusader = "sceptre_crusader", eyrie = "sceptre_eyrie", cleansing = "sceptre_cleansing", tangle = "sceptre_tangle" },
 	implicit = "30% increased Elemental Damage",
 	implicitModTypes = { { "elemental_damage", "damage", "elemental" }, },
@@ -406,7 +406,7 @@ itemBases["Crystal Sceptre"] = {
 itemBases["Lead Sceptre"] = {
 	type = "Sceptre",
 	socketLimit = 3,
-	tags = { onehand = true, sceptre = true, mace = true, weapon = true, one_hand_weapon = true, default = true, },
+	tags = { onehand = true, sceptre = true, weapon = true, one_hand_weapon = true, default = true, },
 	influenceTags = { shaper = "sceptre_shaper", elder = "sceptre_elder", adjudicator = "sceptre_adjudicator", basilisk = "sceptre_basilisk", crusader = "sceptre_crusader", eyrie = "sceptre_eyrie", cleansing = "sceptre_cleansing", tangle = "sceptre_tangle" },
 	implicit = "22% increased Elemental Damage",
 	implicitModTypes = { { "elemental_damage", "damage", "elemental" }, },
@@ -416,7 +416,7 @@ itemBases["Lead Sceptre"] = {
 itemBases["Blood Sceptre"] = {
 	type = "Sceptre",
 	socketLimit = 3,
-	tags = { onehand = true, sceptre = true, mace = true, weapon = true, one_hand_weapon = true, default = true, },
+	tags = { onehand = true, sceptre = true, weapon = true, one_hand_weapon = true, default = true, },
 	influenceTags = { shaper = "sceptre_shaper", elder = "sceptre_elder", adjudicator = "sceptre_adjudicator", basilisk = "sceptre_basilisk", crusader = "sceptre_crusader", eyrie = "sceptre_eyrie", cleansing = "sceptre_cleansing", tangle = "sceptre_tangle" },
 	implicit = "24% increased Elemental Damage",
 	implicitModTypes = { { "elemental_damage", "damage", "elemental" }, },
@@ -426,7 +426,7 @@ itemBases["Blood Sceptre"] = {
 itemBases["Royal Sceptre"] = {
 	type = "Sceptre",
 	socketLimit = 3,
-	tags = { onehand = true, sceptre = true, mace = true, weapon = true, one_hand_weapon = true, default = true, },
+	tags = { onehand = true, sceptre = true, weapon = true, one_hand_weapon = true, default = true, },
 	influenceTags = { shaper = "sceptre_shaper", elder = "sceptre_elder", adjudicator = "sceptre_adjudicator", basilisk = "sceptre_basilisk", crusader = "sceptre_crusader", eyrie = "sceptre_eyrie", cleansing = "sceptre_cleansing", tangle = "sceptre_tangle" },
 	implicit = "24% increased Elemental Damage",
 	implicitModTypes = { { "elemental_damage", "damage", "elemental" }, },
@@ -436,7 +436,7 @@ itemBases["Royal Sceptre"] = {
 itemBases["Abyssal Sceptre"] = {
 	type = "Sceptre",
 	socketLimit = 3,
-	tags = { onehand = true, sceptre = true, mace = true, weapon = true, one_hand_weapon = true, default = true, },
+	tags = { onehand = true, sceptre = true, weapon = true, one_hand_weapon = true, default = true, },
 	influenceTags = { shaper = "sceptre_shaper", elder = "sceptre_elder", adjudicator = "sceptre_adjudicator", basilisk = "sceptre_basilisk", crusader = "sceptre_crusader", eyrie = "sceptre_eyrie", cleansing = "sceptre_cleansing", tangle = "sceptre_tangle" },
 	implicit = "30% increased Elemental Damage",
 	implicitModTypes = { { "elemental_damage", "damage", "elemental" }, },
@@ -446,7 +446,7 @@ itemBases["Abyssal Sceptre"] = {
 itemBases["Stag Sceptre"] = {
 	type = "Sceptre",
 	socketLimit = 3,
-	tags = { maraketh = true, not_for_sale = true, onehand = true, sceptre = true, mace = true, weapon = true, one_hand_weapon = true, default = true, },
+	tags = { maraketh = true, onehand = true, sceptre = true, not_for_sale = true, weapon = true, one_hand_weapon = true, default = true, },
 	influenceTags = { shaper = "sceptre_shaper", elder = "sceptre_elder", adjudicator = "sceptre_adjudicator", basilisk = "sceptre_basilisk", crusader = "sceptre_crusader", eyrie = "sceptre_eyrie", cleansing = "sceptre_cleansing", tangle = "sceptre_tangle" },
 	implicit = "Damage Penetrates 4% Elemental Resistances",
 	implicitModTypes = { { "elemental_damage", "damage", "elemental" }, },
@@ -456,7 +456,7 @@ itemBases["Stag Sceptre"] = {
 itemBases["Karui Sceptre"] = {
 	type = "Sceptre",
 	socketLimit = 3,
-	tags = { onehand = true, sceptre = true, mace = true, weapon = true, one_hand_weapon = true, default = true, },
+	tags = { onehand = true, sceptre = true, weapon = true, one_hand_weapon = true, default = true, },
 	influenceTags = { shaper = "sceptre_shaper", elder = "sceptre_elder", adjudicator = "sceptre_adjudicator", basilisk = "sceptre_basilisk", crusader = "sceptre_crusader", eyrie = "sceptre_eyrie", cleansing = "sceptre_cleansing", tangle = "sceptre_tangle" },
 	implicit = "26% increased Elemental Damage",
 	implicitModTypes = { { "elemental_damage", "damage", "elemental" }, },
@@ -466,7 +466,7 @@ itemBases["Karui Sceptre"] = {
 itemBases["Tyrant's Sekhem"] = {
 	type = "Sceptre",
 	socketLimit = 3,
-	tags = { onehand = true, sceptre = true, mace = true, weapon = true, one_hand_weapon = true, default = true, },
+	tags = { onehand = true, sceptre = true, weapon = true, one_hand_weapon = true, default = true, },
 	influenceTags = { shaper = "sceptre_shaper", elder = "sceptre_elder", adjudicator = "sceptre_adjudicator", basilisk = "sceptre_basilisk", crusader = "sceptre_crusader", eyrie = "sceptre_eyrie", cleansing = "sceptre_cleansing", tangle = "sceptre_tangle" },
 	implicit = "26% increased Elemental Damage",
 	implicitModTypes = { { "elemental_damage", "damage", "elemental" }, },
@@ -476,7 +476,7 @@ itemBases["Tyrant's Sekhem"] = {
 itemBases["Opal Sceptre"] = {
 	type = "Sceptre",
 	socketLimit = 3,
-	tags = { onehand = true, sceptre = true, mace = true, weapon = true, one_hand_weapon = true, default = true, },
+	tags = { onehand = true, sceptre = true, weapon = true, one_hand_weapon = true, default = true, },
 	influenceTags = { shaper = "sceptre_shaper", elder = "sceptre_elder", adjudicator = "sceptre_adjudicator", basilisk = "sceptre_basilisk", crusader = "sceptre_crusader", eyrie = "sceptre_eyrie", cleansing = "sceptre_cleansing", tangle = "sceptre_tangle" },
 	implicit = "40% increased Elemental Damage",
 	implicitModTypes = { { "elemental_damage", "damage", "elemental" }, },
@@ -486,7 +486,7 @@ itemBases["Opal Sceptre"] = {
 itemBases["Platinum Sceptre"] = {
 	type = "Sceptre",
 	socketLimit = 3,
-	tags = { top_tier_base_item_type = true, onehand = true, sceptre = true, mace = true, weapon = true, one_hand_weapon = true, default = true, },
+	tags = { onehand = true, sceptre = true, top_tier_base_item_type = true, weapon = true, one_hand_weapon = true, default = true, },
 	influenceTags = { shaper = "sceptre_shaper", elder = "sceptre_elder", adjudicator = "sceptre_adjudicator", basilisk = "sceptre_basilisk", crusader = "sceptre_crusader", eyrie = "sceptre_eyrie", cleansing = "sceptre_cleansing", tangle = "sceptre_tangle" },
 	implicit = "30% increased Elemental Damage",
 	implicitModTypes = { { "elemental_damage", "damage", "elemental" }, },
@@ -496,7 +496,7 @@ itemBases["Platinum Sceptre"] = {
 itemBases["Vaal Sceptre"] = {
 	type = "Sceptre",
 	socketLimit = 3,
-	tags = { top_tier_base_item_type = true, onehand = true, sceptre = true, mace = true, weapon = true, one_hand_weapon = true, default = true, },
+	tags = { onehand = true, sceptre = true, top_tier_base_item_type = true, weapon = true, one_hand_weapon = true, default = true, },
 	influenceTags = { shaper = "sceptre_shaper", elder = "sceptre_elder", adjudicator = "sceptre_adjudicator", basilisk = "sceptre_basilisk", crusader = "sceptre_crusader", eyrie = "sceptre_eyrie", cleansing = "sceptre_cleansing", tangle = "sceptre_tangle" },
 	implicit = "32% increased Elemental Damage",
 	implicitModTypes = { { "elemental_damage", "damage", "elemental" }, },
@@ -506,7 +506,7 @@ itemBases["Vaal Sceptre"] = {
 itemBases["Carnal Sceptre"] = {
 	type = "Sceptre",
 	socketLimit = 3,
-	tags = { top_tier_base_item_type = true, onehand = true, sceptre = true, mace = true, weapon = true, one_hand_weapon = true, default = true, },
+	tags = { onehand = true, sceptre = true, top_tier_base_item_type = true, weapon = true, one_hand_weapon = true, default = true, },
 	influenceTags = { shaper = "sceptre_shaper", elder = "sceptre_elder", adjudicator = "sceptre_adjudicator", basilisk = "sceptre_basilisk", crusader = "sceptre_crusader", eyrie = "sceptre_eyrie", cleansing = "sceptre_cleansing", tangle = "sceptre_tangle" },
 	implicit = "32% increased Elemental Damage",
 	implicitModTypes = { { "elemental_damage", "damage", "elemental" }, },
@@ -516,7 +516,7 @@ itemBases["Carnal Sceptre"] = {
 itemBases["Void Sceptre"] = {
 	type = "Sceptre",
 	socketLimit = 3,
-	tags = { top_tier_base_item_type = true, onehand = true, sceptre = true, mace = true, weapon = true, one_hand_weapon = true, default = true, },
+	tags = { onehand = true, sceptre = true, top_tier_base_item_type = true, weapon = true, one_hand_weapon = true, default = true, },
 	influenceTags = { shaper = "sceptre_shaper", elder = "sceptre_elder", adjudicator = "sceptre_adjudicator", basilisk = "sceptre_basilisk", crusader = "sceptre_crusader", eyrie = "sceptre_eyrie", cleansing = "sceptre_cleansing", tangle = "sceptre_tangle" },
 	implicit = "40% increased Elemental Damage",
 	implicitModTypes = { { "elemental_damage", "damage", "elemental" }, },
@@ -526,7 +526,7 @@ itemBases["Void Sceptre"] = {
 itemBases["Sambar Sceptre"] = {
 	type = "Sceptre",
 	socketLimit = 3,
-	tags = { maraketh = true, not_for_sale = true, onehand = true, sceptre = true, mace = true, weapon = true, one_hand_weapon = true, default = true, },
+	tags = { maraketh = true, onehand = true, sceptre = true, not_for_sale = true, weapon = true, one_hand_weapon = true, default = true, },
 	influenceTags = { shaper = "sceptre_shaper", elder = "sceptre_elder", adjudicator = "sceptre_adjudicator", basilisk = "sceptre_basilisk", crusader = "sceptre_crusader", eyrie = "sceptre_eyrie", cleansing = "sceptre_cleansing", tangle = "sceptre_tangle" },
 	implicit = "Damage Penetrates 6% Elemental Resistances",
 	implicitModTypes = { { "elemental_damage", "damage", "elemental" }, },
@@ -536,7 +536,7 @@ itemBases["Sambar Sceptre"] = {
 itemBases["Oscillating Sceptre"] = {
 	type = "Sceptre",
 	socketLimit = 3,
-	tags = { weapon = true, not_for_sale = true, onehand = true, sceptre = true, mace = true, experimental_base = true, one_hand_weapon = true, default = true, },
+	tags = { weapon = true, onehand = true, sceptre = true, not_for_sale = true, experimental_base = true, one_hand_weapon = true, default = true, },
 	influenceTags = { shaper = "sceptre_shaper", elder = "sceptre_elder", adjudicator = "sceptre_adjudicator", basilisk = "sceptre_basilisk", crusader = "sceptre_crusader", eyrie = "sceptre_eyrie", cleansing = "sceptre_cleansing", tangle = "sceptre_tangle" },
 	implicit = "Elemental Overload",
 	implicitModTypes = { { "elemental_damage", "damage", "elemental", "critical" }, },
@@ -546,7 +546,7 @@ itemBases["Oscillating Sceptre"] = {
 itemBases["Stabilising Sceptre"] = {
 	type = "Sceptre",
 	socketLimit = 3,
-	tags = { weapon = true, not_for_sale = true, onehand = true, sceptre = true, mace = true, experimental_base = true, one_hand_weapon = true, default = true, },
+	tags = { weapon = true, onehand = true, sceptre = true, not_for_sale = true, experimental_base = true, one_hand_weapon = true, default = true, },
 	influenceTags = { shaper = "sceptre_shaper", elder = "sceptre_elder", adjudicator = "sceptre_adjudicator", basilisk = "sceptre_basilisk", crusader = "sceptre_crusader", eyrie = "sceptre_eyrie", cleansing = "sceptre_cleansing", tangle = "sceptre_tangle" },
 	implicit = "Elemental Equilibrium",
 	implicitModTypes = { { "elemental_damage", "damage", "elemental" }, },
@@ -556,7 +556,7 @@ itemBases["Stabilising Sceptre"] = {
 itemBases["Alternating Sceptre"] = {
 	type = "Sceptre",
 	socketLimit = 3,
-	tags = { weapon = true, not_for_sale = true, onehand = true, sceptre = true, mace = true, experimental_base = true, one_hand_weapon = true, default = true, },
+	tags = { weapon = true, onehand = true, sceptre = true, not_for_sale = true, experimental_base = true, one_hand_weapon = true, default = true, },
 	influenceTags = { shaper = "sceptre_shaper", elder = "sceptre_elder", adjudicator = "sceptre_adjudicator", basilisk = "sceptre_basilisk", crusader = "sceptre_crusader", eyrie = "sceptre_eyrie", cleansing = "sceptre_cleansing", tangle = "sceptre_tangle" },
 	implicit = "Secrets of Suffering",
 	implicitModTypes = { {  }, },

--- a/src/Export/Bases/amulet.txt
+++ b/src/Export/Bases/amulet.txt
@@ -2,7 +2,6 @@
 local itemBases = ...
 
 #type Amulet
-#baseTags amulet
 #influenceBaseTag amulet
 
 #baseMatch Metadata/Items/Amulets/Amulet%d+

--- a/src/Export/Bases/axe.txt
+++ b/src/Export/Bases/axe.txt
@@ -2,13 +2,11 @@
 local itemBases = ...
 
 #type One Handed Axe
-#baseTags weapon onehand axe one_hand_weapon
 #influenceBaseTag axe
 #socketLimit 3
 #baseMatch Metadata/Items/Weapons/OneHandWeapons/OneHandAxes/OneHandAxe
 
 #type Two Handed Axe
-#baseTags weapon twohand axe two_hand_weapon
 #influenceBaseTag 2h_axe
 #socketLimit 6
 #baseMatch Metadata/Items/Weapons/TwoHandWeapons/TwoHandAxes/TwoHandAxe

--- a/src/Export/Bases/belt.txt
+++ b/src/Export/Bases/belt.txt
@@ -2,7 +2,6 @@
 local itemBases = ...
 
 #type Belt
-#baseTags belt
 #influenceBaseTag belt
 #baseMatch Metadata/Items/Belts/Belt%d+
 #forceShow true

--- a/src/Export/Bases/body.txt
+++ b/src/Export/Bases/body.txt
@@ -2,7 +2,6 @@
 local itemBases = ...
 
 #type Body Armour
-#baseTags armour body_armour
 #influenceBaseTag body_armour
 #socketLimit 6
 

--- a/src/Export/Bases/boots.txt
+++ b/src/Export/Bases/boots.txt
@@ -2,7 +2,6 @@
 local itemBases = ...
 
 #type Boots
-#baseTags armour boots
 #influenceBaseTag boots
 #socketLimit 4
 

--- a/src/Export/Bases/bow.txt
+++ b/src/Export/Bases/bow.txt
@@ -2,7 +2,6 @@
 local itemBases = ...
 
 #type Bow
-#baseTags weapon twohand bow ranged two_hand_weapon
 #influenceBaseTag bow
 #socketLimit 6
 #baseMatch Metadata/Items/Weapons/TwoHandWeapons/Bows/Bow

--- a/src/Export/Bases/claw.txt
+++ b/src/Export/Bases/claw.txt
@@ -2,7 +2,6 @@
 local itemBases = ...
 
 #type Claw
-#baseTags weapon onehand claw one_hand_weapon
 #influenceBaseTag claw
 #socketLimit 3
 #baseMatch Metadata/Items/Weapons/OneHandWeapons/Claws/Claw

--- a/src/Export/Bases/dagger.txt
+++ b/src/Export/Bases/dagger.txt
@@ -2,14 +2,12 @@
 local itemBases = ...
 
 #type Dagger
-#baseTags weapon onehand attack_dagger dagger one_hand_weapon
 #influenceBaseTag dagger
 #socketLimit 3
 #baseMatch BaseType Metadata/Items/Weapons/OneHandWeapons/Daggers/AbstractDagger
 
 #type Dagger
 #subType Rune
-#baseTags weapon onehand dagger one_hand_weapon
 #influenceBaseTag rune_dagger
 #socketLimit 3
 #baseMatch BaseType Metadata/Items/Weapons/OneHandWeapons/Daggers/AbstractRuneDagger

--- a/src/Export/Bases/fishing.txt
+++ b/src/Export/Bases/fishing.txt
@@ -2,7 +2,6 @@
 local itemBases = ...
 
 #type Fishing Rod
-#baseTags weapon twohand fishing_rod two_hand_weapon
 #socketLimit 4
 #forceShow true
 #baseMatch Metadata/Items/Weapons/TwoHandWeapon/FishingRods/FishingRod

--- a/src/Export/Bases/flask.txt
+++ b/src/Export/Bases/flask.txt
@@ -3,17 +3,13 @@ local itemBases = ...
 
 #type Flask
 #subType Life
-#baseTags flask life_flask
 #baseMatch Metadata/Items/Flasks/FlaskLife
 
 #subType Mana
-#baseTags flask mana_flask
 #baseMatch Metadata/Items/Flasks/FlaskMana
 
 #subType Hybrid
-#baseTags flask hybrid_flask
 #baseMatch Metadata/Items/Flasks/FlaskHybrid
 
 #subType Utility
-#baseTags flask utility_flask
 #baseMatch Metadata/Items/Flasks/FlaskUtility

--- a/src/Export/Bases/gloves.txt
+++ b/src/Export/Bases/gloves.txt
@@ -2,7 +2,6 @@
 local itemBases = ...
 
 #type Gloves
-#baseTags armour gloves
 #influenceBaseTag gloves
 #socketLimit 4
 

--- a/src/Export/Bases/helmet.txt
+++ b/src/Export/Bases/helmet.txt
@@ -2,7 +2,6 @@
 local itemBases = ...
 
 #type Helmet
-#baseTags armour helmet
 #influenceBaseTag helmet
 #socketLimit 4
 

--- a/src/Export/Bases/jewel.txt
+++ b/src/Export/Bases/jewel.txt
@@ -2,7 +2,6 @@
 local itemBases = ...
 
 #type Jewel
-#baseTags 
 #base Metadata/Items/Jewels/JewelStr
 #base Metadata/Items/Jewels/JewelDex
 #base Metadata/Items/Jewels/JewelInt

--- a/src/Export/Bases/mace.txt
+++ b/src/Export/Bases/mace.txt
@@ -2,7 +2,6 @@
 local itemBases = ...
 
 #type One Handed Mace
-#baseTags weapon onehand mace one_hand_weapon
 #influenceBaseTag mace
 #socketLimit 3
 #baseMatch Metadata/Items/Weapons/OneHandWeapons/OneHandMaces/OneHandMace
@@ -12,7 +11,6 @@ local itemBases = ...
 #baseMatch Metadata/Items/Weapons/OneHandWeapons/OneHandMaces/Sceptre
 
 #type Two Handed Mace
-#baseTags weapon twohand mace two_hand_weapon
 #influenceBaseTag 2h_mace
 #socketLimit 6
 #baseMatch Metadata/Items/Weapons/TwoHandWeapons/TwoHandMaces/TwoHandMace

--- a/src/Export/Bases/quiver.txt
+++ b/src/Export/Bases/quiver.txt
@@ -2,7 +2,6 @@
 local itemBases = ...
 
 #type Quiver
-#baseTags quiver
 #influenceBaseTag quiver
 #forceHide true
 #baseMatch Metadata/Items/Quivers/Quiver%d[0123]?$

--- a/src/Export/Bases/ring.txt
+++ b/src/Export/Bases/ring.txt
@@ -2,7 +2,6 @@
 local itemBases = ...
 
 #type Ring
-#baseTags ring
 #influenceBaseTag ring
 
 #baseMatch Metadata/Items/Rings/Ring%d+

--- a/src/Export/Bases/shield.txt
+++ b/src/Export/Bases/shield.txt
@@ -2,7 +2,6 @@
 local itemBases = ...
 
 #type Shield
-#baseTags armour shield
 #influenceBaseTag shield
 #socketLimit 3
 

--- a/src/Export/Bases/staff.txt
+++ b/src/Export/Bases/staff.txt
@@ -2,14 +2,12 @@
 local itemBases = ...
 
 #type Staff
-#baseTags weapon twohand staff two_hand_weapon
 #influenceBaseTag staff
 #socketLimit 6
 #baseMatch BaseType Metadata/Items/Weapons/TwoHandWeapons/Staves/AbstractStaff
 
 #type Staff
 #subType Warstaff
-#baseTags weapon twohand two_hand_weapon attack_staff staff
 #influenceBaseTag warstaff
 #socketLimit 6
 #baseMatch BaseType Metadata/Items/Weapons/TwoHandWeapons/Staves/AbstractWarstaff

--- a/src/Export/Bases/sword.txt
+++ b/src/Export/Bases/sword.txt
@@ -3,7 +3,6 @@ local itemBases = ...
 
 #type One Handed Sword
 #socketLimit 3
-#baseTags weapon onehand sword one_hand_weapon
 #influenceBaseTag sword
 
 #baseMatch Metadata/Items/Weapons/OneHandWeapons/OneHandSwords/OneHandSword
@@ -22,7 +21,6 @@ local itemBases = ...
 #type Two Handed Sword
 #subType
 #socketLimit 6
-#baseTags weapon twohand sword two_hand_weapon
 #influenceBaseTag 2h_sword
 #baseMatch Metadata/Items/Weapons/TwoHandWeapons/TwoHandSwords/TwoHandSword
 

--- a/src/Export/Bases/wand.txt
+++ b/src/Export/Bases/wand.txt
@@ -2,25 +2,21 @@
 local itemBases = ...
 
 #type Wand
-#baseTags weapon onehand wand ranged one_hand_weapon
 #influenceBaseTag wand
 #socketLimit 3
 #baseMatch Metadata/Items/Weapons/OneHandWeapons/Wands/Wand[ME]?%d+
 
 #type Wand
-#baseTags weapon onehand wand ranged one_hand_weapon weapon_can_roll_minion_modifiers
 #influenceBaseTag wand
 #socketLimit 3
 #base Metadata/Items/Weapons/OneHandWeapons/Wands/WandAtlas1
 
 #type Wand
-#baseTags weapon onehand wand ranged one_hand_weapon weapon_can_roll_minion_modifiers
 #influenceBaseTag wand
 #socketLimit 3
 #base Metadata/Items/Weapons/OneHandWeapons/Wands/WandMinion1
 
 #type Wand
-#baseTags weapon onehand wand ranged one_hand_weapon weapon_can_roll_minion_modifiers
 #influenceBaseTag wand
 #socketLimit 3
 #base Metadata/Items/Weapons/OneHandWeapons/Wands/WandMinion2

--- a/src/Export/Scripts/bases.lua
+++ b/src/Export/Scripts/bases.lua
@@ -13,13 +13,6 @@ directiveTable.subType = function(state, args, out)
 	state.subType = args
 end
 
-directiveTable.baseTags = function(state, args, out)
-	state.baseTags = { "default" }
-	for tag in args:gmatch("[%w_]+") do
-		table.insert(state.baseTags, tag)
-	end
-end
-
 directiveTable.influenceBaseTag = function(state, args, out)
 	state.influenceBaseTag = args
 end
@@ -63,6 +56,8 @@ directiveTable.base = function(state, args, out)
 						table.insert(tags, tag)
 					end
 				end
+			elseif line:match("remove_tag") then
+				table.remove(tags, isValueInTable(tags, line:match("remove_tag = \"(.+)\"")))
 			elseif line:match("tag") then
 				table.insert(tags, line:match("tag = \"(.+)\""))
 			end
@@ -89,9 +84,6 @@ directiveTable.base = function(state, args, out)
 	end
 	out:write('\ttags = { ')
 	local combinedTags = { }
-	for _, tag in ipairs(state.baseTags) do
-		combinedTags[tag] = tag
-	end
 	for _, tag in ipairs(baseItemTags) do
 		combinedTags[tag] = tag
 	end


### PR DESCRIPTION
We no longer need to specify the base tags for item bases as they are already correctly pulled from the files
Also adds support for the `remove_tag` option only found on fishing rods to fix them receiving weapon mods
Fixes #5451, #6184