### PR TITLE
Split Player and Minion Info lines if they are too long

### DIFF
--- a/src/Modules/Build.lua
+++ b/src/Modules/Build.lua
@@ -1484,7 +1484,14 @@ function buildMode:RefreshStatList()
 	self.controls.warnings.lines = {}
 	local statBoxList = wipeTable(self.controls.statBox.list)
 	if self.calcsTab.mainEnv.player.mainSkill.infoMessage then
-		t_insert(statBoxList, { height = 14, align = "CENTER_X", x = 140, colorCodes.CUSTOM .. self.calcsTab.mainEnv.player.mainSkill.infoMessage})
+			if #self.calcsTab.mainEnv.player.mainSkill.infoMessage > 40 then
+				for line in string.gmatch(self.calcsTab.mainEnv.player.mainSkill.infoMessage, "([^:]+)") do
+					t_insert(statBoxList, { height = 14, align = "CENTER_X", x = 140, colorCodes.CUSTOM .. line})
+				end
+			else
+				t_insert(statBoxList, { height = 14, align = "CENTER_X", x = 140, colorCodes.CUSTOM .. self.calcsTab.mainEnv.player.mainSkill.infoMessage})
+			end
+		-- t_insert(statBoxList, { height = 14, align = "CENTER_X", x = 140, colorCodes.CUSTOM .. self.calcsTab.mainEnv.player.mainSkill.infoMessage})
 		if self.calcsTab.mainEnv.player.mainSkill.infoMessage2 then
 			t_insert(statBoxList, { height = 14, align = "CENTER_X", x = 140, "^8" .. self.calcsTab.mainEnv.player.mainSkill.infoMessage2})
 		end

--- a/src/Modules/Build.lua
+++ b/src/Modules/Build.lua
@@ -1492,7 +1492,14 @@ function buildMode:RefreshStatList()
 	if self.calcsTab.mainEnv.minion then
 		t_insert(statBoxList, { height = 18, "^7Minion:" })
 		if self.calcsTab.mainEnv.minion.mainSkill.infoMessage then
-			t_insert(statBoxList, { height = 14, align = "CENTER_X", x = 140, colorCodes.CUSTOM .. self.calcsTab.mainEnv.minion.mainSkill.infoMessage})
+			-- Split the line if too long
+			if #self.calcsTab.mainEnv.minion.mainSkill.infoMessage > 40 then
+				for line in string.gmatch(self.calcsTab.mainEnv.minion.mainSkill.infoMessage, "([^:]+)") do
+					t_insert(statBoxList, { height = 14, align = "CENTER_X", x = 140, colorCodes.CUSTOM .. line})
+				end
+			else
+				t_insert(statBoxList, { height = 14, align = "CENTER_X", x = 140, colorCodes.CUSTOM .. self.calcsTab.mainEnv.minion.mainSkill.infoMessage})
+			end
 			if self.calcsTab.mainEnv.minion.mainSkill.infoMessage2 then
 				t_insert(statBoxList, { height = 14, align = "CENTER_X", x = 140, "^8" .. self.calcsTab.mainEnv.minion.mainSkill.infoMessage2})
 			end

--- a/src/Modules/Build.lua
+++ b/src/Modules/Build.lua
@@ -1491,7 +1491,6 @@ function buildMode:RefreshStatList()
 			else
 				t_insert(statBoxList, { height = 14, align = "CENTER_X", x = 140, colorCodes.CUSTOM .. self.calcsTab.mainEnv.player.mainSkill.infoMessage})
 			end
-		-- t_insert(statBoxList, { height = 14, align = "CENTER_X", x = 140, colorCodes.CUSTOM .. self.calcsTab.mainEnv.player.mainSkill.infoMessage})
 		if self.calcsTab.mainEnv.player.mainSkill.infoMessage2 then
 			t_insert(statBoxList, { height = 14, align = "CENTER_X", x = 140, "^8" .. self.calcsTab.mainEnv.player.mainSkill.infoMessage2})
 		end


### PR DESCRIPTION
Fixes ![image](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/4302241/b6cdd96c-a68e-46ad-9c5e-d6c034fe6e63).

### Description of the problem being solved:
In some cases the info line is too long and it can't be read.

### Steps taken to verify a working solution:
- Import build into PoB and see that the line is split into two.

### Link to a build that showcases this PR:
https://pobb.in/dGqxkOSjJK18  -Minion
https://pobb.in/-viTq9zN-nWg  -Player

### Before screenshot:
![image](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/4302241/b6cdd96c-a68e-46ad-9c5e-d6c034fe6e63).

### After screenshot:
![image](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/4302241/a89e325d-e45b-4e44-b739-985e5c7e74f1)
