### PR TITLE
fix(ci): pin cluacov version

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Install busted
         run: luarocks install busted
       - name: Install cluacov
-        run: luarocks install cluacov
+        run: luarocks install cluacov 0.1.2-1
       - name: Install coveralls integration
         run: luarocks install luacov-coveralls
       - name: Run tests


### PR DESCRIPTION
pin cluacov to 0.1.2-1, new version came out 5d ago that does not work with our current setup

tests before the change: https://github.com/PathOfBuildingCommunity/PathOfBuilding/actions/runs/9015748876/job/24776422704

failing tests on 2024-05-19: https://github.com/PathOfBuildingCommunity/PathOfBuilding/actions/runs/9149221543/job/25152630073?pr=7623

working after pinning the version: https://github.com/FWidm/PathOfBuilding/actions/runs/9149394891/job/25152964011?pr=1