### PR TITLE
Only add abyssal socket if the item is an energy blade

### DIFF
--- a/src/Classes/ImportTab.lua
+++ b/src/Classes/ImportTab.lua
@@ -852,7 +852,7 @@ function ImportTabClass:ImportItem(itemData, slotName)
 			end
 			item.sockets[i] = { group = socket.group, color = socket.sColour }
 		end
-		if item.abyssalSocketCount and item.abyssalSocketCount > 0 then
+		if item.abyssalSocketCount and item.abyssalSocketCount > 0 and item.name:match("Energy Blade") then
 			t_insert(itemData.explicitMods, "Has " .. item.abyssalSocketCount .. " Abyssal Sockets")
 		end
 	end


### PR DESCRIPTION
Fixes a bug that was introduced in #6446 where it would duplicate the abyssal socket explicit modifiers on imported items that weren't energy blades. Specifically, Stygian Vise in general and Darkness Enthroned were affected by this.

### Description of the problem being solved:
Checked with Wires, the insert of the mod was only intended for energy blades, so adding a conditional for that.

### Steps taken to verify a working solution:
- Checked imports with both Stygian Vises and Energy Blades with abyssal sockets, both work as expected

### Link to a build that showcases this PR:
Import Strong_and_intelligent from Xeverous (Ancestor League), or BeethovensRagingSpirit from Lordofdiamonds (EOE Moana league)