### PR TITLE
Fix Snipe doing damage when in trigger mode

### DIFF
--- a/src/Modules/CalcTriggers.lua
+++ b/src/Modules/CalcTriggers.lua
@@ -1226,7 +1226,11 @@ local configTable = {
 				end
 			else
 				-- Snipe is being used as a trigger source, it triggers other skills but does no damage it self
-				env.player.mainSkill.skillData.baseMultiplier = 0
+				env.player.mainSkill.skillModList:NewMod("DealNoLightning", "FLAG", true, { type = "SkillName", skillName = "Snipe", includeTransfigured = true })
+				env.player.mainSkill.skillModList:NewMod("DealNoCold", "FLAG", true, { type = "SkillName", skillName = "Snipe", includeTransfigured = true })
+				env.player.mainSkill.skillModList:NewMod("DealNoFire", "FLAG", true, { type = "SkillName", skillName = "Snipe", includeTransfigured = true })
+				env.player.mainSkill.skillModList:NewMod("DealNoChaos", "FLAG", true, { type = "SkillName", skillName = "Snipe", includeTransfigured = true })
+				env.player.mainSkill.skillModList:NewMod("DealNoPhysical", "FLAG", true, { type = "SkillName", skillName = "Snipe", includeTransfigured = true })
 			end
 		else
 			-- Does snipe have enough stages to trigger this skill?


### PR DESCRIPTION
### Description of the problem being solved:
Snipe should deal no damage it self when it is a trigger for another skill. Currently Snipe has the base multiplier set to 0 when in trigger mode but that allows for added damage to skill count towards dps.

### Link to a build that showcases this PR:


### Before screenshot:
![obraz](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/91493239/a7f78d48-96b7-4129-ac21-6cd7f5988085)

### After screenshot:
![obraz](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/91493239/e7277b65-d019-4df3-8ded-47f549a82a8f)
