### PR TITLE
fix(7622): store widowhail multiplier & apply to clones

### DIFF
--- a/src/Modules/CalcPerform.lua
+++ b/src/Modules/CalcPerform.lua
@@ -1005,7 +1005,7 @@ function calcs.perform(env, skipEHP)
 				env.minion.modDB:AddList(env.player.itemList["Weapon 1"].slotModList[1])
 			end
 			if env.player.itemList["Weapon 2"] and env.player.itemList["Weapon 2"].type == "Quiver" then
-				 env.minion.modDB:ScaleAddList(env.player.itemList["Weapon 2"].modList, env.widowHailModifier or 1)
+				env.minion.modDB:ScaleAddList(env.player.itemList["Weapon 2"].modList, env.widowHailModifier or 1)
 			end
 		end
 		if env.minion.itemSet or env.minion.uses then

--- a/src/Modules/CalcPerform.lua
+++ b/src/Modules/CalcPerform.lua
@@ -1005,7 +1005,7 @@ function calcs.perform(env, skipEHP)
 				env.minion.modDB:AddList(env.player.itemList["Weapon 1"].slotModList[1])
 			end
 			if env.player.itemList["Weapon 2"] and env.player.itemList["Weapon 2"].type == "Quiver" then
-				env.minion.modDB:AddList(env.player.itemList["Weapon 2"].modList)
+				 env.minion.modDB:ScaleAddList(env.player.itemList["Weapon 2"].modList, env.widowHailModifier or 1)
 			end
 		end
 		if env.minion.itemSet or env.minion.uses then

--- a/src/Modules/CalcPerform.lua
+++ b/src/Modules/CalcPerform.lua
@@ -1005,7 +1005,7 @@ function calcs.perform(env, skipEHP)
 				env.minion.modDB:AddList(env.player.itemList["Weapon 1"].slotModList[1])
 			end
 			if env.player.itemList["Weapon 2"] and env.player.itemList["Weapon 2"].type == "Quiver" then
-				env.minion.modDB:ScaleAddList(env.player.itemList["Weapon 2"].modList, env.widowHailModifier or 1)
+				env.minion.modDB:ScaleAddList(env.player.itemList["Weapon 2"].modList, m_max(modDB:Sum("BASE", nil, "WidowHailMultiplier"), 1))
 			end
 		end
 		if env.minion.itemSet or env.minion.uses then

--- a/src/Modules/CalcSetup.lua
+++ b/src/Modules/CalcSetup.lua
@@ -993,7 +993,7 @@ function calcs.initEnv(build, mode, override, specEnv)
 				elseif item.type == "Quiver" and items["Weapon 1"] and items["Weapon 1"].name:match("Widowhail") then
 					local widowHailMod=(1 + (items["Weapon 1"].baseModList:Sum("INC", nil, "EffectOfBonusesFromQuiver") or 100) / 100)
 					scale = scale * widowHailMod
-					env.widowHailModifier = widowHailMod
+					env.modDB:NewMod("WidowHailMultiplier", "BASE", widowHailMod, "Widowhail")
 					local combinedList = new("ModList")
 					for _, mod in ipairs(srcList) do
 						combinedList:MergeMod(mod)

--- a/src/Modules/CalcSetup.lua
+++ b/src/Modules/CalcSetup.lua
@@ -991,7 +991,9 @@ function calcs.initEnv(build, mode, override, specEnv)
 					end
 					env.itemModDB:ScaleAddList(srcList, scale)
 				elseif item.type == "Quiver" and items["Weapon 1"] and items["Weapon 1"].name:match("Widowhail") then
-					scale = scale * (1 + (items["Weapon 1"].baseModList:Sum("INC", nil, "EffectOfBonusesFromQuiver") or 100) / 100)
+					local widowHailMod=(1 + (items["Weapon 1"].baseModList:Sum("INC", nil, "EffectOfBonusesFromQuiver") or 100) / 100)
+					scale = scale * widowHailMod
+					env.widowHailModifier = widowHailMod
 					local combinedList = new("ModList")
 					for _, mod in ipairs(srcList) do
 						combinedList:MergeMod(mod)


### PR DESCRIPTION
Fixes #7622  .

### Description of the problem being solved:
widowhail multiplier only applied to the player not the minions as well

### Steps taken to verify a working solution:
- checked widowhail minion pob
![image](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/3480240/33f1b2de-6270-4d0a-aa0d-80a330700fde)
- checked widowhail non minion pob (values stay the same)
![image](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/3480240/ab731f5f-47aa-48c3-afaf-d22a21d50bdc)

### Link to a build that showcases this PR:
- minion: https://pobb.in/Q1bvbkFDWk4J
- non minion: https://poe.ninja/builds/necropolis/character/Spirituus/Spirituus_Bait_Again?i=6&search=items%3DWidowhail