### PR TITLE
Fix Flamewood support not scaling with spell and projectile damage

### DIFF
--- a/src/Data/Skills/sup_str.lua
+++ b/src/Data/Skills/sup_str.lua
@@ -2327,6 +2327,8 @@ skills["AvengingFlame"] = {
 	baseFlags = {
 		area = true,
 		totem = true,
+		spell = true,
+		projectile = true,
 	},
 	qualityStats = {
 		Default = {

--- a/src/Export/Skills/sup_str.txt
+++ b/src/Export/Skills/sup_str.txt
@@ -318,7 +318,7 @@ local skills, mod, flag, skill = ...
 			-- Display only
 		}
 	},
-#flags area totem
+#flags area totem spell projectile
 #mods
 
 #skill SupportFortify


### PR DESCRIPTION
Tested in game to make sure, and the skill definitely scales with those 2 stats
