### PR TITLE
Make minion instability hitspeed based off the summon speed instead

### DIFF
--- a/src/Data/Skills/minion.lua
+++ b/src/Data/Skills/minion.lua
@@ -1361,6 +1361,9 @@ skills["MinionInstability"] = {
 		fire = true,
 	},
 	skillTypes = { [SkillType.Damage] = true, [SkillType.Area] = true },
+	preDamageFunc = function(activeSkill, output)
+		activeSkill.skillData.hitTimeOverride = 1 / (activeSkill.summonSkill.skillData.summonSpeed or 1)
+	end,
 	baseMods = {
 		skill("FireMin", 1, { type = "PerStat", stat = "Life", div = 1/.33 }),
 		skill("FireMax", 1, { type = "PerStat", stat = "Life", div = 1/.33 }),

--- a/src/Export/Skills/minion.txt
+++ b/src/Export/Skills/minion.txt
@@ -233,6 +233,9 @@ skills["MinionInstability"] = {
 		fire = true,
 	},
 	skillTypes = { [SkillType.Damage] = true, [SkillType.Area] = true },
+	preDamageFunc = function(activeSkill, output)
+		activeSkill.skillData.hitTimeOverride = 1 / (activeSkill.summonSkill.skillData.summonSpeed or 1)
+	end,
 	baseMods = {
 		skill("FireMin", 1, { type = "PerStat", stat = "Life", div = 1/.33 }),
 		skill("FireMax", 1, { type = "PerStat", stat = "Life", div = 1/.33 }),

--- a/src/Modules/CalcOffence.lua
+++ b/src/Modules/CalcOffence.lua
@@ -901,6 +901,9 @@ function calcs.offence(env, actor, activeSkill)
 			output.ActiveMinionLimit = m_floor(env.modDB:Override(nil, activeSkill.minion.minionData.limit) or calcLib.val(skillModList, activeSkill.minion.minionData.limit, skillCfg))
 		end
 		output.SummonedMinionsPerCast = m_floor(calcLib.val(skillModList, "MinionPerCastCount", skillCfg))
+		if output.SummonedMinionsPerCast == 0 then
+			output.SummonedMinionsPerCast = 1
+		end
 	end
 	if skillFlags.chaining then
 		if skillModList:Flag(skillCfg, "CannotChain") then
@@ -3438,6 +3441,10 @@ function calcs.offence(env, actor, activeSkill)
 			end
 			t_insert(breakdown.PvpTotalDPS, s_format("= %.1f", output.PvpTotalDPS))
 		end
+	end
+	
+	if skillFlags.minion then
+		skillData.summonSpeed = output.SummonedMinionsPerCast * (output.HitSpeed or output.Speed) * skillData.dpsMultiplier
 	end
 
 	-- Calculate leech rates


### PR DESCRIPTION
This is due to the minions use-speed of the skill not mattering for dps, and instead the amount of minions summoned per second

This means getting minion cast speed no longer incorrectly scales the explosion dps, and player cast speed does

Few minor things about this PR
1) do we want minion skill parts for single explosion (always hit time of 1, player cast speed doesnt matter) / summon continuously (current method)
this allows the user to toggle off the value of speed on the player
2) what is the best place to store `skillData.summonSpeed`, is it in skill data like I have put it? and where is the best place to set it in code, I did it after dps, but I could have done it directly after speed for instance