### PR TITLE
Add support for converting all trees to latest version

### DIFF
--- a/src/Classes/TreeTab.lua
+++ b/src/Classes/TreeTab.lua
@@ -228,10 +228,16 @@ local TreeTabClass = newClass("TreeTab", "ControlHost", function(self, build)
 		return latestTreeVersion .. (self.specList[self.activeSpec].treeVersion:match("^" .. latestTreeVersion .. "(.*)") or "")
 	end
 	local function buildConvertButtonLabel()
-		return "^2Convert to "..treeVersions[getLatestTreeVersion()].display
+		return colorCodes.POSITIVE.."Convert to "..treeVersions[getLatestTreeVersion()].display
+	end
+	local function buildConvertAllButtonLabel()
+		return colorCodes.POSITIVE.."Convert all trees to "..treeVersions[getLatestTreeVersion()].display
 	end
 	self.controls.specConvert = new("ButtonControl", { "LEFT", self.controls.specConvertText, "RIGHT" }, 8, 0, function() return DrawStringWidth(16, "VAR", buildConvertButtonLabel()) + 20 end, 20, buildConvertButtonLabel, function()
 		self:ConvertToVersion(getLatestTreeVersion(), false, true)
+	end)
+	self.controls.specConvertAll = new("ButtonControl", { "LEFT", self.controls.specConvert, "RIGHT" }, 8, 0, function() return DrawStringWidth(16, "VAR", buildConvertAllButtonLabel()) + 20 end, 20, buildConvertAllButtonLabel, function()
+		self:OpenVersionConvertAllPopup(getLatestTreeVersion())
 	end)
 	self.jumpToNode = false
 	self.jumpToX = 0
@@ -270,6 +276,17 @@ function TreeTabClass:Draw(viewPort, inputEvents)
 	else
 		self.controls.treeSearch:SetAnchor("TOPLEFT", self.controls.specSelect, "BOTTOMLEFT", 0, 4)
 		self.controls.powerReportList:SetAnchor("TOPLEFT", self.controls.treeSearch, "BOTTOMLEFT", 0, self.controls.treeHeatMap.y + self.controls.treeHeatMap.height + 4)
+	end
+	-- determine positions for convert line of controls
+	local convertTwoLineHeight = 24
+	local convertMaxWidth = 900
+	if viewPort.width >= convertMaxWidth then
+		convertTwoLineHeight = 0
+		self.controls.specConvert:SetAnchor("LEFT", self.controls.specConvertText, "RIGHT", 8, 0)
+		self.controls.specConvertText:SetAnchor("BOTTOMLEFT", self.controls.specSelect, "TOPLEFT", 0, -14)
+	else
+		self.controls.specConvert:SetAnchor("TOPLEFT", self.controls.specConvertText, "BOTTOMLEFT", 0, 4)
+		self.controls.specConvertText:SetAnchor("BOTTOMLEFT", self.controls.specSelect, "TOPLEFT", 0, -38)
 	end
 
 	local bottomDrawerHeight = self.controls.powerReportList.shown and 194 or 0
@@ -316,15 +333,16 @@ function TreeTabClass:Draw(viewPort, inputEvents)
 
 	SetDrawColor(0.05, 0.05, 0.05)
 	DrawImage(nil, viewPort.x, viewPort.y + viewPort.height - (28 + bottomDrawerHeight + twoLineHeight), viewPort.width, 28 + bottomDrawerHeight + twoLineHeight)
+	if self.showConvert then
+		local height = viewPort.width < convertMaxWidth and (bottomDrawerHeight + twoLineHeight) or 0
+		SetDrawColor(0.05, 0.05, 0.05)
+		DrawImage(nil, viewPort.x, viewPort.y + viewPort.height - (60 + bottomDrawerHeight + twoLineHeight + convertTwoLineHeight), viewPort.width, 28 + height)
+		SetDrawColor(0.85, 0.85, 0.85)
+		DrawImage(nil, viewPort.x, viewPort.y + viewPort.height - (64 + bottomDrawerHeight + twoLineHeight + convertTwoLineHeight), viewPort.width, 4)
+	end
+	-- let white lines overwrite the black sections, regardless of showConvert
 	SetDrawColor(0.85, 0.85, 0.85)
 	DrawImage(nil, viewPort.x, viewPort.y + viewPort.height - (32 + bottomDrawerHeight + twoLineHeight), viewPort.width, 4)
-
-	if self.showConvert then
-		SetDrawColor(0.05, 0.05, 0.05)
-		DrawImage(nil, viewPort.x, viewPort.y + viewPort.height - (60 + bottomDrawerHeight + twoLineHeight), viewPort.width, 28)
-		SetDrawColor(0.85, 0.85, 0.85)
-		DrawImage(nil, viewPort.x, viewPort.y + viewPort.height - (64 + bottomDrawerHeight + twoLineHeight), viewPort.width, 4)
-	end
 
 	self:DrawControls(viewPort)
 end
@@ -440,6 +458,21 @@ function TreeTabClass:ConvertToVersion(version, remove, success)
 	end
 end
 
+function TreeTabClass:ConvertAllToVersion(version)
+	local currActiveSpec = self.activeSpec
+	local specVersionList = { }
+	for _, spec in ipairs(self.specList) do
+		t_insert(specVersionList, spec.treeVersion)
+	end
+	for index, specVersion in ipairs(specVersionList) do
+		if specVersion ~= version then
+			self:SetActiveSpec(index)
+			self:ConvertToVersion(version, true, false)
+		end
+	end
+	self:SetActiveSpec(currActiveSpec)
+end
+
 function TreeTabClass:OpenSpecManagePopup()
 	local importTree =
 		new("ButtonControl", nil, -99, 259, 90, 20, "Import Tree", function()
@@ -464,18 +497,32 @@ function TreeTabClass:OpenVersionConvertPopup(version)
 	local controls = { }
 	controls.warningLabel = new("LabelControl", nil, 0, 20, 0, 16, "^7Warning: some or all of the passives may be de-allocated due to changes in the tree.\n\n" ..
 		"Convert will replace your current tree.\nCopy + Convert will backup your current tree.\n")
-	controls.convert = new("ButtonControl", nil, -125, 110, 100, 20, "Convert", function()
+	controls.convert = new("ButtonControl", nil, -125, 105, 100, 20, "Convert", function()
 		self:ConvertToVersion(version, true, false)
 		main:ClosePopup()
 	end)
-	controls.convertCopy = new("ButtonControl", nil, 0, 110, 125, 20, "Copy + Convert", function()
+	controls.convertCopy = new("ButtonControl", nil, 0, 105, 125, 20, "Copy + Convert", function()
 		self:ConvertToVersion(version, false, false)
 		main:ClosePopup()
 	end)
-	controls.cancel = new("ButtonControl", nil, 125, 110, 100, 20, "Cancel", function()
+	controls.cancel = new("ButtonControl", nil, 125, 105, 100, 20, "Cancel", function()
 		main:ClosePopup()
 	end)
 	main:OpenPopup(570, 140, "Convert to Version "..treeVersions[version].display, controls, "convert", "edit")
+end
+
+function TreeTabClass:OpenVersionConvertAllPopup(version)
+	local controls = { }
+	controls.warningLabel = new("LabelControl", nil, 0, 20, 0, 16, "^7Warning: some or all of the passives may be de-allocated due to changes in the tree.\n\n" ..
+		"Convert will replace all trees that are not Version "..treeVersions[version].display..".\nThis action cannot be undone.\n")
+	controls.convert = new("ButtonControl", nil, -58, 105, 100, 20, "Convert", function()
+		self:ConvertAllToVersion(version)
+		main:ClosePopup()
+	end)
+	controls.cancel = new("ButtonControl", nil, 58, 105, 100, 20, "Cancel", function()
+		main:ClosePopup()
+	end)
+	main:OpenPopup(570, 140, "Convert all to Version "..treeVersions[version].display, controls, "convert", "edit")
 end
 
 function TreeTabClass:OpenImportPopup()


### PR DESCRIPTION
Fixes #1392

### Description of the problem being solved:
Add ability to update every tree that is not latest all at once instead of needing to manually convert each one. All trees that are converted are replaced. As this action cannot be undone, there is a confirmation pop-up.

### Steps taken to verify a working solution:
- Validate all trees are updated to latest version and load successfully
- Validate any tree that is already latest version is unchanged
- Validate window sizing to avoid cropping the "Convert all" button

### Link to a build that showcases this PR:
<pre>https://pobb.in/CyjKf3xPDZbT</pre>

### After screenshot:
![image](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/92683202/06cc37cc-4736-498c-8047-88fd637a8edd)

![convertAll3](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/92683202/11a31d1d-ffd4-49ab-a780-cd4a1f8be638)

![convertAll2](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/92683202/0976fb4e-3153-4d78-be9b-e2be309a9eb5)
