### PR TITLE
Fix defences on normal and magic Two-Toned Boots

### DIFF
--- a/src/Classes/Item.lua
+++ b/src/Classes/Item.lua
@@ -623,7 +623,7 @@ function ItemClass:ParseRaw(raw)
 						local s, e = self.name:find("Two-Toned Boots", 1, true)
 						if s then
 							-- Hack for Two-Toned Boots
-							baseName = "Two-Toned Boots (Armour/Energy Shield)"
+							baseName = self.baseName
 							self.namePrefix = self.name:sub(1, s - 1)
 							self.nameSuffix = self.name:sub(e + 1)
 						end


### PR DESCRIPTION
Fixes #6222

### Description of the problem being solved:
Two-Toned Boots were hardcoded to Armour/Energy Shield for Normal and Magic rarities when crafting. This PR updates to use the baseName.

### Steps taken to verify a working solution:
- Check Normal and Magic Rarity for each of the three types of Two-Toned Boots

### Before screenshot:
![image](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/92683202/cb84becd-d302-42ec-83d4-3f9565b1abbf)

![image](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/92683202/c5bb298d-f7c0-490c-b986-5bc775923863)

### After screenshot:
![image](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/92683202/89082ffe-c4f9-4a45-ba7b-8e1f30f50502)

![image](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/92683202/36cede75-07a5-4d02-9a82-4e09a414fb04)
