### PR TITLE
Fix channeled melee or attacks halving trigger rate when dual wielding

### DIFF
--- a/src/Modules/CalcTriggers.lua
+++ b/src/Modules/CalcTriggers.lua
@@ -428,7 +428,7 @@ local function defaultTriggerHandler(env, config)
 			end
 
 			--Dual wield
-			if trigRate and source and (source.skillTypes[SkillType.Melee] or source.skillTypes[SkillType.Attack]) and not actor.mainSkill.skillFlags.globalTrigger then
+			if trigRate and source and (source.skillTypes[SkillType.Melee] or source.skillTypes[SkillType.Attack]) and not source.skillTypes[SkillType.Channel] and not actor.mainSkill.skillFlags.globalTrigger then
 				local dualWield = env.player.weaponData1.type and env.player.weaponData2.type
 				trigRate = dualWield and source.skillData.doubleHitsWhenDualWielding and trigRate * 2 or dualWield and trigRate / 2 or trigRate
 				if dualWield and breakdown then


### PR DESCRIPTION
Fixes [issue from reddit post](https://www.reddit.com/r/pathofexile/comments/188r65t/why_does_pob_cut_my_trigger_rate_for_coc_when/)

### Description of the problem being solved:
The check for dual wielding when dealing with channeled skills only checked for the skilltype being melee or attack. Channeled skills are not affected by dual wielding when it comes to their trigger rate.

### Steps taken to verify a working solution:
- Check trigger rate before and after fix
- Confirm that the effective trigger rate is not halved when dual wielding with cyclone after fix

### Link to a build that showcases this PR:
https://pobb.in/t0VBjjT1jhEJ (has massively increased CDR in custom mods to allow for always fully capped trigger rate)