### PR TITLE
Fix a crash relating to accessing gemdata for granted supports

### DIFF
--- a/src/Modules/CalcPerform.lua
+++ b/src/Modules/CalcPerform.lua
@@ -2249,7 +2249,7 @@ function calcs.perform(env, avoidCache, fullDPSSkipEHP)
 		--Handle combustion
 		if activeSkill.activeEffect.grantedEffect.name ~= "Arcanist Brand" and not appliedCombustion then
 			for _, support in ipairs(activeSkill.supportList) do
-				if support.gemData.name == "Combustion" then
+				if support.grantedEffect.name == "Combustion" then
 					if not activeSkill.skillModList:Flag(activeSkill.skillCfg, "CannotIgnite") then
 						local value = activeSkill.skillModList:Sum("BASE", activeSkill.skillCfg, "CombustionFireResist")
 						enemyDB:NewMod("FireResist", "BASE", value, "Combustion", { type = "GlobalEffect", effectType = "Debuff", effectName = "Combustion" }, { type = "Condition", var = "Ignited" })


### PR DESCRIPTION
Fixes an issue introduced in #6320 

### Description of the problem being solved:
Combustion support was identified using the gemdata of the supports. This breaks for any supports that lack gemdata, which includes ones granted by modifiers on items. Accessing the name via the granted effect removes this nullref crash.

### Link to a build that showcases this PR:
https://pobb.in/k0E4VLKJFSse
