### PR TITLE
Fix Lacerate of Haemorrhage "more damage with Bleeding" using increased

### DIFF
--- a/src/Data/SkillStatMap.lua
+++ b/src/Data/SkillStatMap.lua
@@ -1028,7 +1028,7 @@ return {
 	mod("Damage", "INC", nil, 0, KeywordFlag.Bleed),
 },
 ["active_skill_bleeding_damage_+%_final"] = {
-	mod("Damage", "INC", nil, 0, KeywordFlag.Bleed),
+	mod("Damage", "MORE", nil, 0, KeywordFlag.Bleed),
 },
 ["active_skill_bleeding_damage_+%_final_in_blood_stance"] = {
 	mod("Damage", "MORE", nil, 0, KeywordFlag.Bleed, { type = "Condition", var = "BloodStance" }),


### PR DESCRIPTION
fixes #7076

### Description of the problem being solved:
SkillStatMap for More bleed damage was set as increased damage. 
Simple change from `INC` to `MORE`

