### PR TITLE
Fix Templar notables Powerful/Frenzied Faith displaying incorrect Id

### DIFF
--- a/src/Export/Scripts/legionPassives.lua
+++ b/src/Export/Scripts/legionPassives.lua
@@ -3,6 +3,37 @@ if not loadStatFile then
 end
 loadStatFile("passive_skill_stat_descriptions.txt")
 
+-- This table lists errors in the ggpk dat files
+local datErrors = {
+	["templar_notable_minimum_frenzy_charge"] = {
+		["match"] = {
+			["Name"] = "Powerful Faith",
+		},
+		["replace"] = {
+			["Id"] = "templar_notable_minimum_power_charge",
+		},
+	},
+	["templar_notable_minimum_power_charge"] = {
+		["match"] = {
+			["Name"] = "Frenzied Faith",
+		},
+		["replace"] = {
+			["Id"] = "templar_notable_minimum_frenzy_charge",
+		},
+	},
+}
+
+local fixDatErrors = function(row)
+	if datErrors[row.Id] then
+		for field, value in pairs(datErrors[row.Id].match) do
+			if row[field] ~= value then return end
+		end
+		for field, value in pairs(datErrors[row.Id].replace) do
+			row[field] = value
+		end
+	end
+end
+
 local out = io.open("../Data/TimelessJewelData/LegionPassives.lua", "w")
 
 local stats = dat("Stats")
@@ -90,6 +121,7 @@ for i=1, alternatePassiveSkillDat.rowCount do
 		local key = alternatePassiveSkillDat.spec[j].name
 		datFileRow[key] = alternatePassiveSkillDat:ReadCell(i, j)
 	end
+	fixDatErrors(datFileRow)
 	---@type table<string, boolean|string|number|table>
 	local legionPassiveNode = {}
 	-- id


### PR DESCRIPTION
Fixes #7193 .

### Description of the problem being solved:
Small internal error in `AlternativePassiveSkills.dat` which has the row Id swapped around for the Powerful Faith and Frenzied Faith. Created a [bug report](https://www.pathofexile.com/forum/view-thread/3480943) for it.

This PR adds handling to correct errors based on a manual list. 

Note: actual exported file not committed in this PR. 

### Steps taken to verify a working solution:
- Confirmed fix via export and checking the find timeless jewel function

### Before screenshot:
- Check linked issue
![image](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/42928828/e0e9de98-a6f9-40e3-8b11-74e88c7b26cf)


### After screenshot:
![image](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/42928828/4d5ad8bc-a196-4479-a5f3-1799503bc2c0)
![image](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/42928828/393217a8-5c30-417c-a2f2-03eb477a95cf)

