### PR TITLE
FIX: Nightgrip missing "taken" keyword in description

### DIFF
--- a/src/Data/Uniques/gloves.lua
+++ b/src/Data/Uniques/gloves.lua
@@ -1060,6 +1060,6 @@ Requires Level 48, 31 Str, 31 Dex, 31 Int
 +(17-23)% to Chaos Resistance
 {variant:1}Gain Added Chaos Damage equal to 25% of Ward
 {variant:2}Gain Added Chaos Damage equal to 20% of Ward
-75% of Damage bypasses Ward
+75% of Damage taken bypasses Ward
 ]],
 }


### PR DESCRIPTION
Fixes #7379 

### Description of the problem being solved:
Nightgrip was missing the "taken" keyword and this led to an incorrect calculation of Effective Hit Pool

### Steps taken to verify a working solution:
Imported the build below and compared the equipped Nightgrip with the one selected from the uniques tab, now the Effective Hit Pool is not messed up

### Link to a build that showcases this PR:
https://pobb.in/gVGiXS9lqxya

### Before screenshot:
![7379_before](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/43402870/b156ec15-f16a-43e7-a2f5-8c52d416d863)


### After screenshot:
![7379_after](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/43402870/f7c89682-6e10-49c8-a659-96ab08eb3388)

