### PR TITLE
Fix Vaal gems loading incorrect variant after reopening a build

### DIFF
--- a/src/Classes/SkillsTab.lua
+++ b/src/Classes/SkillsTab.lua
@@ -312,7 +312,7 @@ function SkillsTabClass:LoadSkill(node, skillSetId)
 			local gemData
 			local possibleVariants = self.build.data.gemsByGameId[child.attrib.gemId]
 			if possibleVariants then
-				-- If it is a known game, try to determine which variant is used
+				-- If it is a known gem, try to determine which variant is used
 				if child.attrib.variantId then
 					-- New save format from 3.23 that stores the specific variation (transfiguration)
 					gemData = possibleVariants[child.attrib.variantId]

--- a/src/Modules/Data.lua
+++ b/src/Modules/Data.lua
@@ -863,6 +863,7 @@ for gemId, gem in pairs(data.gems) do
 			local newGem = copyTable(gem, true)
 			newGem.name = "Vaal " .. data.skills[gem.secondaryGrantedEffectId..alt].name
 			newGem.secondaryGrantedEffectId = gem.secondaryGrantedEffectId..alt
+			newGem.variantId = gem.variantId..alt
 			--ConPrintf("Adding Gem: " .. newGem.name .. "\t" .. newGem.secondaryGrantedEffectId)
 			data.gems[gemId..alt] = newGem
 			setupGem(newGem, gemId..alt)


### PR DESCRIPTION
Fixes #7071 .

### Description of the problem being solved:
All vaal gems are defaulting to their last variant due to the way the variants are populated in `Data.lua`.
Updated the step to also set the variantId when generating the vaal variants.

### Steps taken to verify a working solution:
Resaved and loaded the build in question to verify it's working. 
