### PR TITLE
Fix Ngamahu, Flame's Advance working correctly with Timeless jewels

### DIFF
--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -2249,11 +2249,16 @@ local specialModList = {
 	["(%d+)%% more damage if you've lost an endurance charge in the past 8 seconds"] = function(num) return { mod("Damage", "MORE", num, { type = "Condition", var = "LostEnduranceChargeInPast8Sec" })	} end,
 	["trigger level (%d+) (.+) when you attack with a non%-vaal slam or strike skill near an enemy"] = function(num, _, skill) return triggerExtraSkill(skill, num) end,
 	["non%-unique jewels cause increases and reductions to other damage types in a (%a+) radius to be transformed to apply to (%a+) damage"] = function(_, radius, dmgType) return {
-		mod("ExtraJewelFunc", "LIST", {radius = firstToUpper(radius), type = "Other", func = getSimpleConv({ "PhysicalDamage","FireDamage","ColdDamage","LightningDamage","ChaosDamage","ElementalDamage" }, (dmgType:gsub("^%l", string.upper)).."Damage", "INC", true)}, {type = "ItemCondition", itemSlot = "{SlotName}", rarityCond = "UNIQUE", neg = true}),
+		mod("ExtraJewelFunc", "LIST", {radius = firstToUpper(radius), type = "Other", func = function(node, out, data)
+			-- Ignore Timeless Jewels
+			if node and not node.conqueredBy then 
+				return getSimpleConv({ "PhysicalDamage","FireDamage","ColdDamage","LightningDamage","ChaosDamage","ElementalDamage" }, (dmgType:gsub("^%l", string.upper)).."Damage", "INC", true)
+			end
+		end}, {type = "ItemCondition", itemSlot = "{SlotName}", rarityCond = "UNIQUE", neg = true}),
 	} end,
 	["non%-unique jewels cause small and notable passive skills in a (%a+) radius to also grant %+(%d+) to (%a+)"] = function(_, radius, val, attr) return {
 		mod("ExtraJewelFunc", "LIST", {radius = (radius:gsub("^%l", string.upper)), type = "Other", func = function(node, out, data)
-		if node and (node.type == "Notable" or node.type == "Normal") then
+		if node and not node.conqueredBy and (node.type == "Notable" or node.type == "Normal") then
 			out:NewMod(firstToUpper(attr):match("^%a%l%l"), "BASE", tonumber(val), data.modSource)
 		end
 	end}, {type = "ItemCondition", itemSlot = "{SlotName}", rarityCond = "UNIQUE", neg = true}),


### PR DESCRIPTION
… Jewels

Fixes #7610.
Fixes #7604.

### Description of the problem being solved:

### Steps taken to verify a working solution:
- Rebuild the mod cache
- Strength from Ngamahu in Timeless Jewel Radius is not applied. Import PoB from #7604 (https://pobb.in/WMBnC0phfGBr), Strength is 1820, same as in-game.
- Ngamahu does not transform damage type from Timeless Jewel. Import PoB from below (https://pobb.in/1TKnO-VH2o8g), node "Revitalising Frost" should not affect flame dash damage

### Link to a build that showcases this PR:
https://pobb.in/1TKnO-VH2o8g
### Before screenshot:
![PassiveBefore](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/56325975/3bf39728-f319-4a04-8ebf-e9fe4592db5e)
![FlamedashBefore](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/56325975/c52c2e7d-ba42-4b78-86ad-ae1d7fb566a5)

### After screenshot:
![PassiveAfter](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/56325975/f47d2747-591e-4849-a816-9711199f0b6d)
![FlamedashAfter](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/56325975/3e3a148b-f0b1-4b13-bc9b-932e24342ff4)

