### PR TITLE
Fix check vaal variants when variants are allowed

### DIFF
--- a/src/Modules/CalcTools.lua
+++ b/src/Modules/CalcTools.lua
@@ -110,7 +110,7 @@ function calcLib.gemIsType(gem, type, allowVariants)
 			(type == "non-vaal" and not gem.tags.vaal) or
 			(type == gem.name:lower()) or
 			(type == gem.name:lower():gsub("^vaal ", "")) or
-			(allowVariants and gem.name:lower():match("^" .. type:lower())) or
+			(allowVariants and (gem.name:lower():match("^" .. type:lower()) or gem.name:lower():gsub("^vaal ", ""):match("^" .. type:lower()))) or
 			((type ~= "active skill" and type ~= "grants_active_skill" and type ~= "skill") and gem.tags[type]))
 end
 


### PR DESCRIPTION
Fixes #7146

### Description of the problem being solved:
https://github.com/PathOfBuildingCommunity/PathOfBuilding/pull/7101 implemented support for matching variants but didn't not add support for matching vaal variants.