### PR TITLE
Widen filename list

### DIFF
--- a/src/Modules/BuildList.lua
+++ b/src/Modules/BuildList.lua
@@ -26,7 +26,7 @@ function listMode:Init(selBuildName, subPath)
 	end
 
 	self.anchor = new("Control", nil, 0, 4, 0, 0)
-	self.anchor.x = function() 
+	self.anchor.x = function()
 		return main.screenW / 2
 	end
 
@@ -36,7 +36,7 @@ function listMode:Init(selBuildName, subPath)
 	self.controls.new = new("ButtonControl", {"TOP",self.anchor,"TOP"}, -259, 0, 60, 20, "New", function()
 		main:SetMode("BUILD", false, "Unnamed build")
 	end)
-	self.controls.newFolder = new("ButtonControl", {"LEFT",self.controls.new,"RIGHT"}, 8, 0, 90, 20, "New_Folder", function()
+	self.controls.newFolder = new("ButtonControl", {"LEFT",self.controls.new,"RIGHT"}, 8, 0, 90, 20, "New Folder", function()
 		self.controls.buildList:NewFolder()
 	end)
 	self.controls.open = new("ButtonControl", {"LEFT",self.controls.newFolder,"RIGHT"}, 8, 0, 60, 20, "Open", function()
@@ -85,7 +85,7 @@ end
 
 function listMode:OnFrame(inputEvents)
 	for id, event in ipairs(inputEvents) do
-		if event.type == "KeyDown" then	
+		if event.type == "KeyDown" then
 			if event.key == "v" and IsKeyDown("CTRL") then
 				if self.controls.buildList.copyBuild then
 					local build = self.controls.buildList.copyBuild
@@ -182,8 +182,8 @@ function listMode:BuildList()
 	handle = NewFileSearch(main.buildPath..self.subPath.."*", true)
 	while handle do
 		local folderName = handle:GetFileName()
-		t_insert(self.list, { 
-			folderName = folderName, 
+		t_insert(self.list, {
+			folderName = folderName,
 			subPath = self.subPath,
 			fullFileName = main.buildPath..self.subPath..folderName,
 		})
@@ -196,7 +196,7 @@ end
 
 function listMode:SortList()
 	local oldSelFileName = self.controls.buildList.selValue and self.controls.buildList.selValue.fileName
-	table.sort(self.list, function(a, b) 
+	table.sort(self.list, function(a, b)
 		if a.folderName and b.folderName then
 			return naturalSortCompare(a.folderName, b.folderName)
 		elseif a.folderName and not b.folderName then

--- a/src/Modules/BuildList.lua
+++ b/src/Modules/BuildList.lua
@@ -27,7 +27,7 @@ function listMode:Init(selBuildName, subPath)
 
 	self.anchor = new("Control", nil, 0, 4, 0, 0)
 	self.anchor.x = function() 
-		return main.screenW / 2 
+		return main.screenW / 2
 	end
 
 	self.subPath = subPath or ""
@@ -36,7 +36,7 @@ function listMode:Init(selBuildName, subPath)
 	self.controls.new = new("ButtonControl", {"TOP",self.anchor,"TOP"}, -259, 0, 60, 20, "New", function()
 		main:SetMode("BUILD", false, "Unnamed build")
 	end)
-	self.controls.newFolder = new("ButtonControl", {"LEFT",self.controls.new,"RIGHT"}, 8, 0, 90, 20, "New Folder", function()
+	self.controls.newFolder = new("ButtonControl", {"LEFT",self.controls.new,"RIGHT"}, 8, 0, 90, 20, "New_Folder", function()
 		self.controls.buildList:NewFolder()
 	end)
 	self.controls.open = new("ButtonControl", {"LEFT",self.controls.newFolder,"RIGHT"}, 8, 0, 60, 20, "Open", function()
@@ -60,7 +60,7 @@ function listMode:Init(selBuildName, subPath)
 		self:SortList()
 	end)
 	self.controls.sort:SelByValue(main.buildSortMode, "sortMode")
-	self.controls.buildList = new("BuildListControl", {"TOP",self.anchor,"TOP"}, 0, 75, 640, 0, self)
+	self.controls.buildList = new("BuildListControl", {"TOP",self.anchor,"TOP"}, 0, 75, 900, 0, self)
 	self.controls.buildList.height = function()
 		return main.screenH - 80
 	end


### PR DESCRIPTION
Fixes not being able to see all the filename.

### Description of the problem being solved:
As there is a maximum filename length, widen the filename list to match it.

### Steps taken to verify a working solution:
- Create a build and save it. Keep typing characters until the input box no longer accepts characters.
- Select Save
- You should see the whole name in the list.

### Link to a build that showcases this PR:
N/A

Note the build "**Lightning SRS Champion - expensive bits needed before switching to SRS - The STRONGEST SRS - NoMoreT**" in both screenshots:
### Before screenshot:
![image](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/4302241/fbefb690-d58a-4946-89a8-9e875e23c2bb)

### After screenshot:
![image](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/4302241/04a58240-60f2-471f-865e-4675365e5157)
