### PR TITLE
Fix tooltip stats comparison always showing ehp calcs.

### DIFF
--- a/src/Modules/CalcPerform.lua
+++ b/src/Modules/CalcPerform.lua
@@ -871,7 +871,7 @@ end
 -- 8. Processes buffs and debuffs
 -- 9. Processes charges and misc buffs (doActorMisc)
 -- 10. Calculates defence and offence stats (calcs.defence, calcs.offence)
-function calcs.perform(env,fullDPSSkipEHP)
+function calcs.perform(env, fullDPSSkipEHP)
 	local modDB = env.modDB
 	local enemyDB = env.enemyDB
 	

--- a/src/Modules/Calcs.lua
+++ b/src/Modules/Calcs.lua
@@ -136,7 +136,7 @@ function calcs.getMiscCalculator(build)
 		GlobalCache.noCache = true
 		-- we need to preserve the override somewhere for use by possible trigger-based build-outs with overrides
 		env.override = override
-		calcs.perform(env, true)
+		calcs.perform(env)
 		if GlobalCache.useFullDPS or build.viewMode == "TREE" then
 			-- prevent upcoming calculation from using Cached Data and thus forcing it to re-calculate new FullDPS roll-up 
 			-- without this, FullDPS increase/decrease when for node/item/gem comparison would be all 0 as it would be comparing


### PR DESCRIPTION
### Description of the problem being solved:
https://github.com/PathOfBuildingCommunity/PathOfBuilding/pull/6566 removed `avoidCache` variable, moving the `fullDPSSkipEHP` in its place in the `calcs.performs` function arguments. I forgot to correct arguments for a call inside of `calcs.getMiscCalculator(build)` causing the issue.