### PR TITLE
Add missing skillTypes to Infernal Legion

### DIFF
--- a/src/Data/Skills/minion.lua
+++ b/src/Data/Skills/minion.lua
@@ -1427,7 +1427,7 @@ skills["InfernalLegion"] = {
 		spell = true,
 		area = true,
 	},
-	skillTypes = { },
+	skillTypes = { [SkillType.DamageOverTime] = true, [SkillType.CausesBurning] = true },
 	baseMods = {
 		skill("FireDot", 1, { type = "Multiplier", var = "InfernalLegionBaseDamage" }),
 		skill("dotIsArea", true),

--- a/src/Export/Skills/minion.txt
+++ b/src/Export/Skills/minion.txt
@@ -301,7 +301,7 @@ skills["InfernalLegion"] = {
 		spell = true,
 		area = true,
 	},
-	skillTypes = { },
+	skillTypes = { [SkillType.DamageOverTime] = true, [SkillType.CausesBurning] = true },
 	baseMods = {
 		skill("FireDot", 1, { type = "Multiplier", var = "InfernalLegionBaseDamage" }),
 		skill("dotIsArea", true),


### PR DESCRIPTION
Fixes #5936 .

### Description of the problem being solved:
Due to missing skillTypes the Infernal Legion minion skill is currently not compatible with many support gems it should be compatible with.

This pr adds the skillTypes manually since the skill has been added manually but a better solution would to be export it from the game data if possible.