### PR TITLE
Fix division by zero in resource recovery calculations

### DIFF
--- a/src/Modules/CalcDefence.lua
+++ b/src/Modules/CalcDefence.lua
@@ -919,7 +919,7 @@ function calcs.defence(env, actor)
 		if output[resource.."RegenRecovery"] > 0 then
 			modDB:NewMod("Condition:CanGain"..resource, "FLAG", true, resourceName.."Regen")
 		end
-		output[resource.."RegenPercent"] = round(output[resource.."RegenRecovery"] / pool * 100, 1)
+		output[resource.."RegenPercent"] = pool > 0 and round(output[resource.."RegenRecovery"] / pool * 100, 1) or 0
 		if breakdown then
 			breakdown[resource.."RegenRecovery"] = { }
 			breakdown.multiChain(breakdown[resource.."RegenRecovery"], {


### PR DESCRIPTION
### Description of the problem being solved:
Having no resource resulted in division by zero in calculations of that resource's recovery. 

### Before screenshot:
![image](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/18018499/dff43a64-e1c3-4682-bd39-286a438ac373)

### After screenshot:
![image](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/18018499/4e9fb500-b7f7-4c95-8c82-97e2c7924c28)
