### PR TITLE
Fix base damage from transfigured shield skills not being applied

### DIFF
--- a/src/Modules/CalcOffence.lua
+++ b/src/Modules/CalcOffence.lua
@@ -1789,6 +1789,14 @@ function calcs.offence(env, actor, activeSkill)
 				source.PhysicalMin = skillData.setOffHandPhysicalMin
 				source.PhysicalMax = skillData.setOffHandPhysicalMax
 			end
+			if skillData.setOffHandFireMin and skillData.setOffHandFireMax then
+				source.FireMin = skillData.setOffHandFireMin
+				source.FireMax = skillData.setOffHandFireMax
+			end
+			if skillData.setOffHandColdMin and skillData.setOffHandColdMax then
+				source.ColdMin = skillData.setOffHandColdMin
+				source.ColdMax = skillData.setOffHandColdMax
+			end
 			if skillData.attackTime then
 				source.AttackRate = 1000 / skillData.attackTime
 			end


### PR DESCRIPTION
Fixes #7263  .

### Description of the problem being solved:
CalcOffence was not processing base fire damage and base cold damage on shield attacks.

### Steps taken to verify a working solution:
- Tested build from linked issue

### Before screenshot:
![image](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/42928828/0a5aec52-f9ef-4774-86be-bebf99f322c6)

### After screenshot:
![image](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/42928828/efd068e8-32dc-4929-89b5-5d7a7bbe4967)
![image](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/42928828/496a5a04-181a-409f-abb5-a3dde2e04986)
