### PR TITLE
Fix supported by edge case

### DIFF
--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -1780,7 +1780,7 @@ local function triggerExtraSkill(name, level, noSupports, sourceSkill, triggerCh
 	end
 end
 local function extraSupport(name, level, slot)
-	local skillId = gemIdLookup[name] or gemIdLookup[name:gsub("^increased ","")]
+	local skillId = gemIdLookup[name] or gemIdLookup[name:gsub("^increased ","")] or gemIdLookup[name:gsub(" support$","")]
 	
 	if itemSlotName == "main hand" then
 		slot = "Weapon 1"


### PR DESCRIPTION
Fixes #6484

### Description of the problem being solved:
The `Supported` at the end of `Socketed Gems are Supported by Level 20 Elemental Army Support` was breaking parsing of the mod.