### PR TITLE
Fix Frost Blades of Katabasis DoT not being scaled by area damage

### DIFF
--- a/src/Data/Skills/act_dex.lua
+++ b/src/Data/Skills/act_dex.lua
@@ -7606,10 +7606,36 @@ skills["FrostBladesAltX"] = {
 	},
 	statDescriptionScope = "skill_stat_descriptions",
 	castTime = 1,
+	parts = {
+		{
+			name = "Melee Hit",
+			attack = true,
+			melee = true,
+			projectile = true,
+			area = false,
+		},
+		{
+			name = "Ground DoT",
+			attack = false,
+			melee = false,
+			projectile = false,
+			area = true,
+		},
+	},
+	statMap = {
+		["base_cold_damage_to_deal_per_minute"] = {
+			skill("ColdDot", nil, { type = "SkillPart", skillPart = 2 }),
+			div = 60,
+		},
+	},
 	baseFlags = {
 		attack = true,
 		melee = true,
 		projectile = true,
+		area = true,
+	},
+	baseMods = {
+		skill("dotIsArea", true, { type = "SkillPart", skillPart = 2 }),
 	},
 	qualityStats = {
 		Default = {

--- a/src/Export/Skills/act_dex.txt
+++ b/src/Export/Skills/act_dex.txt
@@ -1630,7 +1630,30 @@ local skills, mod, flag, skill = ...
 #mods
 
 #skill FrostBladesAltX
-#flags attack melee projectile
+#flags attack melee projectile area
+	parts = {
+		{
+			name = "Melee Hit",
+			attack = true,
+			melee = true,
+			projectile = true,
+			area = false,
+		},
+		{
+			name = "Ground DoT",
+			attack = false,
+			melee = false,
+			projectile = false,
+			area = true,
+		},
+	},
+	statMap = {
+		["base_cold_damage_to_deal_per_minute"] = {
+			skill("ColdDot", nil, { type = "SkillPart", skillPart = 2 }),
+			div = 60,
+		},
+	},
+#baseMod skill("dotIsArea", true, { type = "SkillPart", skillPart = 2 })
 #mods
 
 #skill ShrapnelShot


### PR DESCRIPTION
The gem did not have the area tag on it.
I added it and separated the skill parts so area modifiers would not apply to the hit portion
Fixes #7091