### PR TITLE
Fix boneshatter missing self damage mod

### DIFF
--- a/src/Data/SkillStatMap.lua
+++ b/src/Data/SkillStatMap.lua
@@ -1384,6 +1384,9 @@ return {
 ["mana_granted_when_killed"] = {
 	mod("SelfManaOnKill", "BASE", nil),
 },
+["trauma_strike_self_damage_per_trauma"] = {
+	mod("TraumaSelfDamageTakenLife", "BASE", nil),
+},
 -- Degen
 ["base_physical_damage_%_of_maximum_life_to_deal_per_minute"] = {
 	mod("PhysicalDegen", "BASE", nil, 0, 0, { type = "PerStat", stat = "Life", div = 1 }),

--- a/src/Data/Skills/act_str.lua
+++ b/src/Data/Skills/act_str.lua
@@ -1577,9 +1577,6 @@ skills["Boneshatter"] = {
 			mod("TraumaDuration", "BASE", nil),
 			div = 1000,
 		},
-		["trauma_strike_self_damage_per_trauma"] = {
-			-- Display only
-		},
 		["quality_display_boneshatter_is_gem"] = {
 			-- Display only
 		},
@@ -1691,9 +1688,6 @@ skills["BoneshatterAltX"] = {
 		},
 		["lose_all_trauma_at_X_trauma"] = {
 			mod("Multiplier:TraumaStacksMax", "BASE", nil),
-		},
-		["trauma_strike_self_damage_per_trauma"] = {
-			-- Display only
 		},
 		["quality_display_boneshatter_is_gem"] = {
 			-- Display only

--- a/src/Data/Skills/sup_str.lua
+++ b/src/Data/Skills/sup_str.lua
@@ -4384,9 +4384,6 @@ skills["SupportTrauma"] = {
 		["attack_maximum_added_physical_damage_with_weapons_per_trauma"] = {
 			mod("PhysicalMax", "BASE", nil, bit.bor(ModFlag.Attack, ModFlag.Weapon), 0, { type = "Multiplier", var = "TraumaStacks" })
 		},
-		["trauma_strike_self_damage_per_trauma"] = {
-			mod("TraumaSelfDamageTakenLife", "BASE", nil),
-		},
 		["support_trauma_stun_duration_+%_per_trauma"] = {
 			mod("EnemyStunDuration", "INC", nil, 0, 0, { type = "Multiplier", var = "TraumaStacks" }),
 		},

--- a/src/Export/Skills/act_str.txt
+++ b/src/Export/Skills/act_str.txt
@@ -301,9 +301,6 @@ local skills, mod, flag, skill = ...
 			mod("TraumaDuration", "BASE", nil),
 			div = 1000,
 		},
-		["trauma_strike_self_damage_per_trauma"] = {
-			-- Display only
-		},
 		["quality_display_boneshatter_is_gem"] = {
 			-- Display only
 		},
@@ -334,9 +331,6 @@ local skills, mod, flag, skill = ...
 		},
 		["lose_all_trauma_at_X_trauma"] = {
 			mod("Multiplier:TraumaStacksMax", "BASE", nil),
-		},
-		["trauma_strike_self_damage_per_trauma"] = {
-			-- Display only
 		},
 		["quality_display_boneshatter_is_gem"] = {
 			-- Display only

--- a/src/Export/Skills/sup_str.txt
+++ b/src/Export/Skills/sup_str.txt
@@ -615,9 +615,6 @@ local skills, mod, flag, skill = ...
 		["attack_maximum_added_physical_damage_with_weapons_per_trauma"] = {
 			mod("PhysicalMax", "BASE", nil, bit.bor(ModFlag.Attack, ModFlag.Weapon), 0, { type = "Multiplier", var = "TraumaStacks" })
 		},
-		["trauma_strike_self_damage_per_trauma"] = {
-			mod("TraumaSelfDamageTakenLife", "BASE", nil),
-		},
 		["support_trauma_stun_duration_+%_per_trauma"] = {
 			mod("EnemyStunDuration", "INC", nil, 0, 0, { type = "Multiplier", var = "TraumaStacks" }),
 		},


### PR DESCRIPTION
Fixes #7136

### Description of the problem being solved:
https://github.com/PathOfBuildingCommunity/PathOfBuilding/pull/6976 mistakenly removed the mods as they were related to qualities. This pr also moves the mod to SkillStatMap.