### PR TITLE
Fix Life Mastery not working correctly with Skin of the Loyal

### DIFF
--- a/src/Classes/Item.lua
+++ b/src/Classes/Item.lua
@@ -247,7 +247,7 @@ function ItemClass:FindModifierSubstring(substring, itemSlotName)
 		end
 		if data.itemTagSpecial[substring] and data.itemTagSpecial[substring][itemSlotName] then
 			for _, specialMod in ipairs(data.itemTagSpecial[substring][itemSlotName]) do
-				if v.line:lower():find(specialMod:lower()) then
+				if v.line:lower():find(specialMod:lower()) and (not v.variantList or v.variantList[self.variant]) then
 					return true
 				end
 			end


### PR DESCRIPTION
Fixes #6289 .

### Description of the problem being solved:
The `FindModifierSubstring` function used by the `15% increased maximum Life if there are no Life Modifiers on Equipped Body Armour` mastery matched against all possible variants ignoring the currently selected one causing items such as [Skin of the Loyal](https://www.poewiki.net/wiki/Skin_of_the_Loyal) to incorrectly always match a life modifier regardless of the selected variant/keystone.