### PR TITLE
Add support for importing new ascendancies

### DIFF
--- a/src/Classes/ImportTab.lua
+++ b/src/Classes/ImportTab.lua
@@ -625,7 +625,7 @@ function ImportTabClass:ImportPassiveTreeAndJewels(json, charData)
 		end
 	end
 	for ascendId, ascendClass in pairs(self.tree.alternate_ascendancies) do
-		if charData.afflictionClass == ascendClass then
+		if charData.alternate_ascendancy == ascendClass then
 			charData.secondaryAscendancyClass = ascendId
 			break
 		end

--- a/src/Classes/ImportTab.lua
+++ b/src/Classes/ImportTab.lua
@@ -624,12 +624,13 @@ function ImportTabClass:ImportPassiveTreeAndJewels(json, charData)
 			end
 		end
 	end
-	for ascendId, ascendClass in pairs(self.tree.alternate_ascendancies) do
-		if charData.alternate_ascendancy == ascendClass then
-			charData.secondaryAscendancyClass = ascendId
-			break
-		end
-	end
+	-- Currently we don't get the alternate ascendancy from the unofficial API
+	--for ascendId, ascendClass in pairs(self.build.spec.tree.alternate_ascendancies) do
+	--	if charData.alternate_ascendancy == ascendClass then
+	--		charData.secondaryAscendancyClass = ascendId
+	--		break
+	--	end
+	--end
 	self.build.spec:ImportFromNodeList(charData.classId, charData.ascendancyClass, charData.secondaryAscendancyClass or 0, charPassiveData.hashes, charPassiveData.skill_overrides, charPassiveData.mastery_effects or {}, latestTreeVersion .. (charData.league:match("Ruthless") and "_ruthless" or ""))
 	self.build.spec:AddUndoState()
 	self.build.characterLevel = charData.level

--- a/src/Classes/ImportTab.lua
+++ b/src/Classes/ImportTab.lua
@@ -624,7 +624,13 @@ function ImportTabClass:ImportPassiveTreeAndJewels(json, charData)
 			end
 		end
 	end
-	self.build.spec:ImportFromNodeList(charData.classId, charData.ascendancyClass, 0, charPassiveData.hashes, charPassiveData.skill_overrides, charPassiveData.mastery_effects or {}, latestTreeVersion .. (charData.league:match("Ruthless") and "_ruthless" or ""))
+	for ascendId, ascendClass in pairs(self.tree.alternate_ascendancies) do
+		if charData.afflictionClass == ascendClass then
+			charData.secondaryAscendancyClass = ascendId
+			break
+		end
+	end
+	self.build.spec:ImportFromNodeList(charData.classId, charData.ascendancyClass, charData.secondaryAscendancyClass or 0, charPassiveData.hashes, charPassiveData.skill_overrides, charPassiveData.mastery_effects or {}, latestTreeVersion .. (charData.league:match("Ruthless") and "_ruthless" or ""))
 	self.build.spec:AddUndoState()
 	self.build.characterLevel = charData.level
 	self.build.characterLevelAutoMode = false

--- a/src/Classes/PassiveSpec.lua
+++ b/src/Classes/PassiveSpec.lua
@@ -429,8 +429,8 @@ function PassiveSpecClass:DecodeURL(url)
 	end
 	local classId = b:byte(5)
 	local ascendancyIds = (ver >= 4) and b:byte(6) or 0
-	local ascendClassId = band(ascendancyIds, 0x00000011)
-	local secondaryAscendClassId = band(ascendancyIds, 0x00001100)
+	local ascendClassId = band(ascendancyIds, 3)
+	local secondaryAscendClassId = b_rshift(band(ascendancyIds, 12), 2)
 	if not self.tree.classes[classId] then
 		return "Invalid tree link (bad class ID '"..classId.."')"
 	end

--- a/src/Classes/PassiveSpec.lua
+++ b/src/Classes/PassiveSpec.lua
@@ -1133,6 +1133,15 @@ function PassiveSpecClass:BuildAllDependsAndPaths()
 	for id, node in pairs(self.allocNodes) do
 		node.visited = true
 		local anyStartFound = (node.type == "ClassStart" or node.type == "AscendClassStart")
