### PR TITLE
Fix rare bug affecting allocating imported cluster nodes

### DIFF
--- a/src/Classes/PassiveSpec.lua
+++ b/src/Classes/PassiveSpec.lua
@@ -1365,7 +1365,7 @@ function PassiveSpecClass:BuildSubgraph(jewel, parentSocket, id, upSize, importe
 		if proxyGroup then
 			for id, data in pairs(importedNodes) do
 				if proxyGroup == data.group then
-					if node.oidx == data.orbitIndex and node.type ~= "Mastery" then
+					if node.oidx == data.orbitIndex and not data.isMastery then
 						for _, extendedId in ipairs(importedGroups[proxyGroup].nodes) do
 							if id == tonumber(extendedId) and inExtendedHashes(id) then
 								return true


### PR DESCRIPTION
### Description of the problem being solved:
Mastery nodes always get and index of 0.  Some nodes on cluster jewel could also have an index of 0.  Rarely, if Lua happened to iterate through the nodes and reached the mastery node first, it'd try to allocate it and fail, exiting the loop entirely.  Imported nodes should never contain a mastery node for a cluster jewel, so this check was just checking the wrong node for if it's a mastery or not.  This PR corrects that change.
### Steps taken to verify a working solution:
- Verified against one example of this bug: https://discord.com/channels/676181894152454150/676256416218218496/1151613833224400966
### Link to a build that showcases this PR:
No link applicable, because it only happens on character import.  This was one example, but you may have to ask them to reallocate nodes, as their character has changed since testing: gladvold -> diyu_chiefGoBoom
