### PR TITLE
Add item load coroutine to improve startup time

### DIFF
--- a/src/Classes/ItemDBControl.lua
+++ b/src/Classes/ItemDBControl.lua
@@ -290,7 +290,7 @@ function ItemDBClass:Draw(viewPort)
 		self.listBuilder = coroutine.create(self.ListBuilder)
 		self.listOutputRevision = self.itemsTab.build.outputRevision
 	end
-	if self.listBuilder then
+	if self.listBuilder and not self.db.loading then
 		local res, errMsg = coroutine.resume(self.listBuilder, self)
 		if launch.devMode and not res then
 			error(errMsg)
@@ -298,6 +298,9 @@ function ItemDBClass:Draw(viewPort)
 		if coroutine.status(self.listBuilder) == "dead" then
 			self.listBuilder = nil
 		end
+	end
+	if self.db.loading then
+		self.defaultText = "^7Loading..."
 	end
 	self.ListControl.Draw(self, viewPort)
 end

--- a/src/Modules/Common.lua
+++ b/src/Modules/Common.lua
@@ -525,6 +525,20 @@ function tableDeepEquals(t1, t2)
 	return true
 end
 
+function pairsYield(t)
+	local k
+	local start = GetTime()
+	return function() -- iterator function
+		if coroutine.running() and GetTime() - start > 20 then
+			coroutine.yield()
+			start = GetTime()
+		end
+		local v
+		k, v = next(t, k)
+		return k, v
+	end
+end
+
 -- Based on https://www.lua.org/pil/19.3.html
 function pairsSortByKey(t, f)
 	local sortedKeys = {}


### PR DESCRIPTION
Improves startup time by about 1030 ms.

Moved item loading to coroutine.  Item DB controls show "Loading..." until items are loaded.  If ModCache is being generated then items are loaded without a coroutine so they load before cache saves.

Also added new pairsYield utility function.

### Steps taken to verify a working solution:
- Item DB shows items after load completes, filtering and sorting works
- Tested ModCache generation

### After screenshot:
![image](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/1243476/f687cfec-c0ad-40ff-9318-662f2f1c3e8e)
