### PR TITLE
add devour, volatility and locus mine support

### DIFF
--- a/src/Data/SkillStatMap.lua
+++ b/src/Data/SkillStatMap.lua
@@ -730,13 +730,13 @@ return {
 	mod("Damage", "INC", nil, 0, 0, { type = "Condition", var = "LowLife"})
 },
 ["damage_vs_enemies_on_low_life_+%"] = {
-	mod("Damage", "INC", nil, 0, 0, { type = "ActorCondition", actor = "enemy", var = "LowLife"})
+	mod("Damage", "INC", nil, ModFlag.Hit, 0, { type = "ActorCondition", actor = "enemy", var = "LowLife"})
 },
 ["damage_+%_when_on_full_life"] = {
 	mod("Damage", "INC", nil, 0, 0, { type = "Condition", var = "FullLife"})
 },
 ["damage_+%_vs_enemies_on_full_life"] = {
-	mod("Damage", "INC", nil, 0, 0, {type = "ActorCondition", actor = "enemy", var = "FullLife"})
+	mod("Damage", "INC", nil, 0, bit.bor(KeywordFlag.Hit, KeywordFlag.Ailment), {type = "ActorCondition", actor = "enemy", var = "FullLife"})
 },
 ["hit_damage_+%"] = {
 	mod("Damage", "INC", nil, ModFlag.Hit)
@@ -746,6 +746,10 @@ return {
 },
 ["active_skill_merged_damage_+%_final_while_dual_wielding"] = {
 	mod("Damage", "MORE", nil, 0, 0, { type = "Condition", var = "DualWielding" }),
+},
+-- PvP Damage
+["support_makes_skill_mine_pvp_damage_+%_final"] = {
+	mod("PvpDamageMultiplier", "MORE", nil),
 },
 -- Conversion
 ["physical_damage_%_to_add_as_lightning"] = {

--- a/src/Data/Skills/sup_dex.lua
+++ b/src/Data/Skills/sup_dex.lua
@@ -2609,6 +2609,9 @@ skills["SupportLocusMine"] = {
 	excludeSkillTypes = { SkillType.Rain, SkillType.ProjectilesNotFromUser, SkillType.InbuiltTrigger, SkillType.Triggered, SkillType.HasReservation, SkillType.ReservationBecomesCost, SkillType.NOT, SkillType.AND, SkillType.RemoteMined, SkillType.NOT, SkillType.AND, },
 	ignoreMinionTypes = true,
 	statDescriptionScope = "gem_stat_descriptions",
+	addFlags = {
+		mine = true,
+	},
 	statMap = {
 		["support_locus_mine_damage_+%_final"] = {
 			mod("Damage", "MORE", nil),

--- a/src/Data/Skills/sup_dex.lua
+++ b/src/Data/Skills/sup_dex.lua
@@ -2609,6 +2609,14 @@ skills["SupportLocusMine"] = {
 	excludeSkillTypes = { SkillType.Rain, SkillType.ProjectilesNotFromUser, SkillType.InbuiltTrigger, SkillType.Triggered, SkillType.HasReservation, SkillType.ReservationBecomesCost, SkillType.NOT, SkillType.AND, SkillType.RemoteMined, SkillType.NOT, SkillType.AND, },
 	ignoreMinionTypes = true,
 	statDescriptionScope = "gem_stat_descriptions",
+	statMap = {
+		["support_locus_mine_damage_+%_final"] = {
+			mod("Damage", "MORE", nil),
+		},
+		["number_of_projectiles_+%_final_from_locus_mine_support"] = {
+			mod("ProjectileCount", "MORE", nil),
+		},
+	},
 	qualityStats = {
 		Default = {
 			{ "mine_laying_speed_+%", 0.5 },

--- a/src/Data/Skills/sup_int.lua
+++ b/src/Data/Skills/sup_int.lua
@@ -1879,6 +1879,9 @@ skills["SupportDevour"] = {
 		["killing_blow_consumes_corpse_restore_x_mana"] = {
 			mod("ManaOnKill", "BASE", nil),
 		},
+		["damage_+%_if_you_have_consumed_a_corpse_recently"] = {
+			mod("Damage", "INC", nil, 0, 0, { type = "Condition", var = "ConsumedCorpseRecently" }),
+		},
 	},
 	qualityStats = {
 		Default = {

--- a/src/Data/Skills/sup_int.lua
+++ b/src/Data/Skills/sup_int.lua
@@ -1872,6 +1872,14 @@ skills["SupportDevour"] = {
 	addSkillTypes = { },
 	excludeSkillTypes = { },
 	statDescriptionScope = "gem_stat_descriptions",
+	statMap = {
+		["killing_blow_consumes_corpse_restore_x_life"] = {
+			mod("LifeOnKill", "BASE", nil),
+		},
+		["killing_blow_consumes_corpse_restore_x_mana"] = {
+			mod("ManaOnKill", "BASE", nil),
+		},
+	},
 	qualityStats = {
 		Default = {
 			{ "damage_vs_enemies_on_low_life_+%", 2 },

--- a/src/Data/Skills/sup_str.lua
+++ b/src/Data/Skills/sup_str.lua
@@ -4782,6 +4782,14 @@ skills["SupportVolatility"] = {
 	addSkillTypes = { },
 	excludeSkillTypes = { },
 	statDescriptionScope = "gem_stat_descriptions",
+	statMap = {
+		["minimum_attack_damage_+%_final_from_volatility_support"] = {
+			mod("MinDamage", "MORE", nil),
+		},
+		["maximum_attack_damage_+%_final_from_volatility_support"] = {
+			mod("MaxDamage", "MORE", nil),
+		},
+	},
 	qualityStats = {
 		Default = {
 			{ "damage_+%", 0.5 },

--- a/src/Export/Skills/sup_dex.txt
+++ b/src/Export/Skills/sup_dex.txt
@@ -316,6 +316,9 @@ local skills, mod, flag, skill = ...
 #mods
 
 #skill SupportLocusMine
+	addFlags = {
+		mine = true,
+	},
 	statMap = {
 		["support_locus_mine_damage_+%_final"] = {
 			mod("Damage", "MORE", nil),

--- a/src/Export/Skills/sup_dex.txt
+++ b/src/Export/Skills/sup_dex.txt
@@ -316,6 +316,14 @@ local skills, mod, flag, skill = ...
 #mods
 
 #skill SupportLocusMine
+	statMap = {
+		["support_locus_mine_damage_+%_final"] = {
+			mod("Damage", "MORE", nil),
+		},
+		["number_of_projectiles_+%_final_from_locus_mine_support"] = {
+			mod("ProjectileCount", "MORE", nil),
+		},
+	},
 #mods
 
 #skill SupportChanceToPoison

--- a/src/Export/Skills/sup_int.txt
+++ b/src/Export/Skills/sup_int.txt
@@ -255,6 +255,14 @@ local skills, mod, flag, skill = ...
 #mods
 
 #skill SupportDevour
+	statMap = {
+		["killing_blow_consumes_corpse_restore_x_life"] = {
+			mod("LifeOnKill", "BASE", nil),
+		},
+		["killing_blow_consumes_corpse_restore_x_mana"] = {
+			mod("ManaOnKill", "BASE", nil),
+		},
+	},
 #mods
 
 #skill SupportEfficacy

--- a/src/Export/Skills/sup_int.txt
+++ b/src/Export/Skills/sup_int.txt
@@ -262,6 +262,9 @@ local skills, mod, flag, skill = ...
 		["killing_blow_consumes_corpse_restore_x_mana"] = {
 			mod("ManaOnKill", "BASE", nil),
 		},
+		["damage_+%_if_you_have_consumed_a_corpse_recently"] = {
+			mod("Damage", "INC", nil, 0, 0, { type = "Condition", var = "ConsumedCorpseRecently" }),
+		},
 	},
 #mods
 

--- a/src/Export/Skills/sup_str.txt
+++ b/src/Export/Skills/sup_str.txt
@@ -558,4 +558,12 @@ local skills, mod, flag, skill = ...
 #mods
 
 #skill SupportVolatility
+	statMap = {
+		["minimum_attack_damage_+%_final_from_volatility_support"] = {
+			mod("MinDamage", "MORE", nil),
+		},
+		["maximum_attack_damage_+%_final_from_volatility_support"] = {
+			mod("MaxDamage", "MORE", nil),
+		},
+	},
 #mods


### PR DESCRIPTION
basic functionality of these 3 supports, does not yet support alt quality devour, or minimum projectiles on locus mine, everything else either works or does not work on other supports in PoB anyway (eg throw extra mines)

planning on adding alt quality devour support as well as controlled blaze and fresh meat if I get time