### PR TITLE
ItemCondition rework. Fixes issues, Implements handling for explicit keyword in mods using ItemCondition.

### DIFF
--- a/spec/System/TestItemMods_spec.lua
+++ b/spec/System/TestItemMods_spec.lua
@@ -171,7 +171,7 @@ describe("TetsItemMods", function()
 
         assert.are_not.equals(farDPS, build.calcsTab.mainOutput.TotalDPS)
     end)
-    
+
     it("Kalandra's Touch mod copy", function()
         local initialInt = build.calcsTab.mainOutput.Int
 
@@ -196,5 +196,270 @@ describe("TetsItemMods", function()
         runCallback("OnFrame")
 
         assert.are.equals(genericRingInt - initialInt, build.calcsTab.mainOutput.Int - genericRingInt)
+    end)
+
+    it("Both slots mod (evasion and es mastery)", function()
+
+        build.configTab.input.customMods = "\z
+        20% increased Maximum Energy Shield if both Equipped Rings have an Evasion Modifier\n\z
+        "
+        build.configTab:BuildModList()
+        runCallback("OnFrame")
+
+        build.itemsTab:CreateDisplayItemFromRaw([[Energy Shield Boots
+        Sorcerer Boots
+        Energy Shield: 114
+        EnergyShieldBasePercentile: 1
+        Crafted: true
+        Prefix: {range:0.5}IncreasedLife6
+        Prefix: {range:0.5}LocalIncreasedEnergyShieldPercent5
+        Prefix: {range:0.5}MovementVelocity5
+        Suffix: None
+        Suffix: None
+        Suffix: None
+        Quality: 20
+        Sockets: B-B-B-B
+        LevelReq: 67
+        Implicits: 0
+        74% increased Energy Shield
+        +65 to maximum Life
+        30% increased Movement Speed]])
+        build.itemsTab:AddDisplayItem()
+        runCallback("OnFrame")
+
+        local baseEs = build.calcsTab.mainOutput.EnergyShield
+
+        build.itemsTab:CreateDisplayItemFromRaw([[Chaos Resistance Ring
+        Amethyst Ring
+        LevelReq: 33
+        Implicits: 1
+        +71 to Evasion Rating
+        {tags:chaos,resistance}{range:0.5}+(17-23)% to Chaos Resistance]])
+        build.itemsTab:AddDisplayItem()
+        runCallback("OnFrame")
+
+        assert.are.equals(baseEs, build.calcsTab.mainOutput.EnergyShield) -- No change in es with just one ring.
+
+        build.itemsTab:CreateDisplayItemFromRaw([[Chaos Resistance Ring
+        Amethyst Ring
+        Crafted: true
+        Prefix: {range:0.5}IncreasedEvasionRating4
+        Prefix: None
+        Prefix: None
+        Suffix: None
+        Suffix: None
+        Suffix: None
+        LevelReq: 33
+        Implicits: 1
+        {tags:chaos,resistance}{range:0.5}+(17-23)% to Chaos Resistance
+        +71 to Evasion Rating]])
+        build.itemsTab:AddDisplayItem()
+        runCallback("OnFrame")
+
+        assert.are_not.equals(baseEs, build.calcsTab.mainOutput.EnergyShield)
+        -- Es changes after adding another ring with mod. Regardless of the evasion mod on the first ring being implicit.
+    end)
+
+    it("Both slots explicit mod with mixed mod rings (evasion and es mastery)", function()
+	
+        build.configTab.input.customMods = "\z
+        20% increased Maximum Energy Shield if both Equipped Rings have an Explicit Evasion Modifier\n\z
+        "
+        build.configTab:BuildModList()
+        runCallback("OnFrame")
+
+        build.itemsTab:CreateDisplayItemFromRaw([[Energy Shield Boots
+        Sorcerer Boots
+        Energy Shield: 114
+        EnergyShieldBasePercentile: 1
+        Crafted: true
+        Prefix: {range:0.5}IncreasedLife6
+        Prefix: {range:0.5}LocalIncreasedEnergyShieldPercent5
+        Prefix: {range:0.5}MovementVelocity5
+        Suffix: None
+        Suffix: None
+        Suffix: None
+        Quality: 20
+        Sockets: B-B-B-B
+        LevelReq: 67
+        Implicits: 0
+        74% increased Energy Shield
+        +65 to maximum Life
+        30% increased Movement Speed]])
+        build.itemsTab:AddDisplayItem()
+        runCallback("OnFrame")
+
+        local baseEs = build.calcsTab.mainOutput.EnergyShield
+
+        build.itemsTab:CreateDisplayItemFromRaw([[Chaos Resistance Ring
+        Amethyst Ring
+        LevelReq: 33
+        Implicits: 1
+        +71 to Evasion Rating
+        {tags:chaos,resistance}{range:0.5}+(17-23)% to Chaos Resistance]])
+        build.itemsTab:AddDisplayItem()
+        runCallback("OnFrame")
+
+        assert.are.equals(baseEs, build.calcsTab.mainOutput.EnergyShield) -- No change in es with just one ring.
+
+        build.itemsTab:CreateDisplayItemFromRaw([[Chaos Resistance Ring
+        Amethyst Ring
+        Crafted: true
+        Prefix: {range:0.5}IncreasedEvasionRating4
+        Prefix: None
+        Prefix: None
+        Suffix: None
+        Suffix: None
+        Suffix: None
+        LevelReq: 33
+        Implicits: 1
+        {tags:chaos,resistance}{range:0.5}+(17-23)% to Chaos Resistance
+        +71 to Evasion Rating]])
+        build.itemsTab:AddDisplayItem()
+        runCallback("OnFrame")
+
+        assert.are.equals(baseEs, build.calcsTab.mainOutput.EnergyShield)
+        -- Es does not change after adding another ring with mod due to the first ring having an implicit evasion mod.
+    end)
+
+    it("Both slots explicit mod (evasion and es mastery)", function()
+
+        build.configTab.input.customMods = "\z
+        20% increased Maximum Energy Shield if both Equipped Rings have an Explicit Evasion Modifier\n\z
+        "
+        build.configTab:BuildModList()
+        runCallback("OnFrame")
+
+        build.itemsTab:CreateDisplayItemFromRaw([[Energy Shield Boots
+        Sorcerer Boots
+        Energy Shield: 114
+        EnergyShieldBasePercentile: 1
+        Crafted: true
+        Prefix: {range:0.5}IncreasedLife6
+        Prefix: {range:0.5}LocalIncreasedEnergyShieldPercent5
+        Prefix: {range:0.5}MovementVelocity5
+        Suffix: None
+        Suffix: None
+        Suffix: None
+        Quality: 20
+        Sockets: B-B-B-B
+        LevelReq: 67
+        Implicits: 0
+        74% increased Energy Shield
+        +65 to maximum Life
+        30% increased Movement Speed]])
+        build.itemsTab:AddDisplayItem()
+        runCallback("OnFrame")
+
+        local baseEs = build.calcsTab.mainOutput.EnergyShield
+
+        build.itemsTab:CreateDisplayItemFromRaw([[Chaos Resistance Ring
+        Amethyst Ring
+        Crafted: true
+        Prefix: {range:0.5}IncreasedEvasionRating4
+        Prefix: None
+        Prefix: None
+        Suffix: None
+        Suffix: None
+        Suffix: None
+        LevelReq: 33
+        Implicits: 1
+        {tags:chaos,resistance}{range:0.5}+(17-23)% to Chaos Resistance
+        +71 to Evasion Rating]])
+        build.itemsTab:AddDisplayItem()
+        runCallback("OnFrame")
+
+        assert.are.equals(baseEs, build.calcsTab.mainOutput.EnergyShield) -- No change in es with just one ring.
+
+        build.itemsTab:CreateDisplayItemFromRaw([[Chaos Resistance Ring
+        Amethyst Ring
+        Crafted: true
+        Prefix: {range:0.5}IncreasedEvasionRating4
+        Prefix: None
+        Prefix: None
+        Suffix: None
+        Suffix: None
+        Suffix: None
+        LevelReq: 33
+        Implicits: 1
+        {tags:chaos,resistance}{range:0.5}+(17-23)% to Chaos Resistance
+        +71 to Evasion Rating]])
+        build.itemsTab:AddDisplayItem()
+        runCallback("OnFrame")
+
+        assert.are_not.equals(baseEs, build.calcsTab.mainOutput.EnergyShield)
+        -- Es changes after adding two rings with explicit mods.
+    end)
+
+    it("Both slots explicit mod no rings (evasion and es mastery)", function()
+        build.itemsTab:CreateDisplayItemFromRaw([[Energy Shield Boots
+        Sorcerer Boots
+        Energy Shield: 114
+        EnergyShieldBasePercentile: 1
+        Crafted: true
+        Prefix: {range:0.5}IncreasedLife6
+        Prefix: {range:0.5}LocalIncreasedEnergyShieldPercent5
+        Prefix: {range:0.5}MovementVelocity5
+        Suffix: None
+        Suffix: None
+        Suffix: None
+        Quality: 20
+        Sockets: B-B-B-B
+        LevelReq: 67
+        Implicits: 0
+        74% increased Energy Shield
+        +65 to maximum Life
+        30% increased Movement Speed]])
+        build.itemsTab:AddDisplayItem()
+        runCallback("OnFrame")
+
+        local baseEs = build.calcsTab.mainOutput.EnergyShield
+
+        build.configTab.input.customMods = "\z
+        20% increased Maximum Energy Shield if both Equipped Rings have an Explicit Evasion Modifier\n\z
+        "
+        build.configTab:BuildModList()
+        runCallback("OnFrame")
+
+        assert.are.equals(baseEs, build.calcsTab.mainOutput.EnergyShield) -- No change in es with no rings.
+
+    end)
+
+    it("mod if no mod on x slot", function()
+        local baseLife = build.calcsTab.mainOutput.Life
+
+        build.configTab.input.customMods = "\z
+        15% increased maximum Life if there are no Life Modifiers on Equipped Body Armour\n\z
+        "
+        build.configTab:BuildModList()
+        runCallback("OnFrame")
+
+        assert.are_not.equals(baseLife, build.calcsTab.mainOutput.Life)
+
+        baseLife = build.calcsTab.mainOutput.Life
+
+        build.itemsTab:CreateDisplayItemFromRaw([[Armour Chest
+        Astral Plate
+        Armour: 1696
+        ArmourBasePercentile: 1
+        Crafted: true
+        Prefix: {range:0.5}LocalIncreasedPhysicalDamageReductionRating5
+        Prefix: {range:0.5}LocalIncreasedPhysicalDamageReductionRatingPercent5
+        Prefix: {range:0.5}IncreasedLife9
+        Suffix: None
+        Suffix: None
+        Suffix: None
+        Quality: 20
+        Sockets: R-R-R-R-R-R
+        LevelReq: 62
+        Implicits: 1
+        {tags:elemental,resistance}{range:0.5}+(8-12)% to all Elemental Resistances
+        +92 to Armour
+        74% increased Armour
+        +95 to maximum Life]])
+        build.itemsTab:AddDisplayItem()
+        runCallback("OnFrame")
+
+        assert.are_not.equals(baseLife, build.calcsTab.mainOutput.Life)
     end)
 end)

