### PR TITLE
Updated import code with extra data GGG kindly provided

### DIFF
--- a/src/Classes/ImportTab.lua
+++ b/src/Classes/ImportTab.lua
@@ -610,28 +610,8 @@ function ImportTabClass:ImportPassiveTreeAndJewels(json, charData)
 	end
 	self.build.itemsTab:PopulateSlots()
 	self.build.itemsTab:AddUndoState()
-	for classId, class in pairs(self.build.spec.tree.classes) do
-		if charData.class == class.name then
-			charData.classId = classId
-			charData.ascendancyClass = 0
-			break
-		end
-		for ascendId, ascendancyClass in pairs(class.ascendancies) do
-			if charData.class == ascendancyClass.name then
-				charData.classId = classId
-				charData.ascendancyClass = ascendId
-				break
-			end
-		end
-	end
-	-- Currently we don't get the alternate ascendancy from the unofficial API
-	--for ascendId, ascendClass in pairs(self.build.spec.tree.alternate_ascendancies) do
-	--	if charData.alternate_ascendancy == ascendClass then
-	--		charData.secondaryAscendancyClass = ascendId
-	--		break
-	--	end
-	--end
-	self.build.spec:ImportFromNodeList(charData.classId, charData.ascendancyClass, charData.secondaryAscendancyClass or 0, charPassiveData.hashes, charPassiveData.skill_overrides, charPassiveData.mastery_effects or {}, latestTreeVersion .. (charData.league:match("Ruthless") and "_ruthless" or ""))
+
+	self.build.spec:ImportFromNodeList(charPassiveData.character, charPassiveData.ascendancy, charPassiveData.alternate_ascendancy or 0, charPassiveData.hashes, charPassiveData.skill_overrides, charPassiveData.mastery_effects or {}, latestTreeVersion .. (charData.league:match("Ruthless") and "_ruthless" or ""))
 	self.build.spec:AddUndoState()
 	self.build.characterLevel = charData.level
 	self.build.characterLevelAutoMode = false

--- a/src/Classes/PassiveSpec.lua
+++ b/src/Classes/PassiveSpec.lua
@@ -226,6 +226,8 @@ function PassiveSpecClass:ImportFromNodeList(classId, ascendClassId, secondaryAs
 	end
 	self:ResetNodes()
 	self:SelectClass(classId)
+	self:SelectAscendClass(ascendClassId)
+	self:SelectSecondaryAscendClass(secondaryAscendClassId)
 	self.hashOverrides = hashOverrides
 	-- move above setting allocNodes so we can compare mastery with selection
 	wipeTable(self.masterySelections)
@@ -262,8 +264,6 @@ function PassiveSpecClass:ImportFromNodeList(classId, ascendClassId, secondaryAs
 			self.allocNodes[id] = node
 		end
 	end
-	self:SelectAscendClass(ascendClassId)
-	self:SelectSecondaryAscendClass(secondaryAscendClassId)
 end
 
 function PassiveSpecClass:AllocateDecodedNodes(nodes, isCluster, endian)
@@ -1135,15 +1135,6 @@ function PassiveSpecClass:BuildAllDependsAndPaths()
 	for id, node in pairs(self.allocNodes) do
 		node.visited = true
 		local anyStartFound = (node.type == "ClassStart" or node.type == "AscendClassStart")
-
-		-- Temporary solution until importing secondary ascendancies works
-		if self.tree.alternate_ascendancies and node.ascendancyName and (self.curSecondaryAscendClass == nil or self.curSecondaryAscendClass.id ~= node.ascendancyName) then
-			for id, class in ipairs(self.tree.alternate_ascendancies) do
-				if class.id == node.ascendancyName then
-					self:SelectSecondaryAscendClass(id)
-				end
-			end
-		end
 		for _, other in ipairs(node.linked) do
 			if other.alloc and not isValueInArray(node.depends, other) then
 				-- The other node is allocated and isn't already dependent on this node, so try and find a path to a start node through it


### PR DESCRIPTION
Fixes # .

### Description of the problem being solved:
Before, GGG didn't supply ascendancy IDs in their unofficial API.  Novynn was kind enough to supply these for us, so this PR switches to use them.
### Steps taken to verify a working solution:
- Imported character to empty build
- Imported a different character over an existing build
- Imported a new character on an old build