### PR TITLE
New save format

### DIFF
--- a/src/Classes/SkillsTab.lua
+++ b/src/Classes/SkillsTab.lua
@@ -316,7 +316,7 @@ function SkillsTabClass:LoadSkill(node, skillSetId)
 				if child.attrib.variantId then
 					-- New save format from 3.23 that stores the specific variation (transfiguration)
 					gemData = possibleVariants[child.attrib.variantId]
-				elseif child.attrib.skillId and possibleVariants then
+				elseif child.attrib.skillId then
 					-- Old format relying on the uniqueness of the granted effects id
 					for _, variant in pairs(possibleVariants) do
 						if variant.grantedEffectId == child.attrib.skillId then

--- a/src/Data/Gems.lua
+++ b/src/Data/Gems.lua
@@ -4,6 +4,8 @@
 return {
 	["Metadata/Items/Gems/SkillGemFireball"] = {
 		name = "Fireball",
+		gameId = "Metadata/Items/Gems/SkillGemFireball",
+		variantId = "Fireball",
 		grantedEffectId = "Fireball",
 		tags = {
 			intelligence = true,
@@ -21,6 +23,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemVaalFireball"] = {
 		name = "Vaal Fireball",
+		gameId = "Metadata/Items/Gems/SkillGemVaalFireball",
+		variantId = "VaalFireball",
 		grantedEffectId = "VaalFireballSpiralNova",
 		secondaryGrantedEffectId = "Fireball",
 		vaalGem = true,
@@ -41,6 +45,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemIceNova"] = {
 		name = "Ice Nova",
+		gameId = "Metadata/Items/Gems/SkillGemIceNova",
+		variantId = "IceNova",
 		grantedEffectId = "IceNova",
 		tags = {
 			intelligence = true,
@@ -58,6 +64,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemIceNovaAltX"] = {
 		name = "Ice Nova of Frostbolts",
+		gameId = "Metadata/Items/Gems/SkillGemIceNova",
+		variantId = "IceNovaAltX",
 		grantedEffectId = "IceNovaAltX",
 		tags = {
 			intelligence = true,
@@ -75,6 +83,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemIceNovaAltY"] = {
 		name = "Ice Nova of Deep Freeze",
+		gameId = "Metadata/Items/Gems/SkillGemIceNova",
+		variantId = "IceNovaAltY",
 		grantedEffectId = "IceNovaAltY",
 		tags = {
 			intelligence = true,
@@ -92,6 +102,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemVaalIceNova"] = {
 		name = "Vaal Ice Nova",
+		gameId = "Metadata/Items/Gems/SkillGemVaalIceNova",
+		variantId = "VaalIceNova",
 		grantedEffectId = "VaalIceNova",
 		secondaryGrantedEffectId = "IceNova",
 		vaalGem = true,
@@ -112,6 +124,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemLeapSlam"] = {
 		name = "Leap Slam",
+		gameId = "Metadata/Items/Gems/SkillGemLeapSlam",
+		variantId = "LeapSlam",
 		grantedEffectId = "LeapSlam",
 		tags = {
 			strength = true,
@@ -131,6 +145,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemLeapSlamAltX"] = {
 		name = "Leap Slam of Groundbreaking",
+		gameId = "Metadata/Items/Gems/SkillGemLeapSlam",
+		variantId = "LeapSlamAltX",
 		grantedEffectId = "LeapSlamAltX",
 		tags = {
 			strength = true,
@@ -150,6 +166,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemChargedDash"] = {
 		name = "Charged Dash",
+		gameId = "Metadata/Items/Gems/SkillGemChargedDash",
+		variantId = "ChargedDash",
 		grantedEffectId = "ChargedDash",
 		tags = {
 			dexterity = true,
@@ -169,6 +187,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemChargedAttack"] = {
 		name = "Blade Flurry",
+		gameId = "Metadata/Items/Gems/SkillGemChargedAttack",
+		variantId = "ChargedAttack",
 		grantedEffectId = "ChargedAttack",
 		tags = {
 			dexterity = true,
@@ -187,6 +207,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemChargedAttackAltX"] = {
 		name = "Blade Flurry of Incision",
+		gameId = "Metadata/Items/Gems/SkillGemChargedAttack",
+		variantId = "ChargedAttackAltX",
 		grantedEffectId = "ChargedAttackAltX",
 		tags = {
 			critical = true,
@@ -206,6 +228,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemSweep"] = {
 		name = "Sweep",
+		gameId = "Metadata/Items/Gems/SkillGemSweep",
+		variantId = "Sweep",
 		grantedEffectId = "Sweep",
 		tags = {
 			strength = true,
@@ -223,6 +247,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemGroundSlam"] = {
 		name = "Ground Slam",
+		gameId = "Metadata/Items/Gems/SkillGemGroundSlam",
+		variantId = "GroundSlam",
 		grantedEffectId = "GroundSlam",
 		tags = {
 			strength = true,
@@ -240,6 +266,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemGroundSlamAltX"] = {
 		name = "Ground Slam of Earthshaking",
+		gameId = "Metadata/Items/Gems/SkillGemGroundSlam",
+		variantId = "GroundSlamAltX",
 		grantedEffectId = "GroundSlamAltX",
 		tags = {
 			strength = true,
@@ -257,6 +285,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemVaalGroundSlam"] = {
 		name = "Vaal Ground Slam",
+		gameId = "Metadata/Items/Gems/SkillGemVaalGroundSlam",
+		variantId = "VaalGroundSlam",
 		grantedEffectId = "VaalGroundSlam",
 		secondaryGrantedEffectId = "GroundSlam",
 		vaalGem = true,
@@ -277,6 +307,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemCleave"] = {
 		name = "Cleave",
+		gameId = "Metadata/Items/Gems/SkillGemCleave",
+		variantId = "Cleave",
 		grantedEffectId = "Cleave",
 		tags = {
 			strength = true,
@@ -294,6 +326,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemCleaveAltX"] = {
 		name = "Cleave of Rage",
+		gameId = "Metadata/Items/Gems/SkillGemCleave",
+		variantId = "CleaveAltX",
 		grantedEffectId = "CleaveAltX",
 		tags = {
 			strength = true,
@@ -310,6 +344,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemShieldCharge"] = {
 		name = "Shield Charge",
+		gameId = "Metadata/Items/Gems/SkillGemShieldCharge",
+		variantId = "ShieldCharge",
 		grantedEffectId = "NewShieldCharge",
 		tags = {
 			strength = true,
@@ -329,6 +365,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemEnduringCry"] = {
 		name = "Enduring Cry",
+		gameId = "Metadata/Items/Gems/SkillGemEnduringCry",
+		variantId = "EnduringCry",
 		grantedEffectId = "EnduringCry",
 		tags = {
 			warcry = true,
@@ -345,6 +383,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemDoubleStrike"] = {
 		name = "Double Strike",
+		gameId = "Metadata/Items/Gems/SkillGemDoubleStrike",
+		variantId = "DoubleStrike",
 		grantedEffectId = "DoubleStrike",
 		tags = {
 			dexterity = true,
@@ -362,6 +402,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemDoubleStrikeAltX"] = {
 		name = "Double Strike of Impaling",
+		gameId = "Metadata/Items/Gems/SkillGemDoubleStrike",
+		variantId = "DoubleStrikeAltX",
 		grantedEffectId = "DoubleStrikeAltX",
 		tags = {
 			dexterity = true,
@@ -379,6 +421,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemDoubleStrikeAltY"] = {
 		name = "Double Strike of Momentum",
+		gameId = "Metadata/Items/Gems/SkillGemDoubleStrike",
+		variantId = "DoubleStrikeAltY",
 		grantedEffectId = "DoubleStrikeAltY",
 		tags = {
 			dexterity = true,
@@ -395,6 +439,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemVaalDoubleStrike"] = {
 		name = "Vaal Double Strike",
+		gameId = "Metadata/Items/Gems/SkillGemVaalDoubleStrike",
+		variantId = "VaalDoubleStrike",
 		grantedEffectId = "VaalDoubleStrike",
 		secondaryGrantedEffectId = "DoubleStrike",
 		vaalGem = true,
@@ -416,6 +462,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemLacerate"] = {
 		name = "Lacerate",
+		gameId = "Metadata/Items/Gems/SkillGemLacerate",
+		variantId = "Lacerate",
 		grantedEffectId = "DoubleSlash",
 		tags = {
 			dexterity = true,
@@ -433,6 +481,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemLacerateAltX"] = {
 		name = "Lacerate of Butchering",
+		gameId = "Metadata/Items/Gems/SkillGemLacerate",
+		variantId = "LacerateAltX",
 		grantedEffectId = "DoubleSlashAltX",
 		tags = {
 			dexterity = true,
@@ -449,6 +499,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemLacerateAltY"] = {
 		name = "Lacerate of Haemorrhage",
+		gameId = "Metadata/Items/Gems/SkillGemLacerate",
+		variantId = "LacerateAltY",
 		grantedEffectId = "DoubleSlashAltY",
 		tags = {
 			dexterity = true,
@@ -466,6 +518,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemElementalHit"] = {
 		name = "Elemental Hit",
+		gameId = "Metadata/Items/Gems/SkillGemElementalHit",
+		variantId = "ElementalHit",
 		grantedEffectId = "ElementalHit",
 		tags = {
 			dexterity = true,
@@ -489,6 +543,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemImmortalCall"] = {
 		name = "Immortal Call",
+		gameId = "Metadata/Items/Gems/SkillGemImmortalCall",
+		variantId = "ImmortalCall",
 		grantedEffectId = "ImmortalCall",
 		tags = {
 			strength = true,
@@ -505,6 +561,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemVaalImmortalCall"] = {
 		name = "Vaal Immortal Call",
+		gameId = "Metadata/Items/Gems/SkillGemVaalImmortalCall",
+		variantId = "VaalImmortalCall",
 		grantedEffectId = "VaalImmortalCall",
 		secondaryGrantedEffectId = "ImmortalCall",
 		vaalGem = true,
@@ -524,6 +582,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemDualStrike"] = {
 		name = "Dual Strike",
+		gameId = "Metadata/Items/Gems/SkillGemDualStrike",
+		variantId = "DualStrike",
 		grantedEffectId = "DualStrike",
 		tags = {
 			critical = true,
@@ -541,6 +601,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemDualStrikeAltX"] = {
 		name = "Dual Strike of Ambidexterity",
+		gameId = "Metadata/Items/Gems/SkillGemDualStrike",
+		variantId = "DualStrikeAltX",
 		grantedEffectId = "DualStrikeAltX",
 		tags = {
 			dexterity = true,
@@ -557,6 +619,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemWhirlingBlades"] = {
 		name = "Whirling Blades",
+		gameId = "Metadata/Items/Gems/SkillGemWhirlingBlades",
+		variantId = "WhirlingBlades",
 		grantedEffectId = "WhirlingBlades",
 		tags = {
 			dexterity = true,
@@ -574,6 +638,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemFrenzy"] = {
 		name = "Frenzy",
+		gameId = "Metadata/Items/Gems/SkillGemFrenzy",
+		variantId = "Frenzy",
 		grantedEffectId = "Frenzy",
 		tags = {
 			dexterity = true,
@@ -592,6 +658,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemFrenzyAltX"] = {
 		name = "Frenzy of Onslaught",
+		gameId = "Metadata/Items/Gems/SkillGemFrenzy",
+		variantId = "FrenzyAltX",
 		grantedEffectId = "FrenzyAltX",
 		tags = {
 			dexterity = true,
@@ -610,6 +678,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemDetonateDead"] = {
 		name = "Detonate Dead",
+		gameId = "Metadata/Items/Gems/SkillGemDetonateDead",
+		variantId = "DetonateDead",
 		grantedEffectId = "DetonateDead",
 		tags = {
 			dexterity = true,
@@ -626,6 +696,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemDetonateDeadAltX"] = {
 		name = "Detonate Dead of Scavenging",
+		gameId = "Metadata/Items/Gems/SkillGemDetonateDead",
+		variantId = "DetonateDeadAltX",
 		grantedEffectId = "DetonateDeadAltX",
 		tags = {
 			dexterity = true,
@@ -642,6 +714,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemDetonateDeadAltY"] = {
 		name = "Detonate Dead of Chain Reaction",
+		gameId = "Metadata/Items/Gems/SkillGemDetonateDead",
+		variantId = "DetonateDeadAltY",
 		grantedEffectId = "DetonateDeadAltY",
 		tags = {
 			dexterity = true,
@@ -658,6 +732,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemVaalDetonateDead"] = {
 		name = "Vaal Detonate Dead",
+		gameId = "Metadata/Items/Gems/SkillGemVaalDetonateDead",
+		variantId = "VaalDetonateDead",
 		grantedEffectId = "VaalDetonateDead",
 		secondaryGrantedEffectId = "DetonateDead",
 		vaalGem = true,
@@ -677,6 +753,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemVolatileDead"] = {
 		name = "Volatile Dead",
+		gameId = "Metadata/Items/Gems/SkillGemVolatileDead",
+		variantId = "VolatileDead",
 		grantedEffectId = "VolatileDead",
 		tags = {
 			dexterity = true,
@@ -693,6 +771,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemVolatileDeadAltX"] = {
 		name = "Volatile Dead of Confinement",
+		gameId = "Metadata/Items/Gems/SkillGemVolatileDead",
+		variantId = "VolatileDeadAltX",
 		grantedEffectId = "VolatileDeadAltX",
 		tags = {
 			dexterity = true,
@@ -710,6 +790,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemVolatileDeadAltY"] = {
 		name = "Volatile Dead of Seething",
+		gameId = "Metadata/Items/Gems/SkillGemVolatileDead",
+		variantId = "VolatileDeadAltY",
 		grantedEffectId = "VolatileDeadAltY",
 		tags = {
 			dexterity = true,
@@ -726,6 +808,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemBoneLance"] = {
 		name = "Unearth",
+		gameId = "Metadata/Items/Gems/SkillGemBoneLance",
+		variantId = "BoneLance",
 		grantedEffectId = "BoneLance",
 		tags = {
 			dexterity = true,
@@ -743,6 +827,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemSplitArrow"] = {
 		name = "Split Arrow",
+		gameId = "Metadata/Items/Gems/SkillGemSplitArrow",
+		variantId = "SplitArrow",
 		grantedEffectId = "SplitArrow",
 		tags = {
 			dexterity = true,
@@ -760,6 +846,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemSplitArrowAltX"] = {
 		name = "Split Arrow of Splitting",
+		gameId = "Metadata/Items/Gems/SkillGemSplitArrow",
+		variantId = "SplitArrowAltX",
 		grantedEffectId = "SplitArrowAltX",
 		tags = {
 			dexterity = true,
@@ -776,6 +864,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemAddedFireDamageSupport"] = {
 		name = "Added Fire Damage",
+		gameId = "Metadata/Items/Gems/SupportGemAddedFireDamage",
+		variantId = "AddedFireDamageSupport",
 		grantedEffectId = "SupportAddedFireDamage",
 		tags = {
 			fire = true,
@@ -791,6 +881,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemFasterAttackSupport"] = {
 		name = "Faster Attacks",
+		gameId = "Metadata/Items/Gems/SupportGemFasterAttack",
+		variantId = "FasterAttackSupport",
 		grantedEffectId = "SupportFasterAttack",
 		tags = {
 			attack = true,
@@ -805,6 +897,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemGreaterMultipleProjectilesSupport"] = {
 		name = "Greater Multiple Projectiles",
+		gameId = "Metadata/Items/Gems/SupportGemGreaterMultipleProjectiles",
+		variantId = "GreaterMultipleProjectilesSupport",
 		grantedEffectId = "SupportGreaterMultipleProjectiles",
 		tags = {
 			dexterity = true,
@@ -819,6 +913,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemLesserMultipleProjectilesSupport"] = {
 		name = "Lesser Multiple Projectiles",
+		gameId = "Metadata/Items/Gems/SupportGemLesserMultipleProjectiles",
+		variantId = "LesserMultipleProjectilesSupport",
 		grantedEffectId = "SupportLesserMultipleProjectiles",
 		tags = {
 			dexterity = true,
@@ -833,6 +929,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemFasterProjectilesSupport"] = {
 		name = "Faster Projectiles",
+		gameId = "Metadata/Items/Gems/SupportGemFasterProjectiles",
+		variantId = "FasterProjectilesSupport",
 		grantedEffectId = "SupportFasterProjectiles",
 		tags = {
 			dexterity = true,
@@ -847,6 +945,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemAddedColdDamageSupport"] = {
 		name = "Added Cold Damage",
+		gameId = "Metadata/Items/Gems/SupportGemAddedColdDamage",
+		variantId = "AddedColdDamageSupport",
 		grantedEffectId = "SupportAddedColdDamage",
 		tags = {
 			cold = true,
@@ -861,6 +961,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemAdditionalAccuracySupport"] = {
 		name = "Additional Accuracy",
+		gameId = "Metadata/Items/Gems/SupportGemAdditionalAccuracy",
+		variantId = "AdditionalAccuracySupport",
 		grantedEffectId = "SupportAdditionalAccuracy",
 		tags = {
 			attack = true,
@@ -875,6 +977,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemIncreasedAreaOfEffectSupport"] = {
 		name = "Increased Area of Effect",
+		gameId = "Metadata/Items/Gems/SupportGemIncreasedAreaOfEffect",
+		variantId = "IncreasedAreaOfEffectSupport",
 		grantedEffectId = "SupportIncreasedAreaOfEffect",
 		tags = {
 			intelligence = true,
@@ -889,6 +993,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemAddedLightningDamageSupport"] = {
 		name = "Added Lightning Damage",
+		gameId = "Metadata/Items/Gems/SupportGemAddedLightningDamage",
+		variantId = "AddedLightningDamageSupport",
 		grantedEffectId = "SupportAddedLightningDamage",
 		tags = {
 			lightning = true,
@@ -903,6 +1009,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemColdSnap"] = {
 		name = "Cold Snap",
+		gameId = "Metadata/Items/Gems/SkillGemColdSnap",
+		variantId = "ColdSnap",
 		grantedEffectId = "ColdSnap",
 		tags = {
 			intelligence = true,
@@ -920,6 +1028,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemColdSnapAltX"] = {
 		name = "Cold Snap of Power",
+		gameId = "Metadata/Items/Gems/SkillGemColdSnap",
+		variantId = "ColdSnapAltX",
 		grantedEffectId = "ColdSnapAltX",
 		tags = {
 			critical = true,
@@ -937,6 +1047,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemVaalColdSnap"] = {
 		name = "Vaal Cold Snap",
+		gameId = "Metadata/Items/Gems/SkillGemVaalColdSnap",
+		variantId = "VaalColdSnap",
 		grantedEffectId = "VaalColdSnap",
 		secondaryGrantedEffectId = "ColdSnap",
 		vaalGem = true,
@@ -957,6 +1069,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemRaiseZombie"] = {
 		name = "Raise Zombie",
+		gameId = "Metadata/Items/Gems/SkillGemRaiseZombie",
+		variantId = "RaiseZombie",
 		grantedEffectId = "RaiseZombie",
 		tags = {
 			intelligence = true,
@@ -972,6 +1086,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemRaiseZombieAltX"] = {
 		name = "Raise Zombie of Slamming",
+		gameId = "Metadata/Items/Gems/SkillGemRaiseZombie",
+		variantId = "RaiseZombieAltX",
 		grantedEffectId = "RaiseZombieAltX",
 		tags = {
 			intelligence = true,
@@ -987,6 +1103,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemRaiseZombieAltY"] = {
 		name = "Raise Zombie of Falling",
+		gameId = "Metadata/Items/Gems/SkillGemRaiseZombie",
+		variantId = "RaiseZombieAltY",
 		grantedEffectId = "RaiseZombieAltY",
 		tags = {
 			intelligence = true,
@@ -1002,6 +1120,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemPoisonArrow"] = {
 		name = "Caustic Arrow",
+		gameId = "Metadata/Items/Gems/SkillGemPoisonArrow",
+		variantId = "PoisonArrow",
 		grantedEffectId = "PoisonArrow",
 		tags = {
 			dexterity = true,
@@ -1021,6 +1141,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemPoisonArrowAltX"] = {
 		name = "Caustic Arrow of Poison",
+		gameId = "Metadata/Items/Gems/SkillGemPoisonArrow",
+		variantId = "PoisonArrowAltX",
 		grantedEffectId = "PoisonArrowAltX",
 		tags = {
 			dexterity = true,
@@ -1039,6 +1161,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemBloodRage"] = {
 		name = "Blood Rage",
+		gameId = "Metadata/Items/Gems/SkillGemBloodRage",
+		variantId = "BloodRage",
 		grantedEffectId = "BloodRage",
 		tags = {
 			dexterity = true,
@@ -1055,6 +1179,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemRighteousFire"] = {
 		name = "Righteous Fire",
+		gameId = "Metadata/Items/Gems/SkillGemRighteousFire",
+		variantId = "RighteousFire",
 		grantedEffectId = "RighteousFire",
 		tags = {
 			intelligence = true,
@@ -1071,6 +1197,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemRighteousFireAltX"] = {
 		name = "Righteous Fire of Arcane Devotion",
+		gameId = "Metadata/Items/Gems/SkillGemRighteousFire",
+		variantId = "RighteousFireAltX",
 		grantedEffectId = "RighteousFireAltX",
 		tags = {
 			intelligence = true,
@@ -1087,6 +1215,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemVaalRighteousFire"] = {
 		name = "Vaal Righteous Fire",
+		gameId = "Metadata/Items/Gems/SkillGemVaalRighteousFire",
+		variantId = "VaalRighteousFire",
 		grantedEffectId = "VaalRighteousFire",
 		secondaryGrantedEffectId = "RighteousFire",
 		vaalGem = true,
@@ -1107,6 +1237,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemDischarge"] = {
 		name = "Discharge",
+		gameId = "Metadata/Items/Gems/SkillGemDischarge",
+		variantId = "Discharge",
 		grantedEffectId = "Discharge",
 		tags = {
 			intelligence = true,
@@ -1126,6 +1258,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemDischargeAltX"] = {
 		name = "Discharge of Misery",
+		gameId = "Metadata/Items/Gems/SkillGemDischarge",
+		variantId = "DischargeAltX",
 		grantedEffectId = "DischargeAltX",
 		tags = {
 			intelligence = true,
@@ -1145,6 +1279,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemPortal"] = {
 		name = "Portal",
+		gameId = "Metadata/Items/Gems/SkillGemPortal",
+		variantId = "Portal",
 		grantedEffectId = "Portal",
 		tags = {
 			low_max_level = true,
@@ -1159,6 +1295,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemVaalPortal"] = {
 		name = "Vaal Breach",
+		gameId = "Metadata/Items/Gems/SkillGemVaalPortal",
+		variantId = "VaalPortal",
 		grantedEffectId = "VaalBreach",
 		secondaryGrantedEffectId = "Portal",
 		vaalGem = true,
@@ -1176,6 +1314,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemReducedManaSupport"] = {
 		name = "Inspiration",
+		gameId = "Metadata/Items/Gems/SupportGemReducedMana",
+		variantId = "ReducedManaSupport",
 		grantedEffectId = "SupportReducedMana",
 		tags = {
 			critical = true,
@@ -1190,6 +1330,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemIncreasedCriticalStrikesSupport"] = {
 		name = "Increased Critical Strikes",
+		gameId = "Metadata/Items/Gems/SupportGemIncreasedCriticalStrikes",
+		variantId = "IncreasedCriticalStrikesSupport",
 		grantedEffectId = "SupportIncreasedCriticalStrikes",
 		tags = {
 			critical = true,
@@ -1204,6 +1346,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemIncreasedCriticalDamageSupport"] = {
 		name = "Increased Critical Damage",
+		gameId = "Metadata/Items/Gems/SupportGemIncreasedCriticalDamage",
+		variantId = "IncreasedCriticalDamageSupport",
 		grantedEffectId = "SupportIncreasedCriticalDamage",
 		tags = {
 			critical = true,
@@ -1218,6 +1362,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemKnockbackSupport"] = {
 		name = "Knockback",
+		gameId = "Metadata/Items/Gems/SupportGemKnockback",
+		variantId = "KnockbackSupport",
 		grantedEffectId = "SupportKnockback",
 		tags = {
 			strength = true,
@@ -1231,6 +1377,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemLifeLeechSupport"] = {
 		name = "Life Leech",
+		gameId = "Metadata/Items/Gems/SupportGemLifeLeech",
+		variantId = "LifeLeechSupport",
 		grantedEffectId = "SupportLifeLeech",
 		tags = {
 			strength = true,
@@ -1244,6 +1392,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemManaLeechSupport"] = {
 		name = "Mana Leech",
+		gameId = "Metadata/Items/Gems/SupportGemManaLeech",
+		variantId = "ManaLeechSupport",
 		grantedEffectId = "SupportManaLeech",
 		tags = {
 			dexterity = true,
@@ -1257,6 +1407,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemAddedChaosDamageSupport"] = {
 		name = "Added Chaos Damage",
+		gameId = "Metadata/Items/Gems/SupportGemAddedChaosDamage",
+		variantId = "AddedChaosDamageSupport",
 		grantedEffectId = "SupportAddedChaosDamage",
 		tags = {
 			chaos = true,
@@ -1271,6 +1423,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemFlickerStrike"] = {
 		name = "Flicker Strike",
+		gameId = "Metadata/Items/Gems/SkillGemFlickerStrike",
+		variantId = "FlickerStrike",
 		grantedEffectId = "FlickerStrike",
 		tags = {
 			dexterity = true,
@@ -1289,6 +1443,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemFlickerStrikeAltX"] = {
 		name = "Flicker Strike of Power",
+		gameId = "Metadata/Items/Gems/SkillGemFlickerStrike",
+		variantId = "FlickerStrikeAltX",
 		grantedEffectId = "FlickerStrikeAltX",
 		tags = {
 			critical = true,
@@ -1308,6 +1464,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemVaalFlickerStrike"] = {
 		name = "Vaal Flicker Strike",
+		gameId = "Metadata/Items/Gems/SkillGemVaalFlickerStrike",
+		variantId = "VaalFlickerStrike",
 		grantedEffectId = "VaalFlickerStrike",
 		secondaryGrantedEffectId = "FlickerStrike",
 		vaalGem = true,
@@ -1329,6 +1487,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemSpark"] = {
 		name = "Spark",
+		gameId = "Metadata/Items/Gems/SkillGemSpark",
+		variantId = "Spark",
 		grantedEffectId = "Spark",
 		tags = {
 			intelligence = true,
@@ -1346,6 +1506,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemSparkAltX"] = {
 		name = "Spark of the Nova",
+		gameId = "Metadata/Items/Gems/SkillGemSpark",
+		variantId = "SparkAltX",
 		grantedEffectId = "SparkAltX",
 		tags = {
 			intelligence = true,
@@ -1363,6 +1525,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemSparkAltY"] = {
 		name = "Spark of Unpredictability",
+		gameId = "Metadata/Items/Gems/SkillGemSpark",
+		variantId = "SparkAltY",
 		grantedEffectId = "SparkAltY",
 		tags = {
 			intelligence = true,
@@ -1380,6 +1544,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemVaalSpark"] = {
 		name = "Vaal Spark",
+		gameId = "Metadata/Items/Gems/SkillGemVaalSpark",
+		variantId = "VaalSpark",
 		grantedEffectId = "VaalSparkSpiralNova",
 		secondaryGrantedEffectId = "Spark",
 		vaalGem = true,
@@ -1400,6 +1566,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemStunSupport"] = {
 		name = "Stun",
+		gameId = "Metadata/Items/Gems/SupportGemStun",
+		variantId = "StunSupport",
 		grantedEffectId = "SupportStun",
 		tags = {
 			strength = true,
@@ -1413,6 +1581,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemIceSpear"] = {
 		name = "Ice Spear",
+		gameId = "Metadata/Items/Gems/SkillGemIceSpear",
+		variantId = "IceSpear",
 		grantedEffectId = "IceSpear",
 		tags = {
 			critical = true,
@@ -1430,6 +1600,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemIceSpearAltX"] = {
 		name = "Ice Spear of Splitting",
+		gameId = "Metadata/Items/Gems/SkillGemIceSpear",
+		variantId = "IceSpearAltX",
 		grantedEffectId = "IceSpearAltX",
 		tags = {
 			intelligence = true,
@@ -1446,6 +1618,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemPierceSupport"] = {
 		name = "Pierce",
+		gameId = "Metadata/Items/Gems/SupportGemPierce",
+		variantId = "PierceSupport",
 		grantedEffectId = "SupportPierce",
 		tags = {
 			dexterity = true,
@@ -1460,6 +1634,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemTrapSupport"] = {
 		name = "Trap",
+		gameId = "Metadata/Items/Gems/SupportGemTrap",
+		variantId = "TrapSupport",
 		grantedEffectId = "SupportTrap",
 		tags = {
 			dexterity = true,
@@ -1474,6 +1650,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemRaiseSpectre"] = {
 		name = "Raise Spectre",
+		gameId = "Metadata/Items/Gems/SkillGemRaiseSpectre",
+		variantId = "RaiseSpectre",
 		grantedEffectId = "RaiseSpectre",
 		tags = {
 			intelligence = true,
@@ -1489,6 +1667,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemRaiseSpectreAltX"] = {
 		name = "Raise Spectre of Transience",
+		gameId = "Metadata/Items/Gems/SkillGemRaiseSpectre",
+		variantId = "RaiseSpectreAltX",
 		grantedEffectId = "RaiseSpectreAltX",
 		tags = {
 			intelligence = true,
@@ -1505,6 +1685,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemInfernalBlow"] = {
 		name = "Infernal Blow",
+		gameId = "Metadata/Items/Gems/SkillGemInfernalBlow",
+		variantId = "InfernalBlow",
 		grantedEffectId = "InfernalBlow",
 		tags = {
 			strength = true,
@@ -1524,6 +1706,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemInfernalBlowAltX"] = {
 		name = "Infernal Blow of Immolation",
+		gameId = "Metadata/Items/Gems/SkillGemInfernalBlow",
+		variantId = "InfernalBlowAltX",
 		grantedEffectId = "InfernalBlowAltX",
 		tags = {
 			strength = true,
@@ -1543,6 +1727,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemGlacialHammer"] = {
 		name = "Glacial Hammer",
+		gameId = "Metadata/Items/Gems/SkillGemGlacialHammer",
+		variantId = "GlacialHammer",
 		grantedEffectId = "GlacialHammer",
 		tags = {
 			strength = true,
@@ -1560,6 +1746,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemGlacialHammerAltX"] = {
 		name = "Glacial Hammer of Shattering",
+		gameId = "Metadata/Items/Gems/SkillGemGlacialHammer",
+		variantId = "GlacialHammerAltX",
 		grantedEffectId = "GlacialHammerAltX",
 		tags = {
 			critical = true,
@@ -1578,6 +1766,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemVaalGlacialHammer"] = {
 		name = "Vaal Glacial Hammer",
+		gameId = "Metadata/Items/Gems/SkillGemVaalGlacialHammer",
+		variantId = "VaalGlacialHammer",
 		grantedEffectId = "VaalGlacialHammer",
 		secondaryGrantedEffectId = "GlacialHammer",
 		vaalGem = true,
@@ -1600,6 +1790,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemFrostWall"] = {
 		name = "Frost Wall",
+		gameId = "Metadata/Items/Gems/SkillGemFrostWall",
+		variantId = "FrostWall",
 		grantedEffectId = "FrostWall",
 		tags = {
 			intelligence = true,
@@ -1616,6 +1808,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemFreezingPulse"] = {
 		name = "Freezing Pulse",
+		gameId = "Metadata/Items/Gems/SkillGemFreezingPulse",
+		variantId = "FreezingPulse",
 		grantedEffectId = "FreezingPulse",
 		tags = {
 			intelligence = true,
@@ -1632,6 +1826,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemShockNova"] = {
 		name = "Shock Nova",
+		gameId = "Metadata/Items/Gems/SkillGemShockNova",
+		variantId = "ShockNova",
 		grantedEffectId = "ShockNova",
 		tags = {
 			intelligence = true,
@@ -1649,6 +1845,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemViperStrike"] = {
 		name = "Viper Strike",
+		gameId = "Metadata/Items/Gems/SkillGemViperStrike",
+		variantId = "ViperStrike",
 		grantedEffectId = "ViperStrike",
 		tags = {
 			dexterity = true,
@@ -1667,6 +1865,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemViperStrikeAltX"] = {
 		name = "Viper Strike of the Mamba",
+		gameId = "Metadata/Items/Gems/SkillGemViperStrike",
+		variantId = "ViperStrikeAltX",
 		grantedEffectId = "ViperStrikeAltX",
 		tags = {
 			dexterity = true,
@@ -1685,6 +1885,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemNewPhaseRun"] = {
 		name = "Phase Run",
+		gameId = "Metadata/Items/Gems/SkillGemNewPhaseRun",
+		variantId = "NewPhaseRun",
 		grantedEffectId = "NewPhaseRun",
 		tags = {
 			dexterity = true,
@@ -1703,6 +1905,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemMeleePhysicalDamageSupport"] = {
 		name = "Melee Physical Damage",
+		gameId = "Metadata/Items/Gems/SupportGemMeleePhysicalDamage",
+		variantId = "MeleePhysicalDamageSupport",
 		grantedEffectId = "SupportMeleePhysicalDamage",
 		tags = {
 			melee = true,
@@ -1719,6 +1923,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemItemQuantitySupport"] = {
 		name = "Item Quantity",
+		gameId = "Metadata/Items/Gems/SupportGemItemQuantity",
+		variantId = "ItemQuantitySupport",
 		grantedEffectId = "SupportItemQuantity",
 		tags = {
 			strength = true,
@@ -1732,6 +1938,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemItemRaritySupport"] = {
 		name = "Item Rarity",
+		gameId = "Metadata/Items/Gems/SupportGemItemRarity",
+		variantId = "ItemRaritySupport",
 		grantedEffectId = "SupportItemRarity",
 		tags = {
 			intelligence = true,
@@ -1745,6 +1953,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemFasterCastSupport"] = {
 		name = "Faster Casting",
+		gameId = "Metadata/Items/Gems/SupportGemFasterCast",
+		variantId = "FasterCastSupport",
 		grantedEffectId = "SupportFasterCast",
 		tags = {
 			intelligence = true,
@@ -1759,6 +1969,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemExplosiveArrow"] = {
 		name = "Explosive Arrow",
+		gameId = "Metadata/Items/Gems/SkillGemExplosiveArrow",
+		variantId = "ExplosiveArrow",
 		grantedEffectId = "ExplosiveArrow",
 		tags = {
 			dexterity = true,
@@ -1778,6 +1990,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemTemporalChains"] = {
 		name = "Temporal Chains",
+		gameId = "Metadata/Items/Gems/SkillGemTemporalChains",
+		variantId = "TemporalChains",
 		grantedEffectId = "TemporalChains",
 		tags = {
 			dexterity = true,
@@ -1796,6 +2010,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemElementalWeakness"] = {
 		name = "Elemental Weakness",
+		gameId = "Metadata/Items/Gems/SkillGemElementalWeakness",
+		variantId = "ElementalWeakness",
 		grantedEffectId = "ElementalWeakness",
 		tags = {
 			intelligence = true,
@@ -1814,6 +2030,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemWarlordsMark"] = {
 		name = "Warlord's Mark",
+		gameId = "Metadata/Items/Gems/SkillGemWarlordsMark",
+		variantId = "WarlordsMark",
 		grantedEffectId = "WarlordsMark",
 		tags = {
 			strength = true,
@@ -1830,6 +2048,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemPunishment"] = {
 		name = "Punishment",
+		gameId = "Metadata/Items/Gems/SkillGemPunishment",
+		variantId = "Punishment",
 		grantedEffectId = "Punishment",
 		tags = {
 			strength = true,
@@ -1848,6 +2068,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemEnfeeble"] = {
 		name = "Enfeeble",
+		gameId = "Metadata/Items/Gems/SkillGemEnfeeble",
+		variantId = "Enfeeble",
 		grantedEffectId = "Enfeeble",
 		tags = {
 			intelligence = true,
@@ -1866,6 +2088,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemCriticalWeakness"] = {
 		name = "Assassin's Mark",
+		gameId = "Metadata/Items/Gems/SkillGemCriticalWeakness",
+		variantId = "CriticalWeakness",
 		grantedEffectId = "AssassinsMark",
 		tags = {
 			critical = true,
@@ -1883,6 +2107,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemProjectileWeakness"] = {
 		name = "Sniper's Mark",
+		gameId = "Metadata/Items/Gems/SkillGemProjectileWeakness",
+		variantId = "ProjectileWeakness",
 		grantedEffectId = "SnipersMark",
 		tags = {
 			dexterity = true,
@@ -1899,6 +2125,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemVulnerability"] = {
 		name = "Despair",
+		gameId = "Metadata/Items/Gems/SkillGemVulnerability",
+		variantId = "Vulnerability",
 		grantedEffectId = "Despair",
 		tags = {
 			intelligence = true,
@@ -1918,6 +2146,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemLightningWarp"] = {
 		name = "Lightning Warp",
+		gameId = "Metadata/Items/Gems/SkillGemLightningWarp",
+		variantId = "LightningWarp",
 		grantedEffectId = "LightningWarp",
 		tags = {
 			intelligence = true,
@@ -1937,6 +2167,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemVaalLightningWarp"] = {
 		name = "Vaal Lightning Warp",
+		gameId = "Metadata/Items/Gems/SkillGemVaalLightningWarp",
+		variantId = "VaalLightningWarp",
 		grantedEffectId = "VaalLightningWarpInstant",
 		secondaryGrantedEffectId = "LightningWarp",
 		vaalGem = true,
@@ -1959,6 +2191,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemSummonSkeletons"] = {
 		name = "Summon Skeletons",
+		gameId = "Metadata/Items/Gems/SkillGemSummonSkeletons",
+		variantId = "SummonSkeletons",
 		grantedEffectId = "SummonSkeletons",
 		tags = {
 			intelligence = true,
@@ -1975,6 +2209,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemSummonSkeletonsAltX"] = {
 		name = "Summon Skeletons of Archers",
+		gameId = "Metadata/Items/Gems/SkillGemSummonSkeletons",
+		variantId = "SummonSkeletonsAltX",
 		grantedEffectId = "SummonSkeletonsAltX",
 		tags = {
 			intelligence = true,
@@ -1991,6 +2227,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemSummonSkeletonsAltY"] = {
 		name = "Summon Skeletons of Mages",
+		gameId = "Metadata/Items/Gems/SkillGemSummonSkeletons",
+		variantId = "SummonSkeletonsAltY",
 		grantedEffectId = "SummonSkeletonsAltY",
 		tags = {
 			intelligence = true,
@@ -2008,6 +2246,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemVaalSummonSkeletons"] = {
 		name = "Vaal Summon Skeletons",
+		gameId = "Metadata/Items/Gems/SkillGemVaalSummonSkeletons",
+		variantId = "VaalSummonSkeletons",
 		grantedEffectId = "VaalSummonSkeletons",
 		secondaryGrantedEffectId = "SummonSkeletons",
 		vaalGem = true,
@@ -2027,6 +2267,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemHeavyStrike"] = {
 		name = "Heavy Strike",
+		gameId = "Metadata/Items/Gems/SkillGemHeavyStrike",
+		variantId = "HeavyStrike",
 		grantedEffectId = "HeavyStrike",
 		tags = {
 			strength = true,
@@ -2043,6 +2285,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemDominatingBlow"] = {
 		name = "Dominating Blow",
+		gameId = "Metadata/Items/Gems/SkillGemDominatingBlow",
+		variantId = "DominatingBlow",
 		grantedEffectId = "DominatingBlow",
 		tags = {
 			strength = true,
@@ -2061,6 +2305,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemDominatingBlowAltX"] = {
 		name = "Dominating Blow of Inspiring",
+		gameId = "Metadata/Items/Gems/SkillGemDominatingBlow",
+		variantId = "DominatingBlowAltX",
 		grantedEffectId = "DominatingBlowAltX",
 		tags = {
 			strength = true,
@@ -2079,6 +2325,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemRainOfArrows"] = {
 		name = "Rain of Arrows",
+		gameId = "Metadata/Items/Gems/SkillGemRainOfArrows",
+		variantId = "RainOfArrows",
 		grantedEffectId = "RainOfArrows",
 		tags = {
 			dexterity = true,
@@ -2096,6 +2344,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemRainOfArrowsAltX"] = {
 		name = "Rain of Arrows of Artillery",
+		gameId = "Metadata/Items/Gems/SkillGemRainOfArrows",
+		variantId = "RainOfArrowsAltX",
 		grantedEffectId = "RainOfArrowsAltX",
 		tags = {
 			dexterity = true,
@@ -2113,6 +2363,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemRainOfArrowsAltY"] = {
 		name = "Rain of Arrows of Saturation",
+		gameId = "Metadata/Items/Gems/SkillGemRainOfArrows",
+		variantId = "RainOfArrowsAltY",
 		grantedEffectId = "RainOfArrowsAltY",
 		tags = {
 			dexterity = true,
@@ -2130,6 +2382,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemVaalRainOfArrows"] = {
 		name = "Vaal Rain of Arrows",
+		gameId = "Metadata/Items/Gems/SkillGemVaalRainOfArrows",
+		variantId = "VaalRainOfArrows",
 		grantedEffectId = "VaalRainOfArrows",
 		secondaryGrantedEffectId = "RainOfArrows",
 		vaalGem = true,
@@ -2150,6 +2404,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemConcentratedEffectSupport"] = {
 		name = "Concentrated Effect",
+		gameId = "Metadata/Items/Gems/SupportGemConcentratedEffect",
+		variantId = "ConcentratedEffectSupport",
 		grantedEffectId = "SupportConcentratedEffect",
 		tags = {
 			intelligence = true,
@@ -2164,6 +2420,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemMinionDamageSupport"] = {
 		name = "Minion Damage",
+		gameId = "Metadata/Items/Gems/SupportGemMinionDamage",
+		variantId = "MinionDamageSupport",
 		grantedEffectId = "SupportMinionDamage",
 		tags = {
 			intelligence = true,
@@ -2178,6 +2436,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemIncreasedDurationSupport"] = {
 		name = "Increased Duration",
+		gameId = "Metadata/Items/Gems/SupportGemIncreasedDuration",
+		variantId = "IncreasedDurationSupport",
 		grantedEffectId = "SupportIncreasedDuration",
 		tags = {
 			strength = true,
@@ -2192,6 +2452,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemColdToFireSupport"] = {
 		name = "Cold to Fire",
+		gameId = "Metadata/Items/Gems/SupportGemColdToFire",
+		variantId = "ColdToFireSupport",
 		grantedEffectId = "SupportColdToFire",
 		tags = {
 			cold = true,
@@ -2207,6 +2469,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemChanceToIgniteSupport"] = {
 		name = "Combustion",
+		gameId = "Metadata/Items/Gems/SupportGemChanceToIgnite",
+		variantId = "ChanceToIgniteSupport",
 		grantedEffectId = "SupportChanceToIgnite",
 		tags = {
 			fire = true,
@@ -2221,6 +2485,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemMinionSpeedSupport"] = {
 		name = "Minion Speed",
+		gameId = "Metadata/Items/Gems/SupportGemMinionSpeed",
+		variantId = "MinionSpeedSupport",
 		grantedEffectId = "SupportMinionSpeed",
 		tags = {
 			movement = true,
@@ -2236,6 +2502,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemMinionLifeSupport"] = {
 		name = "Minion Life",
+		gameId = "Metadata/Items/Gems/SupportGemMinionLife",
+		variantId = "MinionLifeSupport",
 		grantedEffectId = "SupportMinionLife",
 		tags = {
 			intelligence = true,
@@ -2250,6 +2518,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemWeaponElementalDamageSupport"] = {
 		name = "Elemental Damage with Attacks",
+		gameId = "Metadata/Items/Gems/SupportGemWeaponElementalDamage",
+		variantId = "WeaponElementalDamageSupport",
 		grantedEffectId = "SupportWeaponElementalDamage",
 		tags = {
 			attack = true,
@@ -2264,6 +2534,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemBloodlustSupport"] = {
 		name = "Bloodlust",
+		gameId = "Metadata/Items/Gems/SupportGemBloodlust",
+		variantId = "BloodlustSupport",
 		grantedEffectId = "SupportBloodlust",
 		tags = {
 			attack = true,
@@ -2280,6 +2552,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemLifeGainOnHitSupport"] = {
 		name = "Life Gain on Hit",
+		gameId = "Metadata/Items/Gems/SupportGemLifeGainOnHit",
+		variantId = "LifeGainOnHitSupport",
 		grantedEffectId = "SupportLifeGainOnHit",
 		tags = {
 			attack = true,
@@ -2294,6 +2568,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemFirestorm"] = {
 		name = "Firestorm",
+		gameId = "Metadata/Items/Gems/SkillGemFirestorm",
+		variantId = "Firestorm",
 		grantedEffectId = "Firestorm",
 		tags = {
 			intelligence = true,
@@ -2311,6 +2587,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemFirestormAltX"] = {
 		name = "Firestorm of Meteors",
+		gameId = "Metadata/Items/Gems/SkillGemFirestorm",
+		variantId = "FirestormAltX",
 		grantedEffectId = "FirestormAltX",
 		tags = {
 			intelligence = true,
@@ -2327,6 +2605,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemFirestormAltY"] = {
 		name = "Firestorm of Pelting",
+		gameId = "Metadata/Items/Gems/SkillGemFirestorm",
+		variantId = "FirestormAltY",
 		grantedEffectId = "FirestormAltY",
 		tags = {
 			intelligence = true,
@@ -2344,6 +2624,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemLightningStrike"] = {
 		name = "Lightning Strike",
+		gameId = "Metadata/Items/Gems/SkillGemLightningStrike",
+		variantId = "LightningStrike",
 		grantedEffectId = "LightningStrike",
 		tags = {
 			dexterity = true,
@@ -2362,6 +2644,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemLightningStrikeAltX"] = {
 		name = "Lightning Strike of Arcing",
+		gameId = "Metadata/Items/Gems/SkillGemLightningStrike",
+		variantId = "LightningStrikeAltX",
 		grantedEffectId = "LightningStrikeAltX",
 		tags = {
 			dexterity = true,
@@ -2381,6 +2665,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemVaalLightningStrike"] = {
 		name = "Vaal Lightning Strike",
+		gameId = "Metadata/Items/Gems/SkillGemVaalLightningStrike",
+		variantId = "VaalLightningStrike",
 		grantedEffectId = "VaalLightningStrike",
 		secondaryGrantedEffectId = "LightningStrike",
 		vaalGem = true,
@@ -2403,6 +2689,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemTempestShield"] = {
 		name = "Tempest Shield",
+		gameId = "Metadata/Items/Gems/SkillGemTempestShield",
+		variantId = "TempestShield",
 		grantedEffectId = "TempestShield",
 		tags = {
 			intelligence = true,
@@ -2419,6 +2707,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemMoltenShell"] = {
 		name = "Molten Shell",
+		gameId = "Metadata/Items/Gems/SkillGemMoltenShell",
+		variantId = "MoltenShell",
 		grantedEffectId = "MoltenShell",
 		tags = {
 			strength = true,
@@ -2438,6 +2728,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemVaalMoltenShell"] = {
 		name = "Vaal Molten Shell",
+		gameId = "Metadata/Items/Gems/SkillGemVaalMoltenShell",
+		variantId = "VaalMoltenShell",
 		grantedEffectId = "VaalMoltenShell",
 		secondaryGrantedEffectId = "MoltenShell",
 		vaalGem = true,
@@ -2460,6 +2752,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemPowerSiphon"] = {
 		name = "Power Siphon",
+		gameId = "Metadata/Items/Gems/SkillGemPowerSiphon",
+		variantId = "PowerSiphon",
 		grantedEffectId = "PowerSiphon",
 		tags = {
 			critical = true,
@@ -2476,6 +2770,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemPowerSiphonAltX"] = {
 		name = "Power Siphon of the Archmage",
+		gameId = "Metadata/Items/Gems/SkillGemPowerSiphon",
+		variantId = "PowerSiphonAltX",
 		grantedEffectId = "PowerSiphonAltX",
 		tags = {
 			critical = true,
@@ -2492,6 +2788,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemVaalPowerSiphon"] = {
 		name = "Vaal Power Siphon",
+		gameId = "Metadata/Items/Gems/SkillGemVaalPowerSiphon",
+		variantId = "VaalPowerSiphon",
 		grantedEffectId = "VaalPowerSiphon",
 		secondaryGrantedEffectId = "PowerSiphon",
 		vaalGem = true,
@@ -2511,6 +2809,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemPuncture"] = {
 		name = "Puncture",
+		gameId = "Metadata/Items/Gems/SkillGemPuncture",
+		variantId = "Puncture",
 		grantedEffectId = "Puncture",
 		tags = {
 			dexterity = true,
@@ -2531,6 +2831,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemLightningArrow"] = {
 		name = "Lightning Arrow",
+		gameId = "Metadata/Items/Gems/SkillGemLightningArrow",
+		variantId = "LightningArrow",
 		grantedEffectId = "LightningArrow",
 		tags = {
 			dexterity = true,
@@ -2549,6 +2851,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemLightningArrowAltX"] = {
 		name = "Lightning Arrow of Electrocution",
+		gameId = "Metadata/Items/Gems/SkillGemLightningArrow",
+		variantId = "LightningArrowAltX",
 		grantedEffectId = "LightningArrowAltX",
 		tags = {
 			dexterity = true,
@@ -2566,6 +2870,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemHaste"] = {
 		name = "Haste",
+		gameId = "Metadata/Items/Gems/SkillGemHaste",
+		variantId = "Haste",
 		grantedEffectId = "Haste",
 		tags = {
 			aura = true,
@@ -2582,6 +2888,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemVaalHaste"] = {
 		name = "Vaal Haste",
+		gameId = "Metadata/Items/Gems/SkillGemVaalHaste",
+		variantId = "VaalHaste",
 		grantedEffectId = "VaalHaste",
 		secondaryGrantedEffectId = "Haste",
 		vaalGem = true,
@@ -2602,6 +2910,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemPurity"] = {
 		name = "Purity of Elements",
+		gameId = "Metadata/Items/Gems/SkillGemPurity",
+		variantId = "Purity",
 		grantedEffectId = "Purity",
 		tags = {
 			aura = true,
@@ -2618,6 +2928,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemVitality"] = {
 		name = "Vitality",
+		gameId = "Metadata/Items/Gems/SkillGemVitality",
+		variantId = "Vitality",
 		grantedEffectId = "Vitality",
 		tags = {
 			aura = true,
@@ -2634,6 +2946,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemDiscipline"] = {
 		name = "Discipline",
+		gameId = "Metadata/Items/Gems/SkillGemDiscipline",
+		variantId = "Discipline",
 		grantedEffectId = "Discipline",
 		tags = {
 			aura = true,
@@ -2650,6 +2964,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemVaalDiscipline"] = {
 		name = "Vaal Discipline",
+		gameId = "Metadata/Items/Gems/SkillGemVaalDiscipline",
+		variantId = "VaalDiscipline",
 		grantedEffectId = "VaalDiscipline",
 		secondaryGrantedEffectId = "Discipline",
 		vaalGem = true,
@@ -2670,6 +2986,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemGrace"] = {
 		name = "Grace",
+		gameId = "Metadata/Items/Gems/SkillGemGrace",
+		variantId = "Grace",
 		grantedEffectId = "Grace",
 		tags = {
 			aura = true,
@@ -2686,6 +3004,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemVaalGrace"] = {
 		name = "Vaal Grace",
+		gameId = "Metadata/Items/Gems/SkillGemVaalGrace",
+		variantId = "VaalGrace",
 		grantedEffectId = "VaalGrace",
 		secondaryGrantedEffectId = "Grace",
 		vaalGem = true,
@@ -2706,6 +3026,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemDetermination"] = {
 		name = "Determination",
+		gameId = "Metadata/Items/Gems/SkillGemDetermination",
+		variantId = "Determination",
 		grantedEffectId = "Determination",
 		tags = {
 			aura = true,
@@ -2723,6 +3045,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemAnger"] = {
 		name = "Anger",
+		gameId = "Metadata/Items/Gems/SkillGemAnger",
+		variantId = "Anger",
 		grantedEffectId = "Anger",
 		tags = {
 			aura = true,
@@ -2740,6 +3064,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemHatred"] = {
 		name = "Hatred",
+		gameId = "Metadata/Items/Gems/SkillGemHatred",
+		variantId = "Hatred",
 		grantedEffectId = "Hatred",
 		tags = {
 			aura = true,
@@ -2757,6 +3083,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemWrath"] = {
 		name = "Wrath",
+		gameId = "Metadata/Items/Gems/SkillGemWrath",
+		variantId = "Wrath",
 		grantedEffectId = "Wrath",
 		tags = {
 			aura = true,
@@ -2774,6 +3102,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemBurningArrow"] = {
 		name = "Burning Arrow",
+		gameId = "Metadata/Items/Gems/SkillGemBurningArrow",
+		variantId = "BurningArrow",
 		grantedEffectId = "BurningArrow",
 		tags = {
 			dexterity = true,
@@ -2791,6 +3121,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemBurningArrowAltX"] = {
 		name = "Burning Arrow of Vigour",
+		gameId = "Metadata/Items/Gems/SkillGemBurningArrow",
+		variantId = "BurningArrowAltX",
 		grantedEffectId = "BurningArrowAltX",
 		tags = {
 			dexterity = true,
@@ -2808,6 +3140,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemVaalBurningArrow"] = {
 		name = "Vaal Burning Arrow",
+		gameId = "Metadata/Items/Gems/SkillGemVaalBurningArrow",
+		variantId = "VaalBurningArrow",
 		grantedEffectId = "VaalBurningArrow",
 		secondaryGrantedEffectId = "BurningArrow",
 		vaalGem = true,
@@ -2829,6 +3163,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemElementalProliferationSupport"] = {
 		name = "Elemental Proliferation",
+		gameId = "Metadata/Items/Gems/SupportGemElementalProliferation",
+		variantId = "ElementalProliferationSupport",
 		grantedEffectId = "SupportElementalProliferation",
 		tags = {
 			cold = true,
@@ -2846,6 +3182,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemBloodMagicSupport"] = {
 		name = "Arrogance",
+		gameId = "Metadata/Items/Gems/SupportGemBloodMagic",
+		variantId = "BloodMagicSupport",
 		grantedEffectId = "SupportBloodMagic",
 		tags = {
 			aura = true,
@@ -2860,6 +3198,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemClarity"] = {
 		name = "Clarity",
+		gameId = "Metadata/Items/Gems/SkillGemClarity",
+		variantId = "Clarity",
 		grantedEffectId = "Clarity",
 		tags = {
 			aura = true,
@@ -2876,6 +3216,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemVaalClarity"] = {
 		name = "Vaal Clarity",
+		gameId = "Metadata/Items/Gems/SkillGemVaalClarity",
+		variantId = "VaalClarity",
 		grantedEffectId = "VaalClarity",
 		secondaryGrantedEffectId = "Clarity",
 		vaalGem = true,
@@ -2896,6 +3238,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemCullingStrikeSupport"] = {
 		name = "Culling Strike",
+		gameId = "Metadata/Items/Gems/SupportGemCullingStrike",
+		variantId = "CullingStrikeSupport",
 		grantedEffectId = "SupportCullingStrike",
 		tags = {
 			dexterity = true,
@@ -2909,6 +3253,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemPointBlankSupport"] = {
 		name = "Point Blank",
+		gameId = "Metadata/Items/Gems/SupportGemPointBlank",
+		variantId = "PointBlankSupport",
 		grantedEffectId = "SupportPointBlank",
 		tags = {
 			projectile = true,
@@ -2924,6 +3270,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemIronGripSupport"] = {
 		name = "Iron Grip",
+		gameId = "Metadata/Items/Gems/SupportGemIronGrip",
+		variantId = "IronGripSupport",
 		grantedEffectId = "SupportIronGrip",
 		tags = {
 			projectile = true,
@@ -2939,6 +3287,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemIronWillSupport"] = {
 		name = "Iron Will",
+		gameId = "Metadata/Items/Gems/SupportGemIronWill",
+		variantId = "IronWillSupport",
 		grantedEffectId = "SupportIronWill",
 		tags = {
 			spell = true,
@@ -2953,6 +3303,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemMeleeDamageOnFullLifeSupport"] = {
 		name = "Damage on Full Life",
+		gameId = "Metadata/Items/Gems/SupportGemMeleeDamageOnFullLife",
+		variantId = "MeleeDamageOnFullLifeSupport",
 		grantedEffectId = "SupportMeleeDamageOnFullLife",
 		tags = {
 			attack = true,
@@ -2967,6 +3319,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemSpellTotemSupport"] = {
 		name = "Spell Totem",
+		gameId = "Metadata/Items/Gems/SupportGemSpellTotem",
+		variantId = "SpellTotemSupport",
 		grantedEffectId = "SupportSpellTotem",
 		tags = {
 			strength = true,
@@ -2982,6 +3336,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemRemoteMineSupport"] = {
 		name = "Blastchain Mine",
+		gameId = "Metadata/Items/Gems/SupportGemRemoteMine",
+		variantId = "RemoteMineSupport",
 		grantedEffectId = "SupportRemoteMine",
 		tags = {
 			intelligence = true,
@@ -2996,6 +3352,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemDetonateMines"] = {
 		name = "Detonate Mines",
+		gameId = "Metadata/Items/Gems/SkillGemDetonateMines",
+		variantId = "DetonateMines",
 		grantedEffectId = "GemDetonateMines",
 		tags = {
 			low_max_level = true,
@@ -3011,6 +3369,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemShockwaveTotem"] = {
 		name = "Shockwave Totem",
+		gameId = "Metadata/Items/Gems/SkillGemShockwaveTotem",
+		variantId = "ShockwaveTotem",
 		grantedEffectId = "ShockwaveTotem",
 		tags = {
 			totem = true,
@@ -3029,6 +3389,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemRejuvenationTotem"] = {
 		name = "Rejuvenation Totem",
+		gameId = "Metadata/Items/Gems/SkillGemRejuvenationTotem",
+		variantId = "RejuvenationTotem",
 		grantedEffectId = "RejuvenationTotem",
 		tags = {
 			totem = true,
@@ -3046,6 +3408,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemFreezeMine"] = {
 		name = "Icicle Mine",
+		gameId = "Metadata/Items/Gems/SkillGemFreezeMine",
+		variantId = "FreezeMine",
 		grantedEffectId = "ColdProjectileMine",
 		tags = {
 			mine = true,
@@ -3066,6 +3430,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemFreezeMineAltX"] = {
 		name = "Icicle Mine of Fanning",
+		gameId = "Metadata/Items/Gems/SkillGemFreezeMine",
+		variantId = "FreezeMineAltX",
 		grantedEffectId = "ColdProjectileMineAltX",
 		tags = {
 			mine = true,
@@ -3086,6 +3452,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemFreezeMineAltY"] = {
 		name = "Icicle Mine of Sabotage",
+		gameId = "Metadata/Items/Gems/SkillGemFreezeMine",
+		variantId = "FreezeMineAltY",
 		grantedEffectId = "ColdProjectileMineAltY",
 		tags = {
 			mine = true,
@@ -3106,6 +3474,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemConversionTrap"] = {
 		name = "Conversion Trap",
+		gameId = "Metadata/Items/Gems/SkillGemConversionTrap",
+		variantId = "ConversionTrap",
 		grantedEffectId = "ConversionTrap",
 		tags = {
 			trap = true,
@@ -3122,6 +3492,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemBearTrap"] = {
 		name = "Bear Trap",
+		gameId = "Metadata/Items/Gems/SkillGemBearTrap",
+		variantId = "BearTrap",
 		grantedEffectId = "BearTrap",
 		tags = {
 			trap = true,
@@ -3139,6 +3511,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemBearTrapAltX"] = {
 		name = "Bear Trap of Skewers",
+		gameId = "Metadata/Items/Gems/SkillGemBearTrap",
+		variantId = "BearTrapAltX",
 		grantedEffectId = "BearTrapAltX",
 		tags = {
 			trap = true,
@@ -3156,6 +3530,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemChanceToFleeSupport"] = {
 		name = "Chance to Flee",
+		gameId = "Metadata/Items/Gems/SupportGemChanceToFlee",
+		variantId = "ChanceToFleeSupport",
 		grantedEffectId = "SupportChanceToFlee",
 		tags = {
 			dexterity = true,
@@ -3169,6 +3545,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemFireTrap"] = {
 		name = "Fire Trap",
+		gameId = "Metadata/Items/Gems/SkillGemFireTrap",
+		variantId = "FireTrap",
 		grantedEffectId = "FireTrap",
 		tags = {
 			trap = true,
@@ -3187,6 +3565,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemFireTrapAltX"] = {
 		name = "Fire Trap of Blasting",
+		gameId = "Metadata/Items/Gems/SkillGemFireTrap",
+		variantId = "FireTrapAltX",
 		grantedEffectId = "FireTrapAltX",
 		tags = {
 			trap = true,
@@ -3205,6 +3585,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemDecoyTotem"] = {
 		name = "Decoy Totem",
+		gameId = "Metadata/Items/Gems/SkillGemDecoyTotem",
+		variantId = "DecoyTotem",
 		grantedEffectId = "DecoyTotem",
 		tags = {
 			totem = true,
@@ -3221,6 +3603,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemDevouringTotem"] = {
 		name = "Devouring Totem",
+		gameId = "Metadata/Items/Gems/SkillGemDevouringTotem",
+		variantId = "DevouringTotem",
 		grantedEffectId = "DevouringTotem",
 		tags = {
 			totem = true,
@@ -3236,6 +3620,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemEtherealKnives"] = {
 		name = "Ethereal Knives",
+		gameId = "Metadata/Items/Gems/SkillGemEtherealKnives",
+		variantId = "EtherealKnives",
 		grantedEffectId = "EtherealKnives",
 		tags = {
 			dexterity = true,
@@ -3252,6 +3638,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemEtherealKnivesAltX"] = {
 		name = "Ethereal Knives of Lingering Blades",
+		gameId = "Metadata/Items/Gems/SkillGemEtherealKnives",
+		variantId = "EtherealKnivesAltX",
 		grantedEffectId = "EtherealKnivesAltX",
 		tags = {
 			dexterity = true,
@@ -3269,6 +3657,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemEtherealKnivesAltY"] = {
 		name = "Ethereal Knives of the Massacre",
+		gameId = "Metadata/Items/Gems/SkillGemEtherealKnives",
+		variantId = "EtherealKnivesAltY",
 		grantedEffectId = "EtherealKnivesAltY",
 		tags = {
 			dexterity = true,
@@ -3285,6 +3675,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemBlindSupport"] = {
 		name = "Blind",
+		gameId = "Metadata/Items/Gems/SupportGemBlind",
+		variantId = "BlindSupport",
 		grantedEffectId = "SupportBlind",
 		tags = {
 			dexterity = true,
@@ -3298,6 +3690,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemIceShot"] = {
 		name = "Ice Shot",
+		gameId = "Metadata/Items/Gems/SkillGemIceShot",
+		variantId = "IceShot",
 		grantedEffectId = "IceShot",
 		tags = {
 			dexterity = true,
@@ -3316,6 +3710,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemArcticBreath"] = {
 		name = "Creeping Frost",
+		gameId = "Metadata/Items/Gems/SkillGemArcticBreath",
+		variantId = "ArcticBreath",
 		grantedEffectId = "ArcticBreath",
 		tags = {
 			intelligence = true,
@@ -3334,6 +3730,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemArc"] = {
 		name = "Arc",
+		gameId = "Metadata/Items/Gems/SkillGemArc",
+		variantId = "Arc",
 		grantedEffectId = "Arc",
 		tags = {
 			intelligence = true,
@@ -3350,6 +3748,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemArcAltX"] = {
 		name = "Arc of Surging",
+		gameId = "Metadata/Items/Gems/SkillGemArc",
+		variantId = "ArcAltX",
 		grantedEffectId = "ArcAltX",
 		tags = {
 			intelligence = true,
@@ -3365,6 +3765,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemArcAltY"] = {
 		name = "Arc of Oscillating",
+		gameId = "Metadata/Items/Gems/SkillGemArc",
+		variantId = "ArcAltY",
 		grantedEffectId = "ArcAltY",
 		tags = {
 			intelligence = true,
@@ -3381,6 +3783,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemVaalArc"] = {
 		name = "Vaal Arc",
+		gameId = "Metadata/Items/Gems/SkillGemVaalArc",
+		variantId = "VaalArc",
 		grantedEffectId = "VaalArcChain",
 		secondaryGrantedEffectId = "Arc",
 		vaalGem = true,
@@ -3401,6 +3805,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemNewArcticArmour"] = {
 		name = "Arctic Armour",
+		gameId = "Metadata/Items/Gems/SkillGemNewArcticArmour",
+		variantId = "NewArcticArmour",
 		grantedEffectId = "ArcticArmour",
 		tags = {
 			dexterity = true,
@@ -3417,6 +3823,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemVaalArcticArmour"] = {
 		name = "Vaal Arctic Armour",
+		gameId = "Metadata/Items/Gems/SkillGemVaalArcticArmour",
+		variantId = "VaalArcticArmour",
 		grantedEffectId = "VaalArcticArmour",
 		secondaryGrantedEffectId = "ArcticArmour",
 		vaalGem = true,
@@ -3436,6 +3844,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemFlameTotem"] = {
 		name = "Holy Flame Totem",
+		gameId = "Metadata/Items/Gems/SkillGemFlameTotem",
+		variantId = "FlameTotem",
 		grantedEffectId = "FlameTotem",
 		tags = {
 			totem = true,
@@ -3455,6 +3865,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemFlameTotemAltX"] = {
 		name = "Holy Flame Totem of Ire",
+		gameId = "Metadata/Items/Gems/SkillGemFlameTotem",
+		variantId = "FlameTotemAltX",
 		grantedEffectId = "FlameTotemAltX",
 		tags = {
 			totem = true,
@@ -3474,6 +3886,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemRangedAttackTotemSupport"] = {
 		name = "Ballista Totem",
+		gameId = "Metadata/Items/Gems/SupportGemRangedAttackTotem",
+		variantId = "RangedAttackTotemSupport",
 		grantedEffectId = "SupportRangedAttackTotem",
 		tags = {
 			bow = true,
@@ -3490,6 +3904,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemFirePenetrationSupport"] = {
 		name = "Fire Penetration",
+		gameId = "Metadata/Items/Gems/SupportGemFirePenetration",
+		variantId = "FirePenetrationSupport",
 		grantedEffectId = "SupportFirePenetration",
 		tags = {
 			fire = true,
@@ -3504,6 +3920,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemColdPenetrationSupport"] = {
 		name = "Cold Penetration",
+		gameId = "Metadata/Items/Gems/SupportGemColdPenetration",
+		variantId = "ColdPenetrationSupport",
 		grantedEffectId = "SupportColdPenetration",
 		tags = {
 			cold = true,
@@ -3518,6 +3936,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemLightningPenetrationSupport"] = {
 		name = "Lightning Penetration",
+		gameId = "Metadata/Items/Gems/SupportGemLightningPenetration",
+		variantId = "LightningPenetrationSupport",
 		grantedEffectId = "SupportLightningPenetration",
 		tags = {
 			lightning = true,
@@ -3532,6 +3952,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemElementalPenetrationSupport"] = {
 		name = "Elemental Penetration",
+		gameId = "Metadata/Items/Gems/SupportGemElementalPenetration",
+		variantId = "ElementalPenetrationSupport",
 		grantedEffectId = "SupportElementalPenetration",
 		tags = {
 			intelligence = true,
@@ -3545,6 +3967,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemChainSupport"] = {
 		name = "Chain",
+		gameId = "Metadata/Items/Gems/SupportGemChain",
+		variantId = "ChainSupport",
 		grantedEffectId = "SupportChain",
 		tags = {
 			dexterity = true,
@@ -3560,6 +3984,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemForkSupport"] = {
 		name = "Fork",
+		gameId = "Metadata/Items/Gems/SupportGemFork",
+		variantId = "ForkSupport",
 		grantedEffectId = "SupportFork",
 		tags = {
 			dexterity = true,
@@ -3574,6 +4000,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemReturningProjectilesSupport"] = {
 		name = "Returning Projectiles",
+		gameId = "Metadata/Items/Gems/SupportGemReturningProjectiles",
+		variantId = "ReturningProjectilesSupport",
 		grantedEffectId = "SupportReturningProjectiles",
 		tags = {
 			dexterity = true,
@@ -3588,6 +4016,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemFlammability"] = {
 		name = "Flammability",
+		gameId = "Metadata/Items/Gems/SkillGemFlammability",
+		variantId = "Flammability",
 		grantedEffectId = "Flammability",
 		tags = {
 			intelligence = true,
@@ -3607,6 +4037,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemFrostbite"] = {
 		name = "Frostbite",
+		gameId = "Metadata/Items/Gems/SkillGemFrostbite",
+		variantId = "Frostbite",
 		grantedEffectId = "Frostbite",
 		tags = {
 			intelligence = true,
@@ -3626,6 +4058,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemConductivity"] = {
 		name = "Conductivity",
+		gameId = "Metadata/Items/Gems/SkillGemConductivity",
+		variantId = "Conductivity",
 		grantedEffectId = "Conductivity",
 		tags = {
 			intelligence = true,
@@ -3645,6 +4079,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemStormBurst"] = {
 		name = "Storm Burst",
+		gameId = "Metadata/Items/Gems/SkillGemStormBurst",
+		variantId = "StormBurst",
 		grantedEffectId = "StormBurstNew",
 		tags = {
 			area = true,
@@ -3664,6 +4100,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemIncinerate"] = {
 		name = "Incinerate",
+		gameId = "Metadata/Items/Gems/SkillGemIncinerate",
+		variantId = "Incinerate",
 		grantedEffectId = "ExpandingFireCone",
 		tags = {
 			intelligence = true,
@@ -3681,6 +4119,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemCyclone"] = {
 		name = "Cyclone",
+		gameId = "Metadata/Items/Gems/SkillGemCyclone",
+		variantId = "Cyclone",
 		grantedEffectId = "Cyclone",
 		tags = {
 			dexterity = true,
@@ -3700,6 +4140,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemCycloneAltX"] = {
 		name = "Cyclone of Tumult",
+		gameId = "Metadata/Items/Gems/SkillGemCyclone",
+		variantId = "CycloneAltX",
 		grantedEffectId = "CycloneAltX",
 		tags = {
 			dexterity = true,
@@ -3719,6 +4161,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemVaalCyclone"] = {
 		name = "Vaal Cyclone",
+		gameId = "Metadata/Items/Gems/SkillGemVaalCyclone",
+		variantId = "VaalCyclone",
 		grantedEffectId = "VaalCyclone",
 		secondaryGrantedEffectId = "Cyclone",
 		vaalGem = true,
@@ -3742,6 +4186,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemMultistrikeSupport"] = {
 		name = "Multistrike",
+		gameId = "Metadata/Items/Gems/SupportGemMultistrike",
+		variantId = "MultistrikeSupport",
 		grantedEffectId = "SupportMultistrike",
 		tags = {
 			attack = true,
@@ -3757,6 +4203,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemMulticastSupport"] = {
 		name = "Spell Echo",
+		gameId = "Metadata/Items/Gems/SupportGemMulticast",
+		variantId = "MulticastSupport",
 		grantedEffectId = "SupportMulticast",
 		tags = {
 			spell = true,
@@ -3771,6 +4219,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemMeleeSplashSupport"] = {
 		name = "Melee Splash",
+		gameId = "Metadata/Items/Gems/SupportGemMeleeSplash",
+		variantId = "MeleeSplashSupport",
 		grantedEffectId = "SupportMeleeSplash",
 		tags = {
 			strength = true,
@@ -3788,6 +4238,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemPowerChargeOnCritSupport"] = {
 		name = "Power Charge On Critical",
+		gameId = "Metadata/Items/Gems/SupportGemPowerChargeOnCrit",
+		variantId = "PowerChargeOnCritSupport",
 		grantedEffectId = "SupportPowerChargeOnCrit",
 		tags = {
 			critical = true,
@@ -3802,6 +4254,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemSearingBond"] = {
 		name = "Searing Bond",
+		gameId = "Metadata/Items/Gems/SkillGemSearingBond",
+		variantId = "SearingBond",
 		grantedEffectId = "SearingBond",
 		tags = {
 			strength = true,
@@ -3818,6 +4272,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemIncreasedBurningDamageSupport"] = {
 		name = "Burning Damage",
+		gameId = "Metadata/Items/Gems/SupportGemIncreasedBurningDamage",
+		variantId = "IncreasedBurningDamageSupport",
 		grantedEffectId = "SupportIncreasedBurningDamage",
 		tags = {
 			fire = true,
@@ -3832,6 +4288,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemSummonElementalResistanceSupport"] = {
 		name = "Elemental Army",
+		gameId = "Metadata/Items/Gems/SupportGemSummonElementalResistance",
+		variantId = "SummonElementalResistanceSupport",
 		grantedEffectId = "SupportSummonElementalResistances",
 		tags = {
 			intelligence = true,
@@ -3846,6 +4304,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemCurseOnHitSupport"] = {
 		name = "Hextouch",
+		gameId = "Metadata/Items/Gems/SupportGemCurseOnHit",
+		variantId = "CurseOnHitSupport",
 		grantedEffectId = "SupportCurseOnHit",
 		secondaryGrantedEffectId = "SupportCurseOnHitCurse",
 		tags = {
@@ -3862,6 +4322,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemReave"] = {
 		name = "Reave",
+		gameId = "Metadata/Items/Gems/SkillGemReave",
+		variantId = "Reave",
 		grantedEffectId = "Reave",
 		tags = {
 			dexterity = true,
@@ -3878,6 +4340,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemReaveAltX"] = {
 		name = "Reave of Refraction",
+		gameId = "Metadata/Items/Gems/SkillGemReave",
+		variantId = "ReaveAltX",
 		grantedEffectId = "ReaveAltX",
 		tags = {
 			dexterity = true,
@@ -3894,6 +4358,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemVaalReave"] = {
 		name = "Vaal Reave",
+		gameId = "Metadata/Items/Gems/SkillGemVaalReave",
+		variantId = "VaalReave",
 		grantedEffectId = "VaalReave",
 		secondaryGrantedEffectId = "Reave",
 		vaalGem = true,
@@ -3913,6 +4379,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemCastOnCritSupport"] = {
 		name = "Cast On Critical Strike",
+		gameId = "Metadata/Items/Gems/SupportGemCastOnCrit",
+		variantId = "CastOnCritSupport",
 		grantedEffectId = "SupportCastOnCrit",
 		secondaryGrantedEffectId = "SupportCastOnCritTriggered",
 		tags = {
@@ -3930,6 +4398,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemCastOnKillSupport"] = {
 		name = "Cast on Melee Kill",
+		gameId = "Metadata/Items/Gems/SupportGemCastOnKill",
+		variantId = "CastOnKillSupport",
 		grantedEffectId = "SupportCastOnMeleeKill",
 		secondaryGrantedEffectId = "SupportCastOnMeleeKillTriggered",
 		tags = {
@@ -3948,6 +4418,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemMultiTrapSupport"] = {
 		name = "Multiple Traps",
+		gameId = "Metadata/Items/Gems/SupportGemMultiTrap",
+		variantId = "MultiTrapSupport",
 		grantedEffectId = "SupportMultiTrap",
 		tags = {
 			dexterity = true,
@@ -3962,6 +4434,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemAdditionalLevelSupport"] = {
 		name = "Empower",
+		gameId = "Metadata/Items/Gems/SupportGemAdditionalLevel",
+		variantId = "AdditionalLevelSupport",
 		grantedEffectId = "SupportAdditionalLevel",
 		tags = {
 			low_max_level = true,
@@ -3977,6 +4451,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemLightningTrap"] = {
 		name = "Lightning Trap",
+		gameId = "Metadata/Items/Gems/SkillGemLightningTrap",
+		variantId = "LightningTrap",
 		grantedEffectId = "LightningTrap",
 		tags = {
 			trap = true,
@@ -3995,6 +4471,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemLightningTrapAltX"] = {
 		name = "Lightning Trap of Sparking",
+		gameId = "Metadata/Items/Gems/SkillGemLightningTrap",
+		variantId = "LightningTrapAltX",
 		grantedEffectId = "LightningTrapAltX",
 		tags = {
 			trap = true,
@@ -4013,6 +4491,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemVaalLightningTrap"] = {
 		name = "Vaal Lightning Trap",
+		gameId = "Metadata/Items/Gems/SkillGemVaalLightningTrap",
+		variantId = "VaalLightningTrap",
 		grantedEffectId = "VaalLightningTrap",
 		secondaryGrantedEffectId = "LightningTrap",
 		vaalGem = true,
@@ -4035,6 +4515,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemSmokeMine"] = {
 		name = "Smoke Mine",
+		gameId = "Metadata/Items/Gems/SkillGemSmokeMine",
+		variantId = "SmokeMine",
 		grantedEffectId = "SmokeMine",
 		tags = {
 			mine = true,
@@ -4055,6 +4537,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemEnduranceChargeOnMeleeStunSupport"] = {
 		name = "Endurance Charge on Melee Stun",
+		gameId = "Metadata/Items/Gems/SupportGemEnduranceChargeOnMeleeStun",
+		variantId = "EnduranceChargeOnMeleeStunSupport",
 		grantedEffectId = "EnduranceChargeOnMeleeStun",
 		tags = {
 			strength = true,
@@ -4070,6 +4554,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemAnimateArmour"] = {
 		name = "Animate Guardian",
+		gameId = "Metadata/Items/Gems/SkillGemAnimateArmour",
+		variantId = "AnimateArmour",
 		grantedEffectId = "AnimateArmour",
 		tags = {
 			strength = true,
@@ -4085,6 +4571,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemAnimateArmourAltX"] = {
 		name = "Animate Guardian of Smiting",
+		gameId = "Metadata/Items/Gems/SkillGemAnimateArmour",
+		variantId = "AnimateArmourAltX",
 		grantedEffectId = "AnimateArmourAltX",
 		tags = {
 			strength = true,
@@ -4101,6 +4589,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemThrownShieldProjectile"] = {
 		name = "Spectral Shield Throw",
+		gameId = "Metadata/Items/Gems/SkillGemThrownShieldProjectile",
+		variantId = "ThrownShieldProjectile",
 		grantedEffectId = "ThrownShield",
 		tags = {
 			dexterity = true,
@@ -4117,6 +4607,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemThrownShieldProjectileAltX"] = {
 		name = "Spectral Shield Throw of Shattering",
+		gameId = "Metadata/Items/Gems/SkillGemThrownShieldProjectile",
+		variantId = "ThrownShieldProjectileAltX",
 		grantedEffectId = "ThrownShieldAltX",
 		tags = {
 			dexterity = true,
@@ -4133,6 +4625,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemThrownWeapon"] = {
 		name = "Spectral Throw",
+		gameId = "Metadata/Items/Gems/SkillGemThrownWeapon",
+		variantId = "ThrownWeapon",
 		grantedEffectId = "ThrownWeapon",
 		tags = {
 			dexterity = true,
@@ -4148,6 +4642,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemVaalThrownWeapon"] = {
 		name = "Vaal Spectral Throw",
+		gameId = "Metadata/Items/Gems/SkillGemVaalThrownWeapon",
+		variantId = "VaalThrownWeapon",
 		grantedEffectId = "VaalThrownWeapon",
 		secondaryGrantedEffectId = "ThrownWeapon",
 		vaalGem = true,
@@ -4166,6 +4662,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemSlowerProjectilesSupport"] = {
 		name = "Slower Projectiles",
+		gameId = "Metadata/Items/Gems/SupportGemSlowerProjectiles",
+		variantId = "SlowerProjectilesSupport",
 		grantedEffectId = "SupportSlowerProjectiles",
 		tags = {
 			dexterity = true,
@@ -4180,6 +4678,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemReducedDurationSupport"] = {
 		name = "Less Duration",
+		gameId = "Metadata/Items/Gems/SupportGemReducedDuration",
+		variantId = "ReducedDurationSupport",
 		grantedEffectId = "SupportReducedDuration",
 		tags = {
 			strength = true,
@@ -4194,6 +4694,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemCastOnDeathSupport"] = {
 		name = "Cast on Death",
+		gameId = "Metadata/Items/Gems/SupportGemCastOnDeath",
+		variantId = "CastOnDeathSupport",
 		grantedEffectId = "SupportCastOnDeath",
 		tags = {
 			dexterity = true,
@@ -4209,6 +4711,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemCastOnDamageTakenSupport"] = {
 		name = "Cast when Damage Taken",
+		gameId = "Metadata/Items/Gems/SupportGemCastOnDamageTaken",
+		variantId = "CastOnDamageTakenSupport",
 		grantedEffectId = "SupportCastOnDamageTaken",
 		tags = {
 			strength = true,
@@ -4224,6 +4728,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemCastOnStunnedSupport"] = {
 		name = "Cast when Stunned",
+		gameId = "Metadata/Items/Gems/SupportGemCastOnStunned",
+		variantId = "CastOnStunnedSupport",
 		grantedEffectId = "SupportCastOnStunned",
 		tags = {
 			intelligence = true,
@@ -4239,6 +4745,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemAnimateWeapon"] = {
 		name = "Animate Weapon",
+		gameId = "Metadata/Items/Gems/SkillGemAnimateWeapon",
+		variantId = "AnimateWeapon",
 		grantedEffectId = "AnimateWeapon",
 		tags = {
 			dexterity = true,
@@ -4256,6 +4764,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemAnimateWeaponAltX"] = {
 		name = "Animate Weapon of Self Reflection",
+		gameId = "Metadata/Items/Gems/SkillGemAnimateWeapon",
+		variantId = "AnimateWeaponAltX",
 		grantedEffectId = "AnimateWeaponAltX",
 		tags = {
 			dexterity = true,
@@ -4272,6 +4782,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemAnimateWeaponAltY"] = {
 		name = "Animate Weapon of Ranged Arms",
+		gameId = "Metadata/Items/Gems/SkillGemAnimateWeapon",
+		variantId = "AnimateWeaponAltY",
 		grantedEffectId = "AnimateWeaponAltY",
 		tags = {
 			dexterity = true,
@@ -4289,6 +4801,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemAdditionalQualitySupport"] = {
 		name = "Enhance",
+		gameId = "Metadata/Items/Gems/SupportGemAdditionalQuality",
+		variantId = "AdditionalQualitySupport",
 		grantedEffectId = "SupportAdditionalQuality",
 		tags = {
 			low_max_level = true,
@@ -4304,6 +4818,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemFireResistAura"] = {
 		name = "Purity of Fire",
+		gameId = "Metadata/Items/Gems/SkillGemFireResistAura",
+		variantId = "FireResistAura",
 		grantedEffectId = "FireResistAura",
 		tags = {
 			aura = true,
@@ -4321,6 +4837,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemVaalFireResistAura"] = {
 		name = "Vaal Impurity of Fire",
+		gameId = "Metadata/Items/Gems/SkillGemVaalFireResistAura",
+		variantId = "VaalFireResistAura",
 		grantedEffectId = "FireImpurity",
 		secondaryGrantedEffectId = "FireResistAura",
 		vaalGem = true,
@@ -4342,6 +4860,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemColdResistAura"] = {
 		name = "Purity of Ice",
+		gameId = "Metadata/Items/Gems/SkillGemColdResistAura",
+		variantId = "ColdResistAura",
 		grantedEffectId = "ColdResistAura",
 		tags = {
 			aura = true,
@@ -4359,6 +4879,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemVaalColdResistAura"] = {
 		name = "Vaal Impurity of Ice",
+		gameId = "Metadata/Items/Gems/SkillGemVaalColdResistAura",
+		variantId = "VaalColdResistAura",
 		grantedEffectId = "ColdImpurity",
 		secondaryGrantedEffectId = "ColdResistAura",
 		vaalGem = true,
@@ -4380,6 +4902,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemLightningResistAura"] = {
 		name = "Purity of Lightning",
+		gameId = "Metadata/Items/Gems/SkillGemLightningResistAura",
+		variantId = "LightningResistAura",
 		grantedEffectId = "LightningResistAura",
 		tags = {
 			aura = true,
@@ -4397,6 +4921,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemVaalLightningResistAura"] = {
 		name = "Vaal Impurity of Lightning",
+		gameId = "Metadata/Items/Gems/SkillGemVaalLightningResistAura",
+		variantId = "VaalLightningResistAura",
 		grantedEffectId = "LightningImpurity",
 		secondaryGrantedEffectId = "LightningResistAura",
 		vaalGem = true,
@@ -4418,6 +4944,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemStormCall"] = {
 		name = "Storm Call",
+		gameId = "Metadata/Items/Gems/SkillGemStormCall",
+		variantId = "StormCall",
 		grantedEffectId = "StormCall",
 		tags = {
 			intelligence = true,
@@ -4435,6 +4963,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemVaalStormCall"] = {
 		name = "Vaal Storm Call",
+		gameId = "Metadata/Items/Gems/SkillGemVaalStormCall",
+		variantId = "VaalStormCall",
 		grantedEffectId = "VaalStormCall",
 		secondaryGrantedEffectId = "StormCall",
 		vaalGem = true,
@@ -4455,6 +4985,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemFlameblast"] = {
 		name = "Flameblast",
+		gameId = "Metadata/Items/Gems/SkillGemFlameblast",
+		variantId = "Flameblast",
 		grantedEffectId = "Flameblast",
 		tags = {
 			intelligence = true,
@@ -4472,6 +5004,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemFlameblastAltX"] = {
 		name = "Flameblast of Celerity",
+		gameId = "Metadata/Items/Gems/SkillGemFlameblast",
+		variantId = "FlameblastAltX",
 		grantedEffectId = "FlameblastAltX",
 		tags = {
 			intelligence = true,
@@ -4489,6 +5023,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemFlameblastAltY"] = {
 		name = "Flameblast of Contraction",
+		gameId = "Metadata/Items/Gems/SkillGemFlameblast",
+		variantId = "FlameblastAltY",
 		grantedEffectId = "FlameblastAltY",
 		tags = {
 			intelligence = true,
@@ -4506,6 +5042,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemVaalFlameblast"] = {
 		name = "Vaal Flameblast",
+		gameId = "Metadata/Items/Gems/SkillGemVaalFlameblast",
+		variantId = "VaalFlameblast",
 		grantedEffectId = "VaalFlameblast",
 		secondaryGrantedEffectId = "Flameblast",
 		vaalGem = true,
@@ -4526,6 +5064,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemBarrage"] = {
 		name = "Barrage",
+		gameId = "Metadata/Items/Gems/SkillGemBarrage",
+		variantId = "Barrage",
 		grantedEffectId = "Barrage",
 		tags = {
 			dexterity = true,
@@ -4542,6 +5082,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemBarrageAltX"] = {
 		name = "Barrage of Volley Fire",
+		gameId = "Metadata/Items/Gems/SkillGemBarrage",
+		variantId = "BarrageAltX",
 		grantedEffectId = "BarrageAltX",
 		tags = {
 			dexterity = true,
@@ -4558,6 +5100,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemBallLightning"] = {
 		name = "Ball Lightning",
+		gameId = "Metadata/Items/Gems/SkillGemBallLightning",
+		variantId = "BallLightning",
 		grantedEffectId = "BallLightning",
 		tags = {
 			intelligence = true,
@@ -4575,6 +5119,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemBallLightningAltX"] = {
 		name = "Ball Lightning of Orbiting",
+		gameId = "Metadata/Items/Gems/SkillGemBallLightning",
+		variantId = "BallLightningAltX",
 		grantedEffectId = "BallLightningAltX",
 		tags = {
 			intelligence = true,
@@ -4592,6 +5138,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemBallLightningAltY"] = {
 		name = "Ball Lightning of Static",
+		gameId = "Metadata/Items/Gems/SkillGemBallLightning",
+		variantId = "BallLightningAltY",
 		grantedEffectId = "BallLightningAltY",
 		tags = {
 			intelligence = true,
@@ -4609,6 +5157,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemPhysicalProjectileAttackDamageSupport"] = {
 		name = "Vicious Projectiles",
+		gameId = "Metadata/Items/Gems/SupportGemPhysicalProjectileAttackDamage",
+		variantId = "PhysicalProjectileAttackDamageSupport",
 		grantedEffectId = "SupportPhysicalProjectileAttackDamage",
 		tags = {
 			projectile = true,
@@ -4626,6 +5176,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemSummonRagingSpirit"] = {
 		name = "Summon Raging Spirit",
+		gameId = "Metadata/Items/Gems/SkillGemSummonRagingSpirit",
+		variantId = "SummonRagingSpirit",
 		grantedEffectId = "SummonRagingSpirit",
 		tags = {
 			intelligence = true,
@@ -4643,6 +5195,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemSummonRagingSpiritAltX"] = {
 		name = "Summon Raging Spirit of Enormity",
+		gameId = "Metadata/Items/Gems/SkillGemSummonRagingSpirit",
+		variantId = "SummonRagingSpiritAltX",
 		grantedEffectId = "SummonRagingSpiritAltX",
 		tags = {
 			intelligence = true,
@@ -4660,6 +5214,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemFlameWhip"] = {
 		name = "Flame Surge",
+		gameId = "Metadata/Items/Gems/SkillGemFlameWhip",
+		variantId = "FlameWhip",
 		grantedEffectId = "FlameWhip",
 		tags = {
 			intelligence = true,
@@ -4677,6 +5233,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemFlameWhipAltX"] = {
 		name = "Flame Surge of Combusting",
+		gameId = "Metadata/Items/Gems/SkillGemFlameWhip",
+		variantId = "FlameWhipAltX",
 		grantedEffectId = "FlameWhipAltX",
 		tags = {
 			intelligence = true,
@@ -4694,6 +5252,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemAdditionalXPSupport"] = {
 		name = "Enlighten",
+		gameId = "Metadata/Items/Gems/SupportGemAdditionalXP",
+		variantId = "AdditionalXPSupport",
 		grantedEffectId = "SupportAdditionalXP",
 		tags = {
 			low_max_level = true,
@@ -4709,6 +5269,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemDesecrate"] = {
 		name = "Desecrate",
+		gameId = "Metadata/Items/Gems/SkillGemDesecrate",
+		variantId = "Desecrate",
 		grantedEffectId = "Desecrate",
 		tags = {
 			dexterity = true,
@@ -4726,6 +5288,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemFleshOffering"] = {
 		name = "Flesh Offering",
+		gameId = "Metadata/Items/Gems/SkillGemFleshOffering",
+		variantId = "FleshOffering",
 		grantedEffectId = "FleshOffering",
 		tags = {
 			minion = true,
@@ -4742,6 +5306,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemBoneOffering"] = {
 		name = "Bone Offering",
+		gameId = "Metadata/Items/Gems/SkillGemBoneOffering",
+		variantId = "BoneOffering",
 		grantedEffectId = "BoneOffering",
 		tags = {
 			minion = true,
@@ -4758,6 +5324,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemSpiritOffering"] = {
 		name = "Spirit Offering",
+		gameId = "Metadata/Items/Gems/SkillGemSpiritOffering",
+		variantId = "SpiritOffering",
 		grantedEffectId = "SpiritOffering",
 		tags = {
 			minion = true,
@@ -4774,6 +5342,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemGlacialCascade"] = {
 		name = "Glacial Cascade",
+		gameId = "Metadata/Items/Gems/SkillGemGlacialCascade",
+		variantId = "GlacialCascade",
 		grantedEffectId = "GlacialCascade",
 		tags = {
 			intelligence = true,
@@ -4791,6 +5361,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemGlacialCascadeAltX"] = {
 		name = "Glacial Cascade of the Fissure",
+		gameId = "Metadata/Items/Gems/SkillGemGlacialCascade",
+		variantId = "GlacialCascadeAltX",
 		grantedEffectId = "GlacialCascadeAltX",
 		tags = {
 			intelligence = true,
@@ -4808,6 +5380,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemBlockChanceReductionSupport"] = {
 		name = "Block Chance Reduction",
+		gameId = "Metadata/Items/Gems/SupportGemBlockChanceReduction",
+		variantId = "BlockChanceReductionSupport",
 		grantedEffectId = "SupportBlockReduction",
 		tags = {
 			dexterity = true,
@@ -4822,6 +5396,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemMoltenStrike"] = {
 		name = "Molten Strike",
+		gameId = "Metadata/Items/Gems/SkillGemMoltenStrike",
+		variantId = "MoltenStrike",
 		grantedEffectId = "MoltenStrike",
 		tags = {
 			strength = true,
@@ -4841,6 +5417,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemMoltenStrikeAltX"] = {
 		name = "Molten Strike of the Zenith",
+		gameId = "Metadata/Items/Gems/SkillGemMoltenStrike",
+		variantId = "MoltenStrikeAltX",
 		grantedEffectId = "MoltenStrikeAltX",
 		tags = {
 			strength = true,
@@ -4860,6 +5438,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemConvocation"] = {
 		name = "Convocation",
+		gameId = "Metadata/Items/Gems/SkillGemConvocation",
+		variantId = "Convocation",
 		grantedEffectId = "Convocation",
 		tags = {
 			minion = true,
@@ -4876,6 +5456,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemFireNovaMine"] = {
 		name = "Pyroclast Mine",
+		gameId = "Metadata/Items/Gems/SkillGemFireNovaMine",
+		variantId = "FireNovaMine",
 		grantedEffectId = "MortarBarrageMine",
 		tags = {
 			mine = true,
@@ -4896,6 +5478,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemFireNovaMineAltX"] = {
 		name = "Pyroclast Mine of Sabotage",
+		gameId = "Metadata/Items/Gems/SkillGemFireNovaMine",
+		variantId = "FireNovaMineAltX",
 		grantedEffectId = "MortarBarrageMineAltX",
 		tags = {
 			mine = true,
@@ -4916,6 +5500,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemTornadoShot"] = {
 		name = "Tornado Shot",
+		gameId = "Metadata/Items/Gems/SkillGemTornadoShot",
+		variantId = "TornadoShot",
 		grantedEffectId = "TornadoShot",
 		tags = {
 			dexterity = true,
@@ -4932,6 +5518,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemTornadoShotAltX"] = {
 		name = "Tornado Shot of Cloudburst",
+		gameId = "Metadata/Items/Gems/SkillGemTornadoShot",
+		variantId = "TornadoShotAltX",
 		grantedEffectId = "TornadoShotAltX",
 		tags = {
 			dexterity = true,
@@ -4948,6 +5536,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemGenerositySupport"] = {
 		name = "Generosity",
+		gameId = "Metadata/Items/Gems/SupportGemGenerosity",
+		variantId = "GenerositySupport",
 		grantedEffectId = "SupportGenerosity",
 		tags = {
 			strength = true,
@@ -4962,6 +5552,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemHeraldOfAsh"] = {
 		name = "Herald of Ash",
+		gameId = "Metadata/Items/Gems/SkillGemHeraldOfAsh",
+		variantId = "HeraldOfAsh",
 		grantedEffectId = "HeraldOfAsh",
 		tags = {
 			strength = true,
@@ -4980,6 +5572,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemHeraldOfIce"] = {
 		name = "Herald of Ice",
+		gameId = "Metadata/Items/Gems/SkillGemHeraldOfIce",
+		variantId = "HeraldOfIce",
 		grantedEffectId = "HeraldOfIce",
 		tags = {
 			dexterity = true,
@@ -4997,6 +5591,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemHeraldOfThunder"] = {
 		name = "Herald of Thunder",
+		gameId = "Metadata/Items/Gems/SkillGemHeraldOfThunder",
+		variantId = "HeraldOfThunder",
 		grantedEffectId = "HeraldOfThunder",
 		tags = {
 			intelligence = true,
@@ -5015,6 +5611,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemHeraldOfAgony"] = {
 		name = "Herald of Agony",
+		gameId = "Metadata/Items/Gems/SkillGemHeraldOfAgony",
+		variantId = "HeraldOfAgony",
 		grantedEffectId = "HeraldOfAgony",
 		tags = {
 			dexterity = true,
@@ -5033,6 +5631,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemHeraldOfPurity"] = {
 		name = "Herald of Purity",
+		gameId = "Metadata/Items/Gems/SkillGemHeraldOfPurity",
+		variantId = "HeraldOfPurity",
 		grantedEffectId = "HeraldOfPurity",
 		tags = {
 			strength = true,
@@ -5051,6 +5651,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemPoachersMark"] = {
 		name = "Poacher's Mark",
+		gameId = "Metadata/Items/Gems/SkillGemPoachersMark",
+		variantId = "PoachersMark",
 		grantedEffectId = "PoachersMark",
 		tags = {
 			physical = true,
@@ -5068,6 +5670,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemLightningTendrils"] = {
 		name = "Lightning Tendrils",
+		gameId = "Metadata/Items/Gems/SkillGemLightningTendrils",
+		variantId = "LightningTendrils",
 		grantedEffectId = "LightningTendrilsChannelled",
 		tags = {
 			critical = true,
@@ -5086,6 +5690,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemLightningTendrilsAltX"] = {
 		name = "Lightning Tendrils of Eccentricity",
+		gameId = "Metadata/Items/Gems/SkillGemLightningTendrils",
+		variantId = "LightningTendrilsAltX",
 		grantedEffectId = "LightningTendrilsChannelledAltX",
 		tags = {
 			critical = true,
@@ -5104,6 +5710,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemLightningTendrilsAltY"] = {
 		name = "Lightning Tendrils of Escalation",
+		gameId = "Metadata/Items/Gems/SkillGemLightningTendrils",
+		variantId = "LightningTendrilsAltY",
 		grantedEffectId = "LightningTendrilsChannelledAltY",
 		tags = {
 			intelligence = true,
@@ -5121,6 +5729,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemKineticBlast"] = {
 		name = "Kinetic Blast",
+		gameId = "Metadata/Items/Gems/SkillGemKineticBlast",
+		variantId = "KineticBlast",
 		grantedEffectId = "ClusterBurst",
 		tags = {
 			intelligence = true,
@@ -5137,6 +5747,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemBlinkArrow"] = {
 		name = "Blink Arrow",
+		gameId = "Metadata/Items/Gems/SkillGemBlinkArrow",
+		variantId = "BlinkArrow",
 		grantedEffectId = "BlinkArrow",
 		tags = {
 			dexterity = true,
@@ -5156,6 +5768,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemBlinkArrowAltX"] = {
 		name = "Blink Arrow of Bombarding Clones",
+		gameId = "Metadata/Items/Gems/SkillGemBlinkArrow",
+		variantId = "BlinkArrowAltX",
 		grantedEffectId = "BlinkArrowAltX",
 		tags = {
 			dexterity = true,
@@ -5175,6 +5789,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemBlinkArrowAltY"] = {
 		name = "Blink Arrow of Prismatic Clones",
+		gameId = "Metadata/Items/Gems/SkillGemBlinkArrow",
+		variantId = "BlinkArrowAltY",
 		grantedEffectId = "BlinkArrowAltY",
 		tags = {
 			dexterity = true,
@@ -5195,6 +5811,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemMirrorArrow"] = {
 		name = "Mirror Arrow",
+		gameId = "Metadata/Items/Gems/SkillGemMirrorArrow",
+		variantId = "MirrorArrow",
 		grantedEffectId = "MirrorArrow",
 		tags = {
 			dexterity = true,
@@ -5214,6 +5832,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemMirrorArrowAltX"] = {
 		name = "Mirror Arrow of Bombarding Clones",
+		gameId = "Metadata/Items/Gems/SkillGemMirrorArrow",
+		variantId = "MirrorArrowAltX",
 		grantedEffectId = "MirrorArrowAltX",
 		tags = {
 			dexterity = true,
@@ -5233,6 +5853,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemMirrorArrowAltY"] = {
 		name = "Mirror Arrow of Prismatic Clones",
+		gameId = "Metadata/Items/Gems/SkillGemMirrorArrow",
+		variantId = "MirrorArrowAltY",
 		grantedEffectId = "MirrorArrowAltY",
 		tags = {
 			dexterity = true,
@@ -5253,6 +5875,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemRiposte"] = {
 		name = "Riposte",
+		gameId = "Metadata/Items/Gems/SkillGemRiposte",
+		variantId = "Riposte",
 		grantedEffectId = "Riposte",
 		tags = {
 			trigger = true,
@@ -5271,6 +5895,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemReckoning"] = {
 		name = "Reckoning",
+		gameId = "Metadata/Items/Gems/SkillGemReckoning",
+		variantId = "Reckoning",
 		grantedEffectId = "Reckoning",
 		tags = {
 			trigger = true,
@@ -5289,6 +5915,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemStaticStrike"] = {
 		name = "Static Strike",
+		gameId = "Metadata/Items/Gems/SkillGemStaticStrike",
+		variantId = "StaticStrike",
 		grantedEffectId = "StaticStrike",
 		tags = {
 			strength = true,
@@ -5309,6 +5937,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemPhysicalToLightningSupport"] = {
 		name = "Physical to Lightning",
+		gameId = "Metadata/Items/Gems/SupportGemPhysicalToLightning",
+		variantId = "PhysicalToLightningSupport",
 		grantedEffectId = "SupportPhysicalToLightning",
 		tags = {
 			lightning = true,
@@ -5324,6 +5954,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemVengeance"] = {
 		name = "Vengeance",
+		gameId = "Metadata/Items/Gems/SkillGemVengeance",
+		variantId = "Vengeance",
 		grantedEffectId = "Vengeance",
 		tags = {
 			trigger = true,
@@ -5342,6 +5974,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemSummonChaosGolem"] = {
 		name = "Summon Chaos Golem",
+		gameId = "Metadata/Items/Gems/SkillGemSummonChaosGolem",
+		variantId = "SummonChaosGolem",
 		grantedEffectId = "SummonChaosGolem",
 		tags = {
 			intelligence = true,
@@ -5359,6 +5993,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemSummonChaosGolemAltX"] = {
 		name = "Summon Chaos Golem of Hordes",
+		gameId = "Metadata/Items/Gems/SkillGemSummonChaosGolem",
+		variantId = "SummonChaosGolemAltX",
 		grantedEffectId = "SummonChaosGolemAltX",
 		tags = {
 			intelligence = true,
@@ -5376,6 +6012,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemSummonChaosGolemAltY"] = {
 		name = "Summon Chaos Golem of the Maelström",
+		gameId = "Metadata/Items/Gems/SkillGemSummonChaosGolem",
+		variantId = "SummonChaosGolemAltY",
 		grantedEffectId = "SummonChaosGolemAltY",
 		tags = {
 			intelligence = true,
@@ -5393,6 +6031,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemSummonIceGolem"] = {
 		name = "Summon Ice Golem",
+		gameId = "Metadata/Items/Gems/SkillGemSummonIceGolem",
+		variantId = "SummonIceGolem",
 		grantedEffectId = "SummonIceGolem",
 		tags = {
 			critical = true,
@@ -5411,6 +6051,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemSummonIceGolemAltX"] = {
 		name = "Summon Ice Golem of Hordes",
+		gameId = "Metadata/Items/Gems/SkillGemSummonIceGolem",
+		variantId = "SummonIceGolemAltX",
 		grantedEffectId = "SummonIceGolemAltX",
 		tags = {
 			dexterity = true,
@@ -5428,6 +6070,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemSummonIceGolemAltY"] = {
 		name = "Summon Ice Golem of Shattering",
+		gameId = "Metadata/Items/Gems/SkillGemSummonIceGolem",
+		variantId = "SummonIceGolemAltY",
 		grantedEffectId = "SummonIceGolemAltY",
 		tags = {
 			dexterity = true,
@@ -5445,6 +6089,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemSummonFlameGolem"] = {
 		name = "Summon Flame Golem",
+		gameId = "Metadata/Items/Gems/SkillGemSummonFlameGolem",
+		variantId = "SummonFlameGolem",
 		grantedEffectId = "SummonFireGolem",
 		tags = {
 			strength = true,
@@ -5462,6 +6108,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemSummonFlameGolemAltX"] = {
 		name = "Summon Flame Golem of Hordes",
+		gameId = "Metadata/Items/Gems/SkillGemSummonFlameGolem",
+		variantId = "SummonFlameGolemAltX",
 		grantedEffectId = "SummonFireGolemAltX",
 		tags = {
 			strength = true,
@@ -5479,6 +6127,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemSummonFlameGolemAltY"] = {
 		name = "Summon Flame Golem of the Meteor",
+		gameId = "Metadata/Items/Gems/SkillGemSummonFlameGolem",
+		variantId = "SummonFlameGolemAltY",
 		grantedEffectId = "SummonFireGolemAltY",
 		tags = {
 			strength = true,
@@ -5496,6 +6146,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemSummonLightningGolem"] = {
 		name = "Summon Lightning Golem",
+		gameId = "Metadata/Items/Gems/SkillGemSummonLightningGolem",
+		variantId = "SummonLightningGolem",
 		grantedEffectId = "SummonLightningGolem",
 		tags = {
 			intelligence = true,
@@ -5513,6 +6165,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemSummonLightningGolemAltX"] = {
 		name = "Summon Lightning Golem of Hordes",
+		gameId = "Metadata/Items/Gems/SkillGemSummonLightningGolem",
+		variantId = "SummonLightningGolemAltX",
 		grantedEffectId = "SummonLightningGolemAltX",
 		tags = {
 			intelligence = true,
@@ -5530,6 +6184,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemBlasphemySupport"] = {
 		name = "Blasphemy",
+		gameId = "Metadata/Items/Gems/SupportGemBlasphemy",
+		variantId = "BlasphemySupport",
 		grantedEffectId = "SupportBlasphemy",
 		tags = {
 			intelligence = true,
@@ -5545,6 +6201,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemIceCrash"] = {
 		name = "Ice Crash",
+		gameId = "Metadata/Items/Gems/SkillGemIceCrash",
+		variantId = "IceCrash",
 		grantedEffectId = "IceCrash",
 		tags = {
 			strength = true,
@@ -5563,6 +6221,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemIceCrashAltX"] = {
 		name = "Ice Crash of Cadence",
+		gameId = "Metadata/Items/Gems/SkillGemIceCrash",
+		variantId = "IceCrashAltX",
 		grantedEffectId = "IceCrashAltX",
 		tags = {
 			strength = true,
@@ -5581,6 +6241,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemRallyingCry"] = {
 		name = "Rallying Cry",
+		gameId = "Metadata/Items/Gems/SkillGemRallyingCry",
+		variantId = "RallyingCry",
 		grantedEffectId = "RallyingCry",
 		tags = {
 			warcry = true,
@@ -5597,6 +6259,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemAbyssalCry"] = {
 		name = "Infernal Cry",
+		gameId = "Metadata/Items/Gems/SkillGemAbyssalCry",
+		variantId = "AbyssalCry",
 		grantedEffectId = "AbyssalCry",
 		secondaryGrantedEffectId = "InfernalCryOnHitExplosion",
 		tags = {
@@ -5618,6 +6282,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemFlameDash"] = {
 		name = "Flame Dash",
+		gameId = "Metadata/Items/Gems/SkillGemFlameDash",
+		variantId = "FlameDash",
 		grantedEffectId = "FlameDash",
 		tags = {
 			intelligence = true,
@@ -5637,6 +6303,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemFlameDashAltY"] = {
 		name = "Flame Dash of Return",
+		gameId = "Metadata/Items/Gems/SkillGemFlameDash",
+		variantId = "FlameDashAltY",
 		grantedEffectId = "FlameDashAltY",
 		tags = {
 			intelligence = true,
@@ -5654,6 +6322,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemVigilantStrike"] = {
 		name = "Vigilant Strike",
+		gameId = "Metadata/Items/Gems/SkillGemVigilantStrike",
+		variantId = "VigilantStrike",
 		grantedEffectId = "VigilantStrike",
 		tags = {
 			attack = true,
@@ -5670,6 +6340,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemFortifySupport"] = {
 		name = "Fortify",
+		gameId = "Metadata/Items/Gems/SupportGemFortify",
+		variantId = "FortifySupport",
 		grantedEffectId = "SupportFortify",
 		tags = {
 			attack = true,
@@ -5685,6 +6357,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemFrostBlades"] = {
 		name = "Frost Blades",
+		gameId = "Metadata/Items/Gems/SkillGemFrostBlades",
+		variantId = "FrostBlades",
 		grantedEffectId = "FrostBlades",
 		tags = {
 			dexterity = true,
@@ -5703,6 +6377,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemFrostBladesAltX"] = {
 		name = "Frost Blades of Katabasis",
+		gameId = "Metadata/Items/Gems/SkillGemFrostBlades",
+		variantId = "FrostBladesAltX",
 		grantedEffectId = "FrostBladesAltX",
 		tags = {
 			dexterity = true,
@@ -5722,6 +6398,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemFrenzyChargeOnSlayingFrozenEnemySupport"] = {
 		name = "Ice Bite",
+		gameId = "Metadata/Items/Gems/SupportGemFrenzyChargeOnSlayingFrozenEnemy",
+		variantId = "FrenzyChargeOnSlayingFrozenEnemySupport",
 		grantedEffectId = "SupportFrenzyChargeOnSlayingFrozenEnemy",
 		tags = {
 			cold = true,
@@ -5736,6 +6414,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemDamageAgainstChilledSupport"] = {
 		name = "Hypothermia",
+		gameId = "Metadata/Items/Gems/SupportGemDamageAgainstChilled",
+		variantId = "DamageAgainstChilledSupport",
 		grantedEffectId = "SupportDamageAgainstChilled",
 		tags = {
 			cold = true,
@@ -5750,6 +6430,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemOnslaughtOnSlayingShockedEnemySupport"] = {
 		name = "Innervate",
+		gameId = "Metadata/Items/Gems/SupportGemOnslaughtOnSlayingShockedEnemy",
+		variantId = "OnslaughtOnSlayingShockedEnemySupport",
 		grantedEffectId = "SupportOnslaughtOnSlayingShockedEnemy",
 		tags = {
 			lightning = true,
@@ -5765,6 +6447,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemMagmaOrb"] = {
 		name = "Rolling Magma",
+		gameId = "Metadata/Items/Gems/SkillGemMagmaOrb",
+		variantId = "MagmaOrb",
 		grantedEffectId = "MagmaOrb",
 		tags = {
 			intelligence = true,
@@ -5783,6 +6467,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemTrapAndMineDamageSupport"] = {
 		name = "Trap and Mine Damage",
+		gameId = "Metadata/Items/Gems/SupportGemTrapAndMineDamage",
+		variantId = "TrapAndMineDamageSupport",
 		grantedEffectId = "SupportTrapAndMineDamage",
 		tags = {
 			dexterity = true,
@@ -5798,6 +6484,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemWildStrike"] = {
 		name = "Wild Strike",
+		gameId = "Metadata/Items/Gems/SkillGemWildStrike",
+		variantId = "WildStrike",
 		grantedEffectId = "WildStrike",
 		tags = {
 			dexterity = true,
@@ -5821,6 +6509,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemWildStrikeAltX"] = {
 		name = "Wild Strike of Extremes",
+		gameId = "Metadata/Items/Gems/SkillGemWildStrike",
+		variantId = "WildStrikeAltX",
 		grantedEffectId = "WildStrikeAltX",
 		tags = {
 			dexterity = true,
@@ -5844,6 +6534,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemIceTrap"] = {
 		name = "Ice Trap",
+		gameId = "Metadata/Items/Gems/SkillGemIceTrap",
+		variantId = "IceTrap",
 		grantedEffectId = "IceTrap",
 		tags = {
 			trap = true,
@@ -5861,6 +6553,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemIceTrapAltX"] = {
 		name = "Ice Trap of Hollowness",
+		gameId = "Metadata/Items/Gems/SkillGemIceTrap",
+		variantId = "IceTrapAltX",
 		grantedEffectId = "IceTrapAltX",
 		tags = {
 			trap = true,
@@ -5878,6 +6572,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemBlastRain"] = {
 		name = "Blast Rain",
+		gameId = "Metadata/Items/Gems/SkillGemBlastRain",
+		variantId = "BlastRain",
 		grantedEffectId = "BlastRain",
 		tags = {
 			fire = true,
@@ -5896,6 +6592,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemShrapnelShot"] = {
 		name = "Galvanic Arrow",
+		gameId = "Metadata/Items/Gems/SkillGemShrapnelShot",
+		variantId = "ShrapnelShot",
 		grantedEffectId = "ShrapnelShot",
 		tags = {
 			lightning = true,
@@ -5914,6 +6612,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemShrapnelShotAltX"] = {
 		name = "Galvanic Arrow of Energy",
+		gameId = "Metadata/Items/Gems/SkillGemShrapnelShot",
+		variantId = "ShrapnelShotAltX",
 		grantedEffectId = "ShrapnelShotAltX",
 		tags = {
 			lightning = true,
@@ -5931,6 +6631,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemShrapnelShotAltY"] = {
 		name = "Galvanic Arrow of Surging",
+		gameId = "Metadata/Items/Gems/SkillGemShrapnelShot",
+		variantId = "ShrapnelShotAltY",
 		grantedEffectId = "ShrapnelShotAltY",
 		tags = {
 			lightning = true,
@@ -5949,6 +6651,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemBladefall"] = {
 		name = "Bladefall",
+		gameId = "Metadata/Items/Gems/SkillGemBladefall",
+		variantId = "Bladefall",
 		grantedEffectId = "Bladefall",
 		tags = {
 			dexterity = true,
@@ -5966,6 +6670,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemBladefallAltX"] = {
 		name = "Bladefall of Volleys",
+		gameId = "Metadata/Items/Gems/SkillGemBladefall",
+		variantId = "BladefallAltX",
 		grantedEffectId = "BladefallAltX",
 		tags = {
 			critical = true,
@@ -5983,6 +6689,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemBladefallAltY"] = {
 		name = "Bladefall of Impaling",
+		gameId = "Metadata/Items/Gems/SkillGemBladefall",
+		variantId = "BladefallAltY",
 		grantedEffectId = "BladefallAltY",
 		tags = {
 			critical = true,
@@ -6000,6 +6708,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemBladeVortex"] = {
 		name = "Blade Vortex",
+		gameId = "Metadata/Items/Gems/SkillGemBladeVortex",
+		variantId = "BladeVortex",
 		grantedEffectId = "BladeVortex",
 		tags = {
 			dexterity = true,
@@ -6017,6 +6727,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemBladeVortexAltX"] = {
 		name = "Blade Vortex of the Scythe",
+		gameId = "Metadata/Items/Gems/SkillGemBladeVortex",
+		variantId = "BladeVortexAltX",
 		grantedEffectId = "BladeVortexAltX",
 		tags = {
 			dexterity = true,
@@ -6034,6 +6746,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemVaalBladeVortex"] = {
 		name = "Vaal Blade Vortex",
+		gameId = "Metadata/Items/Gems/SkillGemVaalBladeVortex",
+		variantId = "VaalBladeVortex",
 		grantedEffectId = "VaalBladeVortex",
 		secondaryGrantedEffectId = "BladeVortex",
 		vaalGem = true,
@@ -6055,6 +6769,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemFrostBomb"] = {
 		name = "Frost Bomb",
+		gameId = "Metadata/Items/Gems/SkillGemFrostBomb",
+		variantId = "FrostBomb",
 		grantedEffectId = "FrostBomb",
 		tags = {
 			intelligence = true,
@@ -6073,6 +6789,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemFrostBombAltX"] = {
 		name = "Frost Bomb of Instability",
+		gameId = "Metadata/Items/Gems/SkillGemFrostBomb",
+		variantId = "FrostBombAltX",
 		grantedEffectId = "FrostBombAltX",
 		tags = {
 			intelligence = true,
@@ -6090,6 +6808,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemFrostBombAltY"] = {
 		name = "Frost Bomb of Forthcoming",
+		gameId = "Metadata/Items/Gems/SkillGemFrostBomb",
+		variantId = "FrostBombAltY",
 		grantedEffectId = "FrostBombAltY",
 		tags = {
 			intelligence = true,
@@ -6107,6 +6827,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemSiegeBallista"] = {
 		name = "Siege Ballista",
+		gameId = "Metadata/Items/Gems/SkillGemSiegeBallista",
+		variantId = "SiegeBallista",
 		grantedEffectId = "SiegeBallista",
 		tags = {
 			dexterity = true,
@@ -6124,6 +6846,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemSiegeBallistaAltX"] = {
 		name = "Siege Ballista of Splintering",
+		gameId = "Metadata/Items/Gems/SkillGemSiegeBallista",
+		variantId = "SiegeBallistaAltX",
 		grantedEffectId = "SiegeBallistaAltX",
 		tags = {
 			dexterity = true,
@@ -6141,6 +6865,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemOrbOfStorms"] = {
 		name = "Orb of Storms",
+		gameId = "Metadata/Items/Gems/SkillGemOrbOfStorms",
+		variantId = "OrbOfStorms",
 		grantedEffectId = "OrbOfStorms",
 		tags = {
 			lightning = true,
@@ -6159,6 +6885,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemSummonRockGolem"] = {
 		name = "Summon Stone Golem",
+		gameId = "Metadata/Items/Gems/SkillGemSummonRockGolem",
+		variantId = "SummonRockGolem",
 		grantedEffectId = "SummonRockGolem",
 		tags = {
 			strength = true,
@@ -6176,6 +6904,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemSummonRockGolemAltX"] = {
 		name = "Summon Stone Golem of Hordes",
+		gameId = "Metadata/Items/Gems/SkillGemSummonRockGolem",
+		variantId = "SummonRockGolemAltX",
 		grantedEffectId = "SummonRockGolemAltX",
 		tags = {
 			strength = true,
@@ -6193,6 +6923,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemSummonRockGolemAltY"] = {
 		name = "Summon Stone Golem of Safeguarding",
+		gameId = "Metadata/Items/Gems/SkillGemSummonRockGolem",
+		variantId = "SummonRockGolemAltY",
 		grantedEffectId = "SummonRockGolemAltY",
 		tags = {
 			strength = true,
@@ -6210,6 +6942,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemEarthquake"] = {
 		name = "Earthquake",
+		gameId = "Metadata/Items/Gems/SkillGemEarthquake",
+		variantId = "Earthquake",
 		grantedEffectId = "Earthquake",
 		tags = {
 			strength = true,
@@ -6228,6 +6962,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemEarthquakeAltX"] = {
 		name = "Earthquake of Amplification",
+		gameId = "Metadata/Items/Gems/SkillGemEarthquake",
+		variantId = "EarthquakeAltX",
 		grantedEffectId = "EarthquakeAltX",
 		tags = {
 			strength = true,
@@ -6246,6 +6982,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemPoisonSupport"] = {
 		name = "Critical Strike Affliction",
+		gameId = "Metadata/Items/Gems/SupportGemPoison",
+		variantId = "PoisonSupport",
 		grantedEffectId = "SupportCriticalStrikeAffliction",
 		tags = {
 			critical = true,
@@ -6260,6 +6998,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemContagion"] = {
 		name = "Contagion",
+		gameId = "Metadata/Items/Gems/SkillGemContagion",
+		variantId = "Contagion",
 		grantedEffectId = "Contagion",
 		tags = {
 			intelligence = true,
@@ -6277,6 +7017,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemContagionAltX"] = {
 		name = "Contagion of Subsiding",
+		gameId = "Metadata/Items/Gems/SkillGemContagion",
+		variantId = "ContagionAltX",
 		grantedEffectId = "ContagionAltX",
 		tags = {
 			intelligence = true,
@@ -6294,6 +7036,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemContagionAltY"] = {
 		name = "Contagion of Transference",
+		gameId = "Metadata/Items/Gems/SkillGemContagion",
+		variantId = "ContagionAltY",
 		grantedEffectId = "ContagionAltY",
 		tags = {
 			intelligence = true,
@@ -6311,6 +7055,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemWither"] = {
 		name = "Wither",
+		gameId = "Metadata/Items/Gems/SkillGemWither",
+		variantId = "Wither",
 		grantedEffectId = "Wither",
 		tags = {
 			intelligence = true,
@@ -6329,6 +7075,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemBlight"] = {
 		name = "Blight",
+		gameId = "Metadata/Items/Gems/SkillGemBlight",
+		variantId = "Blight",
 		grantedEffectId = "Blight",
 		tags = {
 			intelligence = true,
@@ -6347,6 +7095,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemBlightAltX"] = {
 		name = "Blight of Contagion",
+		gameId = "Metadata/Items/Gems/SkillGemBlight",
+		variantId = "BlightAltX",
 		grantedEffectId = "BlightAltX",
 		tags = {
 			intelligence = true,
@@ -6365,6 +7115,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemBlightAltY"] = {
 		name = "Blight of Atrophy",
+		gameId = "Metadata/Items/Gems/SkillGemBlight",
+		variantId = "BlightAltY",
 		grantedEffectId = "BlightAltY",
 		tags = {
 			intelligence = true,
@@ -6383,6 +7135,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemEssenceDrain"] = {
 		name = "Essence Drain",
+		gameId = "Metadata/Items/Gems/SkillGemEssenceDrain",
+		variantId = "EssenceDrain",
 		grantedEffectId = "EssenceDrain",
 		tags = {
 			intelligence = true,
@@ -6401,6 +7155,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemEssenceDrainAltX"] = {
 		name = "Essence Drain of Desperation",
+		gameId = "Metadata/Items/Gems/SkillGemEssenceDrain",
+		variantId = "EssenceDrainAltX",
 		grantedEffectId = "EssenceDrainAltX",
 		tags = {
 			intelligence = true,
@@ -6419,6 +7175,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemEssenceDrainAltY"] = {
 		name = "Essence Drain of Wickedness",
+		gameId = "Metadata/Items/Gems/SkillGemEssenceDrain",
+		variantId = "EssenceDrainAltY",
 		grantedEffectId = "EssenceDrainAltY",
 		tags = {
 			intelligence = true,
@@ -6437,6 +7195,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemVoidManipulationSupport"] = {
 		name = "Void Manipulation",
+		gameId = "Metadata/Items/Gems/SupportGemVoidManipulation",
+		variantId = "VoidManipulationSupport",
 		grantedEffectId = "SupportVoidManipulation",
 		tags = {
 			chaos = true,
@@ -6451,6 +7211,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemControlledDestructionSupport"] = {
 		name = "Controlled Destruction",
+		gameId = "Metadata/Items/Gems/SupportGemControlledDestruction",
+		variantId = "ControlledDestructionSupport",
 		grantedEffectId = "SupportControlledDestruction",
 		tags = {
 			spell = true,
@@ -6466,6 +7228,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemRapidDecaySupport"] = {
 		name = "Swift Affliction",
+		gameId = "Metadata/Items/Gems/SupportGemRapidDecay",
+		variantId = "RapidDecaySupport",
 		grantedEffectId = "SupportRapidDecay",
 		tags = {
 			dexterity = true,
@@ -6480,6 +7244,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemClusterTrapSupport"] = {
 		name = "Cluster Traps",
+		gameId = "Metadata/Items/Gems/SupportGemClusterTrap",
+		variantId = "ClusterTrapSupport",
 		grantedEffectId = "SupportClusterTrap",
 		tags = {
 			trap = true,
@@ -6494,6 +7260,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemMeleeTotem"] = {
 		name = "Ancestral Protector",
+		gameId = "Metadata/Items/Gems/SkillGemMeleeTotem",
+		variantId = "MeleeTotem",
 		grantedEffectId = "TotemMelee",
 		tags = {
 			strength = true,
@@ -6511,6 +7279,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemAncestralWarchief"] = {
 		name = "Ancestral Warchief",
+		gameId = "Metadata/Items/Gems/SkillGemAncestralWarchief",
+		variantId = "AncestralWarchief",
 		grantedEffectId = "AncestorTotemSlam",
 		tags = {
 			strength = true,
@@ -6529,6 +7299,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemSunder"] = {
 		name = "Sunder",
+		gameId = "Metadata/Items/Gems/SkillGemSunder",
+		variantId = "Sunder",
 		grantedEffectId = "NewSunder",
 		tags = {
 			strength = true,
@@ -6546,6 +7318,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemSunderAltX"] = {
 		name = "Sunder of Earthbreaking",
+		gameId = "Metadata/Items/Gems/SkillGemSunder",
+		variantId = "SunderAltX",
 		grantedEffectId = "NewSunderAltX",
 		tags = {
 			strength = true,
@@ -6563,6 +7337,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemFrostBolt"] = {
 		name = "Frostbolt",
+		gameId = "Metadata/Items/Gems/SkillGemFrostBolt",
+		variantId = "FrostBolt",
 		grantedEffectId = "FrostBolt",
 		tags = {
 			intelligence = true,
@@ -6579,6 +7355,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemFrostBoltNova"] = {
 		name = "Vortex",
+		gameId = "Metadata/Items/Gems/SkillGemFrostBoltNova",
+		variantId = "FrostBoltNova",
 		grantedEffectId = "FrostBoltNova",
 		tags = {
 			intelligence = true,
@@ -6597,6 +7375,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemFrostBoltNovaAltX"] = {
 		name = "Vortex of Projection",
+		gameId = "Metadata/Items/Gems/SkillGemFrostBoltNova",
+		variantId = "FrostBoltNovaAltX",
 		grantedEffectId = "FrostBoltNovaAltX",
 		tags = {
 			intelligence = true,
@@ -6615,6 +7395,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemElementalFocusSupport"] = {
 		name = "Elemental Focus",
+		gameId = "Metadata/Items/Gems/SupportGemElementalFocus",
+		variantId = "ElementalFocusSupport",
 		grantedEffectId = "SupportElementalFocus",
 		tags = {
 			intelligence = true,
@@ -6628,6 +7410,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemMinefieldSupport"] = {
 		name = "Minefield",
+		gameId = "Metadata/Items/Gems/SupportGemMinefield",
+		variantId = "MinefieldSupport",
 		grantedEffectId = "SupportMinefield",
 		tags = {
 			intelligence = true,
@@ -6642,6 +7426,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemTrapCooldownSupport"] = {
 		name = "Advanced Traps",
+		gameId = "Metadata/Items/Gems/SupportGemTrapCooldown",
+		variantId = "TrapCooldownSupport",
 		grantedEffectId = "SupportTrapCooldown",
 		tags = {
 			trap = true,
@@ -6656,6 +7442,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemDarkPact"] = {
 		name = "Dark Pact",
+		gameId = "Metadata/Items/Gems/SkillGemDarkPact",
+		variantId = "DarkPact",
 		grantedEffectId = "DarkPact",
 		tags = {
 			minion = true,
@@ -6675,6 +7463,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemFireBeam"] = {
 		name = "Scorching Ray",
+		gameId = "Metadata/Items/Gems/SkillGemFireBeam",
+		variantId = "FireBeam",
 		grantedEffectId = "FireBeam",
 		tags = {
 			intelligence = true,
@@ -6692,6 +7482,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemFireBeamAltX"] = {
 		name = "Scorching Ray of Immolation",
+		gameId = "Metadata/Items/Gems/SkillGemFireBeam",
+		variantId = "FireBeamAltX",
 		grantedEffectId = "FireBeamAltX",
 		tags = {
 			intelligence = true,
@@ -6709,6 +7501,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemCastWhileChannellingSupport"] = {
 		name = "Cast while Channelling",
+		gameId = "Metadata/Items/Gems/SupportGemCastWhileChannelling",
+		variantId = "CastWhileChannellingSupport",
 		grantedEffectId = "SupportCastWhileChannelling",
 		secondaryGrantedEffectId = "SupportCastWhileChannellingTriggered",
 		tags = {
@@ -6726,6 +7520,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemIgniteProliferationSupport"] = {
 		name = "Ignite Proliferation",
+		gameId = "Metadata/Items/Gems/SupportGemIgniteProliferation",
+		variantId = "IgniteProliferationSupport",
 		grantedEffectId = "SupportIgniteProliferation",
 		tags = {
 			fire = true,
@@ -6741,6 +7537,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemChanceToBleedSupport"] = {
 		name = "Chance to Bleed",
+		gameId = "Metadata/Items/Gems/SupportGemChanceToBleed",
+		variantId = "ChanceToBleedSupport",
 		grantedEffectId = "SupportChanceToBleed",
 		tags = {
 			attack = true,
@@ -6756,6 +7554,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemLesserPoisonSupport"] = {
 		name = "Chance to Poison",
+		gameId = "Metadata/Items/Gems/SupportGemLesserPoison",
+		variantId = "LesserPoisonSupport",
 		grantedEffectId = "SupportChanceToPoison",
 		tags = {
 			chaos = true,
@@ -6770,6 +7570,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemDeadlyAilmentsSupport"] = {
 		name = "Deadly Ailments",
+		gameId = "Metadata/Items/Gems/SupportGemDeadlyAilments",
+		variantId = "DeadlyAilmentsSupport",
 		grantedEffectId = "SupportDeadlyAilments",
 		tags = {
 			dexterity = true,
@@ -6783,6 +7585,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemDecaySupport"] = {
 		name = "Decay",
+		gameId = "Metadata/Items/Gems/SupportGemDecay",
+		variantId = "DecaySupport",
 		grantedEffectId = "SupportDecay",
 		tags = {
 			chaos = true,
@@ -6797,6 +7601,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemEfficacySupport"] = {
 		name = "Efficacy",
+		gameId = "Metadata/Items/Gems/SupportGemEfficacy",
+		variantId = "EfficacySupport",
 		grantedEffectId = "SupportEfficacy",
 		tags = {
 			intelligence = true,
@@ -6811,6 +7617,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemVileToxinsSupport"] = {
 		name = "Vile Toxins",
+		gameId = "Metadata/Items/Gems/SupportGemVileToxins",
+		variantId = "VileToxinsSupport",
 		grantedEffectId = "SupportDebilitate",
 		tags = {
 			dexterity = true,
@@ -6824,6 +7632,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemMaimSupport"] = {
 		name = "Maim",
+		gameId = "Metadata/Items/Gems/SupportGemMaim",
+		variantId = "MaimSupport",
 		grantedEffectId = "SupportMaim",
 		tags = {
 			attack = true,
@@ -6839,6 +7649,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemImmolateSupport"] = {
 		name = "Immolate",
+		gameId = "Metadata/Items/Gems/SupportGemImmolate",
+		variantId = "ImmolateSupport",
 		grantedEffectId = "SupportImmolation",
 		tags = {
 			fire = true,
@@ -6853,6 +7665,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemUnboundAilmentsSupport"] = {
 		name = "Unbound Ailments",
+		gameId = "Metadata/Items/Gems/SupportGemUnboundAilments",
+		variantId = "UnboundAilmentsSupport",
 		grantedEffectId = "SupportAilments",
 		tags = {
 			intelligence = true,
@@ -6866,6 +7680,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemBrutalitySupport"] = {
 		name = "Brutality",
+		gameId = "Metadata/Items/Gems/SupportGemBrutality",
+		variantId = "BrutalitySupport",
 		grantedEffectId = "SupportBrutality",
 		tags = {
 			physical = true,
@@ -6880,6 +7696,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemRuthlessSupport"] = {
 		name = "Ruthless",
+		gameId = "Metadata/Items/Gems/SupportGemRuthless",
+		variantId = "RuthlessSupport",
 		grantedEffectId = "SupportRuthless",
 		tags = {
 			slam = true,
@@ -6897,6 +7715,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemOnslaughtSupport"] = {
 		name = "Momentum",
+		gameId = "Metadata/Items/Gems/SupportGemOnslaught",
+		variantId = "OnslaughtSupport",
 		grantedEffectId = "SupportMomentum",
 		tags = {
 			attack = true,
@@ -6912,6 +7732,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemArcaneSurgeSupport"] = {
 		name = "Arcane Surge",
+		gameId = "Metadata/Items/Gems/SupportGemArcaneSurge",
+		variantId = "ArcaneSurgeSupport",
 		grantedEffectId = "SupportArcaneSurge",
 		tags = {
 			arcane = true,
@@ -6928,6 +7750,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemCorpseEruption"] = {
 		name = "Cremation",
+		gameId = "Metadata/Items/Gems/SkillGemCorpseEruption",
+		variantId = "CorpseEruption",
 		grantedEffectId = "CorpseEruption",
 		tags = {
 			dexterity = true,
@@ -6947,6 +7771,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemCorpseEruptionAltX"] = {
 		name = "Cremation of Exhuming",
+		gameId = "Metadata/Items/Gems/SkillGemCorpseEruption",
+		variantId = "CorpseEruptionAltX",
 		grantedEffectId = "CorpseEruptionAltX",
 		tags = {
 			dexterity = true,
@@ -6966,6 +7792,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemCorpseEruptionAltY"] = {
 		name = "Cremation of the Volcano",
+		gameId = "Metadata/Items/Gems/SkillGemCorpseEruption",
+		variantId = "CorpseEruptionAltY",
 		grantedEffectId = "CorpseEruptionAltY",
 		tags = {
 			dexterity = true,
@@ -6985,6 +7813,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemCorpseWarp"] = {
 		name = "Bodyswap",
+		gameId = "Metadata/Items/Gems/SkillGemCorpseWarp",
+		variantId = "CorpseWarp",
 		grantedEffectId = "CorpseWarp",
 		tags = {
 			intelligence = true,
@@ -7003,6 +7833,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemCorpseWarpAltX"] = {
 		name = "Bodyswap of Sacrifice",
+		gameId = "Metadata/Items/Gems/SkillGemCorpseWarp",
+		variantId = "CorpseWarpAltX",
 		grantedEffectId = "CorpseWarpAltX",
 		tags = {
 			intelligence = true,
@@ -7022,6 +7854,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemTectonicSlam"] = {
 		name = "Tectonic Slam",
+		gameId = "Metadata/Items/Gems/SkillGemTectonicSlam",
+		variantId = "TectonicSlam",
 		grantedEffectId = "EnduranceChargeSlam",
 		tags = {
 			fire = true,
@@ -7040,6 +7874,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemTectonicSlamAltX"] = {
 		name = "Tectonic Slam of Cataclysm",
+		gameId = "Metadata/Items/Gems/SkillGemTectonicSlam",
+		variantId = "TectonicSlamAltX",
 		grantedEffectId = "EnduranceChargeSlamAltX",
 		tags = {
 			fire = true,
@@ -7058,6 +7894,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemStormBarrierSupport"] = {
 		name = "Infused Channelling",
+		gameId = "Metadata/Items/Gems/SupportGemStormBarrier",
+		variantId = "StormBarrierSupport",
 		grantedEffectId = "SupportStormBarrier",
 		tags = {
 			intelligence = true,
@@ -7073,6 +7911,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemParallelProjectilesSupport"] = {
 		name = "Volley",
+		gameId = "Metadata/Items/Gems/SupportGemParallelProjectiles",
+		variantId = "ParallelProjectilesSupport",
 		grantedEffectId = "SupportParallelProjectiles",
 		tags = {
 			dexterity = true,
@@ -7087,6 +7927,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemSpellCascadeSupport"] = {
 		name = "Spell Cascade",
+		gameId = "Metadata/Items/Gems/SupportGemSpellCascade",
+		variantId = "SpellCascadeSupport",
 		grantedEffectId = "SupportSpellCascade",
 		tags = {
 			area = true,
@@ -7102,6 +7944,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemSpiritStrikeSupport"] = {
 		name = "Ancestral Call",
+		gameId = "Metadata/Items/Gems/SupportGemSpiritStrike",
+		variantId = "SpiritStrikeSupport",
 		grantedEffectId = "SupportSpiritStrike",
 		tags = {
 			strength = true,
@@ -7118,6 +7962,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemSummonGhostOnKillSupport"] = {
 		name = "Summon Phantasm",
+		gameId = "Metadata/Items/Gems/SupportGemSummonGhostOnKill",
+		variantId = "SummonGhostOnKillSupport",
 		grantedEffectId = "SupportSummonGhostOnKill",
 		tags = {
 			intelligence = true,
@@ -7132,6 +7978,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemMirageArcherSupport"] = {
 		name = "Mirage Archer",
+		gameId = "Metadata/Items/Gems/SupportGemMirageArcher",
+		variantId = "MirageArcherSupport",
 		grantedEffectId = "SupportGemMirageArcher",
 		tags = {
 			bow = true,
@@ -7148,6 +7996,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemNewVulnerability"] = {
 		name = "Vulnerability",
+		gameId = "Metadata/Items/Gems/SkillGemNewVulnerability",
+		variantId = "NewVulnerability",
 		grantedEffectId = "Vulnerability",
 		tags = {
 			strength = true,
@@ -7167,6 +8017,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemShrapnelTrap"] = {
 		name = "Explosive Trap",
+		gameId = "Metadata/Items/Gems/SkillGemShrapnelTrap",
+		variantId = "ShrapnelTrap",
 		grantedEffectId = "ShrapnelTrap",
 		tags = {
 			trap = true,
@@ -7185,6 +8037,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemShrapnelTrapAltX"] = {
 		name = "Explosive Trap of Shrapnel",
+		gameId = "Metadata/Items/Gems/SkillGemShrapnelTrap",
+		variantId = "ShrapnelTrapAltX",
 		grantedEffectId = "ShrapnelTrapAltX",
 		tags = {
 			trap = true,
@@ -7203,6 +8057,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemShrapnelTrapAltY"] = {
 		name = "Explosive Trap of Magnitude",
+		gameId = "Metadata/Items/Gems/SkillGemShrapnelTrap",
+		variantId = "ShrapnelTrapAltY",
 		grantedEffectId = "ShrapnelTrapAltY",
 		tags = {
 			trap = true,
@@ -7220,6 +8076,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemIceSiphonTrap"] = {
 		name = "Siphoning Trap",
+		gameId = "Metadata/Items/Gems/SkillGemIceSiphonTrap",
+		variantId = "IceSiphonTrap",
 		grantedEffectId = "IceSiphonTrap",
 		tags = {
 			trap = true,
@@ -7238,6 +8096,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemFlamethrowerTrap"] = {
 		name = "Flamethrower Trap",
+		gameId = "Metadata/Items/Gems/SkillGemFlamethrowerTrap",
+		variantId = "FlamethrowerTrap",
 		grantedEffectId = "FlamethrowerTrap",
 		tags = {
 			trap = true,
@@ -7256,6 +8116,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemLightningTowerTrap"] = {
 		name = "Lightning Spire Trap",
+		gameId = "Metadata/Items/Gems/SkillGemLightningTowerTrap",
+		variantId = "LightningTowerTrap",
 		grantedEffectId = "LightningTowerTrap",
 		tags = {
 			trap = true,
@@ -7275,6 +8137,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemLightningTowerTrapAltX"] = {
 		name = "Lightning Spire Trap of Zapping",
+		gameId = "Metadata/Items/Gems/SkillGemLightningTowerTrap",
+		variantId = "LightningTowerTrapAltX",
 		grantedEffectId = "LightningTowerTrapAltX",
 		tags = {
 			trap = true,
@@ -7293,6 +8157,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemLightningTowerTrapAltY"] = {
 		name = "Lightning Spire Trap of Overloading",
+		gameId = "Metadata/Items/Gems/SkillGemLightningTowerTrap",
+		variantId = "LightningTowerTrapAltY",
 		grantedEffectId = "LightningTowerTrapAltY",
 		tags = {
 			trap = true,
@@ -7311,6 +8177,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemPhysCascadeTrap"] = {
 		name = "Seismic Trap",
+		gameId = "Metadata/Items/Gems/SkillGemPhysCascadeTrap",
+		variantId = "PhysCascadeTrap",
 		grantedEffectId = "PhysCascadeTrap",
 		tags = {
 			trap = true,
@@ -7329,6 +8197,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemPhysCascadeTrapAltX"] = {
 		name = "Seismic Trap of Swells",
+		gameId = "Metadata/Items/Gems/SkillGemPhysCascadeTrap",
+		variantId = "PhysCascadeTrapAltX",
 		grantedEffectId = "PhysCascadeTrapAltX",
 		tags = {
 			trap = true,
@@ -7346,6 +8216,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemVaalEarthquake"] = {
 		name = "Vaal Earthquake",
+		gameId = "Metadata/Items/Gems/SkillGemVaalEarthquake",
+		variantId = "VaalEarthquake",
 		grantedEffectId = "VaalEarthquake",
 		secondaryGrantedEffectId = "Earthquake",
 		vaalGem = true,
@@ -7367,6 +8239,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemVaalBlight"] = {
 		name = "Vaal Blight",
+		gameId = "Metadata/Items/Gems/SkillGemVaalBlight",
+		variantId = "VaalBlight",
 		grantedEffectId = "VaalBlight",
 		secondaryGrantedEffectId = "Blight",
 		vaalGem = true,
@@ -7389,6 +8263,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemFrenzyPowerOnTrapTriggerSupport"] = {
 		name = "Charged Traps",
+		gameId = "Metadata/Items/Gems/SupportGemFrenzyPowerOnTrapTrigger",
+		variantId = "FrenzyPowerOnTrapTriggerSupport",
 		grantedEffectId = "SupportGemFrenzyPowerOnTrapTrigger",
 		tags = {
 			critical = true,
@@ -7404,6 +8280,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemChargedMinesSupport"] = {
 		name = "Charged Mines",
+		gameId = "Metadata/Items/Gems/SupportGemChargedMines",
+		variantId = "ChargedMinesSupport",
 		grantedEffectId = "SupportChargedMines",
 		tags = {
 			critical = true,
@@ -7419,6 +8297,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemVaalAncestralWarchief"] = {
 		name = "Vaal Ancestral Warchief",
+		gameId = "Metadata/Items/Gems/SkillGemVaalAncestralWarchief",
+		variantId = "VaalAncestralWarchief",
 		grantedEffectId = "VaalAncestralWarchief",
 		secondaryGrantedEffectId = "AncestorTotemSlam",
 		vaalGem = true,
@@ -7440,6 +8320,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemConsecratedPath"] = {
 		name = "Consecrated Path",
+		gameId = "Metadata/Items/Gems/SkillGemConsecratedPath",
+		variantId = "ConsecratedPath",
 		grantedEffectId = "ConsecratedPath",
 		tags = {
 			fire = true,
@@ -7460,6 +8342,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemConsecratedPathAltX"] = {
 		name = "Consecrated Path of Endurance",
+		gameId = "Metadata/Items/Gems/SkillGemConsecratedPath",
+		variantId = "ConsecratedPathAltX",
 		grantedEffectId = "ConsecratedPathAltX",
 		tags = {
 			fire = true,
@@ -7480,6 +8364,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemSmite"] = {
 		name = "Smite",
+		gameId = "Metadata/Items/Gems/SkillGemSmite",
+		variantId = "Smite",
 		grantedEffectId = "Smite",
 		tags = {
 			lightning = true,
@@ -7500,6 +8386,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemSmiteAltX"] = {
 		name = "Smite of Divine Judgement",
+		gameId = "Metadata/Items/Gems/SkillGemSmite",
+		variantId = "SmiteAltX",
 		grantedEffectId = "SmiteAltX",
 		tags = {
 			lightning = true,
@@ -7518,6 +8406,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemScourgeArrow"] = {
 		name = "Scourge Arrow",
+		gameId = "Metadata/Items/Gems/SkillGemScourgeArrow",
+		variantId = "ScourgeArrow",
 		grantedEffectId = "ScourgeArrow",
 		tags = {
 			dexterity = true,
@@ -7536,6 +8426,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemScourgeArrowAltX"] = {
 		name = "Scourge Arrow of Menace",
+		gameId = "Metadata/Items/Gems/SkillGemScourgeArrow",
+		variantId = "ScourgeArrowAltX",
 		grantedEffectId = "ScourgeArrowAltX",
 		tags = {
 			dexterity = true,
@@ -7553,6 +8445,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemToxicRain"] = {
 		name = "Toxic Rain",
+		gameId = "Metadata/Items/Gems/SkillGemToxicRain",
+		variantId = "ToxicRain",
 		grantedEffectId = "RainOfSpores",
 		tags = {
 			dexterity = true,
@@ -7572,6 +8466,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemToxicRainAltX"] = {
 		name = "Toxic Rain of Sporeburst",
+		gameId = "Metadata/Items/Gems/SkillGemToxicRain",
+		variantId = "ToxicRainAltX",
 		grantedEffectId = "RainOfSporesAltX",
 		tags = {
 			dexterity = true,
@@ -7591,6 +8487,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemToxicRainAltY"] = {
 		name = "Toxic Rain of Withering",
+		gameId = "Metadata/Items/Gems/SkillGemToxicRain",
+		variantId = "ToxicRainAltY",
 		grantedEffectId = "RainOfSporesAltY",
 		tags = {
 			dexterity = true,
@@ -7610,6 +8508,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemSummonRelic"] = {
 		name = "Summon Holy Relic",
+		gameId = "Metadata/Items/Gems/SkillGemSummonRelic",
+		variantId = "SummonRelic",
 		grantedEffectId = "SummonRelic",
 		tags = {
 			intelligence = true,
@@ -7625,6 +8525,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemChaosAttacksSupport"] = {
 		name = "Withering Touch",
+		gameId = "Metadata/Items/Gems/SupportGemChaosAttacks",
+		variantId = "ChaosAttacksSupport",
 		grantedEffectId = "SupportChaosAttacks",
 		tags = {
 			chaos = true,
@@ -7642,6 +8544,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemBonechillSupport"] = {
 		name = "Bonechill",
+		gameId = "Metadata/Items/Gems/SupportGemBonechill",
+		variantId = "BonechillSupport",
 		grantedEffectId = "SupportBonechill",
 		tags = {
 			cold = true,
@@ -7656,6 +8560,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemWinterOrb"] = {
 		name = "Winter Orb",
+		gameId = "Metadata/Items/Gems/SkillGemWinterOrb",
+		variantId = "WinterOrb",
 		grantedEffectId = "FrostFury",
 		tags = {
 			cold = true,
@@ -7676,6 +8582,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemLancingSteel"] = {
 		name = "Lancing Steel",
+		gameId = "Metadata/Items/Gems/SkillGemLancingSteel",
+		variantId = "LancingSteel",
 		grantedEffectId = "LancingSteel",
 		tags = {
 			dexterity = true,
@@ -7692,6 +8600,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemLancingSteelAltX"] = {
 		name = "Lancing Steel of Spraying",
+		gameId = "Metadata/Items/Gems/SkillGemLancingSteel",
+		variantId = "LancingSteelAltX",
 		grantedEffectId = "LancingSteelAltX",
 		tags = {
 			dexterity = true,
@@ -7708,6 +8618,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemStormBrand"] = {
 		name = "Storm Brand",
+		gameId = "Metadata/Items/Gems/SkillGemStormBrand",
+		variantId = "StormBrand",
 		grantedEffectId = "ConduitSigil",
 		tags = {
 			lightning = true,
@@ -7727,6 +8639,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemStormBrandAltX"] = {
 		name = "Storm Brand of Indecision",
+		gameId = "Metadata/Items/Gems/SkillGemStormBrand",
+		variantId = "StormBrandAltX",
 		grantedEffectId = "ConduitSigilAltX",
 		tags = {
 			lightning = true,
@@ -7746,6 +8660,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemWarBanner"] = {
 		name = "War Banner",
+		gameId = "Metadata/Items/Gems/SkillGemWarBanner",
+		variantId = "WarBanner",
 		grantedEffectId = "BloodstainedBanner",
 		tags = {
 			strength = true,
@@ -7765,6 +8681,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemDreadBanner"] = {
 		name = "Dread Banner",
+		gameId = "Metadata/Items/Gems/SkillGemDreadBanner",
+		variantId = "DreadBanner",
 		grantedEffectId = "PuresteelBanner",
 		tags = {
 			strength = true,
@@ -7784,6 +8702,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemShatteringSteel"] = {
 		name = "Shattering Steel",
+		gameId = "Metadata/Items/Gems/SkillGemShatteringSteel",
+		variantId = "ShatteringSteel",
 		grantedEffectId = "ShatteringSteel",
 		tags = {
 			dexterity = true,
@@ -7801,6 +8721,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemShatteringSteelAltX"] = {
 		name = "Shattering Steel of Ammunition",
+		gameId = "Metadata/Items/Gems/SkillGemShatteringSteel",
+		variantId = "ShatteringSteelAltX",
 		grantedEffectId = "ShatteringSteelAltX",
 		tags = {
 			dexterity = true,
@@ -7819,6 +8741,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemMultiTotemSupport"] = {
 		name = "Multiple Totems",
+		gameId = "Metadata/Items/Gems/SupportGemMultiTotem",
+		variantId = "MultiTotemSupport",
 		grantedEffectId = "SupportMultiTotem",
 		tags = {
 			totem = true,
@@ -7833,6 +8757,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemArmageddonBrand"] = {
 		name = "Armageddon Brand",
+		gameId = "Metadata/Items/Gems/SkillGemArmageddonBrand",
+		variantId = "ArmageddonBrand",
 		grantedEffectId = "CataclysmSigil",
 		tags = {
 			intelligence = true,
@@ -7851,6 +8777,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemArmageddonBrandAltX"] = {
 		name = "Armageddon Brand of Volatility",
+		gameId = "Metadata/Items/Gems/SkillGemArmageddonBrand",
+		variantId = "ArmageddonBrandAltX",
 		grantedEffectId = "CataclysmSigilAltX",
 		tags = {
 			intelligence = true,
@@ -7869,6 +8797,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemArmageddonBrandAltY"] = {
 		name = "Armageddon Brand of Recall",
+		gameId = "Metadata/Items/Gems/SkillGemArmageddonBrand",
+		variantId = "ArmageddonBrandAltY",
 		grantedEffectId = "CataclysmSigilAltY",
 		tags = {
 			intelligence = true,
@@ -7887,6 +8817,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemRecallBrands"] = {
 		name = "Brand Recall",
+		gameId = "Metadata/Items/Gems/SkillGemRecallBrands",
+		variantId = "RecallBrands",
 		grantedEffectId = "SigilRecall",
 		tags = {
 			brand = true,
@@ -7902,6 +8834,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemSanctify"] = {
 		name = "Purifying Flame",
+		gameId = "Metadata/Items/Gems/SkillGemSanctify",
+		variantId = "Sanctify",
 		grantedEffectId = "Sanctify",
 		tags = {
 			fire = true,
@@ -7920,6 +8854,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemSanctifyAltX"] = {
 		name = "Purifying Flame of Revelations",
+		gameId = "Metadata/Items/Gems/SkillGemSanctify",
+		variantId = "SanctifyAltX",
 		grantedEffectId = "SanctifyAltX",
 		tags = {
 			fire = true,
@@ -7938,6 +8874,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemSoulrend"] = {
 		name = "Soulrend",
+		gameId = "Metadata/Items/Gems/SkillGemSoulrend",
+		variantId = "Soulrend",
 		grantedEffectId = "Soulrend",
 		tags = {
 			chaos = true,
@@ -7956,6 +8894,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemSoulrendAltX"] = {
 		name = "Soulrend of Reaping",
+		gameId = "Metadata/Items/Gems/SkillGemSoulrend",
+		variantId = "SoulrendAltX",
 		grantedEffectId = "SoulrendAltX",
 		tags = {
 			chaos = true,
@@ -7972,6 +8912,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemSoulrendAltY"] = {
 		name = "Soulrend of the Spiral",
+		gameId = "Metadata/Items/Gems/SkillGemSoulrend",
+		variantId = "SoulrendAltY",
 		grantedEffectId = "SoulrendAltY",
 		tags = {
 			chaos = true,
@@ -7990,6 +8932,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemDarkRitual"] = {
 		name = "Bane",
+		gameId = "Metadata/Items/Gems/SkillGemDarkRitual",
+		variantId = "DarkRitual",
 		grantedEffectId = "DarkRitual",
 		secondaryGrantedEffectId = "SupportDarkRitual",
 		tags = {
@@ -8010,6 +8954,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemDarkRitualAltX"] = {
 		name = "Bane of Condemnation",
+		gameId = "Metadata/Items/Gems/SkillGemDarkRitual",
+		variantId = "DarkRitualAltX",
 		grantedEffectId = "DarkRitualAltX",
 		secondaryGrantedEffectId = "SupportDarkRitualAltX",
 		tags = {
@@ -8030,6 +8976,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemEnergyShieldLeechSupport"] = {
 		name = "Energy Leech",
+		gameId = "Metadata/Items/Gems/SupportGemEnergyShieldLeech",
+		variantId = "EnergyShieldLeechSupport",
 		grantedEffectId = "SupportEnergyShieldLeech",
 		tags = {
 			intelligence = true,
@@ -8043,6 +8991,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemPurge"] = {
 		name = "Wave of Conviction",
+		gameId = "Metadata/Items/Gems/SkillGemPurge",
+		variantId = "Purge",
 		grantedEffectId = "Purge",
 		tags = {
 			fire = true,
@@ -8062,6 +9012,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemSpellDamageAura"] = {
 		name = "Zealotry",
+		gameId = "Metadata/Items/Gems/SkillGemSpellDamageAura",
+		variantId = "SpellDamageAura",
 		grantedEffectId = "SpellDamageAura",
 		tags = {
 			aura = true,
@@ -8079,6 +9031,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemDivineTempest"] = {
 		name = "Divine Ire",
+		gameId = "Metadata/Items/Gems/SkillGemDivineTempest",
+		variantId = "DivineTempest",
 		grantedEffectId = "DivineTempest",
 		tags = {
 			lightning = true,
@@ -8097,6 +9051,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemDivineTempestAltX"] = {
 		name = "Divine Ire of Holy Lightning",
+		gameId = "Metadata/Items/Gems/SkillGemDivineTempest",
+		variantId = "DivineTempestAltX",
 		grantedEffectId = "DivineTempestAltX",
 		tags = {
 			lightning = true,
@@ -8115,6 +9071,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemDivineTempestAltY"] = {
 		name = "Divine Ire of Disintegration",
+		gameId = "Metadata/Items/Gems/SkillGemDivineTempest",
+		variantId = "DivineTempestAltY",
 		grantedEffectId = "DivineTempestAltY",
 		tags = {
 			lightning = true,
@@ -8133,6 +9091,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemDamageOverTimeAura"] = {
 		name = "Malevolence",
+		gameId = "Metadata/Items/Gems/SkillGemDamageOverTimeAura",
+		variantId = "DamageOverTimeAura",
 		grantedEffectId = "DamageOverTimeAura",
 		tags = {
 			aura = true,
@@ -8149,6 +9109,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemHandcastSpellBoostSupport"] = {
 		name = "Intensify",
+		gameId = "Metadata/Items/Gems/SupportGemHandcastSpellBoost",
+		variantId = "HandcastSpellBoostSupport",
 		grantedEffectId = "SupportHandcastSpellBoost",
 		tags = {
 			area = true,
@@ -8164,6 +9126,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemHandcastAnticipationSupport"] = {
 		name = "Unleash",
+		gameId = "Metadata/Items/Gems/SupportGemHandcastAnticipation",
+		variantId = "HandcastAnticipationSupport",
 		grantedEffectId = "SupportHandcastAnticipation",
 		tags = {
 			spell = true,
@@ -8178,6 +9142,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemSteelskin"] = {
 		name = "Steelskin",
+		gameId = "Metadata/Items/Gems/SkillGemSteelskin",
+		variantId = "Steelskin",
 		grantedEffectId = "QuickGuard",
 		tags = {
 			strength = true,
@@ -8194,6 +9160,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemDash"] = {
 		name = "Dash",
+		gameId = "Metadata/Items/Gems/SkillGemDash",
+		variantId = "Dash",
 		grantedEffectId = "QuickDodge",
 		tags = {
 			dexterity = true,
@@ -8211,6 +9179,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemBladestorm"] = {
 		name = "Bladestorm",
+		gameId = "Metadata/Items/Gems/SkillGemBladestorm",
+		variantId = "Bladestorm",
 		grantedEffectId = "Bladestorm",
 		tags = {
 			strength = true,
@@ -8228,6 +9198,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemBladestormAltX"] = {
 		name = "Bladestorm of Uncertainty",
+		gameId = "Metadata/Items/Gems/SkillGemBladestorm",
+		variantId = "BladestormAltX",
 		grantedEffectId = "BladestormAltX",
 		tags = {
 			strength = true,
@@ -8245,6 +9217,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemBloodAndSand"] = {
 		name = "Blood and Sand",
+		gameId = "Metadata/Items/Gems/SkillGemBloodAndSand",
+		variantId = "BloodAndSand",
 		grantedEffectId = "BloodSandStance",
 		tags = {
 			low_max_level = true,
@@ -8261,6 +9235,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemBerserk"] = {
 		name = "Berserk",
+		gameId = "Metadata/Items/Gems/SkillGemBerserk",
+		variantId = "Berserk",
 		grantedEffectId = "Berserk",
 		tags = {
 			strength = true,
@@ -8275,6 +9251,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemPerforate"] = {
 		name = "Perforate",
+		gameId = "Metadata/Items/Gems/SkillGemPerforate",
+		variantId = "Perforate",
 		grantedEffectId = "BloodSpears",
 		tags = {
 			physical = true,
@@ -8293,6 +9271,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemPerforateAltX"] = {
 		name = "Perforate of Duality",
+		gameId = "Metadata/Items/Gems/SkillGemPerforate",
+		variantId = "PerforateAltX",
 		grantedEffectId = "BloodSpearsAltX",
 		tags = {
 			physical = true,
@@ -8311,6 +9291,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemPerforateAltY"] = {
 		name = "Perforate of Bloodshed",
+		gameId = "Metadata/Items/Gems/SkillGemPerforate",
+		variantId = "PerforateAltY",
 		grantedEffectId = "BloodSpearsAltY",
 		tags = {
 			physical = true,
@@ -8329,6 +9311,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemChainHook"] = {
 		name = "Chain Hook",
+		gameId = "Metadata/Items/Gems/SkillGemChainHook",
+		variantId = "ChainHook",
 		grantedEffectId = "ChainStrike",
 		tags = {
 			strength = true,
@@ -8346,6 +9330,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemCloseCombatSupport"] = {
 		name = "Close Combat",
+		gameId = "Metadata/Items/Gems/SupportGemCloseCombat",
+		variantId = "CloseCombatSupport",
 		grantedEffectId = "SupportSlashingWeapon",
 		tags = {
 			dexterity = true,
@@ -8362,6 +9348,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemShockwaveSupport"] = {
 		name = "Shockwave",
+		gameId = "Metadata/Items/Gems/SupportGemShockwave",
+		variantId = "ShockwaveSupport",
 		grantedEffectId = "SupportBluntWeapon",
 		secondaryGrantedEffectId = "SupportBluntWeaponShockwave",
 		tags = {
@@ -8380,6 +9368,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemFrostblink"] = {
 		name = "Frostblink",
+		gameId = "Metadata/Items/Gems/SkillGemFrostblink",
+		variantId = "Frostblink",
 		grantedEffectId = "IceDash",
 		tags = {
 			intelligence = true,
@@ -8400,6 +9390,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemFrostblinkAltX"] = {
 		name = "Frostblink of Wintry Blast",
+		gameId = "Metadata/Items/Gems/SkillGemFrostblink",
+		variantId = "FrostblinkAltX",
 		grantedEffectId = "IceDashAltX",
 		tags = {
 			intelligence = true,
@@ -8418,6 +9410,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemPrecision"] = {
 		name = "Precision",
+		gameId = "Metadata/Items/Gems/SkillGemPrecision",
+		variantId = "Precision",
 		grantedEffectId = "AccuracyAndCritsAura",
 		tags = {
 			aura = true,
@@ -8435,6 +9429,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemFleshAndStone"] = {
 		name = "Flesh and Stone",
+		gameId = "Metadata/Items/Gems/SkillGemFleshAndStone",
+		variantId = "FleshAndStone",
 		grantedEffectId = "BloodSandArmour",
 		tags = {
 			strength = true,
@@ -8452,6 +9448,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemImpaleSupport"] = {
 		name = "Impale",
+		gameId = "Metadata/Items/Gems/SupportGemImpale",
+		variantId = "ImpaleSupport",
 		grantedEffectId = "SupportImpale",
 		tags = {
 			attack = true,
@@ -8467,6 +9465,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemPride"] = {
 		name = "Pride",
+		gameId = "Metadata/Items/Gems/SkillGemPride",
+		variantId = "Pride",
 		grantedEffectId = "PhysicalDamageAura",
 		tags = {
 			strength = true,
@@ -8484,6 +9484,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemPulveriseSupport"] = {
 		name = "Pulverise",
+		gameId = "Metadata/Items/Gems/SupportGemPulverise",
+		variantId = "PulveriseSupport",
 		grantedEffectId = "SupportPulverise",
 		tags = {
 			area = true,
@@ -8500,6 +9502,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemRageSupport"] = {
 		name = "Rage",
+		gameId = "Metadata/Items/Gems/SupportGemRage",
+		variantId = "RageSupport",
 		grantedEffectId = "SupportRage",
 		tags = {
 			strength = true,
@@ -8515,6 +9519,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemCobraLash"] = {
 		name = "Cobra Lash",
+		gameId = "Metadata/Items/Gems/SkillGemCobraLash",
+		variantId = "CobraLash",
 		grantedEffectId = "CobraLash",
 		tags = {
 			dexterity = true,
@@ -8531,6 +9537,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemSummonCarrionGolem"] = {
 		name = "Summon Carrion Golem",
+		gameId = "Metadata/Items/Gems/SkillGemSummonCarrionGolem",
+		variantId = "SummonCarrionGolem",
 		grantedEffectId = "SummonBoneGolem",
 		tags = {
 			intelligence = true,
@@ -8548,6 +9556,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemSummonCarrionGolemAltX"] = {
 		name = "Summon Carrion Golem of Hordes",
+		gameId = "Metadata/Items/Gems/SkillGemSummonCarrionGolem",
+		variantId = "SummonCarrionGolemAltX",
 		grantedEffectId = "SummonBoneGolemAltX",
 		tags = {
 			intelligence = true,
@@ -8565,6 +9575,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemSummonCarrionGolemAltY"] = {
 		name = "Summon Carrion Golem of Scavenging",
+		gameId = "Metadata/Items/Gems/SkillGemSummonCarrionGolem",
+		variantId = "SummonCarrionGolemAltY",
 		grantedEffectId = "SummonBoneGolemAltY",
 		tags = {
 			intelligence = true,
@@ -8582,6 +9594,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemWitheringStep"] = {
 		name = "Withering Step",
+		gameId = "Metadata/Items/Gems/SkillGemWitheringStep",
+		variantId = "WitheringStep",
 		grantedEffectId = "Slither",
 		tags = {
 			dexterity = true,
@@ -8602,6 +9616,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemPlagueBearer"] = {
 		name = "Plague Bearer",
+		gameId = "Metadata/Items/Gems/SkillGemPlagueBearer",
+		variantId = "PlagueBearer",
 		grantedEffectId = "CorrosiveShroud",
 		tags = {
 			dexterity = true,
@@ -8618,6 +9634,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemFeedingFrenzySupport"] = {
 		name = "Feeding Frenzy",
+		gameId = "Metadata/Items/Gems/SupportGemFeedingFrenzy",
+		variantId = "FeedingFrenzySupport",
 		grantedEffectId = "SupportMinionOffensiveStance",
 		tags = {
 			intelligence = true,
@@ -8633,6 +9651,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemDeathmarkSupport"] = {
 		name = "Predator",
+		gameId = "Metadata/Items/Gems/SupportGemDeathmark",
+		variantId = "DeathmarkSupport",
 		grantedEffectId = "SupportMinionFocusFire",
 		secondaryGrantedEffectId = "MinionFocusFire",
 		tags = {
@@ -8651,6 +9671,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemNightbladeSupport"] = {
 		name = "Nightblade",
+		gameId = "Metadata/Items/Gems/SupportGemNightblade",
+		variantId = "NightbladeSupport",
 		grantedEffectId = "SupportPuncturingWeapon",
 		tags = {
 			attack = true,
@@ -8666,6 +9688,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemMeatShieldSupport"] = {
 		name = "Meat Shield",
+		gameId = "Metadata/Items/Gems/SupportGemMeatShield",
+		variantId = "MeatShieldSupport",
 		grantedEffectId = "SupportMinionDefensiveStance",
 		tags = {
 			intelligence = true,
@@ -8680,6 +9704,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemStormblastMine"] = {
 		name = "Stormblast Mine",
+		gameId = "Metadata/Items/Gems/SkillGemStormblastMine",
+		variantId = "StormblastMine",
 		grantedEffectId = "LightningExplosionMine",
 		tags = {
 			mine = true,
@@ -8699,6 +9725,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemSummonSkitterbots"] = {
 		name = "Summon Skitterbots",
+		gameId = "Metadata/Items/Gems/SkillGemSummonSkitterbots",
+		variantId = "SummonSkitterbots",
 		grantedEffectId = "Skitterbots",
 		tags = {
 			trap = true,
@@ -8720,6 +9748,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemHighImpactMineSupportSupport"] = {
 		name = "High-Impact Mine",
+		gameId = "Metadata/Items/Gems/SupportGemHighImpactMineSupport",
+		variantId = "HighImpactMineSupportSupport",
 		grantedEffectId = "SupportRemoteMine2",
 		tags = {
 			mine = true,
@@ -8736,6 +9766,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemInfernalLegionSupport"] = {
 		name = "Infernal Legion",
+		gameId = "Metadata/Items/Gems/SupportGemInfernalLegion",
+		variantId = "InfernalLegionSupport",
 		grantedEffectId = "SupportBurningMinions",
 		tags = {
 			fire = true,
@@ -8752,6 +9784,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemPestilentStrike"] = {
 		name = "Pestilent Strike",
+		gameId = "Metadata/Items/Gems/SkillGemPestilentStrike",
+		variantId = "PestilentStrike",
 		grantedEffectId = "MambaStrike",
 		tags = {
 			dexterity = true,
@@ -8771,6 +9805,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemVenomGyre"] = {
 		name = "Venom Gyre",
+		gameId = "Metadata/Items/Gems/SkillGemVenomGyre",
+		variantId = "VenomGyre",
 		grantedEffectId = "SnappingAdder",
 		tags = {
 			dexterity = true,
@@ -8788,6 +9824,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemSwiftAssemblySupport"] = {
 		name = "Swift Assembly",
+		gameId = "Metadata/Items/Gems/SupportGemSwiftAssembly",
+		variantId = "SwiftAssemblySupport",
 		grantedEffectId = "SupportAdditionalTrapMine",
 		tags = {
 			dexterity = true,
@@ -8803,6 +9841,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemShrapnelBallista"] = {
 		name = "Shrapnel Ballista",
+		gameId = "Metadata/Items/Gems/SkillGemShrapnelBallista",
+		variantId = "ShrapnelBallista",
 		grantedEffectId = "ShrapnelBallista",
 		tags = {
 			dexterity = true,
@@ -8821,6 +9861,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemShrapnelBallistaAltX"] = {
 		name = "Shrapnel Ballista of Steel",
+		gameId = "Metadata/Items/Gems/SkillGemShrapnelBallista",
+		variantId = "ShrapnelBallistaAltX",
 		grantedEffectId = "ShrapnelBallistaAltX",
 		tags = {
 			dexterity = true,
@@ -8839,6 +9881,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemArrowNovaSupport"] = {
 		name = "Arrow Nova",
+		gameId = "Metadata/Items/Gems/SupportGemArrowNova",
+		variantId = "ArrowNovaSupport",
 		grantedEffectId = "SupportArrowNova",
 		tags = {
 			bow = true,
@@ -8855,6 +9899,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemBarrageSupport"] = {
 		name = "Barrage Support",
+		gameId = "Metadata/Items/Gems/SupportGemBarrage",
+		variantId = "BarrageSupport",
 		grantedEffectId = "SupportBarrage",
 		tags = {
 			bow = true,
@@ -8871,6 +9917,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemEnsnaringArrow"] = {
 		name = "Ensnaring Arrow",
+		gameId = "Metadata/Items/Gems/SkillGemEnsnaringArrow",
+		variantId = "EnsnaringArrow",
 		grantedEffectId = "EnsnaringArrow",
 		tags = {
 			dexterity = true,
@@ -8888,6 +9936,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemArtilleryBallista"] = {
 		name = "Artillery Ballista",
+		gameId = "Metadata/Items/Gems/SkillGemArtilleryBallista",
+		variantId = "ArtilleryBallista",
 		grantedEffectId = "ArtilleryBallista",
 		tags = {
 			dexterity = true,
@@ -8907,6 +9957,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemGreaterVolleySupport"] = {
 		name = "Greater Volley",
+		gameId = "Metadata/Items/Gems/SupportGemGreaterVolley",
+		variantId = "GreaterVolleySupport",
 		grantedEffectId = "SupportGreaterVolley",
 		tags = {
 			dexterity = true,
@@ -8921,6 +9973,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemAddedFireDamagePlusSupport"] = {
 		name = "Awakened Added Fire Damage",
+		gameId = "Metadata/Items/Gems/SupportGemAddedFireDamagePlus",
+		variantId = "AddedFireDamagePlusSupport",
 		grantedEffectId = "SupportAddedFireDamagePlus",
 		tags = {
 			fire = true,
@@ -8937,6 +9991,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemAncestralCallPlusSupport"] = {
 		name = "Awakened Ancestral Call",
+		gameId = "Metadata/Items/Gems/SupportGemAncestralCallPlus",
+		variantId = "AncestralCallPlusSupport",
 		grantedEffectId = "SupportAncestralCallPlus",
 		tags = {
 			awakened = true,
@@ -8954,6 +10010,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemBrutalityPlusSupport"] = {
 		name = "Awakened Brutality",
+		gameId = "Metadata/Items/Gems/SupportGemBrutalityPlus",
+		variantId = "BrutalityPlusSupport",
 		grantedEffectId = "SupportBrutalityPlus",
 		tags = {
 			physical = true,
@@ -8969,6 +10027,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemBurningDamagePlusSupport"] = {
 		name = "Awakened Burning Damage",
+		gameId = "Metadata/Items/Gems/SupportGemBurningDamagePlus",
+		variantId = "BurningDamagePlusSupport",
 		grantedEffectId = "SupportBurningDamagePlus",
 		tags = {
 			fire = true,
@@ -8984,6 +10044,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemWeaponElementalDamagePlusSupport"] = {
 		name = "Awakened Elemental Damage with Attacks",
+		gameId = "Metadata/Items/Gems/SupportGemWeaponElementalDamagePlus",
+		variantId = "WeaponElementalDamagePlusSupport",
 		grantedEffectId = "SupportWeaponElementalDamagePlus",
 		tags = {
 			attack = true,
@@ -8999,6 +10061,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemFirePenetrationPlusSupport"] = {
 		name = "Awakened Fire Penetration",
+		gameId = "Metadata/Items/Gems/SupportGemFirePenetrationPlus",
+		variantId = "FirePenetrationPlusSupport",
 		grantedEffectId = "SupportFirePenetrationPlus",
 		tags = {
 			fire = true,
@@ -9014,6 +10078,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemGenerosityPlusSupport"] = {
 		name = "Awakened Generosity",
+		gameId = "Metadata/Items/Gems/SupportGemGenerosityPlus",
+		variantId = "GenerosityPlusSupport",
 		grantedEffectId = "SupportGenerosityPlus",
 		tags = {
 			awakened = true,
@@ -9029,6 +10095,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemMeleePhysicalDamagePlusSupport"] = {
 		name = "Awakened Melee Physical Damage",
+		gameId = "Metadata/Items/Gems/SupportGemMeleePhysicalDamagePlus",
+		variantId = "MeleePhysicalDamagePlusSupport",
 		grantedEffectId = "SupportMeleePhysicalDamagePlus",
 		tags = {
 			melee = true,
@@ -9046,6 +10114,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemMeleeSplashPlusSupport"] = {
 		name = "Awakened Melee Splash",
+		gameId = "Metadata/Items/Gems/SupportGemMeleeSplashPlus",
+		variantId = "MeleeSplashPlusSupport",
 		grantedEffectId = "SupportMeleeSplashPlus",
 		tags = {
 			awakened = true,
@@ -9064,6 +10134,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemMultistrikePlusSupport"] = {
 		name = "Awakened Multistrike",
+		gameId = "Metadata/Items/Gems/SupportGemMultistrikePlus",
+		variantId = "MultistrikePlusSupport",
 		grantedEffectId = "SupportMultistrikePlus",
 		tags = {
 			attack = true,
@@ -9080,6 +10152,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemAddedColdDamagePlusSupport"] = {
 		name = "Awakened Added Cold Damage",
+		gameId = "Metadata/Items/Gems/SupportGemAddedColdDamagePlus",
+		variantId = "AddedColdDamagePlusSupport",
 		grantedEffectId = "SupportAddedColdDamagePlus",
 		tags = {
 			cold = true,
@@ -9095,6 +10169,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemArrowNovaPlusSupport"] = {
 		name = "Awakened Arrow Nova",
+		gameId = "Metadata/Items/Gems/SupportGemArrowNovaPlus",
+		variantId = "ArrowNovaPlusSupport",
 		grantedEffectId = "SupportArrowNovaPlus",
 		tags = {
 			bow = true,
@@ -9112,6 +10188,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemCastOnCritPlusSupport"] = {
 		name = "Awakened Cast On Critical Strike",
+		gameId = "Metadata/Items/Gems/SupportGemCastOnCritPlus",
+		variantId = "CastOnCritPlusSupport",
 		grantedEffectId = "SupportCastOnCritPlus",
 		secondaryGrantedEffectId = "SupportCastOnCritTriggeredPlus",
 		tags = {
@@ -9130,6 +10208,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemChainPlusSupport"] = {
 		name = "Awakened Chain",
+		gameId = "Metadata/Items/Gems/SupportGemChainPlus",
+		variantId = "ChainPlusSupport",
 		grantedEffectId = "SupportChainPlus",
 		tags = {
 			awakened = true,
@@ -9146,6 +10226,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemColdPenetrationPlusSupport"] = {
 		name = "Awakened Cold Penetration",
+		gameId = "Metadata/Items/Gems/SupportGemColdPenetrationPlus",
+		variantId = "ColdPenetrationPlusSupport",
 		grantedEffectId = "SupportColdPenetrationPlus",
 		tags = {
 			cold = true,
@@ -9161,6 +10243,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemDeadlyAilmentsPlusSupport"] = {
 		name = "Awakened Deadly Ailments",
+		gameId = "Metadata/Items/Gems/SupportGemDeadlyAilmentsPlus",
+		variantId = "DeadlyAilmentsPlusSupport",
 		grantedEffectId = "SupportDeadlyAilmentsPlus",
 		tags = {
 			awakened = true,
@@ -9175,6 +10259,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemForkPlusSupport"] = {
 		name = "Awakened Fork",
+		gameId = "Metadata/Items/Gems/SupportGemForkPlus",
+		variantId = "ForkPlusSupport",
 		grantedEffectId = "SupportForkPlus",
 		tags = {
 			awakened = true,
@@ -9190,6 +10276,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemGreaterMultipleProjectilesPlusSupport"] = {
 		name = "Awakened Greater Multiple Projectiles",
+		gameId = "Metadata/Items/Gems/SupportGemGreaterMultipleProjectilesPlus",
+		variantId = "GreaterMultipleProjectilesPlusSupport",
 		grantedEffectId = "SupportGreaterMultipleProjectilesPlus",
 		tags = {
 			awakened = true,
@@ -9205,6 +10293,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemSwiftAfflictionPlusSupport"] = {
 		name = "Awakened Swift Affliction",
+		gameId = "Metadata/Items/Gems/SupportGemSwiftAfflictionPlus",
+		variantId = "SwiftAfflictionPlusSupport",
 		grantedEffectId = "SupportSwiftAfflictionPlus",
 		tags = {
 			awakened = true,
@@ -9220,6 +10310,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemVoidManipulationPlusSupport"] = {
 		name = "Awakened Void Manipulation",
+		gameId = "Metadata/Items/Gems/SupportGemVoidManipulationPlus",
+		variantId = "VoidManipulationPlusSupport",
 		grantedEffectId = "SupportVoidManipulationPlus",
 		tags = {
 			chaos = true,
@@ -9235,6 +10327,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemViciousProjectilesPlusSupport"] = {
 		name = "Awakened Vicious Projectiles",
+		gameId = "Metadata/Items/Gems/SupportGemViciousProjectilesPlus",
+		variantId = "ViciousProjectilesPlusSupport",
 		grantedEffectId = "SupportViciousProjectilesPlus",
 		tags = {
 			projectile = true,
@@ -9253,6 +10347,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemAddedChaosDamagePlusSupport"] = {
 		name = "Awakened Added Chaos Damage",
+		gameId = "Metadata/Items/Gems/SupportGemAddedChaosDamagePlus",
+		variantId = "AddedChaosDamagePlusSupport",
 		grantedEffectId = "SupportAddedChaosDamagePlus",
 		tags = {
 			chaos = true,
@@ -9268,6 +10364,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemAddedLightningDamagePlusSupport"] = {
 		name = "Awakened Added Lightning Damage",
+		gameId = "Metadata/Items/Gems/SupportGemAddedLightningDamagePlus",
+		variantId = "AddedLightningDamagePlusSupport",
 		grantedEffectId = "SupportAddedLightningDamagePlus",
 		tags = {
 			lightning = true,
@@ -9283,6 +10381,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemBlasphemyPlusSupport"] = {
 		name = "Awakened Blasphemy",
+		gameId = "Metadata/Items/Gems/SupportGemBlasphemyPlus",
+		variantId = "BlasphemyPlusSupport",
 		grantedEffectId = "SupportBlasphemyPlus",
 		tags = {
 			awakened = true,
@@ -9299,6 +10399,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemCastWhileChannellingPlusSupport"] = {
 		name = "Awakened Cast While Channelling",
+		gameId = "Metadata/Items/Gems/SupportGemCastWhileChannellingPlus",
+		variantId = "CastWhileChannellingPlusSupport",
 		grantedEffectId = "SupportCastWhileChannellingPlus",
 		secondaryGrantedEffectId = "SupportCastWhileChannellingTriggeredPlus",
 		tags = {
@@ -9317,6 +10419,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemControlledDestructionPlusSupport"] = {
 		name = "Awakened Controlled Destruction",
+		gameId = "Metadata/Items/Gems/SupportGemControlledDestructionPlus",
+		variantId = "ControlledDestructionPlusSupport",
 		grantedEffectId = "SupportControlledDestructionPlus",
 		tags = {
 			spell = true,
@@ -9333,6 +10437,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemCurseOnHitPlusSupport"] = {
 		name = "Awakened Hextouch",
+		gameId = "Metadata/Items/Gems/SupportGemCurseOnHitPlus",
+		variantId = "CurseOnHitPlusSupport",
 		grantedEffectId = "SupportCurseOnHitPlus",
 		secondaryGrantedEffectId = "SupportCurseOnHitCursePlus",
 		tags = {
@@ -9350,6 +10456,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemElementalFocusPlusSupport"] = {
 		name = "Awakened Elemental Focus",
+		gameId = "Metadata/Items/Gems/SupportGemElementalFocusPlus",
+		variantId = "ElementalFocusPlusSupport",
 		grantedEffectId = "SupportElementalFocusPlus",
 		tags = {
 			awakened = true,
@@ -9364,6 +10472,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemIncreasedAreaOfEffectPlusSupport"] = {
 		name = "Awakened Increased Area of Effect",
+		gameId = "Metadata/Items/Gems/SupportGemIncreasedAreaOfEffectPlus",
+		variantId = "IncreasedAreaOfEffectPlusSupport",
 		grantedEffectId = "SupportIncreasedAreaOfEffectPlus",
 		tags = {
 			awakened = true,
@@ -9379,6 +10489,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemLightningPenetrationPlusSupport"] = {
 		name = "Awakened Lightning Penetration",
+		gameId = "Metadata/Items/Gems/SupportGemLightningPenetrationPlus",
+		variantId = "LightningPenetrationPlusSupport",
 		grantedEffectId = "SupportLightningPenetrationPlus",
 		tags = {
 			lightning = true,
@@ -9394,6 +10506,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemMinionDamagePlusSupport"] = {
 		name = "Awakened Minion Damage",
+		gameId = "Metadata/Items/Gems/SupportGemMinionDamagePlus",
+		variantId = "MinionDamagePlusSupport",
 		grantedEffectId = "SupportMinionDamagePlus",
 		tags = {
 			awakened = true,
@@ -9409,6 +10523,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemSpellCascadePlusSupport"] = {
 		name = "Awakened Spell Cascade",
+		gameId = "Metadata/Items/Gems/SupportGemSpellCascadePlus",
+		variantId = "SpellCascadePlusSupport",
 		grantedEffectId = "SupportSpellCascadePlus",
 		tags = {
 			area = true,
@@ -9425,6 +10541,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemSpellEchoPlusSupport"] = {
 		name = "Awakened Spell Echo",
+		gameId = "Metadata/Items/Gems/SupportGemSpellEchoPlus",
+		variantId = "SpellEchoPlusSupport",
 		grantedEffectId = "SupportSpellEchoPlus",
 		tags = {
 			spell = true,
@@ -9440,6 +10558,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemUnboundAilmentsPlusSupport"] = {
 		name = "Awakened Unbound Ailments",
+		gameId = "Metadata/Items/Gems/SupportGemUnboundAilmentsPlus",
+		variantId = "UnboundAilmentsPlusSupport",
 		grantedEffectId = "SupportUnboundAilmentsPlus",
 		tags = {
 			awakened = true,
@@ -9454,6 +10574,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemUnleashPlusSupport"] = {
 		name = "Awakened Unleash",
+		gameId = "Metadata/Items/Gems/SupportGemUnleashPlus",
+		variantId = "UnleashPlusSupport",
 		grantedEffectId = "SupportUnleashPlus",
 		tags = {
 			spell = true,
@@ -9469,6 +10591,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemEmpowerPlusSupport"] = {
 		name = "Awakened Empower",
+		gameId = "Metadata/Items/Gems/SupportGemEmpowerPlus",
+		variantId = "EmpowerPlusSupport",
 		grantedEffectId = "SupportAdditionalLevelPlus",
 		tags = {
 			low_max_level = true,
@@ -9485,6 +10609,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemEnlightenPlusSupport"] = {
 		name = "Awakened Enlighten",
+		gameId = "Metadata/Items/Gems/SupportGemEnlightenPlus",
+		variantId = "EnlightenPlusSupport",
 		grantedEffectId = "SupportAdditionalXPPlus",
 		tags = {
 			low_max_level = true,
@@ -9501,6 +10627,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemEnhancePlusSupport"] = {
 		name = "Awakened Enhance",
+		gameId = "Metadata/Items/Gems/SupportGemEnhancePlus",
+		variantId = "EnhancePlusSupport",
 		grantedEffectId = "SupportAdditionalQualityPlus",
 		tags = {
 			low_max_level = true,
@@ -9517,6 +10645,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemArcaneCloak"] = {
 		name = "Arcane Cloak",
+		gameId = "Metadata/Items/Gems/SkillGemArcaneCloak",
+		variantId = "ArcaneCloak",
 		grantedEffectId = "ArcaneCloak",
 		tags = {
 			intelligence = true,
@@ -9535,6 +10665,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemStormBind"] = {
 		name = "Stormbind",
+		gameId = "Metadata/Items/Gems/SkillGemStormBind",
+		variantId = "StormBind",
 		grantedEffectId = "Stormbind",
 		secondaryGrantedEffectId = "RuneBlast",
 		tags = {
@@ -9555,6 +10687,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemStormBindAltX"] = {
 		name = "Stormbind of Teleportation",
+		gameId = "Metadata/Items/Gems/SkillGemStormBind",
+		variantId = "StormBindAltX",
 		grantedEffectId = "StormbindAltX",
 		secondaryGrantedEffectId = "RuneBlastAltX",
 		tags = {
@@ -9578,6 +10712,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemKineticBolt"] = {
 		name = "Kinetic Bolt",
+		gameId = "Metadata/Items/Gems/SkillGemKineticBolt",
+		variantId = "KineticBolt",
 		grantedEffectId = "KineticBolt",
 		tags = {
 			intelligence = true,
@@ -9593,6 +10729,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemKineticBoltAltX"] = {
 		name = "Kinetic Bolt of Fragmentation",
+		gameId = "Metadata/Items/Gems/SkillGemKineticBolt",
+		variantId = "KineticBoltAltX",
 		grantedEffectId = "KineticBoltAltX",
 		tags = {
 			intelligence = true,
@@ -9608,6 +10746,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemBladeBlast"] = {
 		name = "Blade Blast",
+		gameId = "Metadata/Items/Gems/SkillGemBladeBlast",
+		variantId = "BladeBlast",
 		grantedEffectId = "BladeBlast",
 		tags = {
 			dexterity = true,
@@ -9624,6 +10764,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemBladeBlastAltX"] = {
 		name = "Blade Blast of Unloading",
+		gameId = "Metadata/Items/Gems/SkillGemBladeBlast",
+		variantId = "BladeBlastAltX",
 		grantedEffectId = "BladeBlastAltX",
 		tags = {
 			dexterity = true,
@@ -9641,6 +10783,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemBladeBlastAltY"] = {
 		name = "Blade Blast of Dagger Detonation",
+		gameId = "Metadata/Items/Gems/SkillGemBladeBlast",
+		variantId = "BladeBlastAltY",
 		grantedEffectId = "BladeBlastAltY",
 		tags = {
 			dexterity = true,
@@ -9658,6 +10802,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemSpellslinger"] = {
 		name = "Spellslinger",
+		gameId = "Metadata/Items/Gems/SkillGemSpellslinger",
+		variantId = "Spellslinger",
 		grantedEffectId = "Spellslinger",
 		secondaryGrantedEffectId = "SupportSpellslinger",
 		secondaryEffectName = "Spellslinger Support",
@@ -9675,6 +10821,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemArchmageSupport"] = {
 		name = "Archmage",
+		gameId = "Metadata/Items/Gems/SupportGemArchmage",
+		variantId = "ArchmageSupport",
 		grantedEffectId = "SupportArchmage",
 		tags = {
 			lightning = true,
@@ -9691,6 +10839,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemSecondWindSupport"] = {
 		name = "Second Wind",
+		gameId = "Metadata/Items/Gems/SupportGemSecondWind",
+		variantId = "SecondWindSupport",
 		grantedEffectId = "SupportAdditionalCooldown",
 		tags = {
 			dexterity = true,
@@ -9704,6 +10854,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemArcanistBrand"] = {
 		name = "Arcanist Brand",
+		gameId = "Metadata/Items/Gems/SkillGemArcanistBrand",
+		variantId = "ArcanistBrand",
 		grantedEffectId = "BrandSupport",
 		secondaryGrantedEffectId = "SupportBrandSupport",
 		secondaryEffectName = "Arcanist Brand Support",
@@ -9723,6 +10875,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemIntimidatingCry"] = {
 		name = "Intimidating Cry",
+		gameId = "Metadata/Items/Gems/SkillGemIntimidatingCry",
+		variantId = "IntimidatingCry",
 		grantedEffectId = "IntimidatingCry",
 		tags = {
 			warcry = true,
@@ -9740,6 +10894,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemSeismicCry"] = {
 		name = "Seismic Cry",
+		gameId = "Metadata/Items/Gems/SkillGemSeismicCry",
+		variantId = "SeismicCry",
 		grantedEffectId = "SeismicCry",
 		tags = {
 			warcry = true,
@@ -9756,6 +10912,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemAncestralCry"] = {
 		name = "Ancestral Cry",
+		gameId = "Metadata/Items/Gems/SkillGemAncestralCry",
+		variantId = "AncestralCry",
 		grantedEffectId = "AncestralCry",
 		tags = {
 			warcry = true,
@@ -9772,6 +10930,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemPenanceBrand"] = {
 		name = "Penance Brand",
+		gameId = "Metadata/Items/Gems/SkillGemPenanceBrand",
+		variantId = "PenanceBrand",
 		grantedEffectId = "MagmaSigil",
 		tags = {
 			intelligence = true,
@@ -9791,6 +10951,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemPenanceBrandAltX"] = {
 		name = "Penance Brand of Dissipation",
+		gameId = "Metadata/Items/Gems/SkillGemPenanceBrand",
+		variantId = "PenanceBrandAltX",
 		grantedEffectId = "MagmaSigilAltX",
 		tags = {
 			intelligence = true,
@@ -9810,6 +10972,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemPenanceBrandAltY"] = {
 		name = "Penance Brand of Conduction",
+		gameId = "Metadata/Items/Gems/SkillGemPenanceBrand",
+		variantId = "PenanceBrandAltY",
 		grantedEffectId = "MagmaSigilAltY",
 		tags = {
 			intelligence = true,
@@ -9829,6 +10993,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemWintertideBrand"] = {
 		name = "Wintertide Brand",
+		gameId = "Metadata/Items/Gems/SkillGemWintertideBrand",
+		variantId = "WintertideBrand",
 		grantedEffectId = "ImmolationSigil",
 		tags = {
 			intelligence = true,
@@ -9847,6 +11013,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemEarthshatter"] = {
 		name = "Earthshatter",
+		gameId = "Metadata/Items/Gems/SkillGemEarthshatter",
+		variantId = "Earthshatter",
 		grantedEffectId = "SpikeSlam",
 		tags = {
 			strength = true,
@@ -9865,6 +11033,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemEarthshatterAltX"] = {
 		name = "Earthshatter of Fragility",
+		gameId = "Metadata/Items/Gems/SkillGemEarthshatter",
+		variantId = "EarthshatterAltX",
 		grantedEffectId = "SpikeSlamAltX",
 		tags = {
 			strength = true,
@@ -9883,6 +11053,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemEarthshatterAltY"] = {
 		name = "Earthshatter of Prominence",
+		gameId = "Metadata/Items/Gems/SkillGemEarthshatter",
+		variantId = "EarthshatterAltY",
 		grantedEffectId = "SpikeSlamAltY",
 		tags = {
 			strength = true,
@@ -9901,6 +11073,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemGeneralsCry"] = {
 		name = "General's Cry",
+		gameId = "Metadata/Items/Gems/SkillGemGeneralsCry",
+		variantId = "GeneralsCry",
 		grantedEffectId = "GeneralsCry",
 		secondaryGrantedEffectId = "GeneralsCrySupport",
 		secondaryEffectName = "General's Cry Support",
@@ -9919,6 +11093,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemFistOfWarSupport"] = {
 		name = "Fist of War",
+		gameId = "Metadata/Items/Gems/SupportGemFistOfWar",
+		variantId = "FistOfWarSupport",
 		grantedEffectId = "AncestralSlamSupport",
 		tags = {
 			slam = true,
@@ -9936,6 +11112,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemSwiftbrandSupport"] = {
 		name = "Swiftbrand",
+		gameId = "Metadata/Items/Gems/SupportGemSwiftbrand",
+		variantId = "SwiftbrandSupport",
 		grantedEffectId = "SupportRapidActivation",
 		tags = {
 			brand = true,
@@ -9950,6 +11128,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemUrgentOrdersSupport"] = {
 		name = "Urgent Orders",
+		gameId = "Metadata/Items/Gems/SupportGemUrgentOrders",
+		variantId = "UrgentOrdersSupport",
 		grantedEffectId = "SupportUrgentOrders",
 		tags = {
 			warcry = true,
@@ -9964,6 +11144,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemBlazingSalvo"] = {
 		name = "Blazing Salvo",
+		gameId = "Metadata/Items/Gems/SkillGemBlazingSalvo",
+		variantId = "BlazingSalvo",
 		grantedEffectId = "Ember",
 		tags = {
 			intelligence = true,
@@ -9981,6 +11163,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemVoidSphere"] = {
 		name = "Void Sphere",
+		gameId = "Metadata/Items/Gems/SkillGemVoidSphere",
+		variantId = "VoidSphere",
 		grantedEffectId = "BlackHole",
 		tags = {
 			intelligence = true,
@@ -10000,6 +11184,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemVoidSphereAltX"] = {
 		name = "Void Sphere of Rending",
+		gameId = "Metadata/Items/Gems/SkillGemVoidSphere",
+		variantId = "VoidSphereAltX",
 		grantedEffectId = "BlackHoleAltX",
 		tags = {
 			intelligence = true,
@@ -10019,6 +11205,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemCracklingLance"] = {
 		name = "Crackling Lance",
+		gameId = "Metadata/Items/Gems/SkillGemCracklingLance",
+		variantId = "CracklingLance",
 		grantedEffectId = "Disintegrate",
 		tags = {
 			intelligence = true,
@@ -10035,6 +11223,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemCracklingLanceAltX"] = {
 		name = "Crackling Lance of Branching",
+		gameId = "Metadata/Items/Gems/SkillGemCracklingLance",
+		variantId = "CracklingLanceAltX",
 		grantedEffectId = "DisintegrateAltX",
 		tags = {
 			intelligence = true,
@@ -10051,6 +11241,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemCracklingLanceAltY"] = {
 		name = "Crackling Lance of Disintegration",
+		gameId = "Metadata/Items/Gems/SkillGemCracklingLance",
+		variantId = "CracklingLanceAltY",
 		grantedEffectId = "DisintegrateAltY",
 		tags = {
 			intelligence = true,
@@ -10067,6 +11259,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemFrostShield"] = {
 		name = "Frost Shield",
+		gameId = "Metadata/Items/Gems/SkillGemFrostShield",
+		variantId = "FrostShield",
 		grantedEffectId = "FrostGlobe",
 		tags = {
 			critical = true,
@@ -10085,6 +11279,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemSplittingSteel"] = {
 		name = "Splitting Steel",
+		gameId = "Metadata/Items/Gems/SkillGemSplittingSteel",
+		variantId = "SplittingSteel",
 		grantedEffectId = "ImpactingSteel",
 		tags = {
 			dexterity = true,
@@ -10102,6 +11298,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemSplittingSteelAltX"] = {
 		name = "Splitting Steel of Ammunition",
+		gameId = "Metadata/Items/Gems/SkillGemSplittingSteel",
+		variantId = "SplittingSteelAltX",
 		grantedEffectId = "ImpactingSteelAltX",
 		tags = {
 			dexterity = true,
@@ -10119,6 +11317,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemSigilOfPower"] = {
 		name = "Sigil of Power",
+		gameId = "Metadata/Items/Gems/SkillGemSigilOfPower",
+		variantId = "SigilOfPower",
 		grantedEffectId = "CircleOfPower",
 		tags = {
 			intelligence = true,
@@ -10137,6 +11337,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemFlameWall"] = {
 		name = "Flame Wall",
+		gameId = "Metadata/Items/Gems/SkillGemFlameWall",
+		variantId = "FlameWall",
 		grantedEffectId = "Firewall",
 		tags = {
 			intelligence = true,
@@ -10154,6 +11356,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemImpendingDoomSupport"] = {
 		name = "Impending Doom",
+		gameId = "Metadata/Items/Gems/SupportGemImpendingDoom",
+		variantId = "ImpendingDoomSupport",
 		grantedEffectId = "ViciousHexSupport",
 		secondaryGrantedEffectId = "ViciousHexExplosion",
 		tags = {
@@ -10174,6 +11378,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemHexblast"] = {
 		name = "Hexblast",
+		gameId = "Metadata/Items/Gems/SkillGemHexblast",
+		variantId = "Hexblast",
 		grantedEffectId = "DoomBlast",
 		tags = {
 			intelligence = true,
@@ -10191,6 +11397,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemHexblastAltX"] = {
 		name = "Hexblast of Contradiction",
+		gameId = "Metadata/Items/Gems/SkillGemHexblast",
+		variantId = "HexblastAltX",
 		grantedEffectId = "DoomBlastAltX",
 		tags = {
 			intelligence = true,
@@ -10208,6 +11416,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemHexblastAltY"] = {
 		name = "Hexblast of Havoc",
+		gameId = "Metadata/Items/Gems/SkillGemHexblast",
+		variantId = "HexblastAltY",
 		grantedEffectId = "DoomBlastAltY",
 		tags = {
 			intelligence = true,
@@ -10225,6 +11435,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemPinpointSupport"] = {
 		name = "Pinpoint",
+		gameId = "Metadata/Items/Gems/SupportGemPinpoint",
+		variantId = "PinpointSupport",
 		grantedEffectId = "SupportProjectileIntensity",
 		tags = {
 			intelligence = true,
@@ -10240,6 +11452,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemHydrosphere"] = {
 		name = "Hydrosphere",
+		gameId = "Metadata/Items/Gems/SkillGemHydrosphere",
+		variantId = "Hydrosphere",
 		grantedEffectId = "WaterSphere",
 		tags = {
 			intelligence = true,
@@ -10260,6 +11474,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemTrinitySupport"] = {
 		name = "Trinity",
+		gameId = "Metadata/Items/Gems/SupportGemTrinity",
+		variantId = "TrinitySupport",
 		grantedEffectId = "SupportTrinity",
 		tags = {
 			intelligence = true,
@@ -10273,6 +11489,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemExsanguinate"] = {
 		name = "Exsanguinate",
+		gameId = "Metadata/Items/Gems/SkillGemExsanguinate",
+		variantId = "Exsanguinate",
 		grantedEffectId = "Exsanguinate",
 		tags = {
 			strength = true,
@@ -10290,6 +11508,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemExsanguinateAltX"] = {
 		name = "Exsanguinate of Transmission",
+		gameId = "Metadata/Items/Gems/SkillGemExsanguinate",
+		variantId = "ExsanguinateAltX",
 		grantedEffectId = "ExsanguinateAltX",
 		tags = {
 			strength = true,
@@ -10307,6 +11527,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemCorruptingFever"] = {
 		name = "Corrupting Fever",
+		gameId = "Metadata/Items/Gems/SkillGemCorruptingFever",
+		variantId = "CorruptingFever",
 		grantedEffectId = "CorruptingFever",
 		tags = {
 			strength = true,
@@ -10323,6 +11545,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemBloodthirstSupport"] = {
 		name = "Bloodthirst",
+		gameId = "Metadata/Items/Gems/SupportGemBloodthirst",
+		variantId = "BloodthirstSupport",
 		grantedEffectId = "SupportBloodthirst",
 		tags = {
 			attack = true,
@@ -10338,6 +11562,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemBloodreap"] = {
 		name = "Reap",
+		gameId = "Metadata/Items/Gems/SkillGemBloodreap",
+		variantId = "Bloodreap",
 		grantedEffectId = "Bloodreap",
 		tags = {
 			strength = true,
@@ -10355,6 +11581,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemPetrifiedBlood"] = {
 		name = "Petrified Blood",
+		gameId = "Metadata/Items/Gems/SkillGemPetrifiedBlood",
+		variantId = "PetrifiedBlood",
 		grantedEffectId = "PetrifiedBlood",
 		tags = {
 			strength = true,
@@ -10369,6 +11597,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemCrueltySupport"] = {
 		name = "Cruelty",
+		gameId = "Metadata/Items/Gems/SupportGemCruelty",
+		variantId = "CrueltySupport",
 		grantedEffectId = "SupportCruelty",
 		tags = {
 			strength = true,
@@ -10383,6 +11613,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemLifetapSupport"] = {
 		name = "Lifetap",
+		gameId = "Metadata/Items/Gems/SupportGemLifetap",
+		variantId = "LifetapSupport",
 		grantedEffectId = "SupportLifetap",
 		tags = {
 			strength = true,
@@ -10397,6 +11629,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemDefianceBanner"] = {
 		name = "Defiance Banner",
+		gameId = "Metadata/Items/Gems/SkillGemDefianceBanner",
+		variantId = "DefianceBanner",
 		grantedEffectId = "DefianceBanner",
 		tags = {
 			strength = true,
@@ -10416,6 +11650,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemVoltaxicBurst"] = {
 		name = "Voltaxic Burst",
+		gameId = "Metadata/Items/Gems/SkillGemVoltaxicBurst",
+		variantId = "VoltaxicBurst",
 		grantedEffectId = "VoltaxicBurst",
 		tags = {
 			intelligence = true,
@@ -10435,6 +11671,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemRageVortex"] = {
 		name = "Rage Vortex",
+		gameId = "Metadata/Items/Gems/SkillGemRageVortex",
+		variantId = "RageVortex",
 		grantedEffectId = "RageVortex",
 		tags = {
 			strength = true,
@@ -10452,6 +11690,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemRageVortexAltX"] = {
 		name = "Rage Vortex of Berserking",
+		gameId = "Metadata/Items/Gems/SkillGemRageVortex",
+		variantId = "RageVortexAltX",
 		grantedEffectId = "RageVortexAltX",
 		tags = {
 			strength = true,
@@ -10468,6 +11708,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemSpectralHelix"] = {
 		name = "Spectral Helix",
+		gameId = "Metadata/Items/Gems/SkillGemSpectralHelix",
+		variantId = "SpectralHelix",
 		grantedEffectId = "SpectralHelix",
 		tags = {
 			dexterity = true,
@@ -10483,6 +11725,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemBattlemagesCry"] = {
 		name = "Battlemage's Cry",
+		gameId = "Metadata/Items/Gems/SkillGemBattlemagesCry",
+		variantId = "BattlemagesCry",
 		grantedEffectId = "BattlemagesCry",
 		secondaryGrantedEffectId = "BattlemagesCrySupport",
 		secondaryEffectName = "Battlemage's Cry Support",
@@ -10503,6 +11747,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemEarthbreakerSupport"] = {
 		name = "Earthbreaker",
+		gameId = "Metadata/Items/Gems/SupportGemEarthbreaker",
+		variantId = "EarthbreakerSupport",
 		grantedEffectId = "SupportEarthbreaker",
 		tags = {
 			attack = true,
@@ -10521,6 +11767,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemAbsolution"] = {
 		name = "Absolution",
+		gameId = "Metadata/Items/Gems/SkillGemAbsolution",
+		variantId = "Absolution",
 		grantedEffectId = "Absolution",
 		tags = {
 			strength = true,
@@ -10540,6 +11788,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemAbsolutionAltX"] = {
 		name = "Absolution of Inspiring",
+		gameId = "Metadata/Items/Gems/SkillGemAbsolution",
+		variantId = "AbsolutionAltX",
 		grantedEffectId = "AbsolutionAltX",
 		tags = {
 			strength = true,
@@ -10559,6 +11809,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemForbiddenRite"] = {
 		name = "Forbidden Rite",
+		gameId = "Metadata/Items/Gems/SkillGemForbiddenRite",
+		variantId = "ForbiddenRite",
 		grantedEffectId = "ForbiddenRite",
 		tags = {
 			intelligence = true,
@@ -10576,6 +11828,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemForbiddenRiteAltX"] = {
 		name = "Forbidden Rite of Soul Sacrifice",
+		gameId = "Metadata/Items/Gems/SkillGemForbiddenRite",
+		variantId = "ForbiddenRiteAltX",
 		grantedEffectId = "ForbiddenRiteAltX",
 		tags = {
 			intelligence = true,
@@ -10593,6 +11847,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemAmbush"] = {
 		name = "Ambush",
+		gameId = "Metadata/Items/Gems/SkillGemAmbush",
+		variantId = "Ambush",
 		grantedEffectId = "Ambush",
 		tags = {
 			critical = true,
@@ -10611,6 +11867,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemManabond"] = {
 		name = "Manabond",
+		gameId = "Metadata/Items/Gems/SkillGemManabond",
+		variantId = "Manabond",
 		grantedEffectId = "Manabond",
 		tags = {
 			intelligence = true,
@@ -10628,6 +11886,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemBladeTrap"] = {
 		name = "Blade Trap",
+		gameId = "Metadata/Items/Gems/SkillGemBladeTrap",
+		variantId = "BladeTrap",
 		grantedEffectId = "BladeTrap",
 		tags = {
 			trap = true,
@@ -10644,6 +11904,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemBladeTrapAltX"] = {
 		name = "Blade Trap of Greatswords",
+		gameId = "Metadata/Items/Gems/SkillGemBladeTrap",
+		variantId = "BladeTrapAltX",
 		grantedEffectId = "BladeTrapAltX",
 		tags = {
 			trap = true,
@@ -10661,6 +11923,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemBladeTrapAltY"] = {
 		name = "Blade Trap of Laceration",
+		gameId = "Metadata/Items/Gems/SkillGemBladeTrap",
+		variantId = "BladeTrapAltY",
 		grantedEffectId = "BladeTrapAltY",
 		tags = {
 			trap = true,
@@ -10678,6 +11942,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemStormRain"] = {
 		name = "Storm Rain",
+		gameId = "Metadata/Items/Gems/SkillGemStormRain",
+		variantId = "StormRain",
 		grantedEffectId = "StormRain",
 		tags = {
 			dexterity = true,
@@ -10696,6 +11962,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemStormRainAltX"] = {
 		name = "Storm Rain of the Conduit",
+		gameId = "Metadata/Items/Gems/SkillGemStormRain",
+		variantId = "StormRainAltX",
 		grantedEffectId = "StormRainAltX",
 		tags = {
 			dexterity = true,
@@ -10714,6 +11982,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemStormRainAltY"] = {
 		name = "Storm Rain of the Fence",
+		gameId = "Metadata/Items/Gems/SkillGemStormRain",
+		variantId = "StormRainAltY",
 		grantedEffectId = "StormRainAltY",
 		tags = {
 			dexterity = true,
@@ -10732,6 +12002,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemShieldCrush"] = {
 		name = "Shield Crush",
+		gameId = "Metadata/Items/Gems/SkillGemShieldCrush",
+		variantId = "ShieldCrush",
 		grantedEffectId = "ShieldCrush",
 		tags = {
 			strength = true,
@@ -10749,6 +12021,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemShieldCrushAltX"] = {
 		name = "Shield Crush of the Chieftain",
+		gameId = "Metadata/Items/Gems/SkillGemShieldCrush",
+		variantId = "ShieldCrushAltX",
 		grantedEffectId = "ShieldCrushAltX",
 		tags = {
 			strength = true,
@@ -10766,6 +12040,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemFocusedBallistaSupport"] = {
 		name = "Focused Ballista",
+		gameId = "Metadata/Items/Gems/SupportGemFocusedBallista",
+		variantId = "FocusedBallistaSupport",
 		grantedEffectId = "SupportFocusedBallista",
 		tags = {
 			projectile = true,
@@ -10781,6 +12057,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemSummonReaper"] = {
 		name = "Summon Reaper",
+		gameId = "Metadata/Items/Gems/SkillGemSummonReaper",
+		variantId = "SummonReaper",
 		grantedEffectId = "SummonReaper",
 		tags = {
 			intelligence = true,
@@ -10797,6 +12075,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemSummonReaperAltX"] = {
 		name = "Summon Reaper of Revenants",
+		gameId = "Metadata/Items/Gems/SkillGemSummonReaper",
+		variantId = "SummonReaperAltX",
 		grantedEffectId = "SummonReaperAltX",
 		tags = {
 			intelligence = true,
@@ -10812,6 +12092,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemSummonReaperAltY"] = {
 		name = "Summon Reaper of Eviscerating",
+		gameId = "Metadata/Items/Gems/SkillGemSummonReaper",
+		variantId = "SummonReaperAltY",
 		grantedEffectId = "SummonReaperAltY",
 		tags = {
 			intelligence = true,
@@ -10828,6 +12110,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemBeheadSupport"] = {
 		name = "Behead",
+		gameId = "Metadata/Items/Gems/SupportGemBehead",
+		variantId = "BeheadSupport",
 		grantedEffectId = "SupportBehead",
 		tags = {
 			strength = true,
@@ -10844,6 +12128,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemBoneshatter"] = {
 		name = "Boneshatter",
+		gameId = "Metadata/Items/Gems/SkillGemBoneshatter",
+		variantId = "Boneshatter",
 		grantedEffectId = "Boneshatter",
 		tags = {
 			strength = true,
@@ -10863,6 +12149,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemBoneshatterAltX"] = {
 		name = "Boneshatter of Complex Trauma",
+		gameId = "Metadata/Items/Gems/SkillGemBoneshatter",
+		variantId = "BoneshatterAltX",
 		grantedEffectId = "BoneshatterAltX",
 		tags = {
 			strength = true,
@@ -10882,6 +12170,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemBoneshatterAltY"] = {
 		name = "Boneshatter of Carnage",
+		gameId = "Metadata/Items/Gems/SkillGemBoneshatter",
+		variantId = "BoneshatterAltY",
 		grantedEffectId = "BoneshatterAltY",
 		tags = {
 			strength = true,
@@ -10900,6 +12190,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemExplosiveConcoction"] = {
 		name = "Explosive Concoction",
+		gameId = "Metadata/Items/Gems/SkillGemExplosiveConcoction",
+		variantId = "ExplosiveConcoction",
 		grantedEffectId = "ExplosiveConcoction",
 		tags = {
 			dexterity = true,
@@ -10919,6 +12211,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemExplosiveConcoctionAltX"] = {
 		name = "Explosive Concoction of Destruction",
+		gameId = "Metadata/Items/Gems/SkillGemExplosiveConcoction",
+		variantId = "ExplosiveConcoctionAltX",
 		grantedEffectId = "ExplosiveConcoctionAltX",
 		tags = {
 			critical = true,
@@ -10939,6 +12233,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemEyeOfWinter"] = {
 		name = "Eye of Winter",
+		gameId = "Metadata/Items/Gems/SkillGemEyeOfWinter",
+		variantId = "EyeOfWinter",
 		grantedEffectId = "EyeOfWinter",
 		tags = {
 			intelligence = true,
@@ -10955,6 +12251,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemEyeOfWinterAltX"] = {
 		name = "Eye of Winter of Finality",
+		gameId = "Metadata/Items/Gems/SkillGemEyeOfWinter",
+		variantId = "EyeOfWinterAltX",
 		grantedEffectId = "EyeOfWinterAltX",
 		tags = {
 			intelligence = true,
@@ -10971,6 +12269,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemEyeOfWinterAltY"] = {
 		name = "Eye of Winter of Transience",
+		gameId = "Metadata/Items/Gems/SkillGemEyeOfWinter",
+		variantId = "EyeOfWinterAltY",
 		grantedEffectId = "EyeOfWinterAltY",
 		tags = {
 			intelligence = true,
@@ -10987,6 +12287,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemPoisonousConcoction"] = {
 		name = "Poisonous Concoction",
+		gameId = "Metadata/Items/Gems/SkillGemPoisonousConcoction",
+		variantId = "PoisonousConcoction",
 		grantedEffectId = "PoisonousConcoction",
 		tags = {
 			dexterity = true,
@@ -11004,6 +12306,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemTemporalRift"] = {
 		name = "Temporal Rift",
+		gameId = "Metadata/Items/Gems/SkillGemTemporalRift",
+		variantId = "TemporalRift",
 		grantedEffectId = "TemporalRift",
 		tags = {
 			dexterity = true,
@@ -11018,6 +12322,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemTornado"] = {
 		name = "Tornado",
+		gameId = "Metadata/Items/Gems/SkillGemTornado",
+		variantId = "Tornado",
 		grantedEffectId = "Tornado",
 		tags = {
 			dexterity = true,
@@ -11036,6 +12342,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemEnergyBlade"] = {
 		name = "Energy Blade",
+		gameId = "Metadata/Items/Gems/SkillGemEnergyBlade",
+		variantId = "EnergyBlade",
 		grantedEffectId = "EnergyBlade",
 		tags = {
 			intelligence = true,
@@ -11051,6 +12359,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemSoulLink"] = {
 		name = "Soul Link",
+		gameId = "Metadata/Items/Gems/SkillGemSoulLink",
+		variantId = "SoulLink",
 		grantedEffectId = "SoulLink",
 		tags = {
 			intelligence = true,
@@ -11067,6 +12377,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemFlameLink"] = {
 		name = "Flame Link",
+		gameId = "Metadata/Items/Gems/SkillGemFlameLink",
+		variantId = "FlameLink",
 		grantedEffectId = "FlameLink",
 		tags = {
 			strength = true,
@@ -11084,6 +12396,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemVampiricLink"] = {
 		name = "Vampiric Link",
+		gameId = "Metadata/Items/Gems/SkillGemVampiricLink",
+		variantId = "VampiricLink",
 		grantedEffectId = "VampiricLink",
 		tags = {
 			dexterity = true,
@@ -11100,6 +12414,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemProtectiveLink"] = {
 		name = "Protective Link",
+		gameId = "Metadata/Items/Gems/SkillGemProtectiveLink",
+		variantId = "ProtectiveLink",
 		grantedEffectId = "ProtectiveLink",
 		tags = {
 			strength = true,
@@ -11116,6 +12432,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemIntuitiveLink"] = {
 		name = "Intuitive Link",
+		gameId = "Metadata/Items/Gems/SkillGemIntuitiveLink",
+		variantId = "IntuitiveLink",
 		grantedEffectId = "IntuitiveLink",
 		secondaryGrantedEffectId = "SupportIntuitiveLink",
 		secondaryEffectName = "Intuitive Link Support",
@@ -11135,6 +12453,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemDestructiveLink"] = {
 		name = "Destructive Link",
+		gameId = "Metadata/Items/Gems/SkillGemDestructiveLink",
+		variantId = "DestructiveLink",
 		grantedEffectId = "DestructiveLink",
 		tags = {
 			critical = true,
@@ -11152,6 +12472,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemDivineBlessingSupport"] = {
 		name = "Divine Blessing",
+		gameId = "Metadata/Items/Gems/SupportGemDivineBlessing",
+		variantId = "DivineBlessingSupport",
 		grantedEffectId = "SupportAuraDuration",
 		tags = {
 			strength = true,
@@ -11168,6 +12490,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemMarkOnHitSupport"] = {
 		name = "Mark On Hit",
+		gameId = "Metadata/Items/Gems/SupportGemMarkOnHit",
+		variantId = "MarkOnHitSupport",
 		grantedEffectId = "SupportMarkOnHit",
 		tags = {
 			dexterity = true,
@@ -11183,6 +12507,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemEternalBlessingSupport"] = {
 		name = "Eternal Blessing",
+		gameId = "Metadata/Items/Gems/SupportGemEternalBlessing",
+		variantId = "EternalBlessingSupport",
 		grantedEffectId = "SupportMortalConviction",
 		tags = {
 			strength = true,
@@ -11198,6 +12524,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemOverchargeSupport"] = {
 		name = "Overcharge",
+		gameId = "Metadata/Items/Gems/SupportGemOvercharge",
+		variantId = "OverchargeSupport",
 		grantedEffectId = "SupportOvercharge",
 		tags = {
 			lightning = true,
@@ -11212,6 +12540,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemLightningConduit"] = {
 		name = "Lightning Conduit",
+		gameId = "Metadata/Items/Gems/SkillGemLightningConduit",
+		variantId = "LightningConduit",
 		grantedEffectId = "LightningConduit",
 		tags = {
 			intelligence = true,
@@ -11228,6 +12558,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemLightningConduitAltX"] = {
 		name = "Lightning Conduit of the Heavens",
+		gameId = "Metadata/Items/Gems/SkillGemLightningConduit",
+		variantId = "LightningConduitAltX",
 		grantedEffectId = "LightningConduitAltX",
 		tags = {
 			intelligence = true,
@@ -11244,6 +12576,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemGalvanicField"] = {
 		name = "Galvanic Field",
+		gameId = "Metadata/Items/Gems/SkillGemGalvanicField",
+		variantId = "GalvanicField",
 		grantedEffectId = "GalvanicField",
 		tags = {
 			intelligence = true,
@@ -11263,6 +12597,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemGalvanicFieldAltX"] = {
 		name = "Galvanic Field of Intensity",
+		gameId = "Metadata/Items/Gems/SkillGemGalvanicField",
+		variantId = "GalvanicFieldAltX",
 		grantedEffectId = "GalvanicFieldAltX",
 		tags = {
 			intelligence = true,
@@ -11282,6 +12618,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemAlchemistsMark"] = {
 		name = "Alchemist's Mark",
+		gameId = "Metadata/Items/Gems/SkillGemAlchemistsMark",
+		variantId = "AlchemistsMark",
 		grantedEffectId = "AlchemistsMark",
 		tags = {
 			dexterity = true,
@@ -11302,6 +12640,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemVolcanicFissure"] = {
 		name = "Volcanic Fissure",
+		gameId = "Metadata/Items/Gems/SkillGemVolcanicFissure",
+		variantId = "VolcanicFissure",
 		grantedEffectId = "VolcanicFissure",
 		tags = {
 			melee = true,
@@ -11321,6 +12661,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemVolcanicFissureAltX"] = {
 		name = "Volcanic Fissure of Snaking",
+		gameId = "Metadata/Items/Gems/SkillGemVolcanicFissure",
+		variantId = "VolcanicFissureAltX",
 		grantedEffectId = "VolcanicFissureAltX",
 		tags = {
 			melee = true,
@@ -11339,6 +12681,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemVaalVolcanicFissure"] = {
 		name = "Vaal Volcanic Fissure",
+		gameId = "Metadata/Items/Gems/SkillGemVaalVolcanicFissure",
+		variantId = "VaalVolcanicFissure",
 		grantedEffectId = "VaalVolcanicFissure",
 		secondaryGrantedEffectId = "VolcanicFissure",
 		vaalGem = true,
@@ -11361,6 +12705,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemFrozenLegion"] = {
 		name = "Frozen Legion",
+		gameId = "Metadata/Items/Gems/SkillGemFrozenLegion",
+		variantId = "FrozenLegion",
 		grantedEffectId = "FrozenLegion",
 		secondaryGrantedEffectId = "FrozenSweep",
 		tags = {
@@ -11380,6 +12726,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemFrozenLegionAltX"] = {
 		name = "Frozen Legion of Rallying",
+		gameId = "Metadata/Items/Gems/SkillGemFrozenLegion",
+		variantId = "FrozenLegionAltX",
 		grantedEffectId = "FrozenLegionAltX",
 		secondaryGrantedEffectId = "FrozenSweepAltX",
 		tags = {
@@ -11399,6 +12747,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemVaalCleave"] = {
 		name = "Vaal Cleave",
+		gameId = "Metadata/Items/Gems/SkillGemVaalCleave",
+		variantId = "VaalCleave",
 		grantedEffectId = "VaalCleave",
 		secondaryGrantedEffectId = "Cleave",
 		vaalGem = true,
@@ -11420,6 +12770,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemVaalCausticArrow"] = {
 		name = "Vaal Caustic Arrow",
+		gameId = "Metadata/Items/Gems/SkillGemVaalCausticArrow",
+		variantId = "VaalCausticArrow",
 		grantedEffectId = "VaalCausticArrow",
 		secondaryGrantedEffectId = "PoisonArrow",
 		vaalGem = true,
@@ -11442,6 +12794,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemVaalMoltenStrike"] = {
 		name = "Vaal Molten Strike",
+		gameId = "Metadata/Items/Gems/SkillGemVaalMoltenStrike",
+		variantId = "VaalMoltenStrike",
 		grantedEffectId = "VaalMoltenStrike",
 		secondaryGrantedEffectId = "MoltenStrike",
 		vaalGem = true,
@@ -11465,6 +12819,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemCursedGroundSupport"] = {
 		name = "Cursed Ground",
+		gameId = "Metadata/Items/Gems/SupportGemCursedGround",
+		variantId = "CursedGroundSupport",
 		grantedEffectId = "SupportCursedGround",
 		tags = {
 			area = true,
@@ -11481,6 +12837,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemHexBloomSupport"] = {
 		name = "Hex Bloom",
+		gameId = "Metadata/Items/Gems/SupportGemHexBloom",
+		variantId = "HexBloomSupport",
 		grantedEffectId = "SupportHexBloom",
 		tags = {
 			intelligence = true,
@@ -11495,6 +12853,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemVaalVenomGyre"] = {
 		name = "Vaal Venom Gyre",
+		gameId = "Metadata/Items/Gems/SkillGemVaalVenomGyre",
+		variantId = "VaalVenomGyre",
 		grantedEffectId = "VaalSnappingAdder",
 		secondaryGrantedEffectId = "SnappingAdder",
 		vaalGem = true,
@@ -11515,6 +12875,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemVaalSmite"] = {
 		name = "Vaal Smite",
+		gameId = "Metadata/Items/Gems/SkillGemVaalSmite",
+		variantId = "VaalSmite",
 		grantedEffectId = "VaalSmite",
 		secondaryGrantedEffectId = "Smite",
 		vaalGem = true,
@@ -11538,6 +12900,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemVaalChargedAttack"] = {
 		name = "Vaal Blade Flurry",
+		gameId = "Metadata/Items/Gems/SkillGemVaalChargedAttack",
+		variantId = "VaalChargedAttack",
 		grantedEffectId = "VaalChargedAttack",
 		secondaryGrantedEffectId = "ChargedAttack",
 		vaalGem = true,
@@ -11559,6 +12923,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemVaalReap"] = {
 		name = "Vaal Reap",
+		gameId = "Metadata/Items/Gems/SkillGemVaalReap",
+		variantId = "VaalReap",
 		grantedEffectId = "VaalReap",
 		secondaryGrantedEffectId = "Bloodreap",
 		vaalGem = true,
@@ -11579,6 +12945,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemVaalAnimateWeapon"] = {
 		name = "Vaal Animate Weapon",
+		gameId = "Metadata/Items/Gems/SkillGemVaalAnimateWeapon",
+		variantId = "VaalAnimateWeapon",
 		grantedEffectId = "VaalAnimateWeapon",
 		secondaryGrantedEffectId = "AnimateWeapon",
 		vaalGem = true,
@@ -11599,6 +12967,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemVaalLightningArrow"] = {
 		name = "Vaal Lightning Arrow",
+		gameId = "Metadata/Items/Gems/SkillGemVaalLightningArrow",
+		variantId = "VaalLightningArrow",
 		grantedEffectId = "VaalLightningArrow",
 		secondaryGrantedEffectId = "LightningArrow",
 		vaalGem = true,
@@ -11620,6 +12990,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemVaalAbsolution"] = {
 		name = "Vaal Absolution",
+		gameId = "Metadata/Items/Gems/SkillGemVaalAbsolution",
+		variantId = "VaalAbsolution",
 		grantedEffectId = "VaalAbsolution",
 		secondaryGrantedEffectId = "Absolution",
 		vaalGem = true,
@@ -11642,6 +13014,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemVaalDomination"] = {
 		name = "Vaal Domination",
+		gameId = "Metadata/Items/Gems/SkillGemVaalDomination",
+		variantId = "VaalDomination",
 		grantedEffectId = "VaalDomination",
 		secondaryGrantedEffectId = "DominatingBlow",
 		vaalGem = true,
@@ -11664,6 +13038,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemVaalIceShot"] = {
 		name = "Vaal Ice Shot",
+		gameId = "Metadata/Items/Gems/SkillGemVaalIceShot",
+		variantId = "VaalIceShot",
 		grantedEffectId = "VaalIceShot",
 		secondaryGrantedEffectId = "IceShot",
 		vaalGem = true,
@@ -11686,6 +13062,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemVaalFirestorm"] = {
 		name = "Vaal Firestorm",
+		gameId = "Metadata/Items/Gems/SkillGemVaalFirestorm",
+		variantId = "VaalFirestorm",
 		grantedEffectId = "VaalFirestorm",
 		secondaryGrantedEffectId = "Firestorm",
 		vaalGem = true,
@@ -11706,6 +13084,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemVaalRejuvenationTotem"] = {
 		name = "Vaal Rejuvenation Totem",
+		gameId = "Metadata/Items/Gems/SkillGemVaalRejuvenationTotem",
+		variantId = "VaalRejuvenationTotem",
 		grantedEffectId = "VaalRejuvenationTotem",
 		secondaryGrantedEffectId = "RejuvenationTotem",
 		vaalGem = true,
@@ -11726,6 +13106,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemManaforgedArrowsSupport"] = {
 		name = "Manaforged Arrows",
+		gameId = "Metadata/Items/Gems/SupportGemManaforgedArrows",
+		variantId = "ManaforgedArrowsSupport",
 		grantedEffectId = "SupportManaforgedArrows",
 		tags = {
 			bow = true,
@@ -11741,6 +13123,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemPrismaticBurstSupport"] = {
 		name = "Prismatic Burst",
+		gameId = "Metadata/Items/Gems/SupportGemPrismaticBurst",
+		variantId = "PrismaticBurstSupport",
 		grantedEffectId = "SupportPrismaticBurst",
 		secondaryGrantedEffectId = "PrismaticBurst",
 		tags = {
@@ -11763,6 +13147,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemChannelledSnipe"] = {
 		name = "Snipe",
+		gameId = "Metadata/Items/Gems/SkillGemChannelledSnipe",
+		variantId = "ChannelledSnipe",
 		grantedEffectId = "ChannelledSnipe",
 		secondaryGrantedEffectId = "ChannelledSnipeSupport",
 		secondaryEffectName = "Snipe Support",
@@ -11783,6 +13169,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemQuickstep"] = {
 		name = "Quickstep",
+		gameId = "Metadata/Items/Gems/SkillGemQuickstep",
+		variantId = "Quickstep",
 		grantedEffectId = "QuickstepHardMode",
 		tags = {
 			grants_active_skill = true,
@@ -11799,6 +13187,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemTraumaSupport"] = {
 		name = "Trauma",
+		gameId = "Metadata/Items/Gems/SupportGemTrauma",
+		variantId = "TraumaSupport",
 		grantedEffectId = "SupportTrauma",
 		tags = {
 			physical = true,
@@ -11817,6 +13207,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemSpellbladeSupport"] = {
 		name = "Spellblade",
+		gameId = "Metadata/Items/Gems/SupportGemSpellblade",
+		variantId = "SpellbladeSupport",
 		grantedEffectId = "SupportSpellblade",
 		tags = {
 			intelligence = true,
@@ -11831,6 +13223,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemDevourSupport"] = {
 		name = "Devour",
+		gameId = "Metadata/Items/Gems/SupportGemDevour",
+		variantId = "DevourSupport",
 		grantedEffectId = "SupportDevour",
 		tags = {
 			intelligence = true,
@@ -11844,6 +13238,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemFreshMeatSupport"] = {
 		name = "Fresh Meat",
+		gameId = "Metadata/Items/Gems/SupportGemFreshMeat",
+		variantId = "FreshMeatSupport",
 		grantedEffectId = "SupportFreshMeat",
 		tags = {
 			critical = true,
@@ -11859,6 +13255,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemFlamewoodSupport"] = {
 		name = "Flamewood",
+		gameId = "Metadata/Items/Gems/SupportGemFlamewood",
+		variantId = "FlamewoodSupport",
 		grantedEffectId = "SupportFlamewood",
 		secondaryGrantedEffectId = "AvengingFlame",
 		tags = {
@@ -11880,6 +13278,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemCorruptingCrySupport"] = {
 		name = "Corrupting Cry",
+		gameId = "Metadata/Items/Gems/SupportGemCorruptingCry",
+		variantId = "CorruptingCrySupport",
 		grantedEffectId = "SupportCorruptingCry",
 		tags = {
 			area = true,
@@ -11897,6 +13297,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemGuardiansBlessingSupport"] = {
 		name = "Guardian's Blessing",
+		gameId = "Metadata/Items/Gems/SupportGemGuardiansBlessing",
+		variantId = "GuardiansBlessingSupport",
 		grantedEffectId = "SupportGuardiansBlessing",
 		secondaryGrantedEffectId = "SupportGuardiansBlessingMinion",
 		tags = {
@@ -11914,6 +13316,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemSacrificeSupport"] = {
 		name = "Sacrifice",
+		gameId = "Metadata/Items/Gems/SupportGemSacrifice",
+		variantId = "SacrificeSupport",
 		grantedEffectId = "SupportSacrifice",
 		tags = {
 			chaos = true,
@@ -11929,6 +13333,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemFrigidBondSupport"] = {
 		name = "Frigid Bond",
+		gameId = "Metadata/Items/Gems/SupportGemFrigidBond",
+		variantId = "FrigidBondSupport",
 		grantedEffectId = "SupportFrigidBond",
 		tags = {
 			cold = true,
@@ -11945,6 +13351,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemLocusMineSupport"] = {
 		name = "Locus Mine",
+		gameId = "Metadata/Items/Gems/SupportGemLocusMine",
+		variantId = "LocusMineSupport",
 		grantedEffectId = "SupportLocusMine",
 		tags = {
 			bow = true,
@@ -11962,6 +13370,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemSadismSupport"] = {
 		name = "Sadism",
+		gameId = "Metadata/Items/Gems/SupportGemSadism",
+		variantId = "SadismSupport",
 		grantedEffectId = "SupportSadism",
 		tags = {
 			dexterity = true,
@@ -11975,6 +13385,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemControlledBlazeSupport"] = {
 		name = "Controlled Blaze",
+		gameId = "Metadata/Items/Gems/SupportGemControlledBlaze",
+		variantId = "ControlledBlazeSupport",
 		grantedEffectId = "SupportControlledBlaze",
 		tags = {
 			fire = true,
@@ -11991,6 +13403,8 @@ return {
 	},
 	["Metadata/Items/Gems/SkillGemVolatilitySupport"] = {
 		name = "Volatility",
+		gameId = "Metadata/Items/Gems/SupportGemVolatility",
+		variantId = "VolatilitySupport",
 		grantedEffectId = "SupportVolatility",
 		tags = {
 			attack = true,

--- a/src/Export/Scripts/skills.lua
+++ b/src/Export/Scripts/skills.lua
@@ -628,6 +628,8 @@ for skillGem in dat("SkillGems"):Rows() do
 		if gems[gemEffect.Id] then
 			out:write('\t["', "Metadata/Items/Gems/SkillGem" .. gemEffect.Id, '"] = {\n')
 			out:write('\t\tname = "', fullNameGems[skillGem.BaseItemType.Id] and skillGem.BaseItemType.Name or trueGemNames[gemEffect.Id] or skillGem.BaseItemType.Name:gsub(" Support",""), '",\n')
+			out:write('\t\tgameId = "', skillGem.BaseItemType.Id, '",\n')
+			out:write('\t\tvariantId = "', gemEffect.Id, '",\n')
 			out:write('\t\tgrantedEffectId = "', gemEffect.GrantedEffect.Id, '",\n')
 			if gemEffect.GrantedEffect2 then
 				out:write('\t\tsecondaryGrantedEffectId = "', gemEffect.GrantedEffect2.Id, '",\n')

--- a/src/Modules/Data.lua
+++ b/src/Modules/Data.lua
@@ -835,10 +835,13 @@ end
 data.gems = LoadModule("Data/Gems")
 data.gemForSkill = { }
 data.gemForBaseName = { }
+data.gemsByGameId = { }
 local function setupGem(gem, gemId)
 	gem.id = gemId
 	gem.grantedEffect = data.skills[gem.grantedEffectId]
 	data.gemForSkill[gem.grantedEffect] = gemId
+	data.gemsByGameId[gem.gameId] = data.gemsByGameId[gem.gameId] or {}
+	data.gemsByGameId[gem.gameId][gem.variantId] = gem
 	local baseName = gem.name
 	if gem.grantedEffect.support and gem.grantedEffectId ~= "SupportBarrage" then
 		baseName = baseName .. " Support"


### PR DESCRIPTION
Uses the Path of Exile `BaseItemType.Id` for the `gemId` save format attribute in the `<Gem>` element as it always has been. The `skillId` attribute is also kept and maps to the gem's variant primary `GrantedEffect.Id`. Adds a new attribute called `variantId` that maps to the variant of the gem (`GemVariants[n].Id`), eg. Arc, ArcAltX, or ArcAltY. This is to help identify which variant is used rather than relying on every gem variant having its own unique granted effect.

During loading if there is no (known) `gemId` or `variantId` it falls back to looking at `skillId` and eventually by name, as before.

For the a lot of gems `skillId` and `variantId` are the same but it is not true for every case, especially support gems.

Hopefully by relying on the game's identifiers rather than the internal key of the `Data/Gems.lua` table we are both more free to refactor the internals of the application as well as being more aligned with how the game identifies gems and their variants. It should also make it easier for 3rd party developers to understand which skill gems are used.

