### PR TITLE
Fix bug comparing non-number types in the Calcs tab

### DIFF
--- a/src/Classes/CalcBreakdownControl.lua
+++ b/src/Classes/CalcBreakdownControl.lua
@@ -314,7 +314,7 @@ function CalcBreakdownClass:AddModSection(sectionData, modList)
 		end)
 	else -- Sort modifiers by value
 		table.sort(rowList, function(a, b)
-			return a.mod.name > b.mod.name or a.mod.name == b.mod.name and a.value > b.value
+			return a.mod.name > b.mod.name or (a.mod.name == b.mod.name and type(a.value) == "number" and type(b.value) == "number") and a.value > b.value
 		end)
 	end
 

--- a/src/Classes/CalcBreakdownControl.lua
+++ b/src/Classes/CalcBreakdownControl.lua
@@ -307,7 +307,7 @@ function CalcBreakdownClass:AddModSection(sectionData, modList)
 		-- Sort modifiers by type
 		table.sort(rowList, function(a, b)
 			if a.mod.type == b.mod.type then
-				return a.mod.name > b.mod.name or a.mod.name == b.mod.name and a.value > b.value
+				return a.mod.name > b.mod.name or (a.mod.name == b.mod.name and type(a.value) == "number" and type(b.value) == "number") and a.value > b.value
 			else
 				return a.mod.type < b.mod.type
 			end


### PR DESCRIPTION
Fixes #7314 .

### Description of the problem being solved:
Writing this logic, I figured I wouldn't need the explicit check here because you wouldn't be able to have the same stat as a boolean, but I was swiftly proven wrong by transfigured gems
