### PR TITLE
Improve support for minions applying auras

### DIFF
--- a/src/Classes/PartyTab.lua
+++ b/src/Classes/PartyTab.lua
@@ -765,7 +765,7 @@ function PartyTabClass:ParseBuffs(list, buf, buffType, label)
 			else
 				if line:find("|") and currentName ~= "SKIP" and not line:find("MinionModifier|LIST") then
 					if currentModType == "otherEffects" then
-						currentName, currentEffect, line = line:match("([%w ]-%w+)|(%w+)|(.+)")
+						currentName, currentEffect, line = line:match("([%w ']-%w+)|(%w+)|(.+)")
 					end
 					local mod = modLib.parseFormattedSourceMod(line)
 					if mod then

--- a/src/Data/Minions.lua
+++ b/src/Data/Minions.lua
@@ -845,6 +845,31 @@ minions["GuardianSentinel"] = {
 	},
 }
 
+-- This is a fake Minion to apply all 3 auras
+minions["GuardianRelicAll"] = {
+	name = "All Relics",
+	life = 4,
+	energyShield = 0.6,
+	fireResist = 40,
+	coldResist = 40,
+	lightningResist = 40,
+	chaosResist = 20,
+	damage = 1,
+	damageSpread = 0,
+	attackTime = 1,
+	attackRange = 6,
+	accuracy = 1,
+	skillList = {
+		"RelicTeleport",
+		"Anger",
+		"Hatred",
+		"Wrath",
+	},
+	modList = {
+		-- EmergeSpeedHigh [emerge_speed_+% = 0]
+	},
+}
+
 minions["GuardianRelicFire"] = {
 	name = "Fire Relic",
 	life = 4,

--- a/src/Data/Skills/minion.lua
+++ b/src/Data/Skills/minion.lua
@@ -297,7 +297,7 @@ skills["MonsterProjectileSpellLightningGolemSummoned"] = {
 	},
 }
 skills["LightningGolemWrath"] = {
-	name = "Wrath",
+	name = "Lightning Golem Wrath",
 	hidden = true,
 	color = 3,
 	baseEffectiveness = 0.16249999403954,

--- a/src/Data/Skills/other.lua
+++ b/src/Data/Skills/other.lua
@@ -2652,6 +2652,7 @@ skills["SummonGuardianRelic"] = {
 	castTime = 1,
 	fromTree = true,
 	minionList = {
+		"GuardianRelicAll",
 		"GuardianRelicFire",
 		"GuardianRelicCold",
 		"GuardianRelicLightning",

--- a/src/Data/Skills/other.lua
+++ b/src/Data/Skills/other.lua
@@ -2653,9 +2653,6 @@ skills["SummonGuardianRelic"] = {
 	fromTree = true,
 	minionList = {
 		"GuardianRelicAll",
-		"GuardianRelicFire",
-		"GuardianRelicCold",
-		"GuardianRelicLightning",
 	},
 	statMap = {
 		["minion_actor_level_is_user_level_up_to_maximum"] = {

--- a/src/Export/Minions/Minions.txt
+++ b/src/Export/Minions/Minions.txt
@@ -140,6 +140,31 @@ local minions, mod = ...
 #monster Metadata/Monsters/Axis/AxisEliteSoldierRadiance GuardianSentinel
 #emit
 
+-- This is a fake Minion to apply all 3 auras
+minions["GuardianRelicAll"] = {
+	name = "All Relics",
+	life = 4,
+	energyShield = 0.6,
+	fireResist = 40,
+	coldResist = 40,
+	lightningResist = 40,
+	chaosResist = 20,
+	damage = 1,
+	damageSpread = 0,
+	attackTime = 1,
+	attackRange = 6,
+	accuracy = 1,
+	skillList = {
+		"RelicTeleport",
+		"Anger",
+		"Hatred",
+		"Wrath",
+	},
+	modList = {
+		-- EmergeSpeedHigh [emerge_speed_+% = 0]
+	},
+}
+
 #monster Metadata/Monsters/AnimatedItem/ElementalLivingRelicFire GuardianRelicFire
 #emit
 

--- a/src/Export/Skills/minion.txt
+++ b/src/Export/Skills/minion.txt
@@ -47,7 +47,7 @@ local skills, mod, flag, skill = ...
 #flags spell projectile
 #mods
 
-#skill LightningGolemWrath Wrath
+#skill LightningGolemWrath Lightning Golem Wrath
 #flags spell aura area duration
 	statMap = {
 		["attack_minimum_added_lightning_damage"] = {

--- a/src/Export/Skills/other.txt
+++ b/src/Export/Skills/other.txt
@@ -738,9 +738,6 @@ local skills, mod, flag, skill = ...
 	fromTree = true,
 	minionList = {
 		"GuardianRelicAll",
-		"GuardianRelicFire",
-		"GuardianRelicCold",
-		"GuardianRelicLightning",
 	},
 	statMap = {
 		["minion_actor_level_is_user_level_up_to_maximum"] = {

--- a/src/Export/Skills/other.txt
+++ b/src/Export/Skills/other.txt
@@ -737,6 +737,7 @@ local skills, mod, flag, skill = ...
 #flags spell minion duration
 	fromTree = true,
 	minionList = {
+		"GuardianRelicAll",
 		"GuardianRelicFire",
 		"GuardianRelicCold",
 		"GuardianRelicLightning",

--- a/src/Modules/CalcPerform.lua
+++ b/src/Modules/CalcPerform.lua
@@ -2023,6 +2023,12 @@ function calcs.perform(env, fullDPSSkipEHP)
 								if activeMinionSkill.skillData.thisIsNotABuff then
 									buffs[buff.name].notBuff = true
 								end
+								if partyTabEnableExportBuffs then
+									local inc = modStore:Sum("INC", skillCfg, "BuffEffect")
+									local more = modStore:More(skillCfg, "BuffEffect")
+									buffExports["Aura"]["otherEffects"] = buffExports["Aura"]["otherEffects"] or { }
+									buffExports["Aura"]["otherEffects"][buff.name] =  { effectMult = (1 + inc / 100) * more, modList = buff.modList }
+								end
 							end
 							local envMinionCheck = (env.minion and (env.minion == castingMinion or buff.applyAllies))
 							if buff.applyMinions or envMinionCheck then

--- a/src/Modules/CalcPerform.lua
+++ b/src/Modules/CalcPerform.lua
@@ -2039,8 +2039,8 @@ function calcs.perform(env, fullDPSSkipEHP)
 									activeSkill.minion.modDB.conditions["AffectedBy"..buff.name:gsub(" ","")] = true
 								end
 								local srcList = new("ModList")
-								local inc = modStore:Sum("INC", skillCfg, "BuffEffect", "BuffEffectOnMinion", (env.minion == castingMinion) and "BuffEffectOnSelf" or nil)
-								local more = modStore:More(skillCfg, "BuffEffect", "BuffEffectOnMinion", (env.minion == castingMinion) and "BuffEffectOnSelf" or nil)
+								local inc = modStore:Sum("INC", skillCfg, "BuffEffect", (env.minion == castingMinion) and "BuffEffectOnSelf" or nil)
+								local more = modStore:More(skillCfg, "BuffEffect", (env.minion == castingMinion) and "BuffEffectOnSelf" or nil)
 								srcList:ScaleAddList(buff.modList, (1 + inc / 100) * more)
 								mergeBuff(srcList, minionBuffs, buff.name)
 								mergeBuff(buff.modList, minionBuffs, buff.name)

--- a/src/Modules/CalcPerform.lua
+++ b/src/Modules/CalcPerform.lua
@@ -2083,6 +2083,141 @@ function calcs.perform(env, fullDPSSkipEHP)
 			end
 		end
 	end
+	
+	-- Limited support for handling buffs originating from minions like Spectres or guardian elemental relics
+	for _, activeSkill in ipairs(env.player.activeSkillList) do
+		if activeSkill.minion then
+			for _, activeMinionSkill in ipairs(activeSkill.minion.activeSkillList) do
+				if activeMinionSkill.buffList then
+					local skillModList = activeMinionSkill.skillModList
+					local skillCfg = activeMinionSkill.skillCfg
+					for _, buff in ipairs(activeMinionSkill.buffList) do
+						if buff.type == "Buff" and activeMinionSkill.skillData.enable then
+							if buff.applyAllies then
+								activeMinionSkill.buffSkill = true
+								modDB.conditions["AffectedBy"..buff.name:gsub(" ","")] = true
+								local srcList = new("ModList")
+								local inc = skillModList:Sum("INC", skillCfg, "BuffEffect", "BuffEffectOnPlayer")
+								local more = skillModList:More(skillCfg, "BuffEffect", "BuffEffectOnPlayer")
+								srcList:ScaleAddList(buff.modList, (1 + inc / 100) * more)
+								mergeBuff(srcList, buffs, buff.name)
+								mergeBuff(buff.modList, buffs, buff.name)
+								if activeMinionSkill.skillData.thisIsNotABuff then
+									buffs[buff.name].notBuff = true
+								end
+							end
+							if buff.applyMinions then
+								activeMinionSkill.minionBuffSkill = true
+								activeSkill.minion.modDB.conditions["AffectedBy"..buff.name:gsub(" ","")] = true
+								local srcList = new("ModList")
+								local inc = skillModList:Sum("INC", skillCfg, "BuffEffect", "BuffEffectOnMinion")
+								local more = skillModList:More(skillCfg, "BuffEffect", "BuffEffectOnMinion")
+								srcList:ScaleAddList(buff.modList, (1 + inc / 100) * more)
+								mergeBuff(srcList, minionBuffs, buff.name)
+								mergeBuff(buff.modList, minionBuffs, buff.name)
+								if activeMinionSkill.skillData.thisIsNotABuff then
+									buffs[buff.name].notBuff = true
+								end
+							end
+						elseif buff.type == "Aura" then
+							if env.mode_buffs then
+								-- Check for extra modifiers to apply to aura skills
+								local extraAuraModList = { }
+								for _, value in ipairs(activeSkill.minion.modDB:List(skillCfg, "ExtraAuraEffect")) do
+									local add = true
+									for _, mod in ipairs(extraAuraModList) do
+										if modLib.compareModParams(mod, value.mod) then
+											mod.value = mod.value + value.mod.value
+											add = false
+											break
+										end
+									end
+									if add then
+										t_insert(extraAuraModList, copyTable(value.mod, true))
+									end
+								end
+								if not (activeSkill.minion.modDB:Flag(nil, "SelfAurasCannotAffectAllies") or activeSkill.minion.modDB:Flag(nil, "SelfAurasOnlyAffectYou") or activeSkill.minion.modDB:Flag(nil, "SelfAuraSkillsCannotAffectAllies")) then
+									if not modDB:Flag(nil, "AlliesAurasCannotAffectSelf") and not modDB.conditions["AffectedBy"..buff.name:gsub(" ","")] then
+										local inc = skillModList:Sum("INC", skillCfg, "AuraEffect", "BuffEffect", "BuffEffectOnPlayer", "AuraBuffEffect") + modDB:Sum("INC", skillCfg, "BuffEffectOnSelf", "AuraEffectOnSelf")
+										local more = skillModList:More(skillCfg, "AuraEffect", "BuffEffect", "AuraBuffEffect") * modDB:More(skillCfg, "BuffEffectOnSelf", "AuraEffectOnSelf")
+										local mult = (1 + inc / 100) * more
+										if not allyBuffs["Aura"] or not allyBuffs["Aura"][buff.name] or allyBuffs["Aura"][buff.name].effectMult / 100 <= mult then
+											activeMinionSkill.buffSkill = true
+											modDB.conditions["AffectedByAura"] = true
+											if buff.name:sub(1,4) == "Vaal" then
+												modDB.conditions["AffectedBy"..buff.name:sub(6):gsub(" ","")] = true
+											end
+											modDB.conditions["AffectedBy"..buff.name:gsub(" ","")] = true
+											local srcList = new("ModList")
+											srcList:ScaleAddList(buff.modList, mult)
+											srcList:ScaleAddList(extraAuraModList, mult)
+											mergeBuff(srcList, buffs, buff.name)
+										end
+									end
+									if env.minion and not env.minion.modDB.conditions["AffectedBy"..buff.name:gsub(" ","")] then
+										local inc = skillModList:Sum("INC", skillCfg, "AuraEffect", "BuffEffect") + env.minion.modDB:Sum("INC", skillCfg, "BuffEffectOnSelf", "AuraEffectOnSelf")
+										local more = skillModList:More(skillCfg, "AuraEffect", "BuffEffect") * env.minion.modDB:More(skillCfg, "BuffEffectOnSelf", "AuraEffectOnSelf")
+										local mult = (1 + inc / 100) * more
+										if not allyBuffs["Aura"] or  not allyBuffs["Aura"][buff.name] or allyBuffs["Aura"][buff.name].effectMult / 100 <= mult then
+											activeMinionSkill.minionBuffSkill = true
+											env.minion.modDB.conditions["AffectedBy"..buff.name:gsub(" ","")] = true
+											env.minion.modDB.conditions["AffectedByAura"] = true
+											local srcList = new("ModList")
+											srcList:ScaleAddList(buff.modList, mult)
+											srcList:ScaleAddList(extraAuraModList, mult)
+											mergeBuff(srcList, minionBuffs, buff.name)
+										end
+									end
+									local inc = skillModList:Sum("INC", skillCfg, "AuraEffect", "BuffEffect")
+									local more = skillModList:More(skillCfg, "AuraEffect", "BuffEffect")
+									local mult = (1 + inc / 100) * more
+									local newModList = new("ModList")
+									newModList:AddList(buff.modList)
+									newModList:AddList(extraAuraModList)
+									if buffExports["Aura"][buff.name] then
+										buffExports["Aura"][buff.name.."_Debuff"] = buffExports["Aura"][buff.name]
+									end
+									buffExports["Aura"][buff.name] = { effectMult = mult, modList = newModList }
+									if env.player.mainSkill.skillFlags.totem and not env.player.mainSkill.skillModList.conditions["AffectedBy"..buff.name:gsub(" ","")] then
+										activeMinionSkill.totemBuffSkill = true
+										env.player.mainSkill.skillModList.conditions["AffectedBy"..buff.name:gsub(" ","")] = true
+										env.player.mainSkill.skillModList.conditions["AffectedByAura"] = true
+
+										local srcList = new("ModList")
+										local inc = skillModList:Sum("INC", skillCfg, "AuraEffect", "BuffEffect", "AuraBuffEffect")
+										local more = skillModList:More(skillCfg, "AuraEffect", "BuffEffect", "AuraBuffEffect")
+										local lists = {extraAuraModList, buff.modList}
+										local scale = (1 + inc / 100) * more
+										scale = m_max(scale, 0)
+										
+										for _, modList in ipairs(lists) do
+											for _, mod in ipairs(modList) do
+												if mod.name == "EnergyShield" or mod.name == "Armour" or mod.name == "Evasion" or mod.name:match("Resist?M?a?x?$") then
+													local totemMod = copyTable(mod)
+													totemMod.name = "Totem"..totemMod.name
+													if scale ~= 1 then
+														if type(totemMod.value) == "number" then
+															totemMod.value = (m_floor(totemMod.value) == totemMod.value) and m_modf(round(totemMod.value * scale, 2)) or totemMod.value * scale
+														elseif type(totemMod.value) == "table" and totemMod.value.mod then
+															totemMod.value.mod.value = (m_floor(totemMod.value.mod.value) == totemMod.value.mod.value) and m_modf(round(totemMod.value.mod.value * scale, 2)) or totemMod.value.mod.value * scale
+														end
+													end
+													srcList:AddMod(totemMod)
+												end
+											end
+										end
+										mergeBuff(srcList, buffs, "Totem "..buff.name)
+									end
+								end
+							end
+						end
+					end
+				end
+			end
+		end
+	end
+	
+	
 	if allyBuffs["otherEffects"] then
 		for buffName, buff in pairs(allyBuffs["otherEffects"]) do
 			modDB.conditions["AffectedBy"..buffName:gsub(" ","")] = true
@@ -2177,48 +2312,6 @@ function calcs.perform(env, fullDPSSkipEHP)
 				local srcList = new("ModList")
 				srcList:ScaleAddList(link.modList, (link.effectMult or 100) / 100)
 				mergeBuff(srcList, buffs, linkName)
-			end
-		end
-	end
-
-	-- Limited support for handling buffs originating from Spectres
-	for _, activeSkill in ipairs(env.player.activeSkillList) do
-		if activeSkill.minion then
-			for _, activeMinionSkill in ipairs(activeSkill.minion.activeSkillList) do
-				if activeMinionSkill.skillData.enable then
-					local skillModList = activeMinionSkill.skillModList
-					local skillCfg = activeMinionSkill.skillCfg
-					for _, buff in ipairs(activeMinionSkill.buffList) do
-						if buff.type == "Buff" then
-							if buff.applyAllies then
-								activeMinionSkill.buffSkill = true
-								modDB.conditions["AffectedBy"..buff.name:gsub(" ","")] = true
-								local srcList = new("ModList")
-								local inc = skillModList:Sum("INC", skillCfg, "BuffEffect", "BuffEffectOnPlayer")
-								local more = skillModList:More(skillCfg, "BuffEffect", "BuffEffectOnPlayer")
-								srcList:ScaleAddList(buff.modList, (1 + inc / 100) * more)
-								mergeBuff(srcList, buffs, buff.name)
-								mergeBuff(buff.modList, buffs, buff.name)
-								if activeMinionSkill.skillData.thisIsNotABuff then
-									buffs[buff.name].notBuff = true
-								end
-							end
-							if buff.applyMinions then
-								activeMinionSkill.minionBuffSkill = true
-								activeSkill.minion.modDB.conditions["AffectedBy"..buff.name:gsub(" ","")] = true
-								local srcList = new("ModList")
-								local inc = skillModList:Sum("INC", skillCfg, "BuffEffect")
-								local more = skillModList:More(skillCfg, "BuffEffect")
-								srcList:ScaleAddList(buff.modList, (1 + inc / 100) * more)
-								mergeBuff(srcList, minionBuffs, buff.name)
-								mergeBuff(buff.modList, minionBuffs, buff.name)
-								if activeMinionSkill.skillData.thisIsNotABuff then
-									buffs[buff.name].notBuff = true
-								end
-							end
-						end
-					end
-				end
 			end
 		end
 	end

--- a/src/Modules/ConfigOptions.lua
+++ b/src/Modules/ConfigOptions.lua
@@ -541,13 +541,13 @@ return {
 		modList:NewMod("SkillData", "LIST", { key = "beamOverlapMultiplier", value = val }, "Config", { type = "SkillName", skillName = "Storm Rain" })
 	end },
 	{ label = "Summon Elemental Relic:", ifSkill = "Summon Elemental Relic" },
-	{ var = "summonElementalRelicEnableAngerAura", type = "check", label = "Enable Anger Aura:", ifSkill = "Summon Elemental Relic", apply = function(val, modList, enemyModList)
+	{ var = "summonElementalRelicEnableAngerAura", type = "check", defaultState = true, label = "Enable Anger Aura:", ifSkill = "Summon Elemental Relic", apply = function(val, modList, enemyModList)
 		modList:NewMod("SkillData", "LIST", { key = "enable", value = true }, "Config", { type = "SkillId", skillId = "Anger" }, { type = "SkillName", skillName = "Summon Elemental Relic", summonSkill = true })
 	end },
-	{ var = "summonElementalRelicEnableHatredAura", type = "check", label = "Enable Hatred Aura:", ifSkill = "Summon Elemental Relic", apply = function(val, modList, enemyModList)
+	{ var = "summonElementalRelicEnableHatredAura", type = "check", defaultState = true, label = "Enable Hatred Aura:", ifSkill = "Summon Elemental Relic", apply = function(val, modList, enemyModList)
 		modList:NewMod("SkillData", "LIST", { key = "enable", value = true }, "Config", { type = "SkillId", skillId = "Hatred" }, { type = "SkillName", skillName = "Summon Elemental Relic", summonSkill = true })
 	end },
-	{ var = "summonElementalRelicEnableWrathAura", type = "check", label = "Enable Wrath Aura:", ifSkill = "Summon Elemental Relic", apply = function(val, modList, enemyModList)
+	{ var = "summonElementalRelicEnableWrathAura", type = "check", defaultState = true, label = "Enable Wrath Aura:", ifSkill = "Summon Elemental Relic", apply = function(val, modList, enemyModList)
 		modList:NewMod("SkillData", "LIST", { key = "enable", value = true }, "Config", { type = "SkillId", skillId = "Wrath" }, { type = "SkillName", skillName = "Summon Elemental Relic", summonSkill = true })
 	end },
 	{ label = "Summon Holy Relic:", ifSkill = "Summon Holy Relic" },

--- a/src/Modules/ConfigOptions.lua
+++ b/src/Modules/ConfigOptions.lua
@@ -540,6 +540,16 @@ return {
 	{ var = "stormRainBeamOverlap", type = "count", label = "# of Overlapping Beams:", ifSkill = "Storm Rain", apply = function(val, modList, enemyModList)
 		modList:NewMod("SkillData", "LIST", { key = "beamOverlapMultiplier", value = val }, "Config", { type = "SkillName", skillName = "Storm Rain" })
 	end },
+	{ label = "Summon Elemental Relic:", ifSkill = "Summon Elemental Relic" },
+	{ var = "summonElementalRelicEnableAngerAura", type = "check", label = "Enable Anger Aura:", ifSkill = "Summon Elemental Relic", apply = function(val, modList, enemyModList)
+		modList:NewMod("SkillData", "LIST", { key = "enable", value = true }, "Config", { type = "SkillId", skillId = "Anger" }, { type = "SkillName", skillName = "Summon Elemental Relic", summonSkill = true })
+	end },
+	{ var = "summonElementalRelicEnableHatredAura", type = "check", label = "Enable Hatred Aura:", ifSkill = "Summon Elemental Relic", apply = function(val, modList, enemyModList)
+		modList:NewMod("SkillData", "LIST", { key = "enable", value = true }, "Config", { type = "SkillId", skillId = "Hatred" }, { type = "SkillName", skillName = "Summon Elemental Relic", summonSkill = true })
+	end },
+	{ var = "summonElementalRelicEnableWrathAura", type = "check", label = "Enable Wrath Aura:", ifSkill = "Summon Elemental Relic", apply = function(val, modList, enemyModList)
+		modList:NewMod("SkillData", "LIST", { key = "enable", value = true }, "Config", { type = "SkillId", skillId = "Wrath" }, { type = "SkillName", skillName = "Summon Elemental Relic", summonSkill = true })
+	end },
 	{ label = "Summon Holy Relic:", ifSkill = "Summon Holy Relic" },
 	{ var = "summonHolyRelicEnableHolyRelicBoon", type = "check", label = "Enable Holy Relic's Boon Aura:", ifSkill = "Summon Holy Relic", apply = function(val, modList, enemyModList)
 		modList:NewMod("Condition:HolyRelicBoonActive", "FLAG", true, "Config")


### PR DESCRIPTION
Fixes #6739 .

Adds support for minions to apply auras. This still has the issue that only 1 relic is active at a time
![image](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/49933620/392e9f44-bb03-49c6-b41d-03e675c7f065)

