### PR TITLE
Fix allocation issue on tree conversion

### DIFF
--- a/src/Classes/PassiveSpec.lua
+++ b/src/Classes/PassiveSpec.lua
@@ -47,8 +47,7 @@ function PassiveSpecClass:Init(treeVersion, convert)
 	for id, node in pairs(self.nodes) do
 		-- if the node is allocated and between the old and new tree has the same ID but does not share the same name, add to list of nodes to be ignored
 		if convert and previousTreeNodes[id] and self.build.spec.allocNodes[id] and node.name ~= previousTreeNodes[id].name then
-			--Commented out for now as it was breaking nodes when upgrading trees
-			--self.ignoredNodes[id] = previousTreeNodes[id]
+			self.ignoredNodes[id] = previousTreeNodes[id]
 		end
 		for _, otherId in ipairs(node.linkedId) do
 			t_insert(node.linked, self.nodes[otherId])
@@ -894,6 +893,8 @@ function PassiveSpecClass:BuildAllDependsAndPaths()
 		if self.ignoredNodes[id] and self.allocNodes[id] then
 			self.nodes[id].alloc = false
 			self.allocNodes[id] = nil
+			-- remove once processed to avoid allocation issue after convert
+			self.ignoredNodes[id] = nil
 		else
 			if node.type == "Mastery" and self.masterySelections[id] then
 				local effect = self.tree.masteryEffects[self.masterySelections[id]]


### PR DESCRIPTION
### Description of the problem being solved:
Fixes issue where you cannot allocate a node that was ignored for id/name reasons on tree conversions

### Steps taken to verify a working solution:
- Allocate Chieftain Ascendancies on 3.21 (e.g. Valako, Tasalio, Tawhoa, Ramako)
- Convert to 3.22
- Check to see which nodes should have been ignored due to node id/name mismatch, verify not allocated (all but Ramako)
- Verify able to allocate ignored nodes without needing restart
--
- Allocate Dirty Techniques on 3.21
- Convert to 3.22
- Verify Dirty Techniques and two linked nodes are not allocated
- Verify able to allocate all three without needing restart

### Link to a build that showcases this PR:
https://pobb.in/uvWbMkbWLyUZ

### After screenshot:
![convertIssue](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/92683202/1980de9d-492c-4c42-8aed-ef01049349c2)

