### PR TITLE
Fix tooltip for Summon Chaos Golem of the Maelstrom

### DIFF
--- a/src/Classes/ImportTab.lua
+++ b/src/Classes/ImportTab.lua
@@ -740,8 +740,8 @@ function ImportTabClass:ImportItem(itemData, slotName)
 	-- Determine rarity, display name and base type of the item
 	item.rarity = rarityMap[itemData.frameType]
 	if #itemData.name > 0 then
-		item.title = itemLib.sanitiseItemText(itemData.name)
-		item.baseName = itemLib.sanitiseItemText(itemData.typeLine):gsub("Synthesised ","")
+		item.title = sanitiseText(itemData.name)
+		item.baseName = sanitiseText(itemData.typeLine):gsub("Synthesised ","")
 		item.name = item.title .. ", " .. item.baseName
 		if item.baseName == "Two-Toned Boots" then
 			-- Hack for Two-Toned Boots
@@ -754,7 +754,7 @@ function ImportTabClass:ImportItem(itemData, slotName)
 			ConPrintf("Unrecognised base in imported item: %s", item.baseName)
 		end
 	else
-		item.name = itemLib.sanitiseItemText(itemData.typeLine)
+		item.name = sanitiseText(itemData.typeLine)
 		if item.name:match("Energy Blade") then
 			local oneHanded = false
 			for _, p in ipairs(itemData.properties) do

--- a/src/Classes/Item.lua
+++ b/src/Classes/Item.lua
@@ -52,7 +52,7 @@ local influenceInfo = itemLib.influenceInfo
 
 local ItemClass = newClass("Item", function(self, raw, rarity, highQuality)
 	if raw then
-		self:ParseRaw(itemLib.sanitiseItemText(raw), rarity, highQuality)
+		self:ParseRaw(sanitiseText(raw), rarity, highQuality)
 	end	
 end)
 

--- a/src/Classes/ItemsTab.lua
+++ b/src/Classes/ItemsTab.lua
@@ -2016,7 +2016,7 @@ function ItemsTabClass:EditDisplayItemText(alsoAddItem)
 		controls.rarity.selIndex = 3
 	end
 	controls.edit.font = "FIXED"
-	controls.edit.pasteFilter = itemLib.sanitiseItemText
+	controls.edit.pasteFilter = sanitiseText
 	controls.save = new("ButtonControl", nil, -45, 470, 80, 20, self.displayItem and "Save" or "Create", function()
 		local id = self.displayItem and self.displayItem.id
 		self:CreateDisplayItemFromRaw(buildRaw(), not self.displayItem)

--- a/src/Classes/SkillsTab.lua
+++ b/src/Classes/SkillsTab.lua
@@ -271,6 +271,7 @@ end)
 
 -- parse real gem name and quality by omitting the first word if alt qual is set
 function SkillsTabClass:GetBaseNameAndQuality(gemTypeLine, quality)
+	gemTypeLine = sanitiseText(gemTypeLine)
 	-- if quality is default or nil check the gem type line if we have alt qual by comparing to the existing list
 	if gemTypeLine and (quality == nil or quality == "" or quality == "Default") then
 		local firstword, otherwords = gemTypeLine:match("(%w+)%s(.+)")

--- a/src/Classes/SkillsTab.lua
+++ b/src/Classes/SkillsTab.lua
@@ -307,7 +307,7 @@ function SkillsTabClass:LoadSkill(node, skillSetId)
 	socketGroup.gemList = { }
 	for _, child in ipairs(node) do
 		local gemInstance = { }
-		gemInstance.nameSpec = child.attrib.nameSpec or ""
+		gemInstance.nameSpec = sanitiseText(child.attrib.nameSpec or "")
 		if child.attrib.gemId then
 			local gemData
 			local possibleVariants = self.build.data.gemsByGameId[child.attrib.gemId]
@@ -560,7 +560,7 @@ function SkillsTabClass:CopySocketGroup(socketGroup)
 end
 
 function SkillsTabClass:PasteSocketGroup(testInput)
-	local skillText = Paste() or testInput
+	local skillText = sanitiseText(Paste() or testInput)
 	if skillText then
 		local newGroup = { label = "", enabled = true, gemList = { } }
 		local label = skillText:match("Label: (%C+)")

--- a/src/Modules/Common.lua
+++ b/src/Modules/Common.lua
@@ -231,6 +231,34 @@ function convertUTF8to16(text, offset)
 	return table.concat(out)
 end
 
