### PR TITLE
Fix error when toggling 'Include Enchants' checkbox in trader

### DIFF
--- a/src/Classes/TradeQuery.lua
+++ b/src/Classes/TradeQuery.lua
@@ -345,12 +345,12 @@ Lowest Price - Sorts from lowest to highest price of retrieved items
 Highest Weight - Displays the order retrieved from trade]]
 	self.controls.itemSortSelection:SetSel(self.pbItemSortSelectionIndex)
 	self.controls.itemSortSelectionLabel = new("LabelControl", {"TOPRIGHT", self.controls.itemSortSelection, "TOPLEFT"}, -4, 0, 60, 16	, "^7Sort By:")
-	
+
 	-- Use Enchant in DPS sorting
 	self.controls.enchantInSort = new("CheckBoxControl", {"TOPRIGHT",self.controls.fetchCountEdit,"TOPLEFT"}, -8, 0, row_height, "Include Enchants:", function(state)
 		self.enchantInSort = state
-		for index, _ in pairs(self.resultTbl) do
-			self:UpdateControlsWithItems({name = baseSlots[index]}, index)
+		for row_idx, _ in pairs(self.resultTbl) do
+			self:UpdateControlsWithItems(row_idx)
 		end
 	end)
 	self.controls.enchantInSort.tooltipText = "This includes enchants in sorting that occurs after trade results have been retrieved"


### PR DESCRIPTION
- **Fix error when toggling 'Include Enchants' in trader**

Fixes #6216

### Description of the problem being solved:

Lua Error when toggling 'Include Enchants' in trader

### Steps taken to verify a working solution:
- Open trader, 'Trade for these items'
- Activate Session Mode
- Use trader to 'Find best' on weapon
- Check 'Include Enchants' checkbox -> ERROR 

### Link to a build that showcases this PR:

Any build will do

### Before screenshot:

See linked issue #6216

### After screenshot:

No error
