### PR TITLE
Fix self hit damage conversion

### DIFF
--- a/src/Modules/CalcDefence.lua
+++ b/src/Modules/CalcDefence.lua
@@ -50,6 +50,10 @@ function calcs.armourReduction(armour, raw)
 end
 
 -- Based on code from FR and BS found in act_*.txt
+---@param activeSkill/output/breakdown references table passed in from calc offence
+---@param sourceType string type of incoming damage - it will be converted (taken as) from this type if applicable
+---@param baseDmg for which to calculate the damage
+---@return table of taken damage parts, and number, sum of damages
 function calcs.applyDmgTakenConversion(activeSkill, output, breakdown, sourceType, baseDmg)
 	local damageBreakdown = { }
 	local totalDamageTaken = 0

--- a/src/Modules/CalcDefence.lua
+++ b/src/Modules/CalcDefence.lua
@@ -69,9 +69,6 @@ function calcs.applyDmgTakenConversion(activeSkill, output, breakdown, sourceTyp
 		end
 
 		if damageTakenAs ~= 0 then
-			if(totalTakenAs / 100 > 1) then
-				damageTakenAs = damageTakenAs / (totalTakenAs / 100)
-			end
 			local damage = baseDmg * damageTakenAs
 
 			local baseTakenInc = activeSkill.skillModList:Sum("INC", nil, "DamageTaken", damageType.."DamageTaken", "DamageTakenWhenHit", damageType.."DamageTakenWhenHit")

--- a/src/Modules/CalcDefence.lua
+++ b/src/Modules/CalcDefence.lua
@@ -51,21 +51,26 @@ end
 
 -- Based on code from FR and BS found in act_*.txt
 function calcs.applyDmgTakenConversion(activeSkill, output, breakdown, sourceType, baseDmg)
-	local damageBreakdown = {}
+	local damageBreakdown = { }
 	local totalDamageTaken = 0
-	local totalTakenAs = activeSkill.skillModList:Sum("BASE", nil, "PhysicalDamageTakenAsLightning","PhysicalDamageTakenAsCold","PhysicalDamageTakenAsFire","PhysicalDamageTakenAsChaos") / 100
+	local shiftTable = { }
+	local totalTakenAs = 0
+	for _, damageType in ipairs(dmgTypeList) do
+		shiftTable[damageType] = activeSkill.skillModList:Sum("BASE", nil, sourceType.."DamageTakenAs"..damageType, sourceType.."DamageFromHitsTakenAs"..damageType, isElemental[sourceType] and "ElementalDamageTakenAs"..damageType or nil, isElemental[sourceType] and "ElementalDamageFromHitsTakenAs"..damageType or nil)
+		totalTakenAs = totalTakenAs + shiftTable[damageType]
+	end
 	for _, damageType in ipairs(dmgTypeList) do
 		local damageTakenAs = 1
 
 		if damageType ~= sourceType then
-			damageTakenAs = (activeSkill.skillModList:Sum("BASE", nil, sourceType.."DamageTakenAs"..damageType) or 0) / 100
+			damageTakenAs = shiftTable[damageType] / 100
 		else
-			damageTakenAs = math.max(1 - totalTakenAs, 0)
+			damageTakenAs = math.max(1 - totalTakenAs / 100, 0)
 		end
 
 		if damageTakenAs ~= 0 then
-			if(totalTakenAs > 1) then
-				damageTakenAs = damageTakenAs / totalTakenAs
+			if(totalTakenAs / 100 > 1) then
+				damageTakenAs = damageTakenAs / (totalTakenAs / 100)
 			end
 			local damage = baseDmg * damageTakenAs
 


### PR DESCRIPTION
Fixes #7190 and issue created by normalisation, and taken as not applying to non-phys self hits

Fixes taken as being only from phys to something else (present from creation), not any ele to other, as well as normalisation being applied to the taken as (fixed for calc defence in #6844 but not this), and it only including generic and not hit specific taken as (introduced issue in #6803)

This also moves the function to calc defence and cleans it up a little

![image](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/49933620/99515d5f-c46e-4ec0-9773-2c4ca495e670)

I would like to properly dedupe it with other calc defence stuff (eg `takenHitFromDamage`) as it likely has other issues with being out of date, but it is too much work for how much time I have for it at the moment and this is still an improvement.
