### PR TITLE
Fix Law of the Wilds using the wrong minion stats

### DIFF
--- a/src/Data/Minions.lua
+++ b/src/Data/Minions.lua
@@ -222,22 +222,23 @@ minions["SummonedEssenceSpirit"] = {
 minions["SummonedSpectralWolf"] = {
 	name = "Spectral Wolf Companion",
 	monsterCategory = "Beast",
-	life = 4.5,
+	life = 11,
 	fireResist = 40,
 	coldResist = 40,
 	lightningResist = 40,
 	chaosResist = 20,
-	damage = 1.5,
+	damage = 6.2,
 	damageSpread = 0.2,
-	attackTime = 1,
+	attackTime = 1.5,
 	attackRange = 11,
 	accuracy = 3.4,
 	weaponType1 = "Dagger",
 	limit = "ActiveWolfLimit",
 	skillList = {
-		"Melee",
+		"MeleeAtAnimationSpeed",
 	},
 	modList = {
+		mod("PhysicalDamageLifeLeech", "BASE", 100, 1, 0), -- SummonedWolfLifeLeech [life_leech_from_physical_attack_damage_permyriad = 10000]
 	},
 }
 

--- a/src/Data/SkillStatMap.lua
+++ b/src/Data/SkillStatMap.lua
@@ -256,9 +256,6 @@ return {
 ["base_melee_attack_repeat_count"] = {
 	mod("RepeatCount", "BASE", nil, 0, 0, { type = "SkillType", skillType = SkillType.Multistrikeable }),
 },
-["base_display_minion_actor_level"] = {
-	skill("minionLevel", nil),
-},
 ["display_skill_minions_level_is_corpse_level"] = {
 	skill("minionLevelIsEnemyLevel", true),
 },

--- a/src/Export/Minions/Minions.txt
+++ b/src/Export/Minions/Minions.txt
@@ -37,7 +37,7 @@ local minions, mod = ...
 #mod mod("Condition:FullLife", "FLAG", true)
 #emit
 
-#monster Metadata/Monsters/Lion/SummonedSpectralWolf SummonedSpectralWolf
+#monster Metadata/Monsters/SummonedWolf/SummonedWolf SummonedSpectralWolf
 #limit ActiveWolfLimit
 #emit
 


### PR DESCRIPTION
Fixes #6967

### Description of the problem being solved:
Law of the Wilds was using the wrong base minion for its stats so the damage was very far off.

It was also using the wrong actor level for the minion and I believe it always grabs the level from the `levelRequirement` stat and the `base_display_minion_actor_level` is only used for the tooltip in game but not the actual minion itself.
The only other minion with differing `base_display_minion_actor_level ` vs `levelrequirement` is Vaal Summon Skeletons. I'll will check this assumption with GGG

### Steps taken to verify a working solution:
- Test build to make sure the minion stats changed and it uses the new actor level

### Link to a build that showcases this PR:
https://pobb.in/6GoR-wJPrqTJ

### Before screenshot:
![image](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/31035929/c5a41c76-f173-49f4-9e9c-b09b6171dbce)


### After screenshot:
![image](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/31035929/749e55c0-9db8-481a-9e9e-21a5cf0654ae)
