### PR TITLE
Stop sorting unique item list when added item isn't equipped

### DIFF
--- a/src/Classes/ItemListControl.lua
+++ b/src/Classes/ItemListControl.lua
@@ -151,7 +151,6 @@ function ItemListClass:ReceiveDrag(type, value, source)
 		self.itemsTab:AddItem(newItem, true, self.selDragIndex)
 		self.itemsTab:PopulateSlots()
 		self.itemsTab:AddUndoState()
-		self.itemsTab.build.buildFlag = true
 	end
 end
 


### PR DESCRIPTION
### Description of the problem being solved:
Before, when you'd drag an item from the unique list to "All items", it would trigger a rebuild and thus a re-sort of the unique items.  If this sort takes a long time but you're adding several items at once it can get quite frustrating.  The rebuild isn't actually necessary so I removed it.
### Steps taken to verify a working solution:
- Drag item to both items lists, no re-sort happens
- Drag item to item slot, re-sort happens
- Double click item and add to build that way, re-sort happens

### Before screenshot:
![image](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/1209372/c5d813b8-269c-43c7-ab0f-f2d51b4d1aae)

### After screenshot:
![image](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/1209372/dca11b5d-baf4-4752-a7a5-e5ede524f259)
