### PR TITLE
Apply RepeatCount according to their SkillTypes

### DIFF
--- a/src/Data/SkillStatMap.lua
+++ b/src/Data/SkillStatMap.lua
@@ -224,10 +224,10 @@ return {
 	mod("AreaOfEffect", "INC", nil, 0, 0, { type = "Condition", var = "DualWielding", neg = true })
 },
 ["base_spell_repeat_count"] = {
-	mod("RepeatCount", "BASE", nil),
+	mod("RepeatCount", "BASE", nil, 0, 0, {type = "SkillType", skillType = SkillType.Multicastable }),
 },
 ["base_melee_attack_repeat_count"] = {
-	mod("RepeatCount", "BASE", nil),
+	mod("RepeatCount", "BASE", nil, 0, 0, { type = "SkillType", skillType = SkillType.Multistrikeable }),
 },
 ["display_minion_monster_level"] = {
 	skill("minionLevel", nil),

--- a/src/Data/Skills/act_dex.lua
+++ b/src/Data/Skills/act_dex.lua
@@ -4607,6 +4607,9 @@ skills["VaalFlickerStrike"] = {
 		},
 		["base_skill_show_average_damage_instead_of_dps"] = {
 		},
+		["base_melee_attack_repeat_count"] = {
+			mod("RepeatCount", "BASE", nil)
+		},
 	},
 	baseFlags = {
 		attack = true,

--- a/src/Export/Skills/act_dex.txt
+++ b/src/Export/Skills/act_dex.txt
@@ -999,6 +999,9 @@ local skills, mod, flag, skill = ...
 		},
 		["base_skill_show_average_damage_instead_of_dps"] = {
 		},
+		["base_melee_attack_repeat_count"] = {
+			mod("RepeatCount", "BASE", nil)
+		},
 	},
 #baseMod flag("OnlyFinalRepeat")
 #baseMod flag("FinalRepeatSumsDamage")


### PR DESCRIPTION
Fixes #6375  .

### Description of the problem being solved:
Adding RepeatCounts didn't have any flags to make sure they actually belonged to the skill they were supporting.
### Steps taken to verify a working solution:
- Added Summon Skeletons, supported by Spell Echo and Multistrike
- Verified mana cost is only affected by the repeat count from spell echo and not multistrike
- Regression tested Multistrike with Infernal Blow

### Link to a build that showcases this PR:

### Before screenshot:
See issue
### After screenshot:
![image](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/1209372/bebbd4d1-ae1e-431a-a893-1b5421973830)
![image](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/1209372/44873385-b56b-4a5a-a907-f4c36d10bf45)
