### PR TITLE
Fix skill effect duration from buffs not applying to Earthquake of Amplification Aftershock

### DIFF
--- a/src/Modules/CalcPerform.lua
+++ b/src/Modules/CalcPerform.lua
@@ -1072,12 +1072,6 @@ function calcs.perform(env, fullDPSSkipEHP)
 			local effect = activeSkill.skillModList:Sum("BASE", nil, "ShockedGroundEffect") * (1 + activeSkill.skillModList:Sum("INC", nil, "EnemyShockEffect") / 100)
 			modDB:NewMod("ShockOverride", "BASE", effect, "Shocked Ground", { type = "ActorCondition", actor = "enemy", var = "OnShockedGround" } )
 		end
-		if (activeSkill.activeEffect.grantedEffect.name == "Earthquake of Amplification")  and activeSkill.skillPart == 2 then
-			-- Need to calc the duration here as the AoE mod is calculated before Duration in CalcOffence and won't work
-			local full_duration = calcSkillDuration(activeSkill.skillModList, activeSkill.skillCfg, activeSkill.skillData, env, enemyDB)
-			local durationMulti = m_floor(full_duration * 10)
-			activeSkill.skillModList:NewMod("Multiplier:100msEarthquakeDuration", "BASE", durationMulti, "Skill:EarthquakeAltX")
-		end
 		if activeSkill.skillData.supportBonechill and (activeSkill.skillTypes[SkillType.ChillingArea] or activeSkill.skillTypes[SkillType.NonHitChill] or not activeSkill.skillModList:Flag(nil, "CannotChill")) then
 			output.HasBonechill = true
 		end
@@ -2706,6 +2700,12 @@ function calcs.perform(env, fullDPSSkipEHP)
 				local maximum = 7
 				activeSkill.skillModList:NewMod("Multiplier:"..activeSkill.activeEffect.grantedEffect.name:gsub("%s+", "").."MaxStages", "BASE", maximum, "Base")
 				activeSkill.skillModList:NewMod("Multiplier:"..activeSkill.activeEffect.grantedEffect.name:gsub("%s+", "").."StageAfterFirst", "BASE", maximum, "Base")
+				processBuffDebuff(activeSkill)
+			end
+			if (activeSkill.activeEffect.grantedEffect.name == "Earthquake of Amplification")  and activeSkill.skillPart == 2 then
+				local full_duration = calcSkillDuration(activeSkill.skillModList, activeSkill.skillCfg, activeSkill.skillData, env, enemyDB)
+				local durationMulti = m_floor(full_duration * 10)
+				activeSkill.skillModList:NewMod("Multiplier:100msEarthquakeDuration", "BASE", durationMulti, "Skill:EarthquakeAltX")
 				processBuffDebuff(activeSkill)
 			end
 		end


### PR DESCRIPTION
Fixes #7158 .

### Description of the problem being solved:
Current calculation of Earthquake of Amplification Aftershock occurs before buffs are taken into account. This PR moves the calculation into the second pass after buffs are computed.

### Steps taken to verify a working solution:
- Tested build in linked issue to confirm Malevolence now applies to aftershock damage

### After screenshot:
![image](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/42928828/b91708fd-bed3-404f-919c-01fc072eae92)
