### PR TITLE
Sanitize skills passed to createActiveSkill by copyActiveSkill

### DIFF
--- a/src/Modules/CalcActiveSkill.lua
+++ b/src/Modules/CalcActiveSkill.lua
@@ -156,7 +156,15 @@ end
 
 -- Copy an Active Skill
 function calcs.copyActiveSkill(env, mode, skill)
-	local newSkill = calcs.createActiveSkill(skill.activeEffect, skill.supportList, skill.actor, skill.socketGroup, skill.summonSkill)
+	local activeEffect = {
+		grantedEffect = skill.activeEffect.grantedEffect,
+		level = skill.activeEffect.srcInstance.level,
+		quality = skill.activeEffect.srcInstance.quality,
+		qualityId = skill.activeEffect.srcInstance.qualityId,
+		srcInstance = skill.activeEffect.srcInstance,
+		gemData = skill.activeEffect.srcInstance.gemData,
+	}
+	local newSkill = calcs.createActiveSkill(activeEffect, skill.supportList, skill.actor, skill.socketGroup, skill.summonSkill)
 	local newEnv, _, _, _ = calcs.initEnv(env.build, mode, env.override)
 	calcs.buildActiveSkillModList(newEnv, newSkill)
 	newSkill.skillModList = new("ModList", newSkill.baseSkillModList)


### PR DESCRIPTION
Fixes #7160

### Description of the problem being solved:
The `copyActiveSkill` function only used by mirage calculations:
https://github.com/PathOfBuildingCommunity/PathOfBuilding/blob/9d56a02f42792fb7a069c27a4e190f230665a3d9/src/Modules/CalcActiveSkill.lua#L157-L170

calls `copyActiveSkill` :
https://github.com/PathOfBuildingCommunity/PathOfBuilding/blob/9d56a02f42792fb7a069c27a4e190f230665a3d9/src/Modules/CalcActiveSkill.lua#L82

which outside of the `copyActiveSkill` is only ever passed in sanitized activeEffect Tables:

https://github.com/PathOfBuildingCommunity/PathOfBuilding/blob/9d56a02f42792fb7a069c27a4e190f230665a3d9/src/Modules/CalcSetup.lua#L1401-L1425

https://github.com/PathOfBuildingCommunity/PathOfBuilding/blob/9d56a02f42792fb7a069c27a4e190f230665a3d9/src/Modules/CalcSetup.lua#L1499-L1507

https://github.com/PathOfBuildingCommunity/PathOfBuilding/blob/9d56a02f42792fb7a069c27a4e190f230665a3d9/src/Modules/CalcActiveSkill.lua#L157-L159

https://github.com/PathOfBuildingCommunity/PathOfBuilding/blob/9d56a02f42792fb7a069c27a4e190f230665a3d9/src/Modules/CalcMirages.lua#L28-L34

https://github.com/PathOfBuildingCommunity/PathOfBuilding/blob/9d56a02f42792fb7a069c27a4e190f230665a3d9/src/Modules/CalcActiveSkill.lua#L789-L803

This pr add the same sanitisation to `copyActiveSkill` fixing mod doubling that caused the mentioned issue.

### Steps taken to verify a working solution:
- Test mirage archer
- Test Tawhoa's Chosen

### Link to a build that showcases this PR:
```
https://pobb.in/PVjO-o1r1i4P
```
```
https://pobb.in/zrEI-bAy2ia_
```