### PR TITLE
Lower contrast of gem select highlight

### DIFF
--- a/src/Classes/GemSelectControl.lua
+++ b/src/Classes/GemSelectControl.lua
@@ -381,7 +381,7 @@ function GemSelectClass:Draw(viewPort, noTooltip)
 		for index = minIndex, maxIndex do
 			local y = (index - 1) * (height - 4) - scrollBar.offset
 			if index == self.hoverSel or index == self.selIndex or (index == 1 and self.selIndex == 0) then
-				SetDrawColor(0.33, 0.33, 0.33)
+				SetDrawColor(0.13, 0.13, 0.13)
 				DrawImage(nil, 0, y, width - 4, height - 4)
 			end
 			SetDrawColor(1, 1, 1)

--- a/src/Classes/GemSelectControl.lua
+++ b/src/Classes/GemSelectControl.lua
@@ -381,7 +381,7 @@ function GemSelectClass:Draw(viewPort, noTooltip)
 		for index = minIndex, maxIndex do
 			local y = (index - 1) * (height - 4) - scrollBar.offset
 			if index == self.hoverSel or index == self.selIndex or (index == 1 and self.selIndex == 0) then
-				SetDrawColor(0.13, 0.13, 0.13)
+				SetDrawColor(0.2, 0.2, 0.2)
 				DrawImage(nil, 0, y, width - 4, height - 4)
 			end
 			SetDrawColor(1, 1, 1)


### PR DESCRIPTION
Fixes n/a .

### Description of the problem being solved:

It was very hard to read the gems selected due to poor contrast, specially for blue gems

### Steps taken to verify a working solution:
- Go to Skills section
- Select a Gem
- Notice how the selected item is hard to read

### Link to a build that showcases this PR:

n/a

### Before screenshot:

![image](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/44361234/d55ea98d-ecba-4052-9c37-0b3c0a0ee614)


### After screenshot:

![image](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/44361234/161d9789-df92-4f9f-a90f-856523562ed6)

