### PR TITLE
Fix missing source and lack of base mod filtering on resistance conversion

### DIFF
--- a/src/Modules/CalcDefence.lua
+++ b/src/Modules/CalcDefence.lua
@@ -329,7 +329,7 @@ function calcs.defence(env, actor)
 					end
 				end
 				if maxRes ~= 0 then
-					modDB:NewMod(resTo.."ResistMax", "BASE", maxRes * conversionRate)
+					modDB:NewMod(resTo.."ResistMax", "BASE", maxRes * conversionRate, resFrom.." To "..resTo.." Max Resistance Conversion")
 				end
 			end
 		end
@@ -340,8 +340,17 @@ function calcs.defence(env, actor)
 		for _, resTo in ipairs(resistTypeList) do
 			local conversionRate = modDB:Sum("BASE", nil, resFrom.."ResConvertTo"..resTo) / 100
 			if conversionRate ~= 0 then
-				if not res then res = modDB:Sum("BASE", nil, resFrom.."Resist") end
-				modDB:NewMod(resTo.."Resist", "BASE", res * conversionRate)
+				if not res then
+					res = 0
+					for _, mod in ipairs(modDB:Tabulate("BASE", nil, resFrom.."Resist")) do
+						if mod.mod.source ~= "Base" then
+							res = res + mod.value
+						end
+					end
+				end
+				if res ~= 0 then
+					modDB:NewMod(resTo.."Resist", "BASE", res * conversionRate, resFrom.." To "..resTo.." Resistance Conversion")
+				end
 			end
 		end
 	end


### PR DESCRIPTION
Fixes https://www.reddit.com/r/pathofexile/comments/15zn4nx/path_of_building_community_2320_322_tattoos_gems/jxipf1u/

### Description of the problem being solved:
Missing source was causing a lua error when hovering over resistance breakdown in calcs tab. Additionally,  the lack of filtering for base mods on the normal resistance logic block caused the base -60 res mod to be incorrectly taken into account.