--- a/src/Classes/Item.lua
+++ b/src/Classes/Item.lua
@@ -227,6 +227,7 @@ end
 -- Iterate over modifiers to see if specific substring is found (for conditional checking)
 function ItemClass:FindModifierSubstring(substring, itemSlotName)
 	local modLines = {}
+	local substring, explicit = substring:gsub("explicit ", "")
 
 	-- The commented out line below is used at GGPK updates to check if any new modifiers
 	-- have been identified that need to be added to the manually maintained special modifier
@@ -234,11 +235,13 @@ function ItemClass:FindModifierSubstring(substring, itemSlotName)
 	--getTagBasedModifiers(substring, itemSlotName)
 
 	-- merge various modifier lines into one table
-	for _,v in pairs(self.enchantModLines) do t_insert(modLines, v) end
-	for _,v in pairs(self.scourgeModLines) do t_insert(modLines, v) end
-	for _,v in pairs(self.implicitModLines) do t_insert(modLines, v) end
 	for _,v in pairs(self.explicitModLines) do t_insert(modLines, v) end
-	for _,v in pairs(self.crucibleModLines) do t_insert(modLines, v) end
+	if explicit < 1 then
+		for _,v in pairs(self.enchantModLines) do t_insert(modLines, v) end
+		for _,v in pairs(self.scourgeModLines) do t_insert(modLines, v) end
+		for _,v in pairs(self.implicitModLines) do t_insert(modLines, v) end
+		for _,v in pairs(self.crucibleModLines) do t_insert(modLines, v) end
+	end
 
 	for _,v in pairs(modLines) do
 		local currentVariant = false

