### PR TITLE
Restrict trigger source for CwC using CwC gem tags

### DIFF
--- a/src/Modules/CalcTriggers.lua
+++ b/src/Modules/CalcTriggers.lua
@@ -248,7 +248,7 @@ local function CWCHandler(env)
 		for _, skill in ipairs(env.player.activeSkillList) do
 			local match1 = env.player.mainSkill.activeEffect.grantedEffect.fromItem and skill.socketGroup and skill.socketGroup.slot == env.player.mainSkill.socketGroup.slot
 			local match2 = (not env.player.mainSkill.activeEffect.grantedEffect.fromItem) and skill.socketGroup == env.player.mainSkill.socketGroup
-			if skill.skillTypes[SkillType.Channel] and skill ~= env.player.mainSkill and (match1 or match2) and not isTriggered(skill) then
+			if calcLib.canGrantedEffectSupportActiveSkill(env.player.mainSkill.triggeredBy.gemData.grantedEffect, skill) and skill ~= env.player.mainSkill and (match1 or match2) and not isTriggered(skill) then
 				source, trigRate = findTriggerSkill(env, skill, source, trigRate)
 			end
 			if skill.skillData.triggeredWhileChannelling and (match1 or match2) then


### PR DESCRIPTION
Fixes #6653 .

### Description of the problem being solved:
Cast While Channeling support requires the source skill to not have the SkillType.SummonsTotem tag. The handler func was not checking that and then used a value which is added by:

```Lua
skill("triggerTime", nil, { type = "SkillType", skillType = SkillType.Channel } ),
```

which did not exist because cwc was not supporting that trigger source.
