### PR TITLE
Limit Node Depth in Heatmap generation

### DIFF
--- a/src/Classes/CalcsTab.lua
+++ b/src/Classes/CalcsTab.lua
@@ -438,7 +438,7 @@ function CalcsTabClass:BuildOutput()
 	self.miscCalculator = { self.calcs.getMiscCalculator(self.build) }
 end
 
--- Controls the coroutine that calculations node power
+-- Controls the coroutine that calculates node power
 function CalcsTabClass:BuildPower(callbackContext)
 	if self.powerBuildFlag then
 		self.powerBuildFlag = false
@@ -478,59 +478,62 @@ function CalcsTabClass:PowerBuilder()
 	if coroutine.running() then
 		coroutine.yield()
 	end
+
 	local start = GetTime()
 	for nodeId, node in pairs(self.build.spec.nodes) do
 		wipeTable(node.power)
-		if not node.alloc and node.modKey ~= "" and not self.mainEnv.grantedPassives[nodeId] then
-			if not cache[node.modKey] then
-				cache[node.modKey] = calcFunc({ addNodes = { [node] = true } }, { requirementsItems = true, requirementsGems = true, skills = true })
-			end
-			local output = cache[node.modKey]
-			if self.powerStat and self.powerStat.stat and not self.powerStat.ignoreForNodes then
-				node.power.singleStat = self:CalculatePowerStat(self.powerStat, output, calcBase)
-				if node.path and not node.ascendancyName then
-					newPowerMax.singleStat = m_max(newPowerMax.singleStat, node.power.singleStat)
-					node.power.pathPower = node.power.singleStat
-					local pathNodes = { }
-					for _, node in pairs(node.path) do
-						pathNodes[node] = true
-					end
-					if node.pathDist > 1 then
-						node.power.pathPower = self:CalculatePowerStat(self.powerStat, calcFunc({ addNodes = pathNodes }, { requirementsItems = true, requirementsGems = true, skills = true }), calcBase)
-					end
+		if self.nodePowerMaxDepth == nil or self.nodePowerMaxDepth == 0 or self.nodePowerMaxDepth >= node.pathDist then
+			if not node.alloc and node.modKey ~= "" and not self.mainEnv.grantedPassives[nodeId] then
+				if not cache[node.modKey] then
+					cache[node.modKey] = calcFunc({ addNodes = { [node] = true } }, { requirementsItems = true, requirementsGems = true, skills = true })
 				end
-			else
-				if calcBase.Minion then
-					node.power.offence = (output.Minion.CombinedDPS - calcBase.Minion.CombinedDPS) / calcBase.Minion.CombinedDPS
+				local output = cache[node.modKey]
+				if self.powerStat and self.powerStat.stat and not self.powerStat.ignoreForNodes then
+					node.power.singleStat = self:CalculatePowerStat(self.powerStat, output, calcBase)
+					if node.path and not node.ascendancyName then
+						newPowerMax.singleStat = m_max(newPowerMax.singleStat, node.power.singleStat)
+						node.power.pathPower = node.power.singleStat
+						local pathNodes = { }
+						for _, node in pairs(node.path) do
+							pathNodes[node] = true
+						end
+						if node.pathDist > 1 then
+							node.power.pathPower = self:CalculatePowerStat(self.powerStat, calcFunc({ addNodes = pathNodes }, { requirementsItems = true, requirementsGems = true, skills = true }), calcBase)
+						end
+					end
 				else
