### PR TITLE
Fix sorting for unrelated stats

### DIFF
--- a/src/Classes/CalcBreakdownControl.lua
+++ b/src/Classes/CalcBreakdownControl.lua
@@ -152,6 +152,9 @@ function CalcBreakdownClass:AddBreakdownSection(sectionData)
 		local rowList = copyTable(breakdown.rowList, true)
 		local colKey = breakdown.colList[1].key
 		table.sort(rowList, function(a, b)
+			if a.reqNum then
+				return a.reqNum > b.reqNum
+			end
 			return a[colKey] > b[colKey]
 		end)
 		
@@ -300,25 +303,11 @@ function CalcBreakdownClass:AddModSection(sectionData, modList)
 	}
 	t_insert(self.sectionList, section)
 
-	table.sort(rowList, function(a, b)
-		-- Sort Modifiers by descending value
-		if type(a.value) == 'number' and type(b.value) == 'number' then
-			return b.value < a.value
-		end
-		if type(a.value) == 'boolean' and type(b.value) == 'boolean' then
-			return a.value and not b.value
-		end
-		return false
-	end)
-
 	if not modList and not sectionData.modType then
 		-- Sort modifiers by type
-		for i, row in ipairs(rowList) do
-			row.index = i
-		end
 		table.sort(rowList, function(a, b)
 			if a.mod.type == b.mod.type then
-				return a.index < b.index
+				return a.mod.name > b.mod.name or a.mod.name == b.mod.name and a.value > b.value
 			else
 				return a.mod.type < b.mod.type
 			end

--- a/src/Classes/CalcBreakdownControl.lua
+++ b/src/Classes/CalcBreakdownControl.lua
@@ -314,7 +314,7 @@ function CalcBreakdownClass:AddModSection(sectionData, modList)
 		end)
 	else -- Sort modifiers by value
 		table.sort(rowList, function(a, b)
-			return a.value > b.value
+			return a.mod.name > b.mod.name or a.mod.name == b.mod.name and a.value > b.value
 		end)
 	end
 

--- a/src/Classes/CalcBreakdownControl.lua
+++ b/src/Classes/CalcBreakdownControl.lua
@@ -312,6 +312,10 @@ function CalcBreakdownClass:AddModSection(sectionData, modList)
 				return a.mod.type < b.mod.type
 			end
 		end)
+	else -- Sort modifiers by value
+		table.sort(rowList, function(a, b)
+			return a.value > b.value
+		end)
 	end
 
 	local sourceTotals = { }


### PR DESCRIPTION
This fixes sorting of buffs with completely unrelated stats, as well as keeping elemental resistances grouped as they were before.  Ordering switches depending on which resist you look at, is the only oddity
### After screenshot:
![image](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/1209372/ffb6ee58-a7f6-4146-9983-13807dfee11a)
![image](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/1209372/0605a909-0ef1-477d-a1fb-2c1411feb0c3)
