### PR TITLE
fix: shako and megalomaniac displaying variants as explicit modifiers

### DIFF
--- a/src/Data/Uniques/Special/Generated.lua
+++ b/src/Data/Uniques/Special/Generated.lua
@@ -194,8 +194,6 @@ local megalomaniac = {
 	"Source: Drops from the Simulacrum Encounter",
 	"Has Alt Variant: true",
 	"Has Alt Variant Two: true",
-	"Adds 4 Passive Skills",
-	"Added Small Passive Skills grant Nothing",
 }
 local notables = { }
 for name in pairs(data.clusterJewels.notableSortOrder) do
@@ -204,6 +202,10 @@ end
 table.sort(notables)
 for index, name in ipairs(notables) do
 	table.insert(megalomaniac, "Variant: "..name)
+end
+table.insert(megalomaniac, "Adds 4 Passive Skills")
+table.insert(megalomaniac, "Added Small Passive Skills grant Nothing")
+for index, name in ipairs(notables) do
 	table.insert(megalomaniac, "{variant:"..index.."}1 Added Passive Skill is "..name)
 end
 table.insert(data.uniques.generated, table.concat(megalomaniac, "\n"))
@@ -241,12 +243,14 @@ end
 table.sort(gems)
 for index, name in ipairs(gems) do
 	table.insert(forbiddenShako, "Variant: "..name.. " (Low Level)")
-	table.insert(forbiddenShako, "{variant:"..(index * 2 - 1).."}Socketed Gems are Supported by Level (1-10) "..name)
 	table.insert(forbiddenShako, "Variant: "..name.. " (High Level)")
-	table.insert(forbiddenShako, "{variant:"..(index * 2).."}Socketed Gems are Supported by Level (25-35) "..name)
 	table.insert(replicaForbiddenShako, "Variant: "..name.. " (Low Level)")
-	table.insert(replicaForbiddenShako, "{variant:"..(index * 2 - 1).."}Socketed Gems are Supported by Level (1-10) "..name)
 	table.insert(replicaForbiddenShako, "Variant: "..name.. " (High Level)")
+end
+for index, name in ipairs(gems) do
+	table.insert(forbiddenShako, "{variant:"..(index * 2 - 1).."}Socketed Gems are Supported by Level (1-10) "..name)
+	table.insert(forbiddenShako, "{variant:"..(index * 2).."}Socketed Gems are Supported by Level (25-35) "..name)
+	table.insert(replicaForbiddenShako, "{variant:"..(index * 2 - 1).."}Socketed Gems are Supported by Level (1-10) "..name)
 	table.insert(replicaForbiddenShako, "{variant:"..(index * 2).."}Socketed Gems are Supported by Level (25-35) "..name)
 end
 table.insert(forbiddenShako, "+(25-30) to all Attributes")

--- a/src/Modules/Data.lua
+++ b/src/Modules/Data.lua
@@ -697,6 +697,7 @@ data.itemTagSpecialExclusionPattern = {
 			"when on Full Life",
 			"Enemy's life",
 			"Life From You",
+			"Variant: ",
 		},
 	},
 	["evasion"] = {

--- a/src/Modules/Data.lua
+++ b/src/Modules/Data.lua
@@ -697,7 +697,6 @@ data.itemTagSpecialExclusionPattern = {
 			"when on Full Life",
 			"Enemy's life",
 			"Life From You",
-			"Variant: ",
 		},
 	},
 	["evasion"] = {


### PR DESCRIPTION
### Description of the problem being solved:
Shako currently triggers the life modifier check on Utula's. 
This is due to the variant lines with 'life' in it - fixed by adding `Variant: ` into the exclusion pattern.

### Steps taken to verify a working solution:
- Compared Utula and Shako interaction before and after. 
- Also tested the different "socketed gems are supported by <gems with "life" in name>" and seems like there's no issue with the parsing there. 
- Test PoB: https://pobb.in/9vp9FRUvtc0o

### Before screenshot:
![image](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/42928828/b5a68466-8441-4e4d-98d4-4b2501e45659)

### After screenshot:
![image](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/42928828/4e4b633a-3e1c-4a79-bb10-86255069bb9e)
