### PR TITLE
Fix allocated nodes on Cluster Jewels when importing character

### DIFF
--- a/src/Classes/ImportTab.lua
+++ b/src/Classes/ImportTab.lua
@@ -601,6 +601,7 @@ function ImportTabClass:ImportPassiveTreeAndJewels(json, charData)
 	if self.controls.charImportTreeClearJewels.state then
 		for _, slot in pairs(self.build.itemsTab.slots) do
 			if slot.selItemId ~= 0 and slot.nodeId then
+				self.build.itemsTab.build.spec.ignoreAllocatingSubgraph = true -- ignore allocated cluster nodes on Import when Delete Jewel is true, clean slate
 				self.build.itemsTab:DeleteItem(self.build.itemsTab.items[slot.selItemId])
 			end
 		end

--- a/src/Classes/PassiveSpec.lua
+++ b/src/Classes/PassiveSpec.lua
@@ -31,6 +31,7 @@ function PassiveSpecClass:Init(treeVersion, convert)
 	self.treeVersion = treeVersion
 	self.tree = main:LoadTree(treeVersion)
 	self.ignoredNodes = { }
+	self.ignoreAllocatingSubgraph = false
 	local previousTreeNodes = { }
 	if convert then
 		previousTreeNodes = self.build.spec.nodes
@@ -1293,7 +1294,9 @@ function PassiveSpecClass:BuildClusterJewelGraphs()
 				if self.allocNodes[node.id] then
 					-- Reserve the allocation in case the node is regenerated
 					self.allocNodes[node.id] = nil
-					t_insert(self.allocSubgraphNodes, node.id)
+					if not self.ignoreAllocatingSubgraph then -- do not carry over alloc nodes, e.g. cluster jewels on Import when Delete Jewel is true
+						t_insert(self.allocSubgraphNodes, node.id)
+					end
 				end
 			end
 		end
@@ -1302,6 +1305,7 @@ function PassiveSpecClass:BuildClusterJewelGraphs()
 		t_remove(subGraph.parentSocket.linked, index)
 	end
 	wipeTable(self.subGraphs)
+	self.ignoreAllocatingSubgraph = false -- reset after subGraph logic
 
 	local importedGroups = { }
 	local importedNodes = { }


### PR DESCRIPTION
Fixes #6718

### Description of the problem being solved:
On character import, when Delete Jewels is true, we are keeping the state of cluster jewels in a subgraph. This functionality is used elsewhere in the case where you remove a cluster from the tree and then add it back in. We keep the allocated nodes so that it automatically loads back in when the cluster is returned. The problem is when importing, we're keeping the state of the nodes, including any additionally allocated ones, "in case the cluster comes back" and of course it does because it's part of the import data. So we see the cluster again and allocate all the nodes that were there at time of Import, including ones the Import possibly does not have.

So this PR adds a flag that is set true during Import Delete Jewel true that will ignore saving the state of the cluster jewels for that flow. The flag is reset after deallocating all nodes from the jewels.

### Steps taken to verify a working solution:
- Import a character with a cluster jewel, e.g. account name dyfrgi, league Ancestor, character ShockingWaffle.
- Set an extra passive in the large cluster, e.g. the extra small passive in the upper left for Foe Bliss.
- Import the passive tree again with Delete Jewels: true. Observe that the extra passive is NOT allocated.

### Link to a build that showcases this PR:
Account name dyfrgi, league All, character ShockingWaffle.
In this case, the Delete Jewels: true is the problem, so character import is required.

### Before screenshot:
![clusterSubgraph2](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/92683202/97e9e265-9f64-4125-b6c7-bfddf343c35b)

### After screenshot:
![clusterSubgraph](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/92683202/c94aa347-9605-48dc-be59-e4f277b45d4c)

