### PR TITLE
Removing allocated mastery from hover list

### DIFF
--- a/src/Classes/PassiveTreeView.lua
+++ b/src/Classes/PassiveTreeView.lua
@@ -966,13 +966,16 @@ function PassiveTreeViewClass:AddNodeTooltip(tooltip, node, build)
 		tooltip:AddLine(6, "")
 		local lineCount = 0
 		for n, effect in ipairs(mNode.masteryEffects) do
-			effect = build.spec.tree.masteryEffects[effect.effect]
-			for _, line in ipairs(effect.sd) do
-				lineCount = lineCount + 1
-				addModInfoToTooltip(mNode, lineCount, line)
-			end
-			if n < #mNode.masteryEffects then
-				tooltip:AddLine(6, "")
+			local existingMastery = isValueInTable(build.spec.masterySelections, effect.effect)
+			if not existingMastery then
+				effect = build.spec.tree.masteryEffects[effect.effect]
+				for _, line in ipairs(effect.sd) do
+					lineCount = lineCount + 1
+					addModInfoToTooltip(mNode, lineCount, line)
+				end
+				if n < #mNode.masteryEffects then
+					tooltip:AddLine(6, "")
+				end
 			end
 		end
 		tooltip:AddSeparator(24)

--- a/src/Classes/PassiveTreeView.lua
+++ b/src/Classes/PassiveTreeView.lua
@@ -962,7 +962,7 @@ function PassiveTreeViewClass:AddNodeTooltip(tooltip, node, build)
 
 	if mNode.sd[1] and mNode.allMasteryOptions then
 		tooltip:AddSeparator(14)
-		tooltip:AddLine(14, "^7Mastery node options are:")
+		tooltip:AddLine(14, "^7Available Mastery node options are:")
 		tooltip:AddLine(6, "")
 		local lineCount = 0
 		for n, effect in ipairs(mNode.masteryEffects) do


### PR DESCRIPTION
Fixes #6373  .

### Description of the problem being solved:
Hover box for masteries shows all masteries when it might be more clear to only show available ones.
### Steps taken to verify a working solution:
- Hover over mastery, allocate one
- Hover over same mastery category, find it without the previously allocated mastery
