### PR TITLE
Fix Flicker Strike DPS being limited by cooldown

### DIFF
--- a/src/Modules/ConfigOptions.lua
+++ b/src/Modules/ConfigOptions.lua
@@ -329,10 +329,6 @@ return {
 	{ var = "ColdSnapBypassCD", type = "check", label = "Bypass CD?", ifSkill = { "Cold Snap", "Cold Snap of Power" }, apply = function(val, modList, enemyModList)
 		modList:NewMod("CooldownRecovery", "OVERRIDE", 0, "Config", { type = "SkillName", skillNameList = { "Cold Snap", "Cold Snap of Power" } })
 	end },
-	{ label = "Flicker Strike:", ifSkill = { "Flicker Strike", "Flicker Strike of Power" } },
-	{ var = "FlickerStrikeBypassCD", type = "check", label = "Bypass CD?", ifSkill = { "Flicker Strike", "Flicker Strike of Power" }, defaultState = true, apply = function(val, modList, enemyModList)
-		modList:NewMod("CooldownRecovery", "OVERRIDE", 0, "Config", { type = "SkillName", skillNameList = { "Flicker Strike", "Flicker Strike of Power" } })
-	end },
 	{ label = "Consecrated Path of Endurance:", ifSkill = "Consecrated Path of Endurance" },
 	{ var = "ConcPathBypassCD", type = "check", label = "Bypass CD?", ifSkill = "Consecrated Path of Endurance", defaultState = true, apply = function(val, modList, enemyModList)
 		modList:NewMod("CooldownRecovery", "OVERRIDE", 0, "Config", { type = "SkillName", skillName = "Consecrated Path of Endurance" })
@@ -392,6 +388,10 @@ return {
 	{ label = "Flame Wall:", ifSkill = "Flame Wall" },
 	{ var = "flameWallAddedDamage", type = "check", label = "Projectile Travelled through Flame Wall?", ifSkill = "Flame Wall", apply = function(val, modList, enemyModList)
 		modList:NewMod("Condition:FlameWallAddedDamage", "FLAG", true, "Config")
+	end },
+	{ label = "Flicker Strike:", ifSkill = { "Flicker Strike", "Flicker Strike of Power" } },
+	{ var = "FlickerStrikeBypassCD", type = "check", label = "Bypass CD?", ifSkill = { "Flicker Strike", "Flicker Strike of Power" }, defaultState = true, apply = function(val, modList, enemyModList)
+		modList:NewMod("CooldownRecovery", "OVERRIDE", 0, "Config", { type = "SkillName", skillNameList = { "Flicker Strike", "Flicker Strike of Power" } })
 	end },
 	{ label = "Fresh Meat:", ifSkill = "Fresh Meat" },
 	{ var = "freshMeatBuffs", type = "check", label = "Is Fresh Meat active?", ifSkill = "Fresh Meat", apply = function(val, modList, enemyModList)

--- a/src/Modules/ConfigOptions.lua
+++ b/src/Modules/ConfigOptions.lua
@@ -329,8 +329,12 @@ return {
 	{ var = "ColdSnapBypassCD", type = "check", label = "Bypass CD?", ifSkill = { "Cold Snap", "Cold Snap of Power" }, apply = function(val, modList, enemyModList)
 		modList:NewMod("CooldownRecovery", "OVERRIDE", 0, "Config", { type = "SkillName", skillNameList = { "Cold Snap", "Cold Snap of Power" } })
 	end },
+	{ label = "Flicker Strike:", ifSkill = { "Flicker Strike", "Flicker Strike of Power" } },
+	{ var = "FlickerStrikeBypassCD", type = "check", label = "Bypass CD?", ifSkill = { "Flicker Strike", "Flicker Strike of Power" }, defaultState = true, apply = function(val, modList, enemyModList)
+		modList:NewMod("CooldownRecovery", "OVERRIDE", 0, "Config", { type = "SkillName", skillNameList = { "Flicker Strike", "Flicker Strike of Power" } })
+	end },
 	{ label = "Consecrated Path of Endurance:", ifSkill = "Consecrated Path of Endurance" },
-	{ var = "ConcPathBypassCD", type = "check", label = "Bypass CD?", ifSkill = "Consecrated Path of Endurance", apply = function(val, modList, enemyModList)
+	{ var = "ConcPathBypassCD", type = "check", label = "Bypass CD?", ifSkill = "Consecrated Path of Endurance", defaultState = true, apply = function(val, modList, enemyModList)
 		modList:NewMod("CooldownRecovery", "OVERRIDE", 0, "Config", { type = "SkillName", skillName = "Consecrated Path of Endurance" })
 	end },
 	{ label = "Corrupting Cry:", ifSkill = "Corrupting Cry" },


### PR DESCRIPTION
Fixes #7066.

### Changes:
Add cooldown bypass option for flicker strike in config and set default to true.
Set default for consecrated path of endurance bypass cd to true. 

### Steps taken to verify a working solution:
Tested build in linked issue

### After screenshot:
![image](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/42928828/989d141d-da15-4fb7-886e-c3dcc0745271)
