### PR TITLE
Small data error in Replica Bitterdream

### DIFF
--- a/src/Data/Uniques/mace.lua
+++ b/src/Data/Uniques/mace.lua
@@ -287,8 +287,8 @@ Source: Steal from a unique{Curio Display} during a Grand Heist
 Requires Level 32, 52 Str, 62 Int
 Implicits: 1
 22% increased Elemental Damage
-{variant: 1}Socketed Gems are Supported by Level 1 Elemental Penetration
-{variant: 2}Socketed Gems are Supported by Level 15 Elemental Penetration
+{variant:1}Socketed Gems are Supported by Level 1 Elemental Penetration
+{variant:2}Socketed Gems are Supported by Level 15 Elemental Penetration
 Socketed Gems are Supported by Level 15 Immolate
 Socketed Gems are Supported by Level 15 Unbound Ailments
 Socketed Gems are Supported by Level 15 Ice Bite


### PR DESCRIPTION
Fixes an error I found.

### Description of the problem being solved:
Remove a space in a variant tag for one Item
