### PR TITLE
Add support for resetting Search Weights in Item Trader

### DIFF
--- a/src/Classes/TradeQuery.lua
+++ b/src/Classes/TradeQuery.lua
@@ -197,6 +197,19 @@ function TradeQueryClass:PriceBuilderProcessPoENinjaResponse(resp)
 	end
 end
 
+local function initStatSortSelectionList(list)
+	t_insert(list,  {
+		label = "Full DPS",
+		stat = "FullDPS",
+		weightMult = 1.0,
+	})
+	t_insert(list,  {
+		label = "Effective Hit Pool",
+		stat = "TotalEHP",
+		weightMult = 0.5,
+	})
+end
+
 -- Opens the item pricing popup
 function TradeQueryClass:PriceItem()
 	self.tradeQueryGenerator = new("TradeQueryGenerator", self)
@@ -283,16 +296,7 @@ on trade site to work on other leagues and realms)]]
 	-- if the list is nil or empty, set default sorting, otherwise keep whatever was loaded from xml
 	if not self.statSortSelectionList or (#self.statSortSelectionList) == 0 then
 		self.statSortSelectionList = { }
-		t_insert(self.statSortSelectionList,  {
-			label = "Full DPS",
-			stat = "FullDPS",
-			weightMult = 1.0,
-		})
-		t_insert(self.statSortSelectionList,  {
-			label = "Effective Hit Pool",
-			stat = "TotalEHP",
-			weightMult = 0.5,
-		})
+		initStatSortSelectionList(self.statSortSelectionList)
 	end
 	self.controls.StatWeightMultipliersButton = new("ButtonControl", {"TOPRIGHT", self.controls.fetchCountEdit, "BOTTOMRIGHT"}, 0, row_vertical_padding, 150, row_height, "^7Adjust search weights", function()
 		self.itemsTab.modFlag = true
@@ -448,15 +452,14 @@ Highest Weight - Displays the order retrieved from trade]]
 end
 
 -- Popup to set stat weight multipliers for sorting
-function TradeQueryClass:SetStatWeights()
-
+function TradeQueryClass:SetStatWeights(previousSelectionList)
     local controls = { }
     local statList = { }
 	local sliderController = { index = 1 }
     local popupHeight = 285
 	
 	controls.ListControl = new("TradeStatWeightMultiplierListControl", { "TOPLEFT", nil, "TOPRIGHT" }, -410, 45, 400, 200, statList, sliderController)
-	
+
 	for id, stat in pairs(data.powerStatList) do
 		if not stat.ignoreForItems and stat.label ~= "Name" then
 			t_insert(statList, {
@@ -496,7 +499,6 @@ function TradeQueryClass:SetStatWeights()
 	sliderController.SliderLabel = controls.SliderLabel
 	sliderController.Slider = controls.Slider
 	sliderController.SliderValue = controls.SliderValue
-
 	
 	for _, statBase in ipairs(self.statSortSelectionList) do
 		for _, stat in ipairs(statList) do
@@ -510,7 +512,7 @@ function TradeQueryClass:SetStatWeights()
 		end
 	end
 
-	controls.finalise = new("ButtonControl", { "BOTTOM", nil, "BOTTOM" }, -45, -10, 80, 20, "Save", function()
+	controls.finalise = new("ButtonControl", { "BOTTOM", nil, "BOTTOM" }, -90, -10, 80, 20, "Save", function()
 		main:ClosePopup()
 		
 		-- used in ItemsTab to save to xml under TradeSearchWeights node
@@ -528,8 +530,18 @@ function TradeQueryClass:SetStatWeights()
 			self:UpdateControlsWithItems(row_idx)
 		end
     end)
-	controls.cancel = new("ButtonControl", { "BOTTOM", nil, "BOTTOM" }, 45, -10, 80, 20, "Cancel", function()
+	controls.cancel = new("ButtonControl", { "BOTTOM", nil, "BOTTOM" }, 0, -10, 80, 20, "Cancel", function()
+		if previousSelectionList and #previousSelectionList > 0 then
+			self.statSortSelectionList = copyTable(previousSelectionList, true)
+		end
 		main:ClosePopup()
+	end)
+	controls.reset = new("ButtonControl", { "BOTTOM", nil, "BOTTOM" }, 90, -10, 80, 20, "Reset", function()
+		local previousSelectionList = copyTable(self.statSortSelectionList, true) -- this is so we can revert if user hits Cancel after Reset
+		self.statSortSelectionList = { }
+		initStatSortSelectionList(self.statSortSelectionList)
+		main:ClosePopup()
+		self:SetStatWeights(previousSelectionList)
 	end)
 	main:OpenPopup(420, popupHeight, "Stat Weight Multipliers", controls)
 end

--- a/src/Classes/TradeQuery.lua
+++ b/src/Classes/TradeQuery.lua
@@ -210,6 +210,13 @@ local function initStatSortSelectionList(list)
 	})
 end
 
+-- we do not want to overwrite previous list if the new list is the default, e.g. hitting reset multiple times in a row
+local function isSameAsDefaultList(list)
+	return list and #list == 2
+		and list[1].stat == "FullDPS" and list[1].weightMult == 1.0
+		and list[2].stat == "TotalEHP" and list[2].weightMult == 0.5
+end
+
 -- Opens the item pricing popup
 function TradeQueryClass:PriceItem()
 	self.tradeQueryGenerator = new("TradeQueryGenerator", self)
@@ -537,11 +544,16 @@ function TradeQueryClass:SetStatWeights(previousSelectionList)
 		main:ClosePopup()
 	end)
 	controls.reset = new("ButtonControl", { "BOTTOM", nil, "BOTTOM" }, 90, -10, 80, 20, "Reset", function()
-		local previousSelectionList = copyTable(self.statSortSelectionList, true) -- this is so we can revert if user hits Cancel after Reset
+		local previousSelection = { }
+		if isSameAsDefaultList(self.statSortSelectionList) then
+			previousSelection = copyTable(previousSelectionList, true)
+		else
+			previousSelection = copyTable(self.statSortSelectionList, true) -- this is so we can revert if user hits Cancel after Reset
+		end
 		self.statSortSelectionList = { }
 		initStatSortSelectionList(self.statSortSelectionList)
 		main:ClosePopup()
-		self:SetStatWeights(previousSelectionList)
+		self:SetStatWeights(previousSelection)
 	end)
 	main:OpenPopup(420, popupHeight, "Stat Weight Multipliers", controls)
 end


### PR DESCRIPTION
### Description of the problem being solved:
Since we've introduced saving search weights to the build, I thought it would be a good idea to have a way to reset them without needing to jump into the xml, especially if you have a ton of weights set up.

### Steps taken to verify a working solution:
- Resetting should default to FullDPS and TotalEHP stat weighting
- Resetting should work on init popup load and after any updates are made
- Resetting and then Canceling should revert back to previous weights
- Save and Cancel functionality should be unaffected, outside of the reverting mentioned

### After screenshot:
![image](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/92683202/8540e1fd-fa15-4fb0-818c-c2c93fb5f86b)

![resetWeightings](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/92683202/af58d483-f774-4278-9063-f58edd274835)

~PS: I'm aware if you hit Reset twice you lose the previous weights, but I have not figured out a clean solution yet because you kinda have to hardcode compare to the default list's stats and weightMultis.~
Pushed an update for this, still hardcoding a little gross but I moved the boolean function near the other hardcoded logic so they're at least in the same place for visibility.