### PR TITLE
Fix Supreme Ego taking effect with Blood Magic

### DIFF
--- a/src/Classes/ModStore.lua
+++ b/src/Classes/ModStore.lua
@@ -233,14 +233,18 @@ end
 function ModStoreClass:GetStat(stat, cfg)
 	if stat == "ManaReservedPercent" then
 		local reservedPercentMana = 0
-		for _, activeSkill in ipairs(self.actor.activeSkillList) do
-			if (activeSkill.skillTypes[SkillType.Aura] and not activeSkill.skillFlags.disable and activeSkill.buffList and activeSkill.buffList[1] and activeSkill.buffList[1].name == cfg.skillName) then
-				local manaBase = activeSkill.skillData["ManaReservedBase"] or 0
-				reservedPercentMana = manaBase / self.actor.output["Mana"] * 100
-				break
+		-- Check if mana is 0 (i.e. from Blood Magic) to avoid division by 0.
+		local totalMana = self.actor.output["Mana"]
+		if totalMana == 0 then return 0 else
+			for _, activeSkill in ipairs(self.actor.activeSkillList) do
+				if (activeSkill.skillTypes[SkillType.Aura] and not activeSkill.skillFlags.disable and activeSkill.buffList and activeSkill.buffList[1] and activeSkill.buffList[1].name == cfg.skillName) then
+					local manaBase = activeSkill.skillData["ManaReservedBase"] or 0
+					reservedPercentMana = manaBase / totalMana * 100
+					break
+				end
 			end
+			return m_min(reservedPercentMana, 100) --Don't let people get more than 100% reservation for aura effect.
 		end
-		return m_min(reservedPercentMana, 100) --Don't let people get more than 100% reservation for aura effect.
 	end
 	-- if ReservationEfficiency is -100, ManaUnreserved is nan which breaks everything if Arcane Cloak is enabled
 	if stat == "ManaUnreserved" and self.actor.output[stat] ~= self.actor.output[stat] then


### PR DESCRIPTION
Fixes #6193 .

### Description of the problem being solved:
Blood Magic sets the players mana to 0, which caused a division by 0 when calculating mana reservation for Supreme Ego.
This made Supreme Ego incorrectly apply to all auras at full effect.

### Steps taken to verify a working solution:
- Allocating Blood Magic and Supreme Ego with Hatred Aura enabled, and seing that Supreme Ego has no effect.
- Supreme Ego still functions normally on Hatred, when Blood Magic is not allocated.
- Supreme Ego seems to be the only modifer that cares about the `ManaReservedPercent`-stat, so this should not affect anything else.

