### PR TITLE
Improve EHP overkill approximation, especially for MoM

### DIFF
--- a/src/Modules/CalcDefence.lua
+++ b/src/Modules/CalcDefence.lua
@@ -2346,12 +2346,14 @@ function calcs.buildDefenceEstimations(env, actor)
 
 		local iterationMultiplier = 1
 		local damageTotal = 0
+		local lastPositiveLife = poolTable.Life
 		local maxDamage = data.misc.ehpCalcMaxDamage
 		local maxIterations = data.misc.ehpCalcMaxIterationsToCalc
 		while poolTable.Life > 0 and DamageIn["iterations"] < maxIterations do
 			DamageIn["iterations"] = DamageIn["iterations"] + 1
 			local Damage = { }
 			damageTotal = 0
+			lastPositiveLife = poolTable.Life
 			local VaalArcticArmourMultiplier = VaalArcticArmourHitsLeft > 0 and (( 1 - output["VaalArcticArmourMitigation"] * m_min(VaalArcticArmourHitsLeft / iterationMultiplier, 1))) or 1
 			VaalArcticArmourHitsLeft = VaalArcticArmourHitsLeft - iterationMultiplier
 			for _, damageType in ipairs(dmgTypeList) do
@@ -2412,7 +2414,7 @@ function calcs.buildDefenceEstimations(env, actor)
 		end
 		
 		if poolTable.Life < 0 and DamageIn["cycles"] == 1 then -- Don't count overkill damage and only on final pass as to not break speedup.
-			numHits = numHits + poolTable.Life / damageTotal
+			numHits = numHits + poolTable.Life / (lastPositiveLife - poolTable.Life)
 			poolTable.Life = 0
 		end
 		-- Recalculate total hit damage


### PR DESCRIPTION
### Description of the problem being solved:
I was seeing strange breakpoints in my EHP. Normally, increasing my spell block chance by 1% would increase my EHP by <1%, but at certain breakpoints, a 1% spell block increase would cause an 8.8% EHP increase.

Checking the breakdown, I saw that my "mitigated hits" went from 5.99 to 6.52 at this spurious breakpoint.

Examining the function `numberOfHitsToDie`, specifically the part that adds back overkill as a fractional number of hits, I found the reason for this. The correction it performs is:

```
numHits = numHits + poolTable.Life / damageTotal
```

where `poolTable.Life` is the negative amount of life after the overkill, and `damageTotal` is the total damage of the last hit.

However, my character has 50% MoM and significantly more mana than life. Therefore, on the overkill hit, 50% of the damage goes to mana. Now supposing I have almost 0 life right before the overkill hit, `poolTable.Life / damageTotal` would be roughly `-0.50`, which is not correct. The intended correction should be closer to `-1`.

So with my 50% MoM setup, under the current calculation, the # of mitigated hits will never be able to have a fractional part between 0 and 0.5, which is clearly wrong. I will keep seeing these spurious breakpoints - the # of mitigated hits will jump from 5.99 to 6.5, then increase smoothly to 6.99 before it jumps to 7.5, etc.

My PR changes this correction to instead be:

```
numHits = numHits + poolTable.Life / (lastPositiveLife - poolTable.Life)
```

This is still an approximation and not fully accurate, but it should be a lot better than the previous calculation.

### Steps taken to verify a working solution:
- After the change, # mitigated hits is 5.97 before the breakpoint -> 6.02 after the breakpoint.

### Link to a build that showcases this PR:
https://pobb.in/lHDoriHjsnvz
In custom modifiers I have: +5% chance to block spell damage
Before the fix, changing this to +6% triggers the spurious breakpoint (mitigated hits 5.99 -> 6.52, EHP 88085 -> 95910)

### Before screenshot:
With `+5% chance to block spell damage`: 
![image](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/5281913/e887b4b7-f5d3-4063-9cbf-fccaf74cc09c)

With `+6% chance to block spell damage`:
![image](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/5281913/396d52f2-e68a-47cd-827a-35ae2f5745ec)

### After screenshot:
With `+5% chance to block spell damage`: 
![image](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/5281913/e8d9a005-344f-41e7-8f82-48c422feaf80)

With `+6% chance to block spell damage`: 
![image](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/5281913/fabcded0-6ebb-4d51-a48f-7eb0b8f606b1)