### PR TITLE
Fix Lancing Steel less damage multiplier only applying to Hits

### DIFF
--- a/src/Data/Skills/act_dex.lua
+++ b/src/Data/Skills/act_dex.lua
@@ -9174,7 +9174,7 @@ skills["LancingSteel"] = {
 			local percentReducedProjectiles = (output.ProjectileCount - 1) / output.ProjectileCount
 			local mult = (activeSkill.skillModList:More(activeSkill.skillCfg, "LancingSteelSubsequentDamage") - 1) * 100 * percentReducedProjectiles
 			activeSkill.skillData.dpsMultiplier = output.ProjectileCount
-			activeSkill.skillModList:NewMod("Damage", "MORE", mult, "Skill:LancingSteel", ModFlag.Hit)
+			activeSkill.skillModList:NewMod("Damage", "MORE", mult, "Skill:LancingSteel")
 		end
 	end,
 	parts = {
@@ -9281,7 +9281,7 @@ skills["LancingSteelAltX"] = {
 			local percentReducedProjectiles = (output.ProjectileCount - 1) / output.ProjectileCount
 			local mult = (activeSkill.skillModList:More(activeSkill.skillCfg, "LancingSteelSubsequentDamage") - 1) * 100 * percentReducedProjectiles
 			activeSkill.skillData.dpsMultiplier = output.ProjectileCount
-			activeSkill.skillModList:NewMod("Damage", "MORE", mult, "Skill:LancingSteelofSpraying", ModFlag.Hit)
+			activeSkill.skillModList:NewMod("Damage", "MORE", mult, "Skill:LancingSteelAltX", 0)
 		end
 	end,
 	parts = {

--- a/src/Data/Skills/act_dex.lua
+++ b/src/Data/Skills/act_dex.lua
@@ -9281,7 +9281,7 @@ skills["LancingSteelAltX"] = {
 			local percentReducedProjectiles = (output.ProjectileCount - 1) / output.ProjectileCount
 			local mult = (activeSkill.skillModList:More(activeSkill.skillCfg, "LancingSteelSubsequentDamage") - 1) * 100 * percentReducedProjectiles
 			activeSkill.skillData.dpsMultiplier = output.ProjectileCount
-			activeSkill.skillModList:NewMod("Damage", "MORE", mult, "Skill:LancingSteelAltX", 0)
+			activeSkill.skillModList:NewMod("Damage", "MORE", mult, "Skill:LancingSteelAltX")
 		end
 	end,
 	parts = {

--- a/src/Export/Skills/act_dex.txt
+++ b/src/Export/Skills/act_dex.txt
@@ -1482,10 +1482,10 @@ local skills, mod, flag, skill = ...
 		{
 			name = "One trap (bad placement)",
 		},
-		{ 
+		{
 			name = "Average # traps (good placement)",
 		},
-		{ 
+		{
 			name = "Average # traps (bad placement)",
 		},
 	},
@@ -1883,7 +1883,7 @@ local skills, mod, flag, skill = ...
 			local percentReducedProjectiles = (output.ProjectileCount - 1) / output.ProjectileCount
 			local mult = (activeSkill.skillModList:More(activeSkill.skillCfg, "LancingSteelSubsequentDamage") - 1) * 100 * percentReducedProjectiles
 			activeSkill.skillData.dpsMultiplier = output.ProjectileCount
-			activeSkill.skillModList:NewMod("Damage", "MORE", mult, "Skill:LancingSteel", ModFlag.Hit)
+			activeSkill.skillModList:NewMod("Damage", "MORE", mult, "Skill:LancingSteel")
 		end
 	end,
 	parts = {
@@ -1914,7 +1914,7 @@ local skills, mod, flag, skill = ...
 			local percentReducedProjectiles = (output.ProjectileCount - 1) / output.ProjectileCount
 			local mult = (activeSkill.skillModList:More(activeSkill.skillCfg, "LancingSteelSubsequentDamage") - 1) * 100 * percentReducedProjectiles
 			activeSkill.skillData.dpsMultiplier = output.ProjectileCount
-			activeSkill.skillModList:NewMod("Damage", "MORE", mult, "Skill:LancingSteelofSpraying", ModFlag.Hit)
+			activeSkill.skillModList:NewMod("Damage", "MORE", mult, "Skill:LancingSteelAltX")
 		end
 	end,
 	parts = {
@@ -2366,7 +2366,7 @@ local skills, mod, flag, skill = ...
 			name = "Release",
 			stages = true,
 		},
-		{ 
+		{
 			name = "Thorn Arrows",
 			stages = true,
 		},
@@ -3246,7 +3246,7 @@ local skills, mod, flag, skill = ...
 	statMap = {
 		["tornado_base_damage_interval_ms"] = {
 			skill("damageInterval", nil ),
-			div = 1000, 
+			div = 1000,
 		},
 	},
 #mods


### PR DESCRIPTION
Lancing steel less damage multiplier applies to both hit and ailment damage (for both regular and transfigured).
Also fixes Spraying tooltip as it was using wrong skill name as reference

See this for proof: https://www.reddit.com/r/PathOfExileBuilds/comments/18c3yc3/psa_pob_data_is_incorrect_lancing_steel_damage/

Pob:
https://pobb.in/mdmUQv-yXmrb
