### PR TITLE
Show version and branch in error box

### DIFF
--- a/src/Launch.lua
+++ b/src/Launch.lua
@@ -357,7 +357,10 @@ end
 
 function launch:ShowErrMsg(fmt, ...)
 	if not self.promptMsg then
-		self:ShowPrompt(1, 0, 0, "^1Error:\n\n^0" .. string.format(fmt, ...) .. "\n\nPress Enter/Escape to Dismiss, or F5 to restart the application.")
+		local version = self.versionNumber and 
+			"^8v"..self.versionNumber..(self.versionBranch and " "..self.versionBranch or "")
+			or ""
+		self:ShowPrompt(1, 0, 0, "^1Error:\n\n^0"..string.format(fmt, ...).."\n"..version.."\n^0Press Enter/Escape to dismiss, or F5 to restart the application.")
 	end
 end
 


### PR DESCRIPTION
### Description of the problem being solved:
Show version/branch at bottom of error box.  Allows confirming version/branch when people send error screenshots.

### Steps taken to verify a working solution:
- Tested in dev and release master/beta branches

### After screenshot:
![image](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/1243476/4f88de0c-d05b-4721-b71d-e9e595dfa7c9)
