### PR TITLE
Fix mirage archer and manaforged interaction

### DIFF
--- a/src/Data/Skills/act_dex.lua
+++ b/src/Data/Skills/act_dex.lua
@@ -3278,6 +3278,7 @@ skills["VaalDoubleStrike"] = {
 		melee = true,
 		duration = true,
 		vaal = true,
+		mirage = true,
 	},
 	qualityStats = {
 		Default = {
@@ -5747,6 +5748,7 @@ skills["VaalIceShot"] = {
 		projectile = true,
 		area = true,
 		duration = true,
+		mirage = true,
 	},
 	qualityStats = {
 		Default = {

--- a/src/Data/Skills/act_str.lua
+++ b/src/Data/Skills/act_str.lua
@@ -3450,6 +3450,7 @@ skills["FrozenLegion"] = {
 	},
 	baseFlags = {
 		spell = true,
+		mirage = true,
 	},
 	qualityStats = {
 		Default = {
@@ -3674,6 +3675,7 @@ skills["GeneralsCry"] = {
 		warcry = true,
 		area = true,
 		duration = true,
+		mirage = true,
 	},
 	baseMods = {
 		skill("radius", 60),

--- a/src/Data/Skills/other.lua
+++ b/src/Data/Skills/other.lua
@@ -2089,6 +2089,7 @@ skills["UniqueMirageWarriors"] = {
 		spell = true,
 		duration = true,
 		minion = true,
+		mirage = true,
 	},
 	constantStats = {
 		{ "base_skill_effect_duration", 10000 },
@@ -3178,6 +3179,7 @@ skills["SummonMirageChieftain"] = {
 	baseFlags = {
 		spell = true,
 		duration = true,
+		mirage = true,
 	},
 	constantStats = {
 		{ "trigger_on_slam_or_strike_%_chance", 100 },

--- a/src/Data/Skills/sup_dex.lua
+++ b/src/Data/Skills/sup_dex.lua
@@ -2927,6 +2927,9 @@ skills["SupportGemMirageArcher"] = {
 	excludeSkillTypes = { SkillType.Vaal, SkillType.SummonsTotem, SkillType.Trapped, SkillType.RemoteMined, SkillType.Minion, },
 	ignoreMinionTypes = true,
 	statDescriptionScope = "gem_stat_descriptions",
+	addFlags = {
+		mirage = true,
+	},
 	isTrigger = true,
 	statMap = {
 		["support_mirage_archer_base_duration"] = {

--- a/src/Export/Skills/act_dex.txt
+++ b/src/Export/Skills/act_dex.txt
@@ -608,7 +608,7 @@ local skills, mod, flag, skill = ...
 #mods
 
 #skill VaalDoubleStrike
-#flags attack melee duration vaal
+#flags attack melee duration vaal mirage
 #mods
 
 #skill DualStrike
@@ -1247,7 +1247,7 @@ local skills, mod, flag, skill = ...
 #mods
 
 #skill VaalIceShot
-#flags attack projectile area duration
+#flags attack projectile area duration mirage
 #mods
 
 #skill IceTrap

--- a/src/Export/Skills/act_str.txt
+++ b/src/Export/Skills/act_str.txt
@@ -624,7 +624,7 @@ local skills, mod, flag, skill = ...
 #mods
 
 #skill FrozenSweep
-#flags attack area melee
+#flags attack area melee mirage
 	parts = {
 		{
 			name = "1 charge",
@@ -689,7 +689,7 @@ local skills, mod, flag, skill = ...
 #mods
 
 #skill GeneralsCry
-#flags warcry area duration
+#flags warcry area duration mirage
 	statMap = {
 		["spiritual_cry_doubles_summoned_per_5_MP"] = {
 		},

--- a/src/Export/Skills/other.txt
+++ b/src/Export/Skills/other.txt
@@ -583,7 +583,7 @@ local skills, mod, flag, skill = ...
 #mods
 
 #skill UniqueMirageWarriors
-#flags spell duration minion
+#flags spell duration minion mirage
 	fromItem = true,
 	statMap = {
 		["skill_used_by_mirage_warrior_damage_+%_final"] = {
@@ -864,7 +864,7 @@ local skills, mod, flag, skill = ...
 #mods
 
 #skill SummonMirageChieftain
-#flags spell duration
+#flags spell duration mirage
 	fromTree = true,
 	statMap = {
 		["skill_used_by_mirage_chieftain_damage_+%_final"] = {

--- a/src/Export/Skills/sup_dex.txt
+++ b/src/Export/Skills/sup_dex.txt
@@ -352,6 +352,9 @@ local skills, mod, flag, skill = ...
 #mods
 
 #skill SupportGemMirageArcher
+	addFlags = {
+		mirage = true,
+	},
 	isTrigger = true,
 	statMap = {
 		["support_mirage_archer_base_duration"] = {

--- a/src/Modules/Build.lua
+++ b/src/Modules/Build.lua
@@ -1451,6 +1451,13 @@ function buildMode:AddDisplayStatList(statList, actor)
 			InsertIfNew(self.controls.warnings.lines, line)
 		end
 	end
+	if actor.mainSkill.ineffectiveTriggers and #actor.mainSkill.ineffectiveTriggers > 0 then
+		local line = "Potentially ineffective triggers:"
+		for _, skill in ipairs(actor.mainSkill.ineffectiveTriggers or {}) do
+			line = line .. " " .. skill.grantedEffect.name
+		end
+		InsertIfNew(self.controls.warnings.lines, line)
+	end
 end
 
 function buildMode:InsertItemWarnings()

--- a/src/Modules/CalcActiveSkill.lua
+++ b/src/Modules/CalcActiveSkill.lua
@@ -458,7 +458,7 @@ function calcs.buildActiveSkillModList(env, activeSkill)
 			local match = skillEffect.grantedEffect.addSkillTypes and (not skillFlags.disable)
 			if match and skillEffect.grantedEffect.isTrigger then
 				if activeSkill.triggeredBy then
-					if skillEffect.grantedEffect.addFlags.mirage then
+					if skillEffect.grantedEffect.addFlags and skillEffect.grantedEffect.addFlags.mirage then
 						activeSkill.ineffectiveTriggers = activeSkill.ineffectiveTriggers or {}
 						t_insert(activeSkill.ineffectiveTriggers, skillEffect)
 					else

--- a/src/Modules/CalcActiveSkill.lua
+++ b/src/Modules/CalcActiveSkill.lua
@@ -458,8 +458,13 @@ function calcs.buildActiveSkillModList(env, activeSkill)
 			local match = skillEffect.grantedEffect.addSkillTypes and (not skillFlags.disable)
 			if match and skillEffect.grantedEffect.isTrigger then
 				if activeSkill.triggeredBy then
-					skillFlags.disable = true
-					activeSkill.disableReason = "This skill is supported by more than one trigger"
+					if skillEffect.grantedEffect.addFlags.mirage then
+						activeSkill.ineffectiveTriggers = activeSkill.ineffectiveTriggers or {}
+						t_insert(activeSkill.ineffectiveTriggers, skillEffect)
+					else
+						skillFlags.disable = true
+						activeSkill.disableReason = "This skill is supported by more than one trigger"
+					end
 				else
 					activeSkill.triggeredBy = skillEffect
 				end


### PR DESCRIPTION
Fixes #6493

### Description of the problem being solved:
Mirage archer can be triggered by a skill triggered by mana forged but will not attack. Current the skill is disabled as it finds more than one trigger.