### PR TITLE
Hit chance applying twice to triggers relying on crits

### DIFF
--- a/src/Modules/CalcTriggers.lua
+++ b/src/Modules/CalcTriggers.lua
@@ -480,16 +480,17 @@ local function defaultTriggerHandler(env, config)
 
 			--Accuracy and crit chance
 			if source and (source.skillTypes[SkillType.Melee] or source.skillTypes[SkillType.Attack]) and GlobalCache.cachedData["CACHE"][uuid] and not config.triggerOnUse then
-				local sourceHitChance = GlobalCache.cachedData["CACHE"][uuid].HitChance
-				trigRate = trigRate * (sourceHitChance or 0) / 100
-				if breakdown then
-					t_insert(breakdown.EffectiveSourceRate, s_format("x %.0f%% ^8(%s hit chance)", sourceHitChance, source.activeEffect.grantedEffect.name))
-				end
 				if (actor.mainSkill.skillData.triggeredByCospris or actor.mainSkill.skillData.triggeredByCoC or config.triggerName == "Law of the Wilds") and GlobalCache.cachedData["CACHE"][uuid] then
 					local sourceCritChance = GlobalCache.cachedData["CACHE"][uuid].CritChance
 					trigRate = trigRate * (sourceCritChance or 0) / 100
 					if breakdown then
-						t_insert(breakdown.EffectiveSourceRate, s_format("x %.2f%% ^8(%s effective crit chance)", sourceCritChance, source.activeEffect.grantedEffect.name))
+						t_insert(breakdown.EffectiveSourceRate, s_format("x %.2f%% ^8(%s effective crit chance. Includes hit chance)", sourceCritChance, source.activeEffect.grantedEffect.name))
+					end
+				else
+					local sourceHitChance = GlobalCache.cachedData["CACHE"][uuid].HitChance
+					trigRate = trigRate * (sourceHitChance or 0) / 100
+					if breakdown then
+						t_insert(breakdown.EffectiveSourceRate, s_format("x %.0f%% ^8(%s hit chance)", sourceHitChance, source.activeEffect.grantedEffect.name))
 					end
 				end
 			end


### PR DESCRIPTION
Fixes #6778

### Description of the problem being solved:
Prevent hit chance from applying twice as it's already included in effective crit chance,