### PR TITLE
Add support for changing Tree Version

### DIFF
--- a/src/Classes/TreeTab.lua
+++ b/src/Classes/TreeTab.lua
@@ -119,7 +119,28 @@ local TreeTabClass = newClass("TreeTab", "ControlHost", function(self, build)
 	self.controls.export = new("ButtonControl", { "LEFT", self.controls.import, "RIGHT" }, 8, 0, 90, 20, "Export Tree", function()
 		self:OpenExportPopup()
 	end)
-	self.controls.treeSearch = new("EditControl", { "LEFT", self.controls.export, "RIGHT" }, 8, 0, main.portraitMode and 200 or 300, 20, "", "Search", "%c", 100, function(buf)
+	local function convertToVersion(version)
+		local newSpec = new("PassiveSpec", self.build, version, true)
+		newSpec.title = self.build.spec.title
+		newSpec.jewels = copyTable(self.build.spec.jewels)
+		newSpec:RestoreUndoState(self.build.spec:CreateUndoState(), version)
+		newSpec:BuildClusterJewelGraphs()
+		t_insert(self.specList, self.activeSpec + 1, newSpec)
+		self:SetActiveSpec(self.activeSpec + 1)
+		self.modFlag = true
+		main:OpenMessagePopup("Tree Converted", "The tree has been converted to "..treeVersions[version].display..".\nNote that some or all of the passives may have been de-allocated due to changes in the tree.\n\nYou can switch back to the old tree using the tree selector at the bottom left.")
+	end
+	self.controls.versionText = new("LabelControl", { "LEFT", self.controls.export, "RIGHT" }, 8, 0, 0, 16, "Version:")
+	self.controls.versionSelect = new("DropDownControl", { "LEFT", self.controls.versionText, "RIGHT" }, 8, 0, 55, 20, treeVersionList, function(index, value)
+		if value ~= self.build.spec.treeVersion then
+			convertToVersion(value)
+		end
+	end)
+	self.controls.versionSelect.maxDroppedWidth = 1000
+	self.controls.versionSelect.enableDroppedWidth = true
+	self.controls.versionSelect.enableChangeBoxWidth = true
+	self.controls.versionSelect.selIndex = #treeVersionList
+	self.controls.treeSearch = new("EditControl", { "LEFT", self.controls.versionSelect, "RIGHT" }, 8, 0, main.portraitMode and 200 or 300, 20, "", "Search", "%c", 100, function(buf)
 		self.viewer.searchStr = buf
 		self.searchFlag = buf ~= self.viewer.searchStrSaved
 	end)
@@ -172,15 +193,7 @@ local TreeTabClass = newClass("TreeTab", "ControlHost", function(self, build)
 		return self.showConvert
 	end
 	self.controls.specConvert = new("ButtonControl", { "LEFT", self.controls.specConvertText, "RIGHT" }, 8, 0, 120, 20, "^2Convert to "..treeVersions[latestTreeVersion].display, function()
-		local newSpec = new("PassiveSpec", self.build, latestTreeVersion, true)
-		newSpec.title = self.build.spec.title
-		newSpec.jewels = copyTable(self.build.spec.jewels)
-		newSpec:RestoreUndoState(self.build.spec:CreateUndoState(), latestTreeVersion)
-		newSpec:BuildClusterJewelGraphs()
-		t_insert(self.specList, self.activeSpec + 1, newSpec)
-		self:SetActiveSpec(self.activeSpec + 1)
-		self.modFlag = true
-		main:OpenMessagePopup("Tree Converted", "The tree has been converted to "..treeVersions[latestTreeVersion].display..".\nNote that some or all of the passives may have been de-allocated due to changes in the tree.\n\nYou can switch back to the old tree using the tree selector at the bottom left.")
+		convertToVersion(latestTreeVersion)
 	end)
 	self.jumpToNode = false
 	self.jumpToX = 0

--- a/src/Classes/TreeTab.lua
+++ b/src/Classes/TreeTab.lua
@@ -130,16 +130,23 @@ local TreeTabClass = newClass("TreeTab", "ControlHost", function(self, build)
 		self.modFlag = true
 		main:OpenMessagePopup("Tree Converted", "The tree has been converted to "..treeVersions[version].display..".\nNote that some or all of the passives may have been de-allocated due to changes in the tree.\n\nYou can switch back to the old tree using the tree selector at the bottom left.")
 	end
+	self.treeVersions = { }
+	for _, num in ipairs(treeVersionList) do
+		if not num:find("^2") then
+			local vers = num:gsub("%_", ".")
+			t_insert(self.treeVersions, vers)
+		end
+	end
 	self.controls.versionText = new("LabelControl", { "LEFT", self.controls.export, "RIGHT" }, 8, 0, 0, 16, "Version:")
-	self.controls.versionSelect = new("DropDownControl", { "LEFT", self.controls.versionText, "RIGHT" }, 8, 0, 55, 20, treeVersionList, function(index, value)
+	self.controls.versionSelect = new("DropDownControl", { "LEFT", self.controls.versionText, "RIGHT" }, 8, 0, 55, 20, self.treeVersions, function(index, value)
 		if value ~= self.build.spec.treeVersion then
-			convertToVersion(value)
+			convertToVersion(value:gsub("%.", "_"))
 		end
 	end)
 	self.controls.versionSelect.maxDroppedWidth = 1000
 	self.controls.versionSelect.enableDroppedWidth = true
 	self.controls.versionSelect.enableChangeBoxWidth = true
-	self.controls.versionSelect.selIndex = #treeVersionList
+	self.controls.versionSelect.selIndex = #self.treeVersions
 	self.controls.treeSearch = new("EditControl", { "LEFT", self.controls.versionSelect, "RIGHT" }, 8, 0, main.portraitMode and 200 or 300, 20, "", "Search", "%c", 100, function(buf)
 		self.viewer.searchStr = buf
 		self.searchFlag = buf ~= self.viewer.searchStrSaved


### PR DESCRIPTION
Add ability to change to whichever tree version you want. A new spec is created through conversion, keeping as many nodes as it can. Prep for Ruthless tree possibilities. It will not do anything if you select the current spec's version.

### Link to a build that showcases this PR:
<pre>https://pobb.in/hiOrQJswyJzi</pre>

### After screenshot:
Updated to decimal notation and removed 2.6, gif is not updated but the behavior is unchanged

![image](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/92683202/84e17b67-5e41-4cf3-a2ee-31ef08569f16)

![versionchanging](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/92683202/2125de51-d163-4fac-9cab-c271d0d03493)
