### PR TITLE
Fix converting Ruthless trees

### DIFF
--- a/src/Classes/TreeTab.lua
+++ b/src/Classes/TreeTab.lua
@@ -128,7 +128,7 @@ local TreeTabClass = newClass("TreeTab", "ControlHost", function(self, build)
 	self.controls.versionText = new("LabelControl", { "LEFT", self.controls.reset, "RIGHT" }, 8, 0, 0, 16, "Version:")
 	self.controls.versionSelect = new("DropDownControl", { "LEFT", self.controls.versionText, "RIGHT" }, 8, 0, 100, 20, self.treeVersions, function(index, value)
 		if value ~= self.build.spec.treeVersion then
-			self:OpenVersionConvertPopup(value:gsub("[%(%)]", ""):gsub("[%.%s]", "_"))
+			self:OpenVersionConvertPopup(value:gsub("[%(%)]", ""):gsub("[%.%s]", "_"), true)
 		end
 	end)
 	self.controls.versionSelect.maxDroppedWidth = 1000
@@ -437,7 +437,12 @@ function TreeTabClass:SetCompareSpec(specId)
 	self.compareSpec = curSpec
 end
 
-function TreeTabClass:ConvertToVersion(version, remove, success)
+function TreeTabClass:ConvertToVersion(version, remove, success, ignoreRuthlessCheck)
+	if not ignoreRuthlessCheck and self.build.spec.treeVersion:match("ruthless") and not version:match("ruthless") then
+		if isValueInTable(treeVersionList, version.."_ruthless") then
+			version = version.."_ruthless"
+		end
+	end
 	local newSpec = new("PassiveSpec", self.build, version)
 	newSpec.title = self.build.spec.title
 	newSpec.jewels = copyTable(self.build.spec.jewels)
@@ -492,16 +497,16 @@ function TreeTabClass:OpenSpecManagePopup()
 	})
 end
 
