### PR TITLE
Fix Volatility from applying multiple times when conversion is present

### DIFF
--- a/src/Modules/CalcOffence.lua
+++ b/src/Modules/CalcOffence.lua
@@ -121,8 +121,10 @@ local function calcDamage(activeSkill, output, cfg, breakdown, damageType, typeF
 	local modNames = damageStatsForTypes[typeFlags]
 	local inc = 1 + skillModList:Sum("INC", cfg, unpack(modNames)) / 100
 	local more = skillModList:More(cfg, unpack(modNames))
-	local moreMinDamage = skillModList:More(cfg, "MinDamage", "Min"..damageType.."Damage")
-	local moreMaxDamage = skillModList:More(cfg, "MaxDamage", "Max"..damageType.."Damage")
+	local genericMoreMinDamage = skillModList:More(cfg, "MinDamage")
+	local genericMoreMaxDamage = skillModList:More(cfg, "MaxDamage")
+	local moreMinDamage = skillModList:More(cfg, "Min"..damageType.."Damage")
+	local moreMaxDamage = skillModList:More(cfg, "Max"..damageType.."Damage")
 
 	if breakdown then
 		t_insert(breakdown.damageTypes, {
@@ -136,8 +138,8 @@ local function calcDamage(activeSkill, output, cfg, breakdown, damageType, typeF
 		})
 	end
 
-	return 	round(((baseMin * inc * more) + addMin) * moreMinDamage),
-			round(((baseMax * inc * more) + addMax) * moreMaxDamage)
+	return 	round(((baseMin * inc * more) * genericMoreMinDamage + addMin) * moreMinDamage),
+			round(((baseMax * inc * more) * genericMoreMaxDamage + addMax) * moreMaxDamage)
 end
 
 local function calcAilmentSourceDamage(activeSkill, output, cfg, breakdown, damageType, typeFlags)


### PR DESCRIPTION
Fixes #6457

prevent generic more min/max from applying multiple times, while maintaining ryslatha and future type-generic functionality