### PR TITLE
Add support for Guardian's Blessing no reservation for auras

### DIFF
--- a/src/Data/Skills/sup_str.lua
+++ b/src/Data/Skills/sup_str.lua
@@ -2536,6 +2536,16 @@ skills["SupportGuardiansBlessing"] = {
 	addSkillTypes = { SkillType.Blessing, },
 	excludeSkillTypes = { SkillType.SummonsTotem, SkillType.InbuiltTrigger, SkillType.AuraNotOnCaster, SkillType.ZeroReservation, SkillType.Triggered, },
 	statDescriptionScope = "gem_stat_descriptions",
+	statMap = {
+		["aura_skill_no_reservation"] = {
+		},
+	},
+	baseMods = {
+		skill("manaReservationFlat", 0, { type = "SkillType", skillType = SkillType.Aura }),
+		skill("lifeReservationFlat", 0, { type = "SkillType", skillType = SkillType.Aura }),
+		skill("manaReservationPercent", 0, { type = "SkillType", skillType = SkillType.Aura }),
+		skill("lifeReservationPercent", 0, { type = "SkillType", skillType = SkillType.Aura }),
+	},
 	qualityStats = {
 		Default = {
 			{ "aura_effect_+%", 0.25 },

--- a/src/Export/Skills/sup_str.txt
+++ b/src/Export/Skills/sup_str.txt
@@ -286,6 +286,14 @@ local skills, mod, flag, skill = ...
 #mods
 
 #skill SupportGuardiansBlessing
+	statMap = {
+		["aura_skill_no_reservation"] = {
+		},
+	},
+#baseMod skill("manaReservationFlat", 0, { type = "SkillType", skillType = SkillType.Aura })
+#baseMod skill("lifeReservationFlat", 0, { type = "SkillType", skillType = SkillType.Aura })
+#baseMod skill("manaReservationPercent", 0, { type = "SkillType", skillType = SkillType.Aura })
+#baseMod skill("lifeReservationPercent", 0, { type = "SkillType", skillType = SkillType.Aura })
 #mods
 
 #skill SupportGuardiansBlessingMinion


### PR DESCRIPTION
### Description of the problem being solved:

Currently Guardian's Blessing do not makes supported aura not reserve mana in PoB. This implementation mimics Eternal Blessing but with aura limitation

### Steps taken to verify a working solution:
- Enable Guardian's Blessing and link it to aura 
- See that aura no longer reserves mana and costs nothing

### Link to a build that showcases this PR:
https://pobb.in/qNFYY0DNywHf
