### PR TITLE
Fix timeless jewel trade league url

### DIFF
--- a/src/Classes/TreeTab.lua
+++ b/src/Classes/TreeTab.lua
@@ -1892,7 +1892,10 @@ function TreeTabClass:FindTimelessJewel()
 			end
 		end
 
-		Copy("https://www.pathofexile.com/trade/search/"..(self.timelessJewelLeagueSelect or "").."/?q=" .. (s_gsub(dkjson.encode(search), "[^a-zA-Z0-9]", function(a)
+		-- if the league was not selected via dropdown, then default to the first league in the dropdown or "" if the leagues could not be read
+		self.timelessJewelLeagueSelect = self.timelessJewelLeagueSelect or (self.tradeLeaguesList and #self.tradeLeaguesList > 0 and self.tradeLeaguesList[1]) or ""
+
+		Copy("https://www.pathofexile.com/trade/search/"..(self.timelessJewelLeagueSelect).."/?q=" .. (s_gsub(dkjson.encode(search), "[^a-zA-Z0-9]", function(a)
 			return s_format("%%%02X", s_byte(a))
 		end)))
 

--- a/src/Classes/TreeTab.lua
+++ b/src/Classes/TreeTab.lua
@@ -1782,6 +1782,13 @@ function TreeTabClass:FindTimelessJewel()
 	controls.msg = new("LabelControl", nil, -280, 5, 0, 16, "")
 	if #self.tradeLeaguesList > 0 then
 		controls.searchTradeLeagueSelect:SetList(self.tradeLeaguesList)
+		-- restore the last league selected
+		for i, league in ipairs(self.tradeLeaguesList) do
+			if league == self.timelessJewelLeagueSelect then
+				controls.searchTradeLeagueSelect:SetSel(i)
+				break
+			end
+		end
 	else
 		self.tradeQueryRequests:FetchLeagues("pc", function(leagues, errMsg)
 			if errMsg then


### PR DESCRIPTION
Fixes #7564 .

### Description of the problem being solved:
The "Find Timeless Jewel" function does not properly update the selected league for creation of the trade search url.
Details can be found in the bugreport referenced.

Additionally, the window does not restore the last used league when closing and reopening the window.

### Steps taken to verify a working solution:
- Manually performed tests 
- Manually "broke" the HTTP request for fetching the active leagues in order to test fallback scenarios

### Before screenshot:
![before](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/4943606/328862a7-1faa-49fc-9153-3dabd5ccee8e)

### After screenshot:
![after](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/4943606/09217f69-2e62-4cf5-a860-e3d748e5b4b9)
