### PR TITLE
Refactoring Mechanics into Metatables

### DIFF
--- a/src/Modules/CalcDefence.lua
+++ b/src/Modules/CalcDefence.lua
@@ -184,7 +184,7 @@ function calcs.reducePoolsByDamage(poolTable, damageTable, actor)
 			end
 		end
 		-- frost shield / soul link / other taken before you does not count as you taking damage
-		damageRemainder = aegis:takeDamage(damageType, damage)
+		damageRemainder = aegis:takeDamage(damageType, damageRemainder)
 		if guard[damageType] > 0 then
 			local tempDamage = m_min(damageRemainder * output[damageType.."GuardAbsorbRate"] / 100, guard[damageType])
 			guard[damageType] = guard[damageType] - tempDamage

--- a/src/Modules/CalcDefence.lua
+++ b/src/Modules/CalcDefence.lua
@@ -118,12 +118,8 @@ function Aegis:adjustTotalHitPool(output, damageType)
 	output[damageType.."TotalHitPool"] =
 		output[damageType.."TotalHitPool"] +
 		m_max(
-			m_max(
-				output[damageType.."Aegis"],
-				output["sharedAegis"]),
-		isElemental[damageType] and
-		output[damageType.."AegisDisplay"]
-		or 0)
+			m_max(output[damageType.."Aegis"],output["sharedAegis"]),
+			isElemental[damageType] and output[damageType.."AegisDisplay"] or 0)
 end
 
 ---Helper function that reduces pools according to damage taken
@@ -158,10 +154,7 @@ function calcs.reducePoolsByDamage(poolTable, damageTable, actor)
 	end
 	
 	local PoolsLost = poolTbl.PoolsLost or { }
-	local aegis = poolTbl.Aegis
-	if not aegis then
-		aegis = Aegis:new(output)
-	end
+	local aegis = poolTbl.Aegis or Aegis:new(output)
 	local guard = poolTbl.Guard
 	if not guard then
 		guard = { shared = output.sharedGuardAbsorb or 0 }

--- a/src/Modules/CalcDefence.lua
+++ b/src/Modules/CalcDefence.lua
@@ -80,6 +80,52 @@ function calcs.takenHitFromDamage(rawDamage, damageType, actor)
 	return receivedDamageSum, damages
 end
 
+Aegis = {}
+function Aegis:new(output)
+	aegis = {
+		shared = output.sharedAegis or 0,
+		sharedElemental = output.sharedElementalAegis or 0
+	}
+	for _,damageType in pairs(dmgTypeList) do
+		aegis[damageType] = output[damageType.."Aegis"] or 0
+	end
+	self.__index = self
+	return setmetatable(aegis, self)
+end
+
+function Aegis:takeDamage(damageType, damage)
+	local aegis = self
+	local damageRemainder = damage
+	if aegis[damageType] > 0 then
+		local tempDamage = m_min(damageRemainder, aegis[damageType])
+		aegis[damageType] = aegis[damageType] - tempDamage
+		damageRemainder = damageRemainder - tempDamage
+	end
+	if isElemental[damageType] and aegis.sharedElemental > 0 then
+		local tempDamage = m_min(damageRemainder, aegis.sharedElemental)
+		aegis.sharedElemental = aegis.sharedElemental - tempDamage
+		damageRemainder = damageRemainder - tempDamage
+	end
+	if aegis.shared > 0 then
+		local tempDamage = m_min(damageRemainder, aegis.shared)
+		aegis.shared = aegis.shared - tempDamage
+		damageRemainder = damageRemainder - tempDamage
+	end
+	return damageRemainder
+end
+
+function Aegis:adjustTotalHitPool(output, damageType)
+	output[damageType.."TotalHitPool"] =
+		output[damageType.."TotalHitPool"] +
+		m_max(
+			m_max(
+				output[damageType.."Aegis"],
+				output["sharedAegis"]),
+		isElemental[damageType] and
+		output[damageType.."AegisDisplay"]
+		or 0)
+end
+
 ---Helper function that reduces pools according to damage taken
 ---@param poolTable table special pool values to use. Can be nil. Values from actor output are used if this is not provided or a value for some key in this is nil.
 ---@param damageTable table damage table after all the relevant reductions
@@ -114,13 +160,7 @@ function calcs.reducePoolsByDamage(poolTable, damageTable, actor)
 	local PoolsLost = poolTbl.PoolsLost or { }
 	local aegis = poolTbl.Aegis
 	if not aegis then
