### PR TITLE
Fix "Show allocated nodes" button and convert to dropdown

### DIFF
--- a/src/Classes/CalcsTab.lua
+++ b/src/Classes/CalcsTab.lua
@@ -439,10 +439,9 @@ function CalcsTabClass:BuildOutput()
 end
 
 -- Controls the coroutine that calculates node power
-function CalcsTabClass:BuildPower(callbackContext)
+function CalcsTabClass:BuildPower()
 	if self.powerBuildFlag then
 		self.powerBuildFlag = false
-		self.powerBuilderCallback = callbackContext or self.powerBuilderCallback
 		self.powerBuilder = coroutine.create(self.PowerBuilder)
 	end
 	if self.powerBuilder then
@@ -452,8 +451,8 @@ function CalcsTabClass:BuildPower(callbackContext)
 		end
 		if coroutine.status(self.powerBuilder) == "dead" then
 			self.powerBuilder = nil
-			if self.powerBuilderCallback then
-				self.powerBuilderCallback.func(self.powerBuilderCallback.caller)
+			if self.build.powerBuilderCallback then
+				self.build.powerBuilderCallback()
 			end
 		end
 	end

--- a/src/Classes/PowerReportListControl.lua
+++ b/src/Classes/PowerReportListControl.lua
@@ -8,42 +8,62 @@ local t_insert = table.insert
 local t_remove = table.remove
 local t_sort = table.sort
 
-local PowerReportListClass = newClass("PowerReportListControl", "ListControl", function(self, anchor, x, y, width, height, report, powerLabel, nodeSelectCallback)
+local PowerReportListClass = newClass("PowerReportListControl", "ListControl", function(self, anchor, x, y, width, height, nodeSelectCallback)
+	self.ListControl(anchor, x, y, width, height-50, 16, "VERTICAL", false)
 
-	self.originalList = report
-
-	self.ListControl(anchor, x, y, width, height-50, 16, "VERTICAL", false, self:ReList())
-
+	self.powerColumn = { width = width * 0.16, label = "", sortable = true }
 	self.colList = {
 		{ width = width * 0.15, label = "Type", sortable = true },
 		{ width = width * 0.45, label = "Node Name" },
-		{ width = width * 0.16, label = powerLabel, sortable = true },
+		self.powerColumn,
 		{ width = width * 0.05, label = "Points", sortable = true },
 		{ width = width * 0.16, label = "Per Point", sortable = true },
 	}
-	self.label = "Click to focus node on tree"
 	self.colLabels = true
 	self.nodeSelectCallback = nodeSelectCallback
 	self.showClusters = false
+	self.allocated = false
+	self.label = "Building Tree..."
 	
-	self.controls.showClusters = new("CheckBoxControl", {"BOTTOMRIGHT",self,"TOPRIGHT"}, 0, -2, 18, "Show Clusters:", function(state)
-		self.showClusters = state
-		self:ReList()
-		self:ReSort(3)
-	end, "Show Cluster Jewel Notables")
+	self.controls.filterSelect = new("DropDownControl", { "BOTTOMRIGHT", self, "TOPRIGHT" }, 0, -2, 200, 20,
+		{ "Show Unallocated", "Show Unallocated & Clusters", "Show Allocated" },
+		function(index, value)
+			self.showClusters = index == 2
+			self.allocated = index == 3
+			self:ReList()
+			self:ReSort(3) -- Sort by power
+		end)
 end)
 
+function PowerReportListClass:SetReport(stat, report)
+	self.powerColumn.label = stat and stat.label or ""
+	self.originalList = report or {}
+
+	if stat and stat.stat then
+		self.label = report and "Click to focus node on tree" or "Building Tree..."
+	else
+		self.label = "^7\""..self.powerColumn.label.."\" not supported.  Select a specific stat from the dropdown."
+	end
+
+	self:ReList()
+end
+
 function PowerReportListClass:ReSort(colIndex)
+	-- Reverse power sort for allocated because it uses negative numbers
+	local compare = self.allocated and 
+		function(a, b) return a < b end
+		or function(a, b) return a > b end
+
 	if colIndex == 1 then
 		t_sort(self.list, function (a,b)
 			if a.type == b.type then
-				return a.power > b.power
+				return compare(a.power, b.power)
 			end
 			return a.type < b.type
 		end)
 	elseif colIndex == 3 then
 		t_sort(self.list, function (a,b)
-			return a.power > b.power
+			return compare(a.power, b.power)
 		end)
 	elseif colIndex == 4 then
 		t_sort(self.list, function (a,b)
@@ -54,7 +74,7 @@ function PowerReportListClass:ReSort(colIndex)
 				return true
 			end
 			if a.pathDist == b.pathDist then
-				return a.power > b.power
+				return compare(a.power, b.power)
 			end
 			return a.pathDist < b.pathDist
 		end)
@@ -63,47 +83,29 @@ function PowerReportListClass:ReSort(colIndex)
 			if a.pathPower == b.pathPower and type(a.pathDist) == "number" and type(b.pathDist) == "number" then
 				return a.pathDist < b.pathDist
 			end
-			return a.pathPower > b.pathPower
+			return compare(a.pathPower, b.pathPower)
 		end)
 	end
 end
 
 function PowerReportListClass:ReList()
