### PR TITLE
Ordered power calc (tree show node power)

### DIFF
--- a/src/Classes/CalcsTab.lua
+++ b/src/Classes/CalcsTab.lua
@@ -492,6 +492,7 @@ function CalcsTabClass:PowerBuilder()
 	for distance, nodes in pairs(distanceMap) do
 		t_insert(distanceList, { distance, nodes })
 	end
+	distanceMap = nil
 	table.sort(distanceList, function(a, b) return a[1] < b[1] end)
 	for _, data in ipairs(distanceList) do
 		local distance, nodes = data[1], data[2]

--- a/src/Classes/CalcsTab.lua
+++ b/src/Classes/CalcsTab.lua
@@ -496,7 +496,7 @@ function CalcsTabClass:PowerBuilder()
 	table.sort(distanceList, function(a, b) return a[1] < b[1] end)
 	for _, data in ipairs(distanceList) do
 		local distance, nodes = data[1], data[2]
-		if self.nodePowerMaxDepth and self.nodePowerMaxDepth >= distance then
+		if self.nodePowerMaxDepth and self.nodePowerMaxDepth < distance then
 			break
 		end
 		for nodeId, node in pairs(nodes) do

--- a/src/Classes/CalcsTab.lua
+++ b/src/Classes/CalcsTab.lua
@@ -466,6 +466,7 @@ function CalcsTabClass:PowerBuilder()
 	local calcFunc, calcBase = self:GetMiscCalculator()
 	local cache = { }
 	local distanceMap = { }
+	local distanceList = { }
 	local newPowerMax = {
 		singleStat = 0,
 		offence = 0,
@@ -489,6 +490,11 @@ function CalcsTabClass:PowerBuilder()
 		end
 	end
 	for distance, nodes in pairs(distanceMap) do
+		t_insert(distanceList, { distance, nodes })
+	end
+	table.sort(distanceList, function(a, b) return a[1] < b[1] end)
+	for _, data in ipairs(distanceList) do
+		local distance, nodes = data[1], data[2]
 		if self.nodePowerMaxDepth and self.nodePowerMaxDepth >= distance then
 			break
 		end

--- a/src/Classes/CalcsTab.lua
+++ b/src/Classes/CalcsTab.lua
@@ -465,6 +465,7 @@ function CalcsTabClass:PowerBuilder()
 	GlobalCache.useFullDPS = self.powerStat and self.powerStat.stat == "FullDPS" or false
 	local calcFunc, calcBase = self:GetMiscCalculator()
 	local cache = { }
+	local distanceMap = { }
 	local newPowerMax = {
 		singleStat = 0,
 		offence = 0,
@@ -478,11 +479,20 @@ function CalcsTabClass:PowerBuilder()
 	if coroutine.running() then
 		coroutine.yield()
 	end
-
+	
 	local start = GetTime()
 	for nodeId, node in pairs(self.build.spec.nodes) do
 		wipeTable(node.power)
-		if self.nodePowerMaxDepth == nil or self.nodePowerMaxDepth >= node.pathDist then
+		if node.modKey ~= "" and not self.mainEnv.grantedPassives[nodeId] then
+			distanceMap[node.pathDist or 1000] = distanceMap[node.pathDist or 1000] or { }
+			distanceMap[node.pathDist or 1000][nodeId] = node
+		end
+	end
+	for distance, nodes in pairs(distanceMap) do
+		if self.nodePowerMaxDepth and self.nodePowerMaxDepth >= distance then
+			break
+		end
+		for nodeId, node in pairs(nodes) do
 			if not node.alloc and node.modKey ~= "" and not self.mainEnv.grantedPassives[nodeId] then
 				if not cache[node.modKey] then
 					cache[node.modKey] = calcFunc({ addNodes = { [node] = true } }, { requirementsItems = true, requirementsGems = true, skills = true })
@@ -530,10 +540,10 @@ function CalcsTabClass:PowerBuilder()
 					end
 				end
 			end
-		end
-		if coroutine.running() and GetTime() - start > 100 then
-			coroutine.yield()
-			start = GetTime()
+			if coroutine.running() and GetTime() - start > 100 then
+				coroutine.yield()
+				start = GetTime()
+			end
 		end
 	end
 


### PR DESCRIPTION
built on #6828 (that should be merged first)

This creates a distance map to run the power calcs in order of distance, the extra time taken was less than 10 milliseconds and within margin of error

This is being put into draft as theres still a few things I would like to do with this, like use this to show progress on the power report, and to update the power report while its being run, as those seem within scope of this change