### PR TITLE
Reduce clutter in Import character selection list

### DIFF
--- a/src/Classes/ImportTab.lua
+++ b/src/Classes/ImportTab.lua
@@ -485,12 +485,15 @@ function ImportTabClass:BuildCharacterList(league)
 	wipeTable(self.controls.charSelect.list)
 	for i, char in ipairs(self.lastCharList) do
 		if not league or char.league == league then
-			lbl = nil
-			if lbl == "All" then
-				string.format("%s: Level %d %s in %s", char.name or "?", char.level or 0, char.class or "?", char.league or "?")
-			else
-				string.format("%s: Level %d %s", char.name or "?", char.level or 0, char.class or "?")
-			end
+			charLvl = char.level or 0
+			charLeague = char.league or "?"
+			charName = char.name or "?"
+			charClass = char.class or "?"
+			lbl = (league == nil and
+				string.format("%s: Level %d %s in %s", charName, charLvl, charClass, charLeague)
+			or
+				string.format("%s: Level %d %s", charName, charLvl, charClass)
+			)
 			t_insert(self.controls.charSelect.list, {
 				label = lbl,
 				char = char,

--- a/src/Classes/ImportTab.lua
+++ b/src/Classes/ImportTab.lua
@@ -485,8 +485,14 @@ function ImportTabClass:BuildCharacterList(league)
 	wipeTable(self.controls.charSelect.list)
 	for i, char in ipairs(self.lastCharList) do
 		if not league or char.league == league then
+			lbl = nil
+			if lbl == "All" then
+				string.format("%s: Level %d %s in %s", char.name or "?", char.level or 0, char.class or "?", char.league or "?")
+			else
+				string.format("%s: Level %d %s", char.name or "?", char.level or 0, char.class or "?")
+			end
 			t_insert(self.controls.charSelect.list, {
-				label = string.format("%s: Level %d %s in %s", char.name or "?", char.level or 0, char.class or "?", char.league or "?"),
+				label = lbl,
 				char = char,
 			})
 		end


### PR DESCRIPTION
Fixes # .

### Description of the problem being solved:

When i select `Affliction` no need to display `in Affliction`, reserve that to only if select `All`

### Before screenshot:
![image](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/44361234/a5de9cc6-76c6-423a-a8f4-fd658b208eba)

### After screenshot:
![image](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/44361234/47c37355-c237-4d13-b453-f0264364a90f)

