### PR TITLE
Add buttons to filter Active and Support gems in Skills tab

### DIFF
--- a/src/Classes/GemSelectControl.lua
+++ b/src/Classes/GemSelectControl.lua
@@ -39,6 +39,7 @@ local GemSelectClass = newClass("GemSelectControl", "EditControl", function(self
 	self.gemChangeFunc = changeFunc
 	self.forceTooltip = forceTooltip
 	self.list = { }
+	self.mode = ""
 	self.changeFunc = function()
 		if not self.dropped then
 			self.dropped = true
@@ -146,7 +147,8 @@ function GemSelectClass:BuildList(buf)
 
 	self.controls.scrollBar.offset = 0
 	wipeTable(self.list)
-	self.searchStr = buf
+	self.searchStr = buf .. self.mode
+	self.mode = ""
 	if #self.searchStr > 0 then
 		local added = { }
 
@@ -240,6 +242,7 @@ end
 function GemSelectClass:UpdateSortCache()
 	--local start = GetTime()
 	local sortCache = self.sortCache
+
 	-- Don't update the cache if no settings have changed that would impact the ordering
 	if sortCache and sortCache.socketGroup == self.skillsTab.displayGroup and sortCache.gemInstance == self.skillsTab.displayGroup.gemList[self.index]
 		and sortCache.outputRevision == self.skillsTab.build.outputRevision and sortCache.defaultLevel == self.skillsTab.defaultGemLevel
@@ -341,6 +344,7 @@ function GemSelectClass:UpdateSortCache()
 			sortCache.dpsColor[gemId] = "^xFFFF66"
 		end
 	end
+
 	--ConPrintf("Gem Selector time: %d ms", GetTime() - start)
 end
 
@@ -496,6 +500,28 @@ function GemSelectClass:Draw(viewPort, noTooltip)
 		end
 		if mOver and (not self.skillsTab.selControl or self.skillsTab.selControl._className ~= "GemSelectControl" or not self.skillsTab.selControl.dropped) and (not noTooltip or self.forceTooltip) then
 			local gemInstance = self.skillsTab.displayGroup.gemList[self.index]
+
+			local cursorX, cursorY = GetCursorPos()
+			-- if cursorX > (x + width - 20) then
+
+			-- active shortcut
+			sx = x + width - 16 - 2
+			SetDrawColor(1,1,1)
+			DrawImage(nil, sx, y, 16, height)
+			SetDrawColor(0,0,0)
+			DrawImage(nil, sx+1, y+1, 16-2, height-2)
+			SetDrawColor(1,1,1)
+			DrawString(sx + 8, y, "CENTER_X", height - 2, "VAR", "[S]")
+
+			-- support shortcut
+			sx = x + width - (16*2) - (2*2)
+			SetDrawColor(1,1,1)
+			DrawImage(nil, sx, y, 16, height)
+			SetDrawColor(0,0,0)
+			DrawImage(nil, sx+1, y+1, 16-2, height-2)
+			SetDrawColor(1,1,1)
+			DrawString(sx + 8, y, "CENTER_X", height - 2, "VAR", "[A]")
+
 			SetDrawLayer(nil, 10)
 			self.tooltip:Clear()
 			if gemInstance and gemInstance.gemData then
@@ -713,6 +739,17 @@ function GemSelectClass:OnKeyDown(key, doubleClick)
 	if not self:IsShown() or not self:IsEnabled() then
 		return
 	end
+
+	-- for filter overlays overlays
+	local x, y = self:GetPos()
+	local width, height = self:GetSize()
+	local cursorX, cursorY = GetCursorPos()
+	if cursorX > (x + width - 18) then
+		self.mode = ":support:"
+	elseif (cursorX > (x + width - 40) and cursorX < (cursorX + width - 20)) then
+		self.mode = ":active:"
+	end
+
 	local mOverControl = self:GetMouseOverControl()
 	if mOverControl and mOverControl.OnKeyDown then
 		self.selControl = mOverControl

--- a/src/Classes/GemSelectControl.lua
+++ b/src/Classes/GemSelectControl.lua
@@ -502,22 +502,32 @@ function GemSelectClass:Draw(viewPort, noTooltip)
 			local gemInstance = self.skillsTab.displayGroup.gemList[self.index]
 
 			local cursorX, cursorY = GetCursorPos()
+
+
+			colorS = 0.5
+			colorA = 0.5
+			if cursorX > (x + width - 18) then
+				colorS = 1
+			elseif (cursorX > (x + width - 40) and cursorX < (cursorX + width - 20)) then
+				colorA = 1
+			end
+
 			-- support shortcut
 			sx = x + width - 16 - 2
-			SetDrawColor(1,1,1)
+			SetDrawColor(colorS,colorS,colorS)
 			DrawImage(nil, sx, y, 16, height)
 			SetDrawColor(0,0,0)
 			DrawImage(nil, sx+1, y+2, 16-2, height-4)
-			SetDrawColor(1,1,1)
+			SetDrawColor(colorS,colorS,colorS)
 			DrawString(sx + 8, y, "CENTER_X", height - 2, "VAR", "S")
 
 			-- active shortcut
 			sx = x + width - (16*2) - (2*2)
-			SetDrawColor(1,1,1)
+			SetDrawColor(colorA,colorA,colorA)
 			DrawImage(nil, sx, y, 16, height)
 			SetDrawColor(0,0,0)
 			DrawImage(nil, sx+1, y+2, 16-2, height-4)
-			SetDrawColor(1,1,1)
+			SetDrawColor(colorA,colorA,colorA)
 			DrawString(sx + 8, y, "CENTER_X", height - 2, "VAR", "A")
 
 			SetDrawLayer(nil, 10)

--- a/src/Classes/GemSelectControl.lua
+++ b/src/Classes/GemSelectControl.lua
@@ -242,7 +242,6 @@ end
 function GemSelectClass:UpdateSortCache()
 	--local start = GetTime()
 	local sortCache = self.sortCache
-
 	-- Don't update the cache if no settings have changed that would impact the ordering
 	if sortCache and sortCache.socketGroup == self.skillsTab.displayGroup and sortCache.gemInstance == self.skillsTab.displayGroup.gemList[self.index]
 		and sortCache.outputRevision == self.skillsTab.build.outputRevision and sortCache.defaultLevel == self.skillsTab.defaultGemLevel
@@ -500,9 +499,7 @@ function GemSelectClass:Draw(viewPort, noTooltip)
 		end
 		if mOver and (not self.skillsTab.selControl or self.skillsTab.selControl._className ~= "GemSelectControl" or not self.skillsTab.selControl.dropped) and (not noTooltip or self.forceTooltip) then
 			local gemInstance = self.skillsTab.displayGroup.gemList[self.index]
-
 			local cursorX, cursorY = GetCursorPos()
-
 			self.tooltip:Clear()
 			if gemInstance and gemInstance.gemData then
 				-- Check valid qualityId, set to 'Default' if missing
@@ -753,7 +750,7 @@ function GemSelectClass:OnKeyDown(key, doubleClick)
 		return
 	end
 
-	-- for filter overlays overlays
+	-- for filter overlay buttons
 	local x, y = self:GetPos()
 	local width, height = self:GetSize()
 	local cursorX, cursorY = GetCursorPos()

--- a/src/Classes/GemSelectControl.lua
+++ b/src/Classes/GemSelectControl.lua
@@ -503,13 +503,27 @@ function GemSelectClass:Draw(viewPort, noTooltip)
 
 			local cursorX, cursorY = GetCursorPos()
 
+			self.tooltip:Clear()
+			if gemInstance and gemInstance.gemData then
+				-- Check valid qualityId, set to 'Default' if missing
+				if gemInstance.qualityId == nil or gemInstance.qualityId == "" then
+					gemInstance.qualityId = "Default"
+				end
+				self:AddGemTooltip(gemInstance)
+			else
+				self.tooltip:AddLine(16, toolTipText)
+			end
 
 			colorS = 0.5
 			colorA = 0.5
 			if cursorX > (x + width - 18) then
 				colorS = 1
+				self.tooltip:Clear()
+				self.tooltip:AddLine(16, "Only show Support gems")
 			elseif (cursorX > (x + width - 40) and cursorX < (cursorX + width - 20)) then
 				colorA = 1
+				self.tooltip:Clear()
+				self.tooltip:AddLine(16, "Only show Active gems")
 			end
 
 			-- support shortcut
@@ -530,17 +544,8 @@ function GemSelectClass:Draw(viewPort, noTooltip)
 			SetDrawColor(colorA,colorA,colorA)
 			DrawString(sx + 8, y, "CENTER_X", height - 2, "VAR", "A")
 
+
 			SetDrawLayer(nil, 10)
-			self.tooltip:Clear()
-			if gemInstance and gemInstance.gemData then
-				-- Check valid qualityId, set to 'Default' if missing
-				if gemInstance.qualityId == nil or gemInstance.qualityId == "" then
-					gemInstance.qualityId = "Default"
-				end
-				self:AddGemTooltip(gemInstance)
-			else
-				self.tooltip:AddLine(16, toolTipText)
-			end
 			self.tooltip:Draw(x, y, width, height, viewPort)
 			SetDrawLayer(nil, 0)
 		end

--- a/src/Classes/GemSelectControl.lua
+++ b/src/Classes/GemSelectControl.lua
@@ -502,23 +502,23 @@ function GemSelectClass:Draw(viewPort, noTooltip)
 			local gemInstance = self.skillsTab.displayGroup.gemList[self.index]
 
 			local cursorX, cursorY = GetCursorPos()
-			-- active shortcut
+			-- support shortcut
 			sx = x + width - 16 - 2
 			SetDrawColor(1,1,1)
 			DrawImage(nil, sx, y, 16, height)
 			SetDrawColor(0,0,0)
-			DrawImage(nil, sx+1, y+1, 16-2, height-2)
+			DrawImage(nil, sx+1, y+2, 16-2, height-4)
 			SetDrawColor(1,1,1)
-			DrawString(sx + 8, y, "CENTER_X", height - 2, "VAR", "[S]")
+			DrawString(sx + 8, y, "CENTER_X", height - 2, "VAR", "S")
 
-			-- support shortcut
+			-- active shortcut
 			sx = x + width - (16*2) - (2*2)
 			SetDrawColor(1,1,1)
 			DrawImage(nil, sx, y, 16, height)
 			SetDrawColor(0,0,0)
-			DrawImage(nil, sx+1, y+1, 16-2, height-2)
+			DrawImage(nil, sx+1, y+2, 16-2, height-4)
 			SetDrawColor(1,1,1)
-			DrawString(sx + 8, y, "CENTER_X", height - 2, "VAR", "[A]")
+			DrawString(sx + 8, y, "CENTER_X", height - 2, "VAR", "A")
 
 			SetDrawLayer(nil, 10)
 			self.tooltip:Clear()

--- a/src/Classes/GemSelectControl.lua
+++ b/src/Classes/GemSelectControl.lua
@@ -502,8 +502,6 @@ function GemSelectClass:Draw(viewPort, noTooltip)
 			local gemInstance = self.skillsTab.displayGroup.gemList[self.index]
 
 			local cursorX, cursorY = GetCursorPos()
-			-- if cursorX > (x + width - 20) then
-
 			-- active shortcut
 			sx = x + width - 16 - 2
 			SetDrawColor(1,1,1)


### PR DESCRIPTION
Fixes # .

### Description of the problem being solved:

Sometimes you know ahead of time what you want, either active or support gem

These overlay buttons makes it easy to quickly access either one or the other gem list

### After screenshot:
[filter3.webm](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/44361234/27f28a60-ebd5-4489-8a86-bae32301bfa5)


