### PR TITLE
Add support for selecting league for Timeless Jewel search

### DIFF
--- a/src/Classes/TradeQueryRequests.lua
+++ b/src/Classes/TradeQueryRequests.lua
@@ -428,7 +428,7 @@ function TradeQueryRequestsClass:FetchLeagues(realm, callback)
 			end
 			local leagues = {}
 				for _, value in pairs(json_data) do
-					if not value.id:find("SSF") then
+					if (not value.id:find("SSF") and not value.id:find("Solo")) then
 						table.insert(leagues, value.id)
 					end
 				end

--- a/src/Classes/TreeTab.lua
+++ b/src/Classes/TreeTab.lua
@@ -143,6 +143,7 @@ local TreeTabClass = newClass("TreeTab", "ControlHost", function(self, build)
 	end, nil, nil, true)
 	self.controls.treeSearch.tooltipText = "Uses Lua pattern matching for complex searches"
 
+	self.tradeLeaguesList = { }
 	-- Find Timeless Jewel Button
 	self.controls.findTimelessJewel = new("ButtonControl", { "LEFT", self.controls.treeSearch, "RIGHT" }, 8, 0, 150, 20, "Find Timeless Jewel", function()
 		self:FindTimelessJewel()
@@ -1728,31 +1729,34 @@ function TreeTabClass:FindTimelessJewel()
 	end)
 	self.tradeQueryRequests = new("TradeQueryRequests")
 	controls.msg = new("LabelControl", nil, -280, 5, 0, 16, "")
