### PR TITLE
Fix/maji double armour

### DIFF
--- a/src/Modules/CalcDefence.lua
+++ b/src/Modules/CalcDefence.lua
@@ -625,7 +625,6 @@ function calcs.defence(env, actor)
 					if slot == "Body Armour" and modDB:Flag(nil, "Unbreakable") then 
 						armourBase = armourBase * 2
 					end
-
 					armour = armour + armourBase * calcLib.mod(modDB, slotCfg, "Armour", "ArmourAndEvasion", "Defences", slot.."ESAndArmour")
 					gearArmour = gearArmour + armourBase
 					if breakdown then

--- a/src/Modules/CalcDefence.lua
+++ b/src/Modules/CalcDefence.lua
@@ -350,6 +350,12 @@ function calcs.defence(env, actor)
 				if res ~= 0 then
 					modDB:NewMod(resTo.."Resist", "BASE", res * conversionRate, resFrom.." To "..resTo.." Resistance Conversion")
 				end
+				for _, mod in ipairs(modDB:Tabulate("INC", nil, resFrom.."Resist")) do
+					modDB:NewMod(resTo.."Resist", "INC", mod.value * conversionRate, mod.mod.source)
+				end
+				for _, mod in ipairs(modDB:Tabulate("MORE", nil, resFrom.."Resist")) do
+					modDB:NewMod(resTo.."Resist", "MORE", mod.value * conversionRate, mod.mod.source)
+				end
 			end
 		end
 	end

--- a/src/Modules/CalcDefence.lua
+++ b/src/Modules/CalcDefence.lua
@@ -289,14 +289,20 @@ function calcs.defence(env, actor)
 			end
 			armourBase = armourData.Armour or 0
 			if armourBase > 0 then
-				if slot == "Body Armour" and (modDB:Flag(nil, "Unbreakable") or modDB:Flag(nil, "DoubleBodyArmourDefence")) then
+				if slot == "Body Armour" and modDB:Flag(nil, "DoubleBodyArmourDefence") then
+					armourBase = armourBase * 2
+				end
+				if slot == "Body Armour" and modDB:Flag(nil, "Unbreakable") then
 					armourBase = armourBase * 2
 				end
 				output["ArmourOn"..slot] = armourBase
 			end
 			evasionBase = armourData.Evasion or 0
 			if evasionBase > 0 then
-				if slot == "Body Armour" and ((modDB:Flag(nil, "Unbreakable") and modDB:Flag(nil, "IronReflexes")) or modDB:Flag(nil, "DoubleBodyArmourDefence")) then
+				if slot == "Body Armour" and  modDB:Flag(nil, "DoubleBodyArmourDefence") then
+					evasionBase = evasionBase * 2
+				end
+				if (modDB:Flag(nil, "Unbreakable") and modDB:Flag(nil, "IronReflexes")) then
 					evasionBase = evasionBase * 2
 				end
 				output["EvasionOn"..slot] = evasionBase
@@ -343,12 +349,6 @@ function calcs.defence(env, actor)
 				end
 				if res ~= 0 then
 					modDB:NewMod(resTo.."Resist", "BASE", res * conversionRate, resFrom.." To "..resTo.." Resistance Conversion")
-				end
-				for _, mod in ipairs(modDB:Tabulate("INC", nil, resFrom.."Resist")) do
-					modDB:NewMod(resTo.."Resist", "INC", mod.value * conversionRate, mod.mod.source)
-				end
-				for _, mod in ipairs(modDB:Tabulate("MORE", nil, resFrom.."Resist")) do
-					modDB:NewMod(resTo.."Resist", "MORE", mod.value * conversionRate, mod.mod.source)
 				end
 			end
 		end
@@ -619,9 +619,13 @@ function calcs.defence(env, actor)
 				end
 				armourBase = armourData.Armour or 0
 				if armourBase > 0 then
-					if slot == "Body Armour" and (modDB:Flag(nil, "Unbreakable") or modDB:Flag(nil, "DoubleBodyArmourDefence")) then
+					if slot == "Body Armour" and modDB:Flag(nil, "DoubleBodyArmourDefence") then
 						armourBase = armourBase * 2
 					end
+					if slot == "Body Armour" and modDB:Flag(nil, "Unbreakable") then 
+						armourBase = armourBase * 2
+					end
+
 					armour = armour + armourBase * calcLib.mod(modDB, slotCfg, "Armour", "ArmourAndEvasion", "Defences", slot.."ESAndArmour")
 					gearArmour = gearArmour + armourBase
 					if breakdown then
@@ -630,7 +634,10 @@ function calcs.defence(env, actor)
 				end
 				evasionBase = armourData.Evasion or 0
 				if evasionBase > 0 then
-					if slot == "Body Armour" and ((modDB:Flag(nil, "Unbreakable") and ironReflexes) or modDB:Flag(nil, "DoubleBodyArmourDefence")) then
+					if slot == "Body Armour" and modDB:Flag(nil, "DoubleBodyArmourDefence") then
+						evasionBase = evasionBase * 2
+					end
+					if slot == "Body Armour" and (modDB:Flag(nil, "Unbreakable") and ironReflexes) then
 						evasionBase = evasionBase * 2
 					end
 					gearEvasion = gearEvasion + evasionBase

--- a/src/Modules/CalcDefence.lua
+++ b/src/Modules/CalcDefence.lua
@@ -289,21 +289,25 @@ function calcs.defence(env, actor)
 			end
 			armourBase = armourData.Armour or 0
 			if armourBase > 0 then
