### PR TITLE
Prevent stat doubling for radius jewels coming from GrantedPassive mod

### DIFF
--- a/src/Modules/CalcSetup.lua
+++ b/src/Modules/CalcSetup.lua
@@ -962,6 +962,7 @@ function calcs.initEnv(build, mode, override, specEnv)
 			if node and (not override.removeNodes or not override.removeNodes[node.id]) then
 				env.allocNodes[node.id] = env.spec.nodes[node.id] or node -- use the conquered node data, if available
 				env.grantedPassives[node.id] = true
+				env.extraRadiusNodeList[node.id] = nil
 			end
 		end
 	end


### PR DESCRIPTION
Fixes #6277

### Description of the problem being solved:

Because GrantedPassive is processed after radius jewels in CalcSetup.lua added nodes were being added to env.extraRadiusNodeList and later processed twice by jewel funcs.