### PR TITLE
Fix Battlemage's Cry and Redblade Banner not working correctly

### DIFF
--- a/src/Modules/CalcPerform.lua
+++ b/src/Modules/CalcPerform.lua
@@ -921,19 +921,11 @@ local function doActorMisc(env, actor)
 	if modDB:Flag(nil, "UseGhostShrouds") then
 		output.GhostShrouds = modDB:Override(nil, "GhostShrouds") or 3
 	end
-	if modDB:Flag(nil, "CryWolfMinimumPower") and modDB:Sum("BASE", nil, "WarcryPower") < 10 then
-		modDB:NewMod("WarcryPower", "OVERRIDE", 10, "Minimum Warcry Power from CryWolf")
-	end
-	if modDB:Flag(nil, "WarcryInfinitePower") then
-		modDB:NewMod("WarcryPower", "OVERRIDE", 999999, "Warcries have infinite power")
-	end
 	output.BloodCharges = m_min(modDB:Override(nil, "BloodCharges") or output.BloodChargesMax, output.BloodChargesMax)
 	output.SpiritCharges = m_min(modDB:Override(nil, "SpiritCharges") or 0, output.SpiritChargesMax)
 
-	output.WarcryPower = modDB:Override(nil, "WarcryPower") or modDB:Sum("BASE", nil, "WarcryPower") or 0
 	output.CrabBarriers = m_min(modDB:Override(nil, "CrabBarriers") or output.CrabBarriersMax, output.CrabBarriersMax)
 	output.TotalCharges = output.PowerCharges + output.FrenzyCharges + output.EnduranceCharges
-	modDB.multipliers["WarcryPower"] = output.WarcryPower
 	modDB.multipliers["PowerCharge"] = output.PowerCharges
 	modDB.multipliers["PowerChargeMax"] = output.PowerChargesMax
 	modDB.multipliers["RemovablePowerCharge"] = output.RemovablePowerCharges
@@ -1321,6 +1313,16 @@ function calcs.perform(env, avoidCache, fullDPSSkipEHP)
 	end
 
 	local hasGuaranteedBonechill = false
+
+	
+	if modDB:Flag(nil, "CryWolfMinimumPower") and modDB:Sum("BASE", nil, "WarcryPower") < 10 then
+		modDB:NewMod("WarcryPower", "OVERRIDE", 10, "Minimum Warcry Power from CryWolf")
+	end
+	if modDB:Flag(nil, "WarcryInfinitePower") then
+		modDB:NewMod("WarcryPower", "OVERRIDE", 999999, "Warcries have infinite power")
+	end
+	output.WarcryPower = modDB:Override(nil, "WarcryPower") or modDB:Sum("BASE", nil, "WarcryPower") or 0
+	modDB.multipliers["WarcryPower"] = output.WarcryPower
 
 	for _, activeSkill in ipairs(env.player.activeSkillList) do
 		if activeSkill.skillFlags.brand then


### PR DESCRIPTION
Fixes #6208

### Description of the problem being solved:
Applying the warcry power overrides in the actor misc section, after a lot of other stuff, caused some issues. Notably, it caused the increased spell damage from Battlemage's Cry to not apply correctly without manually setting warcry power, even when Redblade Banner was equipped.

This just moves said overrides to apply immediately prior to where warcry power is first used.

### Steps taken to verify a working solution:
- Checked Battlemage's Cry after change, noted that stats don't change between blank and 50000 warcry power in config

### Link to a build that showcases this PR:
https://pobb.in/2f_873aTBknM
