### PR TITLE
Stop reordering gems on import

### DIFF
--- a/src/Classes/ImportTab.lua
+++ b/src/Classes/ImportTab.lua
@@ -1025,12 +1025,7 @@ function ImportTabClass:ImportSocketedItems(item, socketedItems, slotName)
 					itemSocketGroupList[groupID] = { label = "", enabled = true, gemList = { }, slot = slotName }
 				end
 				local socketGroup = itemSocketGroupList[groupID]
-				if not socketedItem.support and socketGroup.gemList[1] and socketGroup.gemList[1].support then
-					-- If the first gemInstance is a support gemInstance, put the first active gemInstance before it
-					t_insert(socketGroup.gemList, 1, gemInstance)
-				else
-					t_insert(socketGroup.gemList, gemInstance)
-				end
+				t_insert(socketGroup.gemList, gemInstance)
 			end
 		end
 	end


### PR DESCRIPTION
Fixes #6721

### Description of the problem being solved:
Currently imported gems are sorted on import. Putting skill gems at the top and support gems at the bottom. This reordering causes issues with importing builds that use [Dialla's Malefaction](https://www.poewiki.net/wiki/Dialla%27s_Malefaction) where the order of gems matters.

This behavior seems to have been implemented a long time ago in https://github.com/PathOfBuildingCommunity/PathOfBuilding/commit/0b2912b22540e0063180023c9cedf1ba0738f9b3#diff-c5b45cc2adeffbfd2d3f81625693c14819ecf7b1b5d5f4a6cd8a1bef1b5d340cR443

I assume this was a way to fix https://github.com/PathOfBuildingCommunity/PathOfBuilding/pull/4886 and https://github.com/PathOfBuildingCommunity/PathOfBuilding/pull/6707 but may not be necessary any more.