### PR TITLE
Fix hidden blade not using main weapon and its supports

### DIFF
--- a/src/Data/Skills/other.lua
+++ b/src/Data/Skills/other.lua
@@ -3358,9 +3358,11 @@ skills["HiddenBlade"] = {
 	statDescriptionScope = "skill_stat_descriptions",
 	castTime = 1,
 	fromItem = true,
+	preferredSlotName = "Weapon 1",
 	baseFlags = {
 		attack = true,
 		projectile = true,
+		forceMainHand = true,
 	},
 	stats = {
 		"skill_has_trigger_from_unique_item",

--- a/src/Export/Skills/other.txt
+++ b/src/Export/Skills/other.txt
@@ -925,8 +925,9 @@ local skills, mod, flag, skill = ...
 #mods
 
 #skill HiddenBlade
-#flags attack projectile
+#flags attack projectile forceMainHand
 	fromItem = true,
+	preferredSlotName = "Weapon 1",
 #mods
 
 #skill VaalBreach

--- a/src/Modules/CalcSetup.lua
+++ b/src/Modules/CalcSetup.lua
@@ -625,7 +625,7 @@ function calcs.initEnv(build, mode, override, specEnv)
 					local grantedSkill = copyTable(skill)
 					grantedSkill.nameSpec = skillData and skillData.name or nil
 					grantedSkill.sourceItem = item
-					grantedSkill.slotName = slotName
+					grantedSkill.slotName = skillData.preferredSlotName or slotName
 					t_insert(env.grantedSkillsItems, grantedSkill)
 				end
 			end


### PR DESCRIPTION
Fixes #6966 

### Description of the problem being solved:
According to the [wiki](https://www.poewiki.net/wiki/Unseen_Strike) Unseen Strike will only use the main hand weapon and the supports socketed in that weapon regardless of which slot it's in.

The fixes causes a small visual inconsistency in the source of the custom group for the skill as it will show as socketed in "Weapon 1" regardless of the actual socketed slot. Fixing this would require relatively significant changes to the group slot logic.

### Steps taken to verify a working solution:
- Tested build from issue
- Tested Hidden blade in both slots
