### PR TITLE
Fix eHP miscalculation with shared guard

### DIFF
--- a/src/Modules/CalcDefence.lua
+++ b/src/Modules/CalcDefence.lua
@@ -141,16 +141,10 @@ function calcs.reducePoolsByDamage(poolTable, damageTable, actor)
 	local LifeLossLostOverTime = poolTbl.LifeLossLostOverTime or 0
 	local LifeBelowHalfLossLostOverTime = poolTbl.LifeBelowHalfLossLostOverTime or 0
 
-	-- Split shared guard between damage types, based on proportion of total damage
-	local sharedGuardPerDamageType = { }
-	if guard.shared > 0 then
-		local damageTotal = 0
-		for _, damage in pairs(damageTable) do
-			damageTotal = damageTotal + damage
-		end
-		for damageType, damage in pairs(damageTable) do
-			sharedGuardPerDamageType[damageType] = guard.shared * damage / damageTotal
-		end
+	local sharedGuardTotal = guard.shared
+	local damageTotal = 0
+	for _, damage in pairs(damageTable) do
+		damageTotal = damageTotal + damage
 	end
 
 	for damageType, damage in pairs(damageTable) do
@@ -187,7 +181,8 @@ function calcs.reducePoolsByDamage(poolTable, damageTable, actor)
 			damageRemainder = damageRemainder - tempDamage
 		end
 		if guard.shared > 0 then
-			local tempDamage = m_min(damageRemainder * output.sharedGuardAbsorbRate / 100, sharedGuardPerDamageType[damageType])
+			-- Apply shared guard proportionial to damage type
+			local tempDamage = m_min(damageRemainder * output.sharedGuardAbsorbRate / 100, sharedGuardTotal * damage / damageTotal)
 			guard.shared = guard.shared - tempDamage
 			damageRemainder = damageRemainder - tempDamage
 		end

--- a/src/Modules/CalcDefence.lua
+++ b/src/Modules/CalcDefence.lua
@@ -85,11 +85,11 @@ end
 ---@param damageTable table damage table after all the relevant reductions
 ---@param actor table actor (with output and modDB) for which to calculate the pools
 ---@return table pools reduced by damage
-function calcs.reducePoolsByDamage(poolTable, damageTable, actor)
+function calcs.reducePoolsByDamage(poolTable, damageTable, actor, numberOfHits)
 	local output = actor.output
 	local modDB = actor.modDB
 	local poolTbl = poolTable or { }
-	
+
 	local alliesTakenBeforeYou = poolTbl.AlliesTakenBeforeYou
 	if not alliesTakenBeforeYou then
 		alliesTakenBeforeYou = {}
@@ -140,107 +140,114 @@ function calcs.reducePoolsByDamage(poolTable, damageTable, actor)
 	local life = poolTbl.Life or output.LifeRecoverable or 0
 	local LifeLossLostOverTime = poolTbl.LifeLossLostOverTime or 0
 	local LifeBelowHalfLossLostOverTime = poolTbl.LifeBelowHalfLossLostOverTime or 0
-	
+
+	numberOfHits = numberOfHits or 1
 	for damageType, damage in pairs(damageTable) do