-					node.power.offence = (output.CombinedDPS - calcBase.CombinedDPS) / calcBase.CombinedDPS
-				end
-				node.power.defence = (output.LifeUnreserved - calcBase.LifeUnreserved) / m_max(3000, calcBase.Life) +
-								(output.Armour - calcBase.Armour) / m_max(10000, calcBase.Armour) +
-								((output.EnergyShieldRecoveryCap or output.EnergyShield) - (calcBase.EnergyShieldRecoveryCap or calcBase.EnergyShield)) / m_max(3000, (calcBase.EnergyShieldRecoveryCap or calcBase.EnergyShield)) +
-								(output.Evasion - calcBase.Evasion) / m_max(10000, calcBase.Evasion) +
-								(output.LifeRegenRecovery - calcBase.LifeRegenRecovery) / 500 +
-								(output.EnergyShieldRegenRecovery - calcBase.EnergyShieldRegenRecovery) / 1000
-				if node.path and not node.ascendancyName then
-					newPowerMax.offence = m_max(newPowerMax.offence, node.power.offence)
-					newPowerMax.defence = m_max(newPowerMax.defence, node.power.defence)
-					newPowerMax.offencePerPoint = m_max(newPowerMax.offencePerPoint, node.power.offence / node.pathDist)
-					newPowerMax.defencePerPoint = m_max(newPowerMax.defencePerPoint, node.power.defence / node.pathDist)
-
-				end
-			end
-		elseif node.alloc and node.modKey ~= "" and not self.mainEnv.grantedPassives[nodeId] then
-			local output = calcFunc({ removeNodes = { [node] = true } }, { requirementsItems = true, requirementsGems = true, skills = true })
-			if self.powerStat and self.powerStat.stat and not self.powerStat.ignoreForNodes then
-				node.power.singleStat = self:CalculatePowerStat(self.powerStat, output, calcBase)
-				if node.depends and not node.ascendancyName then
-					node.power.pathPower = node.power.singleStat
-					local pathNodes = { }
-					for _, node in pairs(node.depends) do
-						pathNodes[node] = true
+					if calcBase.Minion then
+						node.power.offence = (output.Minion.CombinedDPS - calcBase.Minion.CombinedDPS) / calcBase.Minion.CombinedDPS
+					else
+						node.power.offence = (output.CombinedDPS - calcBase.CombinedDPS) / calcBase.CombinedDPS
 					end
-					if #node.depends > 1 then
-						node.power.pathPower = self:CalculatePowerStat(self.powerStat, calcFunc({ removeNodes = pathNodes }, { requirementsItems = true, requirementsGems = true, skills = true }), calcBase)
+					node.power.defence = (output.LifeUnreserved - calcBase.LifeUnreserved) / m_max(3000, calcBase.Life) +
+									(output.Armour - calcBase.Armour) / m_max(10000, calcBase.Armour) +
+									((output.EnergyShieldRecoveryCap or output.EnergyShield) - (calcBase.EnergyShieldRecoveryCap or calcBase.EnergyShield)) / m_max(3000, (calcBase.EnergyShieldRecoveryCap or calcBase.EnergyShield)) +
+									(output.Evasion - calcBase.Evasion) / m_max(10000, calcBase.Evasion) +
+									(output.LifeRegenRecovery - calcBase.LifeRegenRecovery) / 500 +
+									(output.EnergyShieldRegenRecovery - calcBase.EnergyShieldRegenRecovery) / 1000
+					if node.path and not node.ascendancyName then
+						newPowerMax.offence = m_max(newPowerMax.offence, node.power.offence)
+						newPowerMax.defence = m_max(newPowerMax.defence, node.power.defence)
+						newPowerMax.offencePerPoint = m_max(newPowerMax.offencePerPoint, node.power.offence / node.pathDist)
+						newPowerMax.defencePerPoint = m_max(newPowerMax.defencePerPoint, node.power.defence / node.pathDist)
+
+					end
+				end
+			elseif node.alloc and node.modKey ~= "" and not self.mainEnv.grantedPassives[nodeId] then
+				local output = calcFunc({ removeNodes = { [node] = true } }, { requirementsItems = true, requirementsGems = true, skills = true })
+				if self.powerStat and self.powerStat.stat and not self.powerStat.ignoreForNodes then
+					node.power.singleStat = self:CalculatePowerStat(self.powerStat, output, calcBase)
+					if node.depends and not node.ascendancyName then
+						node.power.pathPower = node.power.singleStat
+						local pathNodes = { }
+						for _, node in pairs(node.depends) do
+							pathNodes[node] = true
+						end
+						if #node.depends > 1 then
+							node.power.pathPower = self:CalculatePowerStat(self.powerStat, calcFunc({ removeNodes = pathNodes }, { requirementsItems = true, requirementsGems = true, skills = true }), calcBase)
+						end
 					end
 				end
 			end

--- a/src/Classes/CalcsTab.lua
+++ b/src/Classes/CalcsTab.lua
@@ -482,7 +482,7 @@ function CalcsTabClass:PowerBuilder()
 	local start = GetTime()
 	for nodeId, node in pairs(self.build.spec.nodes) do
 		wipeTable(node.power)
