### PR TITLE
Fix Snipe damage going negative

### DIFF
--- a/src/Modules/CalcPerform.lua
+++ b/src/Modules/CalcPerform.lua
@@ -3626,7 +3626,7 @@ function calcs.perform(env, avoidCache, fullDPSSkipEHP)
 	-- Snipe Support
 	if env.player.mainSkill.skillData.triggeredBySnipe or env.player.mainSkill.activeEffect.grantedEffect.name == "Snipe" and not env.player.mainSkill.skillFlags.minion then
 		local triggerName = "Snipe"
-		local snipeStages = math.min(env.player.modDB:Sum("BASE", nil, "Multiplier:SnipeStage"), env.player.modDB:Sum("BASE", nil, "Multiplier:SnipeStagesMax")) - 0.5 --First stage takes 0.5x time to channel compared to subsequent stages
+		local snipeStages = math.min(m_max(env.player.modDB:Sum("BASE", nil, "Multiplier:SnipeStage"), 1), env.player.modDB:Sum("BASE", nil, "Multiplier:SnipeStagesMax")) - 0.5 --First stage takes 0.5x time to channel compared to subsequent stages
 		local maxSnipeStages = env.player.modDB:Sum("BASE", nil, "Multiplier:SnipeStagesMax") - 0.5
 		if env.player.mainSkill.marked then
 			if env.player.mainSkill.activeEffect.grantedEffect.name == "Snipe" then
@@ -3670,7 +3670,7 @@ function calcs.perform(env, avoidCache, fullDPSSkipEHP)
 				env.player.mainSkill.skillData.baseMultiplier = 0
 				env.player.mainSkill.infoMessage = "Triggering Support Skills:"
 			end
-			env.player.mainSkill.skillData.hitTimeMultiplier = m_max(snipeStages, 0.5)
+			env.player.mainSkill.skillData.hitTimeMultiplier = snipeStages
 		elseif not source or (snipeStages + 0.5) < triggerSkillPosition then
 			env.player.mainSkill.skillData.triggeredBySnipe = nil
 			env.player.mainSkill.infoMessage = s_format("Not enough Snipe stages to Trigger Skill")

--- a/src/Modules/CalcPerform.lua
+++ b/src/Modules/CalcPerform.lua
@@ -3670,7 +3670,7 @@ function calcs.perform(env, avoidCache, fullDPSSkipEHP)
 				env.player.mainSkill.skillData.baseMultiplier = 0
 				env.player.mainSkill.infoMessage = "Triggering Support Skills:"
 			end
-			env.player.mainSkill.skillData.hitTimeMultiplier = snipeStages
+			env.player.mainSkill.skillData.hitTimeMultiplier = m_max(snipeStages, 0.5)
 		elseif not source or (snipeStages + 0.5) < triggerSkillPosition then
 			env.player.mainSkill.skillData.triggeredBySnipe = nil
 			env.player.mainSkill.infoMessage = s_format("Not enough Snipe stages to Trigger Skill")


### PR DESCRIPTION
### Description of the problem being solved:

Snipe damage goes negative when the Snipe stages field is empty or 0. This pr sets the minimum stages of self cast Snipe to 1 but without the damage mods. To get the damage mods the user would need to set the Snipe stages box to one (this will result in the same cast rate).