### PR TITLE
Strip unmet tag from imported jewels

### DIFF
--- a/src/Classes/Item.lua
+++ b/src/Classes/Item.lua
@@ -402,7 +402,10 @@ function ItemClass:ParseRaw(raw)
 			end
 			if not specName then
 				specVal = line:match("^Class:: (.+)$")
-				if specVal then specName = "Requires Class" end
+				if specVal then
+					specName = "Requires Class"
+					specVal = specVal:match("%w+")
+				end
 			end
 			if not specName then
 				specName, specVal = line:match("^(Requires) (.+)$")


### PR DESCRIPTION
Fixes #5610 .

### Description of the problem being solved:
https://github.com/PathOfBuildingCommunity/PathOfBuilding/issues/5610#issuecomment-1665732781

The unmet tag was added when copying the jewel from an incompatible class causing POB to have issues parsing the class restriction.