### PR TITLE
Hacky save fix to not change save format and keep gemId making sense

### DIFF
--- a/src/Classes/SkillsTab.lua
+++ b/src/Classes/SkillsTab.lua
@@ -309,7 +309,7 @@ function SkillsTabClass:LoadSkill(node, skillSetId)
 		local gemInstance = { }
 		gemInstance.nameSpec = child.attrib.nameSpec or ""
 		if child.attrib.gemId then
-			local gemData = self.build.data.gems[child.attrib.gemId]
+			local gemData = self.build.data.gems[child.attrib.gemId:match("Metadata/Items/Gems/SkillGem") .. child.attrib.skillId]
 			if gemData then
 				gemInstance.gemId = gemData.id
 				gemInstance.skillId = gemData.grantedEffectId
@@ -438,7 +438,7 @@ function SkillsTabClass:Save(xml)
 				t_insert(node, { elem = "Gem", attrib = {
 					nameSpec = gemInstance.nameSpec,
 					skillId = gemInstance.skillId,
-					gemId = gemInstance.gemId,
+					gemId = gemInstance.gemId:match("(Metadata/Items/Gems/SkillGem%a+)Alt[XY]"),
 					level = tostring(gemInstance.level),
 					quality = tostring(gemInstance.quality),
 					qualityId = gemInstance.qualityId,

--- a/src/Classes/SkillsTab.lua
+++ b/src/Classes/SkillsTab.lua
@@ -438,7 +438,7 @@ function SkillsTabClass:Save(xml)
 				t_insert(node, { elem = "Gem", attrib = {
 					nameSpec = gemInstance.nameSpec,
 					skillId = gemInstance.skillId,
-					gemId = gemInstance.gemId:match("(Metadata/Items/Gems/SkillGem%a+)Alt[XY]"),
+					gemId = gemInstance.gemId and gemInstance.gemId:match("(Metadata/Items/Gems/SkillGem%a+)Alt[XY]"),
 					level = tostring(gemInstance.level),
 					quality = tostring(gemInstance.quality),
 					qualityId = gemInstance.qualityId,


### PR DESCRIPTION
This may break certain build save files, depending on if they were saved with a `skillId` or not (As far as I know they've all been saved with a `skillId` for a while).

This isn't intended to be a permanent solution, but is a solution to release the transfigured gems with and not be stuck supporting a save file format we may not be happy with.