### PR TITLE
Fix ruthless support applying to mirages that only use the skill once.

### DIFF
--- a/src/Modules/CalcMirages.lua
+++ b/src/Modules/CalcMirages.lua
@@ -34,6 +34,7 @@ local function calculateMirage(env, config)
 		local newSkill, newEnv = calcs.copyActiveSkill(env, env.mode == "CALCS" and "CALCS" or "MAIN", mirageSkill)
 		newSkill.skillCfg.skillCond["usedByMirage"] = true
 		newSkill.skillData.limitedProcessing = true
+		newSkill.skillData.mirageUses = env.player.mainSkill.skillData.storedUses
 		newSkill.skillTypes[SkillType.OtherThingUsesSkill] = true
 
 		_ = config.preCalcFunc and config.preCalcFunc(env, newSkill, newEnv)

--- a/src/Modules/CalcOffence.lua
+++ b/src/Modules/CalcOffence.lua
@@ -2591,7 +2591,7 @@ function calcs.offence(env, actor, activeSkill)
 		if env.mode_combat then
 			-- Calculate Ruthless Blow chance/multipliers + Fist of War multipliers
 			output.RuthlessBlowMaxCount = skillModList:Sum("BASE", cfg, "RuthlessBlowMaxCount")
-			if output.RuthlessBlowMaxCount > 0 then
+			if output.RuthlessBlowMaxCount > 0 and ( not skillCfg.skillCond["usedByMirage"] or (skillData.mirageUses or 0) > output.RuthlessBlowMaxCount ) then
 				output.RuthlessBlowChance = round(100 / output.RuthlessBlowMaxCount)
 			else
 				output.RuthlessBlowChance = 0


### PR DESCRIPTION
Fixes issue mentioned on discord.

### Description of the problem being solved:
Ruthless support applied to skills used by mirages even though the mirage doesn't not use the skill enough times to cause a ruthless hit.

### Steps taken to verify a working solution:
- Test Tawhoa's chosen using consecrated path with ruthless support

### Link to a build that showcases this PR:
https://pobb.in/sZj-egRxyllU
