### PR TITLE
Remove tattoos on tree versions not from 3.22

### DIFF
--- a/src/Classes/PassiveSpec.lua
+++ b/src/Classes/PassiveSpec.lua
@@ -219,7 +219,7 @@ end
 
 -- Import passive spec from the provided class IDs and node hash list
 function PassiveSpecClass:ImportFromNodeList(classId, ascendClassId, secondaryAscendClassId, hashList, hashOverrides, masteryEffects, treeVersion)
-  if hashOverrides == nil then hashOverrides = {} end
+  	if hashOverrides == nil then hashOverrides = {} end
 	if treeVersion and treeVersion ~= self.treeVersion then
 		self:Init(treeVersion)
 		self.build.treeTab.showConvert = self.treeVersion ~= latestTreeVersion
@@ -237,13 +237,20 @@ function PassiveSpecClass:ImportFromNodeList(classId, ascendClassId, secondaryAs
 			self.masterySelections[mastery] = effect
 		end
 	end
+	local removeHashOverrides = {}
 	for id, override in pairs(hashOverrides) do
 		local node = self.nodes[id]
-		if node then
+		-- Remove tattos if tree version is not Ancestor League
+		if node.isTattoo and tonumber(((self.treeVersion):gsub("_", ""))) ~= 322 then
+			t_insert(removeHashOverrides, id)
+		elseif node then
 			override.effectSprites = self.tree.spriteMap[override.activeEffectImage]
 			override.sprites = self.tree.spriteMap[override.icon]
 			self:ReplaceNode(node, override)
 		end
+	end
+	for _, id in ipairs(removeHashOverrides) do
+		self.hashOverrides[id] = nil
 	end
 	for _, id in pairs(hashList) do
 		local node = self.nodes[id]

--- a/src/Classes/PassiveSpec.lua
+++ b/src/Classes/PassiveSpec.lua
@@ -240,7 +240,7 @@ function PassiveSpecClass:ImportFromNodeList(classId, ascendClassId, secondaryAs
 	local removeHashOverrides = {}
 	for id, override in pairs(hashOverrides) do
 		local node = self.nodes[id]
-		-- Remove tattos if tree version is not Ancestor League
+		-- Remove tattoos if tree version is not Ancestor League
 		if node.isTattoo and tonumber(((self.treeVersion):gsub("_", ""))) ~= 322 then
 			t_insert(removeHashOverrides, id)
 		elseif node then


### PR DESCRIPTION
Fixes #6946

### Description of the problem being solved:
This pr will cause tattoos to be removed when the tree version is not set to 3.22.

This may not be worth merging as it will add pollution to the code base but it has been requested by at least 4 people so i decided to put it into code.

