### PR TITLE
Fix totem duration mods not applying

### DIFF
--- a/src/Data/SkillStatMap.lua
+++ b/src/Data/SkillStatMap.lua
@@ -1492,7 +1492,7 @@ return {
     div = 60,
 },
 ["totem_duration_+%"] = {
-	mod("TotemDuration", "INC", nil),
+	mod("Duration", "INC", nil, 0, KeywordFlag.Totem),
 },
 -- Minion
 ["minion_damage_+%"] = {

--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -494,7 +494,7 @@ local modNameList = {
 	-- Totem/trap/mine/brand modifiers
 	["totem placement speed"] = "TotemPlacementSpeed",
 	["totem life"] = "TotemLife",
-	["totem duration"] = "TotemDuration",
+	["totem duration"] = { "Duration", keywordFlags = KeywordFlag.Totem },
 	["maximum number of summoned totems"] = "ActiveTotemLimit",
 	["maximum number of summoned totems."] = "ActiveTotemLimit", -- Mark plz
 	["maximum number of summoned ballista totems"] = { "ActiveBallistaLimit", tag = { type = "SkillType", skillType = SkillType.TotemsAreBallistae } },


### PR DESCRIPTION
Fixes #6360

### Description of the problem being solved:
`TotemDuration` mods were not used anywhere. I converted them to `mod("Duration", "INC", nil, 0, KeywordFlag.Totem)`.