### PR TITLE
Exclude jewels from all slot equipment checks

### DIFF
--- a/src/Classes/ModStore.lua
+++ b/src/Classes/ModStore.lua
@@ -566,7 +566,7 @@ function ModStoreClass:EvalMod(mod, cfg)
 			if items and #items > 0 or allSlots then
 				if searchCond then
 					for slot, item in pairs(items) do
-						if slot ~= itemSlot or not tag.excludeSelf then
+						if (not allSlots or allSlots and item.type ~= "Jewel") and slot ~= itemSlot or not tag.excludeSelf then
 							t_insert(matches, item:FindModifierSubstring(searchCond:lower(), itemSlot:lower()))
 						end
 					end


### PR DESCRIPTION
### Description of the problem being solved:
![image](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/5985728/3d3ef2af-ce42-47a6-a4a5-0809f2c16077)
The item states that jewels do not count as equipped for the purposes of the mod in question, so this excludes them from PoB slot checks for item conditions. 

Flasks are also not checked, but already aren't included in the actor itemlist.

### Steps taken to verify a working solution:
- Checked Utulas and life mastery, both work as intended

### Link to a build that showcases this PR:
https://pobb.in/7Z5o3jqxuueW