### PR TITLE
Fix recursive EnemyMods Party struct

### DIFF
--- a/src/Modules/CalcPerform.lua
+++ b/src/Modules/CalcPerform.lua
@@ -2832,7 +2832,9 @@ function calcs.perform(env, fullDPSSkipEHP)
 								(v[1].type ~= "Condition" or (v[1].var and (enemyDB.mods["Condition:"..v[1].var] and enemyDB.mods["Condition:"..v[1].var][1].value) or v[1].varList and (enemyDB.mods["Condition:"..v[1].varList[1]] and enemyDB.mods["Condition:"..v[1].varList[1]][1].value))) 
 								and (v[1].type ~= "Multiplier" or (enemyDB.mods["Multiplier:"..v[1].var] and enemyDB.mods["Multiplier:"..v[1].var][1].value)))) then
                             if buffExports["EnemyMods"][k] then
-								buffExports["EnemyMods"][k] = { MultiStat = true, buffExports["EnemyMods"][k] }
+								if not buffExports["EnemyMods"][k].MultiStat then
+									buffExports["EnemyMods"][k] = { MultiStat = true, buffExports["EnemyMods"][k] }
+								end
 								t_insert(buffExports["EnemyMods"][k], v)
 							else
 								buffExports["EnemyMods"][k] = v


### PR DESCRIPTION
Fixes #6799

### Description of the problem being solved:
The changed section of code currently creates a sort of a nested tree of mods instead of a list. ModTools funcs don't have the ability to process this kind of structure correctly causing a crash in many cases.

Not sure if this sort of format is expected by any other code so marking as draft for now.

### Steps taken to verify a working solution:
- Test that the build from the issue works correctly

### Link to a build that showcases this PR:
```
https://pobb.in/XQsAYJ86QMMN
```