### PR TITLE
Fix crash when hovering over life mastery mod.

### DIFF
--- a/src/Modules/CalcSetup.lua
+++ b/src/Modules/CalcSetup.lua
@@ -578,10 +578,18 @@ function calcs.initEnv(build, mode, override, specEnv)
 		env.allocNodes = nodes
 	end
 	
-	modDB:NewMod("Multiplier:AllocatedNotable", "BASE", allocatedNotableCount, "")
-	modDB:NewMod("Multiplier:AllocatedMastery", "BASE", allocatedMasteryCount, "")
-	modDB:NewMod("Multiplier:AllocatedMasteryType", "BASE", allocatedMasteryTypeCount, "")
-	modDB:NewMod("Multiplier:AllocatedLifeMastery", "BASE", allocatedMasteryTypes["Life Mastery"])
+	if allocatedNotableCount and allocatedNotableCount > 0 then
+		modDB:NewMod("Multiplier:AllocatedNotable", "BASE", allocatedNotableCount)
+	end
+	if allocatedMasteryCount and allocatedMasteryCount > 0 then
+		modDB:NewMod("Multiplier:AllocatedMastery", "BASE", allocatedMasteryCount)
+	end
+	if allocatedMasteryTypeCount and allocatedMasteryTypeCount > 0 then
+		modDB:NewMod("Multiplier:AllocatedMasteryType", "BASE", allocatedMasteryTypeCount)
+	end
+	if allocatedMasteryTypes["Life Mastery"] and allocatedMasteryTypes["Life Mastery"] > 0 then
+		modDB:NewMod("Multiplier:AllocatedLifeMastery", "BASE", allocatedMasteryTypes["Life Mastery"])
+	end
 	
 	-- Build and merge item modifiers, and create list of radius jewels
 	if not accelerate.requirementsItems then


### PR DESCRIPTION
Fixes #6221 .

### Description of the problem being solved:
With no life masteries allocated `allocatedMasteryTypes["Life Mastery"]` is nil causing the value of the `Multiplier:AllocatedLifeMastery` mod to be nil which causes a crash when taking the `10% more Maximum Life if you have at least 6 Life Masteries allocated` into account for calculations.

### Link to a build that showcases this PR:
`https://pobb.in/1lP4zWwLfT-l`
