### PR TITLE
Fix catalysts not working correctly on Replica Dragonfang's Flight

### DIFF
--- a/src/Data/Uniques/amulet.lua
+++ b/src/Data/Uniques/amulet.lua
@@ -861,9 +861,9 @@ Variant: Pre 3.23.0
 Variant: Current
 LevelReq: 56
 Implicits: 1
-+(10-16) to all Attributes
-{variant:1}+(10-15)% to all Elemental Resistances
-{variant:2}+(5-10)% to all Elemental Resistances
+{tags: jewellery_attribute}+(10-16) to all Attributes
+{variant:1}{tags:jewellery_resistance}+(10-15)% to all Elemental Resistances
+{variant:2}{tags:jewellery_resistance}+(5-10)% to all Elemental Resistances
 +3 to Level of all Spark Gems
 {variant:1}(10-15)% increased Reservation Efficiency of Skills
 {variant:2}(5-10)% increased Reservation Efficiency of Skills


### PR DESCRIPTION
Fixes #7064 .

### Description of the problem being solved:
Replica Dragonfang's Flight was missing tags on the mod lines. Added so that the catalyst dropdown/slider will trigger.

### After screenshot:
![image](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/42928828/90c4af5a-1e28-4737-ac23-ff0bbf52dacd)
