### PR TITLE
Added max level field to the trade query generator

### DIFF
--- a/src/Classes/TradeQueryGenerator.lua
+++ b/src/Classes/TradeQueryGenerator.lua
@@ -970,7 +970,7 @@ function TradeQueryGeneratorClass:RequestQuery(slot, context, statWeights, callb
 
 	local controls = { }
 	local options = { }
-	local popupHeight = 97
+	local popupHeight = 110
 
 	local isJewelSlot = slot and slot.slotName:find("Jewel") ~= nil
 	local isAbyssalJewelSlot = slot and slot.slotName:find("Abyssal") ~= nil
@@ -987,13 +987,6 @@ function TradeQueryGeneratorClass:RequestQuery(slot, context, statWeights, callb
 	
 	local lastItemAnchor = controls.includeCorrupted
 	local includeScourge = self.queryTab.pbLeagueRealName == "Standard" or self.queryTab.pbLeagueRealName == "Hardcore"
-	
-
-	controls.maxLevel = new("EditControl", {"TOPLEFT",lastItemAnchor,"BOTTOMLEFT"}, 0, 5, 70, 18, nil, nil, "%D", nil, function(buf) end)
-	controls.maxLevelLabel = new("LabelControl", {"RIGHT",controls.maxLevel,"LEFT"}, -5, 0, 0, 16, "^7Max Level:")
-
-	lastItemAnchor = controls.maxLevel
-	popupHeight = popupHeight + 23
 	
 	if context.slotTbl.unique then
 		options.special = { itemName = context.slotTbl.slotName }
@@ -1071,6 +1064,13 @@ function TradeQueryGeneratorClass:RequestQuery(slot, context, statWeights, callb
 	controls.maxPriceType = new("DropDownControl", {"LEFT",controls.maxPrice,"RIGHT"}, 5, 0, 150, 18, currencyDropdownNames, function(index, value) end)
 	controls.maxPriceLabel = new("LabelControl", {"RIGHT",controls.maxPrice,"LEFT"}, -5, 0, 0, 16, "^7Max Price:")
 	lastItemAnchor = controls.maxPrice
+	popupHeight = popupHeight + 23
+
+	
+	controls.maxLevel = new("EditControl", {"TOPLEFT",lastItemAnchor,"BOTTOMLEFT"}, 0, 5, 100, 18, nil, nil, "%D", nil, function(buf) end)
+	controls.maxLevelLabel = new("LabelControl", {"RIGHT",controls.maxLevel,"LEFT"}, -5, 0, 0, 16, "Max Level:")
+
+	lastItemAnchor = controls.maxLevel
 	popupHeight = popupHeight + 23
 	
 	for i, stat in ipairs(statWeights) do

--- a/src/Classes/TradeQueryGenerator.lua
+++ b/src/Classes/TradeQueryGenerator.lua
@@ -924,6 +924,19 @@ function TradeQueryGeneratorClass:FinishQuery()
 		end
 	end
 
+	if options.maxLevel and options.maxLevel > 0 then
+		queryTable.query.filters.req_filters = {
+			disabled = false,
+			filters = {
+				lvl = {
+					max = options.maxLevel
+				}
+			}
+		}
+	end
+
+	
+	
 	if options.maxPrice and options.maxPrice > 0 then
 		queryTable.query.filters.trade_filters = {
 			filters = {
@@ -974,6 +987,13 @@ function TradeQueryGeneratorClass:RequestQuery(slot, context, statWeights, callb
 	
 	local lastItemAnchor = controls.includeCorrupted
 	local includeScourge = self.queryTab.pbLeagueRealName == "Standard" or self.queryTab.pbLeagueRealName == "Hardcore"
+	
+
+	controls.maxLevel = new("EditControl", {"TOPLEFT",lastItemAnchor,"BOTTOMLEFT"}, 0, 5, 70, 18, nil, nil, "%D", nil, function(buf) end)
+	controls.maxLevelLabel = new("LabelControl", {"RIGHT",controls.maxLevel,"LEFT"}, -5, 0, 0, 16, "^7Max Level:")
+
+	lastItemAnchor = controls.maxLevel
+	popupHeight = popupHeight + 23
 	
 	if context.slotTbl.unique then
 		options.special = { itemName = context.slotTbl.slotName }
@@ -1081,6 +1101,9 @@ function TradeQueryGeneratorClass:RequestQuery(slot, context, statWeights, callb
 
 		if controls.includeCorrupted then
 			self.lastIncludeCorrupted, options.includeCorrupted = controls.includeCorrupted.state, controls.includeCorrupted.state
+		end
+		if controls.maxLevel.buf then
+			options.maxLevel = tonumber(controls.maxLevel.buf)
 		end
 		if controls.includeSynthesis then
 			self.lastIncludeSynthesis, options.includeSynthesis = controls.includeSynthesis.state, controls.includeSynthesis.state


### PR DESCRIPTION
Useful when leveling or changing gear while not at a high level (for example, trying to buy rings at level 70 sometimes gets you level 80 atlas bases).

### Description of the problem being solved: 
Getting suggested items that you're not able to equip because of your level. This could also be expanded to stat requirements.

### Steps taken to verify a working solution:
- Added a new EditControl to the query popup, next to the "Max Price" field.
- If the number is set and higher than 0, add the filter to the query.
- It does not set a default number since most people don't have to worry about this, but it's optional for leveling characters.

### Before screenshot:
![image](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/28060941/b8f45667-f145-4750-a7f9-7393ad99ab6f)



### After screenshot:

![image](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/28060941/f7704cd6-07df-4ea5-bb8d-650cca9c1aac)

