### PR TITLE
Fix GemProperty mods applying to incorrect gems.

### DIFF
--- a/src/Classes/ConfigTab.lua
+++ b/src/Classes/ConfigTab.lua
@@ -452,7 +452,7 @@ local ConfigTabClass = newClass("ConfigTab", "UndoHandler", "ControlHost", "Cont
 							return false
 						end
 						for skill,_ in pairs(self.build.calcsTab.mainEnv.skillsUsed) do
-							if calcLib.getGameIdFromGemName(skill, true) == calcLib.getGameIdFromGemName(ifOption, true) then
+							if calcLib.isGemIdSame(skill, ifOption, true) then
 								return true
 							end
 						end

--- a/src/Classes/ImportTab.lua
+++ b/src/Classes/ImportTab.lua
@@ -988,14 +988,14 @@ function ImportTabClass:ImportSocketedItems(item, socketedItems, slotName)
 			abyssalSocketId = abyssalSocketId + 1
 		else
 			local normalizedBasename, qualityType = self.build.skillsTab:GetBaseNameAndQuality(socketedItem.typeLine, nil)
-			local gemId = self.build.data.gemForBaseName[normalizedBasename]
+			local gemId = self.build.data.gemForBaseName[normalizedBasename:lower()]
 			if socketedItem.hybrid then
 				-- Used by transfigured gems and dual-skill gems (currently just Stormbind) 
 				normalizedBasename, qualityType  = self.build.skillsTab:GetBaseNameAndQuality(socketedItem.hybrid.baseTypeName, nil)
 				if socketedItem.hybrid.isVaalGem then
 					normalizedBasename = "Vaal " .. normalizedBasename
 				end
-				gemId = self.build.data.gemForBaseName[normalizedBasename]
+				gemId = self.build.data.gemForBaseName[normalizedBasename:lower()]
 			end
 			if gemId then
 				local gemInstance = { level = 20, quality = 0, enabled = true, enableGlobal1 = true, gemId = gemId }

--- a/src/Modules/CalcSetup.lua
+++ b/src/Modules/CalcSetup.lua
@@ -1293,7 +1293,7 @@ function calcs.initEnv(build, mode, override, specEnv)
 						if grantedEffect then
 							t_insert(supportList, {
 								grantedEffect = grantedEffect,
-								gemData = env.data.gems[env.data.gemForBaseName[grantedEffect.name] or env.data.gemForBaseName[grantedEffect.name .. " Support"]],
+								gemData = env.data.gems[env.data.gemForBaseName[grantedEffect.name:lower()] or env.data.gemForBaseName[(grantedEffect.name .. " Support"):lower()]],
 								level = value.level,
 								quality = 0,
 								enabled = true,

--- a/src/Modules/CalcTools.lua
+++ b/src/Modules/CalcTools.lua
@@ -110,7 +110,7 @@ function calcLib.gemIsType(gem, type, includeTransfigured)
 			(type == "non-vaal" and not gem.tags.vaal) or
 			(type == gem.name:lower()) or
 			(type == gem.name:lower():gsub("^vaal ", "")) or
-			(includeTransfigured and calcLib.getGameIdFromGemName(gem.name, true) == calcLib.getGameIdFromGemName(type, true)) or
+			(includeTransfigured and calcLib.isGemIdSame(gem.name, type, true)) or
 			((type ~= "active skill" and type ~= "grants_active_skill" and type ~= "skill") and gem.tags[type]))
 end
 
@@ -236,15 +236,26 @@ end
 
 --- Get the gameId from the gemName which will be the same as the base gem for transfigured gems
 --- @param gemName string
---- @param dropVaal boolean 
+--- @param dropVaal boolean
 --- @return string
 function calcLib.getGameIdFromGemName(gemName, dropVaal)
 	if type(gemName) ~= "string" then
 		return
 	end
-	local gemId = data.gemForBaseName[gemName]
+	local gemId = data.gemForBaseName[gemName:lower()]
 	if not gemId then return end
 	local gameId = data.gems[gemId].gameId
 	if gameId and dropVaal then gameId = gameId:gsub("SkillGemVaal","SkillGem") end
 	return gameId
+end
+
+--- Use getGameIdFromGemName to get gameId from the gemName and passed in type. Return true if they're the same and not nil
+--- @param gemName string
+--- @param type string
+--- @param dropVaal boolean 
+--- @return booleanf
+function calcLib.isGemIdSame(gemName, type, dropVaal)
+	local gemNameId = calcLib.getGameIdFromGemName(gemName, dropVaal)
+	local typeId = calcLib.getGameIdFromGemName(type, dropVaal)
+	return gemNameId and typeId and gemNameId == typeId
 end

--- a/src/Modules/CalcTools.lua
+++ b/src/Modules/CalcTools.lua
@@ -253,9 +253,9 @@ end
 --- @param gemName string
 --- @param type string
 --- @param dropVaal boolean 
---- @return booleanf
-function calcLib.isGemIdSame(gemName, type, dropVaal)
+--- @return boolean
+function calcLib.isGemIdSame(gemName, typeName, dropVaal)
 	local gemNameId = calcLib.getGameIdFromGemName(gemName, dropVaal)
-	local typeId = calcLib.getGameIdFromGemName(type, dropVaal)
+	local typeId = calcLib.getGameIdFromGemName(typeName, dropVaal)
 	return gemNameId and typeId and gemNameId == typeId
 end

--- a/src/Modules/Data.lua
+++ b/src/Modules/Data.lua
@@ -813,7 +813,7 @@ local function setupGem(gem, gemId)
 	if gem.grantedEffect.support and gem.grantedEffectId ~= "SupportBarrage" then
 		baseName = baseName .. " Support"
 	end
-	data.gemForBaseName[baseName] = gemId
+	data.gemForBaseName[baseName:lower()] = gemId
 	gem.secondaryGrantedEffect = gem.secondaryGrantedEffectId and data.skills[gem.secondaryGrantedEffectId]
 	gem.grantedEffectList = {
 		gem.grantedEffect,

--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -1822,7 +1822,7 @@ local function extraSupport(name, level, slot)
 	
 	level = tonumber(level)
 	if skillId then
-		local gemId = data.gemForBaseName[data.skills[skillId].name .. " Support"]
+		local gemId = data.gemForBaseName[(data.skills[skillId].name .. " Support"):lower()]
 		if gemId then
 			local mods = {mod("ExtraSupport", "LIST", { skillId = data.gems[gemId].grantedEffectId, level = level }, { type = "SocketedIn", slotName = slot })}
 			if data.gems[gemId].secondaryGrantedEffect then


### PR DESCRIPTION
Fixes #7215.

### Description of the problem being solved:
The check `calcLib.getGameIdFromGemName(skill, true) == calcLib.getGameIdFromGemName(ifOption, true)` causes a match when both function calls return nil. This often happens when using gemName from a parsed mod as those are lowercase while the keys in `data.gemForBaseName` have uppercase letters which is an issue in and of itself causing some trans gems to not be affected while they should be.

### Steps taken to verify a working solution:
- Test Arc and its variants

### Link to a build that showcases this PR:
https://pobb.in/xpExdA_AV6rg
