### PR TITLE
Fix formless inferno not increasing minion life

### DIFF
--- a/src/Modules/CalcDefence.lua
+++ b/src/Modules/CalcDefence.lua
@@ -438,6 +438,11 @@ function calcs.defence(env, actor)
 		end
 	end
 
+	if actor == env.minion then
+		doActorLifeMana(env.minion)
+		doActorLifeManaReservation(env.minion)
+	end
+
 	-- Block
 	output.BlockChanceMax = modDB:Sum("BASE", nil, "BlockChanceMax")
 	if modDB:Flag(nil, "MaximumBlockAttackChanceIsEqualToParent") then

--- a/src/Modules/CalcPerform.lua
+++ b/src/Modules/CalcPerform.lua
@@ -57,7 +57,7 @@ local function mergeKeystones(env)
 	end
 end
 
-local function doActorLifeMana(actor)
+function doActorLifeMana(actor)
 	local modDB = actor.modDB
 	local output = actor.output
 	local breakdown = actor.breakdown
@@ -437,7 +437,7 @@ end
 
 -- Calculate life/mana reservation
 ---@param actor table
-local function doActorLifeManaReservation(actor)
+function doActorLifeManaReservation(actor)
 	local modDB = actor.modDB
 	local output = actor.output
 	local condList = modDB.conditions
@@ -3015,9 +3015,6 @@ function calcs.perform(env, fullDPSSkipEHP)
 	end
 
 	if env.minion then
-		doActorLifeMana(env.minion)
-		doActorLifeManaReservation(env.minion)
-
 		calcs.defence(env, env.minion)
 		if not fullDPSSkipEHP then -- main.build.calcsTab.input.showMinion and -- should be disabled unless "calcsTab.input.showMinion" is true
 			calcs.buildDefenceEstimations(env, env.minion)


### PR DESCRIPTION
Fixes #6149

### Description of the problem being solved:
Increased life modifier per over-cap fire res from [The Formless Inferno](https://www.poewiki.net/wiki/The_Formless_Inferno) did not apply as minion life was calculated before resistances. This pr moves the calculation of minion life into `calcs.defence` right under the resistance calculations. The values calculated by `doActorLifeMana` `doActorLifeManaReservation` are not used by code above where the calls were moved so this should not affect any other interactions. I understand this is not great code quality wise but i can't think of any other way of fixing this without moving either the functions calls (this pr) or resistance calculations (https://github.com/PathOfBuildingCommunity/PathOfBuilding/pull/6663) and out of the two i think this is a better solution.

My tests tooling (https://github.com/PathOfBuildingCommunity/PathOfBuilding/pull/7162) confirms no changes to output values (Note lack of Output diff sections. Bunch of noise due to the build xml compare. Still haven't really figured out a good solution for that.)
[artefact.md](https://github.com/PathOfBuildingCommunity/PathOfBuilding/files/14470152/artefact.md)

### Link to a build that showcases this PR:

    https://pobb.in/nlI569A3wZc0

### Before screenshot:
![obraz](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/91493239/9d64544d-6557-4a6a-99bc-61394e2cd2b1)

### After screenshot:
![obraz](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/91493239/2a12108a-1a97-46e8-a69f-dbebc7d9c6ea)
