### PR TITLE
Implement flamethrower trap DPS

### DIFF
--- a/src/Data/Skills/act_dex.lua
+++ b/src/Data/Skills/act_dex.lua
@@ -4275,8 +4275,22 @@ skills["FlamethrowerTrap"] = {
 	skillTypes = { [SkillType.Spell] = true, [SkillType.Duration] = true, [SkillType.Damage] = true, [SkillType.Mineable] = true, [SkillType.Area] = true, [SkillType.Trapped] = true, [SkillType.Fire] = true, [SkillType.AreaSpell] = true, [SkillType.Cooldown] = true, },
 	statDescriptionScope = "skill_stat_descriptions",
 	castTime = 1,
+	parts = {
+		{
+			name = "One trap (good placement)",
+		},
+		{
+			name = "One trap (bad placement)",
+		},
+		{ 
+			name = "Average # traps (good placement)",
+		},
+		{ 
+			name = "Average # traps (bad placement)",
+		},
+	},
 	preDamageFunc = function(activeSkill, output, breakdown)
-		-- many unknown stats. can't calculate DPS
+		-- Unknown stats provided by asking GGG
 		local t_insert = table.insert
 		local s_format = string.format
 
@@ -4284,6 +4298,16 @@ skills["FlamethrowerTrap"] = {
 		local cooldown = output.TrapCooldown
 		local averageActiveTraps = duration / cooldown
 		output.AverageActiveTraps = averageActiveTraps
+		if activeSkill.skillPart == 2 or activeSkill.skillPart == 4 then
+			activeSkill.skillData.hitTimeOverride = 0.3
+		else
+			activeSkill.skillData.hitTimeOverride = 0.1
+		end
+
+		if activeSkill.skillPart == 3 or activeSkill.skillPart == 4 then
+			activeSkill.skillData.dpsMultiplier = (activeSkill.skillData.dpsMultiplier or 1) * averageActiveTraps
+		end
+
 		if breakdown then
 			breakdown.AverageActiveTraps = { }
 			t_insert(breakdown.AverageActiveTraps, "Average active traps, not considering stored cooldown uses:")
@@ -4295,6 +4319,8 @@ skills["FlamethrowerTrap"] = {
 	statMap = {
 		["flamethrower_trap_damage_+%_final_vs_burning_enemies"] = {
 			mod("Damage", "MORE", nil, bit.band(ModFlag.Hit, ModFlag.Ailment), 0, { type = "ActorCondition", actor = "enemy", var = "Burning" }),
+		},
+		["base_skill_show_average_damage_instead_of_dps"] = {
 		},
 	},
 	baseFlags = {

--- a/src/Export/Skills/act_dex.txt
+++ b/src/Export/Skills/act_dex.txt
@@ -880,8 +880,22 @@ local skills, mod, flag, skill = ...
 
 #skill FlamethrowerTrap
 #flags spell trap area duration
+	parts = {
+		{
+			name = "One trap (good placement)",
+		},
+		{
+			name = "One trap (bad placement)",
+		},
+		{ 
+			name = "Average # traps (good placement)",
+		},
+		{ 
+			name = "Average # traps (bad placement)",
+		},
+	},
 	preDamageFunc = function(activeSkill, output, breakdown)
-		-- many unknown stats. can't calculate DPS
+		-- Unknown stats provided by asking GGG
 		local t_insert = table.insert
 		local s_format = string.format
 
@@ -889,6 +903,16 @@ local skills, mod, flag, skill = ...
 		local cooldown = output.TrapCooldown
 		local averageActiveTraps = duration / cooldown
 		output.AverageActiveTraps = averageActiveTraps
+		if activeSkill.skillPart == 2 or activeSkill.skillPart == 4 then
+			activeSkill.skillData.hitTimeOverride = 0.3
+		else
+			activeSkill.skillData.hitTimeOverride = 0.1
+		end
+
+		if activeSkill.skillPart == 3 or activeSkill.skillPart == 4 then
+			activeSkill.skillData.dpsMultiplier = (activeSkill.skillData.dpsMultiplier or 1) * averageActiveTraps
+		end
+
 		if breakdown then
 			breakdown.AverageActiveTraps = { }
 			t_insert(breakdown.AverageActiveTraps, "Average active traps, not considering stored cooldown uses:")
@@ -900,6 +924,8 @@ local skills, mod, flag, skill = ...
 	statMap = {
 		["flamethrower_trap_damage_+%_final_vs_burning_enemies"] = {
 			mod("Damage", "MORE", nil, bit.band(ModFlag.Hit, ModFlag.Ailment), 0, { type = "ActorCondition", actor = "enemy", var = "Burning" }),
+		},
+		["base_skill_show_average_damage_instead_of_dps"] = {
 		},
 	},
 #baseMod skill("radius", 32)


### PR DESCRIPTION
### Description of the problem being solved:
Flamethrower trap had hidden stats such as hit rate which made it impossible to accurately implement DPS for it. I asked GGG directly and got answers on how it works, so here's an implementation.

I added two skill parts, one for a single trap and one that takes into account average active traps to take into account using it as a main skill, due to its cooldown.

![image](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/5985728/2869c060-575e-4796-9be8-db46f6971afc)

### Link to a build that showcases this PR:
https://pobb.in/41YgDbTmv4EF

### Before screenshot:
![image](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/5985728/859d5eb4-f8bc-4189-89ea-8c484755594e)


### After screenshot:
![image](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/5985728/f086c41f-e8b3-427a-a68f-0649343c179f)
