### PR TITLE
Fix manage trees in tree compare dropdown

### DIFF
--- a/src/Classes/TreeTab.lua
+++ b/src/Classes/TreeTab.lua
@@ -105,6 +105,8 @@ local TreeTabClass = newClass("TreeTab", "ControlHost", function(self, build)
 	self.controls.compareSelect = new("DropDownControl", { "LEFT", self.controls.compareCheck, "RIGHT" }, 8, 0, 190, 20, nil, function(index, value)
 		if self.specList[index] then
 			self:SetCompareSpec(index)
+		else
+			self:OpenSpecManagePopup()
 		end
 	end)
 	self.controls.compareSelect.shown = false


### PR DESCRIPTION
Fixes #7560 .

### Description of the problem being solved:
The "Manage trees" item in the tree compare dropdown doesn't do anything. It should work the same as it does in the tree list dropdown.

### Steps taken to verify a working solution:
Tried locally