### PR TITLE
Optimize AddMasteryEffectOptionsToNode, improve startup time

### DIFF
--- a/src/Classes/PassiveSpec.lua
+++ b/src/Classes/PassiveSpec.lua
@@ -691,17 +691,18 @@ end
 
 function PassiveSpecClass:AddMasteryEffectOptionsToNode(node)
 	node.sd = {}
-	if node.masteryEffects ~= nil then
+	if node.masteryEffects ~= nil and #node.masteryEffects > 0 then
 		for _, effect in ipairs(node.masteryEffects) do
 			effect = self.tree.masteryEffects[effect.effect]
-			if effect.sd ~= nil then
-				for _, sd in ipairs(effect.sd) do
-					t_insert(node.sd, sd)
-				end
+			local startIndex = #node.sd + 1
+			for _, sd in ipairs(effect.sd) do
+				t_insert(node.sd, sd)
 			end
+			self.tree:ProcessStats(node, startIndex)
 		end
+	else
+		self.tree:ProcessStats(node)
 	end
-	self.tree:ProcessStats(node)
 	node.allMasteryOptions = true
 end
 

--- a/src/Classes/PassiveTree.lua
+++ b/src/Classes/PassiveTree.lua
@@ -537,15 +537,20 @@ local PassiveTreeClass = newClass("PassiveTree", function(self, treeVersion)
 	buildTreeDependentUniques(self)
 end)
 
-function PassiveTreeClass:ProcessStats(node)
-	node.modKey = ""
+function PassiveTreeClass:ProcessStats(node, startIndex)
+	startIndex = startIndex or 1
+	if startIndex == 1 then
+		node.modKey = ""
+		node.mods = { }
+		node.modList = new("ModList")
+	end
+
 	if not node.sd then
 		return
 	end
 
 	-- Parse node modifier lines
-	node.mods = { }
-	local i = 1
+	local i = startIndex
 	while node.sd[i] do
 		if node.sd[i]:match("\n") then
 			local line = node.sd[i]
@@ -597,8 +602,8 @@ function PassiveTreeClass:ProcessStats(node)
 	end
 
 	-- Build unified list of modifiers from all recognised modifier lines
-	node.modList = new("ModList")
-	for _, mod in pairs(node.mods) do
+	for i = startIndex, #node.mods do
+		local mod = node.mods[i]
 		if mod.list and not mod.extra then
 			for i, mod in ipairs(mod.list) do
 				mod = modLib.setSource(mod, "Tree:"..node.id)

--- a/src/Launch.lua
+++ b/src/Launch.lua
@@ -5,6 +5,7 @@
 -- Program entry point; loads and runs the Main module within a protected environment
 --
 
+local startTime = GetTime()
 APP_NAME = "Path of Building"
 
 SetWindowTitle(APP_NAME)
@@ -22,6 +23,7 @@ function launch:OnInit()
 	self.versionPlatform = "?"
 	self.lastUpdateCheck = GetTime()
 	self.subScripts = { }
+	self.startTime = startTime
 	local firstRunFile = io.open("first.run", "r")
 	if firstRunFile then
 		firstRunFile:close()

--- a/src/Modules/Main.lua
+++ b/src/Modules/Main.lua
@@ -217,7 +217,12 @@ the "Releases" section of the GitHub page.]])
 
 	self:LoadSharedItems()
 
-	self.onFrameFuncs = { }
+	self.onFrameFuncs = {
+		["FirstFrame"] = function()
+			self.onFrameFuncs["FirstFrame"] = nil
+			ConPrintf("Startup time: %d ms", GetTime() - launch.startTime)
+		end
+	}
 end
 
 function main:SaveModCache()


### PR DESCRIPTION
Improves startup time by about 400 ms.

AddMasteryEffectOptionsToNode was combining all mastery option mod lines into one node.sd and then calling ProcessStats which led to many mod lines being combined in an attempt to parse them.  These combined lines shouldn't be combined for parsing since they come from different mastery options and they also weren't cached so parsing them was very slow.

This change adds a new startIndex parameter to ProcessStats so it can incrementally parse the mastery options as they are added by AddMasteryEffectOptionsToNode instead of parsing them all at once.

Also added new "Startup time: #### ms" print message that measures from start until the first OnFrame call finishes.  I was measuring just Main:Init before but there is some init code in the first OnFrame call so now I'm measuring until end of first frame.

### Steps taken to verify a working solution:
- Allocating / deallocating mastery nodes still behaves the same
- "Show Node Power" still shows same results
- "Search:" box on passive tree still highlights mastery nodes when it should