### PR TITLE
Only apply dual wield penatly for on weapon triggers requiring attack sources

### DIFF
--- a/src/Modules/CalcTriggers.lua
+++ b/src/Modules/CalcTriggers.lua
@@ -426,13 +426,12 @@ local function defaultTriggerHandler(env, config)
 					t_insert(breakdown.EffectiveSourceRate, s_format("%.2f ^8(%s %s)", trigRate, config.sourceName or source.activeEffect.grantedEffect.name, config.useCastRate and "cast rate" or "attack rate"))
 				end
 			end
-
-			--Dual wield
-			if trigRate and source and (source.skillTypes[SkillType.Melee] or source.skillTypes[SkillType.Attack]) and not source.skillTypes[SkillType.Channel] and not actor.mainSkill.skillFlags.globalTrigger then
-				local dualWield = env.player.weaponData1.type and env.player.weaponData2.type
-				trigRate = dualWield and source.skillData.doubleHitsWhenDualWielding and trigRate * 2 or dualWield and trigRate / 2 or trigRate
-				if dualWield and breakdown then
-					t_insert(breakdown.EffectiveSourceRate, 2, s_format("%s 2 ^8(due to dual wielding)", source.skillData.doubleHitsWhenDualWielding and "*" or "/"))
+			
+			-- Dual wield triggers
+			if trigRate and source and env.player.weaponData1.type and env.player.weaponData2.type and not source.skillData.doubleHitsWhenDualWielding and (source.skillTypes[SkillType.Melee] or source.skillTypes[SkillType.Attack]) and actor.mainSkill.triggeredBy and actor.mainSkill.triggeredBy.grantedEffect.support and actor.mainSkill.triggeredBy.grantedEffect.fromItem then
+				trigRate = trigRate / 2
+				if breakdown then
+					t_insert(breakdown.EffectiveSourceRate, 2, s_format("/ 2 ^8(due to dual wielding)"))
 				end
 			end
 


### PR DESCRIPTION
Fixes https://www.reddit.com/r/pathofexile/comments/188r65t/why_does_pob_cut_my_trigger_rate_for_coc_when/ke93zcv/

### Description of the problem being solved:
It seems the interaction between dual wielding and triggers is incorrect in POB. Not really sure how to implement dual wielding interactions for triggers such as [The Poet's Pen](https://www.poewiki.net/wiki/The_Poet%27s_Pen) or [Cospri's Malice](https://www.poewiki.net/wiki/Cospri%27s_Malice) or if that interaction is even in scope of pob simulations so marking as draft for now.