### PR TITLE
Add support for tornado shot secondary projectiles skill part

### DIFF
--- a/src/Data/Skills/act_dex.lua
+++ b/src/Data/Skills/act_dex.lua
@@ -15164,11 +15164,11 @@ skills["TornadoShot"] = {
 	preDamageFunc = function(activeSkill, output)
 		if activeSkill.skillPart == 2 and (output.ReturnChance or 0) == 0 then
 			local averageSecondaryProjectiles = output.ProjectileCount + (output.SplitCount or 0)
-			-- if barrage then only shoots 1 projectile at a time, but those can still split and still releases atleast 1 secondary projectile
+			-- if barrage then only shoots 1 projectile at a time, but those can still split and still releases at least 1 secondary projectile
 			if activeSkill.skillModList:Flag(nil, "SequentialProjectiles") and not activeSkill.skillModList:Flag(nil, "OneShotProj") and not activeSkill.skillModList:Flag(nil,"NoAdditionalProjectiles") and not activeSkill.skillModList:Flag(nil, "TriggeredBySnipe") then
 				averageSecondaryProjectiles = 1 + (output.SplitCount or 0)
 			end
-			-- default to 20% per secondary projectile, so 60% base, and 80% with helm ench
+			-- default to 20% per secondary projectile, so 60% base, and 80% with helm enchant
 			local chanceForSecondaryProjectilesToHit = math.min((activeSkill.skillData.tornadoShotSecondaryHitChance or (20 * activeSkill.skillModList:Sum("BASE", activeSkill.skillCfg, "tornadoShotSecondaryProjectiles"))) / 100, 1)
 			activeSkill.skillData.dpsMultiplier = (activeSkill.skillData.dpsMultiplier or 1) * (1 + chanceForSecondaryProjectilesToHit * averageSecondaryProjectiles)
 		end

--- a/src/Data/Skills/act_dex.lua
+++ b/src/Data/Skills/act_dex.lua
@@ -15153,6 +15153,31 @@ skills["TornadoShot"] = {
 	},
 	statDescriptionScope = "skill_stat_descriptions",
 	castTime = 1,
+	parts = {
+		{
+			name = "Single Projectile",
+		},
+		{
+			name = "Combined Average Secondary Projectiles",
+		},
+	},
+	preDamageFunc = function(activeSkill, output)
+		if activeSkill.skillPart == 2 and (output.ReturnChance or 0) == 0 then
+			local averageSecondaryProjectiles = output.ProjectileCount + (output.SplitCount or 0)
+			-- if barrage then only shoots 1 projectile at a time, but those can still split and still releases atleast 1 secondary projectile
+			if activeSkill.skillModList:Flag(nil, "SequentialProjectiles") and not activeSkill.skillModList:Flag(nil, "OneShotProj") and not activeSkill.skillModList:Flag(nil,"NoAdditionalProjectiles") and not activeSkill.skillModList:Flag(nil, "TriggeredBySnipe") then
+				averageSecondaryProjectiles = 1 + (output.SplitCount or 0)
+			end
+			-- default to 20% per secondary projectile, so 60% base, and 80% with helm ench
+			local chanceForSecondaryProjectilesToHit = math.min((activeSkill.skillData.tornadoShotSecondaryHitChance or (20 * activeSkill.skillModList:Sum("BASE", activeSkill.skillCfg, "tornadoShotSecondaryProjectiles"))) / 100, 1)
+			activeSkill.skillData.dpsMultiplier = (activeSkill.skillData.dpsMultiplier or 1) * (1 + chanceForSecondaryProjectilesToHit * averageSecondaryProjectiles)
+		end
+	end,
+	statMap = {
+		["tornado_shot_num_of_secondary_projectiles"] = {
+			mod("tornadoShotSecondaryProjectiles", "BASE", nil),
+		},
+	},
 	baseFlags = {
 		attack = true,
 		projectile = true,

--- a/src/Export/Skills/act_dex.txt
+++ b/src/Export/Skills/act_dex.txt
@@ -2937,7 +2937,7 @@ local skills, mod, flag, skill = ...
 			name = "Single Projectile",
 		},
 		{
-			name = "Combined Average Secondary Projectiles",
+			name = "Combined Average Projectiles",
 		},
 	},
 	preDamageFunc = function(activeSkill, output)

