### PR TITLE
Support Cold Snap more chill effect quality

### DIFF
--- a/src/Data/SkillStatMap.lua
+++ b/src/Data/SkillStatMap.lua
@@ -989,7 +989,7 @@ return {
 ["chill_effect_+%"] = {
 	mod("EnemyChillEffect", "INC", nil),
 },
-["chill_effect_+%_final"] = {
+["active_skill_chill_effect_+%_final"] = {
 	mod("EnemyChillEffect", "MORE", nil),
 },
 ["shock_effect_+%"] = {

--- a/src/Modules/CalcOffence.lua
+++ b/src/Modules/CalcOffence.lua
@@ -4642,15 +4642,18 @@ function calcs.offence(env, actor, activeSkill)
 		}
 		if activeSkill.skillTypes[SkillType.ChillingArea] or activeSkill.skillTypes[SkillType.NonHitChill] then
 			skillFlags.chill = true
-			output.ChillEffectMod = skillModList:Sum("INC", cfg, "EnemyChillEffect")
+			local incChill = skillModList:Sum("INC", cfg, "EnemyChillEffect")
+			local moreChill = skillModList:More(cfg, "EnemyChillEffect")
+			output.ChillEffectMod = (1 + incChill / 100) * moreChill
 			output.ChillDurationMod = 1 + skillModList:Sum("INC", cfg, "EnemyChillDuration", "EnemyAilmentDuration", "EnemyElementalAilmentDuration") / 100
-			output.ChillSourceEffect = m_min(skillModList:Override(nil, "ChillMax") or ailmentData.Chill.max, m_floor(ailmentData.Chill.default * (1 + output.ChillEffectMod / 100)))
+			output.ChillSourceEffect = m_min(skillModList:Override(nil, "ChillMax") or ailmentData.Chill.max, m_floor(ailmentData.Chill.default * output.ChillEffectMod))
 			if breakdown then
 				breakdown.DotChill = { }
 				breakdown.multiChain(breakdown.DotChill, {
 					label = s_format("Effect of Chill: ^8(capped at %d%%)", skillModList:Override(nil, "ChillMax") or ailmentData.Chill.max),
 					base = s_format("%d%% ^8(base)", ailmentData.Chill.default),
-					{ "%.2f ^8(increased effect of chill)", 1 + output.ChillEffectMod / 100},
+					{ "%.2f ^8(increased/reduced effect of chill)", 1 + incChill / 100 },
+					{ "%.2f ^8(more/less effect of chill)", moreChill },
 					total = s_format("= %.0f%%", output.ChillSourceEffect)
 				})
 			end

--- a/src/Modules/CalcPerform.lua
+++ b/src/Modules/CalcPerform.lua
@@ -1101,7 +1101,7 @@ function calcs.perform(env, skipEHP)
 				end
 			end
 		elseif activeSkill.skillTypes[SkillType.ChillingArea] or (activeSkill.skillTypes[SkillType.NonHitChill] and not activeSkill.skillModList:Flag(nil, "CannotChill")) then
-			local effect = data.nonDamagingAilment.Chill.default * (1 + activeSkill.skillModList:Sum("INC", nil, "EnemyChillEffect") / 100)
+			local effect = data.nonDamagingAilment.Chill.default * calcLib.mod(activeSkill.skillModList, activeSkill.skillCfg, "EnemyChillEffect")
 			modDB:NewMod("ChillOverride", "BASE", effect, activeSkill.activeEffect.grantedEffect.name)
 			enemyDB:NewMod("Condition:Chilled", "FLAG", true, activeSkill.activeEffect.grantedEffect.name)
 			if activeSkill.skillData.supportBonechill then


### PR DESCRIPTION
Fixes Cold Snap quality "% more effect of chill" not being parsed. Furthermore, fixes "more" modifiers on chill effect not being applied to enemy chill effect/bonechill. The latter also fixes #6777 and #5037.

### Link to a build that showcases this PR:
https://pobb.in/u/Arcinde/hhdZhirZpJ8H

### Before screenshot:
Cold Snap mod not being parsed: 
![image](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/5281913/2554bce6-cf54-4bf3-a77a-5194e487ff37)
Even after parsing Cold Snap mod, it is not calculated in effect of chill, despite the "chill effect mod" line below showing the correct value
![image](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/5281913/f60a7eb0-c822-459d-bd9d-06a88d3ff9b9)
Not calculated in bonechill damage increase
![image](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/5281913/bc0c92ae-9919-439f-86ec-659f6eba42e6)

### After screenshot:
Cold Snap mod is parsed:
![image](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/5281913/1ab396c7-1ec7-496c-a14c-8b6fc97b75a8)
Effect of chill correctly incorporates "more":
![image](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/5281913/7bd68eb9-db28-47f5-84ac-c69e5a14b904)
This value is taken up correctly for the bonechill damage increase of the main skill:
![image](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/5281913/d685a50b-c73c-4076-bc62-8b32b32ef77a)
