### PR TITLE
Add support for linking Tree, Item, and Skill Sets

### DIFF
--- a/src/Classes/ItemSetListControl.lua
+++ b/src/Classes/ItemSetListControl.lua
@@ -48,6 +48,7 @@ function ItemSetListClass:RenameSet(itemSet, addOnName)
 		controls.save.enabled = buf:match("%S")
 	end)
 	controls.save = new("ButtonControl", nil, -45, 70, 80, 20, "Save", function()
+		self.itemsTab.build.linkedSetsTab:RenameSet("item", itemSet.title or "Default", controls.edit.buf)
 		itemSet.title = controls.edit.buf
 		self.itemsTab.modFlag = true
 		if addOnName then

--- a/src/Classes/ItemSetListControl.lua
+++ b/src/Classes/ItemSetListControl.lua
@@ -48,7 +48,7 @@ function ItemSetListClass:RenameSet(itemSet, addOnName)
 		controls.save.enabled = buf:match("%S")
 	end)
 	controls.save = new("ButtonControl", nil, -45, 70, 80, 20, "Save", function()
-		self.itemsTab.build.linkedSetsTab:RenameSet("item", itemSet.title or "Default", controls.edit.buf)
+		self.itemsTab.build.linkedSetsTab:ModifySet("item", "rename", itemSet.title or "Default", controls.edit.buf)
 		itemSet.title = controls.edit.buf
 		self.itemsTab.modFlag = true
 		if addOnName then
@@ -121,6 +121,7 @@ function ItemSetListClass:OnSelDelete(index, itemSetId)
 	if #self.list > 1 then
 		main:OpenConfirmPopup("Delete Item Set", "Are you sure you want to delete '"..(itemSet.title or "Default").."'?\nThis will not delete any items used by the set.", "Delete", function()
 			t_remove(self.list, index)
+			self.itemsTab.build.linkedSetsTab:ModifySet("item", "delete", itemSet.title or "Default")
 			self.itemsTab.itemSets[itemSetId] = nil
 			self.selIndex = nil
 			self.selValue = nil

--- a/src/Classes/ItemsTab.lua
+++ b/src/Classes/ItemsTab.lua
@@ -63,11 +63,9 @@ local ItemsTabClass = newClass("ItemsTab", "UndoHandler", "ControlHost", "Contro
 	self.tradeQuery = new("TradeQuery", self)
 
 	local function loadSetLinks(value)
-		if self.build.linkedSetsTab.enabled then
-			if self.build.linkedSetsTab.itemSetLinks[value] then
-				self.build.treeTab:SetActiveSpecByVal(self.build.linkedSetsTab.itemSetLinks[value].treeSet)
-				self.build.skillsTab:SetActiveSkillSetByVal(self.build.linkedSetsTab.itemSetLinks[value].skillSet)
-			end
+		if self.build.linkedSetsTab.enabled and self.build.linkedSetsTab.itemSetLinks[value] then
+			self.build.treeTab:SetActiveSpecByVal(self.build.linkedSetsTab.itemSetLinks[value].treeSet)
+			self.build.skillsTab:SetActiveSkillSetByVal(self.build.linkedSetsTab.itemSetLinks[value].skillSet)
 		end
 	end
 	-- Set selector

--- a/src/Classes/ItemsTab.lua
+++ b/src/Classes/ItemsTab.lua
@@ -63,10 +63,10 @@ local ItemsTabClass = newClass("ItemsTab", "UndoHandler", "ControlHost", "Contro
 	self.tradeQuery = new("TradeQuery", self)
 
 	local function loadSetLinks(value)
-		if self.build.setManagerTab.enabled then
-			if self.build.setManagerTab.itemSetLinks[value] then
-				self.build.treeTab:SetActiveSpecByVal(self.build.setManagerTab.itemSetLinks[value].treeSet)
-				self.build.skillsTab:SetActiveSkillSetByVal(self.build.setManagerTab.itemSetLinks[value].skillSet)
+		if self.build.linkedSetsTab.enabled then
+			if self.build.linkedSetsTab.itemSetLinks[value] then
+				self.build.treeTab:SetActiveSpecByVal(self.build.linkedSetsTab.itemSetLinks[value].treeSet)
+				self.build.skillsTab:SetActiveSkillSetByVal(self.build.linkedSetsTab.itemSetLinks[value].skillSet)
 			end
 		end
 	end

--- a/src/Classes/ItemsTab.lua
+++ b/src/Classes/ItemsTab.lua
@@ -62,17 +62,11 @@ local ItemsTabClass = newClass("ItemsTab", "UndoHandler", "ControlHost", "Contro
 	-- PoB Trader class initialization
 	self.tradeQuery = new("TradeQuery", self)
 
-	local function loadSetLinks(value)
-		if self.build.linkedSetsTab.enabled and self.build.linkedSetsTab.itemSetLinks[value] then
-			self.build.treeTab:SetActiveSpecByVal(self.build.linkedSetsTab.itemSetLinks[value].treeSet)
-			self.build.skillsTab:SetActiveSkillSetByVal(self.build.linkedSetsTab.itemSetLinks[value].skillSet)
-		end
-	end
 	-- Set selector
 	self.controls.setSelect = new("DropDownControl", {"TOPLEFT",self,"TOPLEFT"}, 96, 8, 216, 20, nil, function(index, value)
 		self:SetActiveItemSet(self.itemSetOrderList[index])
 		self:AddUndoState()
-		loadSetLinks(value)
+		self.build.linkedSetsTab:LoadSetLinks("item", value)
 	end)
 	self.controls.setSelect.enableDroppedWidth = true
 	self.controls.setSelect.enabled = function()
@@ -160,7 +154,7 @@ local ItemsTabClass = newClass("ItemsTab", "UndoHandler", "ControlHost", "Contro
 		if self.build.treeTab.specList[index] then
 			self.build.modFlag = true
 			self.build.treeTab:SetActiveSpec(index)
-			self.build.treeTab:LoadSetLinks(value)
+			self.build.linkedSetsTab:LoadSetLinks("tree", value)
 		end
 	end)
 	self.controls.specSelect.enabled = function()

--- a/src/Classes/ItemsTab.lua
+++ b/src/Classes/ItemsTab.lua
@@ -162,8 +162,7 @@ local ItemsTabClass = newClass("ItemsTab", "UndoHandler", "ControlHost", "Contro
 		if self.build.treeTab.specList[index] then
 			self.build.modFlag = true
 			self.build.treeTab:SetActiveSpec(index)
-			-- TODO: local function works for Loading from TreeTab select, class function fails from both ItemTab and TreeTab on self.build == nil?
-			--self.build.treeTab:LoadSetLinks(value)
+			self.build.treeTab:LoadSetLinks(value)
 		end
 	end)
 	self.controls.specSelect.enabled = function()

--- a/src/Classes/ItemsTab.lua
+++ b/src/Classes/ItemsTab.lua
@@ -62,10 +62,19 @@ local ItemsTabClass = newClass("ItemsTab", "UndoHandler", "ControlHost", "Contro
 	-- PoB Trader class initialization
 	self.tradeQuery = new("TradeQuery", self)
 
+	local function loadSetLinks(value)
+		if self.build.setManagerTab.enabled then
+			if self.build.setManagerTab.itemSetLinks[value] then
+				self.build.treeTab:SetActiveSpecByVal(self.build.setManagerTab.itemSetLinks[value].treeSet)
+				self.build.skillsTab:SetActiveSkillSetByVal(self.build.setManagerTab.itemSetLinks[value].skillSet)
+			end
+		end
+	end
 	-- Set selector
 	self.controls.setSelect = new("DropDownControl", {"TOPLEFT",self,"TOPLEFT"}, 96, 8, 216, 20, nil, function(index, value)
 		self:SetActiveItemSet(self.itemSetOrderList[index])
 		self:AddUndoState()
+		loadSetLinks(value)
 	end)
 	self.controls.setSelect.enableDroppedWidth = true
 	self.controls.setSelect.enabled = function()
@@ -153,6 +162,8 @@ local ItemsTabClass = newClass("ItemsTab", "UndoHandler", "ControlHost", "Contro
 		if self.build.treeTab.specList[index] then
 			self.build.modFlag = true
 			self.build.treeTab:SetActiveSpec(index)
+			-- TODO: local function works for Loading from TreeTab select, class function fails from both ItemTab and TreeTab on self.build == nil?
+			--self.build.treeTab:LoadSetLinks(value)
 		end
 	end)
 	self.controls.specSelect.enabled = function()
@@ -1232,6 +1243,14 @@ function ItemsTabClass:SetActiveItemSet(itemSetId)
 	end
 	self.build.buildFlag = true
 	self:PopulateSlots()
+end
+
+function ItemsTabClass:SetActiveItemSetByVal(itemSetTitle)
+	for _, set in pairs(self.itemSets) do
+		if set.title == itemSetTitle or (itemSetTitle == "Default" and not set.title) then
+			self:SetActiveItemSet(set.id)
+		end
+	end
 end
 
 -- Equips the given item in the given item set

--- a/src/Classes/LinkedSetsTab.lua
+++ b/src/Classes/LinkedSetsTab.lua
@@ -59,7 +59,7 @@ local LinkedSetsTabClass = newClass("LinkedSetsTab", "UndoHandler", "ControlHost
 	self.controls.treeSetLabelDropdownItem = new("LabelControl", {"LEFT",self.controls.treeSetLabelDropdownSkill,"RIGHT"}, dropdownWidth*0.75, 0, 0, 16, "^7Item Sets")
 	self.controls.treeSetDropdown = new("DropDownControl", {"LEFT",self.controls.treeSetLabelRoot,"LEFT"}, 0, 20, dropdownWidth, 18, nil, function(index, value)
 		self:InitLinks("tree", value)
-		self:LoadLinks("tree", value)
+		self:LoadDropdowns("tree", value)
 	end)
 	self.controls.treeSetDropdownSkill = new("DropDownControl", {"LEFT",self.controls.treeSetLabelDropdownSkill,"LEFT"}, 0, 20, dropdownWidth, 18, nil, function(index, value)
 		local treeSetTitle = self.controls.treeSetDropdown.list[self.controls.treeSetDropdown.selIndex]
@@ -82,7 +82,7 @@ local LinkedSetsTabClass = newClass("LinkedSetsTab", "UndoHandler", "ControlHost
 	self.controls.skillSetLabelDropdownItem = new("LabelControl", {"LEFT",self.controls.treeSetLabelDropdownItem,"LEFT"}, 0, 70, 0, 16, "^7Item Sets")
 	self.controls.skillSetDropdown = new("DropDownControl", {"LEFT",self.controls.skillSetLabelRoot,"LEFT"}, 0, 20, dropdownWidth, 18, nil, function(index, value)
 		self:InitLinks("skill", value)
-		self:LoadLinks("skill", value)
+		self:LoadDropdowns("skill", value)
 	end)
 	self.controls.skillSetDropdownTree = new("DropDownControl", {"LEFT",self.controls.skillSetLabelDropdownTree,"LEFT"}, 0, 20, dropdownWidth, 18, nil, function(index, value)
 		local skillSetTitle = self.controls.skillSetDropdown.list[self.controls.skillSetDropdown.selIndex]
@@ -105,7 +105,7 @@ local LinkedSetsTabClass = newClass("LinkedSetsTab", "UndoHandler", "ControlHost
 	self.controls.itemSetLabelDropdownSkill = new("LabelControl", {"LEFT",self.controls.treeSetLabelDropdownItem,"LEFT"}, 0, 140, 0, 16, "^7Skill Sets")
 	self.controls.itemSetDropdown = new("DropDownControl", {"LEFT",self.controls.itemSetLabelRoot,"LEFT"}, 0, 20, dropdownWidth, 18, nil, function(index, value)
 		self:InitLinks("item", value)
-		self:LoadLinks("item", value)
+		self:LoadDropdowns("item", value)
 	end)
 	self.controls.itemSetDropdownTree = new("DropDownControl", {"LEFT",self.controls.itemSetLabelDropdownTree,"LEFT"}, 0, 20, dropdownWidth, 18, nil, function(index, value)
 		local itemSetTitle = self.controls.itemSetDropdown.list[self.controls.itemSetDropdown.selIndex]
@@ -227,7 +227,7 @@ function LinkedSetsTabClass:InitLinks(set, value)
 	end
 end
 
-function LinkedSetsTabClass:LoadLinks(set, value)
+function LinkedSetsTabClass:LoadDropdowns(set, value)
 	if set == "tree" then
 		self.controls.treeSetDropdownItem:SelByValue(self.treeSetLinks[value].itemSet or "None")
 		self.controls.treeSetDropdownSkill:SelByValue(self.treeSetLinks[value].skillSet or "None")
@@ -368,6 +368,21 @@ function LinkedSetsTabClass:Load(xml)
 					["skillSet"] = node.attrib.skillSet or { }
 				}
 			end
+		end
+	end
+end
+
+function LinkedSetsTabClass:LoadSetLinks(type, value)
+	if self.build.linkedSetsTab.enabled then
+		if type == "item" and self.build.linkedSetsTab.itemSetLinks[value] then
+			self.build.treeTab:SetActiveSpecByVal(self.build.linkedSetsTab.itemSetLinks[value].treeSet)
+			self.build.skillsTab:SetActiveSkillSetByVal(self.build.linkedSetsTab.itemSetLinks[value].skillSet)
+		elseif type == "skill" and self.build.linkedSetsTab.skillSetLinks[value] then
+			self.build.treeTab:SetActiveSpecByVal(self.build.linkedSetsTab.skillSetLinks[value].treeSet)
+			self.build.itemsTab:SetActiveItemSetByVal(self.build.linkedSetsTab.skillSetLinks[value].itemSet)
+		elseif type == "tree" and self.build.linkedSetsTab.treeSetLinks[value] then
+			self.build.skillsTab:SetActiveSkillSetByVal(self.build.linkedSetsTab.treeSetLinks[value].skillSet)
+			self.build.itemsTab:SetActiveItemSetByVal(self.build.linkedSetsTab.treeSetLinks[value].itemSet)
 		end
 	end
 end

--- a/src/Classes/LinkedSetsTab.lua
+++ b/src/Classes/LinkedSetsTab.lua
@@ -50,12 +50,12 @@ local LinkedSetsTabClass = newClass("LinkedSetsTab", "UndoHandler", "ControlHost
 		self.modFlag = true
 	end)
 
-	local dropdownWidth = 100
+	local dropdownWidth = 200
 	-- Tree Linked Sets
 	-- Skill and Item controls are anchored to these three labels
-	self.controls.treeSetLabelRoot = new("LabelControl", {"TOPLEFT",self,"TOPLEFT"}, 35, 200, 0, 16, "^7Tree Sets")
-	self.controls.treeSetLabelDropdownSkill = new("LabelControl", {"LEFT",self.controls.treeSetLabelRoot,"RIGHT"}, dropdownWidth*1.1, 0, 0, 16, "^7Skill Sets")
-	self.controls.treeSetLabelDropdownItem = new("LabelControl", {"LEFT",self.controls.treeSetLabelDropdownSkill,"RIGHT"}, dropdownWidth/2, 0, 0, 16, "^7Item Sets")
+	self.controls.treeSetLabelRoot = new("LabelControl", {"TOPLEFT",self,"TOPLEFT"}, 25, 200, 0, 16, "^7Tree Sets")
+	self.controls.treeSetLabelDropdownSkill = new("LabelControl", {"LEFT",self.controls.treeSetLabelRoot,"RIGHT"}, dropdownWidth, 0, 0, 16, "^7Skill Sets")
+	self.controls.treeSetLabelDropdownItem = new("LabelControl", {"LEFT",self.controls.treeSetLabelDropdownSkill,"RIGHT"}, dropdownWidth*0.75, 0, 0, 16, "^7Item Sets")
 	self.controls.treeSetDropdown = new("DropDownControl", {"LEFT",self.controls.treeSetLabelRoot,"LEFT"}, 0, 20, dropdownWidth, 18, nil, function(index, value)
 		self:InitLinks("tree", value)
 		self:LoadLinks("tree", value)
@@ -126,10 +126,24 @@ local LinkedSetsTabClass = newClass("LinkedSetsTab", "UndoHandler", "ControlHost
 		self.modFlag = true
 	end)
 
-	-- Display current links all at once
-	self.controls.displayLinks = new("LabelControl", {"LEFT",self.controls.itemSetDropdown,"LEFT"}, -15, 85, 0, 16, "Current Links:")
+	self.controls.displayLinks = new("LabelControl", {"LEFT",self.controls.itemSetDropdown,"LEFT"}, 0, 85, 0, 16, "Current Links:")
 	self.controls.displayLinks.shown = function() return self:ShowCurrentLinks() end
-	self.controls.displayLinksTree = new("LabelControl", {"LEFT",self.controls.displayLinks,"LEFT"}, 0, 20, 150, 16, function()
+	self.controls.displayLinksTree = new("ButtonControl", {"LEFT",self.controls.displayLinks,"LEFT"}, 100, 0, 150, 18, "^7Show Tree Set Links", function()
+		self.controls.displayLinksTreeLabel.shown = true
+		self.controls.displayLinksSkillLabel.shown = false
+		self.controls.displayLinksItemLabel.shown = false
+	end)
+	self.controls.displayLinksSkill = new("ButtonControl", {"LEFT",self.controls.displayLinksTree,"LEFT"}, 160, 0, 150, 18, "^7Show Skill Set Links", function()
+		self.controls.displayLinksSkillLabel.shown = true
+		self.controls.displayLinksTreeLabel.shown = false
+		self.controls.displayLinksItemLabel.shown = false
+	end)
+	self.controls.displayLinksItem = new("ButtonControl", {"LEFT",self.controls.displayLinksSkill,"LEFT"}, 160, 0, 150, 18, "^7Show Item Set Links", function()
+		self.controls.displayLinksItemLabel.shown = true
+		self.controls.displayLinksTreeLabel.shown = false
+		self.controls.displayLinksSkillLabel.shown = false
+	end)
+	self.controls.displayLinksTreeLabel = new("LabelControl", {"LEFT",self.controls.displayLinks,"LEFT"}, 0, 45, 150, 16, function()
 		local note = "^7{ Tree  -->  Skill, Item }\n\n"
 		for index, link in pairs(self.treeSetLinks) do
 			if isValidLink("tree", index, link) then
@@ -138,7 +152,7 @@ local LinkedSetsTabClass = newClass("LinkedSetsTab", "UndoHandler", "ControlHost
 		end
 		return note
 	end)
-	self.controls.displayLinksSkill = new("LabelControl", {"LEFT",self.controls.displayLinksTree,"RIGHT"}, 85, 0, 150, 16, function()
+	self.controls.displayLinksSkillLabel = new("LabelControl", {"LEFT",self.controls.displayLinks,"LEFT"}, 0, 45, 150, 16, function()
 		local note = "{ Skill  -->  Tree, Item }\n\n"
 		for index, link in pairs(self.skillSetLinks) do
 			if isValidLink("skill", index, link) then
@@ -147,7 +161,7 @@ local LinkedSetsTabClass = newClass("LinkedSetsTab", "UndoHandler", "ControlHost
 		end
 		return note
 	end)
-	self.controls.displayLinksItem = new("LabelControl", {"LEFT",self.controls.displayLinksSkill,"RIGHT"}, 85, 0, 150, 16, function()
+	self.controls.displayLinksItemLabel = new("LabelControl", {"LEFT",self.controls.displayLinks,"LEFT"}, 0, 45, 150, 16, function()
 		local note = "{ Item  -->  Tree, Skill }\n\n"
 		for index, link in pairs(self.itemSetLinks) do
 			if isValidLink("item", index, link) then
@@ -156,6 +170,9 @@ local LinkedSetsTabClass = newClass("LinkedSetsTab", "UndoHandler", "ControlHost
 		end
 		return note
 	end)
+	self.controls.displayLinksTreeLabel.shown = false
+	self.controls.displayLinksSkillLabel.shown = false
+	self.controls.displayLinksItemLabel.shown = false
 end)
 
 function LinkedSetsTabClass:ShowCurrentLinks()

--- a/src/Classes/LinkedSetsTab.lua
+++ b/src/Classes/LinkedSetsTab.lua
@@ -32,9 +32,9 @@ local LinkedSetsTabClass = newClass("LinkedSetsTab", "UndoHandler", "ControlHost
 	With this tab, you can manage links between item, skill, and tree sets.
 	Each set is listed on the left, with two dropdowns on the right to create a link between the sets.
 
-	For example, given Tree Set 1 has Skill Set 2 and Item Set 2 linked, if you change to Tree Set 1 either in the Tree Tab or Items Tab,
+	For example, given Tree Set 2 has Skill Set 2 and Item Set 2 linked, if you change to Tree Set 2 either in the Tree Tab or Items Tab,
 	Skill Set 2 and Item Set 2 should automatically set active as well.
-	But with no other changes, setting Skill Set 2 or Item Set 2 to active would do nothing to the other Sets.]]
+	But given no other links were created, switching Skill Set to Skill Set 1 or Item Set to Item Set 1 would do nothing to the other Sets.]]
 	self.controls.notesDesc = new("LabelControl", {"TOPLEFT",self,"TOPLEFT"}, 8, 8, 150, 16, notesDesc)
 	self.controls.notesDesc.width = function()
 		local width = self.width / 2 - 16
@@ -133,7 +133,7 @@ local LinkedSetsTabClass = newClass("LinkedSetsTab", "UndoHandler", "ControlHost
 		local note = "^7{ Tree  -->  Skill, Item }\n\n"
 		for index, link in pairs(self.treeSetLinks) do
 			if isValidLink("tree", index, link) then
-				note = note .. index .. "  -->  " .. (link.skillSet or "") .. ", " .. (link.itemSet or "") .. "\n"
+				note = note .. index .. "^7  -->  " .. (link.skillSet or "") .. "^7, " .. (link.itemSet or "") .. "\n"
 			end
 		end
 		return note
@@ -142,7 +142,7 @@ local LinkedSetsTabClass = newClass("LinkedSetsTab", "UndoHandler", "ControlHost
 		local note = "{ Skill  -->  Tree, Item }\n\n"
 		for index, link in pairs(self.skillSetLinks) do
 			if isValidLink("skill", index, link) then
-				note = note .. index .. "  -->  " .. (link.treeSet or "") .. ", " .. (link.itemSet or "") .. "\n"
+				note = note .. index .. "^7  -->  " .. (link.treeSet or "") .. "^7, " .. (link.itemSet or "") .. "\n"
 			end
 		end
 		return note
@@ -151,7 +151,7 @@ local LinkedSetsTabClass = newClass("LinkedSetsTab", "UndoHandler", "ControlHost
 		local note = "{ Item  -->  Tree, Skill }\n\n"
 		for index, link in pairs(self.itemSetLinks) do
 			if isValidLink("item", index, link) then
-				note = note .. index .. "  -->  " .. (link.treeSet or "None") .. ", " .. (link.skillSet or "None") .. "\n"
+				note = note .. index .. "^7  -->  " .. (link.treeSet or "None") .. "^7, " .. (link.skillSet or "None") .. "\n"
 			end
 		end
 		return note

--- a/src/Classes/LinkedSetsTab.lua
+++ b/src/Classes/LinkedSetsTab.lua
@@ -13,7 +13,6 @@ local LinkedSetsTabClass = newClass("LinkedSetsTab", "UndoHandler", "ControlHost
 	self.Control()
 
 	self.build = build
-
 	self.treeSetLinks = {}
 	self.itemSetLinks = {}
 	self.skillSetLinks = {}
@@ -52,7 +51,6 @@ local LinkedSetsTabClass = newClass("LinkedSetsTab", "UndoHandler", "ControlHost
 		self:InitLinks("tree", value)
 		self:LoadLinks("tree", value)
 	end)
-
 	self.controls.treeSetDropdownSkill = new("DropDownControl", {"LEFT",self.controls.treeSetLabelDropdownSkill,"LEFT"}, 0, 20, dropdownWidth, 18, nil, function(index, value)
 		local treeSetTitle = self.controls.treeSetDropdown.list[self.controls.treeSetDropdown.selIndex]
 		self:InitLinks("tree", treeSetTitle)
@@ -60,7 +58,6 @@ local LinkedSetsTabClass = newClass("LinkedSetsTab", "UndoHandler", "ControlHost
 		self.modFlag = true
 	end)
 	self.controls.treeSetDropdownSkill.enabled = function() return self.controls.treeSetDropdown.selIndex ~= 1 end
-
 	self.controls.treeSetDropdownItem = new("DropDownControl", {"LEFT",self.controls.treeSetLabelDropdownItem,"LEFT"}, 0, 20, dropdownWidth, 18, nil, function(index, value)
 		local treeSetTitle = self.controls.treeSetDropdown.list[self.controls.treeSetDropdown.selIndex]
 		self:InitLinks("tree", treeSetTitle)
@@ -84,7 +81,6 @@ local LinkedSetsTabClass = newClass("LinkedSetsTab", "UndoHandler", "ControlHost
 		self.modFlag = true
 	end)
 	self.controls.skillSetDropdownTree.enabled = function() return self.controls.skillSetDropdown.selIndex ~= 1 end
-
 	self.controls.skillSetDropdownItem = new("DropDownControl", {"LEFT",self.controls.skillSetLabelDropdownItem,"LEFT"}, 0, 20, dropdownWidth, 18, nil, function(index, value)
 		local skillSetTitle = self.controls.skillSetDropdown.list[self.controls.skillSetDropdown.selIndex]
 		self:InitLinks("skill", skillSetTitle)
@@ -108,7 +104,6 @@ local LinkedSetsTabClass = newClass("LinkedSetsTab", "UndoHandler", "ControlHost
 		self.modFlag = true
 	end)
 	self.controls.itemSetDropdownTree.enabled = function() return self.controls.itemSetDropdown.selIndex ~= 1 end
-
 	self.controls.itemSetDropdownSkill = new("DropDownControl", {"LEFT",self.controls.itemSetLabelDropdownSkill,"LEFT"}, 0, 20, dropdownWidth, 18, nil, function(index, value)
 		local itemSetTitle = self.controls.itemSetDropdown.list[self.controls.itemSetDropdown.selIndex]
 		self:InitLinks("item", itemSetTitle)
@@ -126,27 +121,28 @@ local LinkedSetsTabClass = newClass("LinkedSetsTab", "UndoHandler", "ControlHost
 	self.controls.displayLinks = new("LabelControl", {"LEFT",self.controls.itemSetDropdown,"LEFT"}, -15, 75, 0, 16, "Current Links:")
 	self.controls.displayLinks.shown = function() return self.treeSetLinks ~= {} or self.skillSetLinks ~= {} or self.itemSetLinks ~= {} end
 	self.controls.displayLinksTree = new("LabelControl", {"LEFT",self.controls.displayLinks,"LEFT"}, 0, 25, 150, 16, function()
-		local note = "Tree Links                    Skill, Item\n"
+		local note = "Tree Links  -->  Skill, Item\n\n"
 		for index, link in pairs(self.treeSetLinks) do
-			if index ~= "None" then
+			-- exclude certain cases involving None
+			if index ~= "None" and (link.skillSet or link.itemSet) and not (link.skillSet == "None" and link.itemSet == "None") then
 				note = note .. "   " .. index .. "  -->  " .. (link.skillSet or "") .. ", " .. (link.itemSet or "") .. "\n"
 			end
 		end
 		return note
 	end)
 	self.controls.displayLinksSkill = new("LabelControl", {"LEFT",self.controls.displayLinksTree,"RIGHT"}, 85, 0, 150, 16, function()
-		local note = "Skill Links                    Tree, Item\n"
+		local note = "Skill Links  -->  Tree, Item\n\n"
 		for index, link in pairs(self.skillSetLinks) do
-			if index ~= "None" then
+			if index ~= "None" and (link.treeSet or link.itemSet) and not (link.treeSet == "None" and link.itemSet == "None") then
 				note = note .. "   " .. index .. "  -->  " .. (link.treeSet or "") .. ", " .. (link.itemSet or "") .. "\n"
 			end
 		end
 		return note
 	end)
 	self.controls.displayLinksItem = new("LabelControl", {"LEFT",self.controls.displayLinksSkill,"RIGHT"}, 85, 0, 150, 16, function()
-		local note = "Item Links                    Tree, Skill\n"
+		local note = "Item Links  -->  Tree, Skill\n\n"
 		for index, link in pairs(self.itemSetLinks) do
-			if index ~= "None" then
+			if index ~= "None" and (link.treeSet or link.skillSet) and not (link.treeSet == "None" and link.skillSet == "None") then
 				note = note .. "   " .. index .. "  -->  " .. (link.treeSet or "None") .. ", " .. (link.skillSet or "None") .. "\n"
 			end
 		end
@@ -236,16 +232,6 @@ function LinkedSetsTabClass:Draw(viewPort, inputEvents)
 	self.height = viewPort.height
 
 	self:UpdateSetDropdowns()
-
-	-- TODO: undo, redo
-	--for id, event in ipairs(inputEvents) do
-	--	if event.type == "KeyDown" then
-	--		if event.key == "z" and IsKeyDown("CTRL") then
-	--		elseif event.key == "y" and IsKeyDown("CTRL") then
-	--		end
-	--	end
-	--end
-
 	self:ProcessControlsInput(inputEvents, viewPort)
 	main:DrawBackground(viewPort)
 	self:DrawControls(viewPort)
@@ -268,7 +254,6 @@ function LinkedSetsTabClass:Save(xml)
 			t_insert(xml, child)
 		end
 	end
-
 	for index, skillSet in pairs(self.skillSetLinks) do
 		if index ~= "None" then
 			local child = {
@@ -282,7 +267,6 @@ function LinkedSetsTabClass:Save(xml)
 			t_insert(xml, child)
 		end
 	end
-
 	for index, itemSet in pairs(self.itemSetLinks) do
 		if index ~= "None" then
 			local child = {
@@ -303,7 +287,6 @@ function LinkedSetsTabClass:Load(xml)
 		self.enabled = xml.attrib.enabled == "true"
 		self.controls.enabled.state = self.enabled
 	end
-
 	for _, node in pairs(xml) do
 		if type(node) ~= "boolean" then
 			if node.elem == "TreeSet" then
@@ -333,7 +316,6 @@ function LinkedSetsTabClass:RenameSet(type, old, new)
 			self.treeSetLinks[new] = copyTable(self.treeSetLinks[old])
 			self.treeSetLinks[old] = nil
 		end
-
 		-- replace set in other types
 		for index, _ in pairs(self.skillSetLinks) do
 			if self.skillSetLinks[index].treeSet == old then
@@ -350,7 +332,6 @@ function LinkedSetsTabClass:RenameSet(type, old, new)
 			self.skillSetLinks[new] = copyTable(self.skillSetLinks[old])
 			self.skillSetLinks[old] = nil
 		end
-
 		for index, _ in pairs(self.treeSetLinks) do
 			if self.treeSetLinks[index].skillSet == old then
 				self.treeSetLinks[index].skillSet = new
@@ -366,7 +347,6 @@ function LinkedSetsTabClass:RenameSet(type, old, new)
 			self.itemSetLinks[new] = copyTable(self.itemSetLinks[old])
 			self.itemSetLinks[old] = nil
 		end
-
 		for index, _ in pairs(self.treeSetLinks) do
 			if self.treeSetLinks[index].itemSet == old then
 				self.treeSetLinks[index].itemSet = new

--- a/src/Classes/LinkedSetsTab.lua
+++ b/src/Classes/LinkedSetsTab.lua
@@ -1,13 +1,14 @@
 -- Path of Building
 --
--- Module: Set Manager Tab
--- Set Manager tab for the current build.
+-- Module: Linked Sets Tab
+-- Linked Sets tab for the current build.
 --
 local pairs = pairs
 local ipairs = ipairs
 local t_insert = table.insert
 
-local SetManagerTabClass = newClass("SetManagerTab", "ControlHost", "Control", function(self, build)
+local LinkedSetsTabClass = newClass("LinkedSetsTab", "UndoHandler", "ControlHost", "Control", function(self, build)
+	self.UndoHandler()
 	self.ControlHost()
 	self.Control()
 
@@ -42,8 +43,8 @@ local SetManagerTabClass = newClass("SetManagerTab", "ControlHost", "Control", f
 	end)
 
 	local dropdownWidth = 100
-	-- Tree Set Manager
-	-- Skill and Item Manager controls are anchored to these three labels
+	-- Tree Linked Sets
+	-- Skill and Item controls are anchored to these three labels
 	self.controls.treeSetLabelRoot = new("LabelControl", {"TOPLEFT",self,"TOPLEFT"}, 35, 200, 0, 16, "Tree Sets")
 	self.controls.treeSetLabelDropdownSkill = new("LabelControl", {"LEFT",self.controls.treeSetLabelRoot,"RIGHT"}, dropdownWidth*1.1, 0, 0, 16, "Skill Sets")
 	self.controls.treeSetLabelDropdownItem = new("LabelControl", {"LEFT",self.controls.treeSetLabelDropdownSkill,"RIGHT"}, dropdownWidth/2, 0, 0, 16, "Item Sets")
@@ -68,7 +69,7 @@ local SetManagerTabClass = newClass("SetManagerTab", "ControlHost", "Control", f
 	end)
 	self.controls.treeSetDropdownItem.enabled = function() return self.controls.treeSetDropdown.selIndex ~= 1 end
 
-	-- Skill Set Manager
+	-- Skill Linked Sets
 	self.controls.skillSetLabelRoot = new("LabelControl", {"LEFT",self.controls.treeSetLabelRoot,"LEFT"}, 0, 60, 0, 16, "Skill Sets")
 	self.controls.skillSetLabelDropdownTree = new("LabelControl", {"LEFT",self.controls.treeSetLabelDropdownSkill,"LEFT"}, 0, 60, 0, 16, "Tree Sets")
 	self.controls.skillSetLabelDropdownItem = new("LabelControl", {"LEFT",self.controls.treeSetLabelDropdownItem,"LEFT"}, 0, 60, 0, 16, "Item Sets")
@@ -92,7 +93,7 @@ local SetManagerTabClass = newClass("SetManagerTab", "ControlHost", "Control", f
 	end)
 	self.controls.skillSetDropdownItem.enabled = function() return self.controls.skillSetDropdown.selIndex ~= 1 end
 
-	-- Item Set Manager
+	-- Item Linked Sets
 	self.controls.itemSetLabelRoot = new("LabelControl", {"LEFT",self.controls.treeSetLabelRoot,"LEFT"}, 0, 120, 0, 16, "Item Sets")
 	self.controls.itemSetLabelDropdownTree = new("LabelControl", {"LEFT",self.controls.treeSetLabelDropdownSkill,"LEFT"}, 0, 120, 0, 16, "Tree Sets")
 	self.controls.itemSetLabelDropdownSkill = new("LabelControl", {"LEFT",self.controls.treeSetLabelDropdownItem,"LEFT"}, 0, 120, 0, 16, "Skill Sets")
@@ -153,7 +154,7 @@ local SetManagerTabClass = newClass("SetManagerTab", "ControlHost", "Control", f
 	end)
 end)
 
-function SetManagerTabClass:InitLinks(set, value)
+function LinkedSetsTabClass:InitLinks(set, value)
 	if set == "tree" then
 		if not (self.treeSetLinks[value]) then
 			self.treeSetLinks[value] = { }
@@ -169,7 +170,7 @@ function SetManagerTabClass:InitLinks(set, value)
 	end
 end
 
-function SetManagerTabClass:LoadLinks(set, value)
+function LinkedSetsTabClass:LoadLinks(set, value)
 	if set == "tree" then
 		self.controls.treeSetDropdownItem:SelByValue(self.treeSetLinks[value].itemSet or "None")
 		self.controls.treeSetDropdownSkill:SelByValue(self.treeSetLinks[value].skillSet or "None")
@@ -182,7 +183,7 @@ function SetManagerTabClass:LoadLinks(set, value)
 	end
 end
 
-function SetManagerTabClass:ResetLinks()
+function LinkedSetsTabClass:ResetLinks()
 	wipeTable(self.treeSetLinks)
 	wipeTable(self.skillSetLinks)
 	wipeTable(self.itemSetLinks)
@@ -200,7 +201,7 @@ function SetManagerTabClass:ResetLinks()
 	self.controls.itemSetDropdownSkill.selIndex = 1
 end
 
-function SetManagerTabClass:GetSetTitles(sets)
+function LinkedSetsTabClass:GetSetTitles(sets)
 	local setTitles = { "None" }
 	local title = ""
 	for _, set in pairs(sets) do
@@ -210,7 +211,7 @@ function SetManagerTabClass:GetSetTitles(sets)
 	return setTitles
 end
 
-function SetManagerTabClass:UpdateSetDropdowns()
+function LinkedSetsTabClass:UpdateSetDropdowns()
 	self.treeSetTitles = self:GetSetTitles(self.build.treeTab.specList)
 	self.skillSetTitles = self:GetSetTitles(self.build.skillsTab.skillSets)
 	self.itemSetTitles = self:GetSetTitles(self.build.itemsTab.itemSets)
@@ -228,7 +229,7 @@ function SetManagerTabClass:UpdateSetDropdowns()
 	self.controls.itemSetDropdownSkill:SetList(self.skillSetTitles)
 end
 
-function SetManagerTabClass:Draw(viewPort, inputEvents)
+function LinkedSetsTabClass:Draw(viewPort, inputEvents)
 	self.x = viewPort.x
 	self.y = viewPort.y
 	self.width = viewPort.width
@@ -250,7 +251,7 @@ function SetManagerTabClass:Draw(viewPort, inputEvents)
 	self:DrawControls(viewPort)
 end
 
-function SetManagerTabClass:Save(xml)
+function LinkedSetsTabClass:Save(xml)
 	xml.attrib = {
 		enabled = tostring(self.enabled)
 	}
@@ -297,7 +298,7 @@ function SetManagerTabClass:Save(xml)
 	end
 end
 
-function SetManagerTabClass:Load(xml)
+function LinkedSetsTabClass:Load(xml)
 	if xml.attrib then
 		self.enabled = xml.attrib.enabled == "true"
 		self.controls.enabled.state = self.enabled
@@ -320,6 +321,60 @@ function SetManagerTabClass:Load(xml)
 					["treeSet"] = node.attrib.treeSet or { },
 					["skillSet"] = node.attrib.skillSet or { }
 				}
+			end
+		end
+	end
+end
+
+function LinkedSetsTabClass:RenameSet(type, old, new)
+	if type == "tree" then
+		-- replace index
+		if self.treeSetLinks[old] then
+			self.treeSetLinks[new] = copyTable(self.treeSetLinks[old])
+			self.treeSetLinks[old] = nil
+		end
+
+		-- replace set in other types
+		for index, _ in pairs(self.skillSetLinks) do
+			if self.skillSetLinks[index].treeSet == old then
+				self.skillSetLinks[index].treeSet = new
+			end
+		end
+		for index, _ in pairs(self.itemSetLinks) do
+			if self.itemSetLinks[index].treeSet == old then
+				self.itemSetLinks[index].treeSet = new
+			end
+		end
+	elseif type == "skill" then
+		if self.skillSetLinks[old] then
+			self.skillSetLinks[new] = copyTable(self.skillSetLinks[old])
+			self.skillSetLinks[old] = nil
+		end
+
+		for index, _ in pairs(self.treeSetLinks) do
+			if self.treeSetLinks[index].skillSet == old then
+				self.treeSetLinks[index].skillSet = new
+			end
+		end
+		for index, _ in pairs(self.itemSetLinks) do
+			if self.itemSetLinks[index].skillSet == old then
+				self.itemSetLinks[index].skillSet = new
+			end
+		end
+	elseif type == "item" then
+		if self.itemSetLinks[old] then
+			self.itemSetLinks[new] = copyTable(self.itemSetLinks[old])
+			self.itemSetLinks[old] = nil
+		end
+
+		for index, _ in pairs(self.treeSetLinks) do
+			if self.treeSetLinks[index].itemSet == old then
+				self.treeSetLinks[index].itemSet = new
+			end
+		end
+		for index, _ in pairs(self.skillSetLinks) do
+			if self.skillSetLinks[index].itemSet == old then
+				self.skillSetLinks[index].itemSet = new
 			end
 		end
 	end

--- a/src/Classes/LinkedSetsTab.lua
+++ b/src/Classes/LinkedSetsTab.lua
@@ -37,14 +37,6 @@ local LinkedSetsTabClass = newClass("LinkedSetsTab", "UndoHandler", "ControlHost
 	Skill Set 2 and Item Set 2 should automatically set active as well.
 	But given no other links were created, switching to active Tree Set 1, Skill Set 1, or Item Set 1 would do nothing to the other Sets.]]
 	self.controls.notesDesc = new("LabelControl", {"TOPLEFT",self,"TOPLEFT"}, 8, 8, 150, 16, notesDesc)
-	self.controls.notesDesc.width = function()
-		local width = self.width / 2 - 16
-		if width ~= self.controls.notesDesc.lastWidth then
-			self.controls.notesDesc.lastWidth = width
-			self.controls.notesDesc.label = table.concat(main:WrapString(notesDesc, 16, width - 50), "\n")
-		end
-		return width
-	end
 
 	self.controls.enabled = new("CheckBoxControl", { "TOPLEFT", self, "TOPLEFT" }, 80, 145, 18, "Enabled:", function(state)
 		self.enabled = state
@@ -155,36 +147,17 @@ local LinkedSetsTabClass = newClass("LinkedSetsTab", "UndoHandler", "ControlHost
 		end
 		return note
 	end
-	local function showCurrentLinks()
-		for index, link in pairs(self.treeSetLinks) do
-			if isValidLink("tree", index, link) then
-				return true
-			end
-		end
-		for index, link in pairs(self.skillSetLinks) do
-			if isValidLink("skill", index, link) then
-				return true
-			end
-		end
-		for index, link in pairs(self.itemSetLinks) do
-			if isValidLink("item", index, link) then
-				return true
-			end
-		end
-		return false
-	end
 	self.controls.displayLinks = new("LabelControl", {"LEFT",self.controls.itemSetDropdown,"LEFT"}, 0, 85, 0, 16, "Current Links:")
-	self.controls.displayLinks.shown = function() return showCurrentLinks() end
-	self.controls.displayLinksLabel = new("LabelControl", {"LEFT",self.controls.displayLinks,"LEFT"}, 0, 45, 150, 16, function()
+	self.controls.displayLinksLabel = new("LabelControl", {"LEFT",self.controls.displayLinks,"LEFT"}, 0, 35, 150, 16, function()
 		return currentLinksNote[activeNote] and currentLinksNote[activeNote]() or ""
 	end)
-	self.controls.displayLinksTreeButton = new("ButtonControl", { "LEFT", self.controls.displayLinks, "LEFT"}, 100, 0, 150, 18, "^7Show Tree Set Links", function()
+	self.controls.displayLinksTreeButton = new("ButtonControl", { "LEFT",self.controls.displayLinks, "RIGHT"}, 8, 1, 150, 18, "^7Show Tree Set Links", function()
 		activeNote = "tree"
 	end)
-	self.controls.displayLinksSkillButton = new("ButtonControl", {"LEFT",self.controls.displayLinksTreeButton,"LEFT"}, 160, 0, 150, 18, "^7Show Skill Set Links", function()
+	self.controls.displayLinksSkillButton = new("ButtonControl", {"LEFT",self.controls.displayLinksTreeButton,"RIGHT"}, 8, 0, 150, 18, "^7Show Skill Set Links", function()
 		activeNote = "skill"
 	end)
-	self.controls.displayLinksItemButton = new("ButtonControl", {"LEFT",self.controls.displayLinksSkillButton,"LEFT"}, 160, 0, 150, 18, "^7Show Item Set Links", function()
+	self.controls.displayLinksItemButton = new("ButtonControl", {"LEFT",self.controls.displayLinksSkillButton,"RIGHT"}, 8, 0, 150, 18, "^7Show Item Set Links", function()
 		activeNote = "item"
 	end)
 end)

--- a/src/Classes/PassiveSpecListControl.lua
+++ b/src/Classes/PassiveSpecListControl.lua
@@ -49,7 +49,7 @@ function PassiveSpecListClass:RenameSpec(spec, title, addOnName)
 		controls.save.enabled = buf:match("%S")
 	end)
 	controls.save = new("ButtonControl", nil, -45, 70, 80, 20, "Save", function()
-		self.treeTab.build.linkedSetsTab:RenameSet("tree", spec.title or "Default", controls.edit.buf)
+		self.treeTab.build.linkedSetsTab:ModifySet("tree", "rename", spec.title or "Default", controls.edit.buf)
 		spec.title = controls.edit.buf
 		self.treeTab.modFlag = true
 		if addOnName then
@@ -94,6 +94,7 @@ function PassiveSpecListClass:OnSelDelete(index, spec)
 	if #self.list > 1 then
 		main:OpenConfirmPopup("Delete Tree", "Are you sure you want to delete '"..(spec.title or "Default").."'?", "Delete", function()
 			t_remove(self.list, index)
+			self.treeTab.build.linkedSetsTab:ModifySet("tree", "delete", spec.title or "Default")
 			self.selIndex = nil
 			self.selValue = nil
 			if index == self.treeTab.activeSpec then 

--- a/src/Classes/PassiveSpecListControl.lua
+++ b/src/Classes/PassiveSpecListControl.lua
@@ -49,6 +49,7 @@ function PassiveSpecListClass:RenameSpec(spec, title, addOnName)
 		controls.save.enabled = buf:match("%S")
 	end)
 	controls.save = new("ButtonControl", nil, -45, 70, 80, 20, "Save", function()
+		self.treeTab.build.linkedSetsTab:RenameSet("tree", spec.title or "Default", controls.edit.buf)
 		spec.title = controls.edit.buf
 		self.treeTab.modFlag = true
 		if addOnName then

--- a/src/Classes/SetManagerTab.lua
+++ b/src/Classes/SetManagerTab.lua
@@ -1,0 +1,327 @@
+-- Path of Building
+--
+-- Module: Set Manager Tab
+-- Set Manager tab for the current build.
+--
+local pairs = pairs
+local ipairs = ipairs
+local t_insert = table.insert
+
+local SetManagerTabClass = newClass("SetManagerTab", "ControlHost", "Control", function(self, build)
+	self.ControlHost()
+	self.Control()
+
+	self.build = build
+
+	self.treeSetLinks = {}
+	self.itemSetLinks = {}
+	self.skillSetLinks = {}
+	self.enabled = false
+
+	local notesDesc = [[^7
+	With this tab, you can manage links between item, skill, and tree sets.
+	Each set is listed on the left, with two dropdowns on the right to create a link between the sets.
+
+	For example, given Tree Set 1 has Skill Set 2 and Item Set 2 linked, if you change to Tree Set 1 either in the Tree Tab or Items Tab,
+	Skill Set 2 and Item Set 2 should automatically set active as well.
+	But with no other changes, setting Skill Set 2 or Item Set 2 to active would do nothing to the other Sets.]]
+
+	self.controls.notesDesc = new("LabelControl", {"TOPLEFT",self,"TOPLEFT"}, 8, 8, 150, 16, notesDesc)
+	self.controls.notesDesc.width = function()
+		local width = self.width / 2 - 16
+		if width ~= self.controls.notesDesc.lastWidth then
+			self.controls.notesDesc.lastWidth = width
+			self.controls.notesDesc.label = table.concat(main:WrapString(notesDesc, 16, width - 50), "\n")
+		end
+		return width
+	end
+
+	self.controls.enabled = new("CheckBoxControl", { "TOPLEFT", self, "TOPLEFT" }, 80, 145, 18, "Enabled:", function(state)
+		self.enabled = state
+		self.modFlag = true
+	end)
+
+	local dropdownWidth = 100
+	-- Tree Set Manager
+	-- Skill and Item Manager controls are anchored to these three labels
+	self.controls.treeSetLabelRoot = new("LabelControl", {"TOPLEFT",self,"TOPLEFT"}, 35, 200, 0, 16, "Tree Sets")
+	self.controls.treeSetLabelDropdownSkill = new("LabelControl", {"LEFT",self.controls.treeSetLabelRoot,"RIGHT"}, dropdownWidth*1.1, 0, 0, 16, "Skill Sets")
+	self.controls.treeSetLabelDropdownItem = new("LabelControl", {"LEFT",self.controls.treeSetLabelDropdownSkill,"RIGHT"}, dropdownWidth/2, 0, 0, 16, "Item Sets")
+	self.controls.treeSetDropdown = new("DropDownControl", {"LEFT",self.controls.treeSetLabelRoot,"LEFT"}, 0, 20, dropdownWidth, 18, nil, function(index, value)
+		self:InitLinks("tree", value)
+		self:LoadLinks("tree", value)
+	end)
+
+	self.controls.treeSetDropdownSkill = new("DropDownControl", {"LEFT",self.controls.treeSetLabelDropdownSkill,"LEFT"}, 0, 20, dropdownWidth, 18, nil, function(index, value)
+		local treeSetTitle = self.controls.treeSetDropdown.list[self.controls.treeSetDropdown.selIndex]
+		self:InitLinks("tree", treeSetTitle)
+		self.treeSetLinks[treeSetTitle]["skillSet"] = value
+		self.modFlag = true
+	end)
+	self.controls.treeSetDropdownSkill.enabled = function() return self.controls.treeSetDropdown.selIndex ~= 1 end
+
+	self.controls.treeSetDropdownItem = new("DropDownControl", {"LEFT",self.controls.treeSetLabelDropdownItem,"LEFT"}, 0, 20, dropdownWidth, 18, nil, function(index, value)
+		local treeSetTitle = self.controls.treeSetDropdown.list[self.controls.treeSetDropdown.selIndex]
+		self:InitLinks("tree", treeSetTitle)
+		self.treeSetLinks[treeSetTitle]["itemSet"] = value
+		self.modFlag = true
+	end)
+	self.controls.treeSetDropdownItem.enabled = function() return self.controls.treeSetDropdown.selIndex ~= 1 end
+
+	-- Skill Set Manager
+	self.controls.skillSetLabelRoot = new("LabelControl", {"LEFT",self.controls.treeSetLabelRoot,"LEFT"}, 0, 60, 0, 16, "Skill Sets")
+	self.controls.skillSetLabelDropdownTree = new("LabelControl", {"LEFT",self.controls.treeSetLabelDropdownSkill,"LEFT"}, 0, 60, 0, 16, "Tree Sets")
+	self.controls.skillSetLabelDropdownItem = new("LabelControl", {"LEFT",self.controls.treeSetLabelDropdownItem,"LEFT"}, 0, 60, 0, 16, "Item Sets")
+	self.controls.skillSetDropdown = new("DropDownControl", {"LEFT",self.controls.skillSetLabelRoot,"LEFT"}, 0, 20, dropdownWidth, 18, nil, function(index, value)
+		self:InitLinks("skill", value)
+		self:LoadLinks("skill", value)
+	end)
+	self.controls.skillSetDropdownTree = new("DropDownControl", {"LEFT",self.controls.skillSetLabelDropdownTree,"LEFT"}, 0, 20, dropdownWidth, 18, nil, function(index, value)
+		local skillSetTitle = self.controls.skillSetDropdown.list[self.controls.skillSetDropdown.selIndex]
+		self:InitLinks("skill", skillSetTitle)
+		self.skillSetLinks[skillSetTitle]["treeSet"] = value
+		self.modFlag = true
+	end)
+	self.controls.skillSetDropdownTree.enabled = function() return self.controls.skillSetDropdown.selIndex ~= 1 end
+
+	self.controls.skillSetDropdownItem = new("DropDownControl", {"LEFT",self.controls.skillSetLabelDropdownItem,"LEFT"}, 0, 20, dropdownWidth, 18, nil, function(index, value)
+		local skillSetTitle = self.controls.skillSetDropdown.list[self.controls.skillSetDropdown.selIndex]
+		self:InitLinks("skill", skillSetTitle)
+		self.skillSetLinks[skillSetTitle]["itemSet"] = value
+		self.modFlag = true
+	end)
+	self.controls.skillSetDropdownItem.enabled = function() return self.controls.skillSetDropdown.selIndex ~= 1 end
+
+	-- Item Set Manager
+	self.controls.itemSetLabelRoot = new("LabelControl", {"LEFT",self.controls.treeSetLabelRoot,"LEFT"}, 0, 120, 0, 16, "Item Sets")
+	self.controls.itemSetLabelDropdownTree = new("LabelControl", {"LEFT",self.controls.treeSetLabelDropdownSkill,"LEFT"}, 0, 120, 0, 16, "Tree Sets")
+	self.controls.itemSetLabelDropdownSkill = new("LabelControl", {"LEFT",self.controls.treeSetLabelDropdownItem,"LEFT"}, 0, 120, 0, 16, "Skill Sets")
+	self.controls.itemSetDropdown = new("DropDownControl", {"LEFT",self.controls.itemSetLabelRoot,"LEFT"}, 0, 20, dropdownWidth, 18, nil, function(index, value)
+		self:InitLinks("item", value)
+		self:LoadLinks("item", value)
+	end)
+	self.controls.itemSetDropdownTree = new("DropDownControl", {"LEFT",self.controls.itemSetLabelDropdownTree,"LEFT"}, 0, 20, dropdownWidth, 18, nil, function(index, value)
+		local itemSetTitle = self.controls.itemSetDropdown.list[self.controls.itemSetDropdown.selIndex]
+		self:InitLinks("item", itemSetTitle)
+		self.itemSetLinks[itemSetTitle]["treeSet"] = value
+		self.modFlag = true
+	end)
+	self.controls.itemSetDropdownTree.enabled = function() return self.controls.itemSetDropdown.selIndex ~= 1 end
+
+	self.controls.itemSetDropdownSkill = new("DropDownControl", {"LEFT",self.controls.itemSetLabelDropdownSkill,"LEFT"}, 0, 20, dropdownWidth, 18, nil, function(index, value)
+		local itemSetTitle = self.controls.itemSetDropdown.list[self.controls.itemSetDropdown.selIndex]
+		self:InitLinks("item", itemSetTitle)
+		self.itemSetLinks[itemSetTitle]["skillSet"] = value
+		self.modFlag = true
+	end)
+	self.controls.itemSetDropdownSkill.enabled = function() return self.controls.itemSetDropdown.selIndex ~= 1 end
+
+	self.controls.reset = new("ButtonControl", {"RIGHT",self.controls.treeSetDropdownItem,"RIGHT"}, 0, -74, 75, 18, "Reset", function()
+		self:ResetLinks()
+		self.modFlag = true
+	end)
+
+	-- Display current links all at once
+	self.controls.displayLinks = new("LabelControl", {"LEFT",self.controls.itemSetDropdown,"LEFT"}, -15, 75, 0, 16, "Current Links:")
+	self.controls.displayLinks.shown = function() return self.treeSetLinks ~= {} or self.skillSetLinks ~= {} or self.itemSetLinks ~= {} end
+	self.controls.displayLinksTree = new("LabelControl", {"LEFT",self.controls.displayLinks,"LEFT"}, 0, 25, 150, 16, function()
+		local note = "Tree Links                    Skill, Item\n"
+		for index, link in pairs(self.treeSetLinks) do
+			if index ~= "None" then
+				note = note .. "   " .. index .. "  -->  " .. (link.skillSet or "") .. ", " .. (link.itemSet or "") .. "\n"
+			end
+		end
+		return note
+	end)
+	self.controls.displayLinksSkill = new("LabelControl", {"LEFT",self.controls.displayLinksTree,"RIGHT"}, 85, 0, 150, 16, function()
+		local note = "Skill Links                    Tree, Item\n"
+		for index, link in pairs(self.skillSetLinks) do
+			if index ~= "None" then
+				note = note .. "   " .. index .. "  -->  " .. (link.treeSet or "") .. ", " .. (link.itemSet or "") .. "\n"
+			end
+		end
+		return note
+	end)
+	self.controls.displayLinksItem = new("LabelControl", {"LEFT",self.controls.displayLinksSkill,"RIGHT"}, 85, 0, 150, 16, function()
+		local note = "Item Links                    Tree, Skill\n"
+		for index, link in pairs(self.itemSetLinks) do
+			if index ~= "None" then
+				note = note .. "   " .. index .. "  -->  " .. (link.treeSet or "None") .. ", " .. (link.skillSet or "None") .. "\n"
+			end
+		end
+		return note
+	end)
+end)
+
+function SetManagerTabClass:InitLinks(set, value)
+	if set == "tree" then
+		if not (self.treeSetLinks[value]) then
+			self.treeSetLinks[value] = { }
+		end
+	elseif set == "skill" then
+		if not (self.skillSetLinks[value]) then
+			self.skillSetLinks[value] = { }
+		end
+	elseif set == "item" then
+		if not (self.itemSetLinks[value]) then
+			self.itemSetLinks[value] = { }
+		end
+	end
+end
+
+function SetManagerTabClass:LoadLinks(set, value)
+	if set == "tree" then
+		self.controls.treeSetDropdownItem:SelByValue(self.treeSetLinks[value].itemSet or "None")
+		self.controls.treeSetDropdownSkill:SelByValue(self.treeSetLinks[value].skillSet or "None")
+	elseif set == "skill" then
+		self.controls.skillSetDropdownTree:SelByValue(self.skillSetLinks[value].treeSet or "None")
+		self.controls.skillSetDropdownItem:SelByValue(self.skillSetLinks[value].itemSet or "None")
+	elseif set == "item" then
+		self.controls.itemSetDropdownTree:SelByValue(self.itemSetLinks[value].treeSet or "None")
+		self.controls.itemSetDropdownSkill:SelByValue(self.itemSetLinks[value].skillSet or "None")
+	end
+end
+
+function SetManagerTabClass:ResetLinks()
+	wipeTable(self.treeSetLinks)
+	wipeTable(self.skillSetLinks)
+	wipeTable(self.itemSetLinks)
+
+	self.controls.treeSetDropdown.selIndex = 1
+	self.controls.treeSetDropdownSkill.selIndex = 1
+	self.controls.treeSetDropdownItem.selIndex = 1
+
+	self.controls.skillSetDropdown.selIndex = 1
+	self.controls.skillSetDropdownTree.selIndex = 1
+	self.controls.skillSetDropdownItem.selIndex = 1
+
+	self.controls.itemSetDropdown.selIndex = 1
+	self.controls.itemSetDropdownTree.selIndex = 1
+	self.controls.itemSetDropdownSkill.selIndex = 1
+end
+
+function SetManagerTabClass:GetSetTitles(sets)
+	local setTitles = { "None" }
+	local title = ""
+	for _, set in pairs(sets) do
+		title = set.title or "Default"
+		t_insert(setTitles, title)
+	end
+	return setTitles
+end
+
+function SetManagerTabClass:UpdateSetDropdowns()
+	self.treeSetTitles = self:GetSetTitles(self.build.treeTab.specList)
+	self.skillSetTitles = self:GetSetTitles(self.build.skillsTab.skillSets)
+	self.itemSetTitles = self:GetSetTitles(self.build.itemsTab.itemSets)
+
+	self.controls.treeSetDropdown:SetList(self.treeSetTitles)
+	self.controls.treeSetDropdownSkill:SetList(self.skillSetTitles)
+	self.controls.treeSetDropdownItem:SetList(self.itemSetTitles)
+
+	self.controls.skillSetDropdown:SetList(self.skillSetTitles)
+	self.controls.skillSetDropdownTree:SetList(self.treeSetTitles)
+	self.controls.skillSetDropdownItem:SetList(self.itemSetTitles)
+
+	self.controls.itemSetDropdown:SetList(self.itemSetTitles)
+	self.controls.itemSetDropdownTree:SetList(self.treeSetTitles)
+	self.controls.itemSetDropdownSkill:SetList(self.skillSetTitles)
+end
+
+function SetManagerTabClass:Draw(viewPort, inputEvents)
+	self.x = viewPort.x
+	self.y = viewPort.y
+	self.width = viewPort.width
+	self.height = viewPort.height
+
+	self:UpdateSetDropdowns()
+
+	-- TODO: undo, redo
+	--for id, event in ipairs(inputEvents) do
+	--	if event.type == "KeyDown" then
+	--		if event.key == "z" and IsKeyDown("CTRL") then
+	--		elseif event.key == "y" and IsKeyDown("CTRL") then
+	--		end
+	--	end
+	--end
+
+	self:ProcessControlsInput(inputEvents, viewPort)
+	main:DrawBackground(viewPort)
+	self:DrawControls(viewPort)
+end
+
+function SetManagerTabClass:Save(xml)
+	xml.attrib = {
+		enabled = tostring(self.enabled)
+	}
+	for index, treeSet in pairs(self.treeSetLinks) do
+		if index ~= "None" then
+			local child = {
+				elem = "TreeSet",
+				attrib = {
+					title = index,
+					skillSet = treeSet["skillSet"] or "None",
+					itemSet = treeSet["itemSet"] or "None"
+				}
+			}
+			t_insert(xml, child)
+		end
+	end
+
+	for index, skillSet in pairs(self.skillSetLinks) do
+		if index ~= "None" then
+			local child = {
+				elem = "SkillSet",
+				attrib = {
+					title = index,
+					treeSet = skillSet["treeSet"] or "None",
+					itemSet = skillSet["itemSet"] or "None"
+				}
+			}
+			t_insert(xml, child)
+		end
+	end
+
+	for index, itemSet in pairs(self.itemSetLinks) do
+		if index ~= "None" then
+			local child = {
+				elem = "ItemSet",
+				attrib = {
+					title = index,
+					treeSet = itemSet["treeSet"] or "None",
+					skillSet = itemSet["skillSet"] or "None"
+				}
+			}
+			t_insert(xml, child)
+		end
+	end
+end
+
+function SetManagerTabClass:Load(xml)
+	self:ResetLinks()
+	if xml.attrib then
+		self.enabled = xml.attrib.enabled == "true"
+		self.controls.enabled.state = self.enabled
+	end
+
+	for _, node in pairs(xml) do
+		if type(node) ~= "boolean" then
+			if node.elem == "TreeSet" then
+				self.treeSetLinks[node.attrib.title] = {
+					["skillSet"] = node.attrib.skillSet or { },
+					["itemSet"] = node.attrib.itemSet or { }
+				}
+			elseif node.elem == "SkillSet" then
+				self.skillSetLinks[node.attrib.title] = {
+					["treeSet"] = node.attrib.treeSet or { },
+					["itemSet"] = node.attrib.itemSet or { }
+				}
+			elseif node.elem == "ItemSet" then
+				self.itemSetLinks[node.attrib.title] = {
+					["treeSet"] = node.attrib.treeSet or { },
+					["skillSet"] = node.attrib.skillSet or { }
+				}
+			end
+		end
+	end
+end

--- a/src/Classes/SetManagerTab.lua
+++ b/src/Classes/SetManagerTab.lua
@@ -298,7 +298,6 @@ function SetManagerTabClass:Save(xml)
 end
 
 function SetManagerTabClass:Load(xml)
-	self:ResetLinks()
 	if xml.attrib then
 		self.enabled = xml.attrib.enabled == "true"
 		self.controls.enabled.state = self.enabled

--- a/src/Classes/SkillSetListControl.lua
+++ b/src/Classes/SkillSetListControl.lua
@@ -57,6 +57,7 @@ function SkillSetListClass:RenameSet(skillSet, addOnName)
 		controls.save.enabled = buf:match("%S")
 	end)
 	controls.save = new("ButtonControl", nil, -45, 70, 80, 20, "Save", function()
+		self.skillsTab.build.linkedSetsTab:RenameSet("skill", skillSet.title or "Default", controls.edit.buf)
 		skillSet.title = controls.edit.buf
 		self.skillsTab.modFlag = true
 		if addOnName then

--- a/src/Classes/SkillSetListControl.lua
+++ b/src/Classes/SkillSetListControl.lua
@@ -57,7 +57,7 @@ function SkillSetListClass:RenameSet(skillSet, addOnName)
 		controls.save.enabled = buf:match("%S")
 	end)
 	controls.save = new("ButtonControl", nil, -45, 70, 80, 20, "Save", function()
-		self.skillsTab.build.linkedSetsTab:RenameSet("skill", skillSet.title or "Default", controls.edit.buf)
+		self.skillsTab.build.linkedSetsTab:ModifySet("skill", "rename", skillSet.title or "Default", controls.edit.buf)
 		skillSet.title = controls.edit.buf
 		self.skillsTab.modFlag = true
 		if addOnName then
@@ -101,6 +101,7 @@ function SkillSetListClass:OnSelDelete(index, skillSetId)
 	if #self.list > 1 then
 		main:OpenConfirmPopup("Delete Item Set", "Are you sure you want to delete '"..(skillSet.title or "Default").."'?", "Delete", function()
 			t_remove(self.list, index)
+			self.skillsTab.build.linkedSetsTab:ModifySet("skill", "delete", skillSet.title or "Default")
 			self.skillsTab.skillSets[skillSetId] = nil
 			self.selIndex = nil
 			self.selValue = nil

--- a/src/Classes/SkillsTab.lua
+++ b/src/Classes/SkillsTab.lua
@@ -93,10 +93,10 @@ local SkillsTabClass = newClass("SkillsTab", "UndoHandler", "ControlHost", "Cont
 	self.defaultGemQuality = main.defaultGemQuality
 
 	local function loadSetLinks(value)
-		if self.build.setManagerTab.enabled then
-			if self.build.setManagerTab.skillSetLinks[value] then
-				self.build.treeTab:SetActiveSpecByVal(self.build.setManagerTab.skillSetLinks[value].treeSet)
-				self.build.itemsTab:SetActiveItemSetByVal(self.build.setManagerTab.skillSetLinks[value].itemSet)
+		if self.build.linkedSetsTab.enabled then
+			if self.build.linkedSetsTab.skillSetLinks[value] then
+				self.build.treeTab:SetActiveSpecByVal(self.build.linkedSetsTab.skillSetLinks[value].treeSet)
+				self.build.itemsTab:SetActiveItemSetByVal(self.build.linkedSetsTab.skillSetLinks[value].itemSet)
 			end
 		end
 	end

--- a/src/Classes/SkillsTab.lua
+++ b/src/Classes/SkillsTab.lua
@@ -93,11 +93,9 @@ local SkillsTabClass = newClass("SkillsTab", "UndoHandler", "ControlHost", "Cont
 	self.defaultGemQuality = main.defaultGemQuality
 
 	local function loadSetLinks(value)
-		if self.build.linkedSetsTab.enabled then
-			if self.build.linkedSetsTab.skillSetLinks[value] then
-				self.build.treeTab:SetActiveSpecByVal(self.build.linkedSetsTab.skillSetLinks[value].treeSet)
-				self.build.itemsTab:SetActiveItemSetByVal(self.build.linkedSetsTab.skillSetLinks[value].itemSet)
-			end
+		if self.build.linkedSetsTab.enabled and self.build.linkedSetsTab.skillSetLinks[value] then
+			self.build.treeTab:SetActiveSpecByVal(self.build.linkedSetsTab.skillSetLinks[value].treeSet)
+			self.build.itemsTab:SetActiveItemSetByVal(self.build.linkedSetsTab.skillSetLinks[value].itemSet)
 		end
 	end
 	-- Set selector

--- a/src/Classes/SkillsTab.lua
+++ b/src/Classes/SkillsTab.lua
@@ -92,18 +92,12 @@ local SkillsTabClass = newClass("SkillsTab", "UndoHandler", "ControlHost", "Cont
 	self.defaultGemLevel = "normalMaximum"
 	self.defaultGemQuality = main.defaultGemQuality
 
-	local function loadSetLinks(value)
-		if self.build.linkedSetsTab.enabled and self.build.linkedSetsTab.skillSetLinks[value] then
-			self.build.treeTab:SetActiveSpecByVal(self.build.linkedSetsTab.skillSetLinks[value].treeSet)
-			self.build.itemsTab:SetActiveItemSetByVal(self.build.linkedSetsTab.skillSetLinks[value].itemSet)
-		end
-	end
 	-- Set selector
 	self.controls.setSelect = new("DropDownControl", { "TOPLEFT", self, "TOPLEFT" }, 76, 8, 210, 20, nil, function(index, value)
 		self:SetActiveSkillSet(self.skillSetOrderList[index])
 		self:SetDisplayGroup(self.socketGroupList[1])
 		self:AddUndoState()
-		loadSetLinks(value)
+		self.build.linkedSetsTab:LoadSetLinks("skill", value)
 	end)
 	self.controls.setSelect.enableDroppedWidth = true
 	self.controls.setSelect.enabled = function()

--- a/src/Classes/SkillsTab.lua
+++ b/src/Classes/SkillsTab.lua
@@ -92,11 +92,20 @@ local SkillsTabClass = newClass("SkillsTab", "UndoHandler", "ControlHost", "Cont
 	self.defaultGemLevel = "normalMaximum"
 	self.defaultGemQuality = main.defaultGemQuality
 
+	local function loadSetLinks(value)
+		if self.build.setManagerTab.enabled then
+			if self.build.setManagerTab.skillSetLinks[value] then
+				self.build.treeTab:SetActiveSpecByVal(self.build.setManagerTab.skillSetLinks[value].treeSet)
+				self.build.itemsTab:SetActiveItemSetByVal(self.build.setManagerTab.skillSetLinks[value].itemSet)
+			end
+		end
+	end
 	-- Set selector
 	self.controls.setSelect = new("DropDownControl", { "TOPLEFT", self, "TOPLEFT" }, 76, 8, 210, 20, nil, function(index, value)
 		self:SetActiveSkillSet(self.skillSetOrderList[index])
 		self:SetDisplayGroup(self.socketGroupList[1])
 		self:AddUndoState()
+		loadSetLinks(value)
 	end)
 	self.controls.setSelect.enableDroppedWidth = true
 	self.controls.setSelect.enabled = function()
@@ -1326,4 +1335,12 @@ function SkillsTabClass:SetActiveSkillSet(skillSetId)
 	self.controls.groupList.list = self.socketGroupList
 	self.activeSkillSetId = skillSetId
 	self.build.buildFlag = true
+end
+
+function SkillsTabClass:SetActiveSkillSetByVal(skillSetTitle)
+	for _, set in pairs(self.skillSets) do
+		if set.title == skillSetTitle or (skillSetTitle == "Default" and not set.title) then
+			self:SetActiveSkillSet(set.id)
+		end
+	end
 end

--- a/src/Classes/TreeTab.lua
+++ b/src/Classes/TreeTab.lua
@@ -38,7 +38,7 @@ local TreeTabClass = newClass("TreeTab", "ControlHost", function(self, build)
 		if self.specList[index] then
 			self.build.modFlag = true
 			self:SetActiveSpec(index)
-			self:LoadSetLinks(value)
+			self.build.linkedSetsTab:LoadSetLinks("tree", value)
 		else
 			self:OpenSpecManagePopup()
 		end
@@ -2093,13 +2093,6 @@ function TreeTabClass:FindTimelessJewel()
 	end)
 
 	main:OpenPopup(910, 517, "Find a Timeless Jewel", controls)
-end
-
-function TreeTabClass:LoadSetLinks(value)
-	if self.build.linkedSetsTab.enabled and self.build.linkedSetsTab.treeSetLinks[value] then
-		self.build.skillsTab:SetActiveSkillSetByVal(self.build.linkedSetsTab.treeSetLinks[value].skillSet)
-		self.build.itemsTab:SetActiveItemSetByVal(self.build.linkedSetsTab.treeSetLinks[value].itemSet)
-	end
 end
 
 function TreeTabClass:SetActiveSpecByVal(treeSetTitle)

--- a/src/Classes/TreeTab.lua
+++ b/src/Classes/TreeTab.lua
@@ -34,20 +34,11 @@ local TreeTabClass = newClass("TreeTab", "ControlHost", function(self, build)
 
 	self.anchorControls = new("Control", nil, 0, 0, 0, 20)
 
-	local function loadSetLinks(value)
-		if self.build.setManagerTab.enabled then
-			if self.build.setManagerTab.treeSetLinks[value] then
-				self.build.skillsTab:SetActiveSkillSetByVal(self.build.setManagerTab.treeSetLinks[value].skillSet)
-				self.build.itemsTab:SetActiveItemSetByVal(self.build.setManagerTab.treeSetLinks[value].itemSet)
-			end
-		end
-	end
-
 	self.controls.specSelect = new("DropDownControl", {"LEFT",self.anchorControls,"RIGHT"}, 0, 0, 190, 20, nil, function(index, value)
 		if self.specList[index] then
 			self.build.modFlag = true
 			self:SetActiveSpec(index)
-			loadSetLinks(value)
+			self:LoadSetLinks(value)
 		else
 			self:OpenSpecManagePopup()
 		end

--- a/src/Classes/TreeTab.lua
+++ b/src/Classes/TreeTab.lua
@@ -2096,11 +2096,9 @@ function TreeTabClass:FindTimelessJewel()
 end
 
 function TreeTabClass:LoadSetLinks(value)
-	if self.build.linkedSetsTab.enabled then
-		if self.build.linkedSetsTab.treeSetLinks[value] then
-			self.build.skillsTab:SetActiveSkillSetByVal(self.build.linkedSetsTab.treeSetLinks[value].skillSet)
-			self.build.itemsTab:SetActiveItemSetByVal(self.build.linkedSetsTab.treeSetLinks[value].itemSet)
-		end
+	if self.build.linkedSetsTab.enabled and self.build.linkedSetsTab.treeSetLinks[value] then
+		self.build.skillsTab:SetActiveSkillSetByVal(self.build.linkedSetsTab.treeSetLinks[value].skillSet)
+		self.build.itemsTab:SetActiveItemSetByVal(self.build.linkedSetsTab.treeSetLinks[value].itemSet)
 	end
 end
 

--- a/src/Classes/TreeTab.lua
+++ b/src/Classes/TreeTab.lua
@@ -34,10 +34,20 @@ local TreeTabClass = newClass("TreeTab", "ControlHost", function(self, build)
 
 	self.anchorControls = new("Control", nil, 0, 0, 0, 20)
 
+	local function loadSetLinks(value)
+		if self.build.setManagerTab.enabled then
+			if self.build.setManagerTab.treeSetLinks[value] then
+				self.build.skillsTab:SetActiveSkillSetByVal(self.build.setManagerTab.treeSetLinks[value].skillSet)
+				self.build.itemsTab:SetActiveItemSetByVal(self.build.setManagerTab.treeSetLinks[value].itemSet)
+			end
+		end
+	end
+
 	self.controls.specSelect = new("DropDownControl", {"LEFT",self.anchorControls,"RIGHT"}, 0, 0, 190, 20, nil, function(index, value)
 		if self.specList[index] then
 			self.build.modFlag = true
 			self:SetActiveSpec(index)
+			loadSetLinks(value)
 		else
 			self:OpenSpecManagePopup()
 		end
@@ -2092,4 +2102,23 @@ function TreeTabClass:FindTimelessJewel()
 	end)
 
 	main:OpenPopup(910, 517, "Find a Timeless Jewel", controls)
+end
+
+function TreeTabClass:LoadSetLinks(value)
+	if self.build.setManagerTab.enabled then
+		if self.build.setManagerTab.treeSetLinks[value] then
+			self.build.skillsTab:SetActiveSkillSetByVal(self.build.setManagerTab.treeSetLinks[value].skillSet)
+			self.build.itemsTab:SetActiveItemSetByVal(self.build.setManagerTab.treeSetLinks[value].itemSet)
+		end
+	end
+end
+
+function TreeTabClass:SetActiveSpecByVal(treeSetTitle)
+	if self.specList then
+		for index, spec in ipairs(self.specList) do
+			if spec.title == treeSetTitle or (treeSetTitle == "Default" and not spec.title) then
+				self:SetActiveSpec(index)
+			end
+		end
+	end
 end

--- a/src/Classes/TreeTab.lua
+++ b/src/Classes/TreeTab.lua
@@ -2096,10 +2096,10 @@ function TreeTabClass:FindTimelessJewel()
 end
 
 function TreeTabClass:LoadSetLinks(value)
-	if self.build.setManagerTab.enabled then
-		if self.build.setManagerTab.treeSetLinks[value] then
-			self.build.skillsTab:SetActiveSkillSetByVal(self.build.setManagerTab.treeSetLinks[value].skillSet)
-			self.build.itemsTab:SetActiveItemSetByVal(self.build.setManagerTab.treeSetLinks[value].itemSet)
+	if self.build.linkedSetsTab.enabled then
+		if self.build.linkedSetsTab.treeSetLinks[value] then
+			self.build.skillsTab:SetActiveSkillSetByVal(self.build.linkedSetsTab.treeSetLinks[value].skillSet)
+			self.build.itemsTab:SetActiveItemSetByVal(self.build.linkedSetsTab.treeSetLinks[value].itemSet)
 		end
 	end
 end

--- a/src/Modules/Build.lua
+++ b/src/Modules/Build.lua
@@ -481,6 +481,10 @@ function buildMode:Init(dbFileName, buildName, buildXML, convertBuild)
 		self.viewMode = "PARTY"
 	end)
 	self.controls.modeParty.locked = function() return self.viewMode == "PARTY" end
+	self.controls.modeSetManager = new("ButtonControl", {"LEFT",self.controls.modeParty,"RIGHT"}, 4, 0, 100, 20, "Set Manager", function()
+		self.viewMode = "SETMANAGER"
+	end)
+	self.controls.modeSetManager.locked = function() return self.viewMode == "SETMANAGER" end
 	-- Skills
 	self.controls.mainSkillLabel = new("LabelControl", {"TOPLEFT",self.anchorSideBar,"TOPLEFT"}, 0, 80, 300, 16, "^7Main Skill:")
 	self.controls.mainSocketGroup = new("DropDownControl", {"TOPLEFT",self.controls.mainSkillLabel,"BOTTOMLEFT"}, 0, 2, 300, 18, nil, function(index, value)
@@ -615,6 +619,7 @@ function buildMode:Init(dbFileName, buildName, buildXML, convertBuild)
 	self.treeTab = new("TreeTab", self)
 	self.skillsTab = new("SkillsTab", self)
 	self.calcsTab = new("CalcsTab", self)
+	self.setManagerTab = new("SetManagerTab", self)
 
 	-- Load sections from the build file
 	self.savers = {
@@ -626,6 +631,7 @@ function buildMode:Init(dbFileName, buildName, buildXML, convertBuild)
 		["Items"] = self.itemsTab,
 		["Skills"] = self.skillsTab,
 		["Calcs"] = self.calcsTab,
+		["SetManager"] = self.setManagerTab,
 		["Import"] = self.importTab,
 	}
 	self.legacyLoaders = { -- Special loaders for legacy sections
@@ -946,6 +952,7 @@ function buildMode:ResetModFlags()
 	self.modFlag = false
 	self.notesTab.modFlag = false
 	self.partyTab.modFlag = false
+	self.setManagerTab.modFlag = false
 	self.configTab.modFlag = false
 	self.treeTab.modFlag = false
 	self.treeTab.searchFlag = false
@@ -1056,6 +1063,8 @@ function buildMode:OnFrame(inputEvents)
 		self.importTab:Draw(tabViewPort, inputEvents)  
 	elseif self.viewMode == "NOTES" then
 		self.notesTab:Draw(tabViewPort, inputEvents)
+	elseif self.viewMode == "SETMANAGER" then
+		self.setManagerTab:Draw(tabViewPort, inputEvents)
 	elseif self.viewMode == "PARTY" then
 		self.partyTab:Draw(tabViewPort, inputEvents)
 	elseif self.viewMode == "CONFIG" then
@@ -1070,7 +1079,7 @@ function buildMode:OnFrame(inputEvents)
 		self.calcsTab:Draw(tabViewPort, inputEvents)
 	end
 
-	self.unsaved = self.modFlag or self.notesTab.modFlag or self.partyTab.modFlag or self.configTab.modFlag or self.treeTab.modFlag or self.treeTab.searchFlag or self.spec.modFlag or self.skillsTab.modFlag or self.itemsTab.modFlag or self.calcsTab.modFlag
+	self.unsaved = self.modFlag or self.notesTab.modFlag or self.partyTab.modFlag or self.setManagerTab.modFlag or self.configTab.modFlag or self.treeTab.modFlag or self.treeTab.searchFlag or self.spec.modFlag or self.skillsTab.modFlag or self.itemsTab.modFlag or self.calcsTab.modFlag
 
 	SetDrawLayer(5)
 

--- a/src/Modules/Build.lua
+++ b/src/Modules/Build.lua
@@ -481,10 +481,10 @@ function buildMode:Init(dbFileName, buildName, buildXML, convertBuild)
 		self.viewMode = "PARTY"
 	end)
 	self.controls.modeParty.locked = function() return self.viewMode == "PARTY" end
-	self.controls.modeSetManager = new("ButtonControl", {"LEFT",self.controls.modeParty,"RIGHT"}, 4, 0, 100, 20, "Set Manager", function()
-		self.viewMode = "SETMANAGER"
+	self.controls.modeLinkedSets = new("ButtonControl", {"LEFT",self.controls.modeParty,"RIGHT"}, 4, 0, 100, 20, "Linked Sets", function()
+		self.viewMode = "LINKED_SETS"
 	end)
-	self.controls.modeSetManager.locked = function() return self.viewMode == "SETMANAGER" end
+	self.controls.modeLinkedSets.locked = function() return self.viewMode == "LINKED_SETS" end
 	-- Skills
 	self.controls.mainSkillLabel = new("LabelControl", {"TOPLEFT",self.anchorSideBar,"TOPLEFT"}, 0, 80, 300, 16, "^7Main Skill:")
 	self.controls.mainSocketGroup = new("DropDownControl", {"TOPLEFT",self.controls.mainSkillLabel,"BOTTOMLEFT"}, 0, 2, 300, 18, nil, function(index, value)
@@ -619,7 +619,7 @@ function buildMode:Init(dbFileName, buildName, buildXML, convertBuild)
 	self.treeTab = new("TreeTab", self)
 	self.skillsTab = new("SkillsTab", self)
 	self.calcsTab = new("CalcsTab", self)
-	self.setManagerTab = new("SetManagerTab", self)
+	self.linkedSetsTab = new("LinkedSetsTab", self)
 
 	-- Load sections from the build file
 	self.savers = {
@@ -631,7 +631,7 @@ function buildMode:Init(dbFileName, buildName, buildXML, convertBuild)
 		["Items"] = self.itemsTab,
 		["Skills"] = self.skillsTab,
 		["Calcs"] = self.calcsTab,
-		["SetManager"] = self.setManagerTab,
+		["LinkedSets"] = self.linkedSetsTab,
 		["Import"] = self.importTab,
 	}
 	self.legacyLoaders = { -- Special loaders for legacy sections
@@ -952,7 +952,7 @@ function buildMode:ResetModFlags()
 	self.modFlag = false
 	self.notesTab.modFlag = false
 	self.partyTab.modFlag = false
-	self.setManagerTab.modFlag = false
+	self.linkedSetsTab.modFlag = false
 	self.configTab.modFlag = false
 	self.treeTab.modFlag = false
 	self.treeTab.searchFlag = false
@@ -1063,8 +1063,8 @@ function buildMode:OnFrame(inputEvents)
 		self.importTab:Draw(tabViewPort, inputEvents)  
 	elseif self.viewMode == "NOTES" then
 		self.notesTab:Draw(tabViewPort, inputEvents)
-	elseif self.viewMode == "SETMANAGER" then
-		self.setManagerTab:Draw(tabViewPort, inputEvents)
+	elseif self.viewMode == "LINKED_SETS" then
+		self.linkedSetsTab:Draw(tabViewPort, inputEvents)
 	elseif self.viewMode == "PARTY" then
 		self.partyTab:Draw(tabViewPort, inputEvents)
 	elseif self.viewMode == "CONFIG" then
@@ -1079,7 +1079,7 @@ function buildMode:OnFrame(inputEvents)
 		self.calcsTab:Draw(tabViewPort, inputEvents)
 	end
 
-	self.unsaved = self.modFlag or self.notesTab.modFlag or self.partyTab.modFlag or self.setManagerTab.modFlag or self.configTab.modFlag or self.treeTab.modFlag or self.treeTab.searchFlag or self.spec.modFlag or self.skillsTab.modFlag or self.itemsTab.modFlag or self.calcsTab.modFlag
+	self.unsaved = self.modFlag or self.notesTab.modFlag or self.partyTab.modFlag or self.linkedSetsTab.modFlag or self.configTab.modFlag or self.treeTab.modFlag or self.treeTab.searchFlag or self.spec.modFlag or self.skillsTab.modFlag or self.itemsTab.modFlag or self.calcsTab.modFlag
 
 	SetDrawLayer(5)
 


### PR DESCRIPTION
Fixes #4569 

**August 2023 Update:**
![linkedSets](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/92683202/b0a311cc-dd43-47cb-be37-5603fe4cb284)


XML of above configuration
```
<LinkedSets enabled="true">
	<TreeSet itemSet="Item Set 2" title="Tree Set 2" skillSet="Skill Set 2"/>
	<TreeSet itemSet="Item Set 1" title="Tree Set A" skillSet="Skill Set 1"/>
	<SkillSet treeSet="Tree Set A" itemSet="Item Set 1" title="Skill Set 1"/>
	<SkillSet treeSet="Tree Set 2" itemSet="Item Set 2" title="Skill Set 2"/>
	<ItemSet treeSet="Tree Set 2" title="Item Set 2" skillSet="Skill Set 2"/>
	<ItemSet treeSet="Tree Set A" title="Item Set 1" skillSet="Skill Set 1"/>
</LinkedSets>
``` 
---
My second go at adding support for linking tree, item, and skill sets. Adding a new tab beside Party because of all the space we have now. Still a few things to hammer out and one of those could end up being a big rework... we'll see! Saves to xml as a distinct elem. 

We've got saving, loading, enabling, disabling, resetting, auto-set-active obviously.

Wanted y'alls opinion, ~~especially with "Set Manager" as maybe that isn't the best name~~. **Changed to Linked Sets. The wording Set Links has crossed my mind too, so open to suggestions.**

- [x] Tree Selector in ItemsTab auto-load item set and skill set
- [x] Renaming sets likely to cause bugs (Title vs ID, however spec does not have id like item and skill, maybe a substitute during the rename funcs) **substitute added**
- [x] Figure out why the text is sometimes white and sometimes gray

Things we may want to consider? :
- ~~Redo/Undo (at least for the Reset button)~~ Added confimation popup
- "None" as placeholder Set could be problematic
- Current Links shown function requires at least one valid link or should we always show the headers?
