### PR TITLE
Fix gem display issues with red text when supported

### DIFF
--- a/src/Data/Skills/act_int.lua
+++ b/src/Data/Skills/act_int.lua
@@ -5404,6 +5404,9 @@ skills["GlacialCascade"] = {
 		["glacial_cascade_final_spike_damage_+%_final"] = {
 			mod("Damage", "MORE", nil, 0, 0, { type = "SkillPart", skillPart = 2 }),
 		},
+		["quality_display_glacial_cascade_is_gem"] = {
+			-- Display Only
+		},
 	},
 	baseFlags = {
 		spell = true,
@@ -9034,6 +9037,7 @@ skills["CircleOfPower"] = {
 			mod("Multiplier:SigilOfPowerMaxStages", "BASE", nil, 0, 0, { type = "GlobalEffect", effectType = "Buff" }),
 		},
 		["quality_display_circle_of_power_is_gem"] = {
+			-- Display Only
         },
 	},
 	baseFlags = {
@@ -10125,7 +10129,11 @@ skills["Stormbind"] = {
 		["active_skill_quality_damage_+%_final"] = {
 			mod("Damage", "MORE", nil),
 		},
+		["quality_display_rune_paint_is_gem"] = {
+			-- Display Only
+		},
 		["rune_paint_max_rune_level"] = {
+			-- Display Only
 		},
 	},
 	baseFlags = {

--- a/src/Data/Skills/act_str.lua
+++ b/src/Data/Skills/act_str.lua
@@ -4625,6 +4625,9 @@ skills["IceCrash"] = {
 		["ice_crash_third_hit_damage_+%_final"] = {
 			mod("Damage", "MORE", nil, 0, 0, { type = "SkillPart", skillPart = 3 }),
 		},
+		["quality_display_ice_crash_is_gem"] = {
+			-- Display Only
+		},
 	},
 	baseFlags = {
 		attack = true,
@@ -4724,6 +4727,9 @@ skills["ImmortalCall"] = {
 		["immortal_call_elemental_damage_taken_+%_final_per_endurance_charge_consumed_permyriad"] = {
 			mod("ElementalDamageTaken", "MORE", nil, 0, 0, { type = "GlobalEffect", effectType = "Guard" }, { type = "Multiplier", var = "RemovableEnduranceCharge", limit = 5 }),
 			div = 100,
+		},
+		["quality_display_immortal_call_is_gem"] = {
+			-- Display Only
 		},
 	},
 	baseFlags = {
@@ -5776,6 +5782,9 @@ skills["PetrifiedBlood"] = {
 		},
 		["petrified_blood_%_prevented_life_loss_to_lose_over_time"] = {
 			mod("LifeLossBelowHalfLost", "BASE", nil, 0, 0, { type = "GlobalEffect", effectType = "Buff", effectName = "Petrified Blood" }),
+		},
+		["cannot_recover_above_low_life_except_flasks"] = {
+			-- Display Only, this mod controls multiple lines for some reason
 		},
 	},
 	baseFlags = {

--- a/src/Export/Skills/act_int.txt
+++ b/src/Export/Skills/act_int.txt
@@ -1220,6 +1220,9 @@ local skills, mod, flag, skill = ...
 		["glacial_cascade_final_spike_damage_+%_final"] = {
 			mod("Damage", "MORE", nil, 0, 0, { type = "SkillPart", skillPart = 2 }),
 		},
+		["quality_display_glacial_cascade_is_gem"] = {
+			-- Display Only
+		},
 	},
 #baseMod skill("radius", 12)
 #baseMod mod("AreaOfEffect", "MORE", 100, 0, 0, { type = "SkillPart", skillPart = 2 })
@@ -2059,6 +2062,7 @@ local skills, mod, flag, skill = ...
 			mod("Multiplier:SigilOfPowerMaxStages", "BASE", nil, 0, 0, { type = "GlobalEffect", effectType = "Buff" }),
 		},
 		["quality_display_circle_of_power_is_gem"] = {
+			-- Display Only
         },
 	},
 #baseMod skill("radius", 30)
@@ -2220,7 +2224,11 @@ local skills, mod, flag, skill = ...
 		["active_skill_quality_damage_+%_final"] = {
 			mod("Damage", "MORE", nil),
 		},
+		["quality_display_rune_paint_is_gem"] = {
+			-- Display Only
+		},
 		["rune_paint_max_rune_level"] = {
+			-- Display Only
 		},
 	},
 #baseMod mod("Multiplier:RuneLevel", "BASE", 1, 0, 0, { type = "SkillPart", skillPart = 2 })

--- a/src/Export/Skills/act_str.txt
+++ b/src/Export/Skills/act_str.txt
@@ -842,6 +842,9 @@ local skills, mod, flag, skill = ...
 		["ice_crash_third_hit_damage_+%_final"] = {
 			mod("Damage", "MORE", nil, 0, 0, { type = "SkillPart", skillPart = 3 }),
 		},
+		["quality_display_ice_crash_is_gem"] = {
+			-- Display Only
+		},
 	},
 #baseMod skill("radius", 26)
 #mods
@@ -862,6 +865,9 @@ local skills, mod, flag, skill = ...
 		["immortal_call_elemental_damage_taken_+%_final_per_endurance_charge_consumed_permyriad"] = {
 			mod("ElementalDamageTaken", "MORE", nil, 0, 0, { type = "GlobalEffect", effectType = "Guard" }, { type = "Multiplier", var = "RemovableEnduranceCharge", limit = 5 }),
 			div = 100,
+		},
+		["quality_display_immortal_call_is_gem"] = {
+			-- Display Only
 		},
 	},
 #mods
@@ -1079,6 +1085,9 @@ local skills, mod, flag, skill = ...
 		},
 		["petrified_blood_%_prevented_life_loss_to_lose_over_time"] = {
 			mod("LifeLossBelowHalfLost", "BASE", nil, 0, 0, { type = "GlobalEffect", effectType = "Buff", effectName = "Petrified Blood" }),
+		},
+		["cannot_recover_above_low_life_except_flasks"] = {
+			-- Display Only, this mod controls multiple lines for some reason
 		},
 	},
 #mods


### PR DESCRIPTION
Ice crash, immortal call, petrified blood, stormbind, and glacial cascade all have stats which are supported but are on a different stat to the displayed one, this just turns the text to the correct colour of blue