### PR TITLE
Fix some mod ranges being inverted

### DIFF
--- a/src/Classes/ItemsTab.lua
+++ b/src/Classes/ItemsTab.lua
@@ -633,8 +633,8 @@ holding Shift will put it in the second.]])
 
 				local minA, maxA = getMinMax(modA)
 				local minB, maxB = getMinMax(modB)
-				
-				if (minA and minB and maxA and maxB) then
+				local allInts = minA == m_floor(minA) and maxA == m_floor(maxA) and minB == m_floor(minB) and maxB == m_floor(maxB) -- if the mod goes in steps that aren't 1, then the code below this doesn't work
+				if (minA and minB and maxA and maxB and allInts) then
 					if (minA < minB) then -- ascending
 						return minA + 1 == maxB
 					else -- descending


### PR DESCRIPTION
Fixes #6548 

### Description of the problem being solved:
#6056 introduced an error in cases where mods that scaled in a positive direction were inverted incorrectly, such as the shaper body armour mod for crit chance to spells. It used the value 1 to check for discontinuity between tiers, which works for almost all mods, but for mods with a step of less than 1 it caused issues.

Specifically, it inverted the ranges even for positive mods when the difference between minimum and maximum of different tiers was exactly 1, which for the mods in question applied since the first mod starts at 0.5 and the second ends at 1.5.

Optimally we'd somehow fetch the step value, but I don't have the time or energy to delve into the stat descriptions right now. Looks like divide_by_one_hundred is how we'd find the step value though.

This adds a check to only invert the ranges if the values are integers.

One thing that the original PR never fixed was the tooltip for the slider itself. That's not fixed in this either, that's still incorrect on the flasks. The body armour mods work great though!

### Steps taken to verify a working solution:
- Checked body armour with a shaper crit mod
- Checked flask with a less duration mod

### Link to a build that showcases this PR:
https://pobb.in/OliPnl0lAKej
