### PR TITLE
Improve node in radius calculation performance

### DIFF
--- a/src/Classes/PassiveTree.lua
+++ b/src/Classes/PassiveTree.lua
@@ -415,45 +415,56 @@ local PassiveTreeClass = newClass("PassiveTree", function(self, treeVersion)
 			t_insert(node.linkedId, otherId)
 		end
 	end
+
 	-- Precalculate the lists of nodes that are within each radius of each socket
 	for nodeId, socket in pairs(self.sockets) do
 		socket.nodesInRadius = { }
 		socket.attributesInRadius = { }
-		for radiusIndex, radiusInfo in ipairs(data.jewelRadius) do
+		for radiusIndex, _ in ipairs(data.jewelRadius) do
 			socket.nodesInRadius[radiusIndex] = { }
 			socket.attributesInRadius[radiusIndex] = { }
-			local outerRadiusSquared = radiusInfo.outer * radiusInfo.outer
-			local innerRadiusSquared = radiusInfo.inner * radiusInfo.inner
-			for _, node in pairs(self.nodes) do
-				if node ~= socket and not node.isBlighted and node.group and not node.isProxy and not node.group.isProxy and not node.isMastery then
+		end
+
+		local minX, maxX = socket.x - data.maxJewelRadius, socket.x + data.maxJewelRadius
+		local minY, maxY = socket.y - data.maxJewelRadius, socket.y + data.maxJewelRadius
+
+		for _, node in pairs(self.nodes) do
+			if node.x and node.x >= minX and node.x <= maxX and node.y and node.y >= minY and node.y <= maxY
+				and node ~= socket and not node.isBlighted and node.group and not node.isProxy
+				and not node.group.isProxy and not node.isMastery then
 					local vX, vY = node.x - socket.x, node.y - socket.y
-					local euclideanDistanceSquared = vX * vX + vY * vY
-					if innerRadiusSquared <= euclideanDistanceSquared then
-						if euclideanDistanceSquared <= outerRadiusSquared then
+					local distSquared = vX * vX + vY * vY
+					for radiusIndex, radiusInfo in ipairs(data.jewelRadius) do
+						if distSquared <= radiusInfo.outerSquared and radiusInfo.innerSquared <= distSquared then
 							socket.nodesInRadius[radiusIndex][node.id] = node
 						end
 					end
-				end
 			end
 		end
 	end
 
 	for name, keystone in pairs(self.keystoneMap) do
-		keystone.nodesInRadius = { }
-		for radiusIndex, radiusInfo in ipairs(data.jewelRadius) do
-			keystone.nodesInRadius[radiusIndex] = { }
-			local outerRadiusSquared = radiusInfo.outer * radiusInfo.outer
-			local innerRadiusSquared = radiusInfo.inner * radiusInfo.inner
+		if not keystone.nodesInRadius then
+			keystone.nodesInRadius = { }
+			for radiusIndex, _ in ipairs(data.jewelRadius) do
+				keystone.nodesInRadius[radiusIndex] = { }
+			end
+
 			if (keystone.x and keystone.y) then
+				local minX, maxX = keystone.x - data.maxJewelRadius, keystone.x + data.maxJewelRadius
+				local minY, maxY = keystone.y - data.maxJewelRadius, keystone.y + data.maxJewelRadius
+
 				for _, node in pairs(self.nodes) do
-					if node ~= keystone and not node.isBlighted and node.group and not node.isProxy and not node.group.isProxy and not node.isMastery and not node.isSocket then
-						local vX, vY = node.x - keystone.x, node.y - keystone.y
-						local euclideanDistanceSquared = vX * vX + vY * vY
-						if innerRadiusSquared <= euclideanDistanceSquared then
-							if euclideanDistanceSquared <= outerRadiusSquared then
-								keystone.nodesInRadius[radiusIndex][node.id] = node
+					if node.x and node.x >= minX and node.x <= maxX and node.y and node.y >= minY and node.y <= maxY
+						and node ~= keystone and not node.isBlighted and node.group and not node.isProxy
+						and not node.group.isProxy and not node.isMastery and not node.isSocket then
+							local vX, vY = node.x - keystone.x, node.y - keystone.y
+							local distSquared = vX * vX + vY * vY
+							for radiusIndex, radiusInfo in ipairs(data.jewelRadius) do
+								if distSquared <= radiusInfo.outerSquared and radiusInfo.innerSquared <= distSquared then
+									keystone.nodesInRadius[radiusIndex][node.id] = node
+								end
 							end
-						end
 					end
 				end
 			end

--- a/src/Modules/Data.lua
+++ b/src/Modules/Data.lua
@@ -143,6 +143,17 @@ data.setJewelRadiiGlobally = function(treeVersion)
 	else
 		data.jewelRadius = data.jewelRadii["3_16"]
 	end
+
+	local maxJewelRadius = 0
+	for _, radiusInfo in ipairs(data.jewelRadius) do
+		radiusInfo.outerSquared = radiusInfo.outer * radiusInfo.outer
+		radiusInfo.innerSquared = radiusInfo.inner * radiusInfo.inner
+
+		if radiusInfo.outer > maxJewelRadius then
+			maxJewelRadius = radiusInfo.outer
+		end
+	end
+	data.maxJewelRadius = maxJewelRadius
 end
 
 data.jewelRadii = {


### PR DESCRIPTION
### Description of the problem being solved:
Improves "node in radius" calculation during passive tree loading.

Average time for socket and keystone calculation loops:
Before: 476ms
After: 30ms

Tree loading and startup time is almost half a second faster with this change.

Changes:
- Added quick bounding box check using **maxJewelRadius** before actual distance check
- Distance is only calculated once per node instead of multiple times by moving **jewelRadius** loop
- For keystone check if **nodesInRadius** was already populated because **keystoneMap** contains duplicates

### Steps taken to verify a working solution:
- Serialized **nodesInRadius** to file and checked before/after produced same results