### PR TITLE
Add support for blocking allocated nodes when searching Militant Faith jewels

### DIFF
--- a/src/Classes/DropDownControl.lua
+++ b/src/Classes/DropDownControl.lua
@@ -135,8 +135,12 @@ function DropDownClass:SelByValue(value, key)
 	end
 end
 
-function DropDownClass:GetSelValue(key)
+function DropDownClass:GetSelValueByKey(key)
 	return self.list[self.selIndex][key]
+end
+
+function DropDownClass:GetSelValue()
+	return self.list[self.selIndex]
 end
 
 function DropDownClass:SetSel(newSel, noCallSelFunc)

--- a/src/Classes/ImportTab.lua
+++ b/src/Classes/ImportTab.lua
@@ -473,7 +473,7 @@ function ImportTabClass:DownloadCharacterList()
 				self.controls.charSelectLeague.selIndex = 1
 			end
 			self.lastCharList = charList
-			self:BuildCharacterList(self.controls.charSelectLeague:GetSelValue("league"))
+			self:BuildCharacterList(self.controls.charSelectLeague:GetSelValueByKey("league"))
 
 			-- We only get here if the accountname was correct, found, and not private, so add it to the account history.
 			self:SaveAccountHistory()

--- a/src/Classes/SkillsTab.lua
+++ b/src/Classes/SkillsTab.lua
@@ -386,7 +386,7 @@ function SkillsTabClass:Load(xml, fileName)
 	else
 		self.controls.defaultLevel:SelByValue("normalMaximum", "gemLevel")
 	end
-	self.defaultGemLevel = self.controls.defaultLevel:GetSelValue("gemLevel")
+	self.defaultGemLevel = self.controls.defaultLevel:GetSelValueByKey("gemLevel")
 	self.defaultGemQuality = m_max(m_min(tonumber(xml.attrib.defaultGemQuality) or 0, 23), 0)
 	self.controls.defaultQuality:SetText(self.defaultGemQuality or "")
 	if xml.attrib.sortGemsByDPS then
@@ -399,8 +399,8 @@ function SkillsTabClass:Load(xml, fileName)
 	self.controls.showAltQualityGems.state = self.showAltQualityGems
 	self.controls.showSupportGemTypes:SelByValue(xml.attrib.showSupportGemTypes or "ALL", "show")
 	self.controls.sortGemsByDPSFieldControl:SelByValue(xml.attrib.sortGemsByDPSField or "CombinedDPS", "type") 
-	self.showSupportGemTypes = self.controls.showSupportGemTypes:GetSelValue("show")
-	self.sortGemsByDPSField = self.controls.sortGemsByDPSFieldControl:GetSelValue("type")
+	self.showSupportGemTypes = self.controls.showSupportGemTypes:GetSelValueByKey("show")
+	self.sortGemsByDPSField = self.controls.sortGemsByDPSFieldControl:GetSelValueByKey("type")
 	for _, node in ipairs(xml) do
 		if node.elem == "Skill" then
 			-- Old format, initialize skill sets if needed

