### PR TITLE
Fix Ngamahu, Flame's Advance adding Strength to Unique jewels

### DIFF
--- a/src/Modules/CalcSetup.lua
+++ b/src/Modules/CalcSetup.lua
@@ -1088,6 +1088,7 @@ function calcs.initEnv(build, mode, override, specEnv)
 	if not override or (override and not override.extraJewelFuncs) then
 		override = override or {}
 		override.extraJewelFuncs = new("ModList")
+		override.extraJewelFuncs.actor = env.player
 		for _, mod in ipairs(env.modDB:Tabulate("LIST", nil, "ExtraJewelFunc")) do
 			override.extraJewelFuncs:AddMod(mod.mod)
 		end


### PR DESCRIPTION
Fixes #7140

### Description of the problem being solved:
The ModList holding the to be filtered ExtraJewelFuncs did not have the actor set causing the ItemCondition set on the ExtraJewelMod coming to be evaluated to true as it had the neg tag.