### PR TITLE
Fix Stance Cooldown mastery affecting attack speed

### DIFF
--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -4550,7 +4550,7 @@ local specialModList = {
 	},
 	["warcry skills' cooldown time is (%d+) seconds"] = function(num) return { mod("CooldownRecovery", "OVERRIDE", num, nil, 0, KeywordFlag.Warcry) } end,
 	["warcry skills have (%+%d+) seconds to cooldown"] = function(num) return { mod("CooldownRecovery", "BASE", num, nil, 0, KeywordFlag.Warcry) } end,
-	["stance skills have (%+%d+) seconds to cooldown"] = function(num) return { mod("CooldownRecovery", "BASE", num, nil, { type = "SkillType", skillType = SkillType.Stance }) } end,
+	["stance skills have (%+%d+) seconds to cooldown"] = function(num) return { mod("CooldownRecovery", "BASE", num, { type = "SkillType", skillType = SkillType.Stance }) } end,
 	["using warcries is instant"] = { flag("InstantWarcry") },
 	["attacks with axes or swords grant (%d+) rage on hit, no more than once every second"] = {
 		flag("Condition:CanGainRage", { type = "Condition", varList = { "UsingAxe", "UsingSword" } }),


### PR DESCRIPTION
Fixes #7585.

### Description of the problem being solved:
- Attack mastery "Stance Skills have +6 seconds to Cooldown" applied to all skills
### Steps taken to verify a working solution:
- Rebuild mod cache
- Hold `alt` to check internal modifiers for the mastery
- Select any skill with no cooldown and there should be no cooldown
- Select any lv1 stance skill and the skill cooldown should be base + 6 seconds

### Link to a build that showcases this PR:
https://pobb.in/JjJvNcZ7BdpJ
### Before screenshot:
![StatsBefore](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/56325975/6f423487-1a96-4dc1-904d-78066811e090)

### After screenshot:
![StatAfter](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/56325975/9bea8871-6f41-4e90-80f3-5dec02324db7)
