### PR TITLE
Fix alt Blink/Mirror Arrow using wrong minion

### DIFF
--- a/src/Data/Minions.lua
+++ b/src/Data/Minions.lua
@@ -360,6 +360,48 @@ minions["ArrowClone"] = {
 	},
 }
 
+minions["ArrowCloneRoA"] = {
+	name = "Clone",
+	monsterCategory = "Construct",
+	life = 1.5,
+	fireResist = 40,
+	coldResist = 40,
+	lightningResist = 40,
+	chaosResist = 20,
+	damage = 1,
+	damageSpread = 0,
+	attackTime = 0.83,
+	attackRange = 6,
+	accuracy = 3.4,
+	skillList = {
+		"RainOfArrowsCloneShot",
+	},
+	modList = {
+		mod("EnergyShield", "BASE", 10, 0, 0), -- MirrorArrowEnergyShield [base_maximum_energy_shield = 10]
+	},
+}
+
+minions["ArrowCloneEle"] = {
+	name = "Clone",
+	monsterCategory = "Construct",
+	life = 1.5,
+	fireResist = 40,
+	coldResist = 40,
+	lightningResist = 40,
+	chaosResist = 20,
+	damage = 1,
+	damageSpread = 0,
+	attackTime = 0.83,
+	attackRange = 6,
+	accuracy = 3.4,
+	skillList = {
+		"ElementalHitCloneShot",
+	},
+	modList = {
+		mod("EnergyShield", "BASE", 10, 0, 0), -- MirrorArrowEnergyShield [base_maximum_energy_shield = 10]
+	},
+}
+
 minions["SpiderMinion"] = {
 	name = "Spider Minion",
 	monsterCategory = "Beast",

--- a/src/Data/Skills/act_dex.lua
+++ b/src/Data/Skills/act_dex.lua
@@ -2773,7 +2773,7 @@ skills["BlinkArrowAltX"] = {
 	statDescriptionScope = "minion_attack_skill_stat_descriptions",
 	castTime = 1,
 	minionList = {
-		"ArrowClone",
+		"ArrowCloneRoA",
 	},
 	baseFlags = {
 		attack = true,
@@ -2857,7 +2857,7 @@ skills["BlinkArrowAltY"] = {
 	statDescriptionScope = "minion_attack_skill_stat_descriptions",
 	castTime = 1,
 	minionList = {
-		"ArrowClone",
+		"ArrowCloneEle",
 	},
 	baseFlags = {
 		attack = true,
@@ -10148,7 +10148,7 @@ skills["MirrorArrowAltX"] = {
 	statDescriptionScope = "minion_attack_skill_stat_descriptions",
 	castTime = 1,
 	minionList = {
-		"ArrowClone",
+		"ArrowCloneRoA",
 	},
 	baseFlags = {
 		attack = true,
@@ -10232,7 +10232,7 @@ skills["MirrorArrowAltY"] = {
 	statDescriptionScope = "minion_attack_skill_stat_descriptions",
 	castTime = 1,
 	minionList = {
-		"ArrowClone",
+		"ArrowCloneEle",
 	},
 	baseFlags = {
 		attack = true,

--- a/src/Data/Skills/minion.lua
+++ b/src/Data/Skills/minion.lua
@@ -1844,6 +1844,65 @@ skills["BlinkMirrorArrowMelee"] = {
 		[1] = { damageEffectiveness = 1.75, baseMultiplier = 1.75, levelRequirement = 0, },
 	},
 }
+skills["RainOfArrowsCloneShot"] = {
+	name = "Rain of Arrow",
+	hidden = true,
+	color = 2,
+	description = "Fires multiple arrows into the air, to land in sequence after a delay, starting at the targeted location and spreading outwards in all directions. Each arrow deals damage in an area around it. Half of the arrows will land directly on targets if there are targets in their range.",
+	skillTypes = { [SkillType.Attack] = true, [SkillType.RangedAttack] = true, [SkillType.MirageArcherCanUse] = true, [SkillType.Area] = true, [SkillType.ProjectileSpeed] = true, [SkillType.ProjectileNumber] = true, [SkillType.Totemable] = true, [SkillType.Trappable] = true, [SkillType.Mineable] = true, [SkillType.Triggerable] = true, [SkillType.Rain] = true, },
+	weaponTypes = {
+		["Bow"] = true,
+	},
+	statDescriptionScope = "skill_stat_descriptions",
+	castTime = 1,
+	baseFlags = {
+		attack = true,
+		projectile = true,
+		area = true,
+	},
+	baseMods = {
+		skill("radius", 10),
+		flag("OneShotProj"),
+	},
+	constantStats = {
+		{ "number_of_additional_arrows", 10 },
+	},
+	stats = {
+		"base_is_projectile",
+		"is_area_damage",
+		"skill_can_fire_arrows",
+		"cannot_pierce",
+	},
+	levels = {
+		[1] = { damageEffectiveness = 1.5, baseMultiplier = 1.5, levelRequirement = 0, },
+	},
+}
+skills["ElementalHitCloneShot"] = {
+	name = "Elemental Hit",
+	hidden = true,
+	color = 2,
+	description = "Each attack with this skill will choose an element at random, and will only be able to deal damage of that element. If the attack hits an enemy, it will also deal damage in an area around them, with the radius being larger if that enemy is suffering from an ailment of the chosen element. It will avoid choosing the same element twice in a row.",
+	skillTypes = { [SkillType.Attack] = true, [SkillType.Projectile] = true, [SkillType.ProjectilesFromUser] = true, [SkillType.Totemable] = true, [SkillType.Trappable] = true, [SkillType.Mineable] = true, [SkillType.MeleeSingleTarget] = true, [SkillType.Multistrikeable] = true, [SkillType.Melee] = true, [SkillType.Fire] = true, [SkillType.Cold] = true, [SkillType.Lightning] = true, [SkillType.RangedAttack] = true, [SkillType.MirageArcherCanUse] = true, [SkillType.Area] = true, [SkillType.Triggerable] = true, [SkillType.RandomElement] = true, },
+	statDescriptionScope = "skill_stat_descriptions",
+	castTime = 1,
+	baseFlags = {
+		attack = true,
+		projectile = true,
+		melee = true,
+		area = true,
+	},
+	constantStats = {
+		{ "chance_to_freeze_shock_ignite_%", 20 },
+	},
+	stats = {
+		"is_area_damage",
+		"skill_can_fire_arrows",
+		"skill_can_fire_wand_projectiles",
+	},
+	levels = {
+		[1] = { damageEffectiveness = 5.5, baseMultiplier = 5.5, levelRequirement = 0, },
+	},
+}
 skills["SumonRagingSpiritMelee"] = {
 	name = "Melee",
 	hidden = true,

--- a/src/Export/Minions/Minions.txt
+++ b/src/Export/Minions/Minions.txt
@@ -61,6 +61,12 @@ local minions, mod = ...
 #monster Metadata/Monsters/Clone/MarauderCloneImmobile ArrowClone
 #emit
 
+#monster Metadata/Monsters/Clone/MarauderCloneImmobileRainOfArrows ArrowCloneRoA
+#emit
+
+#monster Metadata/Monsters/Clone/MarauderCloneImmobileElementalShot ArrowCloneEle
+#emit
+
 #monster Metadata/Monsters/SummonedSpider/SummonedSpider SpiderMinion
 #limit ActiveSpiderLimit
 #emit

--- a/src/Export/Skills/act_dex.txt
+++ b/src/Export/Skills/act_dex.txt
@@ -525,7 +525,7 @@ local skills, mod, flag, skill = ...
 #skill BlinkArrowAltX
 #flags attack projectile minion duration
 	minionList = {
-		"ArrowClone",
+		"ArrowCloneRoA",
 	},
 #baseMod skill("minionUseBowAndQuiver", true)
 #mods
@@ -533,7 +533,7 @@ local skills, mod, flag, skill = ...
 #skill BlinkArrowAltY
 #flags attack projectile minion duration
 	minionList = {
-		"ArrowClone",
+		"ArrowCloneEle",
 	},
 #baseMod skill("minionUseBowAndQuiver", true)
 #mods
@@ -2047,7 +2047,7 @@ local skills, mod, flag, skill = ...
 #skill MirrorArrowAltX
 #flags attack projectile minion duration
 	minionList = {
-		"ArrowClone",
+		"ArrowCloneRoA",
 	},
 #baseMod skill("minionUseBowAndQuiver", true)
 #mods
@@ -2055,7 +2055,7 @@ local skills, mod, flag, skill = ...
 #skill MirrorArrowAltY
 #flags attack projectile minion duration
 	minionList = {
-		"ArrowClone",
+		"ArrowCloneEle",
 	},
 #baseMod skill("minionUseBowAndQuiver", true)
 #mods

--- a/src/Export/Skills/minion.txt
+++ b/src/Export/Skills/minion.txt
@@ -415,6 +415,16 @@ skills["GuardianSentinelFireAura"] = {
 #flags attack projectile
 #mods
 
+#skill RainOfArrowsCloneShot Rain of Arrow
+#flags attack projectile area
+#baseMod skill("radius", 10)
+#baseMod flag("OneShotProj")
+#mods
+
+#skill ElementalHitCloneShot Elemental Hit
+#flags attack projectile melee area
+#mods
+
 #skill SumonRagingSpiritMelee Melee
 #flags attack melee
 #mods


### PR DESCRIPTION
The "of Bombarding Clones" and "of Prismatic Clones" variants of the skills are meant to use different minions that use different skills
