### PR TITLE
Fix Inspiration Charges not applying to Minion Skills

### DIFF
--- a/src/Modules/CalcPerform.lua
+++ b/src/Modules/CalcPerform.lua
@@ -600,7 +600,9 @@ local function doActorMisc(env, actor)
 	if modDB:Flag(nil, "UseBlitzCharges") then
 		output.BlitzCharges = modDB:Override(nil, "BlitzCharges") or output.BlitzChargesMax
 	end
-	output.InspirationCharges = modDB:Override(nil, "InspirationCharges") or output.InspirationChargesMax
+	if actor == env.player then
+		output.InspirationCharges = modDB:Override(nil, "InspirationCharges") or output.InspirationChargesMax
+	end
 	if modDB:Flag(nil, "UseGhostShrouds") then
 		output.GhostShrouds = modDB:Override(nil, "GhostShrouds") or 3
 	end

--- a/src/Modules/CalcPerform.lua
+++ b/src/Modules/CalcPerform.lua
@@ -600,9 +600,7 @@ local function doActorMisc(env, actor)
 	if modDB:Flag(nil, "UseBlitzCharges") then
 		output.BlitzCharges = modDB:Override(nil, "BlitzCharges") or output.BlitzChargesMax
 	end
-	if not env.player.mainSkill.minion then 
-		output.InspirationCharges = modDB:Override(nil, "InspirationCharges") or output.InspirationChargesMax
-	end 
+	output.InspirationCharges = modDB:Override(nil, "InspirationCharges") or output.InspirationChargesMax
 	if modDB:Flag(nil, "UseGhostShrouds") then
 		output.GhostShrouds = modDB:Override(nil, "GhostShrouds") or 3
 	end


### PR DESCRIPTION
Fixes #7235 .

### Description of the problem being solved:
Currently PoB has a condition that only applies inspiration charges if the main skill is not a minion skill.
I believe this is to stop inspiration charges from affecting minions however this also removes the buff from the player portion of minion skills. 
This PR changes the condition to only apply when the actor is the player.

### Steps taken to verify a working solution:
- Tested with a few minion skills to confirm inspiration charges doesn't affect minion portion but affects the player portion. 

### Before screenshot:
Refer linked issue

### After screenshot:
![image](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/42928828/da1e5abc-cddb-42ae-aff6-dd22fd6809e3)
