### PR TITLE
Fix Rage Cost of Vaal Skills not displaying correctly for Hateforge 

### DIFF
--- a/src/Modules/CalcOffence.lua
+++ b/src/Modules/CalcOffence.lua
@@ -1590,8 +1590,10 @@ function calcs.offence(env, actor, activeSkill)
 				if skillModList:Flag(skillCfg, "CostRageInsteadOfSouls") then -- Hateforge
 					val.baseCost = val.baseCost + costs.Soul.baseCost
 					val.baseCostNoMult = val.baseCostNoMult + costs.Soul.baseCostNoMult
+					val.finalBaseCost = val.finalBaseCost + costs.Soul.finalBaseCost
 					costs.Soul.baseCost = 0
 					costs.Soul.baseCostNoMult = 0
+					costs.Soul.finalBaseCost = 0
 				end
 			end
 		end


### PR DESCRIPTION
Fixes #7241 .

### Description of the problem being solved:
Rage Cost for Vaal Attack Skills displays as 0 with Hateforge equipped. Cause is due to the the finalBaseCost of Souls resource not being shifted to Rage.

### Steps taken to verify a working solution:
- Tested a few Vaal Attack Skills to confirm Rage Cost now displaying correctly.
### Before screenshot:
![image](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/42928828/7cdfb0e4-6e95-497d-8238-007869cd111d)

### After screenshot:
![image](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/42928828/2651d335-e030-4484-93e8-3e097116fa69)
