### PR TITLE
Fix SkillName mods not applying for skills coming from items

### DIFF
--- a/src/Classes/ModStore.lua
+++ b/src/Classes/ModStore.lua
@@ -669,7 +669,7 @@ function ModStoreClass:EvalMod(mod, cfg)
 		elseif tag.type == "SkillName" then
 			local match = false
 			if tag.includeTransfigured then
-				local matchGameId = tag.summonSkill and (cfg and calcLib.getGameIdFromGemName(cfg.summonSkillName, true) or "") or (cfg and cfg.skillGem and cfg.skillGem.gameId or "")
+				local matchGameId = tag.summonSkill and (cfg and calcLib.getGameIdFromGemName(cfg.summonSkillName, true) or "") or (cfg and cfg.skillGem and cfg.skillGem.gameId or cfg.skillName and calcLib.getGameIdFromGemName(cfg.skillName) or "")
 				if tag.skillNameList then
 					for _, name in pairs(tag.skillNameList) do
 						if name and matchGameId == calcLib.getGameIdFromGemName(name, true) then


### PR DESCRIPTION
Fixes #7287

### Description of the problem being solved:

`activeSkill.skillCfg.skillGem.gameId` is missing on skills coming from items. This pr implements fix suggested by Logik on discord.