### PR TITLE
Only imply recent minion skill use on non-permanent minions

### DIFF
--- a/src/Data/Skills/act_dex.lua
+++ b/src/Data/Skills/act_dex.lua
@@ -5346,6 +5346,7 @@ skills["HeraldOfAgony"] = {
 	baseFlags = {
 		cast = true,
 		minion = true,
+		permanentMinion = true,
 	},
 	qualityStats = {
 		Default = {
@@ -9320,6 +9321,7 @@ skills["SummonIceGolem"] = {
 		spell = true,
 		minion = true,
 		golem = true,
+		permanentMinion = true,
 	},
 	baseMods = {
 		skill("allowTotemBuff", true),

--- a/src/Data/Skills/act_int.lua
+++ b/src/Data/Skills/act_int.lua
@@ -8410,6 +8410,7 @@ skills["RaiseSpectre"] = {
 		minion = true,
 		spectre = true,
 		duration = true,
+		permanentMinion = true,
 	},
 	qualityStats = {
 		Default = {
@@ -8502,6 +8503,7 @@ skills["RaiseZombie"] = {
 	baseFlags = {
 		spell = true,
 		minion = true,
+		permanentMinion = true,
 	},
 	qualityStats = {
 		Default = {
@@ -10663,6 +10665,7 @@ skills["SummonBoneGolem"] = {
 		spell = true,
 		minion = true,
 		golem = true,
+		permanentMinion = true,
 	},
 	baseMods = {
 		skill("allowTotemBuff", true),
@@ -10755,6 +10758,7 @@ skills["SummonChaosGolem"] = {
 		spell = true,
 		minion = true,
 		golem = true,
+		permanentMinion = true,
 	},
 	baseMods = {
 		skill("allowTotemBuff", true),
@@ -10853,6 +10857,7 @@ skills["SummonRelic"] = {
 	baseFlags = {
 		spell = true,
 		minion = true,
+		permanentMinion = true,
 	},
 	qualityStats = {
 		Default = {
@@ -10939,6 +10944,7 @@ skills["SummonLightningGolem"] = {
 		spell = true,
 		minion = true,
 		golem = true,
+		permanentMinion = true,
 	},
 	baseMods = {
 		skill("allowTotemBuff", true),
@@ -11388,6 +11394,7 @@ skills["Skitterbots"] = {
 	baseFlags = {
 		spell = true,
 		minion = true,
+		permanentMinion = true,
 	},
 	baseMods = {
 		skill("radius", 30),

--- a/src/Data/Skills/act_str.lua
+++ b/src/Data/Skills/act_str.lua
@@ -940,6 +940,7 @@ skills["AnimateArmour"] = {
 	baseFlags = {
 		spell = true,
 		minion = true,
+		permanentMinion = true,
 	},
 	qualityStats = {
 		Default = {
@@ -7921,6 +7922,7 @@ skills["SummonFireGolem"] = {
 		spell = true,
 		minion = true,
 		golem = true,
+		permanentMinion = true,
 	},
 	baseMods = {
 		skill("allowTotemBuff", true),
@@ -8011,6 +8013,7 @@ skills["SummonRockGolem"] = {
 		spell = true,
 		minion = true,
 		golem = true,
+		permanentMinion = true,
 	},
 	baseMods = {
 		skill("allowTotemBuff", true),

--- a/src/Export/Skills/act_dex.txt
+++ b/src/Export/Skills/act_dex.txt
@@ -1063,7 +1063,7 @@ local skills, mod, flag, skill = ...
 #mods
 
 #skill HeraldOfAgony
-#flags cast minion
+#flags cast minion permanentMinion
 	minionList = {
 		"HeraldOfAgonySpiderPlated",
 	},
@@ -1794,7 +1794,7 @@ local skills, mod, flag, skill = ...
 #mods
 
 #skill SummonIceGolem
-#flags spell minion golem
+#flags spell minion golem permanentMinion
 	minionList = {
 		"SummonedIceGolem",
 	},

--- a/src/Export/Skills/act_int.txt
+++ b/src/Export/Skills/act_int.txt
@@ -1871,7 +1871,7 @@ local skills, mod, flag, skill = ...
 #mods
 
 #skill RaiseSpectre
-#flags spell minion spectre duration
+#flags spell minion spectre duration permanentMinion
 	minionList = {
 	},
 	statMap = {
@@ -1885,7 +1885,7 @@ local skills, mod, flag, skill = ...
 #mods
 
 #skill RaiseZombie
-#flags spell minion
+#flags spell minion permanentMinion
 	minionList = {
 		"RaisedZombie",
 	},
@@ -2280,7 +2280,7 @@ local skills, mod, flag, skill = ...
 #mods
 
 #skill SummonBoneGolem
-#flags spell minion golem
+#flags spell minion golem permanentMinion
 	minionList = {
 		"SummonedCarrionGolem",
 	},
@@ -2300,7 +2300,7 @@ local skills, mod, flag, skill = ...
 #mods
 
 #skill SummonChaosGolem
-#flags spell minion golem
+#flags spell minion golem permanentMinion
 	minionList = {
 		"SummonedChaosGolem",
 	},
@@ -2314,7 +2314,7 @@ local skills, mod, flag, skill = ...
 #mods
 
 #skill SummonRelic
-#flags spell minion
+#flags spell minion permanentMinion
 	minionList = {
 		"HolyLivingRelic",
 	},
@@ -2336,7 +2336,7 @@ local skills, mod, flag, skill = ...
 #mods
 
 #skill SummonLightningGolem
-#flags spell minion golem
+#flags spell minion golem permanentMinion
 	minionList = {
 		"SummonedLightningGolem",
 	},
@@ -2403,7 +2403,7 @@ local skills, mod, flag, skill = ...
 #mods
 
 #skill Skitterbots
-#flags spell minion
+#flags spell minion permanentMinion
 	minionList = {
 		"SkitterbotCold",
 		"SkitterbotLightning",

--- a/src/Export/Skills/act_str.txt
+++ b/src/Export/Skills/act_str.txt
@@ -146,7 +146,7 @@ local skills, mod, flag, skill = ...
 #mods
 
 #skill AnimateArmour
-#flags spell minion 
+#flags spell minion permanentMinion
 	minionHasItemSet = true,
 	minionUses = {
 		["Weapon 1"] = true,
@@ -1472,7 +1472,7 @@ end,
 #mods
 
 #skill SummonFireGolem
-#flags spell minion golem
+#flags spell minion golem permanentMinion
 	minionList = {
 		"SummonedFlameGolem",
 	},
@@ -1486,7 +1486,7 @@ end,
 #mods
 
 #skill SummonRockGolem
-#flags spell minion golem
+#flags spell minion golem permanentMinion
 	minionList = {
 		"SummonedStoneGolem",
 	},

--- a/src/Modules/CalcPerform.lua
+++ b/src/Modules/CalcPerform.lua
@@ -546,7 +546,7 @@ local function doActorAttribsConditions(env, actor)
 			if actor.mainSkill.skillTypes[SkillType.Movement] then
 				condList["UsedMovementSkillRecently"] = true
 			end
-			if actor.mainSkill.skillFlags.minion then
+			if actor.mainSkill.skillFlags.minion and not actor.mainSkill.skillFlags.permanentMinion then
 				condList["UsedMinionSkillRecently"] = true
 			end
 			if actor.mainSkill.skillTypes[SkillType.Vaal] then


### PR DESCRIPTION
Fixes #669

### Description of the problem being solved:
All minion skills implied a recent use of a minion skill if they were set as primary. This adds a flag to permanent minions and excludes them from the implication. You can still use the config checkbox to enable these interactions on non-permanent minions.

### Steps taken to verify a working solution:
- Allocated Enduring Bond, equipped Summon Holy Relic (permanent) and Summon Raging Spirits
- Deallocating Enduring Bond without the config checked does not affect Summon Holy Relic DPS but does affect Summon Raging Spirits DPS
- Selecting the config checkbox for recent minion use changes the DPS of Summon Holy Relic but not Summon Raging Spirits when Enduring Bond is allocated

### Link to a build that showcases this PR:
https://pobb.in/89pQNZf6IFx1
