### PR TITLE
Fix Bodyswap of Sacrifice explosion not scaling correctly

### DIFF
--- a/src/Data/Skills/act_int.lua
+++ b/src/Data/Skills/act_int.lua
@@ -2344,6 +2344,14 @@ skills["CorpseWarpAltX"] = {
 		["spell_maximum_base_fire_damage"] = {
 			skill("FireMax", nil, { type = "SkillPart", skillPart = 1 }),
 		},
+		["spell_base_fire_damage_%_maximum_life"] = {
+			skill("selfFireExplosionLifeMultiplier", nil, { type = "SkillPart", skillPart = 1 }),
+			div = 100,
+		},
+		["skill_minion_explosion_life_%"] = {
+			skill("selfFireExplosionLifeMultiplier", nil, { type = "SkillPart", skillPart = 2 }),
+			div = 100,
+		},
 		["corpse_warp_area_of_effect_+%_final_when_consuming_minion"] = {
 			mod("AreaOfEffect", "MORE", nil, 0, 0, { type = "SkillPart", skillPart = 2 }),
 		},

--- a/src/Export/Skills/act_int.txt
+++ b/src/Export/Skills/act_int.txt
@@ -581,6 +581,14 @@ local skills, mod, flag, skill = ...
 		["spell_maximum_base_fire_damage"] = {
 			skill("FireMax", nil, { type = "SkillPart", skillPart = 1 }),
 		},
+		["spell_base_fire_damage_%_maximum_life"] = {
+			skill("selfFireExplosionLifeMultiplier", nil, { type = "SkillPart", skillPart = 1 }),
+			div = 100,
+		},
+		["skill_minion_explosion_life_%"] = {
+			skill("selfFireExplosionLifeMultiplier", nil, { type = "SkillPart", skillPart = 2 }),
+			div = 100,
+		},
 		["corpse_warp_area_of_effect_+%_final_when_consuming_minion"] = {
 			mod("AreaOfEffect", "MORE", nil, 0, 0, { type = "SkillPart", skillPart = 2 }),
 		},


### PR DESCRIPTION
The stats on the gem were also in the SkillStatMap so they were not being restricted to the skill parts they affect