-		local damageRemainder = damage
-		for _, allyValues in pairs(alliesTakenBeforeYou) do
-			if not allyValues.damageType or allyValues.damageType == damageType then
-				if allyValues.remaining > 0 then
-					local tempDamage = m_min(damageRemainder * allyValues.percent, allyValues.remaining)
-					allyValues.remaining = allyValues.remaining - tempDamage
+		damageTable[damageType] = damage / numberOfHits
+	end
+	
+	for hit = 1, numberOfHits do
+		for damageType, damage in pairs(damageTable) do
+			local damageRemainder = damage
+			for _, allyValues in pairs(alliesTakenBeforeYou) do
+				if not allyValues.damageType or allyValues.damageType == damageType then
+					if allyValues.remaining > 0 then
+						local tempDamage = m_min(damageRemainder * allyValues.percent, allyValues.remaining)
+						allyValues.remaining = allyValues.remaining - tempDamage
+						damageRemainder = damageRemainder - tempDamage
+					end
+				end
+			end
+			-- frost shield / soul link / other taken before you does not count as you taking damage
+			PoolsLost[damageType] = (PoolsLost[damageType] or 0) + damageRemainder
+			if aegis[damageType] > 0 then
+				local tempDamage = m_min(damageRemainder, aegis[damageType])
+				aegis[damageType] = aegis[damageType] - tempDamage
+				damageRemainder = damageRemainder - tempDamage
+			end
+			if isElemental[damageType] and aegis.sharedElemental > 0 then
+				local tempDamage = m_min(damageRemainder, aegis.sharedElemental)
+				aegis.sharedElemental = aegis.sharedElemental - tempDamage
+				damageRemainder = damageRemainder - tempDamage
+			end
+			if aegis.shared > 0 then
+				local tempDamage = m_min(damageRemainder, aegis.shared)
+				aegis.shared = aegis.shared - tempDamage
+				damageRemainder = damageRemainder - tempDamage
+			end
+			if guard[damageType] > 0 then
+				local tempDamage = m_min(damageRemainder * output[damageType.."GuardAbsorbRate"] / 100, guard[damageType])
+				guard[damageType] = guard[damageType] - tempDamage
+				damageRemainder = damageRemainder - tempDamage
+			end
+			if guard.shared > 0 then
+				local tempDamage = m_min(damageRemainder * output.sharedGuardAbsorbRate / 100, guard.shared)
+				guard.shared = guard.shared - tempDamage
+				damageRemainder = damageRemainder - tempDamage
+			end
+			if ward > 0 then
+				local tempDamage = m_min(damageRemainder * (1 - (modDB:Sum("BASE", nil, "WardBypass") or 0) / 100), ward)
+				ward = ward - tempDamage
+				damageRemainder = damageRemainder - tempDamage
+			end
+			local esBypass = output[damageType.."EnergyShieldBypass"] or 0
+			if energyShield > 0 and (not modDB:Flag(nil, "EnergyShieldProtectsMana")) and (esBypass) < 100 then
+				local tempDamage = m_min(damageRemainder * (1 - esBypass / 100), energyShield)
+				energyShield = energyShield - tempDamage
+				damageRemainder = damageRemainder - tempDamage
+			end
+			if (output.sharedMindOverMatter + output[damageType.."MindOverMatter"]) > 0 then
+				local MoMDamage = damageRemainder * m_min(output.sharedMindOverMatter + output[damageType.."MindOverMatter"], 100) / 100
+				if modDB:Flag(nil, "EnergyShieldProtectsMana") and energyShield > 0 and esBypass < 100 then
+					local tempDamage = m_min(MoMDamage * (1 - esBypass / 100), energyShield)
+					energyShield = energyShield - tempDamage
+					MoMDamage = MoMDamage - tempDamage
+					local tempDamage2 = m_min(MoMDamage, mana)
+					mana = mana - tempDamage2
+					damageRemainder = damageRemainder - tempDamage - tempDamage2
+				elseif mana > 0 then
+					local tempDamage = m_min(MoMDamage, mana)
+					mana = mana - tempDamage
 					damageRemainder = damageRemainder - tempDamage
 				end
 			end
