### PR TITLE
Fix incorrect keystone source on keystones coming from items.

### DIFF
--- a/src/Modules/CalcPerform.lua
+++ b/src/Modules/CalcPerform.lua
@@ -374,8 +374,9 @@ local function mergeKeystones(env)
 	for _, modObj in ipairs(env.modDB:Tabulate("LIST", nil, "Keystone")) do
 		if not env.keystonesAdded[modObj.value] and env.spec.tree.keystoneMap[modObj.value] then
 			env.keystonesAdded[modObj.value] = true
+			local fromTree = modObj.mod.source and not modObj.mod.source:lower():match("tree")
 			for _, mod in ipairs(env.spec.tree.keystoneMap[modObj.value].modList) do
-				env.modDB:AddMod(modObj.mod.source and not modObj.mod.source:lower():match("tree") and modLib.setSource(mod, modObj.mod.source) or mod)
+				env.modDB:AddMod(fromTree and modLib.setSource(mod, modObj.mod.source) or mod)
 			end
 		end
 	end

--- a/src/Modules/CalcPerform.lua
+++ b/src/Modules/CalcPerform.lua
@@ -371,12 +371,12 @@ end
 
 -- Merge keystone modifiers
 local function mergeKeystones(env)
-	local modDB = env.modDB
-
-	for _, name in ipairs(modDB:List(nil, "Keystone")) do
-		if not env.keystonesAdded[name] and env.spec.tree.keystoneMap[name] then
-			env.keystonesAdded[name] = true
-			modDB:AddList(env.spec.tree.keystoneMap[name].modList)
+	for _, modObj in ipairs(env.modDB:Tabulate("LIST", nil, "Keystone")) do
+		if not env.keystonesAdded[modObj.value] and env.spec.tree.keystoneMap[modObj.value] then
+			env.keystonesAdded[modObj.value] = true
+			for _, mod in ipairs(env.spec.tree.keystoneMap[modObj.value].modList) do
+				env.modDB:AddMod(modObj.mod.source and not modObj.mod.source:lower():match("tree") and modLib.setSource(mod, modObj.mod.source) or mod)
+			end
 		end
 	end
 end


### PR DESCRIPTION
Fixes #6255 .

### Description of the problem being solved:
The source on the mods from `env.spec.tree.keystoneMap[name].modList` is always set to one from the tree ignoring the fact that the keystone it self comes from an item.

`modObj.mod.source and not modObj.mod.source:lower():match("tree")` is there to fix the source when the keystones actually do come from the tree.
### Before screenshot:
![obraz](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/91493239/25127488-c5de-4714-ba8c-44d876b7594c)

### After screenshot:
![obraz](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/91493239/feb1ead1-61da-48e0-9e8f-0298a8926f89)
![obraz](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/91493239/2e6066f4-c410-4198-8765-f74b09e605cc)

### With source fix
![obraz](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/91493239/bb7650b7-a7ee-40dc-91b6-89cb42041cba)
