### PR TITLE
Misc FullDPS fixes

### DIFF
--- a/src/Classes/CalcsTab.lua
+++ b/src/Classes/CalcsTab.lua
@@ -568,7 +568,7 @@ function CalcsTabClass:PowerBuilder()
 end
 
 function CalcsTabClass:CalculatePowerStat(selection, original, modified)
-	if modified.Minion then
+	if modified.Minion and not selection.stat == "FullDPS" then
 		original = original.Minion
 		modified = modified.Minion
 	end

--- a/src/Modules/CalcPerform.lua
+++ b/src/Modules/CalcPerform.lua
@@ -871,8 +871,7 @@ end
 -- 8. Processes buffs and debuffs
 -- 9. Processes charges and misc buffs (doActorMisc)
 -- 10. Calculates defence and offence stats (calcs.defence, calcs.offence)
-function calcs.perform(env, avoidCache, fullDPSSkipEHP)
-	local avoidCache = avoidCache or false
+function calcs.perform(env,fullDPSSkipEHP)
 	local modDB = env.modDB
 	local enemyDB = env.enemyDB
 	

--- a/src/Modules/CalcTriggers.lua
+++ b/src/Modules/CalcTriggers.lua
@@ -156,17 +156,12 @@ local function mirageArcherHandler(env)
 		local uuid = cacheSkillUUID(env.player.mainSkill, env)
 		local calcMode = env.mode == "CALCS" and "CALCS" or "MAIN"
 
-		-- cache a new copy of this skill that's affected by Mirage Archer
-		if avoidCache then
-			usedSkill = env.player.mainSkill
-		else
-			if not GlobalCache.cachedData[calcMode][uuid] then
-				calcs.buildActiveSkill(env, calcMode, env.player.mainSkill, {[uuid] = true})
-			end
+		if not GlobalCache.cachedData[calcMode][uuid] then
+			calcs.buildActiveSkill(env, calcMode, env.player.mainSkill, {[uuid] = true})
+		end
 
-			if GlobalCache.cachedData[calcMode][uuid] and not avoidCache then
-				usedSkill = GlobalCache.cachedData[calcMode][uuid].ActiveSkill
-			end
+		if GlobalCache.cachedData[calcMode][uuid] then
+			usedSkill = GlobalCache.cachedData[calcMode][uuid].ActiveSkill
 		end
 
 		if usedSkill then

--- a/src/Modules/Calcs.lua
+++ b/src/Modules/Calcs.lua
@@ -227,7 +227,7 @@ function calcs.calcFullDPS(build, mode, override, specEnv)
 					activeSkill = usedEnv.player.mainSkill
 				else
 					fullEnv.player.mainSkill = activeSkill
-					calcs.perform(fullEnv, true, (GlobalCache.numActiveSkillInFullDPS ~= numActiveSkillInFullDPS))
+					calcs.perform(fullEnv, (GlobalCache.numActiveSkillInFullDPS ~= numActiveSkillInFullDPS))
 					usedEnv = fullEnv
 				end
 				local minionName = nil

--- a/src/Modules/Calcs.lua
+++ b/src/Modules/Calcs.lua
@@ -226,15 +226,9 @@ function calcs.calcFullDPS(build, mode, override, specEnv)
 					usedEnv = cachedData.Env
 					activeSkill = usedEnv.player.mainSkill
 				else
-					local forceCache = false
-					if GlobalCache.noCache then 
-						forceCache = true
-						GlobalCache.noCache = nil
-					end
 					fullEnv.player.mainSkill = activeSkill
 					calcs.perform(fullEnv, true, (GlobalCache.numActiveSkillInFullDPS ~= numActiveSkillInFullDPS))
 					usedEnv = fullEnv
-					GlobalCache.noCache = forceCache
 				end
 				local minionName = nil
 				if activeSkill.minion or usedEnv.minion then
@@ -428,35 +422,6 @@ function calcs.buildOutput(build, mode)
 	calcs.perform(env)
 
 	local output = env.player.output
