### PR TITLE
Fix crash on 100% reduced reservation efficiency for relic of the pact

### DIFF
--- a/src/Data/Skills/other.lua
+++ b/src/Data/Skills/other.lua
@@ -359,6 +359,9 @@ skills["BloodSacramentUnique"] = {
 	castTime = 0.2,
 	fromItem = true,
 	initialFunc = function(activeSkill, output)
+		if output.LifeReservedPercent >= 100 then
+			return
+		end
 		local lifeReservedPercent = activeSkill.skillData["LifeReservedPercent"] or 3
 		local lifeReserved = activeSkill.skillData["LifeReservedBase"] or math.huge
 		activeSkill.skillModList:NewMod("Multiplier:ChannelledLifeReservedPercentPerStage", "BASE", lifeReservedPercent, "Blood Sacrament")

--- a/src/Export/Skills/other.txt
+++ b/src/Export/Skills/other.txt
@@ -150,6 +150,9 @@ local skills, mod, flag, skill = ...
 #flags spell area
 	fromItem = true,
 	initialFunc = function(activeSkill, output)
+		if output.LifeReservedPercent >= 100 then
+			return
+		end
 		local lifeReservedPercent = activeSkill.skillData["LifeReservedPercent"] or 3
 		local lifeReserved = activeSkill.skillData["LifeReservedBase"] or math.huge
 		activeSkill.skillModList:NewMod("Multiplier:ChannelledLifeReservedPercentPerStage", "BASE", lifeReservedPercent, "Blood Sacrament")


### PR DESCRIPTION
Fixes #5568 

### Description of the problem being solved:
Relic of the pact would error out when you achieved 100% reduced reservation efficiency. I simply added an early return in its initialFunc when life reserved percent is 100 or higher.

### Link to a build that showcases this PR:
https://pobb.in/8o91BmwxqVjO