### PR TITLE
(BETA) Fix secondary effect skills being added as supports

### DIFF
--- a/src/Modules/CalcSetup.lua
+++ b/src/Modules/CalcSetup.lua
@@ -1045,6 +1045,7 @@ function calcs.initEnv(build, mode, override, specEnv)
 					quality = 0,
 					enabled = true,
 				}
+				activeGemInstance.fromItem = grantedSkill.sourceItem ~= nil
 				activeGemInstance.gemId = nil
 				activeGemInstance.level = grantedSkill.level
 				activeGemInstance.enableGlobal1 = true

--- a/src/Modules/CalcTriggers.lua
+++ b/src/Modules/CalcTriggers.lua
@@ -30,7 +30,9 @@ local function addTriggerIncMoreMods(activeSkill, sourceSkill)
 end
 
 local function slotMatch(env, skill)
-	local match1 = (env.player.mainSkill.activeEffect.grantedEffect.fromItem or skill.activeEffect.grantedEffect.fromItem) and skill.socketGroup and skill.socketGroup.slot == env.player.mainSkill.socketGroup.slot
+	local fromItem = (env.player.mainSkill.activeEffect.grantedEffect.fromItem or skill.activeEffect.grantedEffect.fromItem)
+	fromItem = fromItem or (env.player.mainSkill.activeEffect.srcInstance.fromItem or skill.activeEffect.srcInstance.fromItem)
+	local match1 = fromItem and skill.socketGroup and skill.socketGroup.slot == env.player.mainSkill.socketGroup.slot
 	local match2 = (not env.player.mainSkill.activeEffect.grantedEffect.fromItem) and skill.socketGroup == env.player.mainSkill.socketGroup
 	return (match1 or match2)
 end

--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -1750,7 +1750,39 @@ local function triggerExtraSkill(name, level, noSupports, sourceSkill, triggerCh
 		}
 	end
 end
-
+local function extraSupport(name, level, slot)
+	local skillId = gemIdLookup[name] or gemIdLookup[name:gsub("^increased ","")]
+	
+	if itemSlotName == "main hand" then
+		slot = "Weapon 1"
+	elseif itemSlotName == "off hand" then
+		slot = "Weapon 2"
+	elseif slot then
+		slot = string.gsub(" "..slot, "%W%l", string.upper):sub(2)
+	else
+		slot = "{SlotName}"
+	end
+	
+	level = tonumber(level)
+	if skillId then
+		local gemId = data.gemForBaseName[data.skills[skillId].name .. " Support"]
+		if gemId then
+			local mods = {mod("ExtraSupport", "LIST", { skillId = data.gems[gemId].grantedEffectId, level = level }, { type = "SocketedIn", slotName = slot })}
+			if data.gems[gemId].secondaryGrantedEffect then
+				if data.gems[gemId].secondaryGrantedEffect.support then
+					t_insert(mods, mod("ExtraSupport", "LIST", { skillId = data.gems[gemId].secondaryGrantedEffectId, level = level }, { type = "SocketedIn", slotName = slot }))
+				else
+					t_insert(mods, mod("ExtraSkill", "LIST", { skillId = data.gems[gemId].secondaryGrantedEffectId, level = level }))
+				end
+			end
+			return mods
+		else
+			return {
+				mod("ExtraSupport", "LIST", { skillId = skillId, level = level }, { type = "SocketedIn", slotName = slot }),
+			}
+		end
+	end
+end
 local explodeFunc = function(chance, amount, type, ...)
 	local amountNumber = tonumber(amount) or (amount == "tenth" and 10) or (amount == "quarter" and 25)
 	if not amountNumber then
@@ -2691,27 +2723,7 @@ local specialModList = {
 	["trigger commandment of inferno on critical strike"] = { mod("ExtraSkill", "LIST", { skillId = "UniqueEnchantmentOfInfernoOnCrit", level = 1, noSupports = true, triggered = true }) },
 	["trigger (.+) on critical strike"] = function( _, skill) return triggerExtraSkill(skill, 1, true) end,
 	["triggers? (.+) when you take a critical strike"] = function( _, skill) return triggerExtraSkill(skill, 1, true) end,
-	["socketed [%a+]* ?gems a?r?e? ?supported by level (%d+) (.+)"] = function(num, _, support)
-		local skillId = gemIdLookup[support] or gemIdLookup[support:gsub("^increased ","")]
-		if skillId then
-			local gemId = data.gemForBaseName[data.skills[skillId].name .. " Support"]
-			if gemId then
-				local mods = {mod("ExtraSupport", "LIST", { skillId = data.gems[gemId].grantedEffectId, level = num }, { type = "SocketedIn", slotName = "{SlotName}" })}
-				if data.gems[gemId].secondaryGrantedEffect then
-					if data.gems[gemId].secondaryGrantedEffect.support then
-						t_insert(mods, mod("ExtraSupport", "LIST", { skillId = data.gems[gemId].secondaryGrantedEffectId, level = num }, { type = "SocketedIn", slotName = "{SlotName}" }))
-					else
-						t_insert(mods, mod("ExtraSkill", "LIST", { skillId = data.gems[gemId].secondaryGrantedEffectId, level = num }))
-					end
-				end
-				return mods
-			else
-				return {
-					mod("ExtraSupport", "LIST", { skillId = skillId, level = num }, { type = "SocketedIn", slotName = "{SlotName}" }),
-				}
-			end
-		end
-	end,
+	["socketed [%a+]* ?gems a?r?e? ?supported by level (%d+) (.+)"] = function(num, _, support) return extraSupport(support, num) end,
 	["socketed support gems can also support skills from your e?q?u?i?p?p?e?d? ?([%a%s]+)"] = function (_, itemSlotName)
 		local targetItemSlotName = "Body Armour"
 		if itemSlotName == "main hand" then

--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -2696,10 +2696,15 @@ local specialModList = {
 		if skillId then
 			local gemId = data.gemForBaseName[data.skills[skillId].name .. " Support"]
 			if gemId then
-				return {
-					mod("ExtraSupport", "LIST", { skillId = data.gems[gemId].grantedEffectId, level = num }, { type = "SocketedIn", slotName = "{SlotName}" }),
-					mod("ExtraSupport", "LIST", { skillId = data.gems[gemId].secondaryGrantedEffectId, level = num }, { type = "SocketedIn", slotName = "{SlotName}" })
-				}
+				local mods = {mod("ExtraSupport", "LIST", { skillId = data.gems[gemId].grantedEffectId, level = num }, { type = "SocketedIn", slotName = "{SlotName}" })}
+				if data.gems[gemId].secondaryGrantedEffect then
+					if data.gems[gemId].secondaryGrantedEffect.support then
+						t_insert(mods, mod("ExtraSupport", "LIST", { skillId = data.gems[gemId].secondaryGrantedEffectId, level = num }, { type = "SocketedIn", slotName = "{SlotName}" }))
+					else
+						t_insert(mods, mod("ExtraSkill", "LIST", { skillId = data.gems[gemId].secondaryGrantedEffectId, level = num }))
+					end
+				end
+				return mods
 			else
 				return {
 					mod("ExtraSupport", "LIST", { skillId = skillId, level = num }, { type = "SocketedIn", slotName = "{SlotName}" }),


### PR DESCRIPTION
Fixes #6385

### Description of the problem being solved:
The ExtraSupport mod parser logic always added an extra mod for the secondary effect which was not always there. If the secondary effect was a skill not a support as is in the case of Doom Blast the skill would be added to the list of supports which prevents it from appearing in the skills drop down.