### PR TITLE
Fix Vaal Gem import to use new lookup table

### DIFF
--- a/src/Classes/ImportTab.lua
+++ b/src/Classes/ImportTab.lua
@@ -995,7 +995,7 @@ function ImportTabClass:ImportSocketedItems(item, socketedItems, slotName)
 				normalizedBasename, qualityType  = self.build.skillsTab:GetBaseNameAndQuality(socketedItem.hybrid.baseTypeName, nil)
 				gemId = self.build.data.gemForBaseName[normalizedBasename:lower()]
 				if gemId and socketedItem.hybrid.isVaalGem then
-					gemId = gemId:gsub("SkillGem", "SkillGemVaal")
+					gemId = self.build.data.gemGrantedEffectIdForVaalGemId[self.build.data.gems[gemId].grantedEffectId]
 				end
 			end
 			if gemId then

--- a/src/Modules/Data.lua
+++ b/src/Modules/Data.lua
@@ -803,6 +803,8 @@ data.gems = LoadModule("Data/Gems")
 data.gemForSkill = { }
 data.gemForBaseName = { }
 data.gemsByGameId = { }
+-- Lookup table - [Gem.grantedEffectId] = VaalGemId
+data.gemGrantedEffectIdForVaalGemId = { }
 local function setupGem(gem, gemId)
 	gem.id = gemId
 	gem.grantedEffect = data.skills[gem.grantedEffectId]
@@ -831,8 +833,12 @@ for gemId, gem in pairs(data.gems) do
     gem.name = sanitiseText(gem.name)
     setupGem(gem, gemId)
     local loc, _ = gemId:find('Vaal')
+	if loc then
+		data.gemGrantedEffectIdForVaalGemId[gem.secondaryGrantedEffectId] = gemId
+	end
     for _, alt in ipairs{"AltX", "AltY"} do
         if loc and data.skills[gem.secondaryGrantedEffectId..alt] then
+			data.gemGrantedEffectIdForVaalGemId[gem.secondaryGrantedEffectId..alt] = gemId..alt
             local newGem = { name, gameId, variantId, grantedEffectId, secondaryGrantedEffectId, vaalGem, tags = {}, tagString, reqStr, reqDex, reqInt, naturalMaxLevel }
 			-- Hybrid gems (e.g. Vaal gems) use the display name of the active skill e.g. Vaal Summon Skeletons of Sorcery
             newGem.name = "Vaal " .. data.skills[gem.secondaryGrantedEffectId..alt].baseTypeName


### PR DESCRIPTION
### Description of the problem being solved:
#7189 introduced a crash for Vaal Gems that have differences in gemId outside of just having an extra "Vaal" term e.g. VaalDomination vs DominatingBlow.

This PR fixes the issue by creating a lookup table `gemGrantedEffectIdForVaalGemId` as part of the gem data initialisation which as the name suggests maps the `grantedEffectId` from a skill gem to it's corresponding Vaal `gemId`. This does away from the previously used `gsub` and should be more robust. 

### Steps taken to verify a working solution:
- Tested imports of Vaal Reap, Vaal Domination and Vaal Caustic Arrow on builds from poe.ninja