### PR TITLE
Fix flamewood crash and Ancestral Bond interaction

### DIFF
--- a/src/Data/Skills/sup_str.lua
+++ b/src/Data/Skills/sup_str.lua
@@ -2301,7 +2301,7 @@ skills["AvengingFlame"] = {
 	name = "Avenging Flame",
 	color = 1,
 	description = "Launches a fiery projectile high into the air, to drop on a target and deal area damage where it lands.",
-	skillTypes = { [SkillType.Spell] = true, [SkillType.Damage] = true, [SkillType.Area] = true, [SkillType.AreaSpell] = true, [SkillType.Fire] = true, [SkillType.ProjectileNumber] = true, [SkillType.ProjectileSpeed] = true, [SkillType.Triggerable] = true, [SkillType.SkillGrantedBySupport] = true, [SkillType.Triggered] = true, [SkillType.InbuiltTrigger] = true, },
+	skillTypes = { [SkillType.Spell] = true, [SkillType.Damage] = true, [SkillType.Area] = true, [SkillType.AreaSpell] = true, [SkillType.Fire] = true, [SkillType.ProjectileNumber] = true, [SkillType.ProjectileSpeed] = true, [SkillType.Triggerable] = true, [SkillType.SkillGrantedBySupport] = true, [SkillType.Triggered] = true, [SkillType.InbuiltTrigger] = true, [SkillType.SummonsTotem] = true, },
 	statDescriptionScope = "debuff_skill_stat_descriptions",
 	castTime = 1,
 	preDamageFunc = function(activeSkill, output)

--- a/src/Export/Skills/sup_str.txt
+++ b/src/Export/Skills/sup_str.txt
@@ -296,6 +296,7 @@ local skills, mod, flag, skill = ...
 	},
 #mods
 
+#addSkillTypes SummonsTotem
 #skill AvengingFlame
 	preDamageFunc = function(activeSkill, output)
 		local uuid = activeSkill.skillData.triggerSourceUUID

--- a/src/Modules/CalcTriggers.lua
+++ b/src/Modules/CalcTriggers.lua
@@ -1199,7 +1199,7 @@ local function defaultTriggerHandler(env, config)
 				end
 			end
 			
-			if trigRate ~= nil and not actor.mainSkill.skillFlags.globalTrigger then
+			if trigRate ~= nil and not actor.mainSkill.skillFlags.globalTrigger and not actor.mainSkill.skillTypes[SkillType.InbuiltTrigger] then
 				output.EffectiveSourceRate = trigRate
 			else
 				output.EffectiveSourceRate = output.TriggerRateCap
@@ -1720,7 +1720,6 @@ local configTable = {
 		end
 	end,
 	["Avenging Flame"]  = function(env)
-		env.player.mainSkill.skillFlags.globalTrigger = true
 		return {triggerSkillCond = function(env, skill) return skill.skillFlags.totem and slotMatch(env, skill) end,
 				comparer = function(uuid, source, currentTotemLife)
 					local totemLife = GlobalCache.cachedData["CACHE"][uuid].Env.player.output.TotemLife


### PR DESCRIPTION
Fixes #6498

### Description of the problem being solved:
Fixes infinite recursion crash when selecting another gem to add to a group with a totem supported Flame wood. Fixes Ancestral Bond disabling Avenging Flame.