### PR TITLE
Fix exclude anoint mod lines for item cond match

### DIFF
--- a/src/Modules/Data.lua
+++ b/src/Modules/Data.lua
@@ -600,6 +600,7 @@ data.itemTagSpecialExclusionPattern = {
 			"your Spectres' Life", -- The Jinxed Juju
 			"when on Full Life",
 			"when on Low Life",
+			"^Allocates",
 		},
 		["body armour"] = {
 			"Life as Physical Damage",
@@ -607,13 +608,15 @@ data.itemTagSpecialExclusionPattern = {
 			"maximum Life as Fire Damage",
 			"when on Full Life",
 			"when on Low Life",
-			"^Socketed Gems are Supported by Level"
+			"^Socketed Gems are Supported by Level",
+			"^Allocates",
 		},
 		["boots"] = {
 			"Enemy's Life", -- Legacy of Fury
 			"^Enemies Cannot Leech Life", -- Sin Trek
 			"when on Full Life",
 			"when on Low Life",
+			"^Allocates",
 		},
 		["belt"] = {
 			"Life as Extra Maximum Energy Shield", -- Soul Tether
@@ -621,12 +624,14 @@ data.itemTagSpecialExclusionPattern = {
 			"Life Flasks gain", -- The Druggery
 			"when on Full Life",
 			"when on Low Life",
+			"^Allocates",
 		},
 		["gloves"] = {
 			"maximum Life as Physical Damage", -- Haemophilia
 			"Traps Cost Life", -- Slavedriver's Hand
 			"when on Full Life",
 			"when on Low Life",
+			"^Allocates",
 		},
 		["helmet"] = {
 			"Recouped as Life", -- Flame Exarch
@@ -636,18 +641,21 @@ data.itemTagSpecialExclusionPattern = {
 			"^Socketed Gems are Supported by Level", -- Shako
 			"when on Full Life",
 			"when on Low Life",
+			"^Allocates",
 		},
 		["ring 1"] = {
 			"Energy Shield instead of Life", -- Valyrium
 			"increased Damage while Leeching Life", -- Synthesis Implicit
 			"when on Full Life",
 			"when on Low Life",
+			"^Allocates",
 		},
 		["ring 2"] = {
 			"Energy Shield instead of Life", -- Valyrium
 			"increased Damage while Leeching Life", -- Synthesis Implicit
 			"when on Full Life",
 			"when on Low Life",
+			"^Allocates",
 		},
 		["weapon 1"] = {
 			"^Socketed Gems are Supported by Level", -- Hiltless, etc
@@ -657,6 +665,7 @@ data.itemTagSpecialExclusionPattern = {
 			"maximum Life as Fire Damage", -- Crucible
 			"when on Full Life",
 			"when on Low Life",
+			"^Allocates",
 
 		},
 		["weapon 2"] = {
@@ -667,6 +676,7 @@ data.itemTagSpecialExclusionPattern = {
 			"maximum Life as Fire Damage", -- Crucible
 			"when on Full Life",
 			"when on Low Life",
+			"^Allocates",
 		}
 	},
 	["evasion"] = {


### PR DESCRIPTION
Fixes #7529

### Description of the problem being solved:
Excludes lines starting with "Allocates" from `FindModifierSubstring` used in ItemCondition type mods.