### PR TITLE
Implement explosive trap +-30% base tertiary radius, fix overlap chance for transfigured version

### DIFF
--- a/src/Data/Skills/act_dex.lua
+++ b/src/Data/Skills/act_dex.lua
@@ -6417,9 +6417,12 @@ skills["ShrapnelTrap"] = {
 			return math.min(damagingAreaRadius * damagingAreaRadius / (areaSpreadRadius * areaSpreadRadius), 1)
 		end
 		local enemyRadius = skillModList:Override(skillCfg, "EnemyRadius") or skillModList:Sum("BASE", skillCfg, "EnemyRadius")
-		local waveRadius = output.AreaOfEffectRadiusTertiary
 		local fullRadius = output.AreaOfEffectRadiusSecondary
-		local overlapChance = hitChance(enemyRadius, waveRadius, fullRadius)
+		local overlapChance = 0
+		local marginWidth = skillData.radiusTertiaryBaseMargin * 2 + 1
+		for smallRadius, occurrenceCount in pairs(output.AreaOfEffectRadiusTertiaryOccurrences) do
+			overlapChance = overlapChance + hitChance(enemyRadius, smallRadius, fullRadius) * occurrenceCount / marginWidth
+		end
 		output.OverlapChance = overlapChance * 100
 		local smallExplosionsPerTrap = skillModList:Sum("BASE", skillCfg, "SmallExplosions")
 		output.SmallExplosionsPerTrap = smallExplosionsPerTrap
@@ -6428,8 +6431,11 @@ skills["ShrapnelTrap"] = {
 			t_insert(breakdown.OverlapChance, "Chance for individual small explosion to land within range to damage enemy:")
 			t_insert(breakdown.OverlapChance, "^8= (area where a small explosion can spawn to damage enemy) / (total area)")
 			t_insert(breakdown.OverlapChance, "^8= (^7tertiary radius^8 + ^7enemy radius^8 - 1) ^ 2 / ^7secondary radius^8 ^ 2")
-			t_insert(breakdown.OverlapChance, s_format("^8= (^7%d^8 +^7 %d^8 - 1) ^ 2 /^7 %d^8 ^ 2", waveRadius, enemyRadius, fullRadius))
-			t_insert(breakdown.OverlapChance, s_format("^8=^7 %.3f^8%%", overlapChance * 100))
+			t_insert(breakdown.OverlapChance, "^8Result is the weighted sum of overlap chances for each possible tertiary radius")
+			for smallRadius, occurrenceCount in pairs(output.AreaOfEffectRadiusTertiaryOccurrences) do
+				t_insert(breakdown.OverlapChance, s_format("^8(^7%d^8 +^7 %d^8 - 1) ^ 2 /^7 %d^8 ^ 2 * ^7%d^8/^7%d^8 +", smallRadius, enemyRadius, fullRadius, occurrenceCount, marginWidth))
+			end
+			t_insert(breakdown.OverlapChance, s_format("^8=^7 %.3f^8%%", output.OverlapChance))
 		end
 		local dpsMultiplier = 1
 		if skillPart == 2 then

--- a/src/Data/Skills/act_dex.lua
+++ b/src/Data/Skills/act_dex.lua
@@ -6418,16 +6418,16 @@ skills["ShrapnelTrap"] = {
 		end
 		local enemyRadius = skillModList:Override(skillCfg, "EnemyRadius") or skillModList:Sum("BASE", skillCfg, "EnemyRadius")
 		local waveRadius = output.AreaOfEffectRadiusTertiary
-		local fullRadius = output.AreaOfEffectRadius
+		local fullRadius = output.AreaOfEffectRadiusSecondary
 		local overlapChance = hitChance(enemyRadius, waveRadius, fullRadius)
 		output.OverlapChance = overlapChance * 100
 		local smallExplosionsPerTrap = skillModList:Sum("BASE", skillCfg, "SmallExplosions")
 		output.SmallExplosionsPerTrap = smallExplosionsPerTrap
 		if breakdown then
 			breakdown.OverlapChance = { }
-			t_insert(breakdown.OverlapChance, "Chance for individual wave to land within range to damage enemy:")
-			t_insert(breakdown.OverlapChance, "^8= (area where wave can spawn to damage enemy) / (total area)")
-			t_insert(breakdown.OverlapChance, "^8= (^7secondary radius^8 + ^7enemy radius^8 - 1) ^ 2 / ^7radius^8 ^ 2")
+			t_insert(breakdown.OverlapChance, "Chance for individual small explosion to land within range to damage enemy:")
+			t_insert(breakdown.OverlapChance, "^8= (area where a small explosion can spawn to damage enemy) / (total area)")
+			t_insert(breakdown.OverlapChance, "^8= (^7tertiary radius^8 + ^7enemy radius^8 - 1) ^ 2 / ^7secondary radius^8 ^ 2")
 			t_insert(breakdown.OverlapChance, s_format("^8= (^7%d^8 +^7 %d^8 - 1) ^ 2 /^7 %d^8 ^ 2", waveRadius, enemyRadius, fullRadius))
 			t_insert(breakdown.OverlapChance, s_format("^8=^7 %.3f^8%%", overlapChance * 100))
 		end
@@ -6471,6 +6471,7 @@ skills["ShrapnelTrap"] = {
 		skill("radiusLabel", "Primary Explosion:"),
 		skill("radiusSecondaryLabel", "Secondary Area:"),
 		skill("radiusTertiaryLabel", "Secondary Explosion:"),
+		skill("radiusTertiaryBaseMargin", 30),
 	},
 	qualityStats = {
 		Default = {
@@ -6553,85 +6554,14 @@ skills["ShrapnelTrapAltX"] = {
 	skillTypes = { [SkillType.Spell] = true, [SkillType.Damage] = true, [SkillType.Mineable] = true, [SkillType.Area] = true, [SkillType.Trapped] = true, [SkillType.Fire] = true, [SkillType.AreaSpell] = true, [SkillType.Physical] = true, },
 	statDescriptionScope = "skill_stat_descriptions",
 	castTime = 1,
-	parts = {
-		{
-			name = "One explosion hitting",
-		},
-		{
-			name = "Average explosions hitting",
-		},
-		{
-			name = "All explosions hitting",
-		},
-	},
-	preDamageFunc = function(activeSkill, output, breakdown)
-		local skillCfg = activeSkill.skillCfg
-		local skillData = activeSkill.skillData
-		local skillPart = activeSkill.skillPart
-		local skillModList = activeSkill.skillModList
-		local t_insert = table.insert
-		local s_format = string.format
-
-		local function hitChance(enemyRadius, areaDamageRadius, areaSpreadRadius) -- not to be confused with attack hit chance
-			local damagingAreaRadius = areaDamageRadius + enemyRadius - 1	-- radius where area damage can land to hit the enemy;
-			-- -1 because of two assumptions: PoE coordinates are integers and damage is not registered if the two areas only share a point or vertex. If either is not correct, then -1 is not needed.
-			return math.min(damagingAreaRadius * damagingAreaRadius / (areaSpreadRadius * areaSpreadRadius), 1)
-		end
-		local enemyRadius = skillModList:Override(skillCfg, "EnemyRadius") or skillModList:Sum("BASE", skillCfg, "EnemyRadius")
-		local waveRadius = output.AreaOfEffectRadiusTertiary
-		local fullRadius = output.AreaOfEffectRadius
-		local overlapChance = hitChance(enemyRadius, waveRadius, fullRadius)
-		output.OverlapChance = overlapChance * 100
-		local smallExplosionsPerTrap = skillModList:Sum("BASE", skillCfg, "SmallExplosions")
-		output.SmallExplosionsPerTrap = smallExplosionsPerTrap
-		if breakdown then
-			breakdown.OverlapChance = { }
-			t_insert(breakdown.OverlapChance, "Chance for individual wave to land within range to damage enemy:")
-			t_insert(breakdown.OverlapChance, "^8= (area where wave can spawn to damage enemy) / (total area)")
-			t_insert(breakdown.OverlapChance, "^8= (^7secondary radius^8 + ^7enemy radius^8 - 1) ^ 2 / ^7radius^8 ^ 2")
-			t_insert(breakdown.OverlapChance, s_format("^8= (^7%d^8 +^7 %d^8 - 1) ^ 2 /^7 %d^8 ^ 2", waveRadius, enemyRadius, fullRadius))
-			t_insert(breakdown.OverlapChance, s_format("^8=^7 %.3f^8%%", overlapChance * 100))
-		end
-		local dpsMultiplier = 1
-		if skillPart == 2 then
-			dpsMultiplier = 1 + smallExplosionsPerTrap * overlapChance
-			if breakdown then
-				breakdown.SkillDPSMultiplier = {}
-				t_insert(breakdown.SkillDPSMultiplier, "DPS multiplier")
-				t_insert(breakdown.SkillDPSMultiplier, "^8= 1 + ^7small explosions^8 * ^7overlap chance^8")
-				t_insert(breakdown.SkillDPSMultiplier, s_format("^8= 1 +^7 %d^8 *^7 %.2f^8", smallExplosionsPerTrap, overlapChance))
-				t_insert(breakdown.SkillDPSMultiplier, s_format("^8=^7 %.3f", dpsMultiplier))
-			end
-		elseif skillPart == 3 then
-			dpsMultiplier = 1 + smallExplosionsPerTrap
-			if breakdown then
-				breakdown.SkillDPSMultiplier = {}
-				t_insert(breakdown.SkillDPSMultiplier, "DPS multiplier")
-				t_insert(breakdown.SkillDPSMultiplier, s_format("^8= 1 +^7 %d (small explosions)", dpsMultiplier))
-			end
-		end
-		if dpsMultiplier ~= 1 then
-			skillData.dpsMultiplier = (skillData.dpsMultiplier or 1) * dpsMultiplier
-			output.SkillDPSMultiplier = (output.SkillDPSMultiplier or 1) * dpsMultiplier
-		end
-	end,
-	statMap = {
-		["shrapnel_trap_number_of_secondary_explosions"] = {
-			mod("SmallExplosions", "BASE", nil),
-		},
-		["quality_display_explosive_trap_is_gem"] = {
-			-- Display only
-		},
-	},
+	parts = skills.ShrapnelTrap.parts,
+	preDamageFunc = skills.ShrapnelTrap.preDamageFunc,
+	statMap = skills.ShrapnelTrap.statMap,
+	baseMods = skills.ShrapnelTrap.baseMods,
 	baseFlags = {
 		spell = true,
 		trap = true,
 		area = true,
-	},
-	baseMods = {
-		skill("radiusLabel", "Primary Explosion:"),
-		skill("radiusSecondaryLabel", "Secondary Area:"),
-		skill("radiusTertiaryLabel", "Secondary Explosion:"),
 	},
 	qualityStats = {
 		Default = {

--- a/src/Data/Skills/act_dex.lua
+++ b/src/Data/Skills/act_dex.lua
@@ -6432,8 +6432,15 @@ skills["ShrapnelTrap"] = {
 			t_insert(breakdown.OverlapChance, "^8= (area where a small explosion can spawn to damage enemy) / (total area)")
 			t_insert(breakdown.OverlapChance, "^8= (^7tertiary radius^8 + ^7enemy radius^8 - 1) ^ 2 / ^7secondary radius^8 ^ 2")
 			t_insert(breakdown.OverlapChance, "^8Result is the weighted sum of overlap chances for each possible tertiary radius")
-			for smallRadius, occurrenceCount in pairs(output.AreaOfEffectRadiusTertiaryOccurrences) do
-				t_insert(breakdown.OverlapChance, s_format("^8(^7%d^8 +^7 %d^8 - 1) ^ 2 /^7 %d^8 ^ 2 * ^7%d^8/^7%d^8 +", smallRadius, enemyRadius, fullRadius, occurrenceCount, marginWidth))
+			local radii = {}
+			for radius in pairs(output.AreaOfEffectRadiusTertiaryOccurrences) do
+				t_insert(radii, radius)
+			end
+			table.sort(radii)
+			for i, smallRadius in ipairs(radii) do
+				t_insert(breakdown.OverlapChance, s_format("^8(^7%d^8 +^7 %d^8 - 1) ^ 2 /^7 %d^8 ^ 2 *^7 %d/%d" ..
+						(i == #radii and "" or " ^8+"),
+						smallRadius, enemyRadius, fullRadius, output.AreaOfEffectRadiusTertiaryOccurrences[smallRadius], marginWidth))
 			end
 			t_insert(breakdown.OverlapChance, s_format("^8=^7 %.3f^8%%", output.OverlapChance))
 		end

--- a/src/Export/Skills/act_dex.txt
+++ b/src/Export/Skills/act_dex.txt
@@ -1345,8 +1345,15 @@ local skills, mod, flag, skill = ...
 			t_insert(breakdown.OverlapChance, "^8= (area where a small explosion can spawn to damage enemy) / (total area)")
 			t_insert(breakdown.OverlapChance, "^8= (^7tertiary radius^8 + ^7enemy radius^8 - 1) ^ 2 / ^7secondary radius^8 ^ 2")
 			t_insert(breakdown.OverlapChance, "^8Result is the weighted sum of overlap chances for each possible tertiary radius")
-			for smallRadius, occurrenceCount in pairs(output.AreaOfEffectRadiusTertiaryOccurrences) do
-				t_insert(breakdown.OverlapChance, s_format("^8(^7%d^8 +^7 %d^8 - 1) ^ 2 /^7 %d^8 ^ 2 * ^7%d^8/^7%d^8 +", smallRadius, enemyRadius, fullRadius, occurrenceCount, marginWidth))
+			local radii = {}
+			for radius in pairs(output.AreaOfEffectRadiusTertiaryOccurrences) do
+				t_insert(radii, radius)
+			end
+			table.sort(radii)
+			for i, smallRadius in ipairs(radii) do
+				t_insert(breakdown.OverlapChance, s_format("^8(^7%d^8 +^7 %d^8 - 1) ^ 2 /^7 %d^8 ^ 2 *^7 %d/%d" ..
+						(i == #radii and "" or " ^8+"),
+						smallRadius, enemyRadius, fullRadius, output.AreaOfEffectRadiusTertiaryOccurrences[smallRadius], marginWidth))
 			end
 			t_insert(breakdown.OverlapChance, s_format("^8=^7 %.3f^8%%", output.OverlapChance))
 		end

--- a/src/Export/Skills/act_dex.txt
+++ b/src/Export/Skills/act_dex.txt
@@ -1330,9 +1330,12 @@ local skills, mod, flag, skill = ...
 			return math.min(damagingAreaRadius * damagingAreaRadius / (areaSpreadRadius * areaSpreadRadius), 1)
 		end
 		local enemyRadius = skillModList:Override(skillCfg, "EnemyRadius") or skillModList:Sum("BASE", skillCfg, "EnemyRadius")
-		local waveRadius = output.AreaOfEffectRadiusTertiary
 		local fullRadius = output.AreaOfEffectRadiusSecondary
-		local overlapChance = hitChance(enemyRadius, waveRadius, fullRadius)
+		local overlapChance = 0
+		local marginWidth = skillData.radiusTertiaryBaseMargin * 2 + 1
+		for smallRadius, occurrenceCount in pairs(output.AreaOfEffectRadiusTertiaryOccurrences) do
+			overlapChance = overlapChance + hitChance(enemyRadius, smallRadius, fullRadius) * occurrenceCount / marginWidth
+		end
 		output.OverlapChance = overlapChance * 100
 		local smallExplosionsPerTrap = skillModList:Sum("BASE", skillCfg, "SmallExplosions")
 		output.SmallExplosionsPerTrap = smallExplosionsPerTrap
@@ -1341,8 +1344,11 @@ local skills, mod, flag, skill = ...
 			t_insert(breakdown.OverlapChance, "Chance for individual small explosion to land within range to damage enemy:")
 			t_insert(breakdown.OverlapChance, "^8= (area where a small explosion can spawn to damage enemy) / (total area)")
 			t_insert(breakdown.OverlapChance, "^8= (^7tertiary radius^8 + ^7enemy radius^8 - 1) ^ 2 / ^7secondary radius^8 ^ 2")
-			t_insert(breakdown.OverlapChance, s_format("^8= (^7%d^8 +^7 %d^8 - 1) ^ 2 /^7 %d^8 ^ 2", waveRadius, enemyRadius, fullRadius))
-			t_insert(breakdown.OverlapChance, s_format("^8=^7 %.3f^8%%", overlapChance * 100))
+			t_insert(breakdown.OverlapChance, "^8Result is the weighted sum of overlap chances for each possible tertiary radius")
+			for smallRadius, occurrenceCount in pairs(output.AreaOfEffectRadiusTertiaryOccurrences) do
+				t_insert(breakdown.OverlapChance, s_format("^8(^7%d^8 +^7 %d^8 - 1) ^ 2 /^7 %d^8 ^ 2 * ^7%d^8/^7%d^8 +", smallRadius, enemyRadius, fullRadius, occurrenceCount, marginWidth))
+			end
+			t_insert(breakdown.OverlapChance, s_format("^8=^7 %.3f^8%%", output.OverlapChance))
 		end
 		local dpsMultiplier = 1
 		if skillPart == 2 then

--- a/src/Export/Skills/act_dex.txt
+++ b/src/Export/Skills/act_dex.txt
@@ -1331,16 +1331,16 @@ local skills, mod, flag, skill = ...
 		end
 		local enemyRadius = skillModList:Override(skillCfg, "EnemyRadius") or skillModList:Sum("BASE", skillCfg, "EnemyRadius")
 		local waveRadius = output.AreaOfEffectRadiusTertiary
-		local fullRadius = output.AreaOfEffectRadius
+		local fullRadius = output.AreaOfEffectRadiusSecondary
 		local overlapChance = hitChance(enemyRadius, waveRadius, fullRadius)
 		output.OverlapChance = overlapChance * 100
 		local smallExplosionsPerTrap = skillModList:Sum("BASE", skillCfg, "SmallExplosions")
 		output.SmallExplosionsPerTrap = smallExplosionsPerTrap
 		if breakdown then
 			breakdown.OverlapChance = { }
-			t_insert(breakdown.OverlapChance, "Chance for individual wave to land within range to damage enemy:")
-			t_insert(breakdown.OverlapChance, "^8= (area where wave can spawn to damage enemy) / (total area)")
-			t_insert(breakdown.OverlapChance, "^8= (^7secondary radius^8 + ^7enemy radius^8 - 1) ^ 2 / ^7radius^8 ^ 2")
+			t_insert(breakdown.OverlapChance, "Chance for individual small explosion to land within range to damage enemy:")
+			t_insert(breakdown.OverlapChance, "^8= (area where a small explosion can spawn to damage enemy) / (total area)")
+			t_insert(breakdown.OverlapChance, "^8= (^7tertiary radius^8 + ^7enemy radius^8 - 1) ^ 2 / ^7secondary radius^8 ^ 2")
 			t_insert(breakdown.OverlapChance, s_format("^8= (^7%d^8 +^7 %d^8 - 1) ^ 2 /^7 %d^8 ^ 2", waveRadius, enemyRadius, fullRadius))
 			t_insert(breakdown.OverlapChance, s_format("^8=^7 %.3f^8%%", overlapChance * 100))
 		end
@@ -1378,83 +1378,15 @@ local skills, mod, flag, skill = ...
 #baseMod skill("radiusLabel", "Primary Explosion:")
 #baseMod skill("radiusSecondaryLabel", "Secondary Area:")
 #baseMod skill("radiusTertiaryLabel", "Secondary Explosion:")
+#baseMod skill("radiusTertiaryBaseMargin", 30)
 #mods
 
 #skill ShrapnelTrapAltX
 #flags spell trap area
-	parts = {
-		{
-			name = "One explosion hitting",
-		},
-		{
-			name = "Average explosions hitting",
-		},
-		{
-			name = "All explosions hitting",
-		},
-	},
-	preDamageFunc = function(activeSkill, output, breakdown)
-		local skillCfg = activeSkill.skillCfg
-		local skillData = activeSkill.skillData
-		local skillPart = activeSkill.skillPart
-		local skillModList = activeSkill.skillModList
-		local t_insert = table.insert
-		local s_format = string.format
-
-		local function hitChance(enemyRadius, areaDamageRadius, areaSpreadRadius) -- not to be confused with attack hit chance
-			local damagingAreaRadius = areaDamageRadius + enemyRadius - 1	-- radius where area damage can land to hit the enemy;
-			-- -1 because of two assumptions: PoE coordinates are integers and damage is not registered if the two areas only share a point or vertex. If either is not correct, then -1 is not needed.
-			return math.min(damagingAreaRadius * damagingAreaRadius / (areaSpreadRadius * areaSpreadRadius), 1)
-		end
-		local enemyRadius = skillModList:Override(skillCfg, "EnemyRadius") or skillModList:Sum("BASE", skillCfg, "EnemyRadius")
-		local waveRadius = output.AreaOfEffectRadiusTertiary
-		local fullRadius = output.AreaOfEffectRadius
-		local overlapChance = hitChance(enemyRadius, waveRadius, fullRadius)
-		output.OverlapChance = overlapChance * 100
-		local smallExplosionsPerTrap = skillModList:Sum("BASE", skillCfg, "SmallExplosions")
-		output.SmallExplosionsPerTrap = smallExplosionsPerTrap
-		if breakdown then
-			breakdown.OverlapChance = { }
-			t_insert(breakdown.OverlapChance, "Chance for individual wave to land within range to damage enemy:")
-			t_insert(breakdown.OverlapChance, "^8= (area where wave can spawn to damage enemy) / (total area)")
-			t_insert(breakdown.OverlapChance, "^8= (^7secondary radius^8 + ^7enemy radius^8 - 1) ^ 2 / ^7radius^8 ^ 2")
-			t_insert(breakdown.OverlapChance, s_format("^8= (^7%d^8 +^7 %d^8 - 1) ^ 2 /^7 %d^8 ^ 2", waveRadius, enemyRadius, fullRadius))
-			t_insert(breakdown.OverlapChance, s_format("^8=^7 %.3f^8%%", overlapChance * 100))
-		end
-		local dpsMultiplier = 1
-		if skillPart == 2 then
-			dpsMultiplier = 1 + smallExplosionsPerTrap * overlapChance
-			if breakdown then
-				breakdown.SkillDPSMultiplier = {}
-				t_insert(breakdown.SkillDPSMultiplier, "DPS multiplier")
-				t_insert(breakdown.SkillDPSMultiplier, "^8= 1 + ^7small explosions^8 * ^7overlap chance^8")
-				t_insert(breakdown.SkillDPSMultiplier, s_format("^8= 1 +^7 %d^8 *^7 %.2f^8", smallExplosionsPerTrap, overlapChance))
-				t_insert(breakdown.SkillDPSMultiplier, s_format("^8=^7 %.3f", dpsMultiplier))
-			end
-		elseif skillPart == 3 then
-			dpsMultiplier = 1 + smallExplosionsPerTrap
-			if breakdown then
-				breakdown.SkillDPSMultiplier = {}
-				t_insert(breakdown.SkillDPSMultiplier, "DPS multiplier")
-				t_insert(breakdown.SkillDPSMultiplier, s_format("^8= 1 +^7 %d (small explosions)", dpsMultiplier))
-			end
-		end
-		if dpsMultiplier ~= 1 then
-			skillData.dpsMultiplier = (skillData.dpsMultiplier or 1) * dpsMultiplier
-			output.SkillDPSMultiplier = (output.SkillDPSMultiplier or 1) * dpsMultiplier
-		end
-	end,
-	statMap = {
-		["shrapnel_trap_number_of_secondary_explosions"] = {
-			mod("SmallExplosions", "BASE", nil),
-		},
-		["quality_display_explosive_trap_is_gem"] = {
-			-- Display only
-		},
-	},
-#baseMod skill("radiusLabel", "Primary Explosion:")
-#baseMod skill("radiusSecondaryLabel", "Secondary Area:")
-#baseMod skill("radiusTertiaryLabel", "Secondary Explosion:")
+	parts = skills.ShrapnelTrap.parts,
+	preDamageFunc = skills.ShrapnelTrap.preDamageFunc,
+	statMap = skills.ShrapnelTrap.statMap,
+	baseMods = skills.ShrapnelTrap.baseMods,
 #mods
 
 #skill ShrapnelTrapAltY

--- a/src/Modules/CalcOffence.lua
+++ b/src/Modules/CalcOffence.lua
@@ -393,7 +393,7 @@ function calcs.offence(env, actor, activeSkill)
 						local radiusForDeviation = calcRadius(adjustedBaseRadius, output.AreaOfEffectModTertiary)
 						radiusForBaseRadius[adjustedBaseRadius] = radiusForDeviation
 						sumOfRandomRadii = sumOfRandomRadii + radiusForDeviation * occurrenceCount
-						radiiOccurrences[radiusForDeviation] = occurrenceCount
+						radiiOccurrences[radiusForDeviation] = (radiiOccurrences[radiusForDeviation] or 0) + occurrenceCount
 					end
 					output.AreaOfEffectRadiusTertiary = sumOfRandomRadii / marginWidth
 					output.AreaOfEffectRadiusTertiaryOccurrences = radiiOccurrences
@@ -402,8 +402,13 @@ function calcs.offence(env, actor, activeSkill)
 						local incAreaBreakpointTertiary, moreAreaBreakpointTertiary, redAreaBreakpointTertiary, lessAreaBreakpointTertiary = math.huge, math.huge, math.huge, math.huge
 						t_insert(out, skillData.radiusTertiaryLabel)
 						t_insert(out, s_format("R ^8(base radius)^7 x %.2f ^8(square root of area of effect modifier)", m_floor(100 * m_sqrt(output.AreaOfEffectModTertiary)) / 100))
-						for adjustedBaseRadius, occurrenceCount in pairs(baseRadiiOccurrences) do
-							t_insert(out, s_format("%.1f%% ^8chance of^7 %.1fm ^8base radius resulting in^7 %.1fm ^8final radius", occurrenceCount / marginWidth * 100, adjustedBaseRadius / 10, radiusForBaseRadius[adjustedBaseRadius] / 10))
+						local baseRadii = {}
+						for adjustedBaseRadius in pairs(baseRadiiOccurrences) do
+							t_insert(baseRadii, adjustedBaseRadius)
+						end
+						table.sort(baseRadii, function(a,b) return a < b end)
+						for _, adjustedBaseRadius in ipairs(baseRadii) do
+							t_insert(out, s_format("%.1f%% ^8chance of^7 %.1fm ^8base radius resulting in^7 %.1fm ^8final radius", baseRadiiOccurrences[adjustedBaseRadius] / marginWidth * 100, adjustedBaseRadius / 10, radiusForBaseRadius[adjustedBaseRadius] / 10))
 							local incAreaBreakpointTertiaryIntermediate, moreAreaBreakpointTertiaryIntermediate, redAreaBreakpointTertiaryIntermediate, lessAreaBreakpointTertiaryIntermediate = calcRadiusBreakpoints(adjustedBaseRadius, incAreaTertiary, moreAreaTertiary)
 							incAreaBreakpointTertiary = math.min(incAreaBreakpointTertiary, incAreaBreakpointTertiaryIntermediate)
 							moreAreaBreakpointTertiary = math.min(moreAreaBreakpointTertiary, moreAreaBreakpointTertiaryIntermediate)

--- a/src/Modules/CalcOffence.lua
+++ b/src/Modules/CalcOffence.lua
@@ -388,12 +388,15 @@ function calcs.offence(env, actor, activeSkill)
 					-- Calculate the modified radius for each base radius
 					local sumOfRandomRadii = 0
 					local radiusForBaseRadius = {}
+					local radiiOccurrences = {}
 					for adjustedBaseRadius, occurrenceCount in pairs(baseRadiiOccurrences) do
 						local radiusForDeviation = calcRadius(adjustedBaseRadius, output.AreaOfEffectModTertiary)
 						radiusForBaseRadius[adjustedBaseRadius] = radiusForDeviation
 						sumOfRandomRadii = sumOfRandomRadii + radiusForDeviation * occurrenceCount
+						radiiOccurrences[radiusForDeviation] = occurrenceCount
 					end
 					output.AreaOfEffectRadiusTertiary = sumOfRandomRadii / marginWidth
+					output.AreaOfEffectRadiusTertiaryOccurrences = radiiOccurrences
 					if breakdown then
 						local out = {}
 						local incAreaBreakpointTertiary, moreAreaBreakpointTertiary, redAreaBreakpointTertiary, lessAreaBreakpointTertiary = math.huge, math.huge, math.huge, math.huge


### PR DESCRIPTION
Fixes #6909 and #7260 .
Supersedes  #7321 .

### Description of the problem being solved:
Explosive Trap of Shrapnel was using wrong variables for it's overlap calculations and producing incorrect values.
The +- 30% base radius on both explosive traps was not yet implemented leading to overestimating the damage output.

### Steps taken to verify a working solution:
- The "Average explosions hitting" setting produces a bit lower overlap chance for normal version and not 100% for trans version

### Link to a build that showcases this PR:
https://pobb.in/HFrrt77bxIjn

### Before screenshots:
![image](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/36479307/325b7546-a6b9-49ae-b417-d558eabfdabd)
![image](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/36479307/9da63095-bd71-4f41-b876-9317cb1f9f60)
![image](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/36479307/bfb3e320-f17b-4818-8304-d8cf7b2fcccc)
![image](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/36479307/d7963b7c-1fb7-4487-90d3-807cb04447ef)

### After screenshots:
![image](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/36479307/55561ace-a6ad-4d21-b15c-d0cd3a791934)
![image](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/36479307/3f157cbb-cd4c-4a64-a70e-f72057129ee1)
![image](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/36479307/b0048c46-9899-4dca-996f-3016edd87b4c)
![image](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/36479307/fef479c3-e13f-4939-93da-26146c879d0a)
