### PR TITLE
Adding popup to specify new user path if default one fails

### DIFF
--- a/src/Modules/Main.lua
+++ b/src/Modules/Main.lua
@@ -73,10 +73,10 @@ function main:Init()
 	if not ignoreBuild then
 		self:SetMode("BUILD", false, "Unnamed build")
 	end
-	--if launch.devMode or (GetScriptPath() == GetRuntimePath() and not launch.installedMode) then
-	--	-- If running in dev mode or standalone mode, put user data in the script path
-	--	self.userPath = GetScriptPath().."/"
-	--else
+	if launch.devMode or (GetScriptPath() == GetRuntimePath() and not launch.installedMode) then
+		-- If running in dev mode or standalone mode, put user data in the script path
+		self.userPath = GetScriptPath().."/"
+	else
 		local invalidPath
 		self.userPath, invalidPath = GetUserPath()
 		if not self.userPath then
@@ -84,7 +84,7 @@ function main:Init()
 		else
 			self.userPath = self.userPath.."/Path of Building/"
 		end
-	--end
+	end
 	if self.userPath then
 		self:ChangeUserPath(self.userPath, ignoreBuild)
 	end

--- a/src/Modules/Main.lua
+++ b/src/Modules/Main.lua
@@ -73,18 +73,18 @@ function main:Init()
 	if not ignoreBuild then
 		self:SetMode("BUILD", false, "Unnamed build")
 	end
-	if launch.devMode or (GetScriptPath() == GetRuntimePath() and not launch.installedMode) then
-		-- If running in dev mode or standalone mode, put user data in the script path
-		self.userPath = GetScriptPath().."/"
-	else
+	--if launch.devMode or (GetScriptPath() == GetRuntimePath() and not launch.installedMode) then
+	--	-- If running in dev mode or standalone mode, put user data in the script path
+	--	self.userPath = GetScriptPath().."/"
+	--else
 		local invalidPath
 		self.userPath, invalidPath = GetUserPath()
 		if not self.userPath then
-			self:OpenPathPopup(invalidPath)
+			self:OpenPathPopup(invalidPath, ignoreBuild)
 		else
 			self.userPath = self.userPath.."/Path of Building/"
 		end
-	end
+	--end
 	if self.userPath then
 		self:ChangeUserPath(self.userPath, ignoreBuild)
 	end
@@ -717,7 +717,7 @@ function main:SaveSettings()
 	end
 end
 
-function main:OpenPathPopup(invalidPath)
+function main:OpenPathPopup(invalidPath, ignoreBuild)
 	local controls = { }
 	local defaultLabelPlacementX = 8
 
@@ -725,6 +725,9 @@ function main:OpenPathPopup(invalidPath)
 		return "^7User settings path contains unicode characters and cannot be loaded."..
 		"\nCurrent Path: "..invalidPath:gsub("?", "^1?^7").."/Path of Building/"..
 		"\nSpecify a new location for your Settings.xml:"
+	end)
+	controls.explainButton = new("ButtonControl", { "LEFT", controls.label, "RIGHT" }, 4, 0, 20, 20, "?", function()
+		OpenURL("https://github.com/PathOfBuildingCommunity/PathOfBuilding/wiki/Why-do-I-have-to-change-my-Settings-path%3F")
 	end)
 	controls.userPath = new("EditControl", { "TOPLEFT", controls.label, "TOPLEFT" }, 0, 60, 206, 20, invalidPath, nil, nil, nil, function(buf)
 		invalidPath = sanitiseText(buf)
@@ -739,7 +742,7 @@ function main:OpenPathPopup(invalidPath)
 		if not res and msg ~= "No error" then
 			self:OpenMessagePopup("Error", "Couldn't create '"..controls.userPath.buf.."' : "..msg)
 		else
-			self:ChangeUserPath(controls.userPath.buf)
+			self:ChangeUserPath(controls.userPath.buf, ignoreBuild)
 			self:ClosePopup()
 		end
 	end)


### PR DESCRIPTION
Fixes #7431  .

### Description of the problem being solved:
This requires https://github.com/PathOfBuildingCommunity/PathOfBuilding-SimpleGraphic/pull/46 to function, and adds a workaround for users who have unicode characters in their default user path.

### Still TODO:

- [x] Find a better way to check for a valid path
- [x] Implement loading settings and shared items after saving
- [x] Restore dev code loading settings from script path (currently always loading from user path for testing)
- [x] Add a link to a workaround document to prevent this from appearing every time

### Screenshot and behaviour

![image](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/1209372/569a72f9-9665-4285-8263-4083bdf9ee4e)

- Popup cannot be closed without specifying a new path
- Popup opens on startup every time until fixing their Documents path to not contain unicode
- Sanitizes input, only allowing Save to be clicked once it contains no ? characters (PoB's unicode representation)
- Save button will load settings.xml and everything else from that path
- Question mark button leads to https://github.com/PathOfBuildingCommunity/PathOfBuilding/wiki/Why-do-I-have-to-change-my-Settings-path%3F

### To Test

Do the opposite of the workaround in this comment and set your Documents path to something with Cyrillic characters in it (e.g. Документи ): https://github.com/PathOfBuildingCommunity/PathOfBuilding/issues/7431#issuecomment-2017643145
You'll also have to comment out the `if launch.devMode or (GetScriptPath() [...]` conditional section on line 76 of `src/Main.lua`, otherwise the `GetUserPath()` function won't even get called.