### PR TITLE
Show Trap Cooldown for Trap Supported Spell in Black Zenith

### DIFF
--- a/src/Modules/CalcOffence.lua
+++ b/src/Modules/CalcOffence.lua
@@ -1155,9 +1155,14 @@ function calcs.offence(env, actor, activeSkill)
 		end
 
 		local baseCooldown = skillData.trapCooldown or skillData.cooldown
-		if baseCooldown then
-			output.TrapCooldown = baseCooldown / calcLib.mod(skillModList, skillCfg, "CooldownRecovery")
-			output.TrapCooldown = m_ceil(output.TrapCooldown * data.misc.ServerTickRate) / data.misc.ServerTickRate
+		if baseCooldown or skillModList:Sum("BASE", skillCfg, "CooldownRecovery") ~= 0 then
+			if baseCooldown then
+				output.TrapCooldown = baseCooldown / calcLib.mod(skillModList, skillCfg, "CooldownRecovery")
+				output.TrapCooldown = m_ceil(output.TrapCooldown * data.misc.ServerTickRate) / data.misc.ServerTickRate
+			else -- Assign Trap Cooldown if the trap/skill does not have cooldown but gain cooldown elsewhere
+				local cooldown, _, _ = calcSkillCooldown(skillModList, skillCfg, skillData)
+				output.TrapCooldown = cooldown;
+			end
 			if breakdown then
 				breakdown.TrapCooldown = {
 					s_format("%.2fs ^8(base)", skillData.trapCooldown or skillData.cooldown or 4),


### PR DESCRIPTION
Fixes #7594 

### Description of the problem being solved:
- When a projectile spell with no cooldown is supported by trap support in Black Zenith, the trap cooldown is not being counted and shown.
### Steps taken to verify a working solution:
- Load sample PoB
- All trap skills socketed in Black Zenith should display trap cooldown
- Trap with built-in cooldown should functions the same

### Link to a build that showcases this PR:
https://pobb.in/0Mgib7TyTvw0
### Before screenshot:
![Stats1](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/56325975/4b10127a-60ce-4825-8639-5ecd5a950bba)
![Stats2](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/56325975/28b1ca70-5d78-4f32-8863-5b905c5fe2c1)
### After screenshot:
![Stats1](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/56325975/d01429df-4945-4ce9-b75f-a25a10581857)
![Stats2](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/56325975/d6ab15a3-5af1-4593-9be3-2497f48578e1)
