### PR TITLE
Change issue tracker link in Github issues templates to include closed issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/accuracy_bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/accuracy_bug_report.yaml
@@ -19,7 +19,7 @@ body:
     attributes:
       label: Check for duplicates
       options:
-        - label: I've checked for duplicate issues by using the search function of the [issue tracker](https://github.com/PathOfBuildingCommunity/PathOfBuilding/issues)
+        - label: I've checked for duplicate issues by using the search function of the [issue tracker](https://github.com/PathOfBuildingCommunity/PathOfBuilding/issues?q=is%3Aissue)
           required: true
   - type: textarea
     id: expected

--- a/.github/ISSUE_TEMPLATE/application_bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/application_bug_report.yaml
@@ -19,7 +19,7 @@ body:
     attributes:
       label: Check for duplicates
       options:
-        - label: I've checked for duplicate issues by using the search function of the [issue tracker](https://github.com/PathOfBuildingCommunity/PathOfBuilding/issues)
+        - label: I've checked for duplicate issues by using the search function of the [issue tracker](https://github.com/PathOfBuildingCommunity/PathOfBuilding/issues?q=is%3Aissue)
           required: true
   - type: textarea
     id: expected

--- a/.github/ISSUE_TEMPLATE/behaviour_bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/behaviour_bug_report.yaml
@@ -19,7 +19,7 @@ body:
     attributes:
       label: Check for duplicates
       options:
-        - label: I've checked for duplicate issues by using the search function of the [issue tracker](https://github.com/PathOfBuildingCommunity/PathOfBuilding/issues)
+        - label: I've checked for duplicate issues by using the search function of the [issue tracker](https://github.com/PathOfBuildingCommunity/PathOfBuilding/issues?q=is%3Aissue)
           required: true
   - type: checkboxes
     id: validity

--- a/.github/ISSUE_TEMPLATE/calculation_bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/calculation_bug_report.yaml
@@ -19,7 +19,7 @@ body:
     attributes:
       label: Check for duplicates
       options:
-        - label: I've checked for duplicate issues by using the search function of the [issue tracker](https://github.com/PathOfBuildingCommunity/PathOfBuilding/issues)
+        - label: I've checked for duplicate issues by using the search function of the [issue tracker](https://github.com/PathOfBuildingCommunity/PathOfBuilding/issues?q=is%3Aissue)
           required: true
   - type: checkboxes
     id: validity

--- a/.github/ISSUE_TEMPLATE/crash_report.yaml
+++ b/.github/ISSUE_TEMPLATE/crash_report.yaml
@@ -19,7 +19,7 @@ body:
     attributes:
       label: Check for duplicates
       options:
-        - label: I've checked for duplicate issues by using the search function of the [issue tracker](https://github.com/PathOfBuildingCommunity/PathOfBuilding/issues)
+        - label: I've checked for duplicate issues by using the search function of the [issue tracker](https://github.com/PathOfBuildingCommunity/PathOfBuilding/issues?q=is%3Aissue)
           required: true
   - type: textarea
     id: context

--- a/.github/ISSUE_TEMPLATE/feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yaml
@@ -12,7 +12,7 @@ body:
     attributes:
       label: Check for duplicates
       options:
-        - label: I've checked for duplicate issues by using the search function of the [issue tracker](https://github.com/PathOfBuildingCommunity/PathOfBuilding/issues)
+        - label: I've checked for duplicate issues by using the search function of the [issue tracker](https://github.com/PathOfBuildingCommunity/PathOfBuilding/issues?q=is%3Aissue)
           required: true
   - type: textarea
     id: problem


### PR DESCRIPTION
### Description of the problem being solved:
Issues are often closed through gh magic words when linked PRs are merged into dev but not yet released. The current issue tracker link in the templates uses gh defaults which only displays open issues.

This PR modifies the issue tracker url params to display both open and closed issues.