### PR TITLE
Change Exporter runall to add to a list which is consumed per frame

### DIFF
--- a/src/Export/Main.lua
+++ b/src/Export/Main.lua
@@ -61,6 +61,7 @@ end
 
 local tempTable1 = { }
 local tempTable2 = { }
+local remainingScripts = { }
 
 
 function main:Init()
@@ -185,10 +186,7 @@ function main:Init()
 		end
 		for _, script in ipairs(self.scriptList) do
 			if script ~= "statdesc" then
-				local errMsg = PLoadModule("Scripts/"..script..".lua")
-				if errMsg then
-					print(errMsg)
-				end
+				t_insert(remainingScripts, script)
 			end
 		end
 	end) {
@@ -353,6 +351,17 @@ function main:OnFrame()
 	end
 
 	wipeTable(self.inputEvents)
+	
+	if #remainingScripts > 0 then
+		local startTime = GetTime()
+		repeat
+			local script = t_remove(remainingScripts)
+			local errMsg = PLoadModule("Scripts/"..script..".lua")
+			if errMsg then
+				print(errMsg)
+			end
+		until ((#remainingScripts == 0) or (GetTime() - startTime > 100))
+	end
 end
 
 function main:OnKeyDown(key, doubleClick)


### PR DESCRIPTION
This allows the exporter to attempt to render frames between the scripts being loaded
This could have been done with a coroutine, but that adds unnecessary complexity in my opinion

This adds around 40 milliseconds on average to export time, which is around 0.1% of the total export time (around 34300 milliseconds on average on my machine), but gives feedback on the export almost 10 seconds earlier (~25 seconds in)

The biggest culprits to the long export are the stat descriptions, which is exported and then processed a second time to be used, as we only export the English versions of stat descriptions, and we process them slightly differently
It takes around 10 seconds to export stat descriptions, and then another almost 14 seconds to obtain stat_descriptions.txt and passive_skill_stat_descriptions.txt for the rest of the scripts

Apparently stat descriptions do not need to be exported first as we still use the internal ones, but leaving it as the first export incase we endup optimising this