### PR TITLE
Disable skill rotation for Cast when Stunned

### DIFF
--- a/src/Modules/CalcTriggers.lua
+++ b/src/Modules/CalcTriggers.lua
@@ -1080,7 +1080,7 @@ local configTable = {
 	["cast when stunned"] = function(env)
         env.player.mainSkill.skillFlags.globalTrigger = true
 		return {triggerChance =  env.player.mainSkill.skillData.chanceToTriggerOnStun,
-				triggeredSkillCond = function(env, skill) return skill.skillData.chanceToTriggerOnStun and slotMatch(env, skill) end}
+				source = env.player.mainSkill}
 	end,
 	["spellslinger"] = function()
 		return {triggerName = "Spellslinger",


### PR DESCRIPTION
Fixes #7354

### Description of the problem being solved:
Disables skill rotation simulation for Cast when stunned as according to the issue it can cast multiple skills simultaneously. Related https://github.com/PathOfBuildingCommunity/PathOfBuilding/pull/6615

### Link to a build that showcases this PR:
```
https://pobb.in/37-nlZpE8pzO
```

