### PR TITLE
Add initial support for Guardian Minions

### DIFF
--- a/src/Data/Minions.lua
+++ b/src/Data/Minions.lua
@@ -823,3 +823,90 @@ minions["SummonedArbalists"] = {
 		-- MonsterCannotBeDamaged [cannot_be_damaged = 1]
 	},
 }
+
+minions["GuardianSentinel"] = {
+	name = "Sentinel of Radiance",
+	life = 12,
+	armour = 0.5,
+	fireResist = 40,
+	coldResist = 40,
+	lightningResist = 40,
+	chaosResist = 20,
+	damage = 20,
+	damageSpread = 0.2,
+	attackTime = 0.83,
+	attackRange = 17,
+	accuracy = 3.4,
+	skillList = {
+		"TeleportVaalDomination",
+		"VaalDominationMelee",
+	},
+	modList = {
+	},
+}
+
+minions["GuardianRelicFire"] = {
+	name = "Fire Relic",
+	life = 4,
+	energyShield = 0.6,
+	fireResist = 40,
+	coldResist = 40,
+	lightningResist = 40,
+	chaosResist = 20,
+	damage = 1,
+	damageSpread = 0,
+	attackTime = 1,
+	attackRange = 6,
+	accuracy = 1,
+	skillList = {
+		"RelicTeleport",
+		"Anger",
+	},
+	modList = {
+		-- EmergeSpeedHigh [emerge_speed_+% = 0]
+	},
+}
+
+minions["GuardianRelicCold"] = {
+	name = "Cold Relic",
+	life = 4,
+	energyShield = 0.6,
+	fireResist = 40,
+	coldResist = 40,
+	lightningResist = 40,
+	chaosResist = 20,
+	damage = 1,
+	damageSpread = 0,
+	attackTime = 1,
+	attackRange = 6,
+	accuracy = 1,
+	skillList = {
+		"RelicTeleport",
+		"Hatred",
+	},
+	modList = {
+		-- EmergeSpeedHigh [emerge_speed_+% = 0]
+	},
+}
+
+minions["GuardianRelicLightning"] = {
+	name = "Lightning Relic",
+	life = 4,
+	energyShield = 0.6,
+	fireResist = 40,
+	coldResist = 40,
+	lightningResist = 40,
+	chaosResist = 20,
+	damage = 1,
+	damageSpread = 0,
+	attackTime = 1,
+	attackRange = 6,
+	accuracy = 1,
+	skillList = {
+		"RelicTeleport",
+		"Wrath",
+	},
+	modList = {
+		-- EmergeSpeedHigh [emerge_speed_+% = 0]
+	},
+}

--- a/src/Data/Skills/other.lua
+++ b/src/Data/Skills/other.lua
@@ -2628,6 +2628,39 @@ skills["SupportCursePillarTriggerCurses"] = {
 		[20] = { levelRequirement = 70, },
 	},
 }
