### PR TITLE
Disable forced ModCache regen for tests

### DIFF
--- a/src/HeadlessWrapper.lua
+++ b/src/HeadlessWrapper.lua
@@ -169,7 +169,7 @@ dofile("Launch.lua")
 -- Prevents loading of ModCache
 -- Allows running mod parsing related tests without pushing ModCache
 -- The CI env var will be true when run from github workflows but should be false for other tools using the headless wrapper 
-mainObject.continuousIntegrationMode = os.getenv("CI") 
+mainObject.continuousIntegrationMode = os.getenv("CI")
 
 runCallback("OnInit")
 runCallback("OnFrame") -- Need at least one frame for everything to initialise

--- a/src/Modules/Main.lua
+++ b/src/Modules/Main.lua
@@ -65,7 +65,7 @@ function main:Init()
 		-- If modLib.parseMod doesn't find a cache entry it generates it.
 		-- Not loading pre-generated cache causes it to be rebuilt
 		self.saveNewModCache = true
-	elseif not launch.continuousIntegrationMode then -- Forces regeneration of modCache if ran from CI
+	else
 		-- Load mod cache
 		LoadModule("Data/ModCache", modLib.parseModCache)
 	end


### PR DESCRIPTION
### Description of the problem being solved:
Due to modCache being sorted now and the decision being made to include it in pull requests this should be unnecessary and only slows down test runs.