### PR TITLE
Improve readability of selected gems

### DIFF
--- a/src/Classes/GemSelectControl.lua
+++ b/src/Classes/GemSelectControl.lua
@@ -381,7 +381,7 @@ function GemSelectClass:Draw(viewPort, noTooltip)
 		for index = minIndex, maxIndex do
 			local y = (index - 1) * (height - 4) - scrollBar.offset
 			if index == self.hoverSel or index == self.selIndex or (index == 1 and self.selIndex == 0) then
-				SetDrawColor(0.2, 0.2, 0.2)
+				SetDrawColor(0.15, 0.15, 0.15)
 				DrawImage(nil, 0, y, width - 4, height - 4)
 			end
 			SetDrawColor(1, 1, 1)


### PR DESCRIPTION
I sent a PR that got merged https://github.com/PathOfBuildingCommunity/PathOfBuilding/pull/6338

But someone changed it nullifying its effect, specially on blue gems

This PR slightly reduce values from my initial PR in case some my initial ones were too low for the person who edited my PR (wich aren't IMO)
