### PR TITLE
Fix scrolling on ItemTrader

### DIFF
--- a/src/Classes/TradeQuery.lua
+++ b/src/Classes/TradeQuery.lua
@@ -495,7 +495,7 @@ Highest Weight - Displays the order retrieved from trade]]
 		self.controls.scrollBar:SetContentDimension(self.pane_height-100, self.effective_rows_height)
 		self.controls.sectionAnchor.y = -self.controls.scrollBar.offset
 	end
-	main:OpenPopup(pane_width, self.pane_height, "Trader", self.controls, nil, nil, "close", scrollBarFunc)
+	main:OpenPopup(pane_width, self.pane_height, "Trader", self.controls, nil, nil, "close", (scrollBarShown and scrollBarFunc or nil))
 end
 
 -- Popup to set stat weight multipliers for sorting


### PR DESCRIPTION
### Description of the problem being solved:
Scrolling with scroll wheel on ItemTrader that does not have a scrollBar still manipulates the screen when there are 2 or more additional slots. So between 2 and 6 sockets for example is an issue.

Gifs will explain. Either no one has found this yet or they don't care.

### Link to a build that showcases this PR:
6 socket aka last without scrollbar, can add one more to see scrollbar and validate scrolling
<pre>eNqtW2t32jgT_tz9FT58JsF37D1k95BALm3S8ELStO-XHmEL8EZYrC0nob9-R5YNDkWOjenpacGaZ26SRjNj0fv7bUmUFxzFAQ3PWtqp2lJw6FE_COdnrceHyxOn9fdff_RGiC3uZ-dJQPjIX3986qWfFYJfMDlrGXpLYSiaY_YtZ2X8BFYrFLIFpuEd-odGV9Q_a32lIW4pUxT6Acu_eQTF8Ve0xGetiQfgloJiD4f-xfZ5RrhAEfIYjm652H7C6B31YZRFCYwuURBOqPeM2VVEkxVY01JeAvwqaG7uRvfjh4JKQVhUCUz61BsRtMbRhCGmxPDPWasPnkFzPEBL-Be4IZIAK_3UNcyuo9uqY7tWt9UpBZ8nUcwO4zBZYexvQNqpaeky0lGEh7MZ9ljwgi-igF0sUOhtBaoyXF3au4SwYEUCHBX0smSI69-Ya6qU_QNliAxGkw2tearbmqGawlVaOY6yjw14CtjinIBPD5DCsTfzMGD4QPCIBjENG9hXhMrnKCEEdmgl2jGOcfSCWPBeLTlvupwG4UHeu0MhuqBxhTnilCMcwf5ntQAT7FEIGXVl1ETeBjNcnbKWHRmgrjaH2TGcVKWrzfgwhcYQHqtRTmhCKlKybZAypFQD_LahcqWR7CbcCnRLeL1Qlp5gH-mWburh9WhDabvdU8swVd2w1K7rSOP8Yh0HHiJ36C1YJksIsA_oGW8FwjaUr5b5goUQHGRY3XVl2MsgwjKYYXTlEYP4h8AWiMZSLZ2SKBOE15Ba9D0vgURhvcXID06-h7beM92Ss9j7kxPfhF61nfkYRmmALRzhJfw5YgwbhicNU4KrQrZCsn1X5aQVsuY4zARuHWWcamWgW4y9xRV4eYwYrhZnt3PQ1Up9y4kr-ZYT7vFtCf_3iBqO4sD9jjJPu2Wgmo4ahjiaryeLAJOCQW4V8lyzC7SqgEw9XYQXPa7b1QTu80cl02p65QlFfrWTo65OLyguRmnN_cBhgr7oK8uUTj-GDBMQPt5JfS15UI_oPzx1JzVx_WhJk6jCQciNEMSVdlh-yIiqZYz9xKt2qp0TqL-qlhOgFSG1EH3GkPc8oP4c1xJSC7Epo1LoJFmtIHDw6d-tZJyywxJy66CQo5yY-sfU97B6i9tYLTtWqwvYUlcWsEkVdqXYVSHVbeFnfXUxBfLKIjYzegfxYQmhP62r72ixtFalmd8lVFSVyqOUsGKZNqKvoPyCt0zietSQFm1Pa6kqEQ5_rSvzf0deScAw9CHDgu1QWcYuYp-Yh2AJwTOOB4ghxc9y6W8oClDI9LSfE2MUeYtbmP1LRMgUosFZq_iUf9sBahzI-fc6ac-Kf7pZrmjEFPzG_xuhiK3PWjNEYiwI0yfAJ2ZBmJbHEHoIaSmTBX3t-y_cigdKSZyDFLRa4dB_x-MhwlhBeSDxuBKpjfyLskQxg5NKLMyYK13oeN343I1KSEGBs1bXcJy2pjq62zZt1dXblubqRtuyXNVuG7ZtmG3T6XadtqsBnaWZZltzVMNoG5rtGG1bVV0V6BxHaxumBXDL6MIgVBlO23IcIDS7ugWDrmNrbd20TaOtq46mtw1HNZ227lhdk9ObVtvUdBtEa13HbpumpgIfXXUB5eg6x5quzZWxAaWbIEXTTLfb1g2nbeuGClaYoIvpOLoDDF3H5TPHS0QUrfvv7Q8DcDcDFxb6ibqRtQqFg7g3P_Uex7fph08Lxlbxn53O6-vr6QqxBZ3hNzhQTz267KwABPNwEj8HhJxwtp0-_Dmf9_ufx7-8L8-6OriLHvTll9FVZH_pWz-6X4b_f8PO6N9k1R8Pvv_68fDj9jn5fD9lT-eDx8f1I706wfPX5eLWWX2Jhr77pJvu9-7Fyfxy9vn2_rnfXSyevoz-PXm5ebgEUWepsp1c257oU8Yd8Y1HsiiA6RbboMPXSLpg-SLiH75ShmM-xh_mX3oTbk6sxLCGr_AyPl9D6LnkedZOqyZbhZx6gpnYR0VM3kD18QwlhD__X4JIwDeFWnx6K5q9IY2WmwIUWMGm4Kek4PiwXvFV27-9FSN9wjJmXFy-Q8ROyBRSAn-7RYVN_OMFIl5qc-8mXCVMCdNG8DKIvZ_TZDbjXV0QwaK0Uz28vBxePNx8G2aRpAhJZ_1nmCynvGkp_s8FghY4zW2UOJnG4uNZ61uAX1NFBpihgEB08yghaBXjzR5Plc4sIIAr4ZZSQRmb94D389oSyDkN33AEIWkOibEXBViq12b8A6WEQJ4088gr48Zbq3JGIie7gIAmknqJp9JOtpwLby1LzeGDJVgI5ohIJWejH3iC8WULuy6YBR4_tMqnnC9yQVXil00PQjrfWUIp55H2qmUMxKAcLPrNMnQ2WuLVtNct9aoYlcMH2ENS28WgHLypE2kIbpJx2VCVcPpKw3SRw6bpB4TnftKZHRK8IZEzvGcLHGXntozTHcSonKR040TBNGHybVygKPFV2r-SeIiPyaGiPSOxgY-VRKJ3DQuJQ4s0claiypcGsjKoqAOk_suqipIpyOpnifvFaIkT8jaCxP5suGSTpPG3_0IDX5SWku2yQ1YWMCCvaM4mrZebs9ktoJtzvIT071k639moHP7IAp6J7OEiEqBKTPimasaB761mHMa7icQWOy5PITb12l5wPlq28bMy7mAOotg8GJ7Wwgej0_A9wDMMFpTG7w1NyfJmSTgAZ7CSpV2RVarW_jiwta4WL3GS7bW0NkexP7O3MGVbWJB8wAiO4uuSZK8ap01L5xojwt-tU9KM4W9vmxrZSVmMQn_Au9INDeVN7WQFzHLN7vdl69sp3eXa6-R1VNqR4JVN1i6ZsIg3Hn5Ruvxx1jrRNP1Uc3TLFX_FQFbxWVmVBynvIADPR-mKycVywu_Aods9dTU7_yNej_RuGJR9WQXKP-cFaBJj8Xr4CaMVDdPHvOgX1ZsglBJlFWNWShMKJSQgRlMor7lJouwTGAVk8UHRM-iUQ84xYUp_uo5jRBRRoit6DXwucpeHVZ-HXolHOnTjA4O0XcQHeacl5_UZv2KiiCdFUVXNmLyi1a4e9hH8YR_BH3ZFf2SNpqJDskc1PHJOYUfvamDUsOIaQzz-bW01XZsH-XHfpFpHmFTtCDzMmg45ROQ--4-xyevwSBO8Wl7fuwL1huvHqK1ynQm6IvQFx02Wyf5dY9fmUNtMrbGZdea2v0wIZkdYgsYR4qpRNa7yVw87cVU8qhFX9_vOrD1fekWl05cT75XOHtVQegwZ7CERQ4Te2iuraZCwanuz-cGmN-bQXAezqePMY50uRi1N_LUiOk_Hj5zWsfIF7TgW6U2nyK7LoHFct49judVYkTqLKo1YWlNna0c4XY62p6zjzIPdMINqng81zeGOtBUrH_v8VsHOsS8e1S8w9cbRspTRIdXRYc481qI-0lwevMkaLsWjHS-V0zl-H2UnnROPDlmMzWtC_Sghc59HjhY3f2fU62TtNnEFK0I-nqQNwifMr_TFmTB-k-s1fcJ_ApZemVNbCkFT3iDkV9-U9K7J-ztzHQlYPbW24E0vV7kOmCJauTs_ksgU3auc0F9cGaHhLJjn9888vKDEx1HmFhzi5Tr7RV1-CaRbvPq9j77487gcZEkhcTAPyP0sfUUBNqfvWXbvm5QIyi-I5BDjA-Xy4LMRoZfTZ9d5KSFjFBYFdT8Q9P4-cAFXDtu8H83pbTlgufldIf-tHI6wP0nvldAkZBNMZgUrrbyxnc12r7P769T_AGD2lks=</pre>

### Before screenshot:
![scrollBad](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/92683202/eb669240-5568-4403-8b5a-75ab012be59b)

![scrollBad6](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/92683202/91d12dd5-2d6a-46e7-af2c-d55656531a98)

### After screenshot:
...hard to show a gif of it NOT scrolling with the wheel so I'll show previous behavior still working, please believe I am spamming my scroll wheel on the 6 socket

![scrollGood](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/92683202/387f4015-1ccb-4917-97cd-2e2f4e1b741a)