-		end
-		-- frost shield / soul link / other taken before you does not count as you taking damage
-		PoolsLost[damageType] = (PoolsLost[damageType] or 0) + damageRemainder
-		if aegis[damageType] > 0 then
-			local tempDamage = m_min(damageRemainder, aegis[damageType])
-			aegis[damageType] = aegis[damageType] - tempDamage
-			damageRemainder = damageRemainder - tempDamage
-		end
-		if isElemental[damageType] and aegis.sharedElemental > 0 then
-			local tempDamage = m_min(damageRemainder, aegis.sharedElemental)
-			aegis.sharedElemental = aegis.sharedElemental - tempDamage
-			damageRemainder = damageRemainder - tempDamage
-		end
-		if aegis.shared > 0 then
-			local tempDamage = m_min(damageRemainder, aegis.shared)
-			aegis.shared = aegis.shared - tempDamage
-			damageRemainder = damageRemainder - tempDamage
-		end
-		if guard[damageType] > 0 then
-			local tempDamage = m_min(damageRemainder * output[damageType.."GuardAbsorbRate"] / 100, guard[damageType])
-			guard[damageType] = guard[damageType] - tempDamage
-			damageRemainder = damageRemainder - tempDamage
-		end
-		if guard.shared > 0 then
-			local tempDamage = m_min(damageRemainder * output.sharedGuardAbsorbRate / 100, guard.shared)
-			guard.shared = guard.shared - tempDamage
-			damageRemainder = damageRemainder - tempDamage
-		end
-		if ward > 0 then
-			local tempDamage = m_min(damageRemainder * (1 - (modDB:Sum("BASE", nil, "WardBypass") or 0) / 100), ward)
-			ward = ward - tempDamage
-			damageRemainder = damageRemainder - tempDamage
-		end
-		local esBypass = output[damageType.."EnergyShieldBypass"] or 0
-		if energyShield > 0 and (not modDB:Flag(nil, "EnergyShieldProtectsMana")) and (esBypass) < 100 then
-			local tempDamage = m_min(damageRemainder * (1 - esBypass / 100), energyShield)
-			energyShield = energyShield - tempDamage
-			damageRemainder = damageRemainder - tempDamage
-		end
-		if (output.sharedMindOverMatter + output[damageType.."MindOverMatter"]) > 0 then
-			local MoMDamage = damageRemainder * m_min(output.sharedMindOverMatter + output[damageType.."MindOverMatter"], 100) / 100
-			if modDB:Flag(nil, "EnergyShieldProtectsMana") and energyShield > 0 and esBypass < 100 then
-				local tempDamage = m_min(MoMDamage * (1 - esBypass / 100), energyShield)
-				energyShield = energyShield - tempDamage
-				MoMDamage = MoMDamage - tempDamage
-				local tempDamage2 = m_min(MoMDamage, mana)
-				mana = mana - tempDamage2
-				damageRemainder = damageRemainder - tempDamage - tempDamage2
-			elseif mana > 0 then
-				local tempDamage = m_min(MoMDamage, mana)
-				mana = mana - tempDamage
-				damageRemainder = damageRemainder - tempDamage
-			end
-		end
-		if output.preventedLifeLossTotal > 0 then
-			local halfLife = output.Life * 0.5
-			local lifeOverHalfLife = m_max(life - halfLife, 0)
-			local preventPercent = output.preventedLifeLoss / 100
-			local poolAboveLow = lifeOverHalfLife / (1 - preventPercent)
-			local preventBelowHalfPercent = modDB:Sum("BASE", nil, "LifeLossBelowHalfPrevented") / 100
-			local damageThatLifeCanStillTake = poolAboveLow + m_max(m_min(life, halfLife), 0) / (1 - preventBelowHalfPercent) / (1 - output.preventedLifeLoss / 100)
-			local overkillDamage = damageThatLifeCanStillTake < damageRemainder and damageRemainder - damageThatLifeCanStillTake or 0
-			if overkillDamage ~= 0 then
-				damageRemainder = damageThatLifeCanStillTake
-			end
-			if output.preventedLifeLossBelowHalf ~= 0 then
-				local damageToSplit = m_min(damageRemainder, poolAboveLow)
-				local lostLife = damageToSplit * (1 - preventPercent)
-				local preventedLoss = damageToSplit * preventPercent
-				damageRemainder = damageRemainder - damageToSplit
-				LifeLossLostOverTime = LifeLossLostOverTime + preventedLoss
-				life = life - lostLife
-				if life <= halfLife then
-					local unspecificallyLowLifePreventedDamage = damageRemainder * preventPercent
-					LifeLossLostOverTime = LifeLossLostOverTime + unspecificallyLowLifePreventedDamage
-					damageRemainder = damageRemainder - unspecificallyLowLifePreventedDamage
-					local specificallyLowLifePreventedDamage = damageRemainder * preventBelowHalfPercent
-					LifeBelowHalfLossLostOverTime = LifeBelowHalfLossLostOverTime + specificallyLowLifePreventedDamage
-					damageRemainder = damageRemainder - specificallyLowLifePreventedDamage
+			if output.preventedLifeLossTotal > 0 then
+				local halfLife = output.Life * 0.5
+				local lifeOverHalfLife = m_max(life - halfLife, 0)
+				local preventPercent = output.preventedLifeLoss / 100
+				local poolAboveLow = lifeOverHalfLife / (1 - preventPercent)
+				local preventBelowHalfPercent = modDB:Sum("BASE", nil, "LifeLossBelowHalfPrevented") / 100
+				local damageThatLifeCanStillTake = poolAboveLow + m_max(m_min(life, halfLife), 0) / (1 - preventBelowHalfPercent) / (1 - output.preventedLifeLoss / 100)
+				local overkillDamage = damageThatLifeCanStillTake < damageRemainder and damageRemainder - damageThatLifeCanStillTake or 0
+				if overkillDamage ~= 0 then
+					damageRemainder = damageThatLifeCanStillTake
 				end
