### PR TITLE
Fix nil sortCache error in SkillsTab in dev

### DIFF
--- a/src/Classes/GemSelectControl.lua
+++ b/src/Classes/GemSelectControl.lua
@@ -245,8 +245,9 @@ end
 function GemSelectClass:UpdateSortCache()
 	--local start = GetTime()
 	local sortCache = self.sortCache
+	local sameSortBy = self.sortGemsBy == self.lastSortGemsBy
 	-- Don't update the cache if no settings have changed that would impact the ordering
-	if self.sortGemsBy == self.lastSortGemsBy and sortCache and sortCache.socketGroup == self.skillsTab.displayGroup and sortCache.gemInstance == self.skillsTab.displayGroup.gemList[self.index]
+	if sameSortBy and sortCache and sortCache.socketGroup == self.skillsTab.displayGroup and sortCache.gemInstance == self.skillsTab.displayGroup.gemList[self.index]
 		and sortCache.outputRevision == self.skillsTab.build.outputRevision and sortCache.defaultLevel == self.skillsTab.defaultGemLevel
 		and (sortCache.characterLevel == self.skillsTab.build.characterLevel or self.skillsTab.defaultGemLevel ~= "characterLevel")
 		and sortCache.defaultQuality == self.skillsTab.defaultGemQuality and sortCache.sortType == self.skillsTab.sortGemsByDPSField
@@ -254,7 +255,7 @@ function GemSelectClass:UpdateSortCache()
 		return
 	end
 
-	if self.sortGemsBy ~= self.lastSortGemsBy or not sortCache or (sortCache.considerAlternates ~= self.skillsTab.showAltQualityGems or sortCache.considerGemType ~= self.skillsTab.showSupportGemTypes
+	if not sameSortBy or not sortCache or (sortCache.considerAlternates ~= self.skillsTab.showAltQualityGems or sortCache.considerGemType ~= self.skillsTab.showSupportGemTypes
 		or sortCache.defaultQuality ~= self.skillsTab.defaultGemQuality
 		or sortCache.defaultLevel ~= self.skillsTab.defaultGemLevel
 		or (sortCache.characterLevel ~= self.skillsTab.build.characterLevel and self.skillsTab.defaultGemLevel == "characterLevel")) then


### PR DESCRIPTION
Sorry for breaking dev

### Description of the problem being solved:
This fixes the nil sortCache error when scrolling the gems in SkillsTab. It also refactors the Active/Support overlay code to be ideally more efficient and less code, and I removed the bypass code so we can add in a real fix to sortGemsByDPS and use that instead of adding another overlay that would do the same thing.

### Steps taken to verify a working solution:
- Scrolling gem list should not throw an error
- Any combination of clicking on the GemSelectControl should result in the correct list returning and the cache used appropriately, i.e. click Full will load the first time but never again if constantly clicked, then click Active/Support, validate a faster load and cache again maintained if the same overlay is clicked

### Link to a build that showcases this PR:
<pre>https://pobb.in/K8TJiRBXcSBG</pre>
### Before screenshot:
![image](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/92683202/33e92d9e-ed9d-45c0-bc36-bdb95447ff3c)

### After screenshot:
![sortCacheFixPR](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/92683202/facfa4c0-8d1e-42c7-9abe-cd7269840f91)
