### PR TITLE
Fix Rigwald's Curse damage conversion with specific claw mods

### DIFF
--- a/src/Modules/CalcOffence.lua
+++ b/src/Modules/CalcOffence.lua
@@ -574,7 +574,7 @@ function calcs.offence(env, actor, activeSkill)
 	end
 	if skillModList:Flag(nil, "ClawDamageAppliesToUnarmed") then
 		-- Claw Damage conversion from Rigwald's Curse
-		for i, value in ipairs(skillModList:Tabulate("INC", { flags = ModFlag.Claw, keywordFlags = KeywordFlag.Hit }, "Damage")) do
+		for i, value in ipairs(skillModList:Tabulate("INC", { flags = bor(ModFlag.Claw, ModFlag.Hit), keywordFlags = KeywordFlag.Hit }, "Damage")) do
 			local mod = value.mod
 			if band(mod.flags, ModFlag.Claw) ~= 0 then
 				skillModList:NewMod("Damage", mod.type, mod.value, mod.source, bor(band(mod.flags, bnot(ModFlag.Claw)), ModFlag.Unarmed, ModFlag.Melee), mod.keywordFlags, unpack(mod))


### PR DESCRIPTION
Fixes #7036

### Description of the problem being solved:
Rigwald's Curse damage conversion was looking specifically for ModFlag Claw.  However, claw damage mods such as "with claws" create a ModFlag of Claw, Hit with no KeywordFlag, whereas something like "Claw Attacks deal increased..." mods create a ModFlag of Claw and KeywordFlag of Hit. 

So this PR has the damage conversion check for ModFlag of Claw, Hit instead, which I assume is safe because the CritChance conversion below it does the same thing at line 595. Although I wonder if this should also add the Attack flag as well, like attack speed does? Unsure if it needs it.

### Link to a build that showcases this PR:
<pre>https://pobb.in/lxBbDeFJcbsE</pre>
### Before screenshot:
![image](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/92683202/ec65725f-ba15-4a34-9d54-8f68a4afd988)
![image](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/92683202/a7261700-ca37-462c-b206-c93a13a6d6ed)
![image](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/92683202/cae695f0-eefe-42e7-b4cf-5f30ea07285d)

### After screenshot:
![image](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/92683202/56c61c86-6725-421f-9d1a-9a55ade07585)
![image](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/92683202/f57afb56-66d8-4d75-b15e-9f2bc35389ce)
![image](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/92683202/9737b22c-a1c2-4f7b-987d-7c4df6b429e1)