### PR TITLE
Fix Forbidden Flesh&Flame (Duellist) Impact doesn't update required class.

### DIFF
--- a/src/Data/Uniques/Special/Generated.lua
+++ b/src/Data/Uniques/Special/Generated.lua
@@ -727,6 +727,7 @@ function buildForbidden(classNotables)
 	local forbidden = { }
 	for _, name in pairs({"Flame", "Flesh"}) do
 		forbidden[name] = { }
+		table.insert(forbidden[name], "Rarity: UNIQUE")
 		table.insert(forbidden[name], "Forbidden " .. name)
 		table.insert(forbidden[name], (name == "Flame" and "Crimson" or "Cobalt") .. " Jewel")
 		local index = 1


### PR DESCRIPTION
Fixes #7614 .

### Description of the problem being solved:
Forbidden Flesh&Flame doesn't update required class when selecting Duelist Impact.
### Steps taken to verify a working solution:
- Select any not Duelist node on Forbidden Flesh/Flame
- Select Duelist Impact node.
- Check the required class.

### Link to a build that showcases this PR:
- No response
### Before screenshot:
![image](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/36129181/9ae66797-a5ac-4cc5-ac56-04ca39323816)

### After screenshot:
![image](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/36129181/580349aa-2c5b-4421-9617-3c065d729583)
