### PR TITLE
Only apply combustion fire resistance effect with skills that can ignite

### DIFF
--- a/src/Data/Skills/sup_int.lua
+++ b/src/Data/Skills/sup_int.lua
@@ -963,7 +963,7 @@ skills["SupportChanceToIgnite"] = {
 			mod("FireDamage", "MORE", nil),
 		},
 		["ignites_apply_fire_resistance_+"] = {
-			mod("FireResist", "BASE", nil, 0, 0, { type = "GlobalEffect", effectType = "Debuff", effectName = "Combustion" }, { type = "Condition", var = "Ignited" }),
+			mod("CombustionFireResist", "BASE", nil),
 		},
 	},
 	qualityStats = {

--- a/src/Modules/CalcOffence.lua
+++ b/src/Modules/CalcOffence.lua
@@ -1223,6 +1223,29 @@ function calcs.offence(env, actor, activeSkill)
 			}
 		end
 	end
+	
+	-- Handle Combustion
+	-- Check each active skill for combustion support, except Arcanist Brand
+	-- If combustion support is present, check if we're able to ignite, and then stop looking at support gems
+	-- If we can ignite, apply the fire resist debuff, then break out of the active skill loop
+	local appliedCombustion = false
+	for _, skill in ipairs(actor.activeSkillList) do
+		if skill.activeEffect.grantedEffect.name ~= "Arcanist Brand" then
+			for _, support in ipairs(skill.supportList) do
+				if support.gemData.name == "Combustion" then
+					if not skill.skillModList:Flag(skill.skillCfg, "CannotIgnite") then
+						local value = skill.skillModList:Sum("BASE", skill.skillCfg, "CombustionFireResist")
+						enemyDB:NewMod("FireResist", "BASE", value, 0, 0, { type = "GlobalEffect", effectType = "Debuff", effectName = "Combustion" }, { type = "Condition", var = "Ignited" })
+						appliedCombustion = true
+					end
+					break
+				end
+			end
+			if appliedCombustion then
+				break
+			end
+		end
+	end
 
 	-- General's Cry
 	if skillData.triggeredByGeneralsCry then

--- a/src/Modules/CalcOffence.lua
+++ b/src/Modules/CalcOffence.lua
@@ -1223,29 +1223,6 @@ function calcs.offence(env, actor, activeSkill)
 			}
 		end
 	end
-	
-	-- Handle Combustion
-	-- Check each active skill for combustion support, except Arcanist Brand
-	-- If combustion support is present, check if we're able to ignite, and then stop looking at support gems
-	-- If we can ignite, apply the fire resist debuff, then break out of the active skill loop
-	local appliedCombustion = false
-	for _, skill in ipairs(actor.activeSkillList) do
-		if skill.activeEffect.grantedEffect.name ~= "Arcanist Brand" then
-			for _, support in ipairs(skill.supportList) do
-				if support.gemData.name == "Combustion" then
-					if not skill.skillModList:Flag(skill.skillCfg, "CannotIgnite") then
-						local value = skill.skillModList:Sum("BASE", skill.skillCfg, "CombustionFireResist")
-						enemyDB:NewMod("FireResist", "BASE", value, 0, 0, { type = "GlobalEffect", effectType = "Debuff", effectName = "Combustion" }, { type = "Condition", var = "Ignited" })
-						appliedCombustion = true
-					end
-					break
-				end
-			end
-			if appliedCombustion then
-				break
-			end
-		end
-	end
 
 	-- General's Cry
 	if skillData.triggeredByGeneralsCry then

--- a/src/Modules/CalcPerform.lua
+++ b/src/Modules/CalcPerform.lua
@@ -2252,7 +2252,7 @@ function calcs.perform(env, avoidCache, fullDPSSkipEHP)
 				if support.gemData.name == "Combustion" then
 					if not activeSkill.skillModList:Flag(activeSkill.skillCfg, "CannotIgnite") then
 						local value = activeSkill.skillModList:Sum("BASE", activeSkill.skillCfg, "CombustionFireResist")
-						enemyDB:NewMod("FireResist", "BASE", value, 0, 0, { type = "GlobalEffect", effectType = "Debuff", effectName = "Combustion" }, { type = "Condition", var = "Ignited" })
+						enemyDB:NewMod("FireResist", "BASE", value, "Combustion", { type = "GlobalEffect", effectType = "Debuff", effectName = "Combustion" }, { type = "Condition", var = "Ignited" })
 						appliedCombustion = true
 					end
 					break


### PR DESCRIPTION
Fixes #853

### Description of the problem being solved:
The negative fire resistance on ignited targets was applying even on skills that were unable to ignite, such as Flame Surge or anything supported by Elemental Focus. This moves the negative fire resistance effect into CalcPerform and limits it to skills that are able to ignite.

### Steps taken to verify a working solution:
- Checked Flame Surge linked with Combustion
- Checked Fireball linked with Combustion
- Checked Fireball linked with Combustion and Elemental Focus

### Link to a build that showcases this PR:
https://pobb.in/R6siifHKrTth