### PR TITLE
Force main hand for skills used by General's cry mirages

### DIFF
--- a/src/Data/Skills/act_str.lua
+++ b/src/Data/Skills/act_str.lua
@@ -4778,6 +4778,9 @@ skills["GeneralsCrySupport"] = {
 	excludeSkillTypes = { SkillType.SummonsTotem, SkillType.Trapped, SkillType.RemoteMined, SkillType.HasReservation, SkillType.Vaal, SkillType.Instant, SkillType.Spell, SkillType.Triggered, SkillType.InbuiltTrigger, SkillType.OwnerCannotUse, },
 	ignoreMinionTypes = true,
 	statDescriptionScope = "gem_stat_descriptions",
+	addFlags = {
+		forceMainHand = true,
+	},
 	statMap = {
 		["support_spiritual_cry_damage_+%_final"] = {
 			mod("Damage", "MORE", nil),


### PR DESCRIPTION
Fixes #7367

### Description of the problem being solved:
Mirages created by General's cry would attack with both weapons when the player is dual wielding. According to the issue this is incorrect. This pr uses logic from https://github.com/PathOfBuildingCommunity/PathOfBuilding/pull/7038 to force use of main hand.