### PR TITLE
Fix resistance penalty none not saving

### DIFF
--- a/src/Modules/ConfigOptions.lua
+++ b/src/Modules/ConfigOptions.lua
@@ -132,7 +132,7 @@ end
 return {
 	-- Section: General options
 	{ section = "General", col = 1 },
-	{ var = "resistancePenalty", type = "list", label = "Resistance penalty:", list = {{val=0,label="None"},{val=-30,label="Act 5 (-30%)"},{val=nil,label="Act 10 (-60%)"}}, defaultIndex = 3 },
+	{ var = "resistancePenalty", type = "list", label = "Resistance penalty:", list = {{val=0,label="None"},{val=-30,label="Act 5 (-30%)"},{val=-60,label="Act 10 (-60%)"}}, defaultIndex = 3 },
 	{ var = "bandit", type = "list", label = "Bandit quest:", tooltipFunc = banditTooltip, list = {{val="None",label="Kill all"},{val="Oak",label="Help Oak"},{val="Kraityn",label="Help Kraityn"},{val="Alira",label="Help Alira"}} },
 	{ var = "pantheonMajorGod", type = "list", label = "Major God:", tooltipFunc = applyPantheonDescription, list = {
 		{ label = "Nothing", val = "None" },


### PR DESCRIPTION
Fixes #6281 .

### Description of the problem being solved:
Due to the act10 penalty value being nil self.defaultState[var] == nil failing the if statement causing the function to return 0 since the val type is "number".

0 is also the value of the none settings causing it to not be saved.

https://github.com/PathOfBuildingCommunity/PathOfBuilding/blob/19818870af754cc17b9fa8e16c026670f20932e6/src/Classes/ConfigTab.lua#L560-L578

https://github.com/PathOfBuildingCommunity/PathOfBuilding/blob/19818870af754cc17b9fa8e16c026670f20932e6/src/Modules/ConfigOptions.lua#L135

https://github.com/PathOfBuildingCommunity/PathOfBuilding/blob/19818870af754cc17b9fa8e16c026670f20932e6/src/Classes/ConfigTab.lua#L580-L582