### PR TITLE
Fix snipe precalculation using wrong calc mode

### DIFF
--- a/src/Modules/CalcTriggers.lua
+++ b/src/Modules/CalcTriggers.lua
@@ -1192,9 +1192,6 @@ local configTable = {
 		local snipeHitMulti = env.player.mainSkill.skillModList:Sum("BASE", env.player.mainSkill.skillCfg, "snipeHitMulti")
 		local snipeAilmentMulti = env.player.mainSkill.skillModList:Sum("BASE", env.player.mainSkill.skillCfg, "snipeAilmentMulti")
 		local triggeredSkills = {}
-		local source
-		local trigRate
-		local uuid
 		local currentSkillSnipeIndex
 
 		for _, skill in ipairs(env.player.activeSkillList) do
@@ -1229,6 +1226,9 @@ local configTable = {
 				env.player.mainSkill.skillData.baseMultiplier = 0
 			end
 		else
+			local source
+			local trigRate
+			local mode = env.mode == "CALCS" and "CALCS" or "MAIN"
 			-- Does snipe have enough stages to trigger this skill?
 			if currentSkillSnipeIndex and currentSkillSnipeIndex <= snipeStages then
 				env.player.mainSkill.skillModList:NewMod("Damage", "MORE", snipeHitMulti * snipeStages , "Snipe", ModFlag.Hit, 0)
@@ -1236,9 +1236,16 @@ local configTable = {
 				for _, skill in ipairs(env.player.activeSkillList) do
 					if skill.activeEffect.grantedEffect.name == "Snipe" and skill.socketGroup and skill.socketGroup.slot == env.player.mainSkill.socketGroup.slot then
 						skill.skillData.hitTimeMultiplier = snipeStages - 0.5
-						source, _, uuid = findTriggerSkill(env, skill, source)
-						trigRate = GlobalCache.cachedData["CACHE"][uuid].Env.player.output.HitSpeed
-						env.player.output.ChannelTimeToTrigger = GlobalCache.cachedData["CACHE"][uuid].Env.player.output.HitTime
+						local uuid = cacheSkillUUID(skill, env)
+						if not GlobalCache.cachedData[mode][uuid] or GlobalCache.noCache then
+							calcs.buildActiveSkill(env, mode, skill)
+						end
+						local cachedSpeed = GlobalCache.cachedData[mode][uuid].Env.player.output.HitSpeed
+						if (skill.skillFlags and not skill.skillFlags.disable) and (skill.skillCfg and not skill.skillCfg.skillCond["usedByMirage"]) and not skill.skillTypes[SkillType.OtherThingUsesSkill] and ((not source and cachedSpeed) or (cachedSpeed and cachedSpeed > (trigRate or 0))) then
+							trigRate = cachedSpeed
+							env.player.output.ChannelTimeToTrigger = GlobalCache.cachedData[mode][uuid].Env.player.output.HitTime
+							source = skill
+						end
 					end
 				end
 

--- a/src/Modules/CalcTriggers.lua
+++ b/src/Modules/CalcTriggers.lua
@@ -1192,18 +1192,10 @@ local configTable = {
 		local snipeHitMulti = env.player.mainSkill.skillModList:Sum("BASE", env.player.mainSkill.skillCfg, "snipeHitMulti")
 		local snipeAilmentMulti = env.player.mainSkill.skillModList:Sum("BASE", env.player.mainSkill.skillCfg, "snipeAilmentMulti")
 		local triggeredSkills = {}
-		local currentSkillSnipeIndex
 
 		for _, skill in ipairs(env.player.activeSkillList) do
 			if skill.skillData.triggeredBySnipe and skill.socketGroup and skill.socketGroup.slot == env.player.mainSkill.socketGroup.slot then
 				t_insert(triggeredSkills, skill)
-			end
-		end
-
-		for index, skill in ipairs(triggeredSkills) do
-			if skill == env.player.mainSkill then
-				currentSkillSnipeIndex = index
-				break
 			end
 		end
 
@@ -1226,11 +1218,19 @@ local configTable = {
 				env.player.mainSkill.skillData.baseMultiplier = 0
 			end
 		else
-			local source
-			local trigRate
-			local mode = env.mode == "CALCS" and "CALCS" or "MAIN"
+			local currentSkillSnipeIndex
+			for index, skill in ipairs(triggeredSkills) do
+				if skill == env.player.mainSkill then
+					currentSkillSnipeIndex = index
+					break
+				end
+			end
+
 			-- Does snipe have enough stages to trigger this skill?
 			if currentSkillSnipeIndex and currentSkillSnipeIndex <= snipeStages then
+				local source
+				local trigRate
+				local mode = env.mode == "CALCS" and "CALCS" or "MAIN"
 				env.player.mainSkill.skillModList:NewMod("Damage", "MORE", snipeHitMulti * snipeStages , "Snipe", ModFlag.Hit, 0)
 				env.player.mainSkill.skillModList:NewMod("Damage", "MORE", snipeAilmentMulti * snipeStages , "Snipe", ModFlag.Ailment, 0)
 				for _, skill in ipairs(env.player.activeSkillList) do


### PR DESCRIPTION
Fixes https://github.com/PathOfBuildingCommunity/PathOfBuilding/issues/7388

### Description of the problem being solved:
Precalcualtion of snipe skill used "CACHE" mode causing similar issue to https://github.com/PathOfBuildingCommunity/PathOfBuilding/pull/7317 . 

### Link to a build that showcases this PR:
```
https://pobb.in/IzUcwIOEbC1d
```