--- a/src/Classes/ModStore.lua
+++ b/src/Classes/ModStore.lua
@@ -559,56 +559,55 @@ function ModStoreClass:EvalMod(mod, cfg)
 			end
 		elseif tag.type == "ItemCondition" then
 			local matches = {}
-			local match = false
-			local searchCond = tag.searchCond
-			local rarityCond = tag.rarityCond
-			local corruptedCond = tag.corruptedCond
-			local allSlots = tag.allSlots
 			local itemSlot = tag.itemSlot:lower():gsub("(%l)(%w*)", function(a,b) return string.upper(a)..b end):gsub('^%s*(.-)%s*$', '%1')
-			local bCheckAllAppropriateSlots = tag.bothSlots
 			local items
-			if allSlots then
+			if tag.allSlots then
 				items = self.actor.itemList
 			elseif self.actor.itemList then
-				items = {self.actor.itemList[itemSlot] or (cfg and cfg.item)}
-				if bCheckAllAppropriateSlots then
+				items = { [itemSlot] = self.actor.itemList[itemSlot] or (cfg and cfg.item)}
+				if tag.bothSlots then
 					local itemSlot1 = self.actor.itemList[itemSlot .. " 1"]
 					local itemSlot2 = self.actor.itemList[itemSlot .. " 2"]
 					if itemSlot1 and itemSlot1.name:match("Kalandra's Touch") then itemSlot1 = itemSlot2 end
 					if itemSlot2 and itemSlot2.name:match("Kalandra's Touch") then itemSlot2 = itemSlot1 end
 					if itemSlot1 and itemSlot2 then
