### PR TITLE
Fix Utula's Hunger interaction with Elevore

### DIFF
--- a/src/Modules/Data.lua
+++ b/src/Modules/Data.lua
@@ -611,6 +611,7 @@ data.itemTagSpecialExclusionPattern = {
 		},
 		["helmet"] = {
 			"Recouped as Life", -- Flame Exarch
+			"Life when you Suppress", -- Elevore
 		},
 	},
 	["evasion"] = {


### PR DESCRIPTION
Fixes #7329

### Description of the problem being solved:
Add Elevore's "Recover life when you suppress" mod to the specialExclusion list.

### Steps taken to verify a working solution:
- Verify life not affected by Elevore with Utula's Hunger equipped

### Link to a build that showcases this PR:
<pre>https://pobb.in/vfca02PkQB4o</pre>

### Before screenshot:
![image](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/92683202/1e01b9b5-285b-4489-8984-9dffd24714ec)

### After screenshot:
![image](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/92683202/a2bb30d3-3371-4b31-aa86-7a8a0b5eaa87)
