### PR TITLE
Filter mods applied by Unnatural Instinct.

### DIFF
--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -5210,7 +5210,7 @@ local jewelSelfUnallocFuncs = {
 			if node.type == "Normal" then
 				data.modList = data.modList or new("ModList")
 
-				-- Filter out "Condtion:ConnectedTo" mods as these nodes are not technically allocated by this jewel func
+				-- Filter out "Condition:ConnectedTo" mods as these nodes are not technically allocated by this jewel func
 				for _, mod in ipairs(out) do
 					if not mod.name:match("^Condition:ConnectedTo") then
 						data.modList:AddMod(mod)

--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -5209,7 +5209,13 @@ local jewelSelfUnallocFuncs = {
 		if node then
 			if node.type == "Normal" then
 				data.modList = data.modList or new("ModList")
-				data.modList:AddList(out)
+
+				-- Filter out "Condtion:ConnectedTo" mods as these nodes are not technically allocated by this jewel func
+				for _, mod in ipairs(out) do
+					if not mod.name:match("^Condition:ConnectedTo") then
+						data.modList:AddMod(mod)
+					end
+				end
 			end
 		elseif data.modList then
 			out:AddList(data.modList)


### PR DESCRIPTION
Fixes #7231.

### Description of the problem being solved:
Unnatural Instinct copied all the mods from the node modlist which also included the `Condition:ConnectedTo` mods which are used to determine whether a given tree is connected to a given starting point. Used in Pure Talent.

### Steps taken to verify a working solution:
- Test build provided from issue
- Try allocating the starting point manually