+skills["SummonGuardianRelic"] = {
+	name = "Summon Elemental Relic",
+	hidden = true,
+	color = 4,
+	description = "Summons a Relic of a random element that stays near you. Depending on the element chosen, the relic minion will have an Anger, Hatred, or Wrath aura. These relics explode when they die, dealing elemental damage to enemies around them. If you already have a relic of the chosen element, its duration will be refreshed instead of summoning a new one.",
+	skillTypes = { [SkillType.Spell] = true, [SkillType.RandomElement] = true, [SkillType.CreatesMinion] = true, [SkillType.Minion] = true, [SkillType.MinionsCanExplode] = true, [SkillType.Duration] = true, [SkillType.Cooldown] = true, [SkillType.Triggerable] = true, [SkillType.Triggered] = true, [SkillType.InbuiltTrigger] = true, },
+	minionSkillTypes = { [SkillType.Damage] = true, [SkillType.Area] = true, [SkillType.Fire] = true, [SkillType.Cold] = true, [SkillType.Lightning] = true, [SkillType.Aura] = true, },
+	statDescriptionScope = "minion_spell_skill_stat_descriptions",
+	castTime = 1,
+	fromTree = true,
+	minionList = {
+		"GuardianRelicFire",
+		"GuardianRelicCold",
+		"GuardianRelicLightning",
+	},
+	baseFlags = {
+		spell = true,
+		minion = true,
+		duration = true,
+	},
+	constantStats = {
+		{ "display_minion_monster_type", 24 },
+		{ "guardian_relic_explode_on_death_for_%_life_as_element_damage", 100 },
+		{ "minion_actor_level_is_user_level_up_to_maximum", 85 },
+		{ "skill_triggered_by_nearby_allies_kill_or_hit_rare_unique_%_chance", 25 },
+	},
+	stats = {
+		"base_skill_effect_duration",
+	},
+	levels = {
+		[20] = { 5000, storedUses = 1, levelRequirement = 85, cooldown = 0.3, statInterpolation = { 1, }, },
+	},
+}
 skills["SummonHarbingerOfTheArcaneUber"] = {
 	name = "Summon Greater Harbinger of the Arcane",
 	hidden = true,
@@ -2958,6 +2991,39 @@ skills["TriggeredSummonGhostOnKill"] = {
 	},
 	levels = {
 		[20] = { manaMultiplier = 20, levelRequirement = 70, },
+	},
+}
+skills["SummonRadiantSentinel"] = {
+	name = "Summon Sentinel of Radiance",
+	hidden = true,
+	color = 4,
+	baseEffectiveness = 2.0517001152039,
+	incrementalEffectiveness = 0.043200001120567,
+	description = "Summons a Sentinel of Radiance which follows you and attacks enemies in melee, while burning enemies around it and taking a portion of damage from hits for you. You can only have one Sentinel of Radiance.",
+	skillTypes = { [SkillType.Spell] = true, [SkillType.Minion] = true, [SkillType.MinionsCanExplode] = true, [SkillType.CreatesMinion] = true, [SkillType.Multicastable] = true, [SkillType.Cascadable] = true, [SkillType.Triggerable] = true, [SkillType.Totemable] = true, [SkillType.Trappable] = true, [SkillType.Mineable] = true, [SkillType.CanRapidFire] = true, },
+	minionSkillTypes = { [SkillType.DamageOverTime] = true, [SkillType.Attack] = true, [SkillType.Melee] = true, [SkillType.MeleeSingleTarget] = true, },
+	statDescriptionScope = "single_minion_spell_skill_stat_descriptions",
+	castTime = 0.75,
+	fromTree = true,
+	minionList = {
+		"GuardianSentinel",
+	},
+	baseFlags = {
+		spell = true,
+		minion = true,
+		duration = true,
+	},
+	constantStats = {
+		{ "display_minion_monster_type", 23 },
+		{ "base_skill_effect_duration", 20000 },
+		{ "minion_actor_level_is_user_level_up_to_maximum", 85 },
+	},
+	stats = {
+		"radiant_sentinel_minion_burning_effect_radius",
+		"radiant_sentinel_minion_fire_%_of_life_to_deal_nearby_per_minute",
+	},
+	levels = {
+		[20] = { 45, 1800, damageEffectiveness = 2, critChance = 6, levelRequirement = 85, statInterpolation = { 1, 1, }, cost = { Mana = 40, }, },
 	},
 }
 skills["SummonRigwaldsPack"] = {

--- a/src/Export/Classes/GGPKData.lua
+++ b/src/Export/Classes/GGPKData.lua
@@ -211,6 +211,7 @@ function GGPKClass:GetNeededFiles()
 		"Data/passiveskilloverridetypes.dat",
 		"Data/passiveskilltattoos.dat",
 		"Data/passiveskilltattootargetsets.dat",
+		"Data/displayminionmonstertype.dat",
 	}
 	local txtFiles = {
 		"Metadata/StatDescriptions/passive_skill_aura_stat_descriptions.txt",

--- a/src/Export/Minions/Minions.txt
+++ b/src/Export/Minions/Minions.txt
@@ -136,3 +136,15 @@ local minions, mod = ...
 #monster Metadata/Monsters/LeagueExpedition/Arbalest/SummonedArbalest SummonedArbalists
 #limit ActiveArbalistLimit
 #emit
+
+#monster Metadata/Monsters/Axis/AxisEliteSoldierRadiance GuardianSentinel
+#emit
+
+#monster Metadata/Monsters/AnimatedItem/ElementalLivingRelicFire GuardianRelicFire
+#emit
+
+#monster Metadata/Monsters/AnimatedItem/ElementalLivingRelicCold GuardianRelicCold
+#emit
+
+#monster Metadata/Monsters/AnimatedItem/ElementalLivingRelicLightning GuardianRelicLightning
+#emit

--- a/src/Export/Skills/other.txt
+++ b/src/Export/Skills/other.txt
@@ -727,6 +727,16 @@ local skills, mod, flag, skill = ...
 #baseMod skill("manaReservationPercent", 0)
 #mods
 
+#skill SummonGuardianRelic
+#flags spell minion duration
+	fromTree = true,
+	minionList = {
+		"GuardianRelicFire",
+		"GuardianRelicCold",
+		"GuardianRelicLightning",
+	},
+#mods
+
 #skill SummonHarbingerOfTheArcaneUber
 #flags spell minion
 	fromItem = true,
@@ -801,6 +811,14 @@ local skills, mod, flag, skill = ...
 		["base_number_of_support_ghosts_allowed"] = {
 			mod("ActivePhantasmLimit", "BASE", nil),
 		},
+	},
+#mods
+
+#skill SummonRadiantSentinel
+#flags spell minion duration
+	fromTree = true,
+	minionList = {
+		"GuardianSentinel",
 	},
 #mods
 

