### PR TITLE
Fix Ignite Max stack below 2 not displayed in the Ignite calc widget. #7592

### DIFF
--- a/src/Modules/CalcSections.lua
+++ b/src/Modules/CalcSections.lua
@@ -929,7 +929,7 @@ return {
 { 1, "Ignite", 1, colorCodes.OFFENCE, {{ defaultCollapsed = false, label = "Ignite", data = {	
 	extra = "{0:output:IgniteChancePerHit}% {1:output:IgniteDPS} {2:output:IgniteDuration}s",
 	flag = "ignite",
-	{ label = "Max Ignite Stacks", flag = "igniteCanStack", { format = "{1:output:IgniteStacksMax}", { modName = "IgniteStacks" }, }, },
+	{ label = "Max Ignite Stacks", { format = "{1:output:IgniteStacksMax}", { modName = "IgniteStacks" }, }, },
 	{ label = "Stack Potential", { format = "{2:output:IgniteStackPotential}", { breakdown = "IgniteStackPotential" } }},
 	{ label = "Average Ignite Roll", { format = "{2:output:IgniteRollAverage}%", { breakdown = "IgniteRollAverage" } }},
 	{ label = "Chance to Ignite", { format = "{0:output:IgniteChancePerHit}%", 


### PR DESCRIPTION
Fixes #7592.

### Description of the problem being solved:
POB adds a lines that display the "Max Ignite Stacks" in the Ignite Widget when the number of max stacks is above 2 and it removes the informational line when the number of stacks max is 1.

### Steps taken to verify a working solution:
- Equip "Emberwake, Ruby ring"
- Check the Ignite Widget in the Calcs tab
- Remove "Emberwake, Ruby ring"
- Check the Ignite Widget in the Calcs tab
### Link to a build that showcases this PR:
```
https://pobb.in/uUpXDOsGJPe4
```
### Before screenshot:
![image](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/36129181/33b3091b-3aeb-4a40-9675-20e20d55c8a4)

### After screenshot:
![image](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/36129181/ba3ff756-e4c1-4edb-8c01-1b3f40304465)