-			else
-				local tempDamage = damageRemainder * output.preventedLifeLoss / 100
-				LifeLossLostOverTime = LifeLossLostOverTime + tempDamage
-				damageRemainder = damageRemainder - tempDamage
+				if output.preventedLifeLossBelowHalf ~= 0 then
+					local damageToSplit = m_min(damageRemainder, poolAboveLow)
+					local lostLife = damageToSplit * (1 - preventPercent)
+					local preventedLoss = damageToSplit * preventPercent
+					damageRemainder = damageRemainder - damageToSplit
+					LifeLossLostOverTime = LifeLossLostOverTime + preventedLoss
+					life = life - lostLife
+					if life <= halfLife then
+						local unspecificallyLowLifePreventedDamage = damageRemainder * preventPercent
+						LifeLossLostOverTime = LifeLossLostOverTime + unspecificallyLowLifePreventedDamage
+						damageRemainder = damageRemainder - unspecificallyLowLifePreventedDamage
+						local specificallyLowLifePreventedDamage = damageRemainder * preventBelowHalfPercent
+						LifeBelowHalfLossLostOverTime = LifeBelowHalfLossLostOverTime + specificallyLowLifePreventedDamage
+						damageRemainder = damageRemainder - specificallyLowLifePreventedDamage
+					end
+				else
+					local tempDamage = damageRemainder * output.preventedLifeLoss / 100
+					LifeLossLostOverTime = LifeLossLostOverTime + tempDamage
+					damageRemainder = damageRemainder - tempDamage
+				end
+				if overkillDamage ~= 0 then
+					life = life - overkillDamage
+				end
 			end
-			if overkillDamage ~= 0 then
-				life = life - overkillDamage
-			end
+			life = life - damageRemainder
 		end
-		life = life - damageRemainder
 	end
 
 	return {
@@ -2223,7 +2230,7 @@ function calcs.buildDefenceEstimations(env, actor)
 				poolTable.Mana = m_min(poolTable.Mana + DamageIn.ManaWhenHit * (gainMult - 1), gainMult * (output.ManaUnreserved or 0))
 				poolTable.EnergyShield = m_min(poolTable.EnergyShield + DamageIn.EnergyShieldWhenHit * (gainMult - 1), gainMult * output.EnergyShieldRecoveryCap)
 			end
-			poolTable = calcs.reducePoolsByDamage(poolTable, Damage, actor)
+			poolTable = calcs.reducePoolsByDamage(poolTable, Damage, actor, iterationMultiplier)
 			
 			-- If still living and the amount of damage exceeds maximum threshold we survived infinite number of hits.
 			if poolTable.Life > 0 and damageTotal >= maxDamage then

--- a/src/Modules/CalcDefence.lua
+++ b/src/Modules/CalcDefence.lua
@@ -89,7 +89,6 @@ function calcs.reducePoolsByDamage(poolTable, damageTable, actor)
 	local output = actor.output
 	local modDB = actor.modDB
 	local poolTbl = poolTable or { }
-
 	local alliesTakenBeforeYou = poolTbl.AlliesTakenBeforeYou
 	if not alliesTakenBeforeYou then
 		alliesTakenBeforeYou = {}
@@ -181,7 +180,7 @@ function calcs.reducePoolsByDamage(poolTable, damageTable, actor)
 			damageRemainder = damageRemainder - tempDamage
 		end
 		if guard.shared > 0 then
-			-- Apply shared guard proportionial to damage type
+			-- Apply shared guard proportional to damage type
 			local tempDamage = m_min(damageRemainder * output.sharedGuardAbsorbRate / 100, sharedGuardTotal * damage / damageTotal)
 			guard.shared = guard.shared - tempDamage
 			damageRemainder = damageRemainder - tempDamage


### PR DESCRIPTION
Fixes #6571 

### Description of the problem being solved:

The `reducePoolsByDamage` function applies shared guard in order of damage types, and so when `numberOfHitsToDie` is chunking the hits for optimisation, the shared guard is not divided between damage types as it would be for individual hits. This inaccuracy can lead to the `numberOfHitsToDie` function "dying" prematurely on return from recursion as it applies all of what should be survivable hits at once.

### Steps taken to verify a working solution:
- Load character: https://pobb.in/FZoF0vtGWJjw
- See the effect of adding a 5% hp node
- Pre-fix you would lose 14.8% eHP from allocating the node

### Link to a build that showcases this PR:

https://pobb.in/FZoF0vtGWJjw

### Before screenshot:

![before](https://i.imgur.com/BE1mZJl.png)

### After screenshot:

![after](https://i.imgur.com/pLG7Jhe.png)