### PR TITLE
FIX: Nightgrip missing "taken" keyword in description (#7379)

### DIFF
--- a/src/Data/Uniques/gloves.lua
+++ b/src/Data/Uniques/gloves.lua
@@ -1060,6 +1060,6 @@ Requires Level 48, 31 Str, 31 Dex, 31 Int
 +(17-23)% to Chaos Resistance
 {variant:1}Gain Added Chaos Damage equal to 25% of Ward
 {variant:2}Gain Added Chaos Damage equal to 20% of Ward
-75% of Damage bypasses Ward
+75% of Damage taken bypasses Ward
 ]],
 }


### PR DESCRIPTION
### Before screenshot:
![7379_before](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/43402870/814a2eac-cae4-438a-aff1-42d5249893eb)

### After screenshot:
![7379_after](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/43402870/55af47ae-9e7a-4742-bf49-dfe513c55952)