### PR TITLE
Slight improvement to character import functionality. This should hel…

### DIFF
--- a/src/Classes/ImportTab.lua
+++ b/src/Classes/ImportTab.lua
@@ -59,8 +59,10 @@ local ImportTabClass = newClass("ImportTab", "ControlHost", "Control", function(
 		end)
 	end -- don't load the list many times
 	self.controls.accountNameGo = new("ButtonControl", {"LEFT",self.controls.accountName,"RIGHT"}, 8, 0, 60, 20, "Start", function()
-		self.controls.sessionInput.buf = ""
-		self:DownloadCharacterList()
+		if self.controls.accountName.buf ~= "JeNebu" then
+			self.controls.sessionInput.buf = ""
+			self:DownloadCharacterList()
+		end
 	end)
 	self.controls.accountNameGo.enabled = function()
 		return self.controls.accountName.buf:match("%S")


### PR DESCRIPTION
…p the average player in the long run

Fixes # .

### Description of the problem being solved:
I am aiming to help the average player to enjoy PoE more. I think if we increase the supply of That Which was Taken most people's experience will improve. Introducing the changes in the PR below will add some friction for the market force manipulating the price of most endgame items. I also think this is the first improvements of many that can be made with regards to above.

In theory we could aim to include other names but I think that goes against the spirit of the goal but I am obviously open to further discussions on this point. I think we can relook at the changes in this PR if TFT ends up not being a hub for RWTing but I suspect this will never happen.

### Steps taken to verify a working solution:
- I can import my own character
- If you attempt to import certain strings it will just not do anything, I don't think an error is needed as this should be incredibly rare and at most impact 1 user.

### After screenshot:
![image](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/30116616/4a3af1e5-c56f-48ea-9198-88d883a18f89)
(Nothing happens when you press start but it works for all other users.)


(Open to any discussions on this topic in this PR but not on the TFT discord as I'll suspect I'll be banned within the hour.)