### PR TITLE
Add Sin Trek and Legacy of Fury to Utula exclude list

### DIFF
--- a/src/Modules/Data.lua
+++ b/src/Modules/Data.lua
@@ -672,7 +672,7 @@ data.itemTagSpecial = {
 			"Vaal Pact",
 			"Zealot's Oath",
 			-- Special Cases
-			"Cannot Leech",
+			"^Cannot Leech$",
 		},
 	},
 	["evasion"] = {
@@ -692,6 +692,8 @@ data.itemTagSpecialExclusionPattern = {
 			"Life as Extra Maximum Energy Shield",
 			"maximum Life as Fire Damage",
 			"when on Full Life",
+			"Enemy's life",
+			"Life From You",
 		},
 	},
 	["evasion"] = {


### PR DESCRIPTION
Fixes #6769 and fixes #6796

### Description of the problem being solved:
Matching for life mods on other items now exclude `Enemy's life` and `Life From You`. This assumes that other mods like Sin Trek's `Enemies cannot leech life from you` are similarly tagless.

The only source I could find of `Cannot Leech` is from a legacy Infractem pre-2.6, but I've simply modified the specialTag for it to only match that complete line instead of any part of the line. This prevents `cannot leech mana` and Sin Trek's mod from disrupting Utula's.

This PR does not address the Searing Exarch's recoup implicit as seen in issue 6715. This behaviour seems inconsistent, since a life recoup mod on unique items certainly disables Utula. From this I'm guessing that eldritch implicits are excluded from Utula searching, but I don't have this confirmed.

### Steps taken to verify a working solution:
- Tested all items that currently have a cannot leech mod
- Tested legacy of fury

### Link to a build that showcases this PR:
https://pobb.in/jXM5M2AxQZJS
