### PR TITLE
Use highest max shock from any active skill, not from main skill

### DIFF
--- a/src/Modules/CalcPerform.lua
+++ b/src/Modules/CalcPerform.lua
@@ -2843,7 +2843,14 @@ function calcs.perform(env, avoidCache, fullDPSSkipEHP)
 				end
 				override = m_max(override, effect or 0)
 			end
-			output["Maximum"..ailment] = modDB:Override(nil, ailment.."Max") or (ailmentData[ailment].max + env.player.mainSkill.baseSkillModList:Sum("BASE", nil, ailment.."Max"))
+			local maxAilment = modDB:Override(nil, ailment.."Max") or 0
+			if not modDB:Override(nil, ailment.."Max") then
+				for _, skill in ipairs(env.player.activeSkillList) do
+					local skillMax = modDB:Override(nil, ailment.."Max") or (ailmentData[ailment].max + skill.baseSkillModList:Sum("BASE", nil, ailment.."Max"))
+					maxAilment = skillMax > maxAilment and skillMax or maxAilment
+				end
+			end
+			output["Maximum"..ailment] = maxAilment
 			output["Current"..ailment] = m_floor(m_min(m_max(override, enemyDB:Sum("BASE", nil, ailment.."Val")), output["Maximum"..ailment]) * (10 ^ ailmentData[ailment].precision)) / (10 ^ ailmentData[ailment].precision)
 			for _, mod in ipairs(val.mods(output["Current"..ailment])) do
 				enemyDB:AddMod(mod)


### PR DESCRIPTION
Fixes #6243

### Description of the problem being solved:
Shock nova has +10% to max effect of shock. However, when using it as a secondary skill, other skills would not be able to set max shock to those 10% higher. This meant that you could not simulate DPS accurately of other skills in situations where your alternate shock nova is able to crit for the max.

This does introduce a potential user error where they use the main skill shock tooltips to try and calculate how much they shock, but there's only so much we can do about that.

### Steps taken to verify a working solution:
- Main skill arc, secondary skill shock nova, set shock to 60%.
- Note that without the change, max shock was set to 50% for Arc and 60% for Shock Nova. Changing shock to 50% did not alter Arc damage. 
- After change, max shock now lists at 60% for both skills. Changing shock to 50% alters damage of both.

### Link to a build that showcases this PR:
https://pobb.in/L7s622aSaPUu