### PR TITLE
Fix DPS on Vaal Flicker when using 2x 1h weapons

### DIFF
--- a/src/Modules/CalcOffence.lua
+++ b/src/Modules/CalcOffence.lua
@@ -2084,11 +2084,11 @@ function calcs.offence(env, actor, activeSkill)
 				output.HitSpeed = 1 / output.HitTime
 			end
 		end
-		-- Other Misc DPS multipliers (like custom source)
-		skillData.dpsMultiplier = ( skillData.dpsMultiplier or 1 ) * ( 1 + skillModList:Sum("INC", cfg, "DPS") / 100 ) * skillModList:More(cfg, "DPS")
-		if env.configInput.repeatMode == "FINAL" or skillModList:Flag(nil, "OnlyFinalRepeat") then
-			skillData.dpsMultiplier = skillData.dpsMultiplier / (output.Repeats or 1)
-		end
+	end
+	-- Other Misc DPS multipliers (like custom source)
+	skillData.dpsMultiplier = ( skillData.dpsMultiplier or 1 ) * ( 1 + skillModList:Sum("INC", cfg, "DPS") / 100 ) * skillModList:More(cfg, "DPS")
+	if env.configInput.repeatMode == "FINAL" or skillModList:Flag(nil, "OnlyFinalRepeat") then
+		skillData.dpsMultiplier = skillData.dpsMultiplier / (output.Repeats or 1)
 	end
 	if skillModList:Flag(nil, "TriggeredBySnipe") then
 		skillFlags.channelRelease = true


### PR DESCRIPTION
The block was inside the 2 pass loop so was running twice
Also fixes the issue when you used a custom `more DPS` mod
