### PR TITLE
Fix Chain count not appearing on Calcs page

### DIFF
--- a/src/Data/Skills/act_int.lua
+++ b/src/Data/Skills/act_int.lua
@@ -2351,6 +2351,7 @@ skills["DarkPact"] = {
 	baseFlags = {
 		spell = true,
 		area = true,
+		chaining = true,
 	},
 	baseMods = {
 		skill("radius", 26),
@@ -9884,6 +9885,7 @@ skills["ConduitSigil"] = {
 		area = true,
 		duration = true,
 		brand = true,
+		chaining = true,
 	},
 	baseMods = {
 		skill("radius", 9),

--- a/src/Data/Skills/act_str.lua
+++ b/src/Data/Skills/act_str.lua
@@ -3226,6 +3226,7 @@ skills["Exsanguinate"] = {
 	baseFlags = {
 		spell = true,
 		duration = true,
+		chaining = true,
 	},
 	baseMods = {
 		skill("debuff", true),

--- a/src/Data/Skills/spectre.lua
+++ b/src/Data/Skills/spectre.lua
@@ -891,6 +891,7 @@ skills["GoatmanFireMagmaOrb"] = {
 		spell = true,
 		area = true,
 		projectile = true,
+		chaining = true,
 	},
 	constantStats = {
 		{ "base_cast_speed_+%", 30 },
@@ -1038,6 +1039,7 @@ skills["GuardianArc"] = {
 	castTime = 0.8,
 	baseFlags = {
 		spell = true,
+		chaining = true,
 	},
 	constantStats = {
 		{ "base_chance_to_shock_%", 5 },
@@ -1618,6 +1620,7 @@ skills["MonsterArc"] = {
 	castTime = 0.8,
 	baseFlags = {
 		spell = true,
+		chaining = true,
 	},
 	constantStats = {
 		{ "base_chance_to_shock_%", 10 },
@@ -2683,6 +2686,7 @@ skills["MotherOfFlamesMagmaOrb3"] = {
 		spell = true,
 		projectile = true,
 		area = true,
+		chaining = true,
 	},
 	constantStats = {
 		{ "base_cast_speed_+%", -66 },

--- a/src/Export/Skills/act_int.txt
+++ b/src/Export/Skills/act_int.txt
@@ -527,7 +527,7 @@ local skills, mod, flag, skill = ...
 #mods
 
 #skill DarkPact
-#flags spell area
+#flags spell area chaining
 	parts = {
 		{
 			name = "Cast on Player",
@@ -2147,7 +2147,7 @@ local skills, mod, flag, skill = ...
 #mods
 
 #skill ConduitSigil
-#flags spell area duration brand
+#flags spell area duration brand chaining
 	preDamageFunc = function(activeSkill, output)
 		activeSkill.skillData.hitTimeOverride = activeSkill.skillData.repeatFrequency / (1 + activeSkill.skillModList:Sum("INC", activeSkill.skillCfg, "Speed", "BrandActivationFrequency") / 100) / activeSkill.skillModList:More(activeSkill.skillCfg, "BrandActivationFrequency")
 	end,

--- a/src/Export/Skills/act_str.txt
+++ b/src/Export/Skills/act_str.txt
@@ -628,7 +628,7 @@ local skills, mod, flag, skill = ...
 #mods
 
 #skill Exsanguinate
-#flags spell duration
+#flags spell duration chaining
 	statMap = {
 		["base_physical_damage_to_deal_per_minute"] = {
 			skill("PhysicalDot", nil, { type = "Condition", var = "ExsanguinateDebuffIsFireDamage", neg = true }),

--- a/src/Export/Skills/spectre.txt
+++ b/src/Export/Skills/spectre.txt
@@ -162,7 +162,7 @@ local skills, mod, flag, skill = ...
 #mods
 
 #skill GoatmanFireMagmaOrb Magma Orb
-#flags spell area projectile
+#flags spell area projectile chaining
 #mods
 
 #skill GoatmanMoltenShell Molten Shell
@@ -178,7 +178,7 @@ local skills, mod, flag, skill = ...
 #mods
 
 #skill GuardianArc Arc
-#flags spell
+#flags spell chaining
 #mods
 
 #skill HalfSkeletonPuncture Puncture
@@ -261,7 +261,7 @@ local skills, mod, flag, skill = ...
 #mods
 
 #skill MonsterArc Arc
-#flags spell
+#flags spell chaining
 #mods
 
 #skill MonsterCausticArrow Caustic Arrow
@@ -417,7 +417,7 @@ local skills, mod, flag, skill = ...
 #mods
 
 #skill MotherOfFlamesMagmaOrb3
-#flags spell projectile area
+#flags spell projectile area chaining
 #mods
 
 #skill NecromancerConductivity Conductivity

--- a/src/Modules/CalcSections.lua
+++ b/src/Modules/CalcSections.lua
@@ -637,7 +637,7 @@ return {
 	{ label = "Projectile Count", flag = "projectile", { format = "{output:ProjectileCount}", { modName = { "NoAdditionalProjectiles" , "ProjectileCount" }, cfg = "skill" }, }, },
 	{ label = "Pierce Count", haveOutput = "PierceCount", { format = "{output:PierceCountString}", { modName = { "CannotPierce", "PierceCount", "PierceAllTargets" }, cfg = "skill" }, }, },
 	{ label = "Fork Count", haveOutput = "ForkCountMax", { format = "{output:ForkCountString}", { modName = { "CannotFork", "ForkCountMax" }, cfg = "skill" }, }, },
-	{ label = "Max Chain Count", haveOutput = "ChainCountMax", { format = "{output:ChainMaxString}", { modName = { "CannotChain", "ChainCountMax" }, cfg = "skill" }, }, }, 
+	{ label = "Max Chain Count", haveOutput = "ChainMax", { format = "{output:ChainMaxString}", { modName = { "CannotChain", "ChainCountMax" }, cfg = "skill" }, }, },
 	{ label = "Proj. Speed Mod", flag = "projectile", { format = "x {2:output:ProjectileSpeedMod}",
 		{ breakdown = "ProjectileSpeedMod" },
 		{ modName = "ProjectileSpeed", cfg = "skill" },

--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -3620,6 +3620,7 @@ local specialModList = {
 	["summoned skeleton warriors are permanent and follow you"] = { flag("RaisedSkeletonPermanentDuration", { type = "SkillName", skillName = "Summon Skeleton" }) },
 	-- Projectiles
 	["skills chain %+(%d) times"] = function(num) return { mod("ChainCountMax", "BASE", num) } end,
+	["arrows chain %+(%d) times"] = function(num) return { mod("ChainCountMax", "BASE", num, nil, ModFlag.Bow) } end,
 	["skills chain an additional time while at maximum frenzy charges"] = { mod("ChainCountMax", "BASE", 1, { type = "StatThreshold", stat = "FrenzyCharges", thresholdStat = "FrenzyChargesMax" }) },
 	["attacks chain an additional time when in main hand"] = { mod("ChainCountMax", "BASE", 1, nil, ModFlag.Attack, { type = "SlotNumber", num = 1 }) },
 	["projectiles chain %+(%d) times while you have phasing"] = function(num) return { mod("ChainCountMax", "BASE", num, nil, ModFlag.Projectile, { type = "Condition", var = "Phasing" }) } end,


### PR DESCRIPTION
Also adds the chaining tag to Dark Pact, Storm Brand, Exsanguinate and many minion skills
Also adds support for the "Arrows chain +x times" mods on quiver corruptions and crucible mods
Fixes #6204