-	self.tradeQueryRequests:FetchLeagues("pc", function(leagues, errMsg)
-		if errMsg then
-			controls.msg.label = "^1Error fetching league list, default league will be used\n"..errMsg.."^7"
-			return
-		end
-		local sorted_leagues = { }
-		local tempLeagueTable = { }
-		for _, league in ipairs(leagues) do
-			if league ~= "Standard" and league ~= "Hardcore" then
-				if not (league:find("Hardcore") or league:find("Ruthless")) then
-					-- set the dynamic, base league name to index 1 to sync league shown in dropdown on load with default/old behavior of copy trade url
-					t_insert(tempLeagueTable, league)
-					for _, val in ipairs(sorted_leagues) do
-						t_insert(tempLeagueTable, val)
+	if #self.tradeLeaguesList > 0 then
+		controls.searchTradeLeagueSelect:SetList(self.tradeLeaguesList)
+	else
+		self.tradeQueryRequests:FetchLeagues("pc", function(leagues, errMsg)
+			if errMsg then
+				controls.msg.label = "^1Error fetching league list, default league will be used\n"..errMsg.."^7"
+				return
+			end
+			local tempLeagueTable = { }
+			for _, league in ipairs(leagues) do
+				if league ~= "Standard" and league ~= "Hardcore" then
+					if not (league:find("Hardcore") or league:find("Ruthless")) then
+						-- set the dynamic, base league name to index 1 to sync league shown in dropdown on load with default/old behavior of copy trade url
+						t_insert(tempLeagueTable, league)
+						for _, val in ipairs(self.tradeLeaguesList) do
+							t_insert(tempLeagueTable, val)
+						end
+						self.tradeLeaguesList = copyTable(tempLeagueTable)
+					else
+						t_insert(self.tradeLeaguesList, league)
 					end
-					sorted_leagues = copyTable(tempLeagueTable)
-				else
-					t_insert(sorted_leagues, league)
 				end
 			end
-		end
-		t_insert(sorted_leagues, "Standard")
-		t_insert(sorted_leagues, "Hardcore")
-		controls.searchTradeLeagueSelect:SetList(sorted_leagues)
-	end)
+			t_insert(self.tradeLeaguesList, "Standard")
+			t_insert(self.tradeLeaguesList, "Hardcore")
+			controls.searchTradeLeagueSelect:SetList(self.tradeLeaguesList)
+		end)
+	end
 	controls.searchTradeButton = new("ButtonControl", { "BOTTOMRIGHT", controls.searchResults, "TOPRIGHT" }, 0, -5, 170, 20, "Copy Trade URL", function()
 		local seedTrades = {}
 		local startRow = controls.searchResults.selIndex or 1

--- a/src/Classes/TreeTab.lua
+++ b/src/Classes/TreeTab.lua
@@ -1723,7 +1723,36 @@ function TreeTabClass:FindTimelessJewel()
 
 	controls.searchResultsLabel = new("LabelControl", { "TOPLEFT", nil, "TOPRIGHT" }, -450, 250, 0, 16, "^7Search Results:")
 	controls.searchResults = new("TimelessJewelListControl", { "TOPLEFT", nil, "TOPRIGHT" }, -450, 275, 438, 200, self.build)
-
+	controls.searchTradeLeagueSelect = new("DropDownControl", { "BOTTOMRIGHT", controls.searchResults, "TOPRIGHT" }, -175, -5, 140, 20, nil, function(_, value)
+		self.timelessJewelLeagueSelect = value
+	end)
+	self.tradeQueryRequests = new("TradeQueryRequests")
+	controls.msg = new("LabelControl", nil, -280, 5, 0, 16, "")
+	self.tradeQueryRequests:FetchLeagues("pc", function(leagues, errMsg)
+		if errMsg then
+			controls.msg.label = "^1Error fetching league list, default league will be used\n"..errMsg.."^7"
+			return
+		end
+		local sorted_leagues = { }
+		local tempLeagueTable = { }
+		for _, league in ipairs(leagues) do
+			if league ~= "Standard" and league ~= "Hardcore" then
+				if not (league:find("Hardcore") or league:find("Ruthless")) then
+					-- set the dynamic, base league name to index 1 to sync league shown in dropdown on load with default/old behavior of copy trade url
+					t_insert(tempLeagueTable, league)
+					for _, val in ipairs(sorted_leagues) do
+						t_insert(tempLeagueTable, val)
+					end
+					sorted_leagues = copyTable(tempLeagueTable)
+				else
+					t_insert(sorted_leagues, league)
+				end
+			end
+		end
+		t_insert(sorted_leagues, "Standard")
+		t_insert(sorted_leagues, "Hardcore")
+		controls.searchTradeLeagueSelect:SetList(sorted_leagues)
+	end)
 	controls.searchTradeButton = new("ButtonControl", { "BOTTOMRIGHT", controls.searchResults, "TOPRIGHT" }, 0, -5, 170, 20, "Copy Trade URL", function()
 		local seedTrades = {}
 		local startRow = controls.searchResults.selIndex or 1
@@ -1806,7 +1835,7 @@ function TreeTabClass:FindTimelessJewel()
 			end
 		end
 
-		Copy("https://www.pathofexile.com/trade/search/?q=" .. (s_gsub(dkjson.encode(search), "[^a-zA-Z0-9]", function(a)
+		Copy("https://www.pathofexile.com/trade/search/"..(self.timelessJewelLeagueSelect or "").."/?q=" .. (s_gsub(dkjson.encode(search), "[^a-zA-Z0-9]", function(a)
 			return s_format("%%%02X", s_byte(a))
 		end)))
 


### PR DESCRIPTION
Fixes #6906 

### Description of the problem being solved:
Adds a trade league dropdown to the timeless jewel search. Given the user does not interact with the dropdown, the current behavior is kept and we create the trade url without the league name which defaults to the current base league. The dropdown is setup to show this same league on load so as to avoid confusion. Once any value is selected, that league specifically is added to the url. 

The realm is hardcoded to PC, which is the same behavior we have today, but we need to supply a realm to get leagues. A lot of this code is similar to what's in TradeQuery.lua (~line 350) but I wasn't sure if there was a clean way to strip that out to reuse. I have it sorting to have Affliction be at index 1, and maybe we'd also like that for the Trade popup in the ItemsTab.

I also added "Solo" in the filter in TradeQueryRequests so "Solo Self-Found" is not shown for this dropdown nor the Trade for Items popup.

#### Considerations:
- The way I coded it to put "Affliction" first could probably be improved
- ~~It makes a call out for realms every single time you open the timeless jewel search, maybe it should be moved somewhere in TreeTab to happen only once?~~

### Steps taken to verify a working solution:
- Default state: open the search, select some nodes, get search results and copy trade url without interacting with the dropdown. Confirm a **PC Affliction** trade search link is created.
- Do the same as above but select any league in the dropdown, confirm a **PC *selected league*** trade search link is generated.
- Manually break the HTTP call to generate an error, and then confirm that a url is still generated with the default behavior (empty league in url -> PC Affliction)

### After screenshot:
![image](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/92683202/f3f37618-3c4d-44d3-80aa-e16581480793)

![image](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/92683202/f21a0387-3cab-407c-96dd-81775c5f3882)