+
+		-- Temporary solution until importing secondary ascendancies works
+		if self.tree.alternate_ascendancies and (self.curSecondaryAscendClass == nil or self.curSecondaryAscendClass.id ~= node.ascendancyName) then
+			for id, class in ipairs(self.tree.alternate_ascendancies) do
+				if class.id == node.ascendancyName then
+					self:SelectSecondaryAscendClass(id)
+				end
+			end
+		end
 		for _, other in ipairs(node.linked) do
 			if other.alloc and not isValueInArray(node.depends, other) then
 				-- The other node is allocated and isn't already dependent on this node, so try and find a path to a start node through it

--- a/src/Classes/PassiveSpec.lua
+++ b/src/Classes/PassiveSpec.lua
@@ -1135,7 +1135,7 @@ function PassiveSpecClass:BuildAllDependsAndPaths()
 		local anyStartFound = (node.type == "ClassStart" or node.type == "AscendClassStart")
 
 		-- Temporary solution until importing secondary ascendancies works
-		if self.tree.alternate_ascendancies and (self.curSecondaryAscendClass == nil or self.curSecondaryAscendClass.id ~= node.ascendancyName) then
+		if self.tree.alternate_ascendancies and node.ascendancyName and (self.curSecondaryAscendClass == nil or self.curSecondaryAscendClass.id ~= node.ascendancyName) then
 			for id, class in ipairs(self.tree.alternate_ascendancies) do
 				if class.id == node.ascendancyName then
 					self:SelectSecondaryAscendClass(id)

--- a/src/Classes/PassiveSpec.lua
+++ b/src/Classes/PassiveSpec.lua
@@ -12,6 +12,8 @@ local m_min = math.min
 local m_max = math.max
 local m_floor = math.floor
 local b_lshift = bit.lshift
