### PR TITLE
Fix fullDPS not working with two part skills

### DIFF
--- a/src/Modules/Calcs.lua
+++ b/src/Modules/Calcs.lua
@@ -169,7 +169,7 @@ local function getActiveSkillCount(activeSkill)
 						return gemData.count or 1,  gemData.enableGlobal2 == true
 					end
 				else
-					if activeSkill.activeEffect.grantedEffect == gemData.gemData.grantedEffect then
+					if (activeSkill.activeEffect.grantedEffect == gemData.gemData.grantedEffect and not gemData.gemData.grantedEffect.support) or (activeSkill.activeEffect.grantedEffect == gemData.gemData.secondaryGrantedEffect) then
 						return gemData.count or 1, true
 					end
 				end


### PR DESCRIPTION
Fixes #6857

### Description of the problem being solved:
https://github.com/PathOfBuildingCommunity/PathOfBuilding/blob/63d4f212c99e9c0839022bb1b24fe294d9698c62/src/Modules/Calcs.lua#L172-L174

Does not take into account the case when the active skill comes from the secondary part of a gem like is the case for Flamewood causing the fullDPS count to be ignored.

### Steps taken to verify a working solution:
- Tested build from issue

