### PR TITLE
Fix loading of Passive Tree dropdown in Items Tab

### DIFF
--- a/src/Classes/ItemsTab.lua
+++ b/src/Classes/ItemsTab.lua
@@ -1220,6 +1220,8 @@ function ItemsTabClass:Draw(viewPort, inputEvents)
 	if self.controls.scrollBarV:IsShown() then
 		self.controls.scrollBarV:Draw(viewPort)
 	end
+
+	self.controls.specSelect:SetList(self.build.treeTab:GetSpecList())
 end
 
 -- Creates a new item set

--- a/src/Classes/TreeTab.lua
+++ b/src/Classes/TreeTab.lua
@@ -283,20 +283,11 @@ function TreeTabClass:Draw(viewPort, inputEvents)
 	self.viewer.compareSpec = self.isComparing and self.specList[self.activeCompareSpec] or nil
 	self.viewer:Draw(self.build, treeViewPort, inputEvents)
 
-	local newSpecList = { }
+	local newSpecList = self:GetSpecList()
 	self.controls.compareSelect.selIndex = self.activeCompareSpec
-	for id, spec in ipairs(self.specList) do
-		t_insert(newSpecList, (spec.treeVersion ~= latestTreeVersion and ("["..treeVersions[spec.treeVersion].display.."] ") or "")..(spec.title or "Default"))
-	end
 	self.controls.compareSelect:SetList(newSpecList)
-
-	self.controls.specSelect.selIndex = self.activeSpec
-	wipeTable(newSpecList)
-	for id, spec in ipairs(self.specList) do
-		t_insert(newSpecList, (spec.treeVersion ~= latestTreeVersion and ("["..treeVersions[spec.treeVersion].display.."] ") or "")..(spec.title or "Default"))
-	end
-	self.build.itemsTab.controls.specSelect:SetList(copyTable(newSpecList)) -- Update the passive tree dropdown control in itemsTab
 	t_insert(newSpecList, "Manage trees... (ctrl-m)")
+	self.controls.specSelect.selIndex = self.activeSpec
 	self.controls.specSelect:SetList(newSpecList)
 
 	if not self.controls.treeSearch.hasFocus then
@@ -327,6 +318,14 @@ function TreeTabClass:Draw(viewPort, inputEvents)
 	end
 
 	self:DrawControls(viewPort)
+end
+
+function TreeTabClass:GetSpecList()
+	local newSpecList = { }
+	for _, spec in ipairs(self.specList) do
+		t_insert(newSpecList, (spec.treeVersion ~= latestTreeVersion and ("["..treeVersions[spec.treeVersion].display.."] ") or "")..(spec.title or "Default"))
+	end
+	return newSpecList
 end
 
 function TreeTabClass:Load(xml, dbFileName)


### PR DESCRIPTION
Fixes #6853 

### Description of the problem being solved:
Before, the passive tree dropdown list in the ItemsTab is only set if the user has accessed the TreeTab or PassiveSpecListControl. This PR moves the SetList() to ItemsTab and creates a class-level function in TreeTab for ItemsTab to use. I also cleaned up the specList creation a little in TreeTab.

### Steps taken to verify a working solution:
- Save build on ItemsTab, reload build and verify dropdown loaded
- Verify tree and compare tree dropdowns are unaffected

### Link to a build that showcases this PR:
<pre>https://pobb.in/MSe5KQque6QF</pre>

### After screenshot:

![itemsTabTreeLoad](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/92683202/962fb8a7-bbfe-4207-a83e-e07deef922b0)