### PR TITLE
Fix Unicode input for PoeCharm

### DIFF
--- a/src/Classes/EditControl.lua
+++ b/src/Classes/EditControl.lua
@@ -42,7 +42,7 @@ local EditClass = newClass("EditControl", "ControlHost", "Control", "UndoHandler
 	self.TooltipHost()
 	self:SetText(init or "")
 	self.prompt = prompt
-	self.filter = filter or "^%w%p "
+	self.filter = filter or (main.unicode and "%c" or "^%w%p ")
 	self.filterPattern = "["..self.filter.."]"
 	self.limit = limit
 	self.changeFunc = changeFunc

--- a/src/Modules/Main.lua
+++ b/src/Modules/Main.lua
@@ -40,6 +40,7 @@ local tempTable2 = { }
 main = new("ControlHost")
 
 function main:Init()
+	self:DetectUnicodeSupport()
 	self.modes = { }
 	self.modes["LIST"] = LoadModule("Modules/BuildList")
 	self.modes["BUILD"] = LoadModule("Modules/Build")
@@ -252,6 +253,15 @@ the "Releases" section of the GitHub page.]])
 				error(errMsg)
 			end
 		end
+	end
+end
+
+function main:DetectUnicodeSupport()
+	-- In PoeCharm returns a valid width, in normal PoB returns 2142240768
+	local w = DrawStringWidth(16, "VAR", "\195\164") -- U+00E4 LATIN SMALL LETTER A WITH DIAERESIS
+	self.unicode = w > 0 and w < 100
+	if self.unicode then
+		ConPrintf("Unicode support detected")
 	end
 end
 


### PR DESCRIPTION
Fixes #6634.

### Description of the problem being solved:
Allow Unicode input in EditControls when running under [PoeCharm](https://github.com/Chuanhsing/PoeCharm).  Added a DetectUnicodeSupport function that uses DrawStringWidth to detect if running under PoeCharm and if so changes the default input filter on EditControl.

I couldn't figure out how to test Unicode input in PoeCharm, even the file boxes it should already work in didn't work for me when I switched Windows languages to try it.  Maybe someone that knows more about PoeCharm can test.

### Steps taken to verify a working solution:
- Tested normal PoB still filters Unicode on those controls
- Tested DetectUnicodeSupport works in PoB and PoeCharm
