### PR TITLE
Fix crash caused by incorrect calc mode used for manaforged source calc

### DIFF
--- a/src/Modules/CalcSetup.lua
+++ b/src/Modules/CalcSetup.lua
@@ -1253,7 +1253,7 @@ function calcs.initEnv(build, mode, override, specEnv)
 		end
 
 		-- Determine main skill group
-		if env.mode == "CALCS" or env.mode == "CACHE" then
+		if env.mode == "CALCS" then
 			env.calcsInput.skill_number = m_min(m_max(#build.skillsTab.socketGroupList, 1), env.calcsInput.skill_number or 1)
 			env.mainSocketGroup = env.calcsInput.skill_number
 		else

--- a/src/Modules/CalcTriggers.lua
+++ b/src/Modules/CalcTriggers.lua
@@ -528,11 +528,12 @@ local function defaultTriggerHandler(env, config)
 
 			-- Handling for mana spending rate for Manaforged Arrows Support
 			if actor.mainSkill.skillData.triggeredByManaforged and trigRate > 0 then
+				local mode = env.mode == "CALCS" and "CALCS" or "MAIN"
 				local triggeredUUID = cacheSkillUUID(actor.mainSkill, env)
-				if not GlobalCache.cachedData["CACHE"][triggeredUUID] then
-					calcs.buildActiveSkill(env, "CACHE", actor.mainSkill, {[triggeredUUID] = true})
+				if not GlobalCache.cachedData[mode][triggeredUUID] then
+					calcs.buildActiveSkill(env, mode, actor.mainSkill, {[triggeredUUID] = true})
 				end
-				local triggeredManaCost = GlobalCache.cachedData["CACHE"][triggeredUUID].Env.player.output.ManaCost or 0
+				local triggeredManaCost = GlobalCache.cachedData[mode][triggeredUUID].Env.player.output.ManaCost or 0
 				if triggeredManaCost > 0 then
 					local manaSpentThreshold = triggeredManaCost * actor.mainSkill.skillData.ManaForgedArrowsPercentThreshold
 					local sourceManaCost = GlobalCache.cachedData["CACHE"][uuid].Env.player.output.ManaCost or 0


### PR DESCRIPTION
Fixes #7316

### Description of the problem being solved:
Pre calculation of current main skill used incorrect env mode causing the wrong skill group to be selected inside of initEnv. This caused the main skill to be missing from player.activeSkillList causing the pre calculation to fail. This in turn caused a nil deref as this line: 

https://github.com/PathOfBuildingCommunity/PathOfBuilding/blob/37b004035af610f1f95f06dd9119ca484a3dc941/src/Modules/CalcTriggers.lua#L532-L535

assume that the calculation succeeded.

### Steps taken to verify a working solution:
- Test build from mentioned issue
- Test build from #6862
