### PR TITLE
Fix: updated the conditions for calcuating costs/s to include mana cost as base es cost and eb interaction

### DIFF
--- a/src/Modules/CalcOffence.lua
+++ b/src/Modules/CalcOffence.lua
@@ -5065,9 +5065,9 @@ function calcs.offence(env, actor, activeSkill)
 
 	--Calculates and displays cost per second for skills that don't already have one (link skills)
 	for resource, val in pairs(costs) do
-		if(val.upfront and output[resource.."HasCost"] and output[resource.."Cost"] > 0 and not output[resource.."PerSecondHasCost"] and (output.Speed > 0 or output.Cooldown)) then
+		local EB = env.modDB:Flag(nil, "EnergyShieldProtectsMana")
+		if(val.upfront and output[resource.."HasCost"] and output[resource.."Cost"] > 0 and not (output[resource.."PerSecondHasCost"] and not (EB and skillModList:Sum("BASE", skillCfg, "ManaCostAsEnergyShieldCost"))) and (output.Speed > 0 or output.Cooldown)) then
 			local usedResource = resource
-			local EB = env.modDB:Flag(nil, "EnergyShieldProtectsMana")
 
 			if EB and resource == "Mana" then
 				usedResource = "ES"
@@ -5093,7 +5093,7 @@ function calcs.offence(env, actor, activeSkill)
 			end
 
 			output[usedResource.."PerSecondHasCost"] = true
-			output[usedResource.."PerSecondCost"] = output[resource.."Cost"] * useSpeed
+			output[usedResource.."PerSecondCost"] = (output[usedResource.."PerSecondCost"] or 0)+ output[resource.."Cost"] * useSpeed
 
 			if breakdown then
 				breakdown[usedResource.."PerSecondCost"] = copyTable(breakdown[resource.."Cost"])


### PR DESCRIPTION
…

Fixes #6962 .

### Description of the problem being solved:
Currently if ES/second already exists, then it will skip the calculation. This interferes with interaction between EB and Replica Covenant's mana cost as es cost mod. 

Added a condition to calculate the cost despite value already existing and summing together for the breakdown.

### Steps taken to verify a working solution:
Tested with Replica Covenant and EB and ES costs are now accurately reflecting intended behaviour.

Compare to image from linked issue. 
![image](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/42928828/bb2f7643-def1-483b-be24-c94abcd83d71)

