### PR TITLE
Remove unnecessary usage of slotcfg for energy shield and ward calculations

### DIFF
--- a/src/Modules/CalcDefence.lua
+++ b/src/Modules/CalcDefence.lua
@@ -670,8 +670,8 @@ function calcs.defence(env, actor)
 
 		if wardBase > 0 then
 			if modDB:Flag(nil, "EnergyShieldToWard") then
-				local inc = modDB:Sum("INC", slotCfg, "Ward", "Defences", "EnergyShield")
-				local more = modDB:More(slotCfg, "Ward", "Defences")
+				local inc = modDB:Sum("INC", nil, "Ward", "Defences", "EnergyShield")
+				local more = modDB:More(nil, "Ward", "Defences")
 				ward = ward + wardBase * (1 + inc / 100) * more
 				if breakdown then
 					t_insert(breakdown["Ward"].slots, {
@@ -693,13 +693,13 @@ function calcs.defence(env, actor)
 		energyShieldBase = modDB:Sum("BASE", nil, "EnergyShield")
 		if energyShieldBase > 0 then
 			if modDB:Flag(nil, "EnergyShieldToWard") then
-				energyShield = energyShield + energyShieldBase * modDB:More(slotCfg, "EnergyShield", "Defences")
+				energyShield = energyShield + energyShieldBase * modDB:More(nil, "EnergyShield", "Defences")
 			else
 				energyShield = energyShield + energyShieldBase * calcLib.mod(modDB, nil, "EnergyShield", "Defences")
 			end
 			if breakdown then
-				local inc = modDB:Sum("INC", slotCfg, "Defences", "EnergyShield")
-				local more = modDB:More(slotCfg, "EnergyShield", "Defences")
+				local inc = modDB:Sum("INC", nil, "Defences", "EnergyShield")
+				local more = modDB:More(nil, "EnergyShield", "Defences")
 				t_insert(breakdown["EnergyShield"].slots, {
 					base = energyShieldBase,
 					inc = (inc ~= 0) and s_format(" x %.2f", 1 + inc/100),


### PR DESCRIPTION
Fixes https://github.com/PathOfBuildingCommunity/PathOfBuilding/issues/7357

### Description of the problem being solved:
The usage of slotcfg seems to have been carried forward initially being added in https://github.com/PathOfBuildingCommunity/PathOfBuilding/commit/ae21519533337a168116ec43fe8a080535e6de2b. For player calculations slotcfg will always be:

```
{
    slotName = "Weapon 2"
}
```

Due to it only ever being set int the loop above https://github.com/PathOfBuildingCommunity/PathOfBuilding/blob/103646b6713ea1a2943a38df459873fa29509991/src/Modules/CalcDefence.lua#L573

This seems incorrect for a global effect and causes the shield only effects to apply causing the mentioned issue. 