### PR TITLE
Fix Vortex of Projection damage when cast on Frostbolt from increased to more

### DIFF
--- a/src/Data/Skills/act_int.lua
+++ b/src/Data/Skills/act_int.lua
@@ -17946,11 +17946,6 @@ skills["FrostBoltNova"] = {
 	preDamageFunc = function(activeSkill, output)
 		activeSkill.skillData.hitTimeOverride = output.Cooldown
 	end,
-	statMap = {
-		["active_skill_damage_+%_when_cast_on_frostbolt"] = {
-			mod("Damage", "INC", nil, 0, 0, { type = "Condition", var = "CastOnFrostbolt" }),
-		},
-	},
 	baseFlags = {
 		spell = true,
 		area = true,
@@ -18036,7 +18031,7 @@ skills["FrostBoltNovaAltX"] = {
 	end,
 	statMap = {
 		["active_skill_if_used_through_frostbolt_damage_+%_final"] = {
-			mod("Damage", "INC", nil, 0, 0, { type = "Condition", var = "CastOnFrostbolt" }),
+			mod("Damage", "MORE", nil, 0, 0, { type = "Condition", var = "CastOnFrostbolt" }),
 		},
 	},
 	baseFlags = {

--- a/src/Export/Skills/act_int.txt
+++ b/src/Export/Skills/act_int.txt
@@ -3821,11 +3821,6 @@ local skills, mod, flag, skill = ...
 	preDamageFunc = function(activeSkill, output)
 		activeSkill.skillData.hitTimeOverride = output.Cooldown
 	end,
-	statMap = {
-		["active_skill_damage_+%_when_cast_on_frostbolt"] = {
-			mod("Damage", "INC", nil, 0, 0, { type = "Condition", var = "CastOnFrostbolt" }),
-		},
-	},
 #baseMod skill("dotIsArea", true)
 #baseMod skill("radiusLabel", "Initial Hit:")
 #baseMod skill("radiusSecondaryLabel", "Ground Degen:")
@@ -3838,7 +3833,7 @@ local skills, mod, flag, skill = ...
 	end,
 	statMap = {
 		["active_skill_if_used_through_frostbolt_damage_+%_final"] = {
-			mod("Damage", "INC", nil, 0, 0, { type = "Condition", var = "CastOnFrostbolt" }),
+			mod("Damage", "MORE", nil, 0, 0, { type = "Condition", var = "CastOnFrostbolt" }),
 		},
 	},
 #baseMod skill("dotIsArea", true)


### PR DESCRIPTION
Fixes #7128 .

### Description of the problem being solved:
Vortex of Projection statMap was set to INC. Changed to MORE.

Also cleaned up the statMap for Vortex as it can no longer be cast on Frostbolt.

### Steps taken to verify a working solution:
- Tested PoB from linked issue

### After screenshot:
![image](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/42928828/b5eeecab-fead-47ad-9f34-73f992b9d7d0)
