### PR TITLE
Update "obtaining an oodle extractor" in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -248,7 +248,7 @@ Note: For this tutorial, you will need a working installation of [Visual Studio 
 as well as some familiarity with build tools such as [CMake](https://cmake.org).
 1. In Visual Studio, clone the following repository using this command:
 
-        git clone -b master https://github.com/zao/ooz
+        git clone --recurse-submodules -b master https://github.com/zao/ooz
 2. Configure CMake.
 3. Build `bun_extract_file.exe`, `libbun.dll` and `libooz.dll`.
 


### PR DESCRIPTION
Updated git command for obtaining an Oodle extractor

### Description of the problem being solved:
[This commit](https://github.com/zao/ooz/commit/bdb3c30bc3e6dd47bfcc79a7e485503eb1d58ae4) introduced a submodule to [Zaos ooz repository](https://github.com/zao/ooz). The [current git command](https://github.com/PathOfBuildingCommunity/PathOfBuilding/blob/d2124ee819e042db401454f5ac3f2091dabbf116/CONTRIBUTING.md?plain=1#LL251C55-L251C55) for cloning the repo does not include submodules, so a fresh install will be missing files.
