### PR TITLE
Resolves lua: Classes/PassiveSpec.lua:237: bad argument #1 to 'pairs' (table expected, got nil)

### DIFF
--- a/src/Classes/PassiveSpec.lua
+++ b/src/Classes/PassiveSpec.lua
@@ -215,6 +215,7 @@ end
 
 -- Import passive spec from the provided class IDs and node hash list
 function PassiveSpecClass:ImportFromNodeList(classId, ascendClassId, hashList, hashOverrides, masteryEffects, treeVersion)
+  if hashOverrides == nil then hashOverrides = {} end
 	if treeVersion and treeVersion ~= self.treeVersion then
 		self:Init(treeVersion)
 		self.build.treeTab.showConvert = self.treeVersion ~= latestTreeVersion


### PR DESCRIPTION
The following exception is thrown when calling `build.importTab:ImportPassiveTreeAndJewels(getPassiveSkillsJSON, charData)` in headless mode.

```
lua: Classes/PassiveSpec.lua:237: bad argument #1 to 'pairs' (table expected, got nil)
stack traceback:
[C]: in function 'pairs'
Classes/PassiveSpec.lua:237: in function 'ImportFromNodeList'
Classes/ImportTab.lua:627: in function 'ImportPassiveTreeAndJewels'
```