### PR TITLE
Sort the Calculations Tab breakdown lists by value

### DIFF
--- a/src/Classes/CalcBreakdownControl.lua
+++ b/src/Classes/CalcBreakdownControl.lua
@@ -291,7 +291,13 @@ function CalcBreakdownClass:AddModSection(sectionData, modList)
 
 	table.sort(rowList, function(a, b)
 		-- Sort Modifiers by descending value
-		return b.value < a.value
+		if type(a.value) == 'number' and type(b.value) == 'number' then
+			return b.value < a.value
+		end
+		if type(a.value) == 'boolean' and type(b.value) == 'boolean' then
+			return a.value and not b.value
+		end
+		return false
 	end)
 
 	if not modList and not sectionData.modType then

--- a/src/Classes/CalcBreakdownControl.lua
+++ b/src/Classes/CalcBreakdownControl.lua
@@ -260,8 +260,8 @@ function CalcBreakdownClass:AddModSection(sectionData, modList)
 	cfg.actor = sectionData.actor
 	local rowList
 	local modStore = (sectionData.enemy and actor.enemy.modDB) or (sectionData.cfg and actor.mainSkill.skillModList) or actor.modDB
-	if modList then	
-		rowList = modList
+	if modList then
+		rowList = copyTable(modList)
 	else
 		if type(sectionData.modName) == "table" then
 			rowList = modStore:Tabulate(sectionData.modType, cfg, unpack(sectionData.modName))

--- a/src/Classes/CalcBreakdownControl.lua
+++ b/src/Classes/CalcBreakdownControl.lua
@@ -289,6 +289,11 @@ function CalcBreakdownClass:AddModSection(sectionData, modList)
 	}
 	t_insert(self.sectionList, section)
 
+	table.sort(rowList, function(a, b)
+		-- Sort Modifiers by descending value
+		return b.value < a.value
+	end)
+
 	if not modList and not sectionData.modType then
 		-- Sort modifiers by type
 		for i, row in ipairs(rowList) do

--- a/src/Classes/CalcBreakdownControl.lua
+++ b/src/Classes/CalcBreakdownControl.lua
@@ -148,12 +148,19 @@ function CalcBreakdownClass:AddBreakdownSection(sectionData)
 	end
 
 	if breakdown.rowList and #breakdown.rowList > 0 then
+		-- sort by the first column (the value)
+		local rowList = copyTable(breakdown.rowList, true)
+		local colKey = breakdown.colList[1].key
+		table.sort(rowList, function(a, b)
+			return a[colKey] > b[colKey]
+		end)
+		
 		-- Generic table
 		local section = {
 			type = "TABLE",
 			label = breakdown.label,
 			footer = breakdown.footer,
-			rowList = breakdown.rowList,
+			rowList = rowList,
 			colList = breakdown.colList,
 		}
 		t_insert(self.sectionList, section)
@@ -225,6 +232,10 @@ function CalcBreakdownClass:AddBreakdownSection(sectionData)
 			rowList = breakdown.slots
 		end
 
+		table.sort(rowList, function(a, b)
+			return a['base'] > b['base']
+		end)
+		
 		local section = { 
 			type = "TABLE",
 			rowList = rowList,


### PR DESCRIPTION
There is already a sort by type, but this is not used for a lot of breakdowns. Applying a sort by value should make it easier to read the breakdown without disrupting the sort by type.

Fixes #4433 #7228

### Description of the problem being solved:

The calculations breakdown popups are unsorted, making it harder to compare between builds.

### Steps taken to verify a working solution:
- Verified the mods are sorted in various controls

### Before screenshot:
![image](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/755683/6b3fc82f-67a9-4e06-b1a1-a97a7567d9ca)

### After screenshot:
![image](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/755683/253df90f-a3cb-45a1-998d-ede300b9e9f0)
