### PR TITLE
Fix Fresh Meat Support incorrectly granting all minions Adrenaline

### DIFF
--- a/src/Data/Skills/sup_int.lua
+++ b/src/Data/Skills/sup_int.lua
@@ -2545,6 +2545,13 @@ skills["SupportFreshMeat"] = {
 		["support_recent_minions_additional_critical_strike_multiplier_from_wakened_fury"] = {
 			mod("MinionModifier", "LIST", { mod = mod("CritMultiplier", "BASE", nil) }, 0, 0, { type = "Condition", var = "FreshMeatActive" }),
 		},
+		["support_recent_minions_life_leech_from_any_damage_permyriad_from_wakened_fury"] = {
+			mod("MinionModifier", "LIST", { mod = mod("DamageLifeLeech", "BASE", nil) }, 0, 0, { type = "Condition", var = "FreshMeatActive" }),
+			div = 100,
+		},
+	},
+	baseMods = {
+		mod("MinionModifier", "LIST", { mod = mod("Condition:Adrenaline", "FLAG", true) }, 0, 0, { type = "Condition", var = "FreshMeatActive" }),
 	},
 	qualityStats = {
 		Default = {

--- a/src/Export/Skills/sup_int.txt
+++ b/src/Export/Skills/sup_int.txt
@@ -359,7 +359,12 @@ local skills, mod, flag, skill = ...
 		["support_recent_minions_additional_critical_strike_multiplier_from_wakened_fury"] = {
 			mod("MinionModifier", "LIST", { mod = mod("CritMultiplier", "BASE", nil) }, 0, 0, { type = "Condition", var = "FreshMeatActive" }),
 		},
+		["support_recent_minions_life_leech_from_any_damage_permyriad_from_wakened_fury"] = {
+			mod("MinionModifier", "LIST", { mod = mod("DamageLifeLeech", "BASE", nil) }, 0, 0, { type = "Condition", var = "FreshMeatActive" }),
+			div = 100,
+		},
 	},
+#baseMod mod("MinionModifier", "LIST", { mod = mod("Condition:Adrenaline", "FLAG", true) }, 0, 0, { type = "Condition", var = "FreshMeatActive" })
 #mods
 
 #skill SupportFrigidBond

--- a/src/Modules/ConfigOptions.lua
+++ b/src/Modules/ConfigOptions.lua
@@ -369,7 +369,6 @@ return {
 	end },
 	{ label = "Fresh Meat:", ifSkill = "Fresh Meat" },
 	{ var = "freshMeatBuffs", type = "check", label = "Is Fresh Meat active?", ifSkill = "Fresh Meat", apply = function(val, modList, enemyModList)
-		modList:NewMod("MinionModifier", "LIST", { mod = modLib.createMod("Condition:FreshMeatActive", "FLAG", true, "Fresh Meat", { type = "Condition", var = "Combat" })}, "Config")
 		modList:NewMod("Condition:FreshMeatActive", "FLAG", true, "Config")
 	end },
 	{ label = "Frost Shield:", ifSkill = "Frost Shield" },

--- a/src/Modules/ConfigOptions.lua
+++ b/src/Modules/ConfigOptions.lua
@@ -369,7 +369,7 @@ return {
 	end },
 	{ label = "Fresh Meat:", ifSkill = "Fresh Meat" },
 	{ var = "freshMeatBuffs", type = "check", label = "Is Fresh Meat active?", ifSkill = "Fresh Meat", apply = function(val, modList, enemyModList)
-		modList:NewMod("MinionModifier", "LIST", { mod = modLib.createMod("Condition:Adrenaline", "FLAG", true, "Fresh Meat", { type = "Condition", var = "Combat" })}, "Config")
+		modList:NewMod("MinionModifier", "LIST", { mod = modLib.createMod("Condition:FreshMeatActive", "FLAG", true, "Fresh Meat", { type = "Condition", var = "Combat" })}, "Config")
 		modList:NewMod("Condition:FreshMeatActive", "FLAG", true, "Config")
 	end },
 	{ label = "Frost Shield:", ifSkill = "Frost Shield" },


### PR DESCRIPTION
Guessing it was left over from when Wires copied over the config for Adrenaline
Fixes #6557