### PR TITLE
fix missing parsing for Freeze As Though Dealing More Damage

### DIFF
--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -2963,6 +2963,7 @@ local specialModList = {
 		end
 		return mods
 	end,
+	["freeze enemies as though dealing (%d+)%% more damage"] = function(num) return { mod("FreezeAsThoughDealing", "MORE", num) } end,
 	["freeze chilled enemies as though dealing (%d+)%% more damage"] = function(num) return { mod("FreezeAsThoughDealing", "MORE", num, { type = "ActorCondition", actor = "enemy", var = "Chilled" }) } end,
 	["manabond and stormbind freeze enemies as though dealing (%d+)%% more damage"] = function(num) return { mod("FreezeAsThoughDealing", "MORE", num, { type = "SkillName", skillNameList = { "Manabond", "Stormbind" } }) } end,
 	["(%d+)%% chance to inflict brittle on enemies when you block their damage"] = function(num) return { mod("EnemyBrittleChance", "BASE", num) } end,


### PR DESCRIPTION
### Description of the problem being solved:
The Helmet Redeemer mod "Freeze Enemies as Though Dealing #% More damage" was not taken into account
The mod seemed to be defined correctly in other places and for its conditional variants, but i believe the base mod was missing from mod parser 

### Steps taken to verify a working solution:
- Open a build using such a helmet and freezing
- Go to calculations
- Check breakdown of freeze duration includes the mod
- Double-check the mod on helmet is not red anymore

### Link to a build that showcases this PR:
Anything that can freeze and has said mod really
https://pobb.in/5RSEidM5mXto

### Before screenshot:
![image](https://user-images.githubusercontent.com/604624/236619833-dddce5e4-98e6-4b1d-b739-8cc3d438dd33.png)

### After screenshot:
![image](https://user-images.githubusercontent.com/604624/236619664-ee487011-f42d-4df0-a5a0-ac56d15dc24f.png)
