### PR TITLE
Stop crucible aoe mod from applying to any skill.

### DIFF
--- a/src/Modules/CalcOffence.lua
+++ b/src/Modules/CalcOffence.lua
@@ -395,11 +395,13 @@ function calcs.offence(env, actor, activeSkill)
 		end
 		if breakdown then
 			breakdown.AreaOfEffectMod = { }
-			breakdown.multiChain(breakdown.AreaOfEffectMod, {
-				{ "%.2f ^8(increased/reduced)", 1 + skillModList:Sum("INC", skillCfg, "AreaOfEffect") / 100 },
-				{ "%.2f ^8(more/less)", skillModList:More(skillCfg, "AreaOfEffect") },
-				total = s_format("= %.2f", output.AreaOfEffectMod),
-			})
+			if output.AreaOfEffectMod ~= 1 then
+				breakdown.multiChain(breakdown.AreaOfEffectMod, {
+					{ "%.2f ^8(increased/reduced)", 1 + skillModList:Sum("INC", skillCfg, "AreaOfEffect") / 100 },
+					{ "%.2f ^8(more/less)", skillModList:More(skillCfg, "AreaOfEffect") },
+					total = s_format("= %.2f", output.AreaOfEffectMod),
+				})
+			end
 		end
 	end
 

--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -4402,7 +4402,7 @@ local specialModList = {
 	["while stationary, gain (%d+)%% increased area of effect every second, up to a maximum of (%d+)%%"] = function(num, _, limit) return {
 		mod("AreaOfEffect", "INC", num, { type = "Multiplier", var = "StationarySeconds", globalLimit = tonumber(limit), globalLimitKey = "ExpansiveMight" }, { type = "Condition", var = "Stationary" }),
 	} end,
-	["fireball and rolling magma have (%d+)%% more area of effect"] = function(num) return { mod("AreaOfEffect", "MORE", num, nil, { type = "SkillName", skillNameList = { "Fireball", "rolling Magma" } }) } end,
+	["fireball and rolling magma have (%d+)%% more area of effect"] = function(num) return { mod("AreaOfEffect", "MORE", num, { type = "SkillName", skillNameList = { "Fireball", "Rolling Magma" } }) } end,
 	["attack skills have added lightning damage equal to (%d+)%% of maximum mana"] = function(num) return {
 		mod("LightningMin", "BASE", 1, nil, ModFlag.Attack, { type = "PercentStat", stat = "Mana", percent = num }),
 		mod("LightningMax", "BASE", 1, nil, ModFlag.Attack, { type = "PercentStat", stat = "Mana", percent = num }),


### PR DESCRIPTION
Fixes #6237 .

### Description of the problem being solved:
Fixes `Fireball and Rolling Magma have 100% more Area of Effect` mod not being limited to just Fireball and Rolling Magma. Prevents showing breakdown for Area of effect mod if it's 1.

### Link to a build that showcases this PR:
`https://pobb.in/s117D8xMKt65`
