### PR TITLE
Fix manaforged arrows calculation crashing

### DIFF
--- a/src/Modules/CalcPerform.lua
+++ b/src/Modules/CalcPerform.lua
@@ -3524,7 +3524,13 @@ function calcs.perform(env, avoidCache, fullDPSSkipEHP)
 	end
 
 	-- Manaforged Arrows
-	if env.player.mainSkill.skillData.triggeredByManaPercentSpent and not env.player.mainSkill.skillFlags.minion and not env.player.mainSkill.marked then
+	if
+		env.player.mainSkill.skillData.triggeredByManaPercentSpent and
+		not env.player.mainSkill.skillFlags.minion and
+		not env.player.mainSkill.marked and
+		env.player.itemList["Weapon 1"] and
+		env.player.itemList["Weapon 1"].base.type == "Bow"
+	then
 		local triggerName = "MfA"
 		local spellCount = 0
 		local icdr = calcLib.mod(env.player.mainSkill.skillModList, env.player.mainSkill.skillCfg, "CooldownRecovery")

--- a/src/Modules/CalcPerform.lua
+++ b/src/Modules/CalcPerform.lua
@@ -3541,11 +3541,12 @@ function calcs.perform(env, avoidCache, fullDPSSkipEHP)
 					-- Below code sets the trigger skill to highest APS skill it finds that meets all conditions
 					local cachedSpeed = GlobalCache.cachedData["CACHE"][uuid].Speed
 					local cachedManaCost = GlobalCache.cachedData["CACHE"][uuid].ManaCost
-					local ManaSpendRate = cachedSpeed * cachedManaCost
-
-					if ((not source and ManaSpendRate) or (ManaSpendRate and ManaSpendRate > trigRate)) then
-						source = skill
-						trigRate = ManaSpendRate
+					if cachedSpeed and cachedManaCost then
+						local ManaSpendRate = cachedSpeed * cachedManaCost
+						if not source or ManaSpendRate > trigRate then
+							source = skill
+							trigRate = ManaSpendRate
+						end
 					end
 				end
 			end


### PR DESCRIPTION
Fixes #6210.

### Description of the problem being solved:
The calculation for trigger rate of a skill supported by manaforged arrows included potential nil values.

### Steps taken to verify a working solution:
- Importing the build mentioned in #6210, swapping weapons and no longer crashing.

### Link to a build that showcases this PR:
```https://pobb.in/xwrfjKa9XBJ0```
