### PR TITLE
move generic damage if consumed a corpse recently to skill stat map

### DIFF
--- a/src/Data/SkillStatMap.lua
+++ b/src/Data/SkillStatMap.lua
@@ -1727,6 +1727,9 @@ return {
 ["snipe_triggered_skill_damage_+%_final"] = {
 	mod("Damage", "MORE", nil),
 },
+["damage_+%_if_you_have_consumed_a_corpse_recently"] = {
+	mod("Damage", "INC", nil, 0, 0, { type = "Condition", var = "ConsumedCorpseRecently" }),
+},
 ["withered_on_hit_chance_%"] = {
 	flag("Condition:CanWither"),
 },

--- a/src/Data/Skills/sup_int.lua
+++ b/src/Data/Skills/sup_int.lua
@@ -1898,9 +1898,6 @@ skills["SupportDevour"] = {
 		["killing_blow_consumes_corpse_restore_x_mana"] = {
 			mod("ManaOnKill", "BASE", nil),
 		},
-		["damage_+%_if_you_have_consumed_a_corpse_recently"] = {
-			mod("Damage", "INC", nil, 0, 0, { type = "Condition", var = "ConsumedCorpseRecently" }),
-		},
 	},
 	qualityStats = {
 		Default = {

--- a/src/Export/Skills/sup_int.txt
+++ b/src/Export/Skills/sup_int.txt
@@ -276,9 +276,6 @@ local skills, mod, flag, skill = ...
 		["killing_blow_consumes_corpse_restore_x_mana"] = {
 			mod("ManaOnKill", "BASE", nil),
 		},
-		["damage_+%_if_you_have_consumed_a_corpse_recently"] = {
-			mod("Damage", "INC", nil, 0, 0, { type = "Condition", var = "ConsumedCorpseRecently" }),
-		},
 	},
 #mods
 


### PR DESCRIPTION
The stat "damage_+%_if_you_have_consumed_a_corpse_recently" is a relatively generic wording and might be added to other skills in the future, moving this now incase it is used in the future