### PR TITLE
Add a warning when exceeding jewel limits

### DIFF
--- a/src/Modules/Build.lua
+++ b/src/Modules/Build.lua
@@ -1452,6 +1452,14 @@ function buildMode:AddDisplayStatList(statList, actor)
 	end
 end
 
+function buildMode:InsertItemWarnings()
+	if self.calcsTab.mainEnv.itemWarnings.jewelLimitWarning then
+		for _, warning in ipairs(self.calcsTab.mainEnv.itemWarnings.jewelLimitWarning) do
+			InsertIfNew(self.controls.warnings.lines, "You are exceeding jewel limit with the jewel "..warning)
+		end
+	end
+end
+
 -- Build list of side bar stats
 function buildMode:RefreshStatList()
 	self.controls.warnings.lines = {}
@@ -1479,6 +1487,7 @@ function buildMode:RefreshStatList()
 		t_insert(statBoxList, { height = 14, align = "CENTER_X", x = 140, self.calcsTab.mainEnv.player.mainSkill.disableReason })
 	end
 	self:AddDisplayStatList(self.displayStats, self.calcsTab.mainEnv.player)
+	self:InsertItemWarnings()
 end
 
 function buildMode:CompareStatList(tooltip, statList, actor, baseOutput, compareOutput, header, nodeCount)

--- a/src/Modules/CalcSetup.lua
+++ b/src/Modules/CalcSetup.lua
@@ -362,6 +362,7 @@ function calcs.initEnv(build, mode, override, specEnv)
 		env.grantedSkillsNodes = { }
 		env.grantedSkillsItems = { }
 		env.explodeSources = { }
+		env.itemWarnings = { }
 		env.flasks = { }
 
 		-- tree based
@@ -635,6 +636,8 @@ function calcs.initEnv(build, mode, override, specEnv)
 							if item.jewelData then
 								item.jewelData.limitDisabled = true
 							end
+							env.itemWarnings.jewelLimitWarning = env.itemWarnings.jewelLimitWarning or { }
+							t_insert(env.itemWarnings.jewelLimitWarning, limitKey)
 							item = nil
 						else
 							jewelLimits[limitKey] = (jewelLimits[limitKey] or 0) + 1


### PR DESCRIPTION
Fixes #227

### Description of the problem being solved:
While jewels above the jewel limit don't add stats, it can be easy to miss that they're not being helpful in a finalized build. This adds a warning using the warning system that a jewel is exceeding its limit, lists what jewels are causing it, and in general adds  a framework for adding warnings based on items.

### Link to a build that showcases this PR:
https://pobb.in/9tbjADMh0GyK

### After screenshot:
![image](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/5985728/776e9a4c-ffaf-4b05-bb84-dcc856b78c13)
