### PR TITLE
Fix Crash when using the Adorned and items with abyssal sockets

### DIFF
--- a/src/Modules/CalcSetup.lua
+++ b/src/Modules/CalcSetup.lua
@@ -952,7 +952,7 @@ function calcs.initEnv(build, mode, override, specEnv)
 						combinedList:MergeMod(mod)
 					end
 					env.itemModDB:ScaleAddList(combinedList, scale)
-				elseif item.type == "Jewel" and item.rarity == "MAGIC" and item.corrupted and env.modDB.multipliers["CorruptedMagicJewelEffect"] and not (item.base.subType == "Charm" or env.build.spec.nodes[tonumber(slot.nodeId)].expansionJewel) then
+				elseif env.modDB.multipliers["CorruptedMagicJewelEffect"] and item.type == "Jewel" and item.rarity == "MAGIC" and item.corrupted and not (item.base.subType == "Charm" or slot.nodeId and env.build.spec.nodes[tonumber(slot.nodeId)].expansionJewel) then
 					scale = scale + env.modDB.multipliers["CorruptedMagicJewelEffect"]
 					env.itemModDB:ScaleAddList(srcList, scale)
 				else


### PR DESCRIPTION
The code was crashing as it was not making sure that the jewel socket was from the tree before trying to check if it was an expansion jewel socket.
Also moved the multiplier check first, as it is pointless to have the jewel and rarity check if The Adorned is not in the build in the first place
