### PR TITLE
Fix IgnitePotentialOverride not overriding ignite uptime 

### DIFF
--- a/src/Modules/CalcOffence.lua
+++ b/src/Modules/CalcOffence.lua
@@ -4280,9 +4280,8 @@ function calcs.offence(env, actor, activeSkill)
 					end
 				end
 				local effectMod = calcLib.mod(skillModList, dotCfg, "AilmentEffect")
-				igniteStacks = 1
 				if not skillData.triggeredOnDeath then
-					igniteStacks = m_min(maxStacks, (output.HitChance / 100) * globalOutput.IgniteDuration / (globalOutput.HitTime or output.Time))
+					igniteStacks = m_min(maxStacks, igniteStacks)
 				end
 				local IgniteDPSUncapped = baseVal * effectMod * rateMod * igniteStacks * effMult
 				local IgniteDPSCapped = m_min(IgniteDPSUncapped, data.misc.DotDpsCap)
@@ -4333,9 +4332,7 @@ function calcs.offence(env, actor, activeSkill)
 						if rateMod ~= 1 then
 							t_insert(breakdown.IgniteDPS, s_format("x %.2f ^8(burn rate modifier)", rateMod))
 						end
-						if skillFlags.igniteCanStack then
-							t_insert(breakdown.IgniteDPS, s_format("x %d ^8(ignite stacks)", output.IgniteStacksMax))
-						end
+						t_insert(breakdown.IgniteDPS, s_format("x %.2f ^8(ignite uptime, not more than max stacks)", igniteStacks))
 						if effMult ~= 1 then
 							t_insert(breakdown.IgniteDPS, s_format("x %.3f ^8(effective DPS modifier from enemy debuffs)", effMult))
 						end


### PR DESCRIPTION
Fixes https://github.com/PathOfBuildingCommunity/PathOfBuilding/issues/6366 .

### Description of the problem being solved:
Case from the issue: 
If you want to override IgnitePotential (whichi is explained as "Stack Potential equates to the number of times you are able to inflict an Ignite on an enemy before the duration of your first Ignite expires") it does override for calculating average damage of ignite, but does nothing in the resulting calculation of DPS because ignite stacks gets recalculating without it just before:

![image](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/12459153/17d59d7a-1519-4443-aab4-974278bf4300)

So in the case when you're refreshing ignite with say "defiled forces" node, and you override IgnitePotential assuming that you hit faster than ignite duration, DPS calculation does not reflect that

### What was done 
- Removed duplicate calculation of igniteStacks:

![image](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/12459153/e29471eb-f4d3-400f-aba8-0a718710ce68)

As it was already calculated here earlier:

![image](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/12459153/d6866799-b099-4dab-9aab-cedeae2d43db)

Just added clamping the value with maxStacks

- Added a tooltip to reflect that IgniteDPS calculation actually includes ignite uptime. Open to formating and naming tips here

-- Also not sure what skillData.triggeredOnDeath condition for. Let me know if it needs more handling

### Steps taken to verify a working solution:
- Used test pob from the issue. Checked values with calculator of what should be 

### Before screenshot:
![image](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/12459153/fc741b9d-bf8a-439a-8ff9-c502890efb2e)

### After screenshot:

![image](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/12459153/dfd82735-b37f-4b42-9edb-9f8ba58d59f4)

And with no override:
![image](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/12459153/d22b908c-fa39-496f-b15a-830c41d39047)
