### PR TITLE
Fix various item mod interactions with Utula's Hunger

### DIFF
--- a/src/Modules/Data.lua
+++ b/src/Modules/Data.lua
@@ -606,6 +606,12 @@ data.itemTagSpecialExclusionPattern = {
 		["boots"] = {
 			"Enemy's Life", -- Legacy of Fury
 		},
+		["belt"] = {
+			"Life as Extra Maximum Energy Shield", -- Soul Tether
+		},
+		["helmet"] = {
+			"Recouped as Life", -- Flame Exarch
+		},
 	},
 	["evasion"] = {
 		["ring"] = {

--- a/src/Modules/Data.lua
+++ b/src/Modules/Data.lua
@@ -603,6 +603,9 @@ data.itemTagSpecialExclusionPattern = {
 			"Life From You",
 			"^Socketed Gems are Supported by Level"
 		},
+		["boots"] = {
+			"Enemy's Life", -- Legacy of Fury
+		},
 	},
 	["evasion"] = {
 		["ring"] = {


### PR DESCRIPTION
Fixes #7310
Fixes #6715

### Description of the problem being solved:
Legacy of Fury's "Enemy's Life" was matching Utula's Hunger's life mod condition. This PR adds a specialExclusion for boots of "Enemy's Life" during item mod's substring matching.

### Link to a build that showcases this PR:
<pre>https://pobb.in/r1Dd4gwvVjgw</pre>

### Before screenshot:
![image](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/92683202/fd0c2372-e1b7-436f-b558-c9ea494c25aa)

### After screenshot:
![image](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/92683202/b31bf56b-1730-4167-8a1d-22aafe7a2b71)
