### PR TITLE
Fix imported magic flasks missing their implicits

### DIFF
--- a/src/Classes/ImportTab.lua
+++ b/src/Classes/ImportTab.lua
@@ -748,10 +748,9 @@ function ImportTabClass:ImportItem(itemData, slotName)
 		return
 	end
 
-	local item = new("Item")
+	local item = new("Item", rarityMap[itemData.frameType])
 
-	-- Determine rarity, display name and base type of the item
-	item.rarity = rarityMap[itemData.frameType]
+	-- Determine display name and base type of the item
 	if #itemData.name > 0 then
 		item.title = itemLib.sanitiseItemText(itemData.name)
 		item.baseName = itemLib.sanitiseItemText(itemData.typeLine):gsub("Synthesised ","")

--- a/src/Classes/ImportTab.lua
+++ b/src/Classes/ImportTab.lua
@@ -748,9 +748,10 @@ function ImportTabClass:ImportItem(itemData, slotName)
 		return
 	end
 
-	local item = new("Item", rarityMap[itemData.frameType])
+	local item = new("Item")
 
-	-- Determine display name and base type of the item
+	-- Determine rarity, display name and base type of the item
+	item.rarity = rarityMap[itemData.frameType]
 	if #itemData.name > 0 then
 		item.title = itemLib.sanitiseItemText(itemData.name)
 		item.baseName = itemLib.sanitiseItemText(itemData.typeLine):gsub("Synthesised ","")

--- a/src/Classes/Item.lua
+++ b/src/Classes/Item.lua
@@ -289,6 +289,7 @@ function ItemClass:ParseRaw(raw, rarity, highQuality)
 	self.name = "?"
 	self.namePrefix = ""
 	self.nameSuffix = ""
+	self.base = nil
 	self.rarity = rarity or "UNIQUE"
 	self.quality = nil
 	self.rawLines = { }

--- a/src/Classes/Item.lua
+++ b/src/Classes/Item.lua
@@ -287,8 +287,8 @@ end
 function ItemClass:ParseRaw(raw, rarity, highQuality)
 	self.raw = raw
 	self.name = "?"
-	self.namePrefix = ""
-	self.nameSuffix = ""
+	self.namePrefix = self.namePrefix or ""
+	self.nameSuffix = self.nameSuffix or ""
 	self.rarity = rarity or "UNIQUE"
 	self.quality = nil
 	self.rawLines = { }

--- a/src/Classes/Item.lua
+++ b/src/Classes/Item.lua
@@ -287,8 +287,8 @@ end
 function ItemClass:ParseRaw(raw, rarity, highQuality)
 	self.raw = raw
 	self.name = "?"
-	self.namePrefix = self.namePrefix or ""
-	self.nameSuffix = self.nameSuffix or ""
+	self.namePrefix = ""
+	self.nameSuffix = ""
 	self.rarity = rarity or "UNIQUE"
 	self.quality = nil
 	self.rawLines = { }


### PR DESCRIPTION
### Description of the problem being solved:
Magic items imported from an account weren't getting names imported correctly.  See Discord report here: https://discord.com/channels/645607528297922560/680796887259021342/1150820315878928394
### Steps taken to verify a working solution:
- Imported flasks

I'd love to write some unit tests around this bug, but the item import code needs to be pulled into the Item class or at least made more testable.  I've left that for a separate PR for now.