### PR TITLE
Fix spell suppression chance not displaying Lucky

### DIFF
--- a/src/Modules/Build.lua
+++ b/src/Modules/Build.lua
@@ -385,7 +385,7 @@ function buildMode:Init(dbFileName, buildName, buildXML, convertBuild)
 		{ stat = "SpellBlockChance", label = "Spell Block Chance", fmt = "d%%", overCapStat = "SpellBlockChanceOverCap" },
 		{ stat = "AttackDodgeChance", label = "Attack Dodge Chance", fmt = "d%%", overCapStat = "AttackDodgeChanceOverCap" },
 		{ stat = "SpellDodgeChance", label = "Spell Dodge Chance", fmt = "d%%", overCapStat = "SpellDodgeChanceOverCap" },
-		{ stat = "SpellSuppressionChance", label = "Spell Suppression Chance", fmt = "d%%", overCapStat = "SpellSuppressionChanceOverCap" },
+		{ stat = "EffectiveSpellSuppressionChance", label = "Spell Suppression Chance", fmt = "d%%", overCapStat = "SpellSuppressionChanceOverCap" },
 		{ },
 		{ stat = "FireResist", label = "Fire Resistance", fmt = "d%%", color = colorCodes.FIRE, condFunc = function() return true end, overCapStat = "FireResistOverCap"},
 		{ stat = "FireResistOverCap", label = "Fire Res. Over Max", fmt = "d%%", hideStat = true },


### PR DESCRIPTION
ab069e8f introduced support for enemies with Cannot be Suppressed, but inadvertently broke the displayed suppress chance in the build sidebar. Use EffectiveSpellSuppressionChance to fix that.

Fixes #6929.

### Description of the problem being solved:
Chance to Suppress Spell Damage is Lucky wasn't being properly reflected in the build sidebar.

### Steps taken to verify a working solution:
- Looked at the Spell Suppression Chance stat in the build sidebar before and after allocating the mastery.

### Link to a build that showcases this PR:
https://pobb.in/14WDSIR07DFM