### PR TITLE
Fix interaction between Chieftain Tasalio node and increased/more fire resistance modifiers

### DIFF
--- a/src/Modules/CalcDefence.lua
+++ b/src/Modules/CalcDefence.lua
@@ -344,6 +344,12 @@ function calcs.defence(env, actor)
 				if res ~= 0 then
 					modDB:NewMod(resTo.."Resist", "BASE", res * conversionRate, resFrom.." To "..resTo.." Resistance Conversion")
 				end
+				for _, mod in ipairs(modDB:Tabulate("INC", nil, resFrom.."Resist")) do
+					modDB:NewMod(resTo.."Resist", "INC", mod.value * conversionRate, mod.mod.source)
+				end
+				for _, mod in ipairs(modDB:Tabulate("MORE", nil, resFrom.."Resist")) do
+					modDB:NewMod(resTo.."Resist", "MORE", mod.value * conversionRate, mod.mod.source)
+				end
 			end
 		end
 	end


### PR DESCRIPTION
Fixes #7191 .

### Description of the problem being solved:
Current implementation in `CalcDefence.lua` only converts base fire resistance but based on screenshots from linked issue, increased modifiers also apply. Extrapolating this to apply to more multipliers as well. 

This PR applies increased and more modifiers to cold and lightning resistances using the conversion rate. 

### For discussion
What is the appropriate source for the converted increased and more modifiers? Should it still be the same as the original source or the same as the base conversion "Fire to X Resistance Conversion"? I've opted for the former due to potential confusion when there are multiple items. 

### Steps taken to verify a working solution:
- Confirmed resistances match in game values from linked issue.

### Link to a build that showcases this PR:
Refer linked issue 

### After screenshot:
![image](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/42928828/a60fdd0a-e728-4b67-b0d0-249eea362ed5)

