### PR TITLE
Fix support gems supporting pseudo active parts from gems granted by the same item

### DIFF
--- a/src/Modules/CalcSetup.lua
+++ b/src/Modules/CalcSetup.lua
@@ -1310,6 +1310,7 @@ function calcs.initEnv(build, mode, override, specEnv)
 						if grantedEffect and not grantedEffect.support then
 							grantedEffect = env.data.skills["Support"..value.skillId]
 						end
+						grantedEffect.fromItem = true
 						if grantedEffect then
 							for _, targetList in ipairs(targetListList) do
 								t_insert(targetList, {

--- a/src/Modules/CalcTools.lua
+++ b/src/Modules/CalcTools.lua
@@ -89,6 +89,11 @@ function calcLib.canGrantedEffectSupportActiveSkill(grantedEffect, activeSkill)
 	if grantedEffect.supportGemsOnly and not activeSkill.activeEffect.gemData then
 		return false
 	end
+
+	-- Special case for things like Forbidden Shako or Hungry Loop with  for example Prismatic Burst and another compatible support
+	if grantedEffect.fromItem and grantedEffect.support and (activeSkill.activeEffect.grantedEffect.fromItem or activeSkill.activeEffect.grantedEffect.modSource:sub(1, #"Item") == "Item" or (activeSkill.activeEffect.srcInstance and activeSkill.activeEffect.srcInstance.fromItem)) then
+		return false
+	end
 	-- if the activeSkill is a Minion's skill like "Default Attack", use minion's skillTypes instead for exclusions
 	-- otherwise compare support to activeSkill directly
 	if grantedEffect.excludeSkillTypes[1] and calcLib.doesTypeExpressionMatch(grantedEffect.excludeSkillTypes, (activeSkill.summonSkill and activeSkill.summonSkill.skillTypes) or activeSkill.skillTypes) then

--- a/src/Modules/CalcTriggers.lua
+++ b/src/Modules/CalcTriggers.lua
@@ -1291,7 +1291,7 @@ local function getUniqueItemTriggerName(skill)
 		return skill.skillData.triggerSource
 	elseif skill.supportList and #skill.supportList >= 1 then
 		for _, gemInstance in ipairs(skill.supportList) do
-			if gemInstance.grantedEffect and gemInstance.grantedEffect.fromItem then
+			if gemInstance.grantedEffect and gemInstance.grantedEffect.fromItem and not gemInstance.grantedEffect.support then
 				return gemInstance.grantedEffect.name
 			end
 		end
@@ -1318,7 +1318,7 @@ function calcs.triggers(env, actor)
         config = config or uniqueNameLower and configTable[uniqueNameLower] and configTable[uniqueNameLower](env)
 		if config then
 		    config.actor = config.actor or actor
-			config.triggerName = config.triggerName or triggerName or uniqueName or skillName
+			config.triggerName = config.triggerName or triggerName or skillName or uniqueName
 			config.triggerChance = config.triggerChance or (actor.mainSkill.activeEffect.srcInstance and actor.mainSkill.activeEffect.srcInstance.triggerChance)
 			local triggerHandler = config.customHandler or defaultTriggerHandler
 		    triggerHandler(env, config)


### PR DESCRIPTION
Fixes #7471 .

### Description of the problem being solved:
When having a support gem with a pseudo active component (for example Prismatic Burst Support or Flamewood Support) and a compatible support gem both granted by an item with the "Socketed Gems are Supported by" Syntax, the support gem could affect the pseudo active part of the other support gem. This doesn't match the behaviour ingame, since the supports each only affect gems explicitly socketed in the item, not each other.

Items that create this issue are for example Forbidden Shako or Hungry Loop.

Additionally i adjusted the "No ... Triggering Skill Found" Message to more accurately represent the correct skill that is being triggered. Before it would prefer the name of the item, now it prefers the name of the skill.

### Steps taken to verify a working solution:
- Created a Forbidden Shako with a problematic gem setup
- Checked if the support gem still supports the pseudo active component

### Link to a build that showcases this PR:
https://pobb.in/_pivwVyFcj5C

### Before screenshot:
![image](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/22834043/c860a85d-c7db-4952-a966-89c07f3da649)

### After screenshot:
![image](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/22834043/8d0c56c0-053d-4081-9869-16d35d7437af)
