### PR TITLE
Lack of config causing conditional minion aura effect mods to not be applied.

### DIFF
--- a/src/Modules/CalcPerform.lua
+++ b/src/Modules/CalcPerform.lua
@@ -2090,8 +2090,8 @@ function calcs.perform(env, avoidCache, fullDPSSkipEHP)
 					end
 					if not (modDB:Flag(nil, "SelfAurasCannotAffectAllies") or modDB:Flag(nil, "SelfAurasOnlyAffectYou") or modDB:Flag(nil, "SelfAuraSkillsCannotAffectAllies")) then
 						if env.minion then
-							local inc = skillModList:Sum("INC", skillCfg, "AuraEffect", "BuffEffect") + env.minion.modDB:Sum("INC", nil, "BuffEffectOnSelf", "AuraEffectOnSelf")
-							local more = skillModList:More(skillCfg, "AuraEffect", "BuffEffect") * env.minion.modDB:More(nil, "BuffEffectOnSelf", "AuraEffectOnSelf")
+							local inc = skillModList:Sum("INC", skillCfg, "AuraEffect", "BuffEffect") + env.minion.modDB:Sum("INC", skillCfg, "BuffEffectOnSelf", "AuraEffectOnSelf")
+							local more = skillModList:More(skillCfg, "AuraEffect", "BuffEffect") * env.minion.modDB:More(skillCfg, "BuffEffectOnSelf", "AuraEffectOnSelf")
 							local mult = (1 + inc / 100) * more
 							if not allyBuffs["Aura"] or  not allyBuffs["Aura"][buff.name] or allyBuffs["Aura"][buff.name].effectMult / 100 <= mult then
 								activeSkill.minionBuffSkill = true


### PR DESCRIPTION
Fixes #5939 .

No config caused mod conditions to fail and the mod from `Matua Tupuna` `20% increased effect of Non-Curse Auras from your Skills on your Minions` to not be applied. This may also be the case here:
https://github.com/PathOfBuildingCommunity/PathOfBuilding/blob/19818870af754cc17b9fa8e16c026670f20932e6/src/Modules/CalcPerform.lua#L2038-L2039

and

https://github.com/PathOfBuildingCommunity/PathOfBuilding/blob/19818870af754cc17b9fa8e16c026670f20932e6/src/Modules/CalcPerform.lua#L2230-L2231C71

but i'm not sure if adding the config there could break something so leaving as is for now.