### PR TITLE
Fix odd null compare caused by column alighnement on odd viewport sizes.

### DIFF
--- a/src/Classes/ConfigTab.lua
+++ b/src/Classes/ConfigTab.lua
@@ -705,7 +705,7 @@ function ConfigTabClass:Draw(viewPort, inputEvents)
 
 	local maxCol = m_floor((viewPort.width - 10) / 370)
 	local maxColY = 0
-	local colY = { }
+	local colY = { 0 }
 	for _, section in ipairs(self.sectionList) do
 		local y = 14
 		section.shown = true


### PR DESCRIPTION
Fixes https://github.com/PathOfBuildingCommunity/PathOfBuilding/issues/7129

### Description of the problem being solved:
Fixes a crash caused by comparing a number to nil. I'm not exactly sure why the code is written the way it is but when the `maxCol` variable is bigger than 1 and `col` defaults to 1 failing this:

https://github.com/PathOfBuildingCommunity/PathOfBuilding/blob/46c98d38129d1ecdc89e914d41a698bef22a6cd9/src/Classes/ConfigTab.lua#L726

check the first element of the colY table is never actually set. This pr defaults the first element to 0 following the logic in the loop:
https://github.com/PathOfBuildingCommunity/PathOfBuilding/blob/46c98d38129d1ecdc89e914d41a698bef22a6cd9/src/Classes/ConfigTab.lua#L731