### PR TITLE
remove triggerDuration from Tawhoa's cooldown calculation

### DIFF
--- a/src/Modules/CalcMirages.lua
+++ b/src/Modules/CalcMirages.lua
@@ -175,7 +175,6 @@ function calcs.mirages(env)
 
 		local triggerCD = env.player.mainSkill.skillData.cooldown
 		local triggeredCD
-		local triggerDuration = calcSkillDuration(env.player.mainSkill.skillModList, env.player.mainSkill.skillCfg, env.player.mainSkill.skillData, env, env.player.enemy.modDB)
 		local icdrSkill
 		local effectiveTriggerCD
 		local modActionCooldown
@@ -212,7 +211,7 @@ function calcs.mirages(env)
 				triggeredCD = newSkill.skillData.cooldown
 				icdrSkill = calcLib.mod(newSkill.skillModList, newSkill.skillCfg, "CooldownRecovery")
 
-				effectiveTriggerCD = (triggerCD / icdrSkill) + triggerDuration
+				effectiveTriggerCD = triggerCD / icdrSkill
 				modActionCooldown = m_max( triggeredCD or 0, effectiveTriggerCD or 0 ) / icdrSkill
 				rateCapAdjusted = m_ceil(modActionCooldown * data.misc.ServerTickRate) / data.misc.ServerTickRate
 				if modActionCooldown ~= 0 then
@@ -286,7 +285,6 @@ function calcs.mirages(env)
 							"",
 							s_format("%.2f ^8(Tawhoa's Chosen base cooldown)", triggerCD),
 							s_format("/ %.2f ^8(increased/reduced cooldown recovery)", icdrSkill),
-							s_format("+ %.2f ^8(only one Tawhoa's Chosen can be active at a time thus we add duration)", triggerDuration),
 							s_format("= %.2f ^8(effective trigger cooldown)", effectiveTriggerCD),
 							"",
 							s_format("%.2f ^8(biggest of trigger cooldown and triggered skill cooldown)", modActionCooldown),
@@ -303,7 +301,6 @@ function calcs.mirages(env)
 							"",
 							s_format("%.2f ^8(Tawhoa's Chosen base cooldown)", triggerCD),
 							s_format("/ %.2f ^8(increased/reduced cooldown recovery)", icdrSkill),
-							s_format("+ %.2f ^8(only one Tawhoa's Chosen can be active at a time thus we add duration)", triggerDuration),
 							s_format("= %.2f ^8(effective trigger cooldown)", effectiveTriggerCD),
 							"",
 							s_format("%.3f ^8(adjusted for server tick rate)", rateCapAdjusted),


### PR DESCRIPTION
Fixes #6664 .

### Description of the problem being solved:
When calculating the Trigger Rate Cap of Tawhoa's Chosen the duration was added to the cooldown, but this behavior has changed in the game with the current Version (3.22). 

### Steps taken to verify a working solution:
- The Trigger Rate Cap does not add the Duration of the Skill to the cooldown
- The Skill Trigger Rate and the DPS of Tawhoa's Chosen is calculated accordingly.

### Link to a build that showcases this PR:
https://pobb.in/MkLqsOqQ4KPt

### Before screenshot:
![image](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/15085553/6b56bd42-cb24-403a-8adf-e24f153d372b)

### After screenshot:
![image](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/15085553/62fa56f0-1242-4b1e-b286-ddd144b9f508)
