### PR TITLE
Fixed dissolution of the flesh changing maximum hit pools

### DIFF
--- a/src/Modules/CalcDefence.lua
+++ b/src/Modules/CalcDefence.lua
@@ -1799,6 +1799,11 @@ function calcs.buildDefenceEstimations(env, actor)
 			output.CappingLife = true
 		end
 	end
+
+	-- Dissolution of the flesh life pool change
+	if modDB:Flag(nil, "DamageInsteadReservesLife") then 
+		output.LifeRecoverable = output.Life
+	end
 	
 	-- Prevented life loss taken over 4 seconds (and Petrified Blood)
 	do

--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -3892,6 +3892,7 @@ local specialModList = {
 	["cannot gain energy shield during f?l?a?s?k? ?effect"] = { flag("CannotGainEnergyShield", { type = "Condition", var = "UsingFlask" }) },
 	["cannot gain life during f?l?a?s?k? ?effect"] = { flag("CannotGainLife", { type = "Condition", var = "UsingFlask" }) },
 	["cannot gain mana during f?l?a?s?k? ?effect"] = { flag("CannotGainMana", { type = "Condition", var = "UsingFlask" }) },
+	["life that would be lost by taking damage is instead reserved"] = { flag("DamageInsteadReservesLife") },
 	["you have no armour or energy shield"] = {
 		mod("Armour", "MORE", -100),
 		mod("EnergyShield", "MORE", -100),


### PR DESCRIPTION
Added a flag to the modifier on dissolution of the flesh to change recoverable life to full life pool rather than just unreserved life.

### Description of the problem being solved:
Reserving life with dissolution of the flesh incorrectly reduces maximum hit pools. In game any skills which reserve life are automatically disabled when too much life is reserved through dissolution of the flesh. 

### Steps taken to verify a working solution:
- Created a build that uses dissolution of the flesh .
- Added an aura that reserves life.
- Checked that maximum hit pool is uneffected buy adding the aura.

### Link to a build that showcases this PR:
https://pobb.in/Eniw8-R3U0Ro

### Before screenshot:
![BuggedDissolution](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/66527432/be3fd3db-b5c3-4422-b19a-1d11dd7022fb)
This screenshot shows the maximum hit pool is based on the unreserved life pool when dissolution of the flesh is equipped.

### After screenshot:
![FixedDissolution](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/66527432/e5f99056-86f3-4fde-a202-d4f4a7c75a21)
This screenshot shows the maximum hit pool is based on the total life pool when dissolution of the flesh if equipped. 