### PR TITLE
PoeCharm detection now checks for global utf8 table

### DIFF
--- a/src/Modules/Main.lua
+++ b/src/Modules/Main.lua
@@ -262,9 +262,8 @@ the "Releases" section of the GitHub page.]])
 end
 
 function main:DetectUnicodeSupport()
-	-- In PoeCharm returns a valid width, in normal PoB returns 2142240768
-	local w = DrawStringWidth(16, "VAR", "\195\164") -- U+00E4 LATIN SMALL LETTER A WITH DIAERESIS
-	self.unicode = w > 0 and w < 100
+	-- PoeCharm has utf8 global that normal PoB doesn't have
+	self.unicode = type(_G.utf8) == "table"
 	if self.unicode then
 		ConPrintf("Unicode support detected")
 	end


### PR DESCRIPTION
### Description of the problem being solved:
Better PoeCharm detection that doesn't rely on DrawStringWidth using invalid glyphs.  Checks for global utf8 table instead.

### Steps taken to verify a working solution:
- Tested in PoeCharm and normal PoB
