### PR TITLE
Fix gem mods on Forbidden Shako not working correctly with Utula's Hunger

### DIFF
--- a/src/Modules/Data.lua
+++ b/src/Modules/Data.lua
@@ -697,6 +697,7 @@ data.itemTagSpecialExclusionPattern = {
 			"when on Full Life",
 			"Enemy's life",
 			"Life From You",
+			"^Socketed Gems are Supported by Level"
 		},
 	},
 	["evasion"] = {


### PR DESCRIPTION
### Description of the problem being solved:
Shako is currently disabling Utula's maximum life when it has a mod that has the word life in it including "Proliferation"
These mods only have the Gem tag. 

Hybrid mods from Shaper and Elder seem to have additional tags but these appear to be due to the other line that accompanies them.
E.g. Socketed Gems are Supported by Level X Minion Life (provides the gem tag)
Minions have X% increased maximum Life (hypothesis is that this provides the life and minion tag on the mod)

Proposed solution is to exclude all "socketed gems are supported by" mods from the Utula check.
It was also mentioned that hybrid mods are parsed as two separate lines anyway so the above minion life mod would still fail the Utula check. 

### Steps taken to verify a working solution:
- Checked Hiltless to confirm that socketed gems supported by lifetap has no life tag

### Before screenshot:
![image](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/42928828/84efddf1-b579-40e3-9bff-1187502b3d27)

### After screenshot:
![image](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/42928828/1eeba9dd-edc6-40f7-a2e2-78317f81d59f)
