### PR TITLE
Only check for mods on current variants of unique items

### DIFF
--- a/src/Classes/Item.lua
+++ b/src/Classes/Item.lua
@@ -231,24 +231,36 @@ function ItemClass:FindModifierSubstring(substring, itemSlotName)
 	for _,v in pairs(self.crucibleModLines) do t_insert(modLines, v) end
 
 	for _,v in pairs(modLines) do
-		if v.line:lower():find(substring) and not v.line:lower():find(substring .. " modifier") then
-			local excluded = false
-			if data.itemTagSpecialExclusionPattern[substring] and data.itemTagSpecialExclusionPattern[substring][itemSlotName] then
-				for _, specialMod in ipairs(data.itemTagSpecialExclusionPattern[substring][itemSlotName]) do
-					if v.line:lower():find(specialMod:lower()) then
-						excluded = true
-						break
-					end
+		local currentVariant = false
+		if v.variantList then
+			for variant, enabled in pairs(v.variantList) do
+				if enabled and variant == self.variant then
+					currentVariant = true
 				end
 			end
-			if not excluded then
-				return true
-			end
+		else
+			currentVariant = true
 		end
-		if data.itemTagSpecial[substring] and data.itemTagSpecial[substring][itemSlotName] then
-			for _, specialMod in ipairs(data.itemTagSpecial[substring][itemSlotName]) do
-				if v.line:lower():find(specialMod:lower()) and (not v.variantList or v.variantList[self.variant]) then
+		if currentVariant then
+			if v.line:lower():find(substring) and not v.line:lower():find(substring .. " modifier") then
+				local excluded = false
+				if data.itemTagSpecialExclusionPattern[substring] and data.itemTagSpecialExclusionPattern[substring][itemSlotName] then
+					for _, specialMod in ipairs(data.itemTagSpecialExclusionPattern[substring][itemSlotName]) do
+						if v.line:lower():find(specialMod:lower()) then
+							excluded = true
+							break
+						end
+					end
+				end
+				if not excluded then
 					return true
+				end
+			end
+			if data.itemTagSpecial[substring] and data.itemTagSpecial[substring][itemSlotName] then
+				for _, specialMod in ipairs(data.itemTagSpecial[substring][itemSlotName]) do
+					if v.line:lower():find(specialMod:lower()) and (not v.variantList or v.variantList[self.variant]) then
+						return true
+					end
 				end
 			end
 		end


### PR DESCRIPTION
Fixes #6533

### Description of the problem being solved:
The find modifier code was checking all variants of unique items for mods, notably breaking Utula's chest with Clayshaper due to the old minion life mod.

This adds a check that a mod line is active for the currently selected variant.

### Steps taken to verify a working solution:
- Checked Utula's chest against clayshaper and any unique that has a life mod on current variant
- Checked Utula's chest against an old clayshaper variant

### Link to a build that showcases this PR:
https://pobb.in/3rBt_2a39lPD