-	if not next(self.originalList) then
-		return { }
+	self.list = { }
+	if not self.originalList then
+		return
 	end
-	local filteredList = { }
-	local iterate = 1
-	local insert = true
 
-	while(true) do
-
-		insert = self.originalList[iterate].power > 0
-		if (not self.showClusters) and (self.originalList[iterate].pathDist == "Cluster") then
+	for _, item in ipairs(self.originalList) do
+		local insert = item.power > 0
+		if not self.showClusters and item.pathDist == "Cluster" then
 			insert = false
 		end
-		if self.allocated and self.originalList[iterate].pathDist ~= "Cluster" then
-			insert = self.originalList[iterate].allocated and (self.originalList[iterate].pathDist <= (self.pathLength or 100))
+		if self.allocated then
+			insert = item.allocated
 		end
 
 		if insert then
-			t_insert(filteredList, self.originalList[iterate])
+			t_insert(self.list, item)
 		end
-
-		iterate = iterate + 1
-		insert = true
-
-		if iterate > #self.originalList then
-			break
-		end		
-	end
-
-	if (next(filteredList)) then
-		self.list = filteredList
-		return filteredList
-	else 
-		self.list = self.originalList
-		return self.originalList
 	end
 end
 
@@ -114,21 +116,10 @@ function PowerReportListClass:OnSelClick(index, report, doubleClick)
 end
 
 function PowerReportListClass:GetRowValue(column, index, report)
-	if column == 1 then
-		return report.type
-	elseif column == 2 then
-		return report.name
-	elseif column == 3 then
-		return report.powerStr
-	elseif column == 4 then
-		if report.pathDist == 1000 then
-			return "Anoint"
-		else
-			return report.pathDist
-		end
-	elseif column == 5 then
-		return report.pathPowerStr
-	else
-		return ""
-	end
+	return column == 1 and report.type
+		or column == 2 and report.name
+		or column == 3 and report.powerStr
+		or column == 4 and (report.pathDist == 1000 and "Anoint" or report.pathDist)
+		or column == 5 and report.pathPowerStr
+		or ""
 end

--- a/src/Classes/TreeTab.lua
+++ b/src/Classes/TreeTab.lua
@@ -268,7 +268,7 @@ function TreeTabClass:Draw(viewPort, inputEvents)
 		self.controls.powerReportList:SetAnchor("TOPLEFT", self.controls.specSelect, "BOTTOMLEFT", 0, self.controls.specSelect.height + 4)
 	else
 		self.controls.treeSearch:SetAnchor("TOPLEFT", self.controls.specSelect, "BOTTOMLEFT", 0, 4)
-		self.controls.powerReportList:SetAnchor("TOPLEFT", self.controls.findTimelessJewel, "BOTTOMLEFT", 0, self.controls.treeHeatMap.y + self.controls.treeHeatMap.height + 4)
+		self.controls.powerReportList:SetAnchor("TOPLEFT", self.controls.treeSearch, "BOTTOMLEFT", 0, self.controls.treeHeatMap.y + self.controls.treeHeatMap.height + 4)
 	end
 
 	local bottomDrawerHeight = self.controls.powerReportList.shown and 194 or 0