-				if slot == "Body Armour" and modDB:Flag(nil, "DoubleBodyArmourDefence") then
-					armourBase = armourBase * 2
-				end
-				if slot == "Body Armour" and modDB:Flag(nil, "Unbreakable") then
-					armourBase = armourBase * 2
+				if slot == "Body Armour" then 
+					if modDB:Flag(nil, "DoubleBodyArmourDefence") then
+						armourBase = armourBase * 2
+					end
+					if modDB:Flag(nil, "Unbreakable") then
+						armourBase = armourBase * 2
+					end
 				end
 				output["ArmourOn"..slot] = armourBase
 			end
 			evasionBase = armourData.Evasion or 0
 			if evasionBase > 0 then
-				if slot == "Body Armour" and  modDB:Flag(nil, "DoubleBodyArmourDefence") then
-					evasionBase = evasionBase * 2
-				end
-				if slot == "Body Armour" and modDB:Flag(nil, "Unbreakable") and modDB:Flag(nil, "IronReflexes") then
-					evasionBase = evasionBase * 2
+				if slot == "Body Armour" then
+					if modDB:Flag(nil, "DoubleBodyArmourDefence") then
+						evasionBase = evasionBase * 2
+					end
+				 	if modDB:Flag(nil, "Unbreakable") and modDB:Flag(nil, "IronReflexes") then
+						evasionBase = evasionBase * 2
+					end
 				end
 				output["EvasionOn"..slot] = evasionBase
 			end
@@ -625,11 +629,13 @@ function calcs.defence(env, actor)
 				end
 				armourBase = armourData.Armour or 0
 				if armourBase > 0 then
-					if slot == "Body Armour" and modDB:Flag(nil, "DoubleBodyArmourDefence") then
-						armourBase = armourBase * 2
-					end
-					if slot == "Body Armour" and modDB:Flag(nil, "Unbreakable") then 
-						armourBase = armourBase * 2
+					if slot == "Body Armour" then
+						if modDB:Flag(nil, "DoubleBodyArmourDefence") then
+							armourBase = armourBase * 2
+						end
+						if modDB:Flag(nil, "Unbreakable") then 
+							armourBase = armourBase * 2
+						end
 					end
 					armour = armour + armourBase * calcLib.mod(modDB, slotCfg, "Armour", "ArmourAndEvasion", "Defences", slot.."ESAndArmour")
 					gearArmour = gearArmour + armourBase
@@ -639,11 +645,13 @@ function calcs.defence(env, actor)
 				end
 				evasionBase = armourData.Evasion or 0
 				if evasionBase > 0 then
-					if slot == "Body Armour" and modDB:Flag(nil, "DoubleBodyArmourDefence") then
-						evasionBase = evasionBase * 2
-					end
-					if slot == "Body Armour" and modDB:Flag(nil, "Unbreakable") and ironReflexes then
-						evasionBase = evasionBase * 2
+					if slot == "Body Armour" then
+						if modDB:Flag(nil, "DoubleBodyArmourDefence") then
+							evasionBase = evasionBase * 2
+						end
+						if modDB:Flag(nil, "Unbreakable") and ironReflexes then
+							evasionBase = evasionBase * 2
+						end
 					end
 					gearEvasion = gearEvasion + evasionBase
 					if breakdown then

--- a/src/Modules/CalcDefence.lua
+++ b/src/Modules/CalcDefence.lua
@@ -302,7 +302,7 @@ function calcs.defence(env, actor)
 				if slot == "Body Armour" and  modDB:Flag(nil, "DoubleBodyArmourDefence") then
 					evasionBase = evasionBase * 2
 				end
-				if (modDB:Flag(nil, "Unbreakable") and modDB:Flag(nil, "IronReflexes")) then
+				if slot == "Body Armour" and modDB:Flag(nil, "Unbreakable") and modDB:Flag(nil, "IronReflexes") then
 					evasionBase = evasionBase * 2
 				end
 				output["EvasionOn"..slot] = evasionBase
@@ -642,7 +642,7 @@ function calcs.defence(env, actor)
 					if slot == "Body Armour" and modDB:Flag(nil, "DoubleBodyArmourDefence") then
 						evasionBase = evasionBase * 2
 					end
-					if slot == "Body Armour" and (modDB:Flag(nil, "Unbreakable") and ironReflexes) then
+					if slot == "Body Armour" and modDB:Flag(nil, "Unbreakable") and ironReflexes then
 						evasionBase = evasionBase * 2
 					end
 					gearEvasion = gearEvasion + evasionBase


### PR DESCRIPTION
Fixes #7184

### Description of the problem being solved:
Oath of the Maji and Unbreakable did stack and armour from body armour would only be double a singled time instead of twice as happens in game.


### Steps taken to verify a working solution:
- Compared values given in the issue, expected (161,682), PoB (110,021) change are now reflect in game values
- Compared armour values with only unbreakable or oath of the maji allocated. Expected armour values were seen
- Compared armour values with neither oath or unbreakable allocated. Expected armour values were seen

### Link to a build that showcases this PR:
https://pobb.in/KUg-NMqiDdx8
### Before screenshot:
![unbreakableBefore](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/67388714/9c03d7e0-c5cb-4e6b-b690-54776f0f9f7f)

### After screenshot:
![UnbreakableAfter](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/67388714/a7c9fc55-11d0-4110-a183-95826992f528)

