### PR TITLE
Fix Spell Suppression being doubled with some weapon combinations

### DIFF
--- a/src/Modules/CalcDefence.lua
+++ b/src/Modules/CalcDefence.lua
@@ -728,7 +728,7 @@ function calcs.defence(env, actor)
 
 	-- Add weapon dependent mods as unflagged mods if the correct weapons are equipped
 	for _, value in ipairs(modDB:Tabulate("BASE",  weaponsCfg, "SpellSuppressionChance")) do
-		if bit.band(value.mod.flags and weaponsCfg.flags) == value.mod.flags then
+		if value.mod.flags ~= 0 and bit.band(value.mod.flags and weaponsCfg.flags) == value.mod.flags then
 			local mod = copyTable(value.mod)
 			mod.flags = 0
 			modDB:AddMod(mod)


### PR DESCRIPTION
Fixes #6195 .

### Description of the problem being solved:
Unconditional spell suppresion was being double

### Steps taken to verify a working solution:
- Allocating spell suppress node

### Link to a build that showcases this PR:
```
https://pobb.in/5ZgQ64MSQZGx
```

### Before screenshot:
![image](https://user-images.githubusercontent.com/48551928/236536486-29a64e91-24ff-4817-bb22-fefdc4f7c8b3.png)

### After screenshot:
![image](https://user-images.githubusercontent.com/48551928/236536557-fd1640d5-f770-4b98-aa91-fdfaada01ecd.png)
