### PR TITLE
Fix Party tab export crash for the node storm weaver

### DIFF
--- a/src/Modules/CalcPerform.lua
+++ b/src/Modules/CalcPerform.lua
@@ -2798,7 +2798,9 @@ function calcs.perform(env, fullDPSSkipEHP)
 								break
 							end
 						end
-                        if not skipValue and (not v[1] or ((v[1].type ~= "Condition" or (enemyDB.mods["Condition:"..v[1].var] and enemyDB.mods["Condition:"..v[1].var][1].value)) and (v[1].type ~= "Multiplier" or (enemyDB.mods["Multiplier:"..v[1].var] and enemyDB.mods["Multiplier:"..v[1].var][1].value)))) then
+                        if not skipValue and (not v[1] or (
+								(v[1].type ~= "Condition" or (v[1].var and (enemyDB.mods["Condition:"..v[1].var] and enemyDB.mods["Condition:"..v[1].var][1].value) or v[1].varList and (enemyDB.mods["Condition:"..v[1].varList[1]] and enemyDB.mods["Condition:"..v[1].varList[1]][1].value))) 
+								and (v[1].type ~= "Multiplier" or (enemyDB.mods["Multiplier:"..v[1].var] and enemyDB.mods["Multiplier:"..v[1].var][1].value)))) then
                             if buffExports["EnemyMods"][k] then
 								buffExports["EnemyMods"][k] = { MultiStat = true, buffExports["EnemyMods"][k] }
 								t_insert(buffExports["EnemyMods"][k], v)


### PR DESCRIPTION
Minor fix, now checks if it is a varlist instead of just var, but currently only checks the first var instead of all in the list, this only affects stormweaver which should almost always be triggered by shock instead of frozen anyway

The method for grabbing "valid" enemy mods is still very messy and should be cleaned up at some point