### PR TITLE
Fix Snipe showing DPS values when triggering support skills

### DIFF
--- a/src/Modules/CalcPerform.lua
+++ b/src/Modules/CalcPerform.lua
@@ -3668,13 +3668,14 @@ function calcs.perform(env, avoidCache, fullDPSSkipEHP)
 		if env.player.mainSkill.activeEffect.grantedEffect.name == "Snipe" then
 			if triggerSkillCount > 0 then
 				env.player.mainSkill.skillData.baseMultiplier = 0
-				env.player.mainSkill.infoMessage = "Triggering Support Skills:"
+				env.player.mainSkill.skillData.damageEffectiveness = 0
+				env.player.mainSkill.infoMessage = "Triggering Support Skills"
 			end
 			env.player.mainSkill.skillData.hitTimeMultiplier = snipeStages
 		elseif not source or (snipeStages + 0.5) < triggerSkillPosition then
 			env.player.mainSkill.skillData.triggeredBySnipe = nil
 			env.player.mainSkill.infoMessage = s_format("Not enough Snipe stages to Trigger Skill")
-			env.player.mainSkill.infoMessage2 = "DPS reported assuming Self-Cast"..triggerSkillCount
+			env.player.mainSkill.infoMessage2 = "DPS reported assuming Self-Cast"
 			env.player.mainSkill.infoTrigger = ""
 		else
 			env.player.mainSkill.skillData.triggered = true


### PR DESCRIPTION
Added damage was still contributing to the damage of the skill so it was showing DPS numbers even if the skill was actually dealing no damage
Also removes the debug tooltip I forgot to remove from testing