--- a/src/Classes/TreeTab.lua
+++ b/src/Classes/TreeTab.lua
@@ -152,10 +152,9 @@ local TreeTabClass = newClass("TreeTab", "ControlHost", function(self, build)
 	self.controls.treeHeatMap = new("CheckBoxControl", { "LEFT", self.controls.findTimelessJewel, "RIGHT" }, 130, 0, 20, "Show Node Power:", function(state)
 		self.viewer.showHeatMap = state
 		self.controls.treeHeatMapStatSelect.shown = state
-		
-		if state == false then 
-			self.showPowerReport = false 
-			self:TogglePowerReport()
+
+		if state == false then
+			self.controls.powerReportList.shown = false 
 		end
 	end)
 
@@ -197,21 +196,28 @@ local TreeTabClass = newClass("TreeTab", "ControlHost", function(self, build)
 	end
 
 	-- Show/Hide Power Report Button
-	self.controls.powerReport = new("ButtonControl", { "LEFT", self.controls.treeHeatMapStatSelect, "RIGHT" }, 8, 0, 150, 20, self.showPowerReport and "Hide Power Report" or "Show Power Report", function()
-		self.showPowerReport = not self.showPowerReport
-		self:TogglePowerReport()
+	self.controls.powerReport = new("ButtonControl", { "LEFT", self.controls.treeHeatMapStatSelect, "RIGHT" }, 8, 0, 150, 20,
+		function() return self.controls.powerReportList.shown and "Hide Power Report" or "Show Power Report" end, function()
+		self.controls.powerReportList.shown = not self.controls.powerReportList.shown
 	end)
-	self.controls.powerReport.enabled = function()
-		return self.build.calcsTab and self.build.calcsTab.powerBuilderInitialized
-	end
-	self.controls.powerReport.tooltipFunc = function(tooltip)
-		tooltip:Clear()
-		if not (self.build.calcsTab and self.build.calcsTab.powerBuilderInitialized) then
-			tooltip:AddLine(14, "Show Power Report is disabled until the first time")
-			tooltip:AddLine(14, "an evaluation of all nodes and clusters completes.")
+
+	-- Power Report List
+	local yPos = self.controls.treeHeatMap.y == 0 and self.controls.specSelect.height + 4 or self.controls.specSelect.height * 2 + 8
+	self.controls.powerReportList = new("PowerReportListControl", {"TOPLEFT", self.controls.specSelect, "BOTTOMLEFT"}, 0, yPos, 700, 220, function(selectedNode)
+		-- this code is called by the list control when the user "selects" one of the passives in the list.
+		-- we use this to set a flag which causes the next Draw() to recenter the passive tree on the desired node.
+		if selectedNode.x then
+			self.jumpToNode = true
+			self.jumpToX = selectedNode.x
+			self.jumpToY = selectedNode.y
 		end
+	end)
+	self.controls.powerReportList.shown = false
+	self.build.powerBuilderCallback = function()
+		local powerStat = self.build.calcsTab.powerStat or data.powerStatList[1]
+		local report = self:BuildPowerReportList(powerStat)
+		self.controls.powerReportList:SetReport(powerStat, report)
 	end
-	self.showPowerReport = false
 
 	self.controls.specConvertText = new("LabelControl", { "BOTTOMLEFT", self.controls.specSelect, "TOPLEFT" }, 0, -14, 0, 16, "^7This is an older tree version, which may not be fully compatible with the current game version.")
 	self.controls.specConvertText.shown = function()
@@ -259,19 +265,13 @@ function TreeTabClass:Draw(viewPort, inputEvents)
 	if viewPort.width >= 1336 + (self.isComparing and 198 or 0) + (self.viewer.showHeatMap and 316 or 0) then
 		twoLineHeight = 0
 		self.controls.treeSearch:SetAnchor("LEFT", self.controls.versionSelect, "RIGHT", 8, 0)
-		if self.controls.powerReportList then
-			self.controls.powerReportList:SetAnchor("TOPLEFT", self.controls.specSelect, "BOTTOMLEFT", 0, self.controls.specSelect.height + 4)
-			self.controls.allocatedNodeToggle:SetAnchor("TOPLEFT", self.controls.powerReportList, "TOPRIGHT", 8, 0)
-		end
+		self.controls.powerReportList:SetAnchor("TOPLEFT", self.controls.specSelect, "BOTTOMLEFT", 0, self.controls.specSelect.height + 4)
 	else
 		self.controls.treeSearch:SetAnchor("TOPLEFT", self.controls.specSelect, "BOTTOMLEFT", 0, 4)
-		if self.controls.powerReportList then
-			self.controls.powerReportList:SetAnchor("TOPLEFT", self.controls.findTimelessJewel, "BOTTOMLEFT", 0, self.controls.treeHeatMap.y + self.controls.treeHeatMap.height + 4)
-			self.controls.allocatedNodeToggle:SetAnchor("TOPLEFT", self.controls.powerReportList, "TOPRIGHT", -76, -44)
-		end
+		self.controls.powerReportList:SetAnchor("TOPLEFT", self.controls.findTimelessJewel, "BOTTOMLEFT", 0, self.controls.treeHeatMap.y + self.controls.treeHeatMap.height + 4)
 	end
 
-	local bottomDrawerHeight = self.showPowerReport and 194 or 0
+	local bottomDrawerHeight = self.controls.powerReportList.shown and 194 or 0
 	self.controls.specSelect.y = -bottomDrawerHeight - twoLineHeight
 
 	local treeViewPort = { x = viewPort.x, y = viewPort.y, width = viewPort.width, height = viewPort.height - (self.showConvert and 64 + bottomDrawerHeight + twoLineHeight or 32 + bottomDrawerHeight + twoLineHeight)}
@@ -309,13 +309,6 @@ function TreeTabClass:Draw(viewPort, inputEvents)
 	self.controls.treeHeatMapStatSelect:CheckDroppedWidth(true)
 	if self.build.calcsTab.powerStat then
 		self.controls.treeHeatMapStatSelect:SelByValue(self.build.calcsTab.powerStat.stat, "stat")
-	end
-	if self.controls.powerReportList then
-		if self.build.calcsTab.powerStat and self.build.calcsTab.powerStat.stat then
-			self.controls.powerReportList.label = self.build.calcsTab.powerBuilder and "Building table..." or "Click to focus node on tree"
-		else
-			self.controls.powerReportList.label = "^7\"Offense/Defense\" not supported.  Select a specific stat from the dropdown."
-		end
 	end
 
 	SetDrawLayer(1)
@@ -765,78 +758,12 @@ function TreeTabClass:OpenMasteryPopup(node, viewPort)
 	end
 end
 
-function TreeTabClass:SetPowerCalc(selection)
+function TreeTabClass:SetPowerCalc(powerStat)
 	self.viewer.showHeatMap = true
 	self.build.buildFlag = true
 	self.build.calcsTab.powerBuildFlag = true
-	self.build.calcsTab.powerStat = selection
-	if self.showPowerReport then
-		self.controls.allocatedNodeToggle.enabled = false
-		self.controls.allocatedNodeDistance.enabled = false
-		self.controls.powerReportList.label = "Building table..."
-		self.build.calcsTab:BuildPower({ func = self.TogglePowerReport, caller = self })
-	end
-end
-
-function TreeTabClass:BuildPowerReportUI()
-	self.controls.powerReport.tooltipText = "A report of node efficacy based on current heat map selection"
-
-	self.controls.allocatedNodeToggle = new("ButtonControl", {"TOPLEFT", self.controls.powerReportList, "TOPRIGHT" }, 8, 4, 160, 20, "Show allocated nodes", function()
-		self.controls.powerReportList.allocated = not self.controls.powerReportList.allocated
-		self.controls.allocatedNodeDistance.shown = self.controls.powerReportList.allocated
-		self.controls.allocatedNodeDistance.enabled = self.controls.powerReportList.allocated
-		self.controls.allocatedNodeToggle.label = self.controls.powerReportList.allocated and "Show Unallocated Nodes" or "Show allocated nodes"
-		self.controls.powerReportList.pathLength = tonumber(self.controls.allocatedNodeDistance.buf or 1)
-		self.controls.powerReportList:ReList()
-	end)
-
-	self.controls.allocatedNodeDistance = new("EditControl", {"TOPLEFT", self.controls.allocatedNodeToggle, "BOTTOMLEFT" }, 0, 4, 125, 20, 1, "Max path", "%D", 100, function(buf)
-		self.controls.powerReportList.pathLength = tonumber(buf)
-		self.controls.powerReportList:ReList()
-	end)
-end
-
-function TreeTabClass:TogglePowerReport(caller)
-	self = self or caller
-	self.controls.powerReport.label = self.showPowerReport and "Hide Power Report" or "Show Power Report"
-	local currentStat = self.build.calcsTab and self.build.calcsTab.powerStat or nil
-	local report = {}
-	if not self.showPowerReport and self.controls.powerReportList then
-		self.controls.powerReportList.shown = false
-		return
-	end
-
-	report = self:BuildPowerReportList(currentStat)
-	local yPos = self.controls.treeHeatMap.y == 0 and self.controls.specSelect.height + 4 or self.controls.specSelect.height * 2 + 8
-	self.controls.powerReportList = new("PowerReportListControl", {"TOPLEFT", self.controls.specSelect, "BOTTOMLEFT"}, 0, yPos, 700, 220, report, currentStat and currentStat.label or "", function(selectedNode)
-		-- this code is called by the list control when the user "selects" one of the passives in the list.
-		-- we use this to set a flag which causes the next Draw() to recenter the passive tree on the desired node.
-		if selectedNode.x then
-			self.jumpToNode = true
-			self.jumpToX = selectedNode.x
-			self.jumpToY = selectedNode.y
-		end
-	end)
-
-	if not self.controls.allocatedNodeToggle then
-		self:BuildPowerReportUI()
-	end
-	self.controls.allocatedNodeToggle:SetAnchor("TOPLEFT", self.controls.powerReportList, main.portraitMode and "BOTTOMLEFT" or "TOPRIGHT")
-	self.controls.powerReportList.shown = self.showPowerReport
-
-	-- the report doesn't support listing the "offense/defense" hybrid heatmap, as it is not a single scalar and I'm unsure how to quantify numerically
-	-- especially given the heatmap's current approach of using the sqrt() of both components. that number is cryptic to users, i suspect.
-	if currentStat and currentStat.stat then
-		self.controls.powerReportList.label = "Click to focus node on tree"
-		self.controls.powerReportList.enabled = true
-	else
-		self.controls.powerReportList.label = "^7\"Offense/Defense\" not supported.  Select a specific stat from the dropdown."
-		self.controls.powerReportList.enabled = false
-	end
-
-	self.controls.allocatedNodeToggle.enabled = self.controls.powerReportList.enabled
-	self.controls.allocatedNodeDistance.shown = self.controls.powerReportList.allocated
-	self.controls.allocatedNodeToggle.label = self.controls.powerReportList.allocated and "Show Unallocated Nodes" or "Show allocated nodes"
+	self.build.calcsTab.powerStat = powerStat
+	self.controls.powerReportList:SetReport(powerStat, nil)
 end
 
 function TreeTabClass:BuildPowerReportList(currentStat)


### PR DESCRIPTION

### Description of the problem being solved:
"Show allocated nodes" button is overlapped by "Show/Hide Power Report" button after #6598.

This change adds a dropdown instead that replaces that button and the "Show clusters" checkbox.  The "show allocated" max path filter box was removed.  I think sorting by points column instead is good enough but let me know.

You can also "Show Power Report" immediately now instead of waiting for the first run to finish.

### Steps taken to verify a working solution:
- Tried different power stats
- Sorted by all power report columns
- Toggled off and on "Show Power Report" and "Show Node Power" in various states

### Before screenshot:
![image](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/1243476/2c7d153d-f88d-4a3b-9ecd-9b97a4398264)

### After screenshot:
![image](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/1243476/d8664925-d618-4fb2-adba-dd4e8aee0ecf)

