### PR TITLE
Fix Dancing Dervish stats (Life, Damage and Damage reduction)

### DIFF
--- a/src/Data/Minions.lua
+++ b/src/Data/Minions.lua
@@ -513,6 +513,11 @@ minions["UniqueAnimatedWeapon"] = {
 		"DancingDervishCycloneChannelled",
 	},
 	modList = {
+		mod("Life", "MORE", 698), -- MonsterUnique2,
+		mod("Damage", "MORE", 70), -- MonsterUnique5,
+		mod("Speed", "MORE", 33, ModFlag.Attack), -- MonsterUnique8,
+		mod("Damage", "MORE", -33, ModFlag.Attack), -- MonsterUnique8,
+		mod("DamageTaken", "MORE", -95), -- monster_inherent_damage_taken_+%_final : UniqueAnimatedWeapon.ot,
 	},
 }
 

--- a/src/Data/Skills/other.lua
+++ b/src/Data/Skills/other.lua
@@ -1897,7 +1897,7 @@ skills["UniqueAnimateWeapon"] = {
 	baseMods = {
 		mod("DisableWeapons", "FLAG", true, 0, 0, { type = "GlobalEffect", effectType = "Buff" }),
 		mod("Condition:Onslaught", "FLAG", true, 0, 0, { type = "GlobalEffect", effectType = "Buff" }),
-		skill("minionLevel", 59),
+		skill("minionLevel", 65),
 	},
 	constantStats = {
 		{ "attack_speed_+%", 25 },

--- a/src/Export/Minions/Minions.txt
+++ b/src/Export/Minions/Minions.txt
@@ -83,6 +83,11 @@ local minions, mod = ...
 #emit
 
 #monster Metadata/Monsters/AnimatedItem/UniqueAnimatedWeapon UniqueAnimatedWeapon
+#mod mod("Life", "MORE", 698), -- MonsterUnique2
+#mod mod("Damage", "MORE", 70), -- MonsterUnique5
+#mod mod("Speed", "MORE", 33, ModFlag.Attack), -- MonsterUnique8
+#mod mod("Damage", "MORE", -33, ModFlag.Attack), -- MonsterUnique8
+#mod mod("DamageTaken", "MORE", -95), -- monster_inherent_damage_taken_+%_final : UniqueAnimatedWeapon.ot
 #emit
 
 #monster Metadata/Monsters/SummonedPhantasm/SummonedPhantasm SummonedPhantasm

--- a/src/Export/Skills/other.txt
+++ b/src/Export/Skills/other.txt
@@ -563,7 +563,7 @@ local skills, mod, flag, skill = ...
 	},
 #baseMod mod("DisableWeapons", "FLAG", true, 0, 0, { type = "GlobalEffect", effectType = "Buff" })
 #baseMod mod("Condition:Onslaught", "FLAG", true, 0, 0, { type = "GlobalEffect", effectType = "Buff" })
-#baseMod skill("minionLevel", 59)
+#baseMod skill("minionLevel", 65)
 #mods
 
 #skill SupportUniqueMjolnerLightningSpellsCastOnHit Mjolner


### PR DESCRIPTION
We previously were using the wrong minion level for Dancing Dervish as the skill itself had a level requirement of 1 so we assumed it would use the level requirement of the weapon but this was incorrect

Since the minion is Unique it is meant to have the Unique monster mods applied to it

The damage taken stat comes from the UniqueAnimatedWeapon.ot file which we previously had never used

Fixes #7294