### PR TITLE
add Colorblind tree search highlight support

### DIFF
--- a/src/Classes/PassiveTreeView.lua
+++ b/src/Classes/PassiveTreeView.lua
@@ -665,7 +665,7 @@ function PassiveTreeViewClass:Draw(build, viewPort, inputEvents)
 		if self.searchStrResults[nodeId] then
 			-- Node matches the search string, show the highlight circle
 			SetDrawLayer(nil, 30)
-			SetDrawColor(1, 0, 0)
+			SetDrawColor(rgbColor[1], rgbColor[2], rgbColor[3])
 			local size = 175 * scale / self.zoom ^ 0.4
 			DrawImage(self.highlightRing, scrX - size, scrY - size, size * 2, size * 2)
 		end

--- a/src/Data/Global.lua
+++ b/src/Data/Global.lua
@@ -25,6 +25,7 @@ colorCodes = {
 	CHAOS = "^xD02090",
 	POSITIVE = "^x33FF77",
 	NEGATIVE = "^xDD0022",
+	HIGHLIGHT ="^xFF0000",
 	OFFENCE = "^xE07030",
 	DEFENCE = "^x8080E0",
 	SCION = "^xFFF0F0",
@@ -70,10 +71,26 @@ colorCodes.RAGE = colorCodes.WARNING
 colorCodes.PHYS = colorCodes.NORMAL
 
 defaultColorCodes = copyTable(colorCodes)
+rgbColor = {1, 0, 0}
 function updateColorCode(code, color)
  	if colorCodes[code] then
 		colorCodes[code] = color:gsub("^0", "^")
+		if code == "HIGHLIGHT" then
+			rgbColor = hexToRGB(color)
+		end
 	end
+end
+
+function hexToRGB(hex)
+	hex = hex:gsub("0x", "") -- Remove "0x" prefix
+	hex = hex:gsub("#","") -- Remove '#' if present
+	if #hex ~= 6 then
+		return nil
+	end
+	local r = (tonumber(hex:sub(1, 2), 16)) / 255
+	local g = (tonumber(hex:sub(3, 4), 16)) / 255
+	local b = (tonumber(hex:sub(5, 6), 16)) / 255
+	return {r, g, b}
 end
 
 ModFlag = { }

--- a/src/Launch.lua
+++ b/src/Launch.lua
@@ -16,6 +16,13 @@ launch = { }
 SetMainObject(launch)
 
 function launch:OnInit()
+	-- This is the path to emmy_core.dll. The ?.dll at the end is intentional.
+	package.cpath = package.cpath .. ";C:/Users/Adam/.vscode/extensions/tangzx.emmylua-0.5.19/debugger/emmy/windows/x86/?.dll"
+	local dbg = require("emmy_core")
+	-- This port must match the Visual Studio Code configuration. Default is 9966.
+	dbg.tcpListen("localhost", 9966)
+	-- Uncomment the next line if you want Path of Building to block until the debugger is attached
+	--dbg.waitIDE()
 	self.devMode = false
 	self.installedMode = false
 	self.versionNumber = "?"

--- a/src/Modules/Main.lua
+++ b/src/Modules/Main.lua
@@ -86,6 +86,7 @@ function main:Init()
 	self.nodePowerTheme = "RED/BLUE"
 	self.colorPositive = defaultColorCodes.POSITIVE
 	self.colorNegative = defaultColorCodes.NEGATIVE
+	self.colorHighlight = defaultColorCodes.HIGHLIGHT
 	self.showThousandsSeparators = true
 	self.thousandsSeparator = ","
 	self.decimalSeparator = "."
@@ -551,6 +552,11 @@ function main:LoadSettings(ignoreBuild)
 					updateColorCode("NEGATIVE", node.attrib.colorNegative)
 					self.colorNegative = node.attrib.colorNegative
 				end
+				if node.attrib.colorHighlight then
+					updateColorCode("HIGHLIGHT", node.attrib.colorHighlight)
+					self.colorHighlight = node.attrib.colorHighlight
+				end
+
 				-- In order to preserve users' settings through renaming/merging this variable, we have this if statement to use the first found setting
 				-- Once the user has closed PoB once, they will be using the new `showThousandsSeparator` variable name, so after some time, this statement may be removed
 				if node.attrib.showThousandsCalcs then
@@ -688,6 +694,7 @@ function main:SaveSettings()
 		nodePowerTheme = self.nodePowerTheme,
 		colorPositive = self.colorPositive,
 		colorNegative = self.colorNegative,
+		colorHighlight = self.colorHighlight,
 		showThousandsSeparators = tostring(self.showThousandsSeparators),
 		thousandsSeparator = self.thousandsSeparator,
 		decimalSeparator = self.decimalSeparator,
@@ -808,6 +815,18 @@ function main:OpenOptionsPopup()
 		"The default value is " .. tostring(defaultColorCodes.NEGATIVE:gsub('^(^)', '0')) .. ".\nIf updating while inside a build, please re-load the build after saving."
 
 	nextRow()
+	controls.colorHighlight = new("EditControl", { "TOPLEFT", nil, "TOPLEFT" }, defaultLabelPlacementX, currentY + 5, 100, 18, tostring(self.colorHighlight:gsub('^(^)', '0')), nil, nil, 8, function(buf)
+		local match = string.match(buf, "0x%x+")
+		if match and #match == 8 then
+			updateColorCode("HIGHLIGHT", buf)
+			self.colorHighlight = buf
+		end
+	end)
+	controls.colorHighlightLabel = new("LabelControl", { "RIGHT", controls.colorHighlight, "LEFT" }, defaultLabelSpacingPx, 0, 0, 16, "^7Hex colour for highlight nodes:")
+	controls.colorHighlight.tooltipText = "Overrides the default hex colour for highlighting nodes in passive tree search. \nExpected format is 0x000000. " ..
+		"The default value is " .. tostring(defaultColorCodes.HIGHLIGHT:gsub('^(^)', '0')) .."\nIf updating while inside a build, please re-load the build after saving."
+			
+	nextRow()
 	controls.betaTest = new("CheckBoxControl", { "TOPLEFT", nil, "TOPLEFT" }, defaultLabelPlacementX, currentY, 20, "^7Opt-in to weekly beta test builds:", function(state)
 		self.betaTest = state
 	end)
@@ -894,6 +913,7 @@ function main:OpenOptionsPopup()
 	local initialNodePowerTheme = self.nodePowerTheme
 	local initialColorPositive = self.colorPositive
 	local initialColorNegative = self.colorNegative
+	local initialColorHighlight = self.colorHighlight
 	local initialThousandsSeparatorDisplay = self.showThousandsSeparators
 	local initialTitlebarName = self.showTitlebarName
 	local initialThousandsSeparator = self.thousandsSeparator
@@ -940,6 +960,8 @@ function main:OpenOptionsPopup()
 		updateColorCode("POSITIVE", self.colorPositive)
 		self.colorNegative = initialColorNegative
 		updateColorCode("NEGATIVE", self.colorNegative)
+		self.colorHighlight = initialColorHighlight
+		updateColorCode("HIGHLIGHT", self.colorHighlight)
 		self.showThousandsSeparators = initialThousandsSeparatorDisplay
 		self.thousandsSeparator = initialThousandsSeparator
 		self.decimalSeparator = initialDecimalSeparator


### PR DESCRIPTION
Fixes # .

### Description of the problem being solved:
This PR solve the isssue "Colorblind tree search highlight support". The functionality was done according to PR #6070.
### Steps taken to verify a working solution:
-create edit and tooltip labels for user input
-create function inside of labels which check hex code and then execute function updateColor
-update function updateColor from which I trigger own created function which convert Hex color code to RGB
-save RGB code to array and change parameters for drawing color function in PassiveTreeView.lua

### Link to a build that showcases this PR:

### Before screenshot:
![image](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/115973400/3e2b909e-ebc6-4495-b9b0-5aeb2d372414)

### After screenshot:
![image](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/115973400/0312aa08-61ce-4f1a-946e-fbf56b206de2)
