### PR TITLE
Fix Suppression from dagger mastery not applying to ancestral vision

### DIFF
--- a/src/Modules/CalcDefence.lua
+++ b/src/Modules/CalcDefence.lua
@@ -1128,7 +1128,7 @@ function calcs.defence(env, actor)
 	if modDB:Flag(nil, "SpellSuppressionAppliesToAilmentAvoidance") then
 		local spellSuppressionToAilmentPercent = (modDB:Sum("BASE", nil, "SpellSuppressionAppliesToAilmentAvoidancePercent") or 0) / 100
 		-- Ancestral Vision
-		modDB:NewMod("AvoidElementalAilments", "BASE", spellSuppressionToAilmentPercent * totalSpellSuppressionChance, "Ancestral Vision")
+		modDB:NewMod("AvoidElementalAilments", "BASE", spellSuppressionToAilmentPercent * spellSuppressionChance, "Ancestral Vision")
 	end
 
 	for _, ailment in ipairs(data.nonElementalAilmentTypeList) do

--- a/src/Modules/CalcDefence.lua
+++ b/src/Modules/CalcDefence.lua
@@ -725,21 +725,25 @@ function calcs.defence(env, actor)
 	local weaponsCfg = {
 		flags = bit.bor(env.player.weaponData1 and env.player.weaponData1.type and ModFlag[env.player.weaponData1.type] or 0, env.player.weaponData2 and env.player.weaponData2.type and ModFlag[env.player.weaponData2.type] or 0)
 	}
-	local spellSuppressionChance =  modDB:Sum("BASE", weaponsCfg, "SpellSuppressionChance")
-	local totalSpellSuppressionChance = modDB:Override(weaponsCfg, "SpellSuppressionChance") or spellSuppressionChance
+	for _, value in ipairs(modDB:Tabulate("BASE",  weaponsCfg, "SpellSuppressionChance")) do
+		value.mod.flags = 0 -- Make mods that match weaponsCfg constant
+	end
+	local spellSuppressionChance =  modDB:Sum("BASE", nil, "SpellSuppressionChance")
 	
 	-- Dodge
 	-- Acrobatics Spell Suppression to Spell Dodge Chance conversion.
 	if modDB:Flag(nil, "ConvertSpellSuppressionToSpellDodge") then
 		modDB:NewMod("SpellDodgeChance", "BASE", spellSuppressionChance / 2, "Acrobatics")
 	end
+
+	local totalSpellSuppressionChance = modDB:Override(nil, "SpellSuppressionChance") or spellSuppressionChance
 	
 	output.SpellSuppressionChance = m_min(totalSpellSuppressionChance, data.misc.SuppressionChanceCap)
-	output.SpellSuppressionEffect = data.misc.SuppressionEffect + modDB:Sum("BASE", weaponsCfg, "SpellSuppressionEffect")
+	output.SpellSuppressionEffect = data.misc.SuppressionEffect + modDB:Sum("BASE", nil, "SpellSuppressionEffect")
 	
-	if env.mode_effective and modDB:Flag(weaponsCfg, "SpellSuppressionChanceIsUnlucky") then
+	if env.mode_effective and modDB:Flag(nil, "SpellSuppressionChanceIsUnlucky") then
 		output.SpellSuppressionChance = output.SpellSuppressionChance / 100 * output.SpellSuppressionChance
-	elseif env.mode_effective and modDB:Flag(weaponsCfg, "SpellSuppressionChanceIsLucky") then
+	elseif env.mode_effective and modDB:Flag(nil, "SpellSuppressionChanceIsLucky") then
 		output.SpellSuppressionChance = (1 - (1 - output.SpellSuppressionChance / 100) ^ 2) * 100
 	end
 	
@@ -1118,7 +1122,7 @@ function calcs.defence(env, actor)
 	if modDB:Flag(nil, "SpellSuppressionAppliesToAilmentAvoidance") then
 		local spellSuppressionToAilmentPercent = (modDB:Sum("BASE", nil, "SpellSuppressionAppliesToAilmentAvoidancePercent") or 0) / 100
 		-- Ancestral Vision
