### PR TITLE
Fix current variant of Lioneye's Glare missing Far Shot

### DIFF
--- a/src/Data/Uniques/bow.lua
+++ b/src/Data/Uniques/bow.lua
@@ -364,7 +364,7 @@ Implicits: 2
 (10-20)% increased Attack Speed
 +(80-100) to maximum Mana
 Hits can't be Evaded
-{variant:4,5}Far Shot
+{variant:4,5,6}Far Shot
 ]],[[
 Null's Inclination
 Ranger Bow


### PR DESCRIPTION
Fixes #7373

### Description of the problem being solved:
As long as wiki is correct, [Lioneye's Glare](https://www.poewiki.net/wiki/Lioneye's_Glare) should have Far Shot.