### PR TITLE
Add legacy tag to Clusters that no longer drop

### DIFF
--- a/src/Data/ClusterJewels.lua
+++ b/src/Data/ClusterJewels.lua
@@ -239,7 +239,7 @@ return {
 					},
 				},
 				["affliction_aura_effect"] = {
-					name = "Aura Effect",
+					name = "Aura Effect (Legacy)",
 					icon = "Art/2DArt/SkillIcons/passives/AuraEffectNode.png",
 					masteryIcon = "Art/2DArt/SkillIcons/passives/AltMasteryAuras.png",
 					tag = "old_do_not_use_affliction_aura_effect",
@@ -249,7 +249,7 @@ return {
 					},
 				},
 				["affliction_curse_effect"] = {
-					name = "Curse Effect",
+					name = "Curse Effect (Legacy)",
 					icon = "Art/2DArt/SkillIcons/passives/CurseEffectNode.png",
 					masteryIcon = "Art/2DArt/SkillIcons/passives/AltMasteryCurse.png",
 					tag = "old_do_not_use_affliction_curse_effect",

--- a/src/Export/Scripts/cluster.lua
+++ b/src/Export/Scripts/cluster.lua
@@ -21,7 +21,11 @@ for jewel in dat("PassiveTreeExpansionJewels"):Rows() do
 	out:write('\t\t\tskills = {\n')
 	for index, skill in ipairs(dat("PassiveTreeExpansionSkills"):GetRowList("JewelSize", jewel.Size)) do
 		out:write('\t\t\t\t["', skill.Node.Id, '"] = {\n')
-		out:write('\t\t\t\t\tname = "', skill.Node.Name, '",\n')
+		if skill.Tag.Id:match("old_do_not_use") then
+			out:write('\t\t\t\t\tname = "', skill.Node.Name, ' (Legacy)",\n')
+			else
+			out:write('\t\t\t\t\tname = "', skill.Node.Name, '",\n')
+		end
 		out:write('\t\t\t\t\ticon = "', skill.Node.Icon:gsub("dds$","png"), '",\n')
 		if skill.Mastery then
 			out:write('\t\t\t\t\tmasteryIcon = "', skill.Mastery.Icon:gsub("dds$","png"), '",\n')


### PR DESCRIPTION
The legacy clusters still exist in standard and can be crafted but they can deceive people in the temp leagues as they are no longer possible to get
This should make it clearer