--- a/src/Export/Skills/act_dex.txt
+++ b/src/Export/Skills/act_dex.txt
@@ -2943,11 +2943,11 @@ local skills, mod, flag, skill = ...
 	preDamageFunc = function(activeSkill, output)
 		if activeSkill.skillPart == 2 and (output.ReturnChance or 0) == 0 then
 			local averageSecondaryProjectiles = output.ProjectileCount + (output.SplitCount or 0)
-			-- if barrage then only shoots 1 projectile at a time, but those can still split and still releases atleast 1 secondary projectile
+			-- if barrage then only shoots 1 projectile at a time, but those can still split and still releases at least 1 secondary projectile
 			if activeSkill.skillModList:Flag(nil, "SequentialProjectiles") and not activeSkill.skillModList:Flag(nil, "OneShotProj") and not activeSkill.skillModList:Flag(nil,"NoAdditionalProjectiles") and not activeSkill.skillModList:Flag(nil, "TriggeredBySnipe") then
 				averageSecondaryProjectiles = 1 + (output.SplitCount or 0)
 			end
-			-- default to 20% per secondary projectile, so 60% base, and 80% with helm ench
+			-- default to 20% per secondary projectile, so 60% base, and 80% with helm enchant
 			local chanceForSecondaryProjectilesToHit = math.min((activeSkill.skillData.tornadoShotSecondaryHitChance or (20 * activeSkill.skillModList:Sum("BASE", activeSkill.skillCfg, "tornadoShotSecondaryProjectiles"))) / 100, 1)
 			activeSkill.skillData.dpsMultiplier = (activeSkill.skillData.dpsMultiplier or 1) * (1 + chanceForSecondaryProjectilesToHit * averageSecondaryProjectiles)
 		end

--- a/src/Export/Skills/act_dex.txt
+++ b/src/Export/Skills/act_dex.txt
@@ -2932,6 +2932,31 @@ local skills, mod, flag, skill = ...
 
 #skill TornadoShot
 #flags attack projectile
+	parts = {
+		{
+			name = "Single Projectile",
+		},
+		{
+			name = "Combined Average Secondary Projectiles",
+		},
+	},
+	preDamageFunc = function(activeSkill, output)
+		if activeSkill.skillPart == 2 and (output.ReturnChance or 0) == 0 then
+			local averageSecondaryProjectiles = output.ProjectileCount + (output.SplitCount or 0)
+			-- if barrage then only shoots 1 projectile at a time, but those can still split and still releases atleast 1 secondary projectile
+			if activeSkill.skillModList:Flag(nil, "SequentialProjectiles") and not activeSkill.skillModList:Flag(nil, "OneShotProj") and not activeSkill.skillModList:Flag(nil,"NoAdditionalProjectiles") and not activeSkill.skillModList:Flag(nil, "TriggeredBySnipe") then
+				averageSecondaryProjectiles = 1 + (output.SplitCount or 0)
+			end
+			-- default to 20% per secondary projectile, so 60% base, and 80% with helm ench
+			local chanceForSecondaryProjectilesToHit = math.min((activeSkill.skillData.tornadoShotSecondaryHitChance or (20 * activeSkill.skillModList:Sum("BASE", activeSkill.skillCfg, "tornadoShotSecondaryProjectiles"))) / 100, 1)
+			activeSkill.skillData.dpsMultiplier = (activeSkill.skillData.dpsMultiplier or 1) * (1 + chanceForSecondaryProjectilesToHit * averageSecondaryProjectiles)
+		end
+	end,
+	statMap = {
+		["tornado_shot_num_of_secondary_projectiles"] = {
+			mod("tornadoShotSecondaryProjectiles", "BASE", nil),
+		},
+	},
 #mods
 
 #skill TornadoShotAltX

--- a/src/Modules/ConfigOptions.lua
+++ b/src/Modules/ConfigOptions.lua
@@ -595,7 +595,7 @@ return {
 		modList:NewMod("Multiplier:NearbyBleedingEnemies", "BASE", val, "Config" )
 	end },
 	{ label = "Tornado Shot:", ifSkill = "Tornado Shot" },