+--- Clean item text by removing or replacing unsupported or redundant characters or sequences
+---@param text string
+---@return string
+function sanitiseText(text)
+	if not text then return nil end
+	-- Something something unicode support something grumble
+	-- Only do these replacements if a char from 128-255 or '<' is found first
+	return text:find("[\128-\255<]") and text
+		:gsub("%b<>", "")
+		:gsub("\226\128\144", "-") -- U+2010 HYPHEN
+		:gsub("\226\128\145", "-") -- U+2011 NON-BREAKING HYPHEN
+		:gsub("\226\128\146", "-") -- U+2012 FIGURE DASH
+		:gsub("\226\128\147", "-") -- U+2013 EN DASH
+		:gsub("\226\128\148", "-") -- U+2014 EM DASH
+		:gsub("\226\128\149", "-") -- U+2015 HORIZONTAL BAR
+		:gsub("\226\136\146", "-") -- U+2212 MINUS SIGN
+		:gsub("\195\164", "a") -- U+00E4 LATIN SMALL LETTER A WITH DIAERESIS
+		:gsub("\195\182", "o") -- U+00F6 LATIN SMALL LETTER O WITH DIAERESIS
+		-- single-byte: Windows-1252 and similar
+		:gsub("\150", "-") -- U+2013 EN DASH
+		:gsub("\151", "-") -- U+2014 EM DASH
+		:gsub("\228", "a") -- U+00E4 LATIN SMALL LETTER A WITH DIAERESIS
+		:gsub("\246", "o") -- U+00F6 LATIN SMALL LETTER O WITH DIAERESIS
+		-- unsupported
+		:gsub("[\128-\255]", "?")
+		or text
+end
+
 do
 	local function toUnsigned(val)
 		return val < 0 and val + 0x100000000 or val

--- a/src/Modules/Data.lua
+++ b/src/Modules/Data.lua
@@ -799,6 +799,7 @@ for _, type in pairs(skillTypes) do
 	LoadModule("Data/Skills/"..type, data.skills, makeSkillMod, makeFlagMod, makeSkillDataMod)
 end
 for skillId, grantedEffect in pairs(data.skills) do
+	grantedEffect.name = sanitiseText(grantedEffect.name)
 	grantedEffect.id = skillId
 	grantedEffect.modSource = "Skill:"..skillId
 	-- Add sources for skill mods, and check for global effects
@@ -856,6 +857,7 @@ local function setupGem(gem, gemId)
 end
 
 for gemId, gem in pairs(data.gems) do
+	gem.name = sanitiseText(gem.name)
 	setupGem(gem, gemId)
 	local loc, _ = gemId:find('Vaal')
 	for _, alt in ipairs{"AltX", "AltY"} do

--- a/src/Modules/ItemTools.lua
+++ b/src/Modules/ItemTools.lua
@@ -109,33 +109,6 @@ function itemLib.applyRange(line, range, valueScalar)
 	return itemLib.applyValueScalar(line, valueScalar, numbers, precision)
 end
 
---- Clean item text by removing or replacing unsupported or redundant characters or sequences
----@param text string
----@return string
-function itemLib.sanitiseItemText(text)
-	-- Something something unicode support something grumble
-	-- Only do these replacements if a char from 128-255 or '<' is found first
-	return text:find("[\128-\255<]") and text
-		:gsub("%b<>", "")
-		:gsub("\226\128\144", "-") -- U+2010 HYPHEN
-		:gsub("\226\128\145", "-") -- U+2011 NON-BREAKING HYPHEN
-		:gsub("\226\128\146", "-") -- U+2012 FIGURE DASH
-		:gsub("\226\128\147", "-") -- U+2013 EN DASH
-		:gsub("\226\128\148", "-") -- U+2014 EM DASH
-		:gsub("\226\128\149", "-") -- U+2015 HORIZONTAL BAR
-		:gsub("\226\136\146", "-") -- U+2212 MINUS SIGN
-		:gsub("\195\164", "a") -- U+00E4 LATIN SMALL LETTER A WITH DIAERESIS
-		:gsub("\195\182", "o") -- U+00F6 LATIN SMALL LETTER O WITH DIAERESIS
-		-- single-byte: Windows-1252 and similar
-		:gsub("\150", "-") -- U+2013 EN DASH
-		:gsub("\151", "-") -- U+2014 EM DASH
-		:gsub("\228", "a") -- U+00E4 LATIN SMALL LETTER A WITH DIAERESIS
-		:gsub("\246", "o") -- U+00F6 LATIN SMALL LETTER O WITH DIAERESIS
-		-- unsupported
-		:gsub("[\128-\255]", "?")
-		or text
-end
-
 function itemLib.formatModLine(modLine, dbMode)
 	local line = (not dbMode and modLine.range and itemLib.applyRange(modLine.line, modLine.range, modLine.valueScalar)) or modLine.line
 	if line:match("^%+?0%%? ") or (line:match(" %+?0%%? ") and not line:match("0 to [1-9]")) or line:match(" 0%-0 ") or line:match(" 0 to 0 ") then -- Hack to hide 0-value modifiers


### PR DESCRIPTION
### Description of the problem being solved:
Chaos Golem of Malestorm was using a special character that can't be rendered.

### Steps taken to verify a working solution:
- Load a file with malestorm old saved
- Paste a malestorm gem
- Add a maelstorm gem in skillTab.
- Import character

### Before screenshot:
![image](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/31533893/68dde052-c19d-4dcc-a29f-58b7d517903a)

### After screenshot:
![image](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/31533893/343579d8-6655-4d05-bdda-39ec4a046430)
