### PR TITLE
Allow selectively matching variants for GemProperty mods

### DIFF
--- a/src/Modules/CalcSetup.lua
+++ b/src/Modules/CalcSetup.lua
@@ -274,12 +274,12 @@ local function applyGemMods(effect, modList)
 		local match = true
 		if value.keywordList then
 			for _, keyword in ipairs(value.keywordList) do
-				if not calcLib.gemIsType(effect.gemData, keyword) then
+				if not calcLib.gemIsType(effect.gemData, keyword, true) then
 					match = false
 					break
 				end
 			end
-		elseif not calcLib.gemIsType(effect.gemData, value.keyword) then
+		elseif not calcLib.gemIsType(effect.gemData, value.keyword, true) then
 			match = false
 		end
 		if match then

--- a/src/Modules/CalcTools.lua
+++ b/src/Modules/CalcTools.lua
@@ -101,7 +101,7 @@ function calcLib.canGrantedEffectSupportActiveSkill(grantedEffect, activeSkill)
 end
 
 -- Check if given gem is of the given type ("all", "strength", "melee", etc)
-function calcLib.gemIsType(gem, type)
+function calcLib.gemIsType(gem, type, allowVariants)
 	return (type == "all" or 
 			(type == "elemental" and (gem.tags.fire or gem.tags.cold or gem.tags.lightning)) or 
 			(type == "aoe" and gem.tags.area) or
@@ -110,6 +110,7 @@ function calcLib.gemIsType(gem, type)
 			(type == "non-vaal" and not gem.tags.vaal) or
 			(type == gem.name:lower()) or
 			(type == gem.name:lower():gsub("^vaal ", "")) or
+			(allowVariants and gem.name:lower():match("^" .. type:lower())) or
 			((type ~= "active skill" and type ~= "grants_active_skill" and type ~= "skill") and gem.tags[type]))
 end
 


### PR DESCRIPTION
Fixes #7069

### Description of the problem being solved:
`calcLib.gemIsType` looks for an exact name match to check if the mod can apply. This adds a parameter allowing to match gems that start with the name to match variants.