### PR TITLE
Fix crash caused by Call to Arms conversion

### DIFF
--- a/src/Classes/PassiveSpec.lua
+++ b/src/Classes/PassiveSpec.lua
@@ -146,10 +146,24 @@ function PassiveSpecClass:Load(xml, dbFileName)
 							return true
 						end
 						
-						local nodeId = tonumber(child.attrib.nodeId)
+						-- In case a tatoo has been replaced by a different one attampt to find the new name for it
+						if not self.tree.tattoo.nodes[child.attrib.dn] then
+							for name ,data in pairs(self.tree.tattoo.nodes) do
+								if data["activeEffectImage"] == child.attrib["activeEffectImage"] and data["icon"] == child.attrib["icon"] then
+									self.tree.tattoo.nodes[child.attrib.dn] = data
+									ConPrintf("[PassiveSpecClass:Load] " .. child.attrib.dn .. " tattoo has been substituted with " .. name)
+								end
+							end
+						end
 
-						self.hashOverrides[nodeId] = copyTable(self.tree.tattoo.nodes[child.attrib.dn], true)
-						self.hashOverrides[nodeId].id = nodeId
+						-- If the above failed remove the tatoo to avoid crashing
+						if self.tree.tattoo.nodes[child.attrib.dn] then
+							local nodeId = tonumber(child.attrib.nodeId)
+							self.hashOverrides[nodeId] = copyTable(self.tree.tattoo.nodes[child.attrib.dn], true)
+							self.hashOverrides[nodeId].id = nodeId
+						else
+							ConPrintf("[PassiveSpecClass:Load] Failed to find a tattoo with dn of: " .. child.attrib.dn)
+						end
 					end
 				end
 			end

--- a/src/Classes/PassiveSpec.lua
+++ b/src/Classes/PassiveSpec.lua
@@ -146,7 +146,7 @@ function PassiveSpecClass:Load(xml, dbFileName)
 							return true
 						end
 						
-						-- In case a tatoo has been replaced by a different one attampt to find the new name for it
+						-- In case a tattoo has been replaced by a different one attempt to find the new name for it
 						if not self.tree.tattoo.nodes[child.attrib.dn] then
 							for name ,data in pairs(self.tree.tattoo.nodes) do
 								if data["activeEffectImage"] == child.attrib["activeEffectImage"] and data["icon"] == child.attrib["icon"] then
@@ -156,7 +156,7 @@ function PassiveSpecClass:Load(xml, dbFileName)
 							end
 						end
 
-						-- If the above failed remove the tatoo to avoid crashing
+						-- If the above failed remove the tattoo to avoid crashing
 						if self.tree.tattoo.nodes[child.attrib.dn] then
 							local nodeId = tonumber(child.attrib.nodeId)
 							self.hashOverrides[nodeId] = copyTable(self.tree.tattoo.nodes[child.attrib.dn], true)


### PR DESCRIPTION
### Description of the problem being solved:
Call to Arms tattoo has been converted to Warlord's Call. This caused a dismissable crash on importing a build that had one slotted. Finding which tattoo converts to which is quite hard without adding historical tattoo data or some kind of conversion table.

This pr adds logic that attempts to find the new name by comparing available stats. Failing that it removes the tattoo to prevent crash. Added logging in both cases.

### Steps taken to verify a working solution:
- Try importing the following builds:
```
https://pobb.in/F7sdQa4QPD2_
```
```
https://pobb.in/m8iRz-fn3uuF
```
```
https://pobb.in/9ACP67JVEGy0
```
