### PR TITLE
Fix The Adorned not applying to jewels in outer tree sockets

### DIFF
--- a/src/Modules/CalcSetup.lua
+++ b/src/Modules/CalcSetup.lua
@@ -952,7 +952,8 @@ function calcs.initEnv(build, mode, override, specEnv)
 						combinedList:MergeMod(mod)
 					end
 					env.itemModDB:ScaleAddList(combinedList, scale)
-				elseif env.modDB.multipliers["CorruptedMagicJewelEffect"] and item.type == "Jewel" and item.rarity == "MAGIC" and item.corrupted and not (item.base.subType == "Charm" or slot.nodeId and env.build.spec.nodes[tonumber(slot.nodeId)].expansionJewel) then
+				elseif env.modDB.multipliers["CorruptedMagicJewelEffect"] and item.type == "Jewel" and item.rarity == "MAGIC" and item.corrupted and slot.nodeId and
+							not (item.base.subType == "Charm" or env.build.spec.nodes[tonumber(slot.nodeId)].expansionJewel and env.build.spec.nodes[tonumber(slot.nodeId)].expansionJewel.parent) then
 					scale = scale + env.modDB.multipliers["CorruptedMagicJewelEffect"]
 					env.itemModDB:ScaleAddList(srcList, scale)
 				else


### PR DESCRIPTION
The check for if the jewel came from the tree was coupled to the check to see if it was an expansion jewel so it didn't stop the jewel applying to Abyssal sockets on gear
The only way I could see to get the jewel to apply to outer tree sockets was to make sure it didn't have a parent attribute in the expansionJewel attribute
Fixes #7079