### PR TITLE
Round Stun and Block Duration to server ticks

### DIFF
--- a/src/Modules/CalcDefence.lua
+++ b/src/Modules/CalcDefence.lua
@@ -11,6 +11,7 @@ local t_insert = table.insert
 local m_min = math.min
 local m_max = math.max
 local m_floor = math.floor
+local m_ceil = math.ceil
 local m_sqrt = math.sqrt
 local m_modf = math.modf
 local m_huge = math.huge
@@ -1806,8 +1807,8 @@ function calcs.buildDefenceEstimations(env, actor)
 			local baseStunDuration = data.misc.StunBaseDuration
 			local stunRecovery = (1 + modDB:Sum("INC", nil, "StunRecovery") / 100)
 			local stunAndBlockRecovery = (1 + modDB:Sum("INC", nil, "StunRecovery", "BlockRecovery") / 100)
-			output.StunDuration = baseStunDuration * stunDuration / stunRecovery
-			output.BlockDuration = baseStunDuration * stunDuration / stunAndBlockRecovery
+			output.StunDuration = m_ceil(baseStunDuration * stunDuration / stunRecovery * data.misc.ServerTickRate) / data.misc.ServerTickRate
+			output.BlockDuration = m_ceil(baseStunDuration * stunDuration / stunAndBlockRecovery * data.misc.ServerTickRate) / data.misc.ServerTickRate
 			if breakdown then
 				breakdown.StunDuration = {s_format("%.2fs ^8(base)", baseStunDuration)}
 				breakdown.BlockDuration = {s_format("%.2fs ^8(base)", baseStunDuration)}
@@ -1821,12 +1822,11 @@ function calcs.buildDefenceEstimations(env, actor)
 				if stunAndBlockRecovery ~= 1 then
 					t_insert(breakdown.BlockDuration, s_format("/ %.2f ^8(increased/reduced block recovery)", stunAndBlockRecovery))
 				end
-				if output.StunDuration ~= baseStunDuration then
-					t_insert(breakdown.StunDuration, s_format("= %.2fs", output.StunDuration))
-				end
-				if output.BlockDuration ~= baseStunDuration then
-					t_insert(breakdown.BlockDuration, s_format("= %.2fs", output.BlockDuration))
-				end
+				t_insert(breakdown.StunDuration, s_format("rounded up to nearest server tick"))
+				t_insert(breakdown.StunDuration, s_format("= %.2fs", output.StunDuration))
+				
+				t_insert(breakdown.BlockDuration, s_format("rounded up to nearest server tick"))
+				t_insert(breakdown.BlockDuration, s_format("= %.2fs", output.BlockDuration))
 			end
 		end
 		output.InterruptStunAvoidChance = m_min(modDB:Sum("BASE", nil, "AvoidInterruptStun"), 100)


### PR DESCRIPTION
Stun and Block duration are meant to round up to the nearest server tick.
People only generally care about the exact value if they are using an Immutable Force where the roll can determine a 1 tick vs 2 tick stun
