### PR TITLE
Add extra wording to clarify 'Check for duplicate' step in Github templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/accuracy_bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/accuracy_bug_report.yaml
@@ -19,7 +19,7 @@ body:
     attributes:
       label: Check for duplicates
       options:
-        - label: I've checked for duplicate issues by using the search function of the [issue tracker](https://github.com/PathOfBuildingCommunity/PathOfBuilding/issues?q=is%3Aissue)
+        - label: I've checked for duplicate open **and closed** issues by using the search function of the [issue tracker](https://github.com/PathOfBuildingCommunity/PathOfBuilding/issues?q=is%3Aissue)
           required: true
   - type: textarea
     id: expected

--- a/.github/ISSUE_TEMPLATE/application_bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/application_bug_report.yaml
@@ -19,7 +19,7 @@ body:
     attributes:
       label: Check for duplicates
       options:
-        - label: I've checked for duplicate issues by using the search function of the [issue tracker](https://github.com/PathOfBuildingCommunity/PathOfBuilding/issues?q=is%3Aissue)
+        - label: I've checked for duplicate open **and closed** issues by using the search function of the [issue tracker](https://github.com/PathOfBuildingCommunity/PathOfBuilding/issues?q=is%3Aissue)
           required: true
   - type: textarea
     id: expected

--- a/.github/ISSUE_TEMPLATE/behaviour_bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/behaviour_bug_report.yaml
@@ -19,7 +19,7 @@ body:
     attributes:
       label: Check for duplicates
       options:
-        - label: I've checked for duplicate issues by using the search function of the [issue tracker](https://github.com/PathOfBuildingCommunity/PathOfBuilding/issues?q=is%3Aissue)
+        - label: I've checked for duplicate open **and closed** issues by using the search function of the [issue tracker](https://github.com/PathOfBuildingCommunity/PathOfBuilding/issues?q=is%3Aissue)
           required: true
   - type: checkboxes
     id: validity

--- a/.github/ISSUE_TEMPLATE/calculation_bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/calculation_bug_report.yaml
@@ -19,7 +19,7 @@ body:
     attributes:
       label: Check for duplicates
       options:
-        - label: I've checked for duplicate issues by using the search function of the [issue tracker](https://github.com/PathOfBuildingCommunity/PathOfBuilding/issues?q=is%3Aissue)
+        - label: I've checked for duplicate open **and closed** issues by using the search function of the [issue tracker](https://github.com/PathOfBuildingCommunity/PathOfBuilding/issues?q=is%3Aissue)
           required: true
   - type: checkboxes
     id: validity

--- a/.github/ISSUE_TEMPLATE/crash_report.yaml
+++ b/.github/ISSUE_TEMPLATE/crash_report.yaml
@@ -19,7 +19,7 @@ body:
     attributes:
       label: Check for duplicates
       options:
-        - label: I've checked for duplicate issues by using the search function of the [issue tracker](https://github.com/PathOfBuildingCommunity/PathOfBuilding/issues?q=is%3Aissue)
+        - label: I've checked for duplicate open **and closed** issues by using the search function of the [issue tracker](https://github.com/PathOfBuildingCommunity/PathOfBuilding/issues?q=is%3Aissue)
           required: true
   - type: textarea
     id: context

--- a/.github/ISSUE_TEMPLATE/feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yaml
@@ -12,7 +12,7 @@ body:
     attributes:
       label: Check for duplicates
       options:
-        - label: I've checked for duplicate issues by using the search function of the [issue tracker](https://github.com/PathOfBuildingCommunity/PathOfBuilding/issues?q=is%3Aissue)
+        - label: I've checked for duplicate open **and closed** issues by using the search function of the [issue tracker](https://github.com/PathOfBuildingCommunity/PathOfBuilding/issues?q=is%3Aissue)
           required: true
   - type: textarea
     id: problem


### PR DESCRIPTION
### Description of the problem being solved:
Per Nightblade's suggestion, adding extra text to the github issues templates to emphasise that users should check for both open and closed issues. 

