### PR TITLE
Fix overlap damage calculation for both Explosive Trap and Explosive Trap of Shrapnel

### DIFF
--- a/src/Data/Skills/act_dex.lua
+++ b/src/Data/Skills/act_dex.lua
@@ -6417,7 +6417,7 @@ skills["ShrapnelTrap"] = {
 			return math.min(damagingAreaRadius * damagingAreaRadius / (areaSpreadRadius * areaSpreadRadius), 1)
 		end
 		local enemyRadius = skillModList:Override(skillCfg, "EnemyRadius") or skillModList:Sum("BASE", skillCfg, "EnemyRadius")
-		local waveRadius = output.AreaOfEffectRadiusTertiary
+		local waveRadius = output.AreaOfEffectRadiusSecondary
 		local fullRadius = output.AreaOfEffectRadius
 		local overlapChance = hitChance(enemyRadius, waveRadius, fullRadius)
 		output.OverlapChance = overlapChance * 100
@@ -6578,7 +6578,7 @@ skills["ShrapnelTrapAltX"] = {
 			return math.min(damagingAreaRadius * damagingAreaRadius / (areaSpreadRadius * areaSpreadRadius), 1)
 		end
 		local enemyRadius = skillModList:Override(skillCfg, "EnemyRadius") or skillModList:Sum("BASE", skillCfg, "EnemyRadius")
-		local waveRadius = output.AreaOfEffectRadiusTertiary
+		local waveRadius = output.AreaOfEffectRadiusSecondary
 		local fullRadius = output.AreaOfEffectRadius
 		local overlapChance = hitChance(enemyRadius, waveRadius, fullRadius)
 		output.OverlapChance = overlapChance * 100

--- a/src/Export/Skills/act_dex.txt
+++ b/src/Export/Skills/act_dex.txt
@@ -1330,7 +1330,7 @@ local skills, mod, flag, skill = ...
 			return math.min(damagingAreaRadius * damagingAreaRadius / (areaSpreadRadius * areaSpreadRadius), 1)
 		end
 		local enemyRadius = skillModList:Override(skillCfg, "EnemyRadius") or skillModList:Sum("BASE", skillCfg, "EnemyRadius")
-		local waveRadius = output.AreaOfEffectRadiusTertiary
+		local waveRadius = output.AreaOfEffectRadiusSecondary
 		local fullRadius = output.AreaOfEffectRadius
 		local overlapChance = hitChance(enemyRadius, waveRadius, fullRadius)
 		output.OverlapChance = overlapChance * 100
@@ -1407,7 +1407,7 @@ local skills, mod, flag, skill = ...
 			return math.min(damagingAreaRadius * damagingAreaRadius / (areaSpreadRadius * areaSpreadRadius), 1)
 		end
 		local enemyRadius = skillModList:Override(skillCfg, "EnemyRadius") or skillModList:Sum("BASE", skillCfg, "EnemyRadius")
-		local waveRadius = output.AreaOfEffectRadiusTertiary
+		local waveRadius = output.AreaOfEffectRadiusSecondary
 		local fullRadius = output.AreaOfEffectRadius
 		local overlapChance = hitChance(enemyRadius, waveRadius, fullRadius)
 		output.OverlapChance = overlapChance * 100


### PR DESCRIPTION

Fixes #7260.

### Steps taken to verify a working solution:
-Checked pob.

### Link to a build that showcases this PR:
https://pobb.in/lZ0fQfewRtIY
### Before screenshot:
![297851492-7f80941b-dae5-47af-a9d2-2fd2dc8acaec](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/57040965/741af312-cf8f-4a13-bb96-0645cb154d80)

### After screenshot:
![kép](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/57040965/fe9f6b0d-7c09-4601-8b6f-4f9c9da9836d)
