### PR TITLE
Fix Build Save method to handle child stats correctly

### DIFF
--- a/src/Modules/Build.lua
+++ b/src/Modules/Build.lua
@@ -883,7 +883,8 @@ function buildMode:Save(xml)
 	local addedStatNames = { }
 	for index, statData in ipairs(self.displayStats) do
 		if not statData.flag or self.calcsTab.mainEnv.player.mainSkill.skillFlags[statData.flag] then
-			if statData.stat and not addedStatNames[statData.stat] then
+			local statName = statData.stat and statData.stat..(statData.childStat or "")
+			if statName and not addedStatNames[statName] then
 				if statData.stat == "SkillDPS" then
 					local statVal = self.calcsTab.mainOutput[statData.stat]
 					for _, skillData in ipairs(statVal) do
@@ -897,12 +898,15 @@ function buildMode:Save(xml)
 						end
 						t_insert(xml, { elem = "FullDPSSkill", attrib = { stat = lhsString, value = tostring(skillData.dps * skillData.count), skillPart = skillData.skillPart or "", source = skillData.source or skillData.trigger or "" } })
 					end
-					addedStatNames[statData.stat] = true
+					addedStatNames[statName] = true
 				else
 					local statVal = self.calcsTab.mainOutput[statData.stat]
+					if statVal and statData.childStat then
+						statVal = statVal[statData.childStat]
+					end
 					if statVal and (statData.condFunc and statData.condFunc(statVal, self.calcsTab.mainOutput) or true) then
-						t_insert(xml, { elem = "PlayerStat", attrib = { stat = statData.stat, value = tostring(statVal) } })
-						addedStatNames[statData.stat] = true
+						t_insert(xml, { elem = "PlayerStat", attrib = { stat = statName, value = tostring(statVal) } })
+						addedStatNames[statName] = true
 					end
 				end
 			end


### PR DESCRIPTION
### Description of the problem being solved:
Currently the `Save` method of the Build class is saving the Value of the Stat but #6034 introduced child stats into the stat section which means the XML should save the Value of the relevant child stat if it exists.

This PR updates the logic so the XML isn't saving memory address of the StatVal and instead saves the correct value. 

### Steps taken to verify a working solution:
- Tested with a few builds manually
- Ran the PR through the new test tooling that Paliak has been working on. Log 
[dockerlog.txt](https://github.com/PathOfBuildingCommunity/PathOfBuilding/files/14119558/dockerlog.txt)
There are 7 luajit errors in the log which existed prior to making these changes in this PR. Need to be investigated separately

### Before screenshot:
![image](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/42928828/80ef2374-fbf9-4b0f-9e97-ac8a51601c09)

### After screenshot:
![image](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/42928828/e952c8c8-d86c-4789-9887-b727bbc95d94)

