### PR TITLE
Fixed an error when searching trade for jewels (Issue #6501)

### DIFF
--- a/src/Modules/CalcSetup.lua
+++ b/src/Modules/CalcSetup.lua
@@ -668,7 +668,7 @@ function calcs.initEnv(build, mode, override, specEnv)
 					end
 					if item and (item.jewelRadiusIndex or #env.extraJewelFuncs > 0) then
 						-- Jewel has a radius, add it to the list
-						local funcList = item.jewelData.funcList or { { type = "Self", func = function(node, out, data)
+						local funcList = (item.jewelData and item.jewelData.funcList) or { { type = "Self", func = function(node, out, data)
 							-- Default function just tallies all stats in radius
 							if node then
 								for _, stat in pairs({"Str","Dex","Int"}) do


### PR DESCRIPTION
Fixes #6501 .

### Description of the problem being solved:

Error when trying to search for jewels while having Ngamahu, Flame's Advance allocated.

### Steps taken to verify a working solution:
- Verified that searching for jewels works in that case
- Verified that comparison of stats works in this case
-

### Link to a build that showcases this PR:
https://pobb.in/ZDkv-dD8zI83

### Before screenshot:
![image](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/107569881/c34ec813-0987-4d60-9153-b7641faa888b)

### After screenshot:
![image](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/107569881/f98218ec-92fb-450f-97a0-306eae1f2b99)

