### PR TITLE
Save trade search weights to build xml

### DIFF
--- a/src/Classes/ItemsTab.lua
+++ b/src/Classes/ItemsTab.lua
@@ -994,13 +994,15 @@ function ItemsTabClass:Load(xml, dbFileName)
 				end
 			end
 			t_insert(self.itemSetOrderList, itemSet.id)
-		elseif node.elem == "TradeStat" then
-			local statSort = {
-				label = node.attrib.label,
-				stat = node.attrib.stat,
-				weightMult = tonumber(node.attrib.weightMult)
-			}
-			t_insert(self.tradeQuery.statSortSelectionList, statSort)
+		elseif node.elem == "TradeSearchWeights" then
+			for _, child in ipairs(node) do
+				local statSort = {
+					label = child.attrib.label,
+					stat = child.attrib.stat,
+					weightMult = tonumber(child.attrib.weightMult)
+				}
+				t_insert(self.tradeQuery.statSortSelectionList, statSort)
+			end
 		end
 	end
 	if not self.itemSetOrderList[1] then
@@ -1080,18 +1082,24 @@ function ItemsTabClass:Save(xml)
 		end
 		t_insert(xml, child)
 	end
-	for _, statSort in ipairs(self.tradeQuery.statSortSelectionList or {}) do
-		if statSort.weightMult and statSort.weightMult ~= 0.0 then
-			local child = {
-				elem = "TradeStat",
+	if self.tradeQuery.statSortSelectionList then
+		local parent = {
+			elem = "TradeSearchWeights"
+		}
+		for _, statSort in ipairs(self.tradeQuery.statSortSelectionList) do
+			if statSort.weightMult and statSort.weightMult > 0 then
+				local child = {
+				elem = "Stat",
 				attrib = {
 					label = statSort.label,
 					stat = statSort.stat,
 					weightMult = s_format("%.2f", tostring(statSort.weightMult))
 				}
 			}
-			t_insert(xml, child)
+			t_insert(parent, child)
+			end
 		end
+		t_insert(xml, parent)
 	end
 end
 

--- a/src/Classes/ItemsTab.lua
+++ b/src/Classes/ItemsTab.lua
@@ -916,6 +916,7 @@ function ItemsTabClass:Load(xml, dbFileName)
 	self.activeItemSetId = 0
 	self.itemSets = { }
 	self.itemSetOrderList = { }
+	self.tradeQuery.statSortSelectionList = { }
 	for _, node in ipairs(xml) do
 		if node.elem == "Item" then
 			local item = new("Item", "")
@@ -993,6 +994,13 @@ function ItemsTabClass:Load(xml, dbFileName)
 				end
 			end
 			t_insert(self.itemSetOrderList, itemSet.id)
+		elseif node.elem == "TradeStat" then
+			local statSort = {
+				label = node.attrib.label,
+				stat = node.attrib.stat,
+				weightMult = tonumber(node.attrib.weightMult)
+			}
+			t_insert(self.tradeQuery.statSortSelectionList, statSort)
 		end
 	end
 	if not self.itemSetOrderList[1] then
@@ -1071,6 +1079,19 @@ function ItemsTabClass:Save(xml)
 			end
 		end
 		t_insert(xml, child)
+	end
+	for _, statSort in ipairs(self.tradeQuery.statSortSelectionList or {}) do
+		if statSort.weightMult and statSort.weightMult ~= 0.0 then
+			local child = {
+				elem = "TradeStat",
+				attrib = {
+					label = statSort.label,
+					stat = statSort.stat,
+					weightMult = s_format("%.2f", tostring(statSort.weightMult))
+				}
+			}
+			t_insert(xml, child)
+		end
 	end
 end
 

--- a/src/Classes/TradeQuery.lua
+++ b/src/Classes/TradeQuery.lua
@@ -280,8 +280,8 @@ on trade site to work on other leagues and realms)]]
 	end
 
 	-- Stat sort popup button
-	-- if the list is empty, set default sorting, otherwise keep whatever was loaded from xml
-	if not next(self.statSortSelectionList or {}) then
+	-- if the list is nil or empty, set default sorting, otherwise keep whatever was loaded from xml
+	if not self.statSortSelectionList or (#self.statSortSelectionList) == 0 then
 		self.statSortSelectionList = { }
 		t_insert(self.statSortSelectionList,  {
 			label = "Full DPS",
@@ -511,7 +511,7 @@ function TradeQueryClass:SetStatWeights()
 	controls.finalise = new("ButtonControl", { "BOTTOM", nil, "BOTTOM" }, -45, -10, 80, 20, "Save", function()
 		main:ClosePopup()
 		
-		-- this needs to save the weights somewhere, maybe the XML? its not necessary but possibly useful QoL
+		-- used in ItemsTab to save to xml under TradeSearchWeights node
 		local statSortSelectionList = {}
 		for stat, statTable in pairs(statList) do
 			if statTable.stat.weightMult > 0 then

--- a/src/Classes/TradeQuery.lua
+++ b/src/Classes/TradeQuery.lua
@@ -280,18 +280,22 @@ on trade site to work on other leagues and realms)]]
 	end
 
 	-- Stat sort popup button
-	self.statSortSelectionList = { }
-	t_insert(self.statSortSelectionList,  {
-		label = "Full DPS",
-		stat = "FullDPS",
-		weightMult = 1.0,
-	})
-	t_insert(self.statSortSelectionList,  {
-		label = "Effective Hit Pool",
-		stat = "TotalEHP",
-		weightMult = 0.5,
-	})
+	-- if the list is empty, set default sorting, otherwise keep whatever was loaded from xml
+	if not next(self.statSortSelectionList or {}) then
+		self.statSortSelectionList = { }
+		t_insert(self.statSortSelectionList,  {
+			label = "Full DPS",
+			stat = "FullDPS",
+			weightMult = 1.0,
+		})
+		t_insert(self.statSortSelectionList,  {
+			label = "Effective Hit Pool",
+			stat = "TotalEHP",
+			weightMult = 0.5,
+		})
+	end
 	self.controls.StatWeightMultipliersButton = new("ButtonControl", {"TOPRIGHT", self.controls.fetchCountEdit, "BOTTOMRIGHT"}, 0, row_vertical_padding, 150, row_height, "^7Adjust search weights", function()
+		self.itemsTab.modFlag = true
 		self:SetStatWeights()
 	end)
 	self.controls.StatWeightMultipliersButton.tooltipFunc = function(tooltip)


### PR DESCRIPTION
### Description of the problem being solved:
Saw a couple comments about this over the past few days so I took a crack at it. This saves the search weights to the xml under the Items node with a new element called "TradeSearchWeights". The default Full DPS and Effective Hit Pool still load on new builds or builds without this element, but any build that adjusts these weights should have them loaded as set from then on.

Open to suggestions on elem wording and xml structure.

### After screenshot:
![image](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/92683202/b0027a8e-2ead-457b-bcbb-f376a0934eed)