### PR TITLE
Flag support was added to spectres and minions, LightningLuckHits was enabled

### DIFF
--- a/src/Export/Minions/Spectres.txt
+++ b/src/Export/Minions/Spectres.txt
@@ -3,7 +3,7 @@
 -- Spectre Data
 -- Monster data (c) Grinding Gear Games
 --
-local minions, mod = ...
+local minions, mod, flag = ...
 
 -- Blackguard
 #spectre Metadata/Monsters/Axis/AxisCaster
@@ -265,4 +265,8 @@ local minions, mod = ...
 -- Spirit of Fortune
 #spectre Metadata/Monsters/LeagueAzmeri/SpecialCorpses/KudukuLow
 #spectre Metadata/Monsters/LeagueAzmeri/SpecialCorpses/KudukuMid
-#spectre Metadata/Monsters/LeagueAzmeri/SpecialCorpses/KudukuHigh
+
+#monster Metadata/Monsters/LeagueAzmeri/SpecialCorpses/KudukuHigh
+#mod mod("MinionModifier", "LIST", { mod = flag("LightningLuckHits") })
+#mod mod("PlayerModifier", "LIST", { mod = flag("LightningLuckHits") })
+#emit

--- a/src/Modules/CalcOffence.lua
+++ b/src/Modules/CalcOffence.lua
@@ -2939,7 +2939,7 @@ function calcs.offence(env, actor, activeSkill)
 					if skillModList:Flag(skillCfg, "LuckyHits")
 					or (pass == 2 and damageType == "Lightning" and skillModList:Flag(skillCfg, "LightningNoCritLucky"))
 					or (pass == 1 and skillModList:Flag(skillCfg, "CritLucky"))
-					or (damageType == "Lightning" and skillModList:Flag(skillCfg, "LightningLuckHits"))
+					or (damageType == "Lightning" and modDB:Flag(nil, "LightningLuckHits"))
 					or ((damageType == "Lightning" or damageType == "Cold" or damageType == "Fire") and skillModList:Flag(skillCfg, "ElementalLuckHits")) then
 						damageTypeLuckyChance = 1
 					else

--- a/src/Modules/Data.lua
+++ b/src/Modules/Data.lua
@@ -853,9 +853,9 @@ end
 
 -- Load minions
 data.minions = { }
-LoadModule("Data/Minions", data.minions, makeSkillMod)
+LoadModule("Data/Minions", data.minions, makeSkillMod, makeFlagMod)
 data.spectres = { }
-LoadModule("Data/Spectres", data.spectres, makeSkillMod)
+LoadModule("Data/Spectres", data.spectres, makeSkillMod, makeFlagMod)
 for name, spectre in pairs(data.spectres) do
 	spectre.limit = "ActiveSpectreLimit"
 	data.minions[name] = spectre


### PR DESCRIPTION
When you use "minionModifier" or "playerModifier" in spectres / minions we are adding those mods in "buff" and "minionBuff"

so now we are enabling "flag" method.

![image](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/80857657/d2e0a520-82fb-4e49-8fd3-f3a7d35e50c5)