-		for _, value in ipairs(modDB:Tabulate("BASE",  weaponsCfg, "SpellSuppressionChance")) do
+		for _, value in ipairs(modDB:Tabulate("BASE",  nil, "SpellSuppressionChance")) do
 			local mod = copyTable(value.mod)
 			mod.name = "AvoidElementalAilments"
 			mod.value = mod.value * spellSuppressionToAilmentPercent

--- a/src/Modules/CalcDefence.lua
+++ b/src/Modules/CalcDefence.lua
@@ -1128,7 +1128,7 @@ function calcs.defence(env, actor)
 	if modDB:Flag(nil, "SpellSuppressionAppliesToAilmentAvoidance") then
 		local spellSuppressionToAilmentPercent = (modDB:Sum("BASE", nil, "SpellSuppressionAppliesToAilmentAvoidancePercent") or 0) / 100
 		-- Ancestral Vision
-		modDB:NewMod("AvoidElementalAilments", "BASE", spellSuppressionToAilmentPercent * spellSuppressionChance, "Ancestral Vision")
+		modDB:NewMod("AvoidElementalAilments", "BASE", m_floor(spellSuppressionToAilmentPercent * spellSuppressionChance), "Ancestral Vision")
 	end
 
 	for _, ailment in ipairs(data.nonElementalAilmentTypeList) do


### PR DESCRIPTION
Fixes #6189 .

### Description of the problem being solved:
Spell suppression chance from dagger mastery did not get applied to elemental ailment avoidance when ancestral vision was equipped.
Also minimizes dependence on the dagger mod flag, hopefully avoiding future bugs where one forgets to include the flags. Do note however, if one includes the flags in `weaponsCfg` as part of a calculation, the mastery will be counted twice.

### Steps taken to verify a working solution:
- Allocating the relevant mastery and Ancestral Vision
- Equipping 0, 1 and 2 daggers.
- Allocating Spell Supression Effect and Spell Supression is Lucky, which used to include the dagger mod flag in their calculation.
- Acrobatics does not interfere with Ancestral Vision

