### PR TITLE
Improve dev mode startup time

### DIFF
--- a/src/Modules/Data.lua
+++ b/src/Modules/Data.lua
@@ -854,7 +854,7 @@ for _, minion in pairs(data.minions) do
 		mod.source = "Minion:"..minion.name
 	end
 end
-if launch.devMode then
+data.printMissingMinionSkills = function()
 	local missing = { }
 	for _, minion in pairs(data.minions) do
 		for _, skillId in ipairs(minion.skillList) do

--- a/src/Modules/Main.lua
+++ b/src/Modules/Main.lua
@@ -220,6 +220,9 @@ the "Releases" section of the GitHub page.]])
 	self.onFrameFuncs = {
 		["FirstFrame"] = function()
 			self.onFrameFuncs["FirstFrame"] = nil
+			if launch.devMode then
+				data.printMissingMinionSkills()
+			end
 			ConPrintf("Startup time: %d ms", GetTime() - launch.startTime)
 		end
 	}


### PR DESCRIPTION
Only in dev mode, improves startup time by about 1200 ms.

Printing to the initial green console that uses native Windows controls is very slow.  This change delays printing missing minion skills until after the native control console closes.  Fixing the console requires changes to SimpleGraphic.dll so easier to do a workaround in Lua for now.