### PR TITLE
Revert preffered slot for Unseen Strike / Fix skillData nil crash

### DIFF
--- a/src/Data/Skills/other.lua
+++ b/src/Data/Skills/other.lua
@@ -3513,7 +3513,6 @@ skills["HiddenBlade"] = {
 	statDescriptionScope = "skill_stat_descriptions",
 	castTime = 1,
 	fromItem = true,
-	preferredSlotName = "Weapon 1",
 	baseFlags = {
 		attack = true,
 		projectile = true,

--- a/src/Export/Skills/other.txt
+++ b/src/Export/Skills/other.txt
@@ -984,7 +984,6 @@ local skills, mod, flag, skill = ...
 #skill HiddenBlade
 #flags attack projectile forceMainHand
 	fromItem = true,
-	preferredSlotName = "Weapon 1",
 #mods
 
 #skill VaalBreach

--- a/src/Modules/CalcSetup.lua
+++ b/src/Modules/CalcSetup.lua
@@ -624,7 +624,7 @@ function calcs.initEnv(build, mode, override, specEnv)
 					local grantedSkill = copyTable(skill)
 					grantedSkill.nameSpec = skillData and skillData.name or nil
 					grantedSkill.sourceItem = item
-					grantedSkill.slotName = skillData.preferredSlotName or slotName
+					grantedSkill.slotName = slotName
 					t_insert(env.grantedSkillsItems, grantedSkill)
 				end
 			end


### PR DESCRIPTION
Fixes #7083, #7070

### Description of the problem being solved:
Reverts forcing Unseen Strike to use main hand supports only added in #7038
