### PR TITLE
Fix Replica Replica Hyrri's Ire not appearing in unique list

### DIFF
--- a/src/Data/Uniques/body.lua
+++ b/src/Data/Uniques/body.lua
@@ -338,6 +338,16 @@ Implicits: 0
 {variant:1,2}Acrobatics
 {variant:3,4,5,6}30% chance to Suppress Spell Damage
 ]],[[
+Replica Hyrri's Ire
+Zodiac Leather
+League: Heist
+Source: Steal from a unique{Curio Display} during a Grand Heist
++30% chance to Suppress Spell Damage
++(40–50) to Dexterity
+(140–220)% increased Evasion Rating
+25% increased Shock Duration on Enemies
+(12–18) to (231–347) Added Lightning Damage with Wand Attacks
+]],[[
 Kintsugi
 Exquisite Leather
 Variant: Pre 3.19.0


### PR DESCRIPTION
The unique was left out when we were implementing all the new uniques and moving last leagues ones to their respective files
