### PR TITLE
Null-check node.finalModList when hovering trees

### DIFF
--- a/src/Modules/CalcSetup.lua
+++ b/src/Modules/CalcSetup.lua
@@ -539,8 +539,10 @@ function calcs.initEnv(build, mode, override, specEnv)
 	local allocatedMasteryTypes = copyTable(env.spec.allocatedMasteryTypes)
 
 	for _, node in pairs(env.spec.allocNodes) do
-		for _, mod in ipairs(node.finalModList:Tabulate("LIST", nil, "ExtraJewelFunc")) do
-			env.extraJewelFuncs:AddMod(mod.mod)
+		if node.finalModList then
+			for _, mod in ipairs(node.finalModList:Tabulate("LIST", nil, "ExtraJewelFunc")) do
+				env.extraJewelFuncs:AddMod(mod.mod)
+			end
 		end
 	end
 


### PR DESCRIPTION
Looks like node.finalModList is not initalized when hovering trees, this simply null checks it.

Closes #6405

### Description of the problem being solved:

When hovering trees in PoB you get error about finalModList being null.

### Steps taken to verify a working solution:
- Open PoB with multiple trees
- Hover different tree
- Observe crash

### Link to a build that showcases this PR:

https://pobb.in/u/thedeathbeam/pf-poison-scourge-arrow
