### PR TITLE
Build Loadouts

### DIFF
--- a/help.txt
+++ b/help.txt
@@ -112,6 +112,10 @@ Militant Faith jewels also have the option to select the other mods on the jewel
 Advanced tricks:
     For Militant Faith, if you don't want any nodes to change, you can just sort by devotion. As unchanged nodes add devotion, the ones with the most devotion will be the ones with unchanged nodes
 	
+---[Build Tab]
+
+Loadouts can be selected from the dropdown in the top middle of the Build Tab. These are identically named sets of your Passive Tree, Items, and Skills. A set with that name has to exist across all three for it to register as a Loadout. When the user selects a Loadout it will switch to these dropdowns in all three locations. The "New Loadout" option allows the user to create all three sets from a single popup for convenience. the "Sync" option is a backup option to force the UI to update in case the user has changed this data behind the scenes.
+
 ---[Party Tab]
 
 The Party tab Allows you to import support characters and have their auras and curses apply

--- a/src/Classes/ItemsTab.lua
+++ b/src/Classes/ItemsTab.lua
@@ -1002,6 +1002,7 @@ function ItemsTabClass:Load(xml, dbFileName)
 	end
 	self:SetActiveItemSet(tonumber(xml.attrib.activeItemSet) or 1)
 	self:ResetUndo()
+	self.build:SyncLoadouts()
 end
 
 function ItemsTabClass:Save(xml)

--- a/src/Classes/SkillsTab.lua
+++ b/src/Classes/SkillsTab.lua
@@ -406,6 +406,7 @@ function SkillsTabClass:Load(xml, fileName)
 	self:SetActiveSkillSet(tonumber(xml.attrib.activeSkillSet) or 1)
 	self:SetDisplayGroup(self.socketGroupList[1])
 	self:ResetUndo()
+	self.build:SyncLoadouts()
 end
 
 function SkillsTabClass:Save(xml)
@@ -1326,4 +1327,7 @@ function SkillsTabClass:SetActiveSkillSet(skillSetId)
 	self.controls.groupList.list = self.socketGroupList
 	self.activeSkillSetId = skillSetId
 	self.build.buildFlag = true
+
+	-- set the loadout option to the dummy option since it is now dirty
+	self.build.controls.buildLoadouts:SetSel(1)
 end

--- a/src/Classes/TreeTab.lua
+++ b/src/Classes/TreeTab.lua
@@ -282,18 +282,14 @@ function TreeTabClass:Draw(viewPort, inputEvents)
 	self.viewer.compareSpec = self.isComparing and self.specList[self.activeCompareSpec] or nil
 	self.viewer:Draw(self.build, treeViewPort, inputEvents)
 
-	local newSpecList = { }
+	local newSpecList = self:GenerateSpecNameList()
 	self.controls.compareSelect.selIndex = self.activeCompareSpec
-	for id, spec in ipairs(self.specList) do
-		t_insert(newSpecList, (spec.treeVersion ~= latestTreeVersion and ("["..treeVersions[spec.treeVersion].display.."] ") or "")..(spec.title or "Default"))
-	end
 	self.controls.compareSelect:SetList(newSpecList)
 
 	self.controls.specSelect.selIndex = self.activeSpec
 	wipeTable(newSpecList)
-	for id, spec in ipairs(self.specList) do
-		t_insert(newSpecList, (spec.treeVersion ~= latestTreeVersion and ("["..treeVersions[spec.treeVersion].display.."] ") or "")..(spec.title or "Default"))
-	end
+	newSpecList = self:GenerateSpecNameList()
+
 	self.build.itemsTab.controls.specSelect:SetList(copyTable(newSpecList)) -- Update the passive tree dropdown control in itemsTab
 	t_insert(newSpecList, "Manage trees... (ctrl-m)")
 	self.controls.specSelect:SetList(newSpecList)
@@ -355,6 +351,7 @@ function TreeTabClass:Load(xml, dbFileName)
 		self.specList[1] = new("PassiveSpec", self.build, latestTreeVersion)
 	end
 	self:SetActiveSpec(tonumber(xml.attrib.activeSpec) or 1)
+	self.build:SyncLoadouts()
 end
 
 function TreeTabClass:PostLoad()
@@ -410,6 +407,9 @@ function TreeTabClass:SetActiveSpec(specId)
 	if self.controls.versionSelect then
 		self.controls.versionSelect:SelByValue(curSpec.treeVersion:gsub("%_", "."):gsub(".ruthless", " (ruthless)"))
 	end
+
+	-- set the loadout option to the dummy option since it is now dirty
+	self.build.controls.buildLoadouts:SetSel(1)
 end
 
 function TreeTabClass:SetCompareSpec(specId)
@@ -905,6 +905,19 @@ function TreeTabClass:BuildPowerReportList(currentStat)
 	end
 
 	return report
+end
+
+function TreeTabClass:GenerateSpecNameList(oldSpecList)
+	local newSpecList = oldSpecList
+	if (newSpecList == nil) then
+		newSpecList = {}
+	end
+
+	for _, spec in ipairs(self.specList) do
+		t_insert(newSpecList, (spec.treeVersion ~= latestTreeVersion and ("["..treeVersions[spec.treeVersion].display.."] ") or "")..(spec.title or "Default"))
+	end
+
+	return newSpecList
 end
 
 function TreeTabClass:FindTimelessJewel()

--- a/src/Modules/Build.lua
+++ b/src/Modules/Build.lua
@@ -227,7 +227,7 @@ function buildMode:Init(dbFileName, buildName, buildXML, convertBuild)
 		self.buildFlag = true
 	end)
 
-	self.controls.buildLoadouts = new("DropDownControl", {"LEFT",self.controls.ascendDrop,"RIGHT"}, 8, 0, 120, 20, {}, function(index, value)
+	self.controls.buildLoadouts = new("DropDownControl", {"LEFT",self.controls.ascendDrop,"RIGHT"}, 8, 0, 190, 20, {}, function(index, value)
 		-- Sync again just in case we're out of date
 		local treeList, itemList, skillList = self:SyncLoadouts()
 

--- a/src/Modules/Build.lua
+++ b/src/Modules/Build.lua
@@ -312,6 +312,7 @@ function buildMode:Init(dbFileName, buildName, buildXML, convertBuild)
 
 		self.controls.buildLoadouts:SelByValue(value)
 	end)
+	self.controls.buildLoadouts.tooltipText = "Loadouts are identically named sets of Passives/Items/Skills"
 	self:SyncLoadouts()
 
 	-- List of display stats


### PR DESCRIPTION
### Description of the problem being solved:
Currently, managing multiple sets of passive trees, items, and skill sets can be a serious pain. This is even worse for the consumer of a build guide who can easily get lost trying to juggle all the differences.

### Solution:
Loadouts!
![6Q4ip7P](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/144043193/7296f84f-4fd6-43e7-8cfc-5d45cf4ec634)

These are automatically generated based on identical namings of item/skills/passive trees, you can also use the dropdown option of "New Loadout" to create a new full set of all three to populate later.

The Sync option is for situations where the user mucks around with the different sets too much and wants to rerun the loadout generating function. This is preferred over triggering in the code every time one of these data sets is touched (there are a LOT of places where we'd have to insert code to listen, the code is not particularly conducive to a clean Observer without some refactoring).

There are a few places where I force it to Sync just so it doesn't get wildly out of date on load/etc.

When selecting a Loadout from the dropdown, all 3 dropdowns will select the proper set.

### Link to a build that showcases this PR:
https://pobb.in/u/Subtractem/1OOStQLc9ePX 

