### PR TITLE
ItemCondition fixes. Kalandra's Touch not adding to influenced items multiplier.

### DIFF
--- a/spec/System/TestItemMods_spec.lua
+++ b/spec/System/TestItemMods_spec.lua
@@ -171,7 +171,7 @@ describe("TetsItemMods", function()
 
         assert.are_not.equals(farDPS, build.calcsTab.mainOutput.TotalDPS)
     end)
-    
+
     it("Kalandra's Touch mod copy", function()
         local initialInt = build.calcsTab.mainOutput.Int
 
@@ -196,5 +196,270 @@ describe("TetsItemMods", function()
         runCallback("OnFrame")
 
         assert.are.equals(genericRingInt - initialInt, build.calcsTab.mainOutput.Int - genericRingInt)
+    end)
+
+    it("Both slots mod (evasion and es mastery)", function()
+
+        build.configTab.input.customMods = "\z
+        20% increased Maximum Energy Shield if both Equipped Rings have an Evasion Modifier\n\z
+        "
+        build.configTab:BuildModList()
+        runCallback("OnFrame")
+
+        build.itemsTab:CreateDisplayItemFromRaw([[Energy Shield Boots
+        Sorcerer Boots
+        Energy Shield: 114
+        EnergyShieldBasePercentile: 1
+        Crafted: true
+        Prefix: {range:0.5}IncreasedLife6
+        Prefix: {range:0.5}LocalIncreasedEnergyShieldPercent5
+        Prefix: {range:0.5}MovementVelocity5
+        Suffix: None
+        Suffix: None
+        Suffix: None
+        Quality: 20
+        Sockets: B-B-B-B
+        LevelReq: 67
+        Implicits: 0
+        74% increased Energy Shield
+        +65 to maximum Life
+        30% increased Movement Speed]])
+        build.itemsTab:AddDisplayItem()
+        runCallback("OnFrame")
+
+        local baseEs = build.calcsTab.mainOutput.EnergyShield
+
+        build.itemsTab:CreateDisplayItemFromRaw([[Chaos Resistance Ring
+        Amethyst Ring
+        LevelReq: 33
+        Implicits: 1
+        +71 to Evasion Rating
+        {tags:chaos,resistance}{range:0.5}+(17-23)% to Chaos Resistance]])
+        build.itemsTab:AddDisplayItem()
+        runCallback("OnFrame")
+
+        assert.are.equals(baseEs, build.calcsTab.mainOutput.EnergyShield) -- No change in es with just one ring.
+
+        build.itemsTab:CreateDisplayItemFromRaw([[Chaos Resistance Ring
+        Amethyst Ring
+        Crafted: true
+        Prefix: {range:0.5}IncreasedEvasionRating4
+        Prefix: None
+        Prefix: None
+        Suffix: None
+        Suffix: None
+        Suffix: None
+        LevelReq: 33
+        Implicits: 1
+        {tags:chaos,resistance}{range:0.5}+(17-23)% to Chaos Resistance
+        +71 to Evasion Rating]])
+        build.itemsTab:AddDisplayItem()
+        runCallback("OnFrame")
+
+        assert.are_not.equals(baseEs, build.calcsTab.mainOutput.EnergyShield)
+        -- Es changes after adding another ring with mod. Regardless of the evasion mod on the first ring being implicit.
+    end)
+
+    it("Both slots explicit mod with mixed mod rings (evasion and es mastery)", function()
+	
+        build.configTab.input.customMods = "\z
+        20% increased Maximum Energy Shield if both Equipped Rings have an Explicit Evasion Modifier\n\z
+        "
+        build.configTab:BuildModList()
+        runCallback("OnFrame")
+
+        build.itemsTab:CreateDisplayItemFromRaw([[Energy Shield Boots
+        Sorcerer Boots
+        Energy Shield: 114
+        EnergyShieldBasePercentile: 1
+        Crafted: true
+        Prefix: {range:0.5}IncreasedLife6
+        Prefix: {range:0.5}LocalIncreasedEnergyShieldPercent5
+        Prefix: {range:0.5}MovementVelocity5
+        Suffix: None
+        Suffix: None
+        Suffix: None
+        Quality: 20
+        Sockets: B-B-B-B
+        LevelReq: 67
+        Implicits: 0
+        74% increased Energy Shield
+        +65 to maximum Life
+        30% increased Movement Speed]])
+        build.itemsTab:AddDisplayItem()
+        runCallback("OnFrame")
+
+        local baseEs = build.calcsTab.mainOutput.EnergyShield
+
+        build.itemsTab:CreateDisplayItemFromRaw([[Chaos Resistance Ring
+        Amethyst Ring
+        LevelReq: 33
+        Implicits: 1
+        +71 to Evasion Rating
+        {tags:chaos,resistance}{range:0.5}+(17-23)% to Chaos Resistance]])
+        build.itemsTab:AddDisplayItem()
+        runCallback("OnFrame")
+
+        assert.are.equals(baseEs, build.calcsTab.mainOutput.EnergyShield) -- No change in es with just one ring.
+
+        build.itemsTab:CreateDisplayItemFromRaw([[Chaos Resistance Ring
+        Amethyst Ring
+        Crafted: true
+        Prefix: {range:0.5}IncreasedEvasionRating4
+        Prefix: None
+        Prefix: None
+        Suffix: None
+        Suffix: None
+        Suffix: None
+        LevelReq: 33
+        Implicits: 1
+        {tags:chaos,resistance}{range:0.5}+(17-23)% to Chaos Resistance
+        +71 to Evasion Rating]])
+        build.itemsTab:AddDisplayItem()
+        runCallback("OnFrame")
+
+        assert.are.equals(baseEs, build.calcsTab.mainOutput.EnergyShield)
+        -- Es does not change after adding another ring with mod due to the first ring having an implicit evasion mod.
+    end)
+
+    it("Both slots explicit mod (evasion and es mastery)", function()
+
+        build.configTab.input.customMods = "\z
+        20% increased Maximum Energy Shield if both Equipped Rings have an Explicit Evasion Modifier\n\z
+        "
+        build.configTab:BuildModList()
+        runCallback("OnFrame")
+
+        build.itemsTab:CreateDisplayItemFromRaw([[Energy Shield Boots
+        Sorcerer Boots
+        Energy Shield: 114
+        EnergyShieldBasePercentile: 1
+        Crafted: true
+        Prefix: {range:0.5}IncreasedLife6
+        Prefix: {range:0.5}LocalIncreasedEnergyShieldPercent5
+        Prefix: {range:0.5}MovementVelocity5
+        Suffix: None
+        Suffix: None
+        Suffix: None
+        Quality: 20
+        Sockets: B-B-B-B
+        LevelReq: 67
+        Implicits: 0
+        74% increased Energy Shield
+        +65 to maximum Life
+        30% increased Movement Speed]])
+        build.itemsTab:AddDisplayItem()
+        runCallback("OnFrame")
+
+        local baseEs = build.calcsTab.mainOutput.EnergyShield
+
+        build.itemsTab:CreateDisplayItemFromRaw([[Chaos Resistance Ring
+        Amethyst Ring
+        Crafted: true
+        Prefix: {range:0.5}IncreasedEvasionRating4
+        Prefix: None
+        Prefix: None
+        Suffix: None
+        Suffix: None
+        Suffix: None
+        LevelReq: 33
+        Implicits: 1
+        {tags:chaos,resistance}{range:0.5}+(17-23)% to Chaos Resistance
+        +71 to Evasion Rating]])
+        build.itemsTab:AddDisplayItem()
+        runCallback("OnFrame")
+
+        assert.are.equals(baseEs, build.calcsTab.mainOutput.EnergyShield) -- No change in es with just one ring.
+
+        build.itemsTab:CreateDisplayItemFromRaw([[Chaos Resistance Ring
+        Amethyst Ring
+        Crafted: true
+        Prefix: {range:0.5}IncreasedEvasionRating4
+        Prefix: None
+        Prefix: None
+        Suffix: None
+        Suffix: None
+        Suffix: None
+        LevelReq: 33
+        Implicits: 1
+        {tags:chaos,resistance}{range:0.5}+(17-23)% to Chaos Resistance
+        +71 to Evasion Rating]])
+        build.itemsTab:AddDisplayItem()
+        runCallback("OnFrame")
+
+        assert.are_not.equals(baseEs, build.calcsTab.mainOutput.EnergyShield)
+        -- Es changes after adding two rings with explicit mods.
+    end)
+
+    it("Both slots explicit mod no rings (evasion and es mastery)", function()
+        build.itemsTab:CreateDisplayItemFromRaw([[Energy Shield Boots
+        Sorcerer Boots
+        Energy Shield: 114
+        EnergyShieldBasePercentile: 1
+        Crafted: true
+        Prefix: {range:0.5}IncreasedLife6
+        Prefix: {range:0.5}LocalIncreasedEnergyShieldPercent5
+        Prefix: {range:0.5}MovementVelocity5
+        Suffix: None
+        Suffix: None
+        Suffix: None
+        Quality: 20
+        Sockets: B-B-B-B
+        LevelReq: 67
+        Implicits: 0
+        74% increased Energy Shield
+        +65 to maximum Life
+        30% increased Movement Speed]])
+        build.itemsTab:AddDisplayItem()
+        runCallback("OnFrame")
+
+        local baseEs = build.calcsTab.mainOutput.EnergyShield
+
+        build.configTab.input.customMods = "\z
+        20% increased Maximum Energy Shield if both Equipped Rings have an Explicit Evasion Modifier\n\z
+        "
+        build.configTab:BuildModList()
+        runCallback("OnFrame")
+
+        assert.are.equals(baseEs, build.calcsTab.mainOutput.EnergyShield) -- No change in es with no rings.
+
+    end)
+
+    it("mod if no mod on x slot", function()
+        local baseLife = build.calcsTab.mainOutput.Life
+
+        build.configTab.input.customMods = "\z
+        15% increased maximum Life if there are no Life Modifiers on Equipped Body Armour\n\z
+        "
+        build.configTab:BuildModList()
+        runCallback("OnFrame")
+
+        assert.are_not.equals(baseLife, build.calcsTab.mainOutput.Life)
+
+        baseLife = build.calcsTab.mainOutput.Life
+
+        build.itemsTab:CreateDisplayItemFromRaw([[Armour Chest
+        Astral Plate
+        Armour: 1696
+        ArmourBasePercentile: 1
+        Crafted: true
+        Prefix: {range:0.5}LocalIncreasedPhysicalDamageReductionRating5
+        Prefix: {range:0.5}LocalIncreasedPhysicalDamageReductionRatingPercent5
+        Prefix: {range:0.5}IncreasedLife9
+        Suffix: None
+        Suffix: None
+        Suffix: None
+        Quality: 20
+        Sockets: R-R-R-R-R-R
+        LevelReq: 62
+        Implicits: 1
+        {tags:elemental,resistance}{range:0.5}+(8-12)% to all Elemental Resistances
+        +92 to Armour
+        74% increased Armour
+        +95 to maximum Life]])
+        build.itemsTab:AddDisplayItem()
+        runCallback("OnFrame")
+
+        assert.are_not.equals(baseLife, build.calcsTab.mainOutput.Life)
     end)
 end)