-function TreeTabClass:OpenVersionConvertPopup(version)
+function TreeTabClass:OpenVersionConvertPopup(version, ignoreRuthlessCheck)
 	local controls = { }
 	controls.warningLabel = new("LabelControl", nil, 0, 20, 0, 16, "^7Warning: some or all of the passives may be de-allocated due to changes in the tree.\n\n" ..
 		"Convert will replace your current tree.\nCopy + Convert will backup your current tree.\n")
 	controls.convert = new("ButtonControl", nil, -125, 105, 100, 20, "Convert", function()
-		self:ConvertToVersion(version, true, false)
+		self:ConvertToVersion(version, true, false, ignoreRuthlessCheck)
 		main:ClosePopup()
 	end)
 	controls.convertCopy = new("ButtonControl", nil, 0, 105, 125, 20, "Copy + Convert", function()
-		self:ConvertToVersion(version, false, false)
+		self:ConvertToVersion(version, false, false, ignoreRuthlessCheck)
 		main:ClosePopup()
 	end)
 	controls.cancel = new("ButtonControl", nil, 125, 105, 100, 20, "Cancel", function()


### PR DESCRIPTION
### Description of the problem being solved:
Single convert or mass convert would take 3.22 R and convert to 3.23, this PR will fix it and maintain the version, even with mix and matched trees in the specList. 

So 3.22 R should convert to 3.23 R and 3.22 (or anything other than 3.23) should convert to 3.23.

Also had to account for versionSelect for things like 3.23 R to 3.23, which shouldn't really happen but people be peoplin.

### Link to a build that showcases this PR:
Empty trees with 3.22 and 3.23, both versions
<pre>eNrlW1tz4rgSfp79FS7eJwQIJJkiu0VCblXJhAOZmd2nKWEL0EaWKFkmYX_9aUk2OAxyJOw6dap2HjKAur--SN3qbkP_j7eYBissEsLZRaN1dNwIMAt5RNj8ovHt-ebzWeOP33_rj5BcPM0uU0LVyu-_ferr1wHFK0yBrxFIJOZYfs-ROj8BaYmYXGDOHtHfXNzy6KLxlTPcCKaIRUTm70KKkuQrivFFYxICcyNASYhZdLX9PCNcIIFCicWDkjpIJX_kEaxKkcJqjAib8PAFy1vB06VWakXwq6G5fxw9jZ8LKhFWVAks-tQfUbTGYiKRDBL4c9EYgGPQHA9RDH8BDdEUoNpHJ6fdRrOU5TIVifThmywxjjakraO2jXAk8PVshkNJVvhKEHm1QCzcCjm28fnSPqZUkiUlWBS0sqp_9wv4-bmN9plLRIejScEx56flxFx-rPQPIheXFLzoCq0Y7ueMSOzDMeIk4cxX_SK93e0ppRBdTrRjnGCxQpK818WOzeMpYe7OeUQMXfHEwe-KcoQFRKz0YpjgkEOQ-8rw5HwgM-xO6WVHxuCrzWF2XE9c6byBD1NoDKnNjXLCU-pIKbfJpm2lGuI3B6p7Jp2wVlzqO-cj3XQkX9-NNpTd86NWq9M5Pj45b_daLWu-XqwTEiL6iN5InMaQKJ_RC94K7JUclvlCMkgINtbOmY31hgjsz3XFaXQA1wLxxJ_tEa7rO6gDNqQSTSn-Ehy_tU860cnpzMr5NJuVMJ61S6PPwe9wFYdfFO09C91C-hsTOh0XbvBeKcMYAk0VCqC4I8dWRBau21v5-ANRc8wyeWs3cx4wDhe3sD9jJLFbct5GRblbFa2TWxXhHrd2HRk8nKQYLU46Oi9j8nTTNcNivp4sCKaRH3Wu2BVaOuRQ5eYit5O734vzOjFFVk-X_EAicrtpfHVaoaSY1Vu9cncZcreDiaHGBIYIu1bTI8H_VvU69WMbiJinwnHDDbGTAfmFZLqTMY7S0O0GvKTQXblqD1pR6sUxkBKFL0MezbGXEC-OTeukWSfpcgkZQ-29K4C6WaH2JoVy5nPPgfoJDq5T_KpL2F3AltpZwKascJeyw-JuiyoNPIzZkjuL2GzoI6SGGFK-bqSh59_GvnVzoN1y6p00oWMPN-KvoPlCDUMSP2ooobZlk1UVgdk_a2f8d-ROAq5ZlAoVCs4ydjn2iXkmMaTNJBkiiYIoq7m_I0EQk209qUkwEuHiAbb-BlE6hUxw0Sh-qt7tMLbyve039TBKvbqPl1zIAL-p_0ZIyPVFY4Zogg2h_gRwEkmY7p0h7VDaCCYL_jqIVsqKZ85pkjMFaLnELHqH8SwwDlCeRMKLxomZHqk3QYwSCTeUOZWJUrowy7qPlBsDxkEBKGXOzjodZaLquZBYD94TMgJ6SZBVGKm1Oz9FKhfKk9nYzEAq-Z_638YP-sWnhZTL5Euz-fr6erREcsFn-A1un6OQx80lMIHmn5MXQulnhd8cwL_L-UD_00DNHKlv5mlJ07xTQSkIKG82taks_t-Z_q-zuP3v3ez2_5HF_aaKePXiK5c4UWvqw_xNf6JEJUECCecWx8nlGu6JG1UM7wzdspShqCdYmqRX5Mnn2BGeoZSqz_-TIkpUBjsufvpgRu6Mi3gzVQAoyGCqnDGIz-ulcv3g4cGsDKjMwJS4PJ2Z7cwUCki0zafGJvXyCtFQ29y_Z8tUBkzP42OShD-n6WymhusgQgr9vOD65ub66vn--3WW9ossekd-sjSeqomy-X97OU-wLkKDJJ0m5uVF4zvBr1qRIZaIUBUFnFK0TPAmIWulMwso8JWgaao7shnK78faEtiRrt-wgPtjDt1LKAi26rVZ_0ApI1B1NuqatKGpGbgdyBTPVxCVpvOyeEo_ZLCjqLm_1Ry1WMILNy-iVsnZ6geekOrYQtSRGQlVhVG-5eqQG6oSv4QhFCfhumS_s8rfjqEfKtgAzKKd2TwusHFnqyVe1c8nrF41q3b2IQ6R1XazaGfeNPOcgZtsKBuqEqSvnOlDDkEzIFRV6dadvaZ4Q2IHfJILLLLLx4b0CDkqJykNHEGmqbSHcYGixFd6tGjxkFqzs5rxmcUGtVaSid6NlCwOLdLYocwoxprIylhNx2b1X9b_lWxBNuiwuN-sljghn_VY7M-WS4JE59_BipPIzAAs4bJDVpYwoK6oDqMHG9Vhdicd1RFvoDR7se53tmpn_yaJqkT2oJgCyAlEBVU1BBVb1RDGu4XElndcXkJsmuu9zPlqWeBnPffBCGYycDC7HlwczK3T9xDPMFhQmr83NCXHW6ZsCM6QJUfbEUqrtT8PbK3zwjI32V5LvRFNfGaP18pC2JB8AARX8V1JseeGtBm-3WFE1VcjOK0G-MtjxEp2cpkgFg3Vo4OKhqonD-kSwHLNnvZV69st3UXtN_M-So-PVGeTzbYmUqju-R_O4790o6deZS1eJ2vroMYdEnC10Eckl6MI_8zncv17CY1d1mOq13mLmSbYPNX_gdGSM_2xarlNf2YIrURZT5g1y5RDkwgcoyk00Epp09gZngBkqUXTsTfLWS4xlcFguk4SRAPThAdtD_5c5C5G1x-jXQNGK5i8ouUuUK8Gg3o1GOSDcckhZnYBOh4Adxgy3i97W_VsHOSGfXvSrWFPWjVgnHg6pK4zWUeQ-WDoEsrL63tPYLvi-el4q-yzQbeUr3BS5Zjsj5qeN4K3ma3KZvrs7SBOKZY1HMFODWmxU9n0E293-5zjMVRoh8SrSXzexlUN0a63M6pfK-3KCNV1OKnquJO6cnvHS5NoHZjJSv15q1vXbd2qx6J21S3yrqAqp5ZePZZ3KyvS8c1YrarObtWQ22uLqW49-9CrWL9Ur0aqVlA1hWKnrtRQG9AhrcVhvqjrTNa0FQfHSMWTVNvt0K4hUdSB0arLoNqy1q9A_WY26tGzKD0r0g_3OZuRef61rhAvOI2wyERghuN19rO0_HH9afFr1Pvoi78yy5m6VpaEzAl9mulh8kQiPRHf_WZAiaD8UX7O0vlAuTwONyLa5fTZN2Q5pWPEioJOPxD0_iu2Bb5yts2TrJy-Z2eINz_PUz9KwwJHE_0NAJ4yOcF0VrCym48gs93uN3d_zflfsBSCWQ==</pre>

### After screenshot:
![ruthlessConvert](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/92683202/8e77ec3b-f368-46db-ace3-041ec13e47f6)