+local b_rshift = bit.rshift
+local band = bit.band
 
 local PassiveSpecClass = newClass("PassiveSpec", "UndoHandler", function(self, build, treeVersion, convert)
 	self.UndoHandler()
@@ -425,13 +427,16 @@ function PassiveSpecClass:DecodeURL(url)
 		return "Invalid tree link (unknown version number '"..ver.."')"
 	end
 	local classId = b:byte(5)
-	local ascendClassId = (ver >= 4) and b:byte(6) or 0
+	local ascendancyIds = (ver >= 4) and b:byte(6) or 0
+	local ascendClassId = band(ascendancyIds, 0x00001111)
+	local secondaryAscendClassId = b_rshift(ascendancyIds, 4)
 	if not self.tree.classes[classId] then
 		return "Invalid tree link (bad class ID '"..classId.."')"
 	end
 	self:ResetNodes()
 	self:SelectClass(classId)
 	self:SelectAscendClass(ascendClassId)
+	self:SelectSecondaryAscendClass(secondaryAscendClassId)
 
 	local nodesStart = ver >= 4 and 8 or 7
 	local nodesEnd = ver >= 5 and 7 + (b:byte(7) * 2) or -1
@@ -460,7 +465,7 @@ end
 -- Encodes the current spec into a URL, using the official skill tree's format
 -- Prepends the URL with an optional prefix
 function PassiveSpecClass:EncodeURL(prefix)
-	local a = { 0, 0, 0, 6, self.curClassId, self.curAscendClassId }
+	local a = { 0, 0, 0, 6, self.curClassId, band(b_lshift(self.curSecondaryAscendClassId, 4), self.curAscendClassId) }
 
 	local nodeCount = 0
 	local clusterCount = 0
@@ -556,7 +561,7 @@ function PassiveSpecClass:SelectAscendClass(ascendClassId)
 end
 
 function PassiveSpecClass:SelectSecondaryAscendClass(ascendClassId)
-	-- if Secondary Ascendency does not exist on this tree version
+	-- if Secondary Ascendancy does not exist on this tree version
 	if not self.tree.alternate_ascendancies then
 		return
 	end

--- a/src/Classes/PassiveSpec.lua
+++ b/src/Classes/PassiveSpec.lua
@@ -465,7 +465,7 @@ end
 -- Encodes the current spec into a URL, using the official skill tree's format
 -- Prepends the URL with an optional prefix
 function PassiveSpecClass:EncodeURL(prefix)
-	local a = { 0, 0, 0, 6, self.curClassId, band(b_lshift(self.curSecondaryAscendClassId, 4), self.curAscendClassId) }
+	local a = { 0, 0, 0, 6, self.curClassId, band(b_lshift(self.curSecondaryAscendClassId or 0, 4), self.curAscendClassId) }
 
 	local nodeCount = 0
 	local clusterCount = 0

--- a/src/Classes/PassiveSpec.lua
+++ b/src/Classes/PassiveSpec.lua
@@ -14,6 +14,7 @@ local m_floor = math.floor
 local b_lshift = bit.lshift
 local b_rshift = bit.rshift
 local band = bit.band
+local bor = bit.bor
 
 local PassiveSpecClass = newClass("PassiveSpec", "UndoHandler", function(self, build, treeVersion, convert)
 	self.UndoHandler()
@@ -428,8 +429,8 @@ function PassiveSpecClass:DecodeURL(url)
 	end
 	local classId = b:byte(5)
 	local ascendancyIds = (ver >= 4) and b:byte(6) or 0
-	local ascendClassId = band(ascendancyIds, 0x00001111)
-	local secondaryAscendClassId = b_rshift(ascendancyIds, 4)
+	local ascendClassId = band(ascendancyIds, 0x00000011)
+	local secondaryAscendClassId = b_rshift(ascendancyIds, 2)
 	if not self.tree.classes[classId] then
 		return "Invalid tree link (bad class ID '"..classId.."')"
 	end
@@ -465,7 +466,7 @@ end
 -- Encodes the current spec into a URL, using the official skill tree's format
 -- Prepends the URL with an optional prefix
 function PassiveSpecClass:EncodeURL(prefix)
-	local a = { 0, 0, 0, 6, self.curClassId, band(b_lshift(self.curSecondaryAscendClassId or 0, 4), self.curAscendClassId) }
+	local a = { 0, 0, 0, 6, self.curClassId, bor(b_lshift(self.curSecondaryAscendClassId or 0, 2), self.curAscendClassId) }
 
 	local nodeCount = 0
 	local clusterCount = 0

--- a/src/Classes/PassiveSpec.lua
+++ b/src/Classes/PassiveSpec.lua
@@ -430,7 +430,7 @@ function PassiveSpecClass:DecodeURL(url)
 	local classId = b:byte(5)
 	local ascendancyIds = (ver >= 4) and b:byte(6) or 0
 	local ascendClassId = band(ascendancyIds, 0x00000011)
-	local secondaryAscendClassId = b_rshift(ascendancyIds, 2)
+	local secondaryAscendClassId = band(ascendancyIds, 0x00001100)
 	if not self.tree.classes[classId] then
 		return "Invalid tree link (bad class ID '"..classId.."')"
 	end

--- a/src/Modules/Build.lua
+++ b/src/Modules/Build.lua
@@ -771,7 +771,7 @@ function buildMode:EstimatePlayerProgress()
 		self.controls.characterLevel:SetText(self.characterLevel)
 	end
 
-	-- Ascendency points for lab
+	-- Ascendancy points for lab
 	-- this is a recommendation for beginners who are using Path of Building for the first time and trying to map out progress in PoB
 	local labSuggest = level < 33 and ""
 		or level < 55 and "\nLabyrinth: Normal Lab"


### PR DESCRIPTION
### Description of the problem being solved:
Supports importing new ascendancy classes from a tree link and the import tab.  Also fixes some typos that snuck through.

Can't really test this yet until the league is live, but you can export a tree link and it'll import again just fine.