--- a/spec/System/TestItemMods_spec.lua
+++ b/spec/System/TestItemMods_spec.lua
@@ -197,6 +197,49 @@ describe("TetsItemMods", function()
 
         assert.are.equals(genericRingInt - initialInt, build.calcsTab.mainOutput.Int - genericRingInt)
     end)
+	
+	it("Kalandra's Touch influence copy", function()
+        local dmg = build.calcsTab.mainOutput.AverageDamage
+
+        build.configTab.input.customMods = "\z
+        Gain 5% of Elemental Damage as Extra Chaos Damage per Shaper Item Equipped\n\z
+        "
+        build.configTab:BuildModList()
+        runCallback("OnFrame")
+
+        assert.are.equals(build.calcsTab.mainOutput.AverageDamage, dmg)
+
+        build.itemsTab:CreateDisplayItemFromRaw([[New Item
+        Cerulean Ring
+        Shaper Item
+        Crafted: true
+        Prefix: None
+        Prefix: None
+        Prefix: None
+        Suffix: None
+        Suffix: None
+        Suffix: None
+        Quality: 0
+        LevelReq: 80
+        Implicits: 0]])
+        build.itemsTab:AddDisplayItem()
+        runCallback("OnFrame")
+
+        assert.is_true(build.calcsTab.mainOutput.AverageDamage > dmg)
+
+        local dmgOneRing = build.calcsTab.mainOutput.AverageDamage
+
+        build.itemsTab:CreateDisplayItemFromRaw([[Kalandra's Touch
+        Ring
+        League: Kalandra
+        Implicits: 0
+        Reflects your other Ring
+        Mirrored]])
+        build.itemsTab:AddDisplayItem()
+        runCallback("OnFrame")
+
+        assert.is_true(build.calcsTab.mainOutput.AverageDamage > dmgOneRing)
+    end)
 
     it("Both slots mod (evasion and es mastery)", function()
 

--- a/spec/System/TestItemMods_spec.lua
+++ b/spec/System/TestItemMods_spec.lua
@@ -199,6 +199,10 @@ describe("TetsItemMods", function()
     end)
 	
 	it("Kalandra's Touch influence copy", function()
+
+        build.skillsTab:PasteSocketGroup("Slot: Weapon 1\nSmite 20/0 Default  1\n")
+        runCallback("OnFrame")
+
         local dmg = build.calcsTab.mainOutput.AverageDamage
 
         build.configTab.input.customMods = "\z

--- a/src/Classes/Item.lua
+++ b/src/Classes/Item.lua
@@ -227,6 +227,7 @@ end
 -- Iterate over modifiers to see if specific substring is found (for conditional checking)
 function ItemClass:FindModifierSubstring(substring, itemSlotName)
 	local modLines = {}
+	local substring, explicit = substring:gsub("explicit ", "")
 
 	-- The commented out line below is used at GGPK updates to check if any new modifiers
 	-- have been identified that need to be added to the manually maintained special modifier
@@ -234,11 +235,13 @@ function ItemClass:FindModifierSubstring(substring, itemSlotName)
 	--getTagBasedModifiers(substring, itemSlotName)
 
 	-- merge various modifier lines into one table
-	for _,v in pairs(self.enchantModLines) do t_insert(modLines, v) end
-	for _,v in pairs(self.scourgeModLines) do t_insert(modLines, v) end
-	for _,v in pairs(self.implicitModLines) do t_insert(modLines, v) end
 	for _,v in pairs(self.explicitModLines) do t_insert(modLines, v) end
-	for _,v in pairs(self.crucibleModLines) do t_insert(modLines, v) end
+	if explicit < 1 then
+		for _,v in pairs(self.enchantModLines) do t_insert(modLines, v) end
+		for _,v in pairs(self.scourgeModLines) do t_insert(modLines, v) end
+		for _,v in pairs(self.implicitModLines) do t_insert(modLines, v) end
+		for _,v in pairs(self.crucibleModLines) do t_insert(modLines, v) end
+	end
 
 	for _,v in pairs(modLines) do
 		local currentVariant = false

--- a/src/Classes/ModStore.lua
+++ b/src/Classes/ModStore.lua
@@ -559,56 +559,69 @@ function ModStoreClass:EvalMod(mod, cfg)
 			end
 		elseif tag.type == "ItemCondition" then
 			local matches = {}
-			local match = false
-			local searchCond = tag.searchCond
-			local rarityCond = tag.rarityCond
-			local corruptedCond = tag.corruptedCond
-			local allSlots = tag.allSlots
 			local itemSlot = tag.itemSlot:lower():gsub("(%l)(%w*)", function(a,b) return string.upper(a)..b end):gsub('^%s*(.-)%s*$', '%1')
-			local bCheckAllAppropriateSlots = tag.bothSlots
 			local items
-			if allSlots then
+			if tag.allSlots then
 				items = self.actor.itemList
 			elseif self.actor.itemList then
-				items = {self.actor.itemList[itemSlot] or (cfg and cfg.item)}
-				if bCheckAllAppropriateSlots then
+				if tag.bothSlots then
 					local itemSlot1 = self.actor.itemList[itemSlot .. " 1"]
 					local itemSlot2 = self.actor.itemList[itemSlot .. " 2"]
 					if itemSlot1 and itemSlot1.name:match("Kalandra's Touch") then itemSlot1 = itemSlot2 end
 					if itemSlot2 and itemSlot2.name:match("Kalandra's Touch") then itemSlot2 = itemSlot1 end
 					if itemSlot1 and itemSlot2 then
-						t_insert(items, itemSlot1)
-						t_insert(items, itemSlot2)
+						items = {[itemSlot .. " 1"] = itemSlot1, [itemSlot .. " 2"] = itemSlot2}
+					end
+				else
+					local item = self.actor.itemList[itemSlot] or (cfg and cfg.item)
+					if item and item.name and item.name:match("Kalandra's Touch") then
+						item = self.actor.itemList[itemSlot:gsub("%d$", {["1"] = "2", ["2"] = "1"})]
+					end
+					items = { [itemSlot] = (item or (cfg and cfg.item)) }
+				end
+			end
+			if tag.searchCond then
+				for slot, item in pairs(items) do
+					if (not tag.allSlots or tag.allSlots and item.type ~= "Jewel") and slot ~= itemSlot or not tag.excludeSelf then
+						t_insert(matches, item:FindModifierSubstring(tag.searchCond:lower(), slot:lower()))
 					end
 				end
 			end
-			if items and #items > 0 or allSlots then
-				if searchCond then
-					for slot, item in pairs(items) do
-						if (not allSlots or allSlots and item.type ~= "Jewel") and slot ~= itemSlot or not tag.excludeSelf then
-							t_insert(matches, item:FindModifierSubstring(searchCond:lower(), itemSlot:lower()))
-						end
-					end
-				end
-				if rarityCond then
-					for _, item in pairs(items) do
-						t_insert(matches, item.rarity == rarityCond)
-					end
-				end
-				if corruptedCond then
-					for _, item in pairs(items) do
-						t_insert(matches, item.corrupted == corruptedCond)
-					end
+			if tag.rarityCond then
+				for _, item in pairs(items) do
+					t_insert(matches, item.rarity == tag.rarityCond)
 				end
 			end
+			if tag.corruptedCond then
+				for _, item in pairs(items) do
+					t_insert(matches, item.corrupted == tag.corruptedCond)
+				end
+			end
+			if tag.shaperCond then
+				for _, item in pairs(items) do
+					t_insert(matches, item.shaper == tag.shaperCond)
+				end
+			end
+			if tag.elderCond then
+				for _, item in pairs(items) do
+					t_insert(matches, item.elder == tag.elderCond)
+				end
+			end
+
+			local hasItems = false
+			for _, item in pairs(items) do
+				hasItems = true
+				break
+			end
+
+			local match = true
 			for _, bool in ipairs(matches) do
-				if bool then
-					match = not tag.neg
+				if bool == (tag.neg or false) then
+					match = false
 					break
 				end
-				match = tag.neg == true
 			end
-			if not match and #matches > 0 then
+			if not match or (not hasItems and not tag.neg) then
 				return
 			end
 		elseif tag.type == "SocketedIn" then

--- a/src/Classes/ModStore.lua
+++ b/src/Classes/ModStore.lua
@@ -560,7 +560,7 @@ function ModStoreClass:EvalMod(mod, cfg)
 		elseif tag.type == "ItemCondition" then
 			local matches = {}
 			local itemSlot = tag.itemSlot:lower():gsub("(%l)(%w*)", function(a,b) return string.upper(a)..b end):gsub('^%s*(.-)%s*$', '%1')
-			local items
+			local items = {}
 			if tag.allSlots then
 				items = self.actor.itemList
 			elseif self.actor.itemList then

--- a/src/Data/ModCache.lua
+++ b/src/Data/ModCache.lua
@@ -5523,7 +5523,7 @@ c["70% increased Armour"]={{[1]={flags=0,keywordFlags=0,name="Armour",type="INC"
 c["70% increased Armour and Energy Shield"]={{[1]={flags=0,keywordFlags=0,name="ArmourAndEnergyShield",type="INC",value=70}},nil}
 c["70% increased Armour and Evasion"]={{[1]={flags=0,keywordFlags=0,name="ArmourAndEvasion",type="INC",value=70}},nil}
 c["70% increased Aspect of the Spider Area of Effect"]={{[1]={[1]={skillName="Aspect of the Spider",type="SkillName"},flags=0,keywordFlags=0,name="AreaOfEffect",type="INC",value=70}},nil}
-c["70% increased Attack Damage if your other Ring is a Shaper Item"]={{[1]={[1]={type="Condition",var="ShaperItemInRing {OtherSlotNum}"},flags=1,keywordFlags=0,name="Damage",type="INC",value=70}},nil}
+c["70% increased Attack Damage if your other Ring is a Shaper Item"]={{[1]={[1]={itemSlot="Ring {OtherSlotNum}",shaperCond=true,type="ItemCondition"},flags=1,keywordFlags=0,name="Damage",type="INC",value=70}},nil}
 c["70% increased Burning Damage"]={{[1]={flags=0,keywordFlags=134217728,name="FireDamage",type="INC",value=70}},nil}
 c["70% increased Charges per use"]={{[1]={flags=0,keywordFlags=0,name="FlaskChargesUsed",type="INC",value=70}},nil}
 c["70% increased Critical Strike Chance"]={{[1]={flags=0,keywordFlags=0,name="CritChance",type="INC",value=70}},nil}
@@ -5547,7 +5547,7 @@ c["70% increased Life Recovery from Flasks while affected by Vitality"]={{[1]={[
 c["70% increased Physical Damage"]={{[1]={flags=0,keywordFlags=0,name="PhysicalDamage",type="INC",value=70}},nil}
 c["70% increased Rarity of Items found"]={{[1]={flags=0,keywordFlags=0,name="LootRarity",type="INC",value=70}},nil}
 c["70% increased Spell Damage"]={{[1]={flags=2,keywordFlags=0,name="Damage",type="INC",value=70}},nil}
-c["70% increased Spell Damage if your other Ring is an Elder Item"]={{[1]={[1]={type="Condition",var="ElderItemInRing {OtherSlotNum}"},flags=2,keywordFlags=0,name="Damage",type="INC",value=70}},nil}
+c["70% increased Spell Damage if your other Ring is an Elder Item"]={{[1]={[1]={elderCond=true,itemSlot="Ring {OtherSlotNum}",type="ItemCondition"},flags=2,keywordFlags=0,name="Damage",type="INC",value=70}},nil}
 c["70% increased Stun Duration on Enemies"]={{[1]={flags=0,keywordFlags=0,name="EnemyStunDuration",type="INC",value=70}},nil}
 c["70% less Ward during Effect"]={{[1]={[1]={type="Condition",var="UsingFlask"},flags=0,keywordFlags=0,name="Ward",type="MORE",value=-70}},nil}
 c["70% more Main Hand attack speed"]={{[1]={[1]={type="Condition",var="MainHandAttack"},[2]={skillType=1,type="SkillType"},flags=1,keywordFlags=0,name="Speed",type="MORE",value=70}},nil}
@@ -5700,7 +5700,7 @@ c["80% increased Armour"]={{[1]={flags=0,keywordFlags=0,name="Armour",type="INC"
 c["80% increased Armour and Energy Shield"]={{[1]={flags=0,keywordFlags=0,name="ArmourAndEnergyShield",type="INC",value=80}},nil}
 c["80% increased Armour and Evasion"]={{[1]={flags=0,keywordFlags=0,name="ArmourAndEvasion",type="INC",value=80}},nil}
 c["80% increased Armour while stationary"]={{[1]={[1]={type="Condition",var="Stationary"},flags=0,keywordFlags=0,name="Armour",type="INC",value=80}},nil}
-c["80% increased Attack Damage if your other Ring is a Shaper Item"]={{[1]={[1]={type="Condition",var="ShaperItemInRing {OtherSlotNum}"},flags=1,keywordFlags=0,name="Damage",type="INC",value=80}},nil}
+c["80% increased Attack Damage if your other Ring is a Shaper Item"]={{[1]={[1]={itemSlot="Ring {OtherSlotNum}",shaperCond=true,type="ItemCondition"},flags=1,keywordFlags=0,name="Damage",type="INC",value=80}},nil}
 c["80% increased Burning Damage"]={{[1]={flags=0,keywordFlags=134217728,name="FireDamage",type="INC",value=80}},nil}
 c["80% increased Chaos Damage"]={{[1]={flags=0,keywordFlags=0,name="ChaosDamage",type="INC",value=80}},nil}
 c["80% increased Charges per use"]={{[1]={flags=0,keywordFlags=0,name="FlaskChargesUsed",type="INC",value=80}},nil}
@@ -5738,7 +5738,7 @@ c["80% increased Physical Damage with Axes"]={{[1]={flags=65540,keywordFlags=0,n
 c["80% increased Projectile Attack Damage"]={{[1]={flags=1025,keywordFlags=0,name="Damage",type="INC",value=80}},nil}
 c["80% increased Projectile Damage"]={{[1]={flags=1024,keywordFlags=0,name="Damage",type="INC",value=80}},nil}
 c["80% increased Spell Damage"]={{[1]={flags=2,keywordFlags=0,name="Damage",type="INC",value=80}},nil}
-c["80% increased Spell Damage if your other Ring is an Elder Item"]={{[1]={[1]={type="Condition",var="ElderItemInRing {OtherSlotNum}"},flags=2,keywordFlags=0,name="Damage",type="INC",value=80}},nil}
+c["80% increased Spell Damage if your other Ring is an Elder Item"]={{[1]={[1]={elderCond=true,itemSlot="Ring {OtherSlotNum}",type="ItemCondition"},flags=2,keywordFlags=0,name="Damage",type="INC",value=80}},nil}
 c["80% increased Stun Duration on Enemies"]={{[1]={flags=0,keywordFlags=0,name="EnemyStunDuration",type="INC",value=80}},nil}
 c["80% increased Stun and Block Recovery"]={{[1]={flags=0,keywordFlags=0,name="StunRecovery",type="INC",value=80}},nil}
 c["80% increased Ward"]={{[1]={flags=0,keywordFlags=0,name="Ward",type="INC",value=80}},nil}

--- a/src/Modules/CalcSetup.lua
+++ b/src/Modules/CalcSetup.lua
@@ -943,6 +943,15 @@ function calcs.initEnv(build, mode, override, specEnv)
 							end
 						end
 						env.itemModDB:ScaleAddList(otherRingList, scale)
+						for mult, property in pairs({["CorruptedItem"] = "corrupted", ["ShaperItem"] = "shaper", ["ElderItem"] = "elder"}) do
+							if otherRing[property] and not item[property] then
+								env.itemModDB.multipliers[mult] = (env.itemModDB.multipliers[mult] or 0) + 1
+								env.itemModDB.multipliers["Non"..mult] = (env.itemModDB.multipliers["Non"..mult] or 0) - 1
+							end
+						end
+						if (otherRing.elder or otherRing.shaper) and not (item.elder or item.shaper) then
+							env.itemModDB.multipliers.ShaperOrElderItem = (env.itemModDB.multipliers.ShaperOrElderItem or 0) + 1
+						end
 					end
 					env.itemModDB:ScaleAddList(srcList, scale)
 				elseif item.type == "Quiver" and items["Weapon 1"] and items["Weapon 1"].name:match("Widowhail") then
@@ -976,22 +985,12 @@ function calcs.initEnv(build, mode, override, specEnv)
 					end
 					env.itemModDB.multipliers[key] = (env.itemModDB.multipliers[key] or 0) + 1
 					env.itemModDB.conditions[key .. "In" .. slotName] = true
-					if item.corrupted then
-						env.itemModDB.multipliers.CorruptedItem = (env.itemModDB.multipliers.CorruptedItem or 0) + 1
-					else
-						env.itemModDB.multipliers.NonCorruptedItem = (env.itemModDB.multipliers.NonCorruptedItem or 0) + 1
-					end
-					if item.shaper then
-						env.itemModDB.multipliers.ShaperItem = (env.itemModDB.multipliers.ShaperItem or 0) + 1
-						env.itemModDB.conditions["ShaperItemIn"..slotName] = true
-					else
-						env.itemModDB.multipliers.NonShaperItem = (env.itemModDB.multipliers.NonShaperItem or 0) + 1
-					end
-					if item.elder then
-						env.itemModDB.multipliers.ElderItem = (env.itemModDB.multipliers.ElderItem or 0) + 1
-						env.itemModDB.conditions["ElderItemIn"..slotName] = true
-					else
-						env.itemModDB.multipliers.NonElderItem = (env.itemModDB.multipliers.NonElderItem or 0) + 1
+					for mult, property in pairs({["CorruptedItem"] = "corrupted", ["ShaperItem"] = "shaper", ["ElderItem"] = "elder"}) do
+						if item[property] then
+							env.itemModDB.multipliers[mult] = (env.itemModDB.multipliers[mult] or 0) + 1
+						else
+							env.itemModDB.multipliers["Non"..mult] = (env.itemModDB.multipliers["Non"..mult] or 0) + 1
+						end
 					end
 					if item.shaper or item.elder then
 						env.itemModDB.multipliers.ShaperOrElderItem = (env.itemModDB.multipliers.ShaperOrElderItem or 0) + 1

--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -1390,8 +1390,8 @@ local modTagList = {
 	["w?i?t?h? main hand"] = { tagList = { { type = "Condition", var = "MainHandAttack" }, { type = "SkillType", skillType = SkillType.Attack } } },
 	["w?i?t?h? off hand"] = { tagList = { { type = "Condition", var = "OffHandAttack" }, { type = "SkillType", skillType = SkillType.Attack } } },
 	["[fi]?[rn]?[of]?[ml]?[ i]?[hc]?[it]?[te]?[sd]? ? with this weapon"] = { tagList = { { type = "Condition", var = "{Hand}Attack" }, { type = "SkillType", skillType = SkillType.Attack } } },
-	["if your other ring is a shaper item"] = { tag = { type = "Condition", var = "ShaperItemInRing {OtherSlotNum}" } },
-	["if your other ring is an elder item"] = { tag = { type = "Condition", var = "ElderItemInRing {OtherSlotNum}" } },
+	["if your other ring is a shaper item"] = { tag = { type = "ItemCondition", itemSlot = "Ring {OtherSlotNum}", shaperCond = true} },
+	["if your other ring is an elder item"] = { tag = { type = "ItemCondition", itemSlot = "Ring {OtherSlotNum}", elderCond = true}},
 	["if you have a (%a+) (%a+) in (%a+) slot"] = function(_, rarity, item, slot) return { tag = { type = "Condition", var = rarity:gsub("^%l", string.upper).."ItemIn"..item:gsub("^%l", string.upper).." "..(slot == "right" and 2 or slot == "left" and 1) } } end,
 	["of skills supported by spellslinger"] = { tag = { type = "Condition", var = "SupportedBySpellslinger" } },
 	-- Equipment conditions


### PR DESCRIPTION
Fixes #7179, https://github.com/PathOfBuildingCommunity/PathOfBuilding/issues/7145. Contains https://github.com/PathOfBuildingCommunity/PathOfBuilding/pull/7152

### Description of the problem being solved:
Fixes issues with `ItemCondition` condition not working properly when no matching items were found.
Implements handling for explicit keyword in mods using `ItemCondition` .
Fixes Kalandra's Touch not adding to the `CorruptedItem` multiplier even if the other ring was corrupted.

