### PR TITLE
Fix projectile count being 1 higher on all skills

### DIFF
--- a/src/Data/SkillStatMap.lua
+++ b/src/Data/SkillStatMap.lua
@@ -1199,13 +1199,17 @@ return {
 },
 ["base_number_of_arrows"] = {
 	mod("ProjectileCount", "BASE", nil),
+	base = -1,
 },
-["number_of_additional_projectiles"] = {
+["number_of_additional_arrows"] = {
 	mod("ProjectileCount", "BASE", nil),
 },
 ["base_number_of_projectiles"] = {
 	mod("ProjectileCount", "BASE", nil),
 	base = -1,
+},
+["number_of_additional_projectiles"] = {
+	mod("ProjectileCount", "BASE", nil),
 },
 ["projectile_damage_+%_per_remaining_chain"] = {
 	mod("Damage", "INC", nil, ModFlag.Projectile, 0, { type = "PerStat", stat = "ChainRemaining" }),

--- a/src/Data/SkillStatMap.lua
+++ b/src/Data/SkillStatMap.lua
@@ -1205,6 +1205,7 @@ return {
 },
 ["base_number_of_projectiles"] = {
 	mod("ProjectileCount", "BASE", nil),
+	base = -1,
 },
 ["projectile_damage_+%_per_remaining_chain"] = {
 	mod("Damage", "INC", nil, ModFlag.Projectile, 0, { type = "PerStat", stat = "ChainRemaining" }),


### PR DESCRIPTION
GGG changed the stat on all their gems from `number_of_additional_projectiles` to `base_number_of_projectiles`so it now included the 1 base projectile all the skills inherently have
Fixes #6997 