--- a/src/Export/spec.lua
+++ b/src/Export/spec.lua
@@ -10497,6 +10497,22 @@ return {
 	},
 	ZanaQuests={
 	},
+	displayminionmonstertype={
+		[1]={
+			list=false,
+			name="Id",
+			refTo="",
+			type="Int",
+			width=50
+		},
+		[2]={
+			list=false,
+			name="MonsterVarieties",
+			refTo="MonsterVarieties",
+			type="Key",
+			width=400
+		}
+	},
 	passiveoverridelimits={
 		[1]={
 			list=false,

--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -2771,6 +2771,7 @@ local specialModList = {
 	["%d+%% chance to trigger level (%d+) (.+) when you use a socketed skill"] = function(num, _, skill) return triggerExtraSkill(skill, num) end,
 	["%d+%% chance to trigger level (%d+) (.+) when you gain avian's might or avian's flight"] = function(num, _, skill) return triggerExtraSkill(skill, num) end,
 	["%d+%% chance to trigger level (%d+) (.+) on critical strike with this weapon"] = function(num, _, skill) return triggerExtraSkill(skill, num) end,
+	["%d+%% chance to trigger level (%d+) (.+) when you or a nearby ally kill an enemy, or hit a rare or unique enemy"] = function(num, _, skill) return triggerExtraSkill(skill, num) end,
 	["%d+%% chance to [ct][ar][si][tg]g?e?r? level (%d+) (.+) on %a+"] = function(num, _, skill) return triggerExtraSkill(skill, num) end,
 	["attack with level (%d+) (.+) when you kill a bleeding enemy"] = function(num, _, skill) return triggerExtraSkill(skill, num) end,
 	["triggers? level (%d+) (.+) when you kill a bleeding enemy"] = function(num, _, skill) return triggerExtraSkill(skill, num) end,


### PR DESCRIPTION
Adds support for the new Guardian minions to show in the sidebar. The level is manually set to 85 right now as we don't support the `minion_actor_level_is_user_level_up_to_maximum` stat yet
