### PR TITLE
Fix Tree conversion stopping you from allocating some tree nodes

### DIFF
--- a/src/Classes/PassiveSpec.lua
+++ b/src/Classes/PassiveSpec.lua
@@ -47,7 +47,8 @@ function PassiveSpecClass:Init(treeVersion, convert)
 	for id, node in pairs(self.nodes) do
 		-- if the node is allocated and between the old and new tree has the same ID but does not share the same name, add to list of nodes to be ignored
 		if convert and previousTreeNodes[id] and self.build.spec.allocNodes[id] and node.name ~= previousTreeNodes[id].name then
-			self.ignoredNodes[id] = previousTreeNodes[id]
+			--Commented out for now as it was breaking nodes when upgrading trees
+			--self.ignoredNodes[id] = previousTreeNodes[id]
 		end
 		for _, otherId in ipairs(node.linkedId) do
 			t_insert(node.linked, self.nodes[otherId])


### PR DESCRIPTION
When converting a tree to a different version, if the node changed name but not node ID, it would not allow you to allocate the node in the same location until you re-opened the build.
This just temporarily fixes the issue before we find the root cause
Fixes #6345
