### PR TITLE
Don't try to flip ranges that aren't ranges

### DIFF
--- a/src/Classes/ItemsTab.lua
+++ b/src/Classes/ItemsTab.lua
@@ -633,6 +633,11 @@ holding Shift will put it in the second.]])
 
 				local minA, maxA = getMinMax(modA)
 				local minB, maxB = getMinMax(modB)
+
+				if not minA or not minB or not maxA or not maxB then
+					return false
+				end
+
 				local allInts = minA == m_floor(minA) and maxA == m_floor(maxA) and minB == m_floor(minB) and maxB == m_floor(maxB) -- if the mod goes in steps that aren't 1, then the code below this doesn't work
 				if (minA and minB and maxA and maxB and allInts) then
 					if (minA < minB) then -- ascending


### PR DESCRIPTION
Fixes #6620

### Description of the problem being solved:
Mods that had no range for its value (gain flask charges when hit on flasks, reduced attribute reqs on weapons) the code to flip the ranges crashed. This simply early returns false when one or both of the mods is not a range.

### Steps taken to verify a working solution:
- Tried crafting a flask with charge gain on hit and a weapon with reduced attribute requirements.