### PR TITLE
Fix settings not saving for certain users

### DIFF
--- a/src/Modules/Main.lua
+++ b/src/Modules/Main.lua
@@ -85,28 +85,6 @@ function main:Init()
 			self.userPath = self.userPath.."/Path of Building/"
 		end
 	end
-	if self.userPath then
-		self:ChangeUserPath(self.userPath, ignoreBuild)
-	else
-		self:LoadSettings(ignoreBuild)
-	end
-
-	if launch.devMode and IsKeyDown("CTRL") then
-		-- If modLib.parseMod doesn't find a cache entry it generates it.
-		-- Not loading pre-generated cache causes it to be rebuilt
-		self.saveNewModCache = true
-	else
-		-- Load mod cache
-		LoadModule("Data/ModCache", modLib.parseModCache)
-	end
-
-	if launch.devMode and IsKeyDown("CTRL") and IsKeyDown("SHIFT") then
-		self.allowTreeDownload = true
-	end
-
-
-	self.inputEvents = { }
-	self.tooltipLines = { }
 
 	self.buildSortMode = "NAME"
 	self.connectionProtocol = 0
@@ -122,6 +100,26 @@ function main:Init()
 	self.showWarnings = true
 	self.slotOnlyTooltips = true
 	self.POESESSID = ""
+
+	if self.userPath then
+		self:ChangeUserPath(self.userPath, ignoreBuild)
+	end
+
+	if launch.devMode and IsKeyDown("CTRL") then
+		-- If modLib.parseMod doesn't find a cache entry it generates it.
+		-- Not loading pre-generated cache causes it to be rebuilt
+		self.saveNewModCache = true
+	else
+		-- Load mod cache
+		LoadModule("Data/ModCache", modLib.parseModCache)
+	end
+
+	if launch.devMode and IsKeyDown("CTRL") and IsKeyDown("SHIFT") then
+		self.allowTreeDownload = true
+	end
+
+	self.inputEvents = { }
+	self.tooltipLines = { }
 
 	self.tree = { }
 	self:LoadTree(latestTreeVersion)
@@ -770,8 +768,6 @@ function main:OpenOptionsPopup()
 
 	local currentY = 20
 	local popupWidth = 600
-
-	self:LoadSettings(true)
 
 	-- local func to make a new line with a heightModifier
 	local function nextRow(heightModifier)

--- a/src/Modules/Main.lua
+++ b/src/Modules/Main.lua
@@ -87,6 +87,8 @@ function main:Init()
 	end
 	if self.userPath then
 		self:ChangeUserPath(self.userPath, ignoreBuild)
+	else
+		self:LoadSettings(ignoreBuild)
 	end
 
 	if launch.devMode and IsKeyDown("CTRL") then
@@ -768,6 +770,8 @@ function main:OpenOptionsPopup()
 
 	local currentY = 20
 	local popupWidth = 600
+
+	self:LoadSettings(true)
 
 	-- local func to make a new line with a heightModifier
 	local function nextRow(heightModifier)


### PR DESCRIPTION
For some reason we were loading ``Settings.xml`` and then immediately overwriting all of the values loaded with defaults. This fixes that by.. setting the defaults first, then loading.