### PR TITLE
Enemy damaging ailments

### DIFF
--- a/src/Data/ModCache.lua
+++ b/src/Data/ModCache.lua
@@ -7470,7 +7470,7 @@ c["Critical Strike Chance is 30% for Hits with this Weapon"]={{[1]={[1]={type="C
 c["Critical Strike Chance is increased by Lightning Resistance"]={{[1]={flags=0,keywordFlags=0,name="CritChanceIncreasedByLightningRes",type="FLAG",value=true}},nil}
 c["Critical Strike Chance is increased by Overcapped Lightning Resistance"]={{[1]={flags=0,keywordFlags=0,name="CritChanceIncreasedByOvercappedLightningRes",type="FLAG",value=true}},nil}
 c["Critical Strikes Penetrate 10% of Enemy Elemental Resistances while affected by Zealotry"]={{[1]={[1]={type="Condition",var="CriticalStrike"},[2]={type="Condition",var="AffectedByZealotry"},flags=0,keywordFlags=0,name="ElementalPenetration",type="BASE",value=10}},nil}
-c["Critical Strikes against you do not inherently inflict Elemental Ailments"]={nil,"Critical Strikes  do not inherently inflict Elemental Ailments "}
+c["Critical Strikes against you do not inherently inflict Elemental Ailments"]={{[1]={flags=0,keywordFlags=0,name="CritsOnYouDontAlwaysApplyElementalAilments",type="FLAG",value=true}},nil}
 c["Critical Strikes deal no Damage"]={{[1]={[1]={type="Condition",var="CriticalStrike"},flags=0,keywordFlags=0,name="Damage",type="MORE",value=-100}},nil}
 c["Critical Strikes do not always Freeze"]={{[1]={flags=0,keywordFlags=0,name="CritsDontAlwaysFreeze",type="FLAG",value=true}},nil}
 c["Critical Strikes do not inherently Ignite"]={{[1]={flags=0,keywordFlags=0,name="CritsDontAlwaysIgnite",type="FLAG",value=true}},nil}

--- a/src/Data/ModMap.lua
+++ b/src/Data/ModMap.lua
@@ -156,6 +156,8 @@ return {
 			type = "check",
 			tooltipLines = { "All Monster Damage from Hits always Ignites" },
 			apply = function(val, mapModEffect, modList, enemyModList)
+				enemyModList:NewMod("IgniteChance", "BASE", 100, "Map mod Conflagrating")
+				enemyModList:NewMod("AllDamageIgnites", "FLAG", true, "Map mod Conflagrating")
 			end
 		},
 		["Impaling"] = {
@@ -171,6 +173,7 @@ return {
 			tooltipLines = { "Monsters have a %d%% chance to Ignite, Freeze and Shock on Hit" },
 			values = { 0, 15, 20 },
 			apply = function(val, mapModEffect, values, modList, enemyModList)
+				enemyModList:NewMod("ElementalAilmentChance", "BASE", values[val] * mapModEffect, "Map mod Empowered")
 			end
 		},
 		["Overlord's"] = {
@@ -351,6 +354,7 @@ return {
 			type = "check",
 			tooltipLines = { "Monsters Poison on Hit" },
 			apply = function(val, mapModEffect, modList, enemyModList)
+				enemyModList:NewMod("PoisonChance", "BASE", 100, "Map mod of Venom")
 			end
 		},
 		["of Deadliness"] = {
@@ -413,6 +417,8 @@ return {
 		{ val = "Profane", label = "Enemy Phys As Chaos                                 Monsters deal to extra Physical Damage Inflict Withered for seconds on Hit Profane" },
 		{ val = "Fleet", label = "Enemy Inc Speed                                 to increased Monster Movement Attack Cast".."Fleet" },
 		{ val = "Impaling", label = "Enemy Impale                                 Monsters have chance to with Attacks Impaling" },
+		{ val = "Conflagrating", label = "Hits always Ignites                                 All Monster Damage from Conflagrating" },
+		{ val = "Empowered", label = "Elemental Ailments on Hit                                 Monsters have chance to cause Empowered" },
 		{ val = "Overlord's", label = "Boss Inc Damage / Speed                                 Unique deals increased has Attack and Cast".."Overlord's" },
 	},
 	Suffix = {
@@ -430,6 +436,7 @@ return {
 		{ val = "of Fatigue", label = "Less Cooldown Recovery                                 Players have Rate".."of Fatigue" },
 		{ val = "of Doubt", label = "Reduced Aura Effect                                 Players have Non-Curse Auras from Skills".."of Doubt" },
 		{ val = "of Imprecision", label = "Less Accuracy                                 Players have Rating".."of Imprecision" },
+		{ val = "of Venom", label = "Poison On Hit                                 Monsters of Venom" },
 		{ val = "of Deadliness", label = "Enemy Critical Strike                                 Monsters have to increased Chance Monster Multiplier".."of Deadliness" },
 	},
 }

--- a/src/Modules/CalcDefence.lua
+++ b/src/Modules/CalcDefence.lua
@@ -3252,7 +3252,7 @@ function calcs.buildDefenceEstimations(env, actor)
 			end
 		end
 		local enemyCritAilmentEffect = 1 + output.EnemyCritChance / 100 * 0.5 * (1 - output.CritExtraDamageReduction / 100)
-		-- this is just used so that ailments dont always showup if the enemy has no other way of applying the ailment and they have a low crit chance
+		-- this is just used so that ailments don't always showup if the enemy has no other way of applying the ailment and they have a low crit chance
 		local enemyCritThreshold = 10.1
 		local enemyBleedChance = 0
 		local enemyIgniteChance = 0

--- a/src/Modules/CalcDefence.lua
+++ b/src/Modules/CalcDefence.lua
@@ -3471,18 +3471,30 @@ function calcs.buildDefenceEstimations(env, actor)
 						end
 					end
 				end
-				output.ComprehensiveNetLifeRegen = output.ComprehensiveNetLifeRegen - totalLifeDegen
-				output.ComprehensiveNetManaRegen = output.ComprehensiveNetManaRegen - totalManaDegen
-				output.ComprehensiveNetEnergyShieldRegen = output.ComprehensiveNetEnergyShieldRegen - totalEnergyShieldDegen
+				output.ComprehensiveNetLifeRegen = output.ComprehensiveNetLifeRegen + (output.LifeRecoupRecoveryAvg or 0) - totalLifeDegen - (output.LifeLossLostAvg or 0)
+				output.ComprehensiveNetManaRegen = output.ComprehensiveNetManaRegen + (output.ManaRecoupRecoveryAvg or 0) - totalManaDegen
+				output.ComprehensiveNetEnergyShieldRegen = output.ComprehensiveNetEnergyShieldRegen + (output.EnergyShieldRecoupRecoveryAvg or 0) - totalEnergyShieldDegen
 				output.ComprehensiveTotalNetRegen = output.ComprehensiveNetLifeRegen + output.ComprehensiveNetManaRegen + output.ComprehensiveNetEnergyShieldRegen
 				if breakdown then
 					t_insert(breakdown.ComprehensiveNetLifeRegen, s_format("%.1f ^8(total life regen)", output.LifeRegenRecovery))
+					if (output.LifeRecoupRecoveryAvg or 0) ~= 0 then
+						t_insert(breakdown.ComprehensiveNetLifeRegen, s_format("+ %.1f ^8(average life recoup)", (output.LifeRecoupRecoveryAvg or 0)))
+					end
 					t_insert(breakdown.ComprehensiveNetLifeRegen, s_format("- %.1f ^8(total life degen)", totalLifeDegen))
+					if (output.LifeLossLostAvg or 0) ~= 0 then
+						t_insert(breakdown.ComprehensiveNetLifeRegen, s_format("- %.1f ^8(average life lost over time)", (output.LifeLossLostAvg or 0)))
+					end
 					t_insert(breakdown.ComprehensiveNetLifeRegen, s_format("= %.1f", output.ComprehensiveNetLifeRegen))
 					t_insert(breakdown.ComprehensiveNetManaRegen, s_format("%.1f ^8(total mana regen)", output.ManaRegenRecovery))
+					if (output.ManaRecoupRecoveryAvg or 0) ~= 0 then
+						t_insert(breakdown.ComprehensiveNetManaRegen, s_format("+ %.1f ^8(average mana recoup)", (output.ManaRecoupRecoveryAvg or 0)))
+					end
 					t_insert(breakdown.ComprehensiveNetManaRegen, s_format("- %.1f ^8(total mana degen)", totalManaDegen))
 					t_insert(breakdown.ComprehensiveNetManaRegen, s_format("= %.1f", output.ComprehensiveNetManaRegen))
 					t_insert(breakdown.ComprehensiveNetEnergyShieldRegen, s_format("%.1f ^8(total energy shield regen)", output.EnergyShieldRegenRecovery))
+					if (output.EnergyShieldRecoupRecoveryAvg or 0) ~= 0 then
+						t_insert(breakdown.ComprehensiveNetEnergyShieldRegen, s_format("+ %.1f ^8(average energy shield recoup)", (output.EnergyShieldRecoupRecoveryAvg or 0)))
+					end
 					t_insert(breakdown.ComprehensiveNetEnergyShieldRegen, s_format("- %.1f ^8(total energy shield degen)", totalEnergyShieldDegen))
 					t_insert(breakdown.ComprehensiveNetEnergyShieldRegen, s_format("= %.1f", output.ComprehensiveNetEnergyShieldRegen))
 					breakdown.ComprehensiveTotalNetRegen = {

--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -4215,6 +4215,7 @@ local specialModList = {
 	["immun[ei]t?y? to chill"] = { flag("ChillImmune"), },
 	["cannot be ignited"] = { flag("IgniteImmune"), },
 	["immun[ei]t?y? to ignite"] = { flag("IgniteImmune"), },
+	["critical strikes against you do not inherently inflict elemental ailments"] = { flag("CritsOnYouDontAlwaysApplyElementalAilments"), },
 	["cannot be ignited while at maximum endurance charges"] = { flag("IgniteImmune", {type = "StatThreshold", stat = "EnduranceCharges", thresholdStat = "EnduranceChargesMax" }, { type = "GlobalEffect", effectType = "Global", unscalable = true }), },
 	["grants immunity to ignite for (%d+) seconds if used while ignited"] = { flag("IgniteImmune", { type = "Condition", var = "UsingFlask" }), },
 	["grants immunity to bleeding for (%d+) seconds if used while bleeding"] = { flag("BleedImmune", { type = "Condition", var = "UsingFlask" }) },


### PR DESCRIPTION
Built ontop of #6809, merge that one first
Only the last commit is unique at the moment

adds support for enemy damaging ailments, either if the enemy has a chance to apply them or above a certain critical strike threshold, this is just so that it doesnt always show the enemy as being able to ignite you
![image](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/49933620/f4a0a51e-b3f0-46de-ba13-fbd56ab7d5ef)


This also correctly scales with unaffected by/immune to, and also will not apply if the duration is 0, but applies regardless of chance if the chance is greater than 0