### PR TITLE
Fix rare incorrect calculations bug when mirages use forced active skills

### DIFF
--- a/src/Modules/CalcMirages.lua
+++ b/src/Modules/CalcMirages.lua
@@ -49,7 +49,6 @@ end
 
 function calcs.mirages(env)
 	local config
-	local calcMode = env.mode == "CALCS" and "CALCS" or "MAIN"
 
 	if env.player.mainSkill.skillData.triggeredByMirageArcher then
 		config = {
@@ -116,17 +115,17 @@ function calcs.mirages(env)
 			compareFunc = function(skill, env, config, mirageSkill)
 				if skill ~= env.player.mainSkill and skill.skillTypes[SkillType.Attack] and not skill.skillTypes[SkillType.Totem] and not skill.skillTypes[SkillType.SummonsTotem] and band(skill.skillCfg.flags, bor(ModFlag.Sword, ModFlag.Weapon1H)) == bor(ModFlag.Sword, ModFlag.Weapon1H) and not skill.skillCfg.skillCond["usedByMirage"] then
 					local uuid = cacheSkillUUID(skill, env)
-					if not GlobalCache.cachedData[calcMode][uuid] or GlobalCache.noCache then
-						calcs.buildActiveSkill(env, calcMode, skill)
+					if not GlobalCache.cachedData["CACHE"][uuid] or GlobalCache.noCache then
+						calcs.buildActiveSkill(env, "CACHE", skill)
 					end
 
-					if GlobalCache.cachedData[calcMode][uuid] and GlobalCache.cachedData[calcMode][uuid].CritChance and GlobalCache.cachedData[calcMode][uuid].CritChance > 0 then
+					if GlobalCache.cachedData["CACHE"][uuid] and GlobalCache.cachedData["CACHE"][uuid].CritChance and GlobalCache.cachedData["CACHE"][uuid].CritChance > 0 then
 						if not mirageSkill then
-							usedSkillBestDps = GlobalCache.cachedData[calcMode][uuid].TotalDPS
-							return GlobalCache.cachedData[calcMode][uuid].ActiveSkill
-						elseif GlobalCache.cachedData[calcMode][uuid].TotalDPS > usedSkillBestDps then
-							usedSkillBestDps = GlobalCache.cachedData[calcMode][uuid].TotalDPS
-							return GlobalCache.cachedData[calcMode][uuid].ActiveSkill
+							usedSkillBestDps = GlobalCache.cachedData["CACHE"][uuid].TotalDPS
+							return GlobalCache.cachedData["CACHE"][uuid].ActiveSkill
+						elseif GlobalCache.cachedData["CACHE"][uuid].TotalDPS > usedSkillBestDps then
+							usedSkillBestDps = GlobalCache.cachedData["CACHE"][uuid].TotalDPS
+							return GlobalCache.cachedData["CACHE"][uuid].ActiveSkill
 						end
 					end
 				end
@@ -190,21 +189,21 @@ function calcs.mirages(env)
 				local isDisabled = skill.skillFlags and skill.skillFlags.disable
 				if skill ~= env.player.mainSkill and (skill.skillTypes[SkillType.Slam] or skill.skillTypes[SkillType.Melee]) and skill.skillTypes[SkillType.Attack] and not skill.skillTypes[SkillType.Vaal] and not isTriggered(skill) and not isDisabled and not skill.skillTypes[SkillType.Totem] and not skill.skillTypes[SkillType.SummonsTotem] and not skill.skillCfg.skillCond["usedByMirage"] then
 					local uuid = cacheSkillUUID(skill, env)
-					if not GlobalCache.cachedData[calcMode][uuid] or GlobalCache.noCache then
-						calcs.buildActiveSkill(env, calcMode, skill)
+					if not GlobalCache.cachedData["CACHE"][uuid] or GlobalCache.noCache then
+						calcs.buildActiveSkill(env, "CACHE", skill)
 					end
 
-					if GlobalCache.cachedData[calcMode][uuid] then
+					if GlobalCache.cachedData["CACHE"][uuid] then
 						if not mirageSkill then
-							usedSkillBestDps = GlobalCache.cachedData[calcMode][uuid].TotalDPS
-							EffectiveSourceRate = GlobalCache.cachedData[calcMode][uuid].Speed
-							return  GlobalCache.cachedData[calcMode][uuid].ActiveSkill
+							usedSkillBestDps = GlobalCache.cachedData["CACHE"][uuid].TotalDPS
+							EffectiveSourceRate = GlobalCache.cachedData["CACHE"][uuid].Speed
+							return  GlobalCache.cachedData["CACHE"][uuid].ActiveSkill
 
 						else
-							if GlobalCache.cachedData[calcMode][uuid].TotalDPS > usedSkillBestDps then
-								usedSkillBestDps = GlobalCache.cachedData[calcMode][uuid].TotalDPS
-								EffectiveSourceRate = GlobalCache.cachedData[calcMode][uuid].Speed
-								return GlobalCache.cachedData[calcMode][uuid].ActiveSkill
+							if GlobalCache.cachedData["CACHE"][uuid].TotalDPS > usedSkillBestDps then
+								usedSkillBestDps = GlobalCache.cachedData["CACHE"][uuid].TotalDPS
+								EffectiveSourceRate = GlobalCache.cachedData["CACHE"][uuid].Speed
+								return GlobalCache.cachedData["CACHE"][uuid].ActiveSkill
 							end
 						end
 					end


### PR DESCRIPTION
### Description of the problem being solved:
If a mirage decides to use a forced active skill the calculations sometimes may not be correct due to incorrect calcs mode used.