### PR TITLE
Fix crash on unusable weapon swap

### DIFF
--- a/src/Modules/CalcOffence.lua
+++ b/src/Modules/CalcOffence.lua
@@ -1522,7 +1522,7 @@ function calcs.offence(env, actor, activeSkill)
 		if GlobalCache.cachedData["CACHE"][uuid] then
 			local cachedTriggerData = GlobalCache.cachedData["CACHE"][uuid]
 			local manaThreshold = output.ManaCost * reqManaCostMulti
-			local manaSpendPerSec = cachedTriggerData.ManaCost * cachedTriggerData.Speed
+			local manaSpendPerSec = (cachedTriggerData.ManaCost or 0) * (cachedTriggerData.Speed or 0)
 			local manaSpendTriggerRate = manaSpendPerSec / manaThreshold
 			output.SourceTriggerRate = manaSpendTriggerRate
 			local trigRate = m_min(manaSpendTriggerRate, skillData.triggerRate)

--- a/src/Modules/CalcPerform.lua
+++ b/src/Modules/CalcPerform.lua
@@ -3539,8 +3539,8 @@ function calcs.perform(env, avoidCache, fullDPSSkipEHP)
 
 				if GlobalCache.cachedData["CACHE"][uuid] then
 					-- Below code sets the trigger skill to highest APS skill it finds that meets all conditions
-					local cachedSpeed = GlobalCache.cachedData["CACHE"][uuid].Speed
-					local cachedManaCost = GlobalCache.cachedData["CACHE"][uuid].ManaCost
+					local cachedSpeed = GlobalCache.cachedData["CACHE"][uuid].Speed or 0
+					local cachedManaCost = GlobalCache.cachedData["CACHE"][uuid].ManaCost or 0
 					local ManaSpendRate = cachedSpeed * cachedManaCost
 
 					if ((not source and ManaSpendRate) or (ManaSpendRate and ManaSpendRate > trigRate)) then


### PR DESCRIPTION
Fixes #6210

### Description of the problem being solved:
When changing weapons between usable and unusable weapons for a given active skill, a crash would occur when the cache contained nil data for speed. This simply adds a fallback 0 for both stats, which never causes any problems because they're always hidden by skill cannot be used.

### Link to a build that showcases this PR:
https://pobb.in/xwrfjKa9XBJ0

### Steps to reproduce error and test solution
- Import above build
- Change weapon to any one handed axe (or any weapon that cannot be used with Lightning Arrow or Kinetic Blast)
