### PR TITLE
Fix dual wield penalty on wand attacks

### DIFF
--- a/src/Modules/CalcTriggers.lua
+++ b/src/Modules/CalcTriggers.lua
@@ -428,7 +428,7 @@ local function defaultTriggerHandler(env, config)
 			end
 
 			--Dual wield
-			if trigRate and source and (source.skillTypes[SkillType.Melee] or source.skillTypes[SkillType.Attack]) and not source.skillTypes[SkillType.Channel] and not actor.mainSkill.skillFlags.globalTrigger then
+			if trigRate and source and (source.skillTypes[SkillType.Melee] or source.skillTypes[SkillType.Attack]) and not source.skillTypes[SkillType.Channel] and not ((not source.weaponTypes or (source.weaponTypes and source.weaponTypes["Wand"])) and source.skillTypes[SkillType.Attack]) and not actor.mainSkill.skillFlags.globalTrigger then
 				local dualWield = env.player.weaponData1.type and env.player.weaponData2.type
 				trigRate = dualWield and source.skillData.doubleHitsWhenDualWielding and trigRate * 2 or dualWield and trigRate / 2 or trigRate
 				if dualWield and breakdown then


### PR DESCRIPTION
Fixes issue mentioned on discord

### Description of the problem being solved:
Dual wield penalty was applied to skills triggered by wand attacks. https://pobb.in/6dv2xqiLSGRL
