### PR TITLE
Fix crash caused by trigger source being disabled.

### DIFF
--- a/src/Modules/CalcTriggers.lua
+++ b/src/Modules/CalcTriggers.lua
@@ -72,7 +72,7 @@ local function findTriggerSkill(env, skill, source, triggerRate, comparer)
 		calcs.buildActiveSkill(env, "CACHE", skill)
 	end
 
-	if GlobalCache.cachedData["CACHE"][uuid] and comparer(uuid, source, triggerRate) then
+	if GlobalCache.cachedData["CACHE"][uuid] and comparer(uuid, source, triggerRate) and (skill.skillFlags and not skill.skillFlags.disable) then
 		return skill, GlobalCache.cachedData["CACHE"][uuid].Speed, uuid
 	end
 	return source, triggerRate, source and cacheSkillUUID(source, env)


### PR DESCRIPTION
Fixes  #6554

### Description of the problem being solved:
Disabled skills were considered valid sources for cwc which causes a crash as `source.skillData.triggerTime` is assumed to exist for valid sources.

Disabled skills will now be completely ignored.