### PR TITLE
Fix scrolling on search and hide all configurations input

### DIFF
--- a/src/Classes/ConfigTab.lua
+++ b/src/Classes/ConfigTab.lua
@@ -28,11 +28,19 @@ local ConfigTabClass = newClass("ConfigTab", "UndoHandler", "ControlHost", "Cont
 	self.varControls = { }
 	
 	self:BuildModList()
+	
+	self.toggleConfigs = false
 
-  self.controls.search = new("EditControl", { "TOPLEFT", self, "TOPLEFT" }, 8, 5, 360, 20, "", "Search", "%c", 100, function()
+	self.controls.sectionAnchor = new("LabelControl", { "TOPLEFT", self, "TOPLEFT" }, 0, 20, 0, 0, "")
+	self.controls.search = new("EditControl", { "TOPLEFT", self.controls.sectionAnchor, "TOPLEFT" }, 8, -15, 360, 20, "", "Search", "%c", 100, function()
 		self:UpdateControls()
 	end, nil, nil, true)
-	self.controls.sectionAnchor = new("LabelControl", { "TOPLEFT", self.controls.search, "TOPLEFT" }, -10, 15, 0, 0, "")
+	self.controls.toggleConfigs = new("ButtonControl", { "LEFT", self.controls.search, "RIGHT" }, 10, 0, 200, 20, function()
+		-- dynamic text
+		return self.toggleConfigs and "Hide Ineligible Configurations" or "Show All Configurations"
+	end, function()
+		self.toggleConfigs = not self.toggleConfigs
+	end)
 
 	local function searchMatch(varData)
 		local searchStr = self.controls.search.buf:lower():gsub("[%-%.%+%[%]%$%^%%%?%*]", "%%%0")
@@ -45,14 +53,6 @@ local ConfigTabClass = newClass("ConfigTab", "UndoHandler", "ControlHost", "Cont
 		end
 		return true
 	end
-  
-	self.toggleConfigs = false
-	self.controls.toggleConfigs = new("ButtonControl", { "LEFT", self.controls.search, "RIGHT" }, 10, 0, 200, 20, function()
-		-- dynamic text
-		return self.toggleConfigs and "Hide Ineligible Configurations" or "Show All Configurations"
-	end, function()
-		self.toggleConfigs = not self.toggleConfigs
-	end)
 
 	-- blacklist for Show All Configurations
 	local function isShowAllConfig(varData)


### PR DESCRIPTION
### Description of the problem being solved:

Current search and hide all configurations is always on top and overlaps inputs when scrollng

### Before screenshot:
![image](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/5115805/97d99356-9e6e-4b62-838b-7f8fd2fac62e)

![image](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/5115805/0d190bb0-0b6f-43f1-94cb-77663cafe3d3)

### After screenshot:

![image](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/5115805/2c674c15-ec83-4ab6-965d-4636da1efb25)
![image](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/5115805/030d5653-d5f2-47f9-a761-7a4d1834b10b)

