### PR TITLE
Add name to top left Timeless Jewel socket

### DIFF
--- a/src/Classes/TreeTab.lua
+++ b/src/Classes/TreeTab.lua
@@ -863,6 +863,8 @@ function TreeTabClass:FindTimelessJewel()
 				keystone = "Marauder"
 			elseif socketId == 54127 then
 				keystone = "Duelist"
+			elseif socketId == 7960 then
+				keystone = "Templar/Witch"
 			else
 				local minDistance = math.huge
 				for _, nodeInRadius in pairs(treeData.nodes[socketId].nodesInRadius[3]) do


### PR DESCRIPTION
Fixes #6090 .

### Description of the problem being solved:
Timeless Jewel find - socket name was missing because no keystone node was nearby.
I added name based on nearby classes, to follow the same pattern as already used for sockets:

- Marauder 26725
- Duelist 54127

### Before screenshot:
![image](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/6293201/4f3e9f1e-28ee-4310-88e9-24cf93077525)

### After screenshot:
![image](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/6293201/b651ee0a-bdb8-4ff8-ad42-1816f424f9e9)
