### PR TITLE
Fix Widowhail multiplying mods individually, oddly interacting with weapon swaps.

### DIFF
--- a/src/Classes/ItemsTab.lua
+++ b/src/Classes/ItemsTab.lua
@@ -3563,7 +3563,7 @@ function ItemsTabClass:AddItemTooltip(tooltip, item, slot, dbMode)
 				local selItem = self.items[compareSlot.selItemId]
 				local storedGlobalCacheDPSView = GlobalCache.useFullDPS
 				GlobalCache.useFullDPS = GlobalCache.numActiveSkillInFullDPS > 0
-				local output = calcFunc({ repSlotName = compareSlot.slotName, repItem = item ~= selItem and item }, {})
+				local output = calcFunc({ repSlotName = compareSlot.slotName, repItem = item ~= selItem and item or nil}, {})
 				GlobalCache.useFullDPS = storedGlobalCacheDPSView
 				local header
 				if item == selItem then

--- a/src/Modules/CalcSetup.lua
+++ b/src/Modules/CalcSetup.lua
@@ -948,11 +948,13 @@ function calcs.initEnv(build, mode, override, specEnv)
 						env.itemModDB:ScaleAddList(otherRingList, scale)
 					end
 					env.itemModDB:ScaleAddList(srcList, scale)
-				elseif item.type == "Quiver" and ((not slot.slotName:match("Swap") and build.itemsTab.items[build.itemsTab.slots["Weapon 1"].selItemId] and build.itemsTab.items[build.itemsTab.slots["Weapon 1"].selItemId].name:match("Widowhail"))
-													or (build.itemsTab.items[build.itemsTab.slots["Weapon 1 Swap"].selItemId] and build.itemsTab.items[build.itemsTab.slots["Weapon 1 Swap"].selItemId].name:match("Widowhail"))) then
-					local WidowHailBaseMods = not slot.slotName:match("Swap") and build.itemsTab.items[build.itemsTab.slots["Weapon 1"].selItemId].baseModList or build.itemsTab.items[build.itemsTab.slots["Weapon 1 Swap"].selItemId].baseModList
-					scale = scale * (1 + (WidowHailBaseMods:Sum("INC", nil, "EffectOfBonusesFromQuiver") or 100) / 100)
-					env.itemModDB:ScaleAddList(srcList, scale)
+				elseif item.type == "Quiver" and items["Weapon 1"] and items["Weapon 1"].name:match("Widowhail") then
+					scale = scale * (1 + (items["Weapon 1"].baseModList:Sum("INC", nil, "EffectOfBonusesFromQuiver") or 100) / 100)
+					local combinedList = new("ModList")
+					for _, mod in ipairs(srcList) do
+						combinedList:MergeMod(mod)
+					end
+					env.itemModDB:ScaleAddList(combinedList, scale)
 				else
 					env.itemModDB:ScaleAddList(srcList, scale)
 				end


### PR DESCRIPTION
Fixes #6877 #6846

### Description of the problem being solved:
Fixes Widowhail multiplying mods individually by merging mods from the equipped quiver first before adding them to the main mod list. Fixes odd interaction with weapon swaps, not sure what changed but my last implementation had issues. Fixes tooltip calcFunc call setting repItem to False at times causing odd behavior in CalcSetup.

### Steps taken to verify a working solution:
- Test build from #6877
- Test build from #6846
