### PR TITLE
Fix guardian minion levels

### DIFF
--- a/src/Data/Skills/other.lua
+++ b/src/Data/Skills/other.lua
@@ -2652,6 +2652,11 @@ skills["SummonGuardianRelic"] = {
 		"GuardianRelicCold",
 		"GuardianRelicLightning",
 	},
+	statMap = {
+		["minion_actor_level_is_user_level_up_to_maximum"] = {
+			skill("minionLevelIsPlayerLevel", true),
+		},
+	},
 	baseFlags = {
 		spell = true,
 		minion = true,
@@ -2667,7 +2672,7 @@ skills["SummonGuardianRelic"] = {
 		"base_skill_effect_duration",
 	},
 	levels = {
-		[20] = { 5000, storedUses = 1, levelRequirement = 85, cooldown = 0.3, statInterpolation = { 1, }, },
+		[20] = { 5000, storedUses = 1, levelRequirement = 4, cooldown = 0.3, statInterpolation = { 1, }, },
 	},
 }
 skills["SummonHarbingerOfTheArcaneUber"] = {
@@ -3027,6 +3032,9 @@ skills["SummonRadiantSentinel"] = {
 			mod("MinionModifier", "LIST", { mod = mod("Multiplier:GuardianSentinelFireAuraRadius", "BASE", nil) }),
 			mod("ExtraMinionSkill", "LIST", { skillId = "GuardianSentinelFireAura" }),
 		},
+		["minion_actor_level_is_user_level_up_to_maximum"] = {
+			skill("minionLevelIsPlayerLevel", true),
+		},
 	},
 	baseFlags = {
 		spell = true,
@@ -3043,7 +3051,7 @@ skills["SummonRadiantSentinel"] = {
 		"radiant_sentinel_minion_fire_%_of_life_to_deal_nearby_per_minute",
 	},
 	levels = {
-		[20] = { 45, 1800, damageEffectiveness = 2, critChance = 6, levelRequirement = 85, statInterpolation = { 1, 1, }, cost = { Mana = 40, }, },
+		[20] = { 45, 1800, damageEffectiveness = 2, critChance = 6, levelRequirement = 12, statInterpolation = { 1, 1, }, cost = { Mana = 40, }, },
 	},
 }
 skills["SummonRigwaldsPack"] = {

--- a/src/Export/Skills/other.txt
+++ b/src/Export/Skills/other.txt
@@ -737,6 +737,11 @@ local skills, mod, flag, skill = ...
 		"GuardianRelicCold",
 		"GuardianRelicLightning",
 	},
+	statMap = {
+		["minion_actor_level_is_user_level_up_to_maximum"] = {
+			skill("minionLevelIsPlayerLevel", true),
+		},
+	},
 #mods
 
 #skill SummonHarbingerOfTheArcaneUber
@@ -831,6 +836,9 @@ local skills, mod, flag, skill = ...
 		["radiant_sentinel_minion_burning_effect_radius"] = {
 			mod("MinionModifier", "LIST", { mod = mod("Multiplier:GuardianSentinelFireAuraRadius", "BASE", nil) }),
 			mod("ExtraMinionSkill", "LIST", { skillId = "GuardianSentinelFireAura" }),
+		},
+		["minion_actor_level_is_user_level_up_to_maximum"] = {
+			skill("minionLevelIsPlayerLevel", true),
 		},
 	},
 #mods

--- a/src/Modules/CalcActiveSkill.lua
+++ b/src/Modules/CalcActiveSkill.lua
@@ -609,7 +609,7 @@ function calcs.buildActiveSkillModList(env, activeSkill)
 			minion.enemy = env.enemy
 			minion.type = minionType
 			minion.minionData = env.data.minions[minionType]
-			minion.level = activeSkill.skillData.minionLevelIsEnemyLevel and env.enemyLevel or activeSkill.skillData.minionLevel or activeEffect.grantedEffectLevel.levelRequirement
+			minion.level = activeSkill.skillData.minionLevelIsEnemyLevel and env.enemyLevel or activeSkill.skillData.minionLevelIsPlayerLevel and (m_min(env.build and env.build.characterLevel or minion.level, 85)) or activeSkill.skillData.minionLevel or activeEffect.grantedEffectLevel.levelRequirement
 			-- fix minion level between 1 and 100
 			minion.level = m_min(m_max(minion.level,1),100) 
 			minion.itemList = { }

--- a/src/Modules/CalcActiveSkill.lua
+++ b/src/Modules/CalcActiveSkill.lua
@@ -609,7 +609,9 @@ function calcs.buildActiveSkillModList(env, activeSkill)
 			minion.enemy = env.enemy
 			minion.type = minionType
 			minion.minionData = env.data.minions[minionType]
-			minion.level = activeSkill.skillData.minionLevelIsEnemyLevel and env.enemyLevel or activeSkill.skillData.minionLevelIsPlayerLevel and (m_min(env.build and env.build.characterLevel or minion.level, 85)) or activeSkill.skillData.minionLevel or activeEffect.grantedEffectLevel.levelRequirement
+			minion.level = activeSkill.skillData.minionLevelIsEnemyLevel and env.enemyLevel or 
+								activeSkill.skillData.minionLevelIsPlayerLevel and (m_min(env.build and env.build.characterLevel or activeSkill.skillData.minionLevel or activeEffect.grantedEffectLevel.levelRequirement, activeSkill.skillData.minionLevelIsPlayerLevel)) or 
+								activeSkill.skillData.minionLevel or activeEffect.grantedEffectLevel.levelRequirement
 			-- fix minion level between 1 and 100
 			minion.level = m_min(m_max(minion.level,1),100) 
 			minion.itemList = { }


### PR DESCRIPTION
Fixes the guardian minions level not following the player level, 

Should probs make use of the value of "minion_actor_level_is_user_level_up_to_maximum" rather than hardcoding it to cap at 85