### PR TITLE
'Wait for max unleash seals' mana cost fix 

### DIFF
--- a/src/Modules/CalcOffence.lua
+++ b/src/Modules/CalcOffence.lua
@@ -4919,7 +4919,7 @@ function calcs.offence(env, actor, activeSkill)
 				useSpeed = (output.Cooldown and output.Cooldown > 0 and (output.TotemPlacementSpeed > 0 and output.TotemPlacementSpeed or 1 / output.Cooldown) or output.TotemPlacementSpeed) / repeats
 				timeType = "totem placement"
 			elseif skillModList:Flag(nil, "HasSeals") and skillModList:Flag(nil, "UseMaxUnleash") then
-				useSpeed = 1 / env.player.mainSkill.skillData.hitTimeOverride / repeats
+				useSpeed = env.player.mainSkill.skillData.hitTimeOverride / repeats
 				timeType = "full unleash"
 			else
 				useSpeed = (output.Cooldown and output.Cooldown > 0 and (output.Speed > 0 and output.Speed or 1 / output.Cooldown) or output.Speed) / repeats


### PR DESCRIPTION
### Description of the problem being solved:
- Mana usage of skills when 'Do you wait for Max Unleash Seals' was increasing mana cost per second rather than reducing it.
-Example (using the following POB : https://pobb.in/1bHJnA2_Q3Nm):
    - Unchecked: 
![image](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/23219318/7e6ff293-a570-4d70-8be5-c10133f7b058)
    - 'Do you wait for Max Unleash Seals' Checked:
![image](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/23219318/8c20c4be-0618-4d12-a77a-ae99127238df)
- Inversion of the value is already done to hitTimeOverride earlier on, so inverting the value again (the removal of which is the change I've made) results in the mana cost being higher than it should:
![image](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/23219318/90cd79d8-9fa6-40a5-8e8a-44222bc9ec4e)

### Steps taken to verify a working solution:
- Using same POB as the original example (https://pobb.in/1bHJnA2_Q3Nm)
    - Unchecked: 
![image](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/23219318/dbc9667e-4924-4717-902d-7e78ba39533a)
    - 'Do you wait for Max Unleash Seals' checked:
![image](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/23219318/23c6d1df-428d-4f90-aa5f-52f3f23d785f)