### Link to a build that showcases this PR:
```
eNq9W1134jYTvt7-Ch-uScAfGNID7SHfacOGQrLbXu0RtgA3skVsmYT--nck2eCwyNjY581FYqx5RjOj0WhmRPq_f_hEW-Mw8mgwaOjn7YaGA4e6XrAYNF6eb896jd9_-6U_Rmz5NL-MPcJHfvvlS188awSvMRk0DKOhMRQuMPuWsjJ_AKsVCtgS02CE_qXhHXUHja80wA1thgLXY-knh6Ao-op8PGhMHQA3NBQ5OHCvdu8TwiUKkcNw-MinHcaMjqgLoyyMYdRHXjClzitmdyGNVyBVQ1t7-F3SPIzGT5PnjEhekBUJVPrSHxO0weGUIaZF8GvQGIJl0AJfIx9-AzdEYmDVO7-wMj-NVi74Mg4jdhqH6QpjdwuCxempKMchvpnPscO8Nb4KPXa1RIGzm6-twpWlHcWEeSvi4TAjVkeFuP-Jud5Wsn-mDJHr8XRLe3Fu2_nElB2X-rvHlpcE7FiUNQc8LAKP4TKIMfUiGpQVP0uvtntMCGy6QrQTHOFwjZj3WRY1b-rPvKC4cYYhRk9z6WoT5HpxtIVZSjcYoQBd0ajAYnHKMQ5h87NSgCl2KMSLsnOURD56c_yJ0s6jLKVHAjggjX1u9QpMU1KVm2lRutKMTxNoAuGxGOWUxqQgJctEKaOj3jNvnyg7Sspr_LEL4Tl78C1LaHZVhA_BTgkjj90nwhzp1pSJ4_OYYUT4ubkf75he9M4No23bttVTb_7xchN5DiIj9OH5sQ_R_Rm94iCjQ45_L5YsgCimwuodQ4W99UJ8AuyKEvcU2BLRSIlTW5_vxV0sVFsCznTnV078EDjF4sJLEIqonkkFci09xxPYeDz5mBFcFLKbJNm_W2DnyFQLHCTzbYrp84ixs7yDZG2CGC4WrwvsdW5WTlrIrJywpOQcUlLymwCHi8106WHilqNOxbpCq4KqZ9GFTPB5ulKmyEJLmuQ7Ct1ih0FZmdYoysY-wzDz7SXps6bqKs_ZEYYEEhAu3ktnbV2dkNN_eTpOSuKGoU_jsOCiS-KsDoZ1LHjLSmSC3dgpdlhcEqipitYIIBYhpRBDxpDzek3dBS41SXnENF6tIMjxZd-vSnp5Zw_k1F4m3TgzjePUT-C1hTYvP6WKT7CjLjzB9uQtPssepLgu_Ojcn8YuQl54im2RO4K44MMxJUpkqPB3a6lcHCijCtVEgrBgbTam7yD5krc-onLUkGLsUkSlKCEO_tsU5v-JvNAEN4Ebh3wvFJ5jH3FommfPh4gZRdeIIc1N0tJvKPRQwAy-RFqEUegsH2HpbxEhM4gAg0b2Lf-0B9TTte23RO-JPz34KxoyDX_wP2MUss2gMUckwpJQvAE-EfMCURNDuCGkoU2X9H3orrkWz5SSKAVpaLXCgfuJx3OIsYaEz_GYy4UQOvIP2T7Vg8uNpvkoYnBgST-NuBoBBQHANrZlNfV2z7homhbkh03T7LR7TetC7_aa-oUOo-ZFz9abZqfTNuG9bQJlu2vCc69nAI2t292mZXeAvgMgu2ka7Qu9aVk60Bvtnm40DQtwgL3gNF2jCxzsXk9v6la7YzeNnmm24fkCfnd68KFpGF0-l2l2rYbGQNNM-87Qk86c1Iwr_aX_MnkUD1-WjK2iX1ut9_f38xViSzrHH3DYnTvUb60ABOY6i149Qs4429YQfi4Xw-Hdwur9-Wrc_fPw-Pp-ufpz80ese28_Ljvm4us6fP_xR_fvzeZ1dfHd_rh_efmYR6ORbXbP_rp5ntHZG7VfiLd--24Bt8FACNRKJerL1l8kPbDFl0f4Cl8__vCVMhzxMf4y_dCfchEjLQL3ucN-dLmBXX_L85q91kjiAJx6ipl04Swm7UG6eI5iwt__FSPicX9sZ98-yn5pQEN_W0cBK_BHfjpJjs-bFXeY4eOjHBkSljDj06XOKZ0wEUjz3NQxk5eiGzrcSX2FiBMJub3AIbEL5UcSEEEaD_YEQTMuGW__8rrBzXZVM3y203zpgzQJ8R2hM0SMFJI0hfXGp2E9HRZuwZ3qHoFvQOR-k9rxV9fSUg1tgX3-eYQZciGKtB4Y6N7iBmgJOeBpDy4svSe8Q-NArlaA_GT_JrCWNJbkdtxwwkb_N9MZ7WO24y3uwJ0S5J9svwMsitpQQjWB_cmQySO4pdiAcovxR2FKQfEQrGIm-A0avhc5P2bxfM779KAhC8Xdw83t7c3V88O3m-RMyUKEFX4EsT_jfWj5d3fyT7HIbLUonkXycdD45uF3Icg1GMQjEVeLELSK8Dbaiz2USE4Al8NNUN17267-YV47AjWnmw8cwuG0gLrICT2slGs7fkQoOSGvmfgZrOLGG-dqRjIjv4KDTNZ0CkuJuwk1F35boFSHD-Zg4VhHRDlzMnrEEoxHUXBWb-45PH3JX3IecyVVjl0cBzIfZ5Oz3kldoeYhbiJUDOSgGizvGFToZDTHquJSQ2lVOaqGX2MHKXWXg2rwtk1AAzCTisuWKofTVxoIJ4dNM_QILwGUK3tD8JZEzfCJLXGY5GsqTiOIUSlJ7sYJvVnM1Ns4Q5FjK9FJVFiIj6mhslem0IGP5USiT80qhUGzNGpWssmjDGR5UFkOKu2XFJc5S5C0TxTml6M5Rki7SAr9k-GcTSLi73BNPVd2GBTbZY8sL2BAWludjeiWVGez30epzvEWKoxX5Xono2r4C_N43nKAi0xeCjHhm6oaB763qnGY7CcSO-wkP4UQ8QvyPgyGzg1gW5qc9WVxcA2HHMtZ24KshFiHN8JOtVK8ZCg_qGlpjtJBk8udPB-WJEcYwVl0n5PtFOO0bW3dY0T4Fwooqcbwp0usSnpSFqHAveZd-YqK8qZ-vAJmqWRPh9LV3ZLuc-230kJCNGd4ap90jqYs5GXYf5T6_wwaZ7ptyQ9J1W0mlTbkedceWDsUXpJOxQn_5ihDXoD2RcmUVP78OS384wjLm-3vGK1oIF7zOlCWKZJQSfS5UicUSndAjGcvk0fRLBL1DRR9a-7hfEh2X1r5ADmJppeAXFJYUW0420QRIppsnmidMgwwYft4owRehETNPEFLbfqOVvtTW6cwqqB-wsOogcdhhewaFLJrUOgkHocUquydZg0WMerSpoy_3WM4ulglexzYbHZlCYzSHCpPadZl_04NzqDXsD30GuSwSnpCXSHGqLojrRoMWP7MqC3EmlX1Nypu4XICuBtNVrBVfFDmFlU4HN7Yncoc7LqWVa8rxpR3zep2tCqvZacepyqj_NCPCWY1REKzhoBiVtyUVkW8Xo_9Tz4pSzutVRpxShZV0aqdqrG6pmWx6gouteXVJ5dQJXATL1iUWsLDocmoZw1qOynqKPis03Qqa_zqZ3xNyUansiDVjzi7bDCoGjx-nrDfSlo9oiMlekXijpsGc2-RfnXKwUtKXBwmrHGA_U3yT13prXU3-73sQ_T8rjS9aE5B5hFM6mIpvWEcnyP9TmSK6eRDku-RUkImKMjK1j0i2_aOJQXY3XzA52-uZiZKu4GJyfut_f9S_B9J1RMN
```

### Before screenshot:
![image](https://user-images.githubusercontent.com/48551928/236632999-e1f2429d-f48d-4fc9-ad75-d737896abc9c.png)

### After screenshot:
![image](https://user-images.githubusercontent.com/48551928/236633032-1ee31864-646e-4744-a2e5-0c7318e75c9b.png)