-	
-	for _, skill in ipairs(env.player.activeSkillList) do
-		local uuid = cacheSkillUUID(skill, env)
-		if not GlobalCache.cachedData["CACHE"][uuid] then
-			calcs.buildActiveSkill(env, "CACHE", skill)
-		end
-		if GlobalCache.cachedData["CACHE"][uuid] then
-			output.EnergyShieldProtectsMana = env.modDB:Flag(nil, "EnergyShieldProtectsMana")
-			for pool, costResource in pairs({["LifeUnreserved"] = "LifeCost", ["ManaUnreserved"] = "ManaCost", ["Rage"] = "RageCost", ["EnergyShield"] = "ESCost"}) do
-				local cachedCost = GlobalCache.cachedData["CACHE"][uuid].Env.player.output[costResource]
-				if cachedCost then
-					local totalPool = (output.EnergyShieldProtectsMana and costResource == "ManaCost" and output["EnergyShield"] or 0) + (output[pool] or 0)
-					if totalPool < cachedCost then
-						output[costResource.."Warning"] = output[costResource.."Warning"] or {}
-						t_insert(output[costResource.."Warning"], skill.activeEffect.grantedEffect.name)
-					end
-				end
-			end
-			for pool, costResource in pairs({["LifeUnreservedPercent"] = "LifePercentCost", ["ManaUnreservedPercent"] = "ManaPercentCost"}) do
-				local cachedCost = GlobalCache.cachedData["CACHE"][uuid].Env.player.output[costResource]
-				if cachedCost then
-					if (output[pool] or 0) < cachedCost then
-						output[costResource.."PercentCostWarning"] = output[costResource.."PercentCostWarning"] or {}
-						t_insert(output[costResource.."PercentCostWarning"], skill.activeEffect.grantedEffect.name)
-					end
-				end
-			end
-		end
-	end
 
 	-- Build output across all skills added to FullDPS skills
 	GlobalCache.noCache = true
@@ -469,6 +434,35 @@ function calcs.buildOutput(build, mode)
 	env.player.output.FullDotDPS = fullDPS.TotalDotDPS
 
 	if mode == "MAIN" then
+		for _, skill in ipairs(env.player.activeSkillList) do
+			local uuid = cacheSkillUUID(skill, env)
+			if not GlobalCache.cachedData["CACHE"][uuid] then
+				calcs.buildActiveSkill(env, "CACHE", skill)
+			end
+			if GlobalCache.cachedData["CACHE"][uuid] then
+				output.EnergyShieldProtectsMana = env.modDB:Flag(nil, "EnergyShieldProtectsMana")
+				for pool, costResource in pairs({["LifeUnreserved"] = "LifeCost", ["ManaUnreserved"] = "ManaCost", ["Rage"] = "RageCost", ["EnergyShield"] = "ESCost"}) do
+					local cachedCost = GlobalCache.cachedData["CACHE"][uuid].Env.player.output[costResource]
+					if cachedCost then
+						local totalPool = (output.EnergyShieldProtectsMana and costResource == "ManaCost" and output["EnergyShield"] or 0) + (output[pool] or 0)
+						if totalPool < cachedCost then
+							output[costResource.."Warning"] = output[costResource.."Warning"] or {}
+							t_insert(output[costResource.."Warning"], skill.activeEffect.grantedEffect.name)
+						end
+					end
+				end
+				for pool, costResource in pairs({["LifeUnreservedPercent"] = "LifePercentCost", ["ManaUnreservedPercent"] = "ManaPercentCost"}) do
+					local cachedCost = GlobalCache.cachedData["CACHE"][uuid].Env.player.output[costResource]
+					if cachedCost then
+						if (output[pool] or 0) < cachedCost then
+							output[costResource.."PercentCostWarning"] = output[costResource.."PercentCostWarning"] or {}
+							t_insert(output[costResource.."PercentCostWarning"], skill.activeEffect.grantedEffect.name)
+						end
+					end
+				end
+			end
+		end
+	
 		output.ExtraPoints = env.modDB:Sum("BASE", nil, "ExtraPoints")
 
 		local specCfg = {


### PR DESCRIPTION
Fixes #6467 and potentially #4666

### Description of the problem being solved:
Cost warnings were always calculated even for CALCS and CACHE modes which slowed down heat map generation considerably.
Heat map when in FullDPS mode was incorrectly looking into minion output for full dps variable to compare causing no changes to show up. #6467
I'm not sure what the `forceCache` code implemented in https://github.com/PathOfBuildingCommunity/PathOfBuilding/commit/8fbfe6e1ca5c78fb6e0e1b2b37f791c5cedb87d9 was supposed to accomplish but it's causing issues by caching only partially computed skills.

### Steps taken to verify a working solution:
- Test vaal skills since they were mentioned in https://github.com/PathOfBuildingCommunity/PathOfBuilding/commit/8fbfe6e1ca5c78fb6e0e1b2b37f791c5cedb87d9
- Test caching vars by testing triggers
- Test builds from #6467 and #4666
- Test warnings
