### PR TITLE
Party Tab, remove unnecessary addition to modDB for player life

### DIFF
--- a/src/Classes/PartyTab.lua
+++ b/src/Classes/PartyTab.lua
@@ -707,9 +707,6 @@ function PartyTabClass:ParseBuffs(list, buf, buffType, label)
 					else
 						local k, v = line:match("([%w ]-%w+)=(.+)")
 						label[k] = tonumber(v)
-						if k == "Life" then -- special cases that needs to be mods
-							list:NewMod(k, "BASE", v, "Party")
-						end
 					end
 				elseif line ~= "" then
 					list:NewMod(line, "FLAG", true, "Party")


### PR DESCRIPTION
The special case for adding the party members life to the modDB is unnecessary as its grabbed directly out of output anyway, so removing unnecessary code that may cause bugs in the future if that modDB is used