### PR TITLE
Chore: spellcheck action: bump versions 

### DIFF
--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
 
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ inputs.ref }}
 
@@ -33,7 +33,7 @@ jobs:
             ${{ env.CONFIG_URL }}/contribs-dict.txt
 
       - name: Run cspell
-        uses: streetsidesoftware/cspell-action@v2.4.0
+        uses: streetsidesoftware/cspell-action@v5
         with:
           files: '**' # needed as workaround for non-incremental runs (overrides in config still work ok)
           config: "cspell.json"


### PR DESCRIPTION
In response to workflow warning:

> Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/checkout@v3, streetsidesoftware/cspell-action@v2.4.0. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.