-		if self.nodePowerMaxDepth == nil or self.nodePowerMaxDepth == 0 or self.nodePowerMaxDepth >= node.pathDist then
+		if self.nodePowerMaxDepth == nil or self.nodePowerMaxDepth >= node.pathDist then
 			if not node.alloc and node.modKey ~= "" and not self.mainEnv.grantedPassives[nodeId] then
 				if not cache[node.modKey] then
 					cache[node.modKey] = calcFunc({ addNodes = { [node] = true } }, { requirementsItems = true, requirementsGems = true, skills = true })

--- a/src/Classes/TreeTab.lua
+++ b/src/Classes/TreeTab.lua
@@ -34,6 +34,7 @@ local TreeTabClass = newClass("TreeTab", "ControlHost", function(self, build)
 
 	self.anchorControls = new("Control", nil, 0, 0, 0, 20)
 
+	-- Tree list dropdown
 	self.controls.specSelect = new("DropDownControl", {"LEFT",self.anchorControls,"RIGHT"}, 0, 0, 190, 20, nil, function(index, value)
 		if self.specList[index] then
 			self.build.modFlag = true
@@ -87,6 +88,8 @@ local TreeTabClass = newClass("TreeTab", "ControlHost", function(self, build)
 			end
 		end
 	end
+
+	-- Compare checkbox
 	self.controls.compareCheck = new("CheckBoxControl", { "LEFT", self.controls.specSelect, "RIGHT" }, 74, 0, 20, "Compare:", function(state)
 		self.isComparing = state
 		self:SetCompareSpec(self.activeCompareSpec)
@@ -97,6 +100,8 @@ local TreeTabClass = newClass("TreeTab", "ControlHost", function(self, build)
 			self.controls.reset:SetAnchor("LEFT", self.controls.compareCheck, "RIGHT", nil, nil, nil)
 		end
 	end)
+
+	-- Compare tree dropdown
 	self.controls.compareSelect = new("DropDownControl", { "LEFT", self.controls.compareCheck, "RIGHT" }, 8, 0, 190, 20, nil, function(index, value)
 		if self.specList[index] then
 			self:SetCompareSpec(index)
@@ -114,12 +119,18 @@ local TreeTabClass = newClass("TreeTab", "ControlHost", function(self, build)
 			self.build.buildFlag = true
 		end)
 	end)
+
+	-- Import button
 	self.controls.import = new("ButtonControl", { "LEFT", self.controls.reset, "RIGHT" }, 8, 0, 90, 20, "Import Tree", function()
 		self:OpenImportPopup()
 	end)
+
+	-- Export button
 	self.controls.export = new("ButtonControl", { "LEFT", self.controls.import, "RIGHT" }, 8, 0, 90, 20, "Export Tree", function()
 		self:OpenExportPopup()
 	end)
+
+	-- Convert notification
 	local function convertToVersion(version)
 		local newSpec = new("PassiveSpec", self.build, version, true)
 		newSpec.title = self.build.spec.title
@@ -131,6 +142,8 @@ local TreeTabClass = newClass("TreeTab", "ControlHost", function(self, build)
 		self.modFlag = true
 		main:OpenMessagePopup("Tree Converted", "The tree has been converted to "..treeVersions[version].display..".\nNote that some or all of the passives may have been de-allocated due to changes in the tree.\n\nYou can switch back to the old tree using the tree selector at the bottom left.")
 	end
+
+	-- Tree Version Dropdown
 	self.treeVersions = { }
 	for _, num in ipairs(treeVersionList) do
 		t_insert(self.treeVersions, treeVersions[num].display)
@@ -145,14 +158,20 @@ local TreeTabClass = newClass("TreeTab", "ControlHost", function(self, build)
 	self.controls.versionSelect.enableDroppedWidth = true
 	self.controls.versionSelect.enableChangeBoxWidth = true
 	self.controls.versionSelect.selIndex = #self.treeVersions
+
+	-- Tree Search Textbox
 	self.controls.treeSearch = new("EditControl", { "LEFT", self.controls.versionSelect, "RIGHT" }, 8, 0, main.portraitMode and 200 or 300, 20, "", "Search", "%c", 100, function(buf)
 		self.viewer.searchStr = buf
 		self.searchFlag = buf ~= self.viewer.searchStrSaved
 	end, nil, nil, true)
 	self.controls.treeSearch.tooltipText = "Uses Lua pattern matching for complex searches"
+
+	-- Find Timeless Jewel Button
 	self.controls.findTimelessJewel = new("ButtonControl", { "LEFT", self.controls.treeSearch, "RIGHT" }, 8, 0, 150, 20, "Find Timeless Jewel", function()
 		self:FindTimelessJewel()
 	end)
+
+	-- Show Node Power Checkbox
 	self.controls.treeHeatMap = new("CheckBoxControl", { "LEFT", self.controls.findTimelessJewel, "RIGHT" }, 130, 0, 20, "Show Node Power:", function(state)
 		self.viewer.showHeatMap = state
 		self.controls.treeHeatMapStatSelect.shown = state
@@ -162,7 +181,26 @@ local TreeTabClass = newClass("TreeTab", "ControlHost", function(self, build)
 			self:TogglePowerReport()
 		end
 	end)
-	self.controls.treeHeatMapStatSelect = new("DropDownControl", { "LEFT", self.controls.treeHeatMap, "RIGHT" }, 8, 0, 150, 20, nil, function(index, value)
+
+	-- Control for setting max node depth to limit calculation time of the heat map
+	self.controls.nodePowerMaxDepthSelect = new("DropDownControl", { "LEFT", self.controls.treeHeatMap, "RIGHT" }, 8, 0, 70, 20, "Node Depth:", function(index, value)
+		-- Save "All" string option as 0
+		if type(value) == "number" then
+			self.build.calcsTab.nodePowerMaxDepth = value
+		else
+			self.build.calcsTab.nodePowerMaxDepth = 0
+		end
+
+		-- If the heat map is shown, tell it to recalculate with the current value
+		if self.viewer.showHeatMap then
+			self:SetPowerCalc(self.build.calcsTab.powerStat)
+		end
+	end)
+	self.controls.nodePowerMaxDepthSelect.tooltipText = "Limit of Node Distance To Search (lower = faster)"
+	self.controls.nodePowerMaxDepthSelect.list = {"All", 5, 10}
+
+	-- Control for selecting the power stat to sort by (Defense, DPS, etc)
+	self.controls.treeHeatMapStatSelect = new("DropDownControl", { "LEFT", self.controls.nodePowerMaxDepthSelect, "RIGHT" }, 8, 0, 150, 20, nil, function(index, value)
 		self:SetPowerCalc(value)
 	end)
 	self.controls.treeHeatMap.tooltipText = function()
@@ -177,6 +215,7 @@ local TreeTabClass = newClass("TreeTab", "ControlHost", function(self, build)
 		end
 	end
 
+	-- Show/Hide Power Report Button
 	self.controls.powerReport = new("ButtonControl", { "LEFT", self.controls.treeHeatMapStatSelect, "RIGHT" }, 8, 0, 150, 20, self.showPowerReport and "Hide Power Report" or "Show Power Report", function()
 		self.showPowerReport = not self.showPowerReport
 		self:TogglePowerReport()

--- a/src/Classes/TreeTab.lua
+++ b/src/Classes/TreeTab.lua
@@ -120,16 +120,6 @@ local TreeTabClass = newClass("TreeTab", "ControlHost", function(self, build)
 		end)
 	end)
 
-	-- Import button
-	self.controls.import = new("ButtonControl", { "LEFT", self.controls.reset, "RIGHT" }, 8, 0, 90, 20, "Import Tree", function()
-		self:OpenImportPopup()
-	end)
-
-	-- Export button
-	self.controls.export = new("ButtonControl", { "LEFT", self.controls.import, "RIGHT" }, 8, 0, 90, 20, "Export Tree", function()
-		self:OpenExportPopup()
-	end)
-
 	-- Convert notification
 	local function convertToVersion(version)
 		local newSpec = new("PassiveSpec", self.build, version, true)
@@ -148,7 +138,7 @@ local TreeTabClass = newClass("TreeTab", "ControlHost", function(self, build)
 	for _, num in ipairs(treeVersionList) do
 		t_insert(self.treeVersions, treeVersions[num].display)
 	end
-	self.controls.versionText = new("LabelControl", { "LEFT", self.controls.export, "RIGHT" }, 8, 0, 0, 16, "Version:")
+	self.controls.versionText = new("LabelControl", { "LEFT", self.controls.reset, "RIGHT" }, 8, 0, 0, 16, "Version:")
 	self.controls.versionSelect = new("DropDownControl", { "LEFT", self.controls.versionText, "RIGHT" }, 8, 0, 100, 20, self.treeVersions, function(index, value)
 		if value ~= self.build.spec.treeVersion then
 			convertToVersion(value:gsub("[%(%)]", ""):gsub("[%.%s]", "_"))
@@ -158,7 +148,7 @@ local TreeTabClass = newClass("TreeTab", "ControlHost", function(self, build)
 	self.controls.versionSelect.enableDroppedWidth = true
 	self.controls.versionSelect.enableChangeBoxWidth = true
 	self.controls.versionSelect.selIndex = #self.treeVersions
-
+	
 	-- Tree Search Textbox
 	self.controls.treeSearch = new("EditControl", { "LEFT", self.controls.versionSelect, "RIGHT" }, 8, 0, main.portraitMode and 200 or 300, 20, "", "Search", "%c", 100, function(buf)
 		self.viewer.searchStr = buf
@@ -183,7 +173,7 @@ local TreeTabClass = newClass("TreeTab", "ControlHost", function(self, build)
 	end)
 
 	-- Control for setting max node depth to limit calculation time of the heat map
-	self.controls.nodePowerMaxDepthSelect = new("DropDownControl", { "LEFT", self.controls.treeHeatMap, "RIGHT" }, 8, 0, 70, 20, "Node Depth:", function(index, value)
+	self.controls.nodePowerMaxDepthSelect = new("DropDownControl", { "LEFT", self.controls.treeHeatMap, "RIGHT" }, 8, 0, 50, 20, "Node Depth:", function(index, value)
 		if type(value) == "number" then
 			self.build.calcsTab.nodePowerMaxDepth = value
 		else
@@ -445,9 +435,24 @@ function TreeTabClass:SetCompareSpec(specId)
 end
 
 function TreeTabClass:OpenSpecManagePopup()
+--	local importTree = 
+--		new("ButtonControl", { "LEFT", nil, "RIGHT" }, -328, 124, 90, 20, "Import Tree", function()
+--			self:OpenImportPopup()
+--		end)
+	local importTree = 
+		new("ButtonControl", nil, -99, 259, 90, 20, "Import Tree", function()
+			self:OpenImportPopup()
+		end)
+	local exportTree =
+		new("ButtonControl", { "LEFT", importTree, "RIGHT" }, 8, 0, 90, 20, "Export Tree", function()
+			self:OpenExportPopup()
+		end)
+
 	main:OpenPopup(370, 290, "Manage Passive Trees", {
 		new("PassiveSpecListControl", nil, 0, 50, 350, 200, self),
-		new("ButtonControl", nil, 0, 260, 90, 20, "Done", function()
+		importTree,
+		exportTree,
+		new("ButtonControl", {"LEFT", exportTree, "RIGHT"}, 8, 0, 90, 20, "Done", function()
 			main:ClosePopup()
 		end),
 	})

--- a/src/Classes/TreeTab.lua
+++ b/src/Classes/TreeTab.lua
@@ -174,7 +174,7 @@ local TreeTabClass = newClass("TreeTab", "ControlHost", function(self, build)
 
 	-- Control for setting max node depth to limit calculation time of the heat map
 	self.controls.nodePowerMaxDepthSelect = new("DropDownControl", 
-	{ "LEFT", self.controls.treeHeatMap, "RIGHT" }, 8, 0, 50, 20, {"All", 5, 10 , 15}, function(index, value)
+	{ "LEFT", self.controls.treeHeatMap, "RIGHT" }, 8, 0, 50, 20, { "All", 5, 10, 15 }, function(index, value)
 		local oldMax = self.build.calcsTab.nodePowerMaxDepth
 
 		if type(value) == "number" then
@@ -191,7 +191,7 @@ local TreeTabClass = newClass("TreeTab", "ControlHost", function(self, build)
 			end
 		end
 	end)
-	self.controls.nodePowerMaxDepthSelect.tooltipText = "Limit of Node Distance To Search (lower = faster)"
+	self.controls.nodePowerMaxDepthSelect.tooltipText = "Limit of Node distance to search (lower = faster)"
 
 	-- Control for selecting the power stat to sort by (Defense, DPS, etc)
 	self.controls.treeHeatMapStatSelect = new("DropDownControl", { "LEFT", self.controls.nodePowerMaxDepthSelect, "RIGHT" }, 8, 0, 150, 20, nil, function(index, value)

--- a/src/Classes/TreeTab.lua
+++ b/src/Classes/TreeTab.lua
@@ -173,20 +173,25 @@ local TreeTabClass = newClass("TreeTab", "ControlHost", function(self, build)
 	end)
 
 	-- Control for setting max node depth to limit calculation time of the heat map
-	self.controls.nodePowerMaxDepthSelect = new("DropDownControl", { "LEFT", self.controls.treeHeatMap, "RIGHT" }, 8, 0, 50, 20, "Node Depth:", function(index, value)
+	self.controls.nodePowerMaxDepthSelect = new("DropDownControl", 
+	{ "LEFT", self.controls.treeHeatMap, "RIGHT" }, 8, 0, 50, 20, {"All", 5, 10 , 15}, function(index, value)
+		local oldMax = self.build.calcsTab.nodePowerMaxDepth
+
 		if type(value) == "number" then
 			self.build.calcsTab.nodePowerMaxDepth = value
 		else
 			self.build.calcsTab.nodePowerMaxDepth = nil
 		end
 
-		-- If the heat map is shown, tell it to recalculate with the current value
-		if self.viewer.showHeatMap then
-			self:SetPowerCalc(self.build.calcsTab.powerStat)
+		-- If the heat map is shown, tell it to recalculate
+		-- if the new value is larger than the old
+		if oldMax ~= value and self.viewer.showHeatMap then
+			if oldMax ~= nil and (self.build.calcsTab.nodePowerMaxDepth == nil or self.build.calcsTab.nodePowerMaxDepth > oldMax) then
+				self:SetPowerCalc(self.build.calcsTab.powerStat)
+			end
 		end
 	end)
 	self.controls.nodePowerMaxDepthSelect.tooltipText = "Limit of Node Distance To Search (lower = faster)"
-	self.controls.nodePowerMaxDepthSelect.list = {"All", 5, 10}
 
 	-- Control for selecting the power stat to sort by (Defense, DPS, etc)
 	self.controls.treeHeatMapStatSelect = new("DropDownControl", { "LEFT", self.controls.nodePowerMaxDepthSelect, "RIGHT" }, 8, 0, 150, 20, nil, function(index, value)
@@ -435,10 +440,6 @@ function TreeTabClass:SetCompareSpec(specId)
 end
 
 function TreeTabClass:OpenSpecManagePopup()
---	local importTree = 
---		new("ButtonControl", { "LEFT", nil, "RIGHT" }, -328, 124, 90, 20, "Import Tree", function()
---			self:OpenImportPopup()
---		end)
 	local importTree = 
 		new("ButtonControl", nil, -99, 259, 90, 20, "Import Tree", function()
 			self:OpenImportPopup()

--- a/src/Classes/TreeTab.lua
+++ b/src/Classes/TreeTab.lua
@@ -184,11 +184,10 @@ local TreeTabClass = newClass("TreeTab", "ControlHost", function(self, build)
 
 	-- Control for setting max node depth to limit calculation time of the heat map
 	self.controls.nodePowerMaxDepthSelect = new("DropDownControl", { "LEFT", self.controls.treeHeatMap, "RIGHT" }, 8, 0, 70, 20, "Node Depth:", function(index, value)
-		-- Save "All" string option as 0
 		if type(value) == "number" then
 			self.build.calcsTab.nodePowerMaxDepth = value
 		else
-			self.build.calcsTab.nodePowerMaxDepth = 0
+			self.build.calcsTab.nodePowerMaxDepth = nil
 		end
 
 		-- If the heat map is shown, tell it to recalculate with the current value


### PR DESCRIPTION
New Feature: User selectable limiter on node depth for Node Power heatmap generation.

### Description of the problem being solved:
Currently, generating the full heatmap can take multiple minutes for certain builds on slower machines. In the vast majority of cases the user doesn't care about nodes more than a certain distance away from currently allocated nodes. By giving the user a dropdown to choose to only check against nodes with a max distance we can dramatically speed up the operation.

Too much choice seemed frivolous so I went with only 5 and 10 . We could easily expand this to more choices if we wanted. More than 10 is often close to the entire tree anyway for many builds.

### Steps taken to verify a working solution:
Generate a Node Power heat map after selecting from the new dropdown to the right of the checkbox on the Tree Tab.

### Link to a build that showcases this PR:
All builds will show this functionality, even no build at all.

### Before screenshot:
![LO6syo9](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/144043193/4a738664-7124-4760-abc1-0a69b4d58c58)

![smziMbK](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/144043193/548a93de-540d-4e71-9c5f-ddaf66f9ddeb)

### After screenshot:
![uSmm9y9](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/144043193/bb261093-00d0-4fb5-a37f-81408af4260a)

![dMKEmKK](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/144043193/c21b4003-76b7-499a-aec7-c0638aa0be47)