--- a/src/Classes/TreeTab.lua
+++ b/src/Classes/TreeTab.lua
@@ -1280,7 +1280,8 @@ function TreeTabClass:FindTimelessJewel()
 	controls.jewelSelectLabel = new("LabelControl", { "TOPRIGHT", nil, "TOPLEFT" }, 405, 25, 0, 16, "^7Jewel Type:")
 	controls.jewelSelect = new("DropDownControl", { "LEFT", controls.jewelSelectLabel, "RIGHT" }, 10, 0, 200, 18, jewelTypes, function(index, value)
 		timelessData.jewelType = value
-		controls.devotionSelectLabel.shown = value.id == 4
+		controls.devotionSelectLabel.shown = value.id == 4 -- Militant Faith
+		controls.blockAllocatedLabel.shown = (value.id == 4 and controls.socketFilter.state)
 		controls.conquerorSelect.list = conquerorTypes[timelessData.jewelType.id]
 		controls.conquerorSelect.selIndex = 1
 		timelessData.conquerorType = conquerorTypes[timelessData.jewelType.id][1]
@@ -1311,6 +1312,31 @@ function TreeTabClass:FindTimelessJewel()
 		end
 	end
 
+	local allocatedNodes = { }
+	local blockedNodes = { }
+	local blockedNodesCount = 0
+	local function setAllocatedNodes() -- grab allocated nodes in radius for Militant Faith filtering
+		local nodeNames = { }
+		local radiusNodes = treeData.nodes[timelessData.jewelSocket.id].nodesInRadius[3] -- large radius around timelessData.jewelSocket.id
+		for nodeId in pairs(radiusNodes) do
+			if self.build.calcsTab.mainEnv.grantedPassives[nodeId] ~= nil or self.build.spec.allocNodes[nodeId] ~= nil then
+				allocatedNodes[nodeId] = true
+				if treeData.nodes[nodeId] and treeData.nodes[nodeId].isNotable then
+					t_insert(nodeNames, treeData.nodes[nodeId].dn)
+				end
+			end
+		end
+		controls.blockAllocatedSelect:SetList(nodeNames)
+	end
+	local function clearBlocked() -- clear all controls, nodes related to Militant Faith filtering
+		blockedNodesCount = 0
+		blockedNodes = { }
+		for index, _ in pairs(controls) do
+			if index:find("blocked:") then
+				controls[index] = nil
+			end
+		end
+	end
 	controls.socketFilterLabel = new("LabelControl", { "TOPRIGHT", nil, "TOPLEFT" }, 405, 100, 0, 16, "^7Filter Nodes:")
 	controls.socketFilter = new("CheckBoxControl", { "LEFT", controls.socketFilterLabel, "RIGHT" }, 10, 0, 18, nil, function(value)
 		timelessData.socketFilter = value
@@ -1318,6 +1344,13 @@ function TreeTabClass:FindTimelessJewel()
 		controls.socketFilterAdditionalDistanceLabel.shown = value
 		controls.socketFilterAdditionalDistance.shown = value
 		controls.socketFilterAdditionalDistanceValue.shown = value
+		controls.blockAllocatedLabel.shown = (value and timelessData.jewelType.label == "Militant Faith")
+
+		if value then
+			setAllocatedNodes()
+		else
+			clearBlocked()
+		end
 	end)
 	controls.socketFilter.tooltipFunc = function(tooltip, mode, index, value)
 		tooltip:Clear()
@@ -1325,6 +1358,32 @@ function TreeTabClass:FindTimelessJewel()
 		tooltip:AddLine(16, "^7This can be useful if you're never going to path towards those excluded nodes and don't care what happens to them.")
 	end
 	controls.socketFilter.state = timelessData.socketFilter
+
+	-- Militant Faith block notables controls
+	controls.blockAllocatedLabel = new("LabelControl", { "TOPLEFT", nil, "TOPLEFT" }, 15, 25, 0, 16, "^7Block allocated nodes for search:")
+	controls.blockAllocatedSelect = new("DropDownControl", { "TOPLEFT", controls.blockAllocatedLabel, "BOTTOMLEFT" }, 0, 8, 200, 18, nil, nil)
+	controls.blockAllocatedButtonAdd = new("ButtonControl", { "LEFT", controls.blockAllocatedSelect, "RIGHT" }, 5, 0, 44, 18, "Add", function()
+		local selValue = controls.blockAllocatedSelect:GetSelValue()
+		if selValue and not controls["blocked:"..selValue] then
+			blockedNodesCount = blockedNodesCount + 1
+			t_insert(blockedNodes, selValue)
+			controls["blocked:"..selValue] = new("LabelControl", { "TOPLEFT", controls.blockAllocatedSelect, "BOTTOMLEFT" }, 0, 16*blockedNodesCount-10, 0, 16, "^7"..selValue)
+		end
+	end)
+	controls.blockAllocatedButtonClear = new("ButtonControl", { "LEFT", controls.blockAllocatedButtonAdd, "RIGHT" }, 5, 0, 44, 18, "Clear", function()
+		clearBlocked()
+	end)
+	-- set shown and list on load
+	if controls.socketFilter.state then
+		setAllocatedNodes()
+	end
+	controls.blockAllocatedLabel.shown = controls.jewelSelect.selIndex == 4 and controls.socketFilter.state
+
+	controls.blockAllocatedButtonAdd.tooltipFunc = function(tooltip, mode, index, value)
+		tooltip:Clear()
+		tooltip:AddLine(16, "^7Block allocated nodes during search.")
+		tooltip:AddLine(16, "^7This can be useful if transforming certain notables would break your build.")
+	end
 
 	local socketFilterAdditionalDistanceMAX = 10
 	controls.socketFilterAdditionalDistanceLabel = new("LabelControl", { "LEFT", controls.socketFilter, "RIGHT" }, 10, 0, 0, 16, "^7Node Distance:")
@@ -2018,7 +2077,8 @@ function TreeTabClass:FindTimelessJewel()
 				if not rootNodes[nodeId]
 				and not treeData.nodes[nodeId].isJewelSocket
 				and not treeData.nodes[nodeId].isKeystone
-				and (not controls.socketFilter.state or allocatedNodes[nodeId] or (timelessData.socketFilterDistance > 0 and unAllocatedNodesDistance[nodeId] <= timelessData.socketFilterDistance)) then
+				and (not controls.socketFilter.state or allocatedNodes[nodeId] or (timelessData.socketFilterDistance > 0 and unAllocatedNodesDistance[nodeId] <= timelessData.socketFilterDistance))
+				and (not (timelessData.jewelType.id == 4) or (timelessData.jewelType.id == 4 and not isValueInTable(blockedNodes, treeData.nodes[nodeId].dn))) then -- if searching not militant faith or militant faith and not blocked
 					if (treeData.nodes[nodeId].isNotable or timelessData.jewelType.id == 1) then
 						targetNodes[nodeId] = true
 					elseif desiredNodes["totalStat"] and not treeData.nodes[nodeId].isNotable then
@@ -2195,6 +2255,7 @@ function TreeTabClass:FindTimelessJewel()
 		updateSearchList("", false)
 		wipeTable(timelessData.searchResults)
 		controls.searchTradeButton.enabled = false
+		clearBlocked()
 	end)
 	controls.closeButton = new("ButtonControl", nil, buttonX + (width + divider) * 2, 485, width, 20, "Cancel", function()
 		main:ClosePopup()

--- a/src/Modules/Build.lua
+++ b/src/Modules/Build.lua
@@ -1012,7 +1012,7 @@ function buildMode:OnFrame(inputEvents)
 	self:ProcessControlsInput(inputEvents, main.viewPort)
 
 	self.controls.classDrop:SelByValue(self.spec.curClassId, "classId")
-	self.controls.ascendDrop.list = self.controls.classDrop:GetSelValue("ascendancies")
+	self.controls.ascendDrop.list = self.controls.classDrop:GetSelValueByKey("ascendancies")
 	self.controls.ascendDrop:SelByValue(self.spec.curAscendClassId, "ascendClassId")
 	self.controls.secondaryAscendDrop.list = {{label = "None", ascendClassId = 0}, {label = "Warden", ascendClassId = 1}, {label = "Warlock", ascendClassId = 2}, {label = "Primalist", ascendClassId = 3}}
 	self.controls.secondaryAscendDrop:SelByValue(self.spec.curSecondaryAscendClassId, "ascendClassId")


### PR DESCRIPTION
Fixes #7180 

### Description of the problem being solved:
Allow users to keep selected allocated notables safe during Militant Faith search. This feature is only for Militant Faith selected and Filter Nodes true and does not care for node distance, only allocated nodes. This PR should not affect any of the other timeless jewels. The trade URL should be the same as well so users don't have to manually find the safe ones in the list returned, which also means they can use the URL to filter the devotions on the Trade site if preferred.

### Steps taken to verify a working solution:
There are quite a few scenarios here to make sure only Militant Faith is affected

- Regardless of blocked nodes, no other timeless jewel should be affected, so for each other jewel, I've tested one/all allocated notables blocked for Militant Faith and validated those nodes are not blocked for the other jewel
- On Find Timeless Jewel load, depending on the settings the user left it on, sometimes Militant Faith would be selected instead of Glorious Vanity and sometimes Filter Nodes would be true on load, so in all these cases, the allocated nodes in radius need to be populated and the label/controls should be shown/hidden correctly
- - Militant Faith and Filter true, show controls and populate
- - Militant Faith and Filter false, do not show controls (populate does not matter because turning Filter true will populate)
- - Any other timeless jewel, controls should not show regardless of Filter

- Biggest one, obviously, is validating nodes blocked are not returned in the search for Militant Faith, Filter Nodes true
- - Validate all possible return with none blocked
- - Validate none return with all blocked

- Allocated nodes list should be accurate every time you open the Timeless Jewel search

### Link to a build that showcases this PR:
<pre>eNqtW-1z2jgT_9z7Kzz-TELMW8gN3A0JSZObpOEgbe8-dYQtQKks8chyEu6vf1aSDQ5Fjo2d6TQE7f72RavV7mIGf76F1HnBIiKcDV3v9Mx1MPN5QNhy6H59ujnpu3_-8dtgguTqcXEZE6pW_vjt00C_dih-wRT4PNeRSCyx_JZCtX8A1BoxucKcPaBnLj7zYOh-4Qy7zhyxgMj0L5-iKPqCQjx0Zz4wuw6KfMyCq937CeEKCeRLLO6V2FEs-QMPYFWKGFZDRNiM-z-x_Cx4vAatXOeF4FdDc_cweZw-ZVQiLKsSmPRpMKFog8VMIulE8N_QHYFn0BKPUQj_AxqiMUC1TrtuM5fhMhaRLM41W2McbAm90063ZSOdCHy9WGBfkhd8JYi8WiHm74Sc2fjK0j7EVJI1JVhk9LIacPsLuHdmhX_iEtHxZLalbZ_22vnEXH6s9XciV5cUHFkUWjHcLRmRuAzHhJOIs7LqZ-ntfo8phdNViHaKIyxekCTvdbFj83BOWHHnPCCGrnhUwO-KcoIFHFhZimGGfQ5nvKyMkpz3ZIGLU5ayI2Eoq81xdlzPitKVBj5OoSnktmKUMx7TgpRyl21aVqoxftuFsDUl3TFZCOuFS33lfKSbPsnXt5MMaPv0onPW7_d6Fxddz5qwV5uI-Ig-oDcSxiFkyif0E7MMzLk9WpYrySAj2Hi91oWN94YIfATbFafBMWwrxKMj-B7gyr6FWmDk-zHc7Jstz0XuESriPLhT_d8V8R3zd6p082C_MqGzauYuzt2dBZ7CgVE3_pzioiw7Icm5K3JlGllLzBKBm2Kp5h5jf_UZfDxFEhfLsjttvLNc1yrirGtzUQ94Ngf_PUcJNynGw27yTi_ymEo66pphsdzMVgTToBx1qtgVWhdIh8rPWe5C_n4vrlTMZFlLuuQ7EkGxS6OsTi8oyiZor5fvLkNeLDIxlIvAEOCilfFE8GdVe9NybCMR8lgU3HBDXMiA9G4xncYUB7Ff7DK7pNAnFdUetKK0FMdISuT_HPNgiUsJKcWxbYM06yxeryFjqL0vCqCuSCijSaYyOekVoH6EwC10ftVlWlzAjrqwgG2BUFzKHktxW9QNX8KYHXlhEdsNfYDUEELK120xdO-ZLH5mvcBvoHkq1AlpwoId2YS_gvIrNdmIylFDMbQrUq2qCMz-2xTGf0deSMA1C6CugtNQWMY-xyExTySEzBlFYySR84xfMX3arPFdALWP6wRJRf0NCYKYbOkxjCYysxlF1umf9_quE2Ek_NU9xMgNonQOKWPoZt8dulIV3T8iCYYv5arheA3nDP4Bkca6IVRiMQZSpbGyal-8p8VDV_O_GAsuUj299wjJBElZN2jqwZZ6dReuuZAOflO_JkjIzdBdIBolhPodkBdJwnQfDnmPUteZrfjrKHhRGj1xTqOUyUHrNWbBO4wngbGD0izmK8W0h9UfTogi0G1jjkWkXJMZiykrwFzGQQHYmXa30214F63-eaPn9c-7De3iRrffb7cbrX6r5TVanV6n3ehctM8vGl7X63QaF14f1rrnHeV01fkhsRm9F8EIWATux5m5XqudjOyMDkrhT4Ov03v94tNKynX0e7P5-vp6ukZyxRf4De7LU5-HzTUwgakn0U9C6YmCbY7g53I5Gl3xh79m3uItOu-N5s_e8u_--PlxsxzT8AQDyVALaaZSBiaWoqb5S6UYQcATJj6byn16L5V_1YsvXOJIrak30z8GM6VGBJEg5GccRpcbyAk3qvbZG5ckG6SoZ1gm0ZPhSQeQAV6gmKr3_44RJSpezrLv3pthKeMi3PaDAAXxom4vg6giFDZ0dH9vVkZUJmBKXBo8JkgShRyiI9pEr7FJvbxC1Nc2D-7YOpYO04PUkET-j3m8WKipKIiQQk96r29urq-e7r5dJ0c8y6J36weLw7kaBprfqUDQAuuaw4nieWReDt1vBL9qRcZYIkIjdQIpResIb8NfK51YQIEvB01TQVeZzlMPY-0I7EjXb1jAaV1CseoLgq16bdc_UMoIVIWsSok2NDW9tAOZWukKzroptC2e0hNiO4oa2VrNUYs5vJDnELVKTlY_8IRUYQunjiyIr26T_C1XQW6ocvyyHQlY9zsp9OwYehxsAzCLdmYz6LVxJ6s5XtWTZatXzaqdfYx9ZLXdLNqZt70bZ-AmG8qWKgfpC2c6yOHQjAhVRZl1Z68p3pLYAR_lCovkSrMhPUCOSklyD44g81jaj3GGIsdXep5k8ZBas7OaeYnFBrWWk4neTRAsDs3S2KFM521NZHmspkC3-i8p93O2IOlrLe43qzlOSFt7i_3Jcs4h0fl39MJJYFo-y3HZI8tLGFBXVIfRfWx1mP3GtjriDZRtP637naza2b9KoiqRAyimACoEog5VNQR1tqohTPcLiR3vNL-E2DZSB5nT1byDn_RXRyOYLvBodt2kHs2t0_cYLzBYkJu_tzQ54S1jNgZnyJzQLgil1TqcB3bWlcIyN9lBS0sjmvOZfCiSd4QNyQdAcBXf5hR7xZC2s5ZbjKj6UJvTaoC_fPhTyU4uI8SCsZoUVzRUDZrjNYClmj0eqtZ3W7qPOmimfZRu1lVnk0woZlKonvw_zsN_h26rdXrW67bTH_N-0vD1kiYPKt4xAccLHTCpVEX4z9A98c6904557mNwJ6HZS_pO9TptO-MIm89ov2O05ky_rVp007MZQitR0icmDTTl0DgCx2QOTbUyxDR7hscBWWrRdPjNfJZLTKUzmm-iCFHHNOZOqwR_KnIfo1seo1UDhufMXtF6H6hXg0G9Ggwqg3HJ4RztA7RLANxiyIK_7G3V2DjKDYf2pFvDnng1YHRKOqSumKzjkJXB0GVVKa8fjMBWxfhpl1a5zAZ9pvwFR1XC5PCp6ZVGKG2mV9nMMns7CmOKZQ0h2K4hLbYrm94p7e6DcZx8xgHkejaf-bTDsP6lPglxkrey0B-InELZd8yBN5mztHeqnvFuaW9Wv5dalRGq69Cp6rhOXZdDu5QmwcYx45r6E1-3ruveq8eiVtUtKl2CVc5NvXos71ZWpExQ6YzlVXW2V8PlUNuZ6tazD72KBVD1cqZqCVbTUWzXlRpqAzqmNznOF3XFZE1bcfQZqRhJtd0OrRoSRR0YXl0G1Za1fgUaNJNZkR5w6WGTfmKAswVZps8F-XjFaYBFIgIzHG6SLyqlzwCcZx_FPUSf_dZRytS1skRkSejjQk-oZxLpMfv-4wY5gtLnA1KW9gfKpedwK6KVT588ZckpnSKWFXT-gaD3j2lm-PLZth-PpfQ9O0O4_bqW-o4SFjiY6ccKeMzkDNNFxspuOtdMdnvQ3P9y3_8BmPzjQw==</pre>

### After screenshot:
![militantFaithBlocking](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/92683202/83811921-9df3-417b-a164-2d5ab3388ac3)
