### PR TITLE
Fix remove redundant cacheSkillUUID calls

### DIFF
--- a/src/Modules/CalcMirages.lua
+++ b/src/Modules/CalcMirages.lua
@@ -123,7 +123,7 @@ function calcs.mirages(env)
 				if skill ~= env.player.mainSkill and skill.skillTypes[SkillType.Attack] and not skill.skillTypes[SkillType.Totem] and not skill.skillTypes[SkillType.SummonsTotem] and band(skill.skillCfg.flags, bor(ModFlag.Sword, ModFlag.Weapon1H)) == bor(ModFlag.Sword, ModFlag.Weapon1H) and not skill.skillCfg.skillCond["usedByMirage"] then
 					local uuid = cacheSkillUUID(skill, env)
 					if not GlobalCache.cachedData[env.mode][uuid] then
-						calcs.buildActiveSkill(env, env.mode, skill)
+						calcs.buildActiveSkill(env, env.mode, skill, uuid)
 					end
 
 					if GlobalCache.cachedData[env.mode][uuid] and GlobalCache.cachedData[env.mode][uuid].CritChance and GlobalCache.cachedData[env.mode][uuid].CritChance > 0 then
@@ -192,7 +192,7 @@ function calcs.mirages(env)
 				if skill ~= env.player.mainSkill and (skill.skillTypes[SkillType.Slam] or skill.skillTypes[SkillType.Melee]) and skill.skillTypes[SkillType.Attack] and not skill.skillTypes[SkillType.Vaal] and not isTriggered(skill) and not isDisabled and not skill.skillTypes[SkillType.Totem] and not skill.skillTypes[SkillType.SummonsTotem] and not skill.skillCfg.skillCond["usedByMirage"] then
 					local uuid = cacheSkillUUID(skill, env)
 					if not GlobalCache.cachedData[env.mode][uuid] or env.mode == "CALCULATOR" then
-						calcs.buildActiveSkill(env, env.mode, skill)
+						calcs.buildActiveSkill(env, env.mode, skill, uuid)
 					end
 
 					if GlobalCache.cachedData[env.mode][uuid] then

--- a/src/Modules/CalcTriggers.lua
+++ b/src/Modules/CalcTriggers.lua
@@ -74,7 +74,7 @@ local function findTriggerSkill(env, skill, source, triggerRate, comparer)
 
 	local uuid = cacheSkillUUID(skill, env)
 	if not GlobalCache.cachedData[env.mode][uuid] or env.mode == "CALCULATOR" then
-		calcs.buildActiveSkill(env, env.mode, skill)
+		calcs.buildActiveSkill(env, env.mode, skill, uuid)
 	end
 
 	if GlobalCache.cachedData[env.mode][uuid] and comparer(uuid, source, triggerRate) and (skill.skillFlags and not skill.skillFlags.disable) and (skill.skillCfg and not skill.skillCfg.skillCond["usedByMirage"]) and not skill.skillTypes[SkillType.OtherThingUsesSkill] then
@@ -530,7 +530,7 @@ local function defaultTriggerHandler(env, config)
 			if actor.mainSkill.skillData.triggeredByManaforged and trigRate > 0 then
 				local triggeredUUID = cacheSkillUUID(actor.mainSkill, env)
 				if not GlobalCache.cachedData[env.mode][triggeredUUID] then
-					calcs.buildActiveSkill(env, env.mode, actor.mainSkill, {[triggeredUUID] = true})
+					calcs.buildActiveSkill(env, env.mode, actor.mainSkill, triggeredUUID, {[triggeredUUID] = true})
 				end
 				local triggeredManaCost = GlobalCache.cachedData[env.mode][triggeredUUID].Env.player.output.ManaCost or 0
 				if triggeredManaCost > 0 then
@@ -1240,7 +1240,7 @@ local configTable = {
 						skill.skillData.hitTimeMultiplier = snipeStages - 0.5
 						local uuid = cacheSkillUUID(skill, env)
 						if not GlobalCache.cachedData[env.mode][uuid] or env.mode == "CALCULATOR" then
-							calcs.buildActiveSkill(env, env.mode, skill)
+							calcs.buildActiveSkill(env, env.mode, skill, uuid)
 						end
 						local cachedSpeed = GlobalCache.cachedData[env.mode][uuid].Env.player.output.HitSpeed
 						if (skill.skillFlags and not skill.skillFlags.disable) and (skill.skillCfg and not skill.skillCfg.skillCond["usedByMirage"]) and not skill.skillTypes[SkillType.OtherThingUsesSkill] and ((not source and cachedSpeed) or (cachedSpeed and cachedSpeed > (trigRate or 0))) then

--- a/src/Modules/Calcs.lua
+++ b/src/Modules/Calcs.lua
@@ -401,12 +401,14 @@ function calcs.calcFullDPS(build, mode, override, specEnv)
 end
 
 -- Process active skill
-function calcs.buildActiveSkill(env, mode, skill, limitedProcessingFlags)
+function calcs.buildActiveSkill(env, mode, skill, targetUUID, limitedProcessingFlags)
 	local fullEnv, _, _, _ = calcs.initEnv(env.build, mode, env.override)
+	targetUUID = targetUUID or cacheSkillUUID(skill, env)
 	for _, activeSkill in ipairs(fullEnv.player.activeSkillList) do
-		if cacheSkillUUID(activeSkill, fullEnv) == cacheSkillUUID(skill, env) then
+		local activeSkillUUID = cacheSkillUUID(activeSkill, fullEnv)
+		if activeSkillUUID == targetUUID then
 			fullEnv.player.mainSkill = activeSkill
-			fullEnv.player.mainSkill.skillData.limitedProcessing = limitedProcessingFlags and limitedProcessingFlags[cacheSkillUUID(activeSkill, fullEnv)]
+			fullEnv.player.mainSkill.skillData.limitedProcessing = limitedProcessingFlags and limitedProcessingFlags[activeSkillUUID]
 			calcs.perform(fullEnv, true)
 			return
 		end
@@ -434,7 +436,7 @@ function calcs.buildOutput(build, mode)
 		for _, skill in ipairs(env.player.activeSkillList) do
 			local uuid = cacheSkillUUID(skill, env)
 			if not GlobalCache.cachedData[mode][uuid] then
-				calcs.buildActiveSkill(env, mode, skill)
+				calcs.buildActiveSkill(env, mode, skill, uuid)
 			end
 			if GlobalCache.cachedData[mode][uuid] then
 				output.EnergyShieldProtectsMana = env.modDB:Flag(nil, "EnergyShieldProtectsMana")


### PR DESCRIPTION
### Description of the problem being solved:
There was a bunch of redundant calls to `cacheSkillUUID`. While the function is not super expensive this could maybe slightly speed up trigger related calculations.