-	{ var = "tornadoShotSecondaryHitChance", type = "count", label = "% chance for second proj to hit:", tooltip = "Override to the percent chance for the secondary projectiles to hit, defualt of 60% or 80% with helm enchant. (20% per secondary projectile)", ifSkill = "Tornado Shot", apply = function(val, modList, enemyModList)
+	{ var = "tornadoShotSecondaryHitChance", type = "count", label = "% chance for second proj to hit:", tooltip = "Override to the percent chance for the secondary projectiles to hit, default of 60% or 80% with helm enchant. (20% per secondary projectile)", ifSkill = "Tornado Shot", apply = function(val, modList, enemyModList)
 		modList:NewMod("SkillData", "LIST", { key = "tornadoShotSecondaryHitChance", value = val }, "Config", { type = "SkillName", skillName = "Tornado Shot" })
 	end },
 	{ label = "Toxic Rain:", ifSkill = "Toxic Rain", includeTransfigured = true },

--- a/src/Modules/ConfigOptions.lua
+++ b/src/Modules/ConfigOptions.lua
@@ -594,6 +594,10 @@ return {
 	{ var = "nearbyBleedingEnemies", type = "count", label = "# of Nearby Bleeding Enemies:", ifSkill = "Thirst for Blood", apply = function(val, modList, enemyModList)
 		modList:NewMod("Multiplier:NearbyBleedingEnemies", "BASE", val, "Config" )
 	end },
+	{ label = "Tornado Shot:", ifSkill = "Tornado Shot" },
+	{ var = "tornadoShotSecondaryHitChance", type = "count", label = "% chance for second proj to hit:", tooltip = "Override to the percent chance for the secondary projectiles to hit, defualt of 60% or 80% with helm enchant. (20% per secondary projectile)", ifSkill = "Tornado Shot", apply = function(val, modList, enemyModList)
+		modList:NewMod("SkillData", "LIST", { key = "tornadoShotSecondaryHitChance", value = val }, "Config", { type = "SkillName", skillName = "Tornado Shot" })
+	end },
 	{ label = "Toxic Rain:", ifSkill = "Toxic Rain", includeTransfigured = true },
 	{ var = "toxicRainPodOverlap", type = "count", label = "# of Overlapping Pods:", tooltip = "Maximum is limited by the number of Projectiles.", ifSkill = "Toxic Rain", includeTransfigured = true, apply = function(val, modList, enemyModList)
 		modList:NewMod("SkillData", "LIST", { key = "podOverlapMultiplier", value = val }, "Config", { type = "SkillName", skillName = "Toxic Rain", includeTransfigured = true })

--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -3824,6 +3824,7 @@ local specialModList = {
 	["caustic arrow and scourge arrow fire (%d+)%% more projectiles"] = function(num) return { mod("ProjectileCount", "MORE", num, nil, { type = "SkillName", skillNameList = { "Caustic Arrow", "Scourge Arrow" }, includeTransfigured = true }) } end,
 	["essence drain and soulrend fire (%d+) additional projectiles"] = function(num) return { mod("ProjectileCount", "BASE", num, nil, { type = "SkillName", skillNameList = { "Essence Drain", "Soulrend" }, includeTransfigured = true }) } end,
 	["(%d+)%% reduced essence drain and soulrend projectile speed"] = function(num) return { mod("ProjectileSpeed", "INC", -num, nil, { type = "SkillName", skillNameList = { "Essence Drain", "Soulrend" }, includeTransfigured = true }) } end,
+	["tornado shot fires an additional secondary projectile"] = { mod("tornadoShotSecondaryProjectiles", "BASE", 1, nil, { type = "SkillName", skillNameList = { "Tornado Shot" } }) },
 	["projectiles pierce an additional target"] = { mod("PierceCount", "BASE", 1) },
 	["projectiles pierce (%d+) targets?"] = function(num) return { mod("PierceCount", "BASE", num) } end,
 	["projectiles pierce (%d+) additional targets?"] = function(num) return { mod("PierceCount", "BASE", num) } end,


### PR DESCRIPTION
Adds a second skill part for tornado shot, which deals extra dps based on the combined average number of secondary projectiles which hit

If tornado shot does not return, each projectile tornado shot shoots (and any from splitting) fires 3-4 secondary projectiles, of which 1 can hit the original target again, the chance this happens is configurable, and if not configured increases with the helm enchant

Uses #6738 and #6744 but they are not required to be merged for this to function