### PR TITLE
Attempt to open help popup at index of current tab

### DIFF
--- a/src/Modules/Main.lua
+++ b/src/Modules/Main.lua
@@ -437,7 +437,8 @@ function main:OnFrame()
 	if self.inputEvents and not itemLib.wiki.triggered then
 		for _, event in ipairs(self.inputEvents) do
 			if event.type == "KeyUp" and event.key == "F1" then
-				self:OpenAboutPopup(1)
+				local tabName = self.modes[self.mode].viewMode:lower() .. " tab"
+				self:OpenAboutPopup(tabName or 1)
 				break
 			end
 		end
@@ -1077,9 +1078,9 @@ function main:OpenAboutPopup(helpSectionIndex)
 		end
 	end
 	if helpSectionIndex and not helpSections[helpSectionIndex] then
-		local newIndex = nil
+		local newIndex = 1
 		for sectionIndex, sectionValues in ipairs(helpSections) do
-			if sectionValues.title == helpSectionIndex then
+			if sectionValues.title:lower() == helpSectionIndex then
 				newIndex = sectionIndex
 				break
 			end


### PR DESCRIPTION
If you use the hotkey to open the help popup, it will open it at the current tab if it exists (and named correctly) in the help file (eg currently party tab and items tab), 

This could be done better by tagging what the tab is actually called in the help file sections to match that instead of section name, but this works for the 2 tabs we currently have help sections for