### PR TITLE
Fix Armour and ES breakdowns for "100% increased..." Armour and ES Mastery

### DIFF
--- a/src/Modules/CalcDefence.lua
+++ b/src/Modules/CalcDefence.lua
@@ -629,7 +629,7 @@ function calcs.defence(env, actor)
 						energyShield = energyShield + energyShieldBase * calcLib.mod(modDB, slotCfg, "EnergyShield", "Defences", slot.."ESAndArmour")
 						gearEnergyShield = gearEnergyShield + energyShieldBase
 						if breakdown then
-							breakdown.slot(slot, nil, slotCfg, energyShieldBase, nil, "EnergyShield", "Defences")
+							breakdown.slot(slot, nil, slotCfg, energyShieldBase, nil, "EnergyShield", "Defences", slot.."ESAndArmour")
 						end
 					end
 				end
@@ -646,7 +646,7 @@ function calcs.defence(env, actor)
 					armour = armour + armourBase * calcLib.mod(modDB, slotCfg, "Armour", "ArmourAndEvasion", "Defences", slot.."ESAndArmour")
 					gearArmour = gearArmour + armourBase
 					if breakdown then
-						breakdown.slot(slot, nil, slotCfg, armourBase, nil, "Armour", "ArmourAndEvasion", "Defences")
+						breakdown.slot(slot, nil, slotCfg, armourBase, nil, "Armour", "ArmourAndEvasion", "Defences", slot.."ESAndArmour")
 					end
 				end
 				evasionBase = armourData.Evasion or 0


### PR DESCRIPTION
Fixes #7386

### Description of the problem being solved:
Update breakdowns to show the 100% increased Armour and Energy Shield on Body Armour from the Armour and Energy Shield Mastery.

### Steps taken to verify a working solution:
- Validate breakdown of armour equals total armour
- Validate breakdown of energy shield equals total energy shield

### Link to a build that showcases this PR:
<pre>https://pobb.in/ROa3CR-0WuiJ</pre>

### Before screenshot:
![image](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/92683202/ea786104-0afd-4adc-ba18-7f95e9a44af8)

![image](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/92683202/8f1474a2-4c31-42e9-a6df-2984eeadee49)

### After screenshot:
![image](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/92683202/643ae3e1-7142-44b6-9054-378037fb7a55)

![image](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/92683202/cc1d0853-49ee-45e8-95e4-915b302d2e79)
