### PR TITLE
Fix Crash when opening Timeless Jewel search

### DIFF
--- a/src/Classes/TreeTab.lua
+++ b/src/Classes/TreeTab.lua
@@ -1014,7 +1014,7 @@ function TreeTabClass:FindTimelessJewel()
 	}
 	local jewelSockets = { }
 	for socketId, socketData in pairs(self.build.spec.nodes) do
-		if socketData.isJewelSocket then
+		if socketData.isJewelSocket and socketData.name ~= "Charm Socket"then
 			local keystone = "Unknown"
 			if socketId == 26725 then
 				keystone = "Marauder"


### PR DESCRIPTION
There was no check to exclude Charm Sockets from the nodes in radius check
Fixes #6994