### PR TITLE
Add support for showing only Support Gems in SkillsTab

### DIFF
--- a/src/Classes/GemSelectControl.lua
+++ b/src/Classes/GemSelectControl.lua
@@ -108,10 +108,11 @@ function GemSelectClass:PopulateGemList()
 	local showAwakened = self.skillsTab.showSupportGemTypes == "AWAKENED"
 	local showNormal = self.skillsTab.showSupportGemTypes == "NORMAL"
 	local matchLevel = self.skillsTab.defaultGemLevel == "characterLevel"
+	local showOnlySupportGems = self.skillsTab.showOnlySupportGems == true
 	local characterLevel = self.skillsTab.build and self.skillsTab.build.characterLevel or 1
 	for gemId, gemData in pairs(self.skillsTab.build.data.gems) do
 		local levelRequirement = gemData.grantedEffect.levels[1].levelRequirement or 1
-		if characterLevel >= levelRequirement or not matchLevel then
+		if (showOnlySupportGems and (gemData.tags["support"] == true) or not showOnlySupportGems) and (characterLevel >= levelRequirement or not matchLevel) then
 			if (showAwakened or showAll) and gemData.grantedEffect.plusVersionOf then
 				self.gems["Default:" .. gemId] = gemData
 			elseif showNormal or showAll then
@@ -245,6 +246,7 @@ function GemSelectClass:UpdateSortCache()
 		and sortCache.outputRevision == self.skillsTab.build.outputRevision and sortCache.defaultLevel == self.skillsTab.defaultGemLevel
 		and (sortCache.characterLevel == self.skillsTab.build.characterLevel or self.skillsTab.defaultGemLevel ~= "characterLevel")
 		and sortCache.defaultQuality == self.skillsTab.defaultGemQuality and sortCache.sortType == self.skillsTab.sortGemsByDPSField
+		and sortCache.showOnlySupportGems == self.skillsTab.showOnlySupportGems
 		and sortCache.considerAlternates == self.skillsTab.showAltQualityGems and sortCache.considerGemType == self.skillsTab.showSupportGemTypes then
 		return
 	end
@@ -252,6 +254,7 @@ function GemSelectClass:UpdateSortCache()
 	if not sortCache or (sortCache.considerAlternates ~= self.skillsTab.showAltQualityGems or sortCache.considerGemType ~= self.skillsTab.showSupportGemTypes
 		or sortCache.defaultQuality ~= self.skillsTab.defaultGemQuality
 		or sortCache.defaultLevel ~= self.skillsTab.defaultGemLevel
+		or sortCache.showOnlySupportGems ~= self.skillsTab.showOnlySupportGems
 		or (sortCache.characterLevel ~= self.skillsTab.build.characterLevel and self.skillsTab.defaultGemLevel == "characterLevel")) then
 		self:PopulateGemList()
 	end
@@ -265,6 +268,7 @@ function GemSelectClass:UpdateSortCache()
 		outputRevision = self.skillsTab.build.outputRevision,
 		defaultLevel = self.skillsTab.defaultGemLevel,
 		defaultQuality = self.skillsTab.defaultGemQuality,
+		showOnlySupportGems = self.skillsTab.showOnlySupportGems,
 		characterLevel = self.skillsTab.build and self.skillsTab.build.characterLevel or 1,
 		canSupport = { },
 		dps = { },

--- a/src/Classes/SkillsTab.lua
+++ b/src/Classes/SkillsTab.lua
@@ -122,7 +122,7 @@ local SkillsTabClass = newClass("SkillsTab", "UndoHandler", "ControlHost", "Cont
 	-- Gem options
 	local optionInputsX = 170
 	local optionInputsY = 45
-	self.controls.optionSection = new("SectionControl", { "TOPLEFT", self.controls.groupList, "BOTTOMLEFT" }, 0, optionInputsY + 50, 360, 156, "Gem Options")
+	self.controls.optionSection = new("SectionControl", { "TOPLEFT", self.controls.groupList, "BOTTOMLEFT" }, 0, optionInputsY + 50, 360, 176, "Gem Options")
 	self.controls.sortGemsByDPS = new("CheckBoxControl", { "TOPLEFT", self.controls.groupList, "BOTTOMLEFT" }, optionInputsX, optionInputsY + 70, 20, "Sort gems by DPS:", function(state)
 		self.sortGemsByDPS = state
 	end, nil, true)
@@ -150,7 +150,10 @@ local SkillsTabClass = newClass("SkillsTab", "UndoHandler", "ControlHost", "Cont
 	self.controls.showAltQualityGems = new("CheckBoxControl", { "TOPLEFT", self.controls.groupList, "BOTTOMLEFT" }, optionInputsX, optionInputsY + 166, 20, "^7Show quality variants:", function(state)
 		self.showAltQualityGems = state
 	end)
-
+	self.controls.showOnlySupportGems = new("CheckBoxControl", { "TOPLEFT", self.controls.groupList, "BOTTOMLEFT" }, optionInputsX, optionInputsY + 190, 20, "^7Show only support gems:", function(state)
+		self.showOnlySupportGems = state
+	end)
+	self.controls.showOnlySupportGems.tooltipText = "Only calculate gems that support the active skill."
 	-- Socket group details
 	if main.portraitMode then
 		self.anchorGroupDetail = new("Control", { "TOPLEFT", self.controls.optionSection, "BOTTOMLEFT" }, 0, 20, 0, 0)


### PR DESCRIPTION
### Description of the problem being solved:
Allow users to calculate only support gems in the gem list dropdown. This option is default false and is not saved to the build xml, so users will need to actively turn this feature on/off as desired.

### Steps taken to verify a working solution:
- Validate lists before and after show the same support gems in DPS order
- Validate non-support gems do not show with checkbox true
- Validate no issues if active skill does not exist in group
- Validate no issues if there are multiple active skills (active skill used is based on Main Skill/DPS Sort Type which is pre-existing feature)

### Link to a build that showcases this PR:
<pre>https://pobb.in/HkzpB0fR13fR</pre>

### After screenshot:
Before and After, False/True for Combined DPS of the Main Skill (Smite)
Full DPS takes more time and shows similar speed improvements

![image](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/92683202/01251e92-2f3d-4b19-b6e8-02358c9a4011)