### Link to a build that showcases this PR:
```
eNqtW-1z4jYT_3z8FR5mnpnnmRLiF8xLJmmHBHJHm9zlIMm1n24UW4AaYVFbTsJ1-r8_K8kGQ5FjY9qZxKD97ZtWq92N7_yXtwU1XnAYERZc1K2mWTdw4DGfBLOL-sP99Um3_svPtfM7xOdfppcxoWLl59qHc_lsUPyCKeDsusFROMP8MWXlfAdWSxTwOWbBLfqThR-Zf1H_zAJcN55Q4BOefvIoiqLPaIEv6mMUzHBYN1Dk4cC_yi4QXyx4cxQij-PwRkjux5zdMh_WeRgDpwUiwYR5z5h_DFm8BMXqxgvBr4pmdHv3ZXyf0YoEWa3Aqg_ndxStcDjhiBsR_Lio98E5aIYHaAE_gRuiMbBqW81ey-6Ybrdjmp1u_TQXfBmHET-Mw2SJsb8GWU23paO8C_FwOsUeJy_4KiT8ao4CbyPPMpumVsoh9Lcx5WRJidiVtXptVwf5tEeCqSO-ZxzRwd1kTdtzm07P6rQ7ptPr2VY-jvE1TivhG-HzSwq-PUCKwI5mAeH4APAdIxELskCn3bRt9x367eDptJtmR48RCv5bjmV2mrZptl3HcUHD93y4BbWaXbPb7bYdLewqphRSQxaldf4YRzh8QZxsK6ilv2KLJxJs71VBa25RgK5YVCAiBOUdDiHv8FKACfYYpKqyMkoib8gUF6csZUcCKKvNYXYMJ0XpSjM-TKExnKtilBMW04KUfJMTbW3CHuC3TfLIOSt_bRFqD_0o4AWEArssoeVYevVemDih75srM8bw011GvNM0e61Wy-p2OvoLa76KiIfoLXoji3gBF8Q9esYbeVavpY-_2ZwHkG60WH0CviYhPgB2xah_CGyOWHQATpywIp6A-sA7E8SjwCt2bh-CUKbfbFmR5-kpHsNxEoXME8VFIRshyakscusrWTMcJAJXxQy6wdibf4TKb4w4LpaDMxdbN9ezgriQZwXhPs_q-W8jSrhJAPe7yW5aeaCSjhoGOJytJnOCqV-OOlXsCi0LJEvh5yy6kL-3xZWKmSy0pEu-odAvdqWU1ekFRdlca7_jLkWe9ZSlvRhuMdS5gPDxTgFu6lsJ9qdoJGg5WD9csDgsuOOKuNBepxeFKoLH2I-9YhfTJYVecLfrcHPUonQfRG8w58h7HjB_VthHUkh5xCReLiFViE3fwbXNvIsOKm2SqVhOilB_gZAtdHLFlVhcwIa6sID1NV9cyg6kuC3ini5hzIa8sIh1d34LSWEByV729rcsc1toNweaq0KdkiTc7t30x4q9guZzMbaJylFDPbPpXrWqhDj4sSrMf4u8kIBh4MehOAuFZewi9om5JwvIl1E0QBwZflIDP6KQoIDbcqAUYRR68xvY-mtE6RNkgIt69lvxaQdopXt7firnZuJptFiykBv4Tfy6QyFfXdSniEZYEcpvgE_ESSA7ZUg3lNaNyZy99v0XYcU9YzRKQQZaLnHgb_G4DzE2kIw5kXOFEtJG8SE7Yhv50rAFijjcVipOgfHfbbvrOg3bdC33n7oRMNAGHNVtOw3XbLm9Rs9x3Uar1-t0G22n03MbTq_bthoO_Oo1Wq7puI2ERavl2A1AtuGn024BpW3bnQZ0792G223Bo9tzOmYDlsxe3eCgeGaSCGWyGhIKRW1pw4fzh_GNfPgw53wZnZ2evr6-NpeIz9kUv8HV1fTY4nQJILD-JHomlJ4Itqd9-O9yNrocvHZ__3X0Mvjy8vxj0fk2fEPfw94fj1PvV-_jzIb69m3xm3sSdr5_7V8-XN1Z868XF1LwaSr5XI0aI6VG8km6SegpvVA3CMcLpfapAp1mUPABtkLGhdgr8fCZcSzXxJfph_OJ0D8yIgiVj3gRXa7ghF-LAmZnOJJstqCeYK7CNYtJB6U-nqKYiu-_xogSEXtm9tsbNdcNWLhYN2jACmJP3ESK4_1qKeKhf3OjVvqUJ8yEuDQQVcAlChnE35wEZZN4vELUU_4YBcsYXChHvgsSed-f4ulUTG9BBA_lUHp4fT28uh89DpMDm4XIbf4exIsnMZVUvzdpdYJl3WBE8VOkHi_qjwS_SkUGmCNCIYl4jFK0jPD6KEmlEwso4HK4SSpo89Jx3X5eGwI9p-EbDuHkz6Di9EKCtXqt199RSgkU1ahIcDpuYnSqZ6TKnSvIEqpa1nhKTqz1XMTsWGuOWMzBQs5EVCs5WX3HE1yELZw6MiWeuBvyt1wEuaLK8YvnwbXirXL2Oyna9DzkLFrHQC3qwWrWq0MnqzlelbNsrVfVqh4-wB7S2q4W9eB1A8YCcJOOy5oqh9PnZEoOh6ZPqKivtDs7pHhNomf4hc9xmFyGOk63kKNSktyDE5KnmOuPcYYix1dyJqTxkFjTQ9XQQ2ODWMvJRFtjAI1DszR6Vqp91iayPKiqtbX-Syr3nC1IelON-9VqjhPS_lxjf7Kcc0hk_u2_MOKr9k1zXHbI8hIGlBHV2chWtDqb3Sa1OsdrqPeet_dblS6CTbKoRz9wIgqRakzEmarGQRytahzGu3XEBjvOryBk-hrgKQY_5-avNU3O9vI4GMAdx3e3dqNNQU5Sq3ePQSlmKpPvtbS0eio-kyl9XggrkncYwVX0KafYKcZpPTb4hBEVf9dltBrDf_01opKdjEco8Adi3FnRUDEtjZfALNXsy75qdbOlu1zPT9M-Qja-orJPuvIJhy7ARzP5askPxhZ_XNRPbKfT7LU6LdOynZbbUQtJ39NOeh0o_AYE_B_KuEmFC8LfgUPPNpuu01tzkEqMoN-Lkj5MPKdtWBxh9WfJbxgtWSC_DghV_ZEgTHoj2SSOEdTBqzPj4fPo68OwJkZnxigEf0EtF_Da8AdbrDg2BtKkWtJ1nRm2WUuayzPj8gT-r0l7xvivM6Nt16A-psQjYtWqOeZ_DBJ4IUbgVuMjZU-IGqL8FpNWAzxGnrGhytbaT47BmSF5GWxqIEqNdCZryMxvyFrZEH1fbQBhCk2wAUWWOJfwQW2UbH6hlZOv-Bih-AlNZ9OtZ5rCPAr7XYp0hHMq3LntV3uvX_tiV3kIKj4ScWvVHklIfIIC41f8imnthiyg9PXBeOGxjPvM2t9S-BnI_uen_7onlvk_4aIBfuNYiKiBktBg4DASXys3iqf0ikzcpjwDDo2YmN_Q1Ta1zJMZR6ZFq4G44cL-wV5ABiSh8ShmWEdy8I77RNeui91syJ5PKONy2nH39DC-EUMw1ZNDaL2ItJwOQsxUER1ACTGsDcR6D3LJIA0Z_adVFImQVIMYt4TMS0z5Lt4ugZf3uOEcYKUxeUXLXdGtQxhVMD_hYR-Bx36D2kcwqH0Eg_bykEsjHxjsDu8UM5kMjMw8LxVWVIl9HrHKROe-8HaO4FL7EJdWDdhPGLIYr-SPPae1XVkDuzSHyiKdY_nfPUIwWEc4X9YR9GiVjIRj5Si76olsHcGB5S-do-Vop6r9dsUjXE4Bf2WosU2VGFTFSRUO-w-2W5lD-1jbah0rx5QPzep-bFXeS_c4QVXG-P4ippgfIRM6R0goTsVD2aqIt47j_4NvytJB2yqNOKSKKtPc7PGqWzVXH2lbWsdKLu1jMTq4ByuBG5NgVmrX96cm-zh7cLSb4hgdY-swm8o6v_odf6Riw62sSPUrrl02GVRNHv8WqIZGE8zlHFbOQOWLHSyYkln6MpaH54z6OExY4wAvVsm_b0tf1ehkX3veRy8mlOnbFSnIeQeThlhKb9vvy0jfskwxbj4keTWVUSpna1mD8oHrPyymgHYnH7D9MmxGUDoDT1x-frr7bzb_DxfaTy4=
```
### Before screenshot:
![image](https://user-images.githubusercontent.com/48551928/236228798-efeee649-3734-43c1-8301-6c7546afd132.png)
![image](https://user-images.githubusercontent.com/48551928/236228875-502939c1-bd7b-44c2-88b8-fbfdd9d620be.png)


### After screenshot:
![image](https://user-images.githubusercontent.com/48551928/236228984-6c4b0952-cd06-4f2a-86f4-49f594f8f63f.png)
![image](https://user-images.githubusercontent.com/48551928/236229084-19287166-e2d3-4ebb-8da1-829f10c6aa8a.png)
