### PR TITLE
Fix crash when opening Item Trader after selecting a different league

### DIFF
--- a/src/Classes/TradeQuery.lua
+++ b/src/Classes/TradeQuery.lua
@@ -474,14 +474,21 @@ Highest Weight - Displays the order retrieved from trade]]
 		return scrollBarShown
 	end
 
+	local function wipeItemControls()
+		for index, _ in pairs(self.controls) do
+			if index:match("%d") then
+				self.controls[index] = nil
+			end
+		end
+	end
 	self.controls.fullPrice = new("LabelControl", {"BOTTOM", nil, "BOTTOM"}, 0, -row_height - pane_margins_vertical - row_vertical_padding, pane_width - 2 * pane_margins_horizontal, row_height, "")
 	GlobalCache.useFullDPS = GlobalCache.numActiveSkillInFullDPS > 0
 	self.controls.close = new("ButtonControl", {"BOTTOM", nil, "BOTTOM"}, 0, -pane_margins_vertical, 90, row_height, "Done", function()
 		GlobalCache.useFullDPS = self.storedGlobalCacheDPSView
 		main:ClosePopup()
 		-- there's a case where if you have a socket(s) allocated, open TradeQuery, close it, dealloc, then open TradeQuery again
-		-- the deallocated socket controls were still showing, so this will give us a clean slate of controls every time
-		wipeTable(self.controls)
+		-- the deallocated socket controls were still showing, so this will remove all dynamically created controls from items
+		wipeItemControls()
 	end)
 
 	self.controls.updateCurrencyConversion = new("ButtonControl", {"BOTTOMLEFT", nil, "BOTTOMLEFT"}, pane_margins_horizontal, -pane_margins_vertical, 240, row_height, "Get Currency Conversion Rates", function()


### PR DESCRIPTION
### Description of the problem being solved:
Fixing the bug I introduced; when we close item trader, I was wiping all controls to fix an edge case with sockets, but this added a bug related to some of the other non-item controls. This PR changes to only clear the item slot controls.

### Steps taken to verify a working solution:
- Open Trader, change league, close Trader, open Trader -> success
- Validate old case, open Trader, see all 21 sockets, close Trader, deallocated one socket, open Trader, verify 20 sockets

### Link to a build that showcases this PR:
<pre>eNqtHNt22jjwufsVHJ5N8P2yJ9k9JECSNhcKpEn2pUcYAW6FTWw5hHz9jiQDjosdG-gDAXnu0sxoRnJP_32bk9orDiMv8M_qyolcr2HfDcaePz2rPwy7Dbv-7z9_nfYQnd1PzmOPsCf__PXllH-vEfyKyVndMeo1isIppj_WpLSfQGqBfDrDgX-LfgXhZTA-q98FPq7XRsgfe3T9yyUoiu7QHJ_VBy4g12socrE_vtiOJ4AzFCKX4vCGsW3FNLgNxvB0gkgEj-fI8weB-xvTyzCIF6BOvfbq4aUAur7t3feHKZk8Py0T6PTltEfQCocDimgtgo-zegtMg6a4jebwCdQQiYGUfKLrqlFvFuKcx2FEKyEOFhiPN7DKia6YeaC9EHcmE-xS7xVfhB69mCHfTfHJw6sKexsT6i2Ih8OUXLkKXP1B3HDyYIcBRaTdG6RsY6qmYRfDB_RzuR89OjsnYMoK1BnO9dT3KK6I1Au8KPD30OMDSu4UxISAv5WC7eMIh6-IehlxcmkH85HnV7LSLfLRRRCVmAMG2cMheDGthDDAbgCOX5VHRcwbb4LLQ1bSI0GoKs1-enQGZeEqE95PoD4Eu3KQgyAmJSHpNvaoTi5YG79twczcEHXtb1mqegG114DyVPSZeNyfO1e9bXzUFe1EM3TT0GVFyfWl3mwVeS4it-jNm8dzCJ1D9BtvGSqaVbBipjPqQ2DIRZa1XMZdL8T74F0EZLwX3gwFUR6iren57u35V7BPaLluDFl_tcGx8o3KXCllQa0o1bp_M-hr3y3noQ9-yANsOkMXMGAoffActhcYEVwaZ8sm8cCUjeViZlPsJxxXKU84sYqwbjB2Z5dg6T6iuFzI3c6DrRaalwGnzVuYVnaYt4D-R4wKlmKIuy2lOCeF7CpaquPjcLoazDxMthrlT30afC3aBVqUwOSmTqOnTa6a5RjuMkgp1Spa5RGF43JZpKpMryhKh2vV1osNJuDTtnLyIxGG3SRgjHHZrXMvDH6xzTmphtYK50EclkiJTAUBnNYgP52tk40oR_p4HLvlsts5gXqqrPggFiGVMFqUIvd3OxhPcSUmlTA2hRJHHcSLBQQONvsZAkphyoTttZfarjQ09XPoe1i8aS-Wi3JreQZb6NIMNjuG8lwyKOV1Yfk-y8YsA16axWZGbyE8zCH088oZyvxUkSrnRswuFFWlKiQOWLJS6wVLEH7GeiBRNWjYGm3DfK4oIfbfV6XpfwAvxaDjj2GXBe5QmkcWYxeboTeH2BlFbURRbZzsqX-g0EM-VXl_JsIodGc3MPtdRMgIosFZPT3Kf_GeTtcjFIdtGGNMmWBZigqjyBifNnl3in27ni-CkNbwG_vTQyFdrdtFHJCPAJ2Iej4vnSEmEVKvDWbBsjV-ZZyGQUCiTY8JLRbYH3-gMQwxrqF1hHGZEFx59qM2RxFIvRIrNmLapHpb12Ouhh-AALDf0WxbUjXdUiRFtlVHMlTNkhTTsgxJdxTLhgFDVgFEVi1JM01NlzRdtzVJVRxbl1TLNExJ1zRLl0zNsUxJNS0VcE0DcFXVkjVJ0VVHlTQABSzVVICmoTiypMOIDNQUYK6psgOfhsrEsTVNlgxZV4GvoxmapCkmcNQdUzYkxkqWLPguKVDtGJIqywojo8vwqRmyDcwdGNEdB0YUR9F1SQeZgLxjm_AJfxxJsVRZkUwVZJM0W9YBy7ZVm1HQQXxFNRlDB5RQgIkpGWALUzItxwLyGkig25bJNNQtADQBFwSxZUsyHAfImJqlgraaxuylaUxAwwBbGKpjgkwG8IZKTVMlMAeA6KYMJgKrAJJhgkISqAbULV0xwFqODAKAxibjyuxqMhuoUAFpkgP2BNsCB8V2GKJpgHqGbRswI7KlGTCbMJ_wHYwgQXFoOJLtaEBEZxYHyeFTN4C7oYEqQFoBMJuRVhQd1DVVTXGYcjBuyIYls2VgMUuZmgLjjm3BlOmwYACSTQozOPAHAqqtqmBkqE4dSdcVthYcS2Eyqg7MJEjHYAy-dgAWZJTZutBVWHGKDnMFs2mqYB3VAh66zmxnKAosUFkHQFhLMGLAZMFT0EjXTLZGVZtpC7MsaRZowzybdRNQuGp9dAPfA6-j4EmpBrKqJb1h4SfMqb6cPvRv-JcvM0oX0d_N5nK5PFkgOgsm-A02XCduMG8uAAncsRH99ghpMLLNFvw7n7Zak_67-2jaL8N-X_n-PGldRvLj4-S-dxmg9x_4PLr4RuIGngX_jZ5Wj99sTbn6aT12wyfy4l7PnqjzqPvPo5ew4_jfFtjunb89926v3qb2zYP-MptfXBg3bmMZv31b3XjDufXYeXu4fbMd9SG4Me3pcj67sW_Nu_jXt8Hs5Y5-HzSm3clXuvra7zeC58Y9HX0NrrH3Yj9EnSX1b4dvXvj9dgWRa9l_mKK3CXqOfz2-Botg3L1etIz_fr799n9o3zVixPLP3moS3V8Yw-s4-BobrX776f15-Dh77vudyJzcvT48vHe9wLmcKk6_AVNz2X22vl3CwmrEUV9-_6k2xnr7sYGd95uX-GX1cj56ugzDYffJalntwS_zPzIcjpbtuPO9cffaeI1_r1yw6tkZn5jmemZORQ8-aopfLKuHHkQ4kRKaLCzyGM3iJvtyF1AcsWdscP3jdMCmLoLYH9JLPI_OV5CGu6zkyHQuk8DLoAeYipySxjmr0zDGLFdMUEzY-PcYEY_lAVVOD9-Ioww_COebrgzQgkTAtoyC5HC1YJG6dXMjnrQITagxfuusIKJ_IlHNG2_TklCKfb1AxOVKn177i5jWfH7MMfci9-conkzYkQWwoCE_h-l0u52L4fWPTpJW0yh8if_04_mI9ejF3zVDkALzjX4tikeR-HpW_-HhJRekjSnyCKR6NyAELSK8yWtc6EQDAngF1DjUlbc56dhNawuQT6nzhkNIw1MoEt3Qw7lybZ5_IpRgyApItg3Jo8aOFPIJiQLlApK4KHBzLMUPbvKpsJOUXHXYwwJc2MAgkss5efqJJShbtuB23sRz2Q6ueMrZIhdQBXbZNOVy5zuprvJp8DOaPALiYT6yOHfJw06eFliVn_XkWlU8zUdvYxfl6i4e5iNveiaBD2bKo7KBKqB0F_h8kYPTtDzCCqHcme0QvAHJJ3hPZzhM9qp5lG4hRq1BCh0n9EYxzXfjFESBrXhDN8dC7Fk-quhV5ujAnhVEog_NuxyDpmHySYmOV24gK0IVRXGu_ZISu2AKkm5SjvnF0wIjrFtqOfonjwuchMff1mvgjUWfJcddMmBFAQM2FoeT4c2jw8lku0mHU-zCXvd37nwnT_PRH6jHdiI7qIgdUCkizKkOo8B86zAK_exGYovbL95CbJoXO5HXT4scP-lp7E1BdF72RueNob2xefhu4wkGDQrj9wamYHnT2G-DMWjB0i5Jiou1Ow5statES2SynZpWpij8MzmWLHJhAfIJIUjFVwWbvXKUNv3NK4wIu2MSkMMI_nH8epCeAY2QP26zE5oDFWUHPPECiK0lu9-1W99OaZbqaXNdR_EuHKtskt7hgIas2fYeBPNnKIdM5UQTv5Iyz0hKO9jntj0wd8iXyZoXA3xi3fETRXO2_wTPawq1XlJ3su_rsjOOsLgr8YjRIvD5cKogTEALwJJSMSmiSQC1I-D0RlBYM11EvSewasCPPRSdkWYxyjkmtNYaraIIkZoozmtqBfw1yywNozoNtRQN_uh6DAR4b5Q9ZP2sNa2veIlJTYykWZVVY7BEi6wc5hHsYR7BHmZJe_DO6UeDJEMVLHIegCtnJdAqaHGFIRD_sbYOXZt72XHXpBpHmFTlCDT0igbZh-Uu_Y_h5GrJBclbvx8XZDJUYUHyrWGladu5hNUDF2AVFxAiV5nhSxK84uiQdbbb7cqHDlNTsqGDD1WYKSFCZTspZcM9O4rJxHsxVEHG3Yausrpa85hgegQv0o6QGrSStuOngR9tlwztst2uBcKOFjMLRAyVJMCPoDISiKGDZ0-vvOTKBjB-iPhR6GSopNb85DFDQAxV0LoPBcQ-cVskwMpR6NBIa1SejsO3F-rBFA6XQT_UcHrZQMiOjTOBUAyVXJX8fD-Tl8XQsbbOWiVbjFc10Xo8fgI0jrVvLJul-O2LTKAUQ5U24bkmUQ9dZWZVAgdvY8zjLAbjYEGqrEoedJVDja0cIcfrx9r6G8eZB_PAnXTZMMcuwGQ2DHzk4P3CoaWAchw7lt278dtVmYgihqpHa_XgaF1IaJ8qfT9jHssnjjSXe_toWV9gV6kyziCGSqZ8diHvI74YKYnO74hlay8-VLZ-YNcLM4tYDJWtH9i9xawF-FCVvLrDm4-2QyhdVLDLi5maQAzt48-Ht3fUoyStXRY5Wub6k9BpM-mdizvFIRrjAW_yP2J2Rz1KmLGryUs-wt5a5nfAYdETNGL9fnaXu8YvjH28BN7MQZZPjC3y5jymduXRmjiOybz9lwi6Uzghv7j2FfgTb7q-UO3iWUDGOEzMgn08XyUvga8vclnpd5l2waff6F4jGcUoH98GSV0aU9PvwOQxy2JpnwiYvHMSENJHfhrRykecb147Z-9Y4xCPB_weVhD7dIDJJCXzJ7quM8gaXtcNRylG2Vx8WOPYmm3nokTe1CP3E35wC0Ly0-ePt_BOm-tZP21m_x-F_wE4xl7m</pre>

### Before screenshot:
![image](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/92683202/7336de81-5119-4450-8cad-b46ca2b17fda)

### After screenshot:
![itemTraderBug](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/92683202/7a0bee26-ea99-4e12-ad02-f13fd0cab03e)