-		aegis = {
-			shared = output.sharedAegis or 0,
-			sharedElemental = output.sharedElementalAegis or 0
-		}
-		for damageType in pairs(damageTable) do
-			aegis[damageType] = output[damageType.."Aegis"] or 0
-		end
+		aegis = Aegis:new(output)
 	end
 	local guard = poolTbl.Guard
 	if not guard then
@@ -151,22 +191,7 @@ function calcs.reducePoolsByDamage(poolTable, damageTable, actor)
 			end
 		end
 		-- frost shield / soul link / other taken before you does not count as you taking damage
-		PoolsLost[damageType] = (PoolsLost[damageType] or 0) + damageRemainder
-		if aegis[damageType] > 0 then
-			local tempDamage = m_min(damageRemainder, aegis[damageType])
-			aegis[damageType] = aegis[damageType] - tempDamage
-			damageRemainder = damageRemainder - tempDamage
-		end
-		if isElemental[damageType] and aegis.sharedElemental > 0 then
-			local tempDamage = m_min(damageRemainder, aegis.sharedElemental)
-			aegis.sharedElemental = aegis.sharedElemental - tempDamage
-			damageRemainder = damageRemainder - tempDamage
-		end
-		if aegis.shared > 0 then
-			local tempDamage = m_min(damageRemainder, aegis.shared)
-			aegis.shared = aegis.shared - tempDamage
-			damageRemainder = damageRemainder - tempDamage
-		end
+		damageRemainder = aegis:takeDamage(damageType, damage)
 		if guard[damageType] > 0 then
 			local tempDamage = m_min(damageRemainder * output[damageType.."GuardAbsorbRate"] / 100, guard[damageType])
 			guard[damageType] = guard[damageType] - tempDamage
@@ -2050,13 +2075,10 @@ function calcs.buildDefenceEstimations(env, actor)
 		if (not modDB:Flag(nil, "WardNotBreak")) and DamageIn["cycles"] > 1 then
 			ward = 0
 		end
-		local aegis = { }
-		aegis["shared"] = output["sharedAegis"] or 0
-		aegis["sharedElemental"] = output["sharedElementalAegis"] or 0
+		local aegis = Aegis:new(output)
 		local guard = { }
 		guard["shared"] = output.sharedGuardAbsorb or 0
 		for _, damageType in ipairs(dmgTypeList) do
-			aegis[damageType] = output[damageType.."Aegis"] or 0
 			guard[damageType] = output[damageType.."GuardAbsorb"] or 0
 		end
 		local alliesTakenBeforeYou = {}
@@ -2709,8 +2731,7 @@ function calcs.buildDefenceEstimations(env, actor)
 		else
 			output[damageType.."TotalHitPool"] = output[damageType.."TotalHitPool"] + output.Ward or 0
 		end
-		-- aegis
-		output[damageType.."TotalHitPool"] = output[damageType.."TotalHitPool"] + m_max(m_max(output[damageType.."Aegis"], output["sharedAegis"]), isElemental[damageType] and output[damageType.."AegisDisplay"] or 0)
+		Aegis:adjustTotalHitPool(output, damageType)
 		-- guard skill
 		local GuardAbsorbRate = output["sharedGuardAbsorbRate"] or 0 + output[damageType.."GuardAbsorbRate"] or 0
 		if GuardAbsorbRate > 0 then


### PR DESCRIPTION
This is a minimal working example of a bigger code refactor I hope to do. This PR draft is mainly to spark discussion, and I have some initial questions to start:

1. I personally like to pack behaviour specific to a table / object  into a metatable / class. But how do we feel about behaviour that is only conceptually relevant to the metatable? More specifically, `Aegis:adjustTotalHitPool` does not use any values from an `Aegis` table in its calculation, so it does not strictly need to be tied to the table.
However, it does make it more clear on line 2743, what mechanic is actually adjusting the hit pool. I could see a world where the loop on line 2723 calls a `Ward:adjustTotalHitPool`, `Aegis:adjustTotalHitPool` and `Guard:adjustTotalHitPool`.
I could also see an argument to instead have the entire loop be its own function, and then keeping the entire calculation within that function, rather than spreading it out across three different metatables. I am open to both approaches.

2. Packing the behaviour of `Aegis` together also makes it possible to seperate it into its own file, but how big should a mechanic be for it to get its own file? Creating a small `Aegis.lua` file is possible, but you could also take a broader view and say that `Aegis` is only part of a wider mechanic called `Hit Pools`, so it should live in a `Pools.lua` alongside `Ward` and `Guard`