### PR TITLE
Sort ModCache when generated

### DIFF
--- a/src/Modules/Common.lua
+++ b/src/Modules/Common.lua
@@ -525,6 +525,22 @@ function tableDeepEquals(t1, t2)
 	return true
 end
 
+-- Based on https://www.lua.org/pil/19.3.html
+function pairsSortByKey(t, f)
+	local sortedKeys = {}
+	for key in pairs(t) do t_insert(sortedKeys, key) end
+	table.sort(sortedKeys, f)
+	local i = 0
+	return function() -- iterator function
+		i = i + 1
+		if sortedKeys[i] == nil then
+			return nil
+		else
+			return sortedKeys[i], t[sortedKeys[i]]
+		end
+	end
+end
+
 -- Natural sort comparator
 function naturalSortCompare(a, b)
 	local aIndex, bIndex = 1, 1

--- a/src/Modules/Main.lua
+++ b/src/Modules/Main.lua
@@ -227,7 +227,7 @@ function main:SaveModCache()
 	-- Update mod cache
 	local out = io.open("Data/ModCache.lua", "w")
 	out:write('local c=...')
-	for line, dat in pairs(modLib.parseModCache) do
+	for line, dat in pairsSortByKey(modLib.parseModCache) do
 		if not dat[1] or not dat[1][1] or (dat[1][1].name ~= "JewelFunc" and dat[1][1].name ~= "ExtraJewelFunc") then
 			out:write('c["', line:gsub("\n","\\n"), '"]={')
 			if dat[1] then


### PR DESCRIPTION
### Description of the problem being solved:

Sorts ModCache when it's generated.  Was working on some startup optimization involving ModCache and it helps to have it sorted to have useful diffs.  Only adds about 25ms to generation time.

Didn't include the new ModCache file itself. You'll have to generate it to see the sorted file.

### Steps taken to verify a working solution:
- Tested generating ModCache
