### PR TITLE
Fix "Deal 10% more Chaos Damage to enemies which have Energy Shield" chaos mastery should be limited to hits and ailments #7582

### DIFF
--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -1716,7 +1716,7 @@ local modTagList = {
 	["against enemies that are on full life"] = { tag = { type = "ActorCondition", actor = "enemy", var = "FullLife" } },
 	["against enemies on low life"] = { tag = { type = "ActorCondition", actor = "enemy", var = "LowLife" } },
 	["against enemies that are on low life"] = { tag = { type = "ActorCondition", actor = "enemy", var = "LowLife" } },
-	["to enemies which have energy shield"] = { tag = { type = "ActorCondition", actor = "enemy", var = "HaveEnergyShield" } },
+	["to enemies which have energy shield"] = { tag = { type = "ActorCondition", actor = "enemy", var = "HaveEnergyShield" }, keywordFlags = bor(KeywordFlag.Hit, KeywordFlag.Ailment) },
 	["against cursed enemies"] = { tag = { type = "ActorCondition", actor = "enemy", var = "Cursed" } },
 	["against stunned enemies"] = { tag = { type = "ActorCondition", actor = "enemy", var = "Stunned" } },
 	["on cursed enemies"] = { tag = { type = "ActorCondition", actor = "enemy", var = "Cursed" } },


### PR DESCRIPTION
Fixes #7582.

### Description of the problem being solved:
Only hits and ailments can check conditions on the enemy. Non-ailment DoT can't benefit from a stat that needs to check the enemy for ES. But the mastery applies to all chaos damage, even non-ailment chaos DoT that doesn't calculate base damage against a specific enemy, like CA's Caustic Ground.
### Steps taken to verify a working solution:
- Import build 
- Confirm that checking `Does the enemy have energy shield` affects poison DPS, but doesn't affect Decay DPS.

### Link to a build that showcases this PR:
```
eNq1W1uT2rgSfk5-hYuq88aA78AW7BbDXE_NbYdJsvuUErYAJbLF2jIz5NT570cXGwyDPDb2ycMErO5P3a3uVqtlhn-8BVhbwyhGJBy1jI7e0mDoER-Fi1Hry8vVWb_1x--fh0-ALh_n5wnCfOT3z5-G4rOG4RpixjdoaRREC0i_ZlDWdwa1AiFdQhLegx8kuib-qPVAQtjSZiD0Ec2-eRjE8QMI4Kg19RhzSwOxB0N_snueEi5BBDwKozs-7Tih5J74bJRGCRsNAAqnxPsJ6XVEkhWTqqWtEXyVNLf3T4_PLzmRUJgXian0afiEwQZGUwqoFrM_o9aYWQYs4A2iDArghOEY1sDqOINWt5DjPIliegEC9rEs53QFob8j7thm3-kZ6V8V01MEL-dz6FG0hpMI0ckShN5uSlfFV5X2PsEUrTCCUU5CR8Vx8w7c0HUV8QuhAF88TXe0g4He6WfqD4r5yG5llDN8Q3R5jpl1T5iF894uQkThCcxPBMUkzDO6eq-jW7rzAceB45iG3dFdo0jG91NZPdPpmEbmQyrmC-iBzZ5upslms9yP7J7nMQdOv2Pr_Q_sMUkwZukjz6lctGcYw2gNKNrXSkk_IcEMhftrbA_sQcd0jA9McA9CMCHxzpPMQtInGLHsRPc49A8YptAjLKHlWax-ZxffapvlZjyOo5z6Ds1hecpKWqUMVaU5TY_LaVm6ysCnCfTMgrMc5ZQkuCQl3WVW01EH69uOqiB0_skT2n0V4W2Y29cK8fYonQL51oSKHfwjfUUWubx52qnTdzolwuFpuYmRB_A9eENBErCd5gX8hGEuExV44GJJQ5Z_VLxGX5lir1AET2CbEOyfwrYEJD6Bj8dYGUuwUsP7jRPfhl65yP0SRiIf5yqUQkvP4TMLKF4LzTAsy7KbJI3LMuWDnGsBw3TCzZbJ6fSLmO4g9JbXrGZ8BhSWS-S52OsX2pYTl7ItJzxmWzX-PkcFQ3FGlaGMIqaKhroMYbTYTJcIYr8adSbYBKxKJExu5zx3KXvvT3fMGKVYK5rkG4j8cttKVZnWIM6nW8MtNpckL-eZkFXMjMGHB6W8rj6LkB_8JIKrsY2jgCRRyQWXxKUUyHYKWUw_Qz_xym1N55gdIstKz6TCuBLHmFLg_bwg_gJWmqQSx_ZQKFinyWrFMgZf-7IAfMNjJTjK1S5nbgnqR-a4peKXb43lJ9hRl55gu92Xn-WApbwufL-uoMyOvPQU2wW9Z6khYClftAvuSa5joFwcduoqdYQShPsHO3V0kVcm-ZL3fOJq1Kyu2Z2BlKJEMPy1KY2_R15qgsvQTyIeCqXnOOQ4Ns0LCljajOMLQIHmp8XwVxAhEFJTNKRiCCJveceW_gpgPGOZYNTKPxXfRBPrCmEKowv2jE_KBTtENLJFH3ZFN45_ug1WJKIafOP_PYGIbkatOcAxlITiCcOJKQrF2ZrlI4xb2nRJXsf-ms_0QgiOMyYNrFYw9PcwXiIINZBlF48LIZTnX7QAxEzqjXRXBvMf03LsXtvsu73-f_cae7e-0CkkTJpRq2f1-21r0LeNtum6pt52-n3LajvOQHfblmX3Bux5z9bbVl-3-23XGvTctsR2XLdntG3XYqO22XP1tqHbA53R2GzU7pmOwXCsnsU-D-xB27Yt12y7OputbTHePrc_P_2BaDPely9EzDaU6Ztra5p22rGUCnDVPw2_PN-JD5-WlK7i37rd19fXzgrQJZnDN7YjdjwSdFeMiRntLP6JMD7jsN0x-3e-GI-vzn95gXsVfn9YoUXsE__f08UZXM7OBsac_jkNJ5Mf7mAA7Z-D5UOim3SarJMf-t_j8V_j62_f45EQoptJMZRt0Lgrv_EkEyFmZumkXb5Qwmv4SvIPD4TCmI_xh9mX4ZSLGTNvjOg1DOJz3iW64tXPQbMldQVOPYVUenmeJ-vP-nAOEsyf_5kAjLhn6vmnd7KXHJIo2J7vGBTzTL5_ScSXzYp7y_juTo6MMU3B-HSZm0p3TAXSkJ-5aPpQdIrHO6knAHuxkBuFHk58dixKc-Y2DDCYcdl4c5yfaPx8zzmHtJ3o05DJkxJfYzID2MxY0pY5O25rCxhwJ7qHFPgsY3RvKVOiyzXpCjj2aRyJUkfEO6cV34UDbb_9k7Nm-pmPXUjDtvakMDIpDvTwSBLKpQtBkIY1B-82pM12AUW7cU8j8SQlyKmWPknp_186Svg0TqTR0xhJvUfEiYwE_lG4iqC4DVcJFUijVoBi7_ssmc_5VQPTgUbi-uTy6upy8nL79TLdHfIsQs_vYRLMeEtd_r_bw6dQ1KpanMxi-XHU-orgqxDkghkY4ZgrhDFYxXCbnoWrp5JjxleAJqhu0PaO4jjWjkCNdPkGI7abLNghx4sQVMq1Hf9AKDkhPwDx3VSFxhv_aiBZY0_YXiQPaApLiRsXNQq_-FCqwwcLeNk-DLBy5nT0A0tQnuyYm6I58nghUrzkPDVKqgK7eB6rYbxNwXqnBwQ1hrhJUQHIQTWzvKZQcaejBVYVNzFKq8pRNXuaTBQetUsFR5m3Z34SivvA4yhbqgKkh_SGhwXNGGFezCtX9hLDLYka8JEuYZSWXCqke5ajMpLCwInQLKHqMM5RFNhKNCIVFuJjalbZZ1PowMcKMtFe50lh0DyNGkp2bJSJrIhVHuyU9kuPiQVLkPZDFOaXowVGyFpCCv3T4YIgEfl3vCbIl60CRbgckBUlDFaN1ocR_Y_6MIcNkfqIV-ww8FO53umomv0LRbycOYIiy5ZSIDyo6iHw2KqH8HxYSOx4n4tLiO0Z_ChzNloU-OnR_GQE2UA4mV30N07mFumblbKQaVCYv7c0Be5Nk_CCGYMWuHZJKCHW8Tyw064SltzJjmpaGVHGZ3o1VhTCkuQDILYV3xQUe-WQtj26GwgwfyWD4HqA764Aa-lJaAxC_4LfMNRUlF9QJCsGlkn2eKxa3y3pIeqwm52jRDOJn2zSFtiURvyU_YuQ4O9R68yyjE5v4MoHaX-gl_YEWKl7gZjFI-Ep2XSc8C_GObDMjm315YtTQ3EUTRsV_HPWp0hiKC_-v0GwIqF4nGshpKQFZPvNBUyoxirQ4Gn25fmO6yHPepJL4_0FKs_IenbkVLGcQ0y18WwTxwBrspujmRX4sykPMZzqGGYDGIY2fQWrQyC3AYXcBhSqgnFOWBgdAlgVAG4gS4Lv1raub5xkhmNr4jSwJkYDGHZFgzTlk00EWRUMUVVVsvpRDzRr-o9VWeQqC3SNyRrGddzkeNS4lREqq2nUVrPK2o6DBEPagAtaDaRFq7bqdmVzV_HjZ1a0nRKvMvFVVq5uiDqVjVF_WzFrI9SXwa5rOLup3G5VksTfaLLZ0nzecprarY1mNDLrLlHlCqp2anGb0dypLYhVNWMZdY1tNJDbG4spp5l1cGvWL_WrkboVVEOhaDWVGhoDOuVocZotmvLJhpbi5Bip6UmN7Q5mA4miCQyjKYUay1rvgYbdtNkj3-OKgA-noiP1DfKXAmPZthJ9JPEeAAnnaPHuVt9LYkqCe-LHu7cADF3_F__lYuhBjRJtJe44PwOMNV-0xTQPhOnTI-8J8K4T4l23yxAGmxuwhvu3XDNCMARh2v7avrrmwSXBPoxSFMiZ0x8YZu8a9PKvih-jz_9GMGNyilnSd20Jxs8gXMD8ZB_Plb2KkPFYap4YLRB-nIu2-5QCcXdw-A7Fe65g-yNG_os5GEF_Kl4T4O-FTCGe5zA-0DPLV1t61y5m2N7KbQ2Z_43ZMY7915dzVrGzFmrqgsPu4Y9z_we2UAlC
```
### Before screenshot:
![image](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/36129181/c3589fa8-8599-405d-8ac0-639dd0ed78c0)
![image](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/36129181/8baf1c21-2195-4a2e-b331-568c1e3aa6c0)


### After screenshot:
![image](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/36129181/a1592d2e-4070-48d9-a970-faf959658a42)
![image](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/36129181/9633dc1b-2787-4144-88fb-ab5971a56077)
