### PR TITLE
Add a remove account button to ImportTab

### DIFF
--- a/src/Classes/ImportTab.lua
+++ b/src/Classes/ImportTab.lua
@@ -72,7 +72,7 @@ local ImportTabClass = newClass("ImportTab", "ControlHost", "Control", function(
 	self.controls.accountHistory:SelByValue(main.lastAccountName)
 	self.controls.accountHistory:CheckDroppedWidth(true)
 
-	self.controls.removeAccount = new("ButtonControl", {"TOPLEFT",self.controls.accountRealm,"BOTTOMLEFT"}, 0, 8, 120, 20, "Remove account", function()
+	self.controls.removeAccount = new("ButtonControl", {"LEFT",self.controls.accountHistory,"RIGHT"}, 8, 0, 20, 20, "X", function()
 		local accountName = self.controls.accountHistory.list[self.controls.accountHistory.selIndex]
 		if (accountName ~= nil) then
 		t_remove(self.controls.accountHistory.list, self.controls.accountHistory.selIndex)
@@ -81,7 +81,12 @@ local ImportTabClass = newClass("ImportTab", "ControlHost", "Control", function(
 		end
 	end)
 
-	self.controls.accountNameUnicode = new("LabelControl", {"TOPLEFT",self.controls.removeAccount,"BOTTOMLEFT"}, 0, 16, 0, 14, "^7Note: if the account name contains non-ASCII characters then it must be URL encoded first.")
+	self.controls.removeAccount.tooltipFunc = function(tooltip)
+		tooltip:Clear()
+		tooltip:AddLine(16, "^7Removes account from the dropdown list")
+	end
+
+	self.controls.accountNameUnicode = new("LabelControl", {"TOPLEFT",self.controls.accountRealm,"BOTTOMLEFT"}, 0, 16, 0, 14, "^7Note: if the account name contains non-ASCII characters then it must be URL encoded first.")
 	self.controls.accountNameURLEncoder = new("ButtonControl", {"TOPLEFT",self.controls.accountNameUnicode,"BOTTOMLEFT"}, 0, 4, 170, 18, "^x4040FFhttps://www.urlencoder.org/", function()
 		OpenURL("https://www.urlencoder.org/")
 	end)

--- a/src/Classes/ImportTab.lua
+++ b/src/Classes/ImportTab.lua
@@ -5,6 +5,7 @@
 --
 local ipairs = ipairs
 local t_insert = table.insert
+local t_remove = table.remove
 local b_rshift = bit.rshift
 local band = bit.band
 
@@ -71,7 +72,16 @@ local ImportTabClass = newClass("ImportTab", "ControlHost", "Control", function(
 	self.controls.accountHistory:SelByValue(main.lastAccountName)
 	self.controls.accountHistory:CheckDroppedWidth(true)
 
-	self.controls.accountNameUnicode = new("LabelControl", {"TOPLEFT",self.controls.accountRealm,"BOTTOMLEFT"}, 0, 16, 0, 14, "^7Note: if the account name contains non-ASCII characters then it must be URL encoded first.")
+	self.controls.removeAccount = new("ButtonControl", {"TOPLEFT",self.controls.accountRealm,"BOTTOMLEFT"}, 0, 8, 120, 20, "Remove account", function()
+		local accountName = self.controls.accountHistory.list[self.controls.accountHistory.selIndex]
+		if (accountName ~= nil) then
+		t_remove(self.controls.accountHistory.list, self.controls.accountHistory.selIndex)
+		self.controls.accountHistory.list[accountName] = nil
+		main.gameAccounts[accountName] = nil
+		end
+	end)
+
+	self.controls.accountNameUnicode = new("LabelControl", {"TOPLEFT",self.controls.removeAccount,"BOTTOMLEFT"}, 0, 16, 0, 14, "^7Note: if the account name contains non-ASCII characters then it must be URL encoded first.")
 	self.controls.accountNameURLEncoder = new("ButtonControl", {"TOPLEFT",self.controls.accountNameUnicode,"BOTTOMLEFT"}, 0, 4, 170, 18, "^x4040FFhttps://www.urlencoder.org/", function()
 		OpenURL("https://www.urlencoder.org/")
 	end)


### PR DESCRIPTION
### Description of the problem being solved:

I often help people optimize and fix problems with their builds, and most of the time only want to import their account once.  This has led to me having a large list of account names that I had no intention of importing again in the future.  I know I can remove them manually from the settings.xml file, though I figured this might be a nice feature since this is a more convenient method, and some might not know to do that, 

### Steps taken to verify a working solution:
- Add some accounts to the list by importing them
- Click remove and the selected account will be removed from the dropdown, as well as from the settings.xml file once changes are saved

### Link to a build that showcases this PR:

https://github.com/CrazieJester/PathOfBuilding

### Before screenshot:

![image](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/11903802/c428a230-2ae8-4eee-aef0-0cf7e55aaadd)

### After screenshot:

![image](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/11903802/2eb0774d-caee-4d7b-8ca6-0a035334c6ad)

And after clicking the X button with CrazieJester selected

![image](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/11903802/c044b005-cc82-490d-89db-a06ed708b0c9)