### PR TITLE
Add Ctrl-M to the tree drop down to open manage trees dialog

### DIFF
--- a/help.txt
+++ b/help.txt
@@ -29,6 +29,7 @@ Ctrl + I	Jump to import tab
 Ctrl + A	Select all
 Ctrl + C	Copy
 Ctrl + F	Show find / search box (e.g. unique item / tree)
+Ctrl + M	Manage Trees (Tree tab only)
 Ctrl + N	New build (in build selection menu)
 Ctrl + S	Save build to file
 Ctrl + U	Check for update

--- a/src/Classes/TreeTab.lua
+++ b/src/Classes/TreeTab.lua
@@ -203,6 +203,8 @@ function TreeTabClass:Draw(viewPort, inputEvents)
 				inputEvents[id] = nil
 			elseif event.key == "f" and IsKeyDown("CTRL") then
 				self:SelectControl(self.controls.treeSearch)
+			elseif event.key == "m" and IsKeyDown("CTRL") then
+				self:OpenSpecManagePopup()
 			end
 		end
 	end
@@ -249,7 +251,7 @@ function TreeTabClass:Draw(viewPort, inputEvents)
 		t_insert(newSpecList, (spec.treeVersion ~= latestTreeVersion and ("["..treeVersions[spec.treeVersion].display.."] ") or "")..(spec.title or "Default"))
 	end
 	self.build.itemsTab.controls.specSelect:SetList(copyTable(newSpecList)) -- Update the passive tree dropdown control in itemsTab
-	t_insert(newSpecList, "Manage trees...")
+	t_insert(newSpecList, "Manage trees... (ctrl-m)")
 	self.controls.specSelect:SetList(newSpecList)
 
 	if not self.controls.treeSearch.hasFocus then


### PR DESCRIPTION
Fixes my annoyance at constantly clicking and scrolling to the bottom of a long list of trees, to find the "Manage Trees" entry and then possibly misclicking and having to do it all again.

### Description of the problem being solved:
Technical solution to a management problem

### Steps taken to verify a working solution:
- Select the trees tab, select Ctrl-M. See that the "manage trees" dialog opens.
- Select other tabs and select Ctrl-M. Confirm that the "manage trees" dialog DOES NOT open.
-

### Question:
Do we want Ctrl-M or ctrl-m ??

### Link to a build that showcases this PR:
N/A

### Before screenshot:
![image](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/4302241/89cb5f13-d1c7-4b51-94b5-8d3771a82525)

### After screenshot:
![image](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/4302241/dfd13c40-e978-4e37-95a8-528644e03f71)
