### PR TITLE
Fix rare crash ccaused by forcing active an inactive group containing a trigger setup.

### DIFF
--- a/src/Modules/CalcSetup.lua
+++ b/src/Modules/CalcSetup.lua
@@ -1189,7 +1189,7 @@ function calcs.initEnv(build, mode, override, specEnv)
 		end
 
 		-- Determine main skill group
-		if env.mode == "CALCS" then
+		if env.mode == "CALCS" or env.mode == "CACHE" then
 			env.calcsInput.skill_number = m_min(m_max(#build.skillsTab.socketGroupList, 1), env.calcsInput.skill_number or 1)
 			env.mainSocketGroup = env.calcsInput.skill_number
 		else


### PR DESCRIPTION
Fixes #6862

### Description of the problem being solved:
If a disabled group containing a triggered skill is forced active a crash can occur due to incorrect main socket group selection in CACHE mode. When a wrong socket group is considered main the player.mainSkill will not be in fullEnv.player.activeSkillList 

https://github.com/PathOfBuildingCommunity/PathOfBuilding/blob/63d4f212c99e9c0839022bb1b24fe294d9698c62/src/Modules/Calcs.lua#L406-L417

causing the assumption in the manaforged mana cost pre calculation to cause a nil de reference:
https://github.com/PathOfBuildingCommunity/PathOfBuilding/blob/63d4f212c99e9c0839022bb1b24fe294d9698c62/src/Modules/CalcTriggers.lua#L509-L512

### Steps taken to verify a working solution:
- Test build from issue
- Run tests from https://github.com/PathOfBuildingCommunity/PathOfBuilding/pull/6574
