### PR TITLE
Add support for generic damage range for Volatility support

### DIFF
--- a/src/Modules/CalcOffence.lua
+++ b/src/Modules/CalcOffence.lua
@@ -120,8 +120,8 @@ local function calcDamage(activeSkill, output, cfg, breakdown, damageType, typeF
 	local modNames = damageStatsForTypes[typeFlags]
 	local inc = 1 + skillModList:Sum("INC", cfg, unpack(modNames)) / 100
 	local more = skillModList:More(cfg, unpack(modNames))
-	local moreMinDamage = skillModList:More(cfg, "Min"..damageType.."Damage")
-	local moreMaxDamage = skillModList:More(cfg, "Max"..damageType.."Damage")
+	local moreMinDamage = skillModList:More(cfg, "MinDamage", "Min"..damageType.."Damage")
+	local moreMaxDamage = skillModList:More(cfg, "MaxDamage", "Max"..damageType.."Damage")
 
 	if breakdown then
 		t_insert(breakdown.damageTypes, {


### PR DESCRIPTION
> Added a new Strength Support Gem - Volatility: Supports attack skills, causing them to deal more Maximum Attack Damage, but less Minimum Attack Damage. Supported Skills also deal increased Damage.

Not support for the gem itself, that needs to wait for gem export, but precursor to make it easier to support