### PR TITLE
Fix tooltip for maximum charges granted from overriding sources

### DIFF
--- a/src/Modules/CalcPerform.lua
+++ b/src/Modules/CalcPerform.lua
@@ -751,9 +751,21 @@ local function doActorCharges(env, actor)
 	output.PowerChargesMin = m_max(modDB:Sum("BASE", nil, "PowerChargesMin"), 0)
 	output.PowerChargesMax = m_max(modDB:Sum("BASE", nil, "PowerChargesMax"), 0)
     output.PowerChargesDuration = m_floor(modDB:Sum("BASE", nil, "ChargeDuration") * (1 + modDB:Sum("INC", nil, "PowerChargesDuration", "ChargeDuration") / 100))
+	if modDB:Flag(nil, "MaximumFrenzyChargesIsMaximumPowerCharges") then
+		local source = modDB.mods["MaximumFrenzyChargesIsMaximumPowerCharges"][1].source
+		if not modDB:HasMod("OVERRIDE", {source = source:match("[^:]+")}, "FrenzyChargesMax") then
+			modDB:NewMod("FrenzyChargesMax", "OVERRIDE", output.PowerChargesMax, source)
+		end
+	end
 	output.FrenzyChargesMin = m_max(modDB:Sum("BASE", nil, "FrenzyChargesMin"), 0)
 	output.FrenzyChargesMax = m_max(modDB:Flag(nil, "MaximumFrenzyChargesIsMaximumPowerCharges") and output.PowerChargesMax or modDB:Sum("BASE", nil, "FrenzyChargesMax"), 0)
 	output.FrenzyChargesDuration = m_floor(modDB:Sum("BASE", nil, "ChargeDuration") * (1 + modDB:Sum("INC", nil, "FrenzyChargesDuration", "ChargeDuration") / 100))
+	if modDB:Flag(nil, "MaximumEnduranceChargesIsMaximumFrenzyCharges") then
+		local source = modDB.mods["MaximumEnduranceChargesIsMaximumFrenzyCharges"][1].source
+		if not modDB:HasMod("OVERRIDE", {source = source:match("[^:]+")}, "EnduranceChargesMax") then
+			modDB:NewMod("EnduranceChargesMax", "OVERRIDE", output.FrenzyChargesMax, source)
+		end
+	end
 	output.EnduranceChargesMin = m_max(modDB:Sum("BASE", nil, "EnduranceChargesMin"), 0)
 	output.EnduranceChargesMax = m_max(env.partyMembers.modDB:Flag(nil, "PartyMemberMaximumEnduranceChargesEqualToYours") and env.partyMembers.output.EnduranceChargesMax or (modDB:Flag(nil, "MaximumEnduranceChargesIsMaximumFrenzyCharges") and output.FrenzyChargesMax or modDB:Sum("BASE", nil, "EnduranceChargesMax")), 0)
 	output.EnduranceChargesDuration = m_floor(modDB:Sum("BASE", nil, "ChargeDuration") * (1 + modDB:Sum("INC", nil, "EnduranceChargesDuration", "ChargeDuration") / 100))


### PR DESCRIPTION
Fixes #7326 .

### Description of the problem being solved:
Currently there is no mod in the modDB to display for overridden maximum charges from Badge of the Brotherhood and the Masterful Form Slayer Ascendancy. 

This PR implements a step in `doActorCharges` to add an `OVERRIDE` mod to the modDB which gets picked up in the tooltip. 

I'm not sure this is the best way of doing things as adding to the modDB during the calcs seems like bad practice. Happy to discuss and implement changes as suggested by others.

Also given how many times doActorCharges is called, this implementation uses a `modDB:HasMod()` call to check if the mod already exists. It seems like `modDB:HasModInternal` has a very unique implementation of source matching:
```lua
(not source or mod.source:match("[^:]+") == source)
```
As such, I've ensured that the sources in the `modDB:HasMod()` call follow the same treatment but it appears the matches would occur for any source that matches `Item` or `Tree` for the sources Badge of the Brotherhood and Masterful Form respectively.

### Steps taken to verify a working solution:
- Tested with Badge of the Brotherhood and the Masterful Form Slayer Ascendancy to see if power charges are reflected correctly in the Calcs tab. 


### After screenshot:
![image](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/42928828/da249396-30c5-4adf-ba7a-951e3f2a4a7b)
![image](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/42928828/dc2d5c19-784a-48c3-8e93-cf4b0db784c6)