-						t_insert(items, itemSlot1)
-						t_insert(items, itemSlot2)
+						items[itemSlot .. " 1"] = itemSlot1
+						items[itemSlot .. " 2"] = itemSlot2
 					end
 				end
 			end
-			if items and #items > 0 or allSlots then
-				if searchCond then
-					for slot, item in pairs(items) do
-						if (not allSlots or allSlots and item.type ~= "Jewel") and slot ~= itemSlot or not tag.excludeSelf then
-							t_insert(matches, item:FindModifierSubstring(searchCond:lower(), itemSlot:lower()))
-						end
-					end
-				end
-				if rarityCond then
-					for _, item in pairs(items) do
-						t_insert(matches, item.rarity == rarityCond)
-					end
-				end
-				if corruptedCond then
-					for _, item in pairs(items) do
-						t_insert(matches, item.corrupted == corruptedCond)
+			if tag.searchCond then
+				for slot, item in pairs(items) do
+					if (not tag.allSlots or tag.allSlots and item.type ~= "Jewel") and slot ~= itemSlot or not tag.excludeSelf then
+						t_insert(matches, item:FindModifierSubstring(tag.searchCond:lower(), slot:lower()))
 					end
 				end
 			end
+			if tag.rarityCond then
+				for _, item in pairs(items) do
+					t_insert(matches, item.rarity == tag.rarityCond)
+				end
+			end
+			if tag.corruptedCond then
+				for _, item in pairs(items) do
+					t_insert(matches, item.corrupted == tag.corruptedCond)
+				end
+			end
+
+			local hasItems = false
+			for _, item in pairs(items) do
+				hasItems = true
+				break
+			end
+
+			local match = true
 			for _, bool in ipairs(matches) do
-				if bool then
-					match = not tag.neg
+				if bool == (tag.neg or false) then
+					match = false
 					break
 				end
-				match = tag.neg == true
 			end
-			if not match and #matches > 0 then
+			if not match or (not hasItems and not tag.neg) then
 				return
 			end
 		elseif tag.type == "SocketedIn" then


### PR DESCRIPTION
Fixes #7145

### Description of the problem being solved:
Fixes issues with `ItemCondition` condition not working properly when no matching items were found. Implements handling for explicit keyword in mods using `ItemCondition` .