### PR TITLE
Version dropdown QoL

### DIFF
--- a/src/Classes/TreeTab.lua
+++ b/src/Classes/TreeTab.lua
@@ -393,6 +393,10 @@ function TreeTabClass:SetActiveSpec(specId)
 	end
 	-- Update the passive tree dropdown control in itemsTab
 	self.build.itemsTab.controls.specSelect.selIndex = specId
+	-- Update Version dropdown to active spec's
+	if self.controls.versionSelect then
+		self.controls.versionSelect:SelByValue(curSpec.treeVersion:gsub("%_", "."))
+	end
 end
 
 function TreeTabClass:SetCompareSpec(specId)

--- a/src/Classes/TreeTab.lua
+++ b/src/Classes/TreeTab.lua
@@ -395,7 +395,7 @@ function TreeTabClass:SetActiveSpec(specId)
 	self.build.itemsTab.controls.specSelect.selIndex = specId
 	-- Update Version dropdown to active spec's
 	if self.controls.versionSelect then
-		self.controls.versionSelect:SelByValue(curSpec.treeVersion:gsub("%_", "."))
+		self.controls.versionSelect:SelByValue(curSpec.treeVersion:gsub("%_", "."):gsub(".ruthless", " (ruthless)"))
 	end
 end
 


### PR DESCRIPTION
### Description of the problem being solved:
Small QoL for the version dropdown. On switching to any spec, this will update the dropdown to match the version.

### After screenshot:
![dropdownQoL](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/92683202/b255f299-4430-4a3e-92db-65f6bc019eff)
