### PR TITLE
fix Primal Aegis typo in Calcs tab #6350

### DIFF
--- a/src/Classes/CalcBreakdownControl.lua
+++ b/src/Classes/CalcBreakdownControl.lua
@@ -497,7 +497,7 @@ function CalcBreakdownClass:FormatVarNameOrList(var, varList)
 end
 
 function CalcBreakdownClass:FormatModBase(mod, base)
-	return mod.type == "BASE" and string.format("%+g", math.abs(base)) or math.abs(base).."%"
+	return mod.type == "BASE" and string.format("%+g", math.abs(base)) or mod.name == "ElementalAegisValue" and math.abs(base) or math.abs(base).."%"
 end
 
 function CalcBreakdownClass:FormatModValue(value, modType)

--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -5164,7 +5164,7 @@ local jewelOtherFuncs = {
 	["Passive Skills in Radius also grant (%d+)%% increased Global Critical Strike Chance"] = function(num)
 		return function(node, out, data)
 			if node and node.type ~= "Keystone" then
-				out:NewMod("CritChance", "INC", num, data.modSource)
+				out:NewMod("CritChance", "INC", tonumber(num), data.modSource)
 			end
 		end
 	end,

--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -5164,7 +5164,7 @@ local jewelOtherFuncs = {
 	["Passive Skills in Radius also grant (%d+)%% increased Global Critical Strike Chance"] = function(num)
 		return function(node, out, data)
 			if node and node.type ~= "Keystone" then
-				out:NewMod("CritChance", "INC", tonumber(num), data.modSource)
+				out:NewMod("CritChance", "INC", num, data.modSource)
 			end
 		end
 	end,


### PR DESCRIPTION
Fixes #6350. _This fix kinda brute._

### Description of the problem being solved:

What is the wording in-game?
Primal Aegis, granted by the Elementalist's Bastion of Elements notable, says it "can take 75 Elemental Damage per Allocated Notable Passive Skill".

What is the wording in Path of Building?
Under the Calcs tab, this is presented as 75% per allocated Notable.

### Steps taken to verify a working solution:
Take the Bastion of Elements in Witch Elementalist ascendancy.
Check out description of Aegis value in Calcs tab.

### Link to a build that showcases this PR:
https://pobb.in/HMDm0xdepwnx

### Before screenshot:
![image](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/36129181/59a5f6f9-3a60-4b72-96b8-05e8799da21a)

### After screenshot:
![image](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/36129181/a0f363cd-f9d5-4571-a5aa-b87fe43d8404)