### PR TITLE
move contribs to separate file

### DIFF
--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -1,4 +1,4 @@
-name: 'spellcheck'
+name: 'Spell Checker'
 
 on:
   pull_request:
@@ -29,7 +29,8 @@ jobs:
             ${{ env.CONFIG_URL }}/pob-dict.txt \
             ${{ env.CONFIG_URL }}/poe-dict.txt \
             ${{ env.CONFIG_URL }}/ignore-dict.txt \
-            ${{ env.CONFIG_URL }}/extra-en-dict.txt
+            ${{ env.CONFIG_URL }}/extra-en-dict.txt \
+            ${{ env.CONFIG_URL }}/contribs-dict.txt
 
       - name: Run cspell
         uses: streetsidesoftware/cspell-action@v2.4.0
@@ -37,4 +38,3 @@ jobs:
           files: '**' # needed as workaround for non-incremental runs (overrides in config still work ok)
           config: "cspell.json"
           incremental_files_only: ${{ github.event_name != 'workflow_dispatch' }}
-


### PR DESCRIPTION
Move contributor's GitHub logins from `pob-dict.txt` to `contribs-dict.txt`.  This new file will (hopefully) be auto-generated in future.