### PR TITLE
Fix config options not applying to Vaal skill gems 

### DIFF
--- a/src/Classes/ModStore.lua
+++ b/src/Classes/ModStore.lua
@@ -669,7 +669,7 @@ function ModStoreClass:EvalMod(mod, cfg)
 		elseif tag.type == "SkillName" then
 			local match = false
 			if tag.includeTransfigured then
-				local matchGameId = tag.summonSkill and (cfg and calcLib.getGameIdFromGemName(cfg.summonSkillName, true) or "") or (cfg and cfg.skillGem and cfg.skillGem.gameId or "")
+				local matchGameId = tag.summonSkill and (cfg and calcLib.getGameIdFromGemName(cfg.summonSkillName, true) or "") or (cfg and cfg.skillName and calcLib.getGameIdFromGemName(cfg.skillName, true) or "")
 				if tag.skillNameList then
 					for _, name in pairs(tag.skillNameList) do
 						if name and matchGameId == calcLib.getGameIdFromGemName(name, true) then

--- a/src/Modules/CalcTools.lua
+++ b/src/Modules/CalcTools.lua
@@ -248,8 +248,12 @@ function calcLib.getGameIdFromGemName(gemName, dropVaal)
 	end
 	local gemId = data.gemForBaseName[gemName:lower()]
 	if not gemId then return end
-	local gameId = data.gems[gemId].gameId
-	if gameId and dropVaal then gameId = gameId:gsub("SkillGemVaal","SkillGem") end
+	local gameId 
+	if dropVaal and data.gems[gemId].vaalGem then
+		gameId = data.gems[data.gemVaalGemIdForBaseGemId[gemId]].gameId
+	else
+		gameId = data.gems[gemId].gameId
+	end
 	return gameId
 end
 

--- a/src/Modules/Data.lua
+++ b/src/Modules/Data.lua
@@ -805,6 +805,7 @@ data.gemForBaseName = { }
 data.gemsByGameId = { }
 -- Lookup table - [Gem.grantedEffectId] = VaalGemId
 data.gemGrantedEffectIdForVaalGemId = { }
+data.gemVaalGemIdForBaseGemId = { }
 local function setupGem(gem, gemId)
 	gem.id = gemId
 	gem.grantedEffect = data.skills[gem.grantedEffectId]
@@ -835,10 +836,17 @@ for gemId, gem in pairs(data.gems) do
     local loc, _ = gemId:find('Vaal')
 	if loc then
 		data.gemGrantedEffectIdForVaalGemId[gem.secondaryGrantedEffectId] = gemId
+		for otherGemId, otherGem in pairs(data.gems) do
+			if otherGem.grantedEffectId == gem.secondaryGrantedEffectId then
+				data.gemVaalGemIdForBaseGemId[gemId] = otherGemId 
+				break
+			end
+		end
 	end
     for _, alt in ipairs{"AltX", "AltY"} do
         if loc and data.skills[gem.secondaryGrantedEffectId..alt] then
 			data.gemGrantedEffectIdForVaalGemId[gem.secondaryGrantedEffectId..alt] = gemId..alt
+			data.gemVaalGemIdForBaseGemId[gemId..alt] = data.gemVaalGemIdForBaseGemId[gemId]..alt
             local newGem = { name, gameId, variantId, grantedEffectId, secondaryGrantedEffectId, vaalGem, tags = {}, tagString, reqStr, reqDex, reqInt, naturalMaxLevel }
 			-- Hybrid gems (e.g. Vaal gems) use the display name of the active skill e.g. Vaal Summon Skeletons of Sorcery
             newGem.name = "Vaal " .. data.skills[gem.secondaryGrantedEffectId..alt].baseTypeName


### PR DESCRIPTION
Fixes #7292  .

### Description of the problem being solved:
#7126 introduced a bug where the ModStore comparison would use `cfg.SkillGem` with the intent to save a function call as the `GameId` seemed to be immediately accessible. This is not the case for item provided skills as fixed in #7291 and also presents an issue for Vaal skill gems as the comparison should be based on the base skill.

This PR removes the logic accessing `cfg.SkillGem` in favouring of using `calcLib.getGameIdFromGemName` for all the comparisons (essentially superseding #7291).

A further change is made to update the logic that applies the `dropVaal` flag in `calcLib.getGameIdFromGemName`. This was using a `gsub` which proved problematic for skills like Reap, Caustic Arrow, Dominating blow etc where the gemIds of the Vaal gem differ with the base gemIds in more than just a `Vaal` term. 
A lookup table from VaalGemId => BaseGemId has been implemented in `Data.lua` to allow for a robust method of obtaining the base gems of vaal gems. 

### Steps taken to verify a working solution:
- Tested build from issue as well as build from #7287 to ensure both are working correctly. 

### After screenshot:
![image](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/42928828/ec8945f7-127b-40af-8e24-9a3017c0bb4c)
