### PR TITLE
Reset ascendancy class before changing base class again

### DIFF
--- a/src/Classes/PassiveSpec.lua
+++ b/src/Classes/PassiveSpec.lua
@@ -522,6 +522,8 @@ function PassiveSpecClass:SelectClass(classId)
 		self.allocNodes[oldStartNodeId] = nil
 	end
 
+	self:ResetAscendClass()
+
 	self.curClassId = classId
 	local class = self.tree.classes[classId]
 	self.curClass = class
@@ -537,7 +539,7 @@ function PassiveSpecClass:SelectClass(classId)
 	self:SelectAscendClass(0)
 end
 
-function PassiveSpecClass:SelectAscendClass(ascendClassId)
+function PassiveSpecClass:ResetAscendClass()
 	if self.curAscendClassId then
 		-- Deallocate the current ascendancy class's start node
 		local ascendClass = self.curClass.classes[self.curAscendClassId] or self.curClass.classes[0]
@@ -547,6 +549,10 @@ function PassiveSpecClass:SelectAscendClass(ascendClassId)
 			self.allocNodes[oldStartNodeId] = nil
 		end
 	end
+end
+
+function PassiveSpecClass:SelectAscendClass(ascendClassId)
+	self:ResetAscendClass()
 
 	self.curAscendClassId = ascendClassId
 	local ascendClass = self.curClass.classes[ascendClassId] or self.curClass.classes[0]


### PR DESCRIPTION
Fixes #6963

### Description of the problem being solved:
In the changes made to support secondary ascendancy classes, the code to reset the current ascendancy class when changing base class was changed to deallocate the old ascendancy instead of all ascendancies that isn't the new one. This didn't work because selectClass already changes the current class before calling selectAscendClass.

This change is pretty simple, it simply makes the reset a function that is called by both SelectClass and SelectAscendClass. This does mean we're running it unnecessarily in SelectAscendClass when called from SelectClass, but this way avoids breaking any of the other uses so I felt like this was a fair compromise.

### Steps taken to verify a working solution:
- Swapped between various ascendancies. The bug doesn't seem to always appear, but swapping between ascendant and other classes always seems to cause the issue.
