### PR TITLE
Force skill groups to display as active based on main skill

### DIFF
--- a/src/Classes/SkillListControl.lua
+++ b/src/Classes/SkillListControl.lua
@@ -49,11 +49,15 @@ end)
 function SkillListClass:GetRowValue(column, index, socketGroup)
 	if column == 1 then
 		local label = socketGroup.displayLabel or "?"
-		if not socketGroup.enabled or not socketGroup.slotEnabled then
-			label = "^x7F7F7F" .. label .. " (Disabled)"
+		local currentMainSkill = self.skillsTab.build.mainSocketGroup == index
+		local disabled = not socketGroup.enabled or not socketGroup.slotEnabled
+		if disabled then
+			local colour = currentMainSkill and "" or "^x7F7F7F"
+			label = colour .. label .. " (Disabled)"
 		end
-		if self.skillsTab.build.mainSocketGroup == index then 
-			label = label .. colorCodes.RELIC .. " (Active)"
+		if currentMainSkill then 
+			local activeLabel = disabled and " (Forced Active)" or " (Active)"
+			label = label .. colorCodes.RELIC .. activeLabel
 		end
 		if socketGroup.includeInFullDPS then 
 			label = label .. colorCodes.CUSTOM .. " (FullDPS)"


### PR DESCRIPTION
Fixes #2976

### Description of the problem being solved:
Path of Building treats the currently selected Main Skill as active regardless of the Enabled config in the skill group itself. This is to ensure that it can be calculated properly for the build sidebar. However, it also leads to some unintuitive behaviour for the end user, notably that any auras in the skill group are treated as enabled even though the group itself is disabled.

It's probably desireable that the main skill is treated as active, but the user needs feedback that this is the case. This PR changes the display of the main skill's skill tab group to not be coloured, and state that it's forced active, without actually changing the state of the group. This means that changing main skill back off the disabled skill will once again show it as disabled.

### Link to a build that showcases this PR:
https://pobb.in/fXSPGxmEI6jO

### Before screenshot:
![image](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/5985728/28ec4e05-0572-48b2-93ca-cd60cdcc5549)
Note the 50% mana reservation, despite the skill group (gloves, number 2) being listed as (Disabled) (Active)

### After screenshot:
![image](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/5985728/863d3851-e532-4529-b175-031b86396c8c)
![image](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/5985728/1c213276-3262-4eaf-a26a-23e5d3f5fc6c)
