### PR TITLE
Fix spellsinger triggered skill trigger rate not being capped by spellslinger cooldown

### DIFF
--- a/src/Modules/CalcTriggers.lua
+++ b/src/Modules/CalcTriggers.lua
@@ -1081,12 +1081,21 @@ local configTable = {
 		return {triggerChance =  env.player.mainSkill.skillData.chanceToTriggerOnStun,
 				source = env.player.mainSkill}
 	end,
-	["spellslinger"] = function()
-		return {triggerName = "Spellslinger",
+	["spellslinger"] = function(env)
+		if env.player.mainSkill.activeEffect.grantedEffect.name == "Spellslinger" then
+			return {triggerName = "Spellslinger",
 				triggerOnUse = true,
 				triggerSkillCond = function(env, skill)
 					local isWandAttack = (not skill.weaponTypes or (skill.weaponTypes and skill.weaponTypes["Wand"])) and skill.skillTypes[SkillType.Attack]
 					return isWandAttack and not skill.skillData.triggeredBySpellSlinger
+				end}
+		end
+		env.player.mainSkill.skillData.sourceRateIsFinal = true
+		env.player.mainSkill.skillData.ignoresTickRate = true
+		return {triggerOnUse = true,
+				useCastRate = true,
+				triggerSkillCond = function(env, skill)
+					return skill.activeEffect.grantedEffect.name == "Spellslinger"
 				end}
 	end,
 	["mark on hit"] = function()

--- a/src/Modules/CalcTriggers.lua
+++ b/src/Modules/CalcTriggers.lua
@@ -1091,7 +1091,6 @@ local configTable = {
 				end}
 		end
 		env.player.mainSkill.skillData.sourceRateIsFinal = true
-		env.player.mainSkill.skillData.ignoresTickRate = true
 		return {triggerOnUse = true,
 				useCastRate = true,
 				triggerSkillCond = function(env, skill)


### PR DESCRIPTION
### Description of the problem being solved:
Currently skills triggered by spellslinger only considered the cooldown imposed on them by spell slinger in addition to their own but not the cooldown of the main skill gem. This works fine as as long as the cooldown of the main effect is equal to the cooldown of the support effect as they both will go off at the same time. Problem is there currently exist conditional cooldown recovery mods which could affect only one of the cooldowns making this assumption no longer hold. This pr basically extends the logic from https://github.com/PathOfBuildingCommunity/PathOfBuilding/pull/7558 to solve the issue effectively taking a max of the cooldown of the main gem and the effective cooldown of the triggered skill while taking the correct cooldown recovery mods into consideration.
### Steps taken to verify a working solution:
- Tested a few builds from poe.ninja

### Link to a build that showcases this PR:

```
eNq9G2tv4kjy8_ArLKSV7rSX8CYPJbsir0l0YcJBZubu06ixG-hN283a7STsav_7VXXbxhDa2Nh3iZQYd72rurqqbC5-fXe59Ur9gAnvst46btYt6tnCYd78sv71-e7otP7rL7WLEZGLp9lVyDiu_FL7dKGuLU5fKQe8uiWJP6fyW0yp8wMoLYknF1R4Q_Kb8D8L57L-RXi0bk2J5zAZf7I5CYIvxKWX9YkNyHWLBDb1nOv1_QhwQXxiS-o_ItdBKMVQOLAq_RBWXcK8ibBfqPzsi3CphHpl9E3DPAxHT-PnlEjMS4sEGn26GHGyov5EEmkF8OeyPgDDkDm9IS78BWqEh0Dq5PS40ztrdtutbr_fOqs3MpGvQj-Qh1GYLCl1EqTWcb9rghz59HY2o7Zkr_TaZ_J6QTx7ze_0uGdE3Qne7XX7WQjDkEu25Iz6KfFOTkwo9x9YnBmVfhaS8JvRZE24DeI3T0_bZ6120yyWxhMywWuaIL8zubjiYNoDuCDuw9xjkh6IPBIsEF4J_dKoRhWvQ85hn-aCHdOA-q9Esk2xzLSFO2XeQdYb-JQ8zXSkjonDwmBIpU-DVBAZ43RIPHItgrV_W_0s0BH1IYfIDYzmHoQJtQWknTRKu3_c7ubgsxvbyPCRzWh-yEK6RAhFpTlMj9tJXrjChA8TaAxpNh_kRIQ8J6RcZ7m2EeqGvueAevBkDqgx_T0N2Do9NXN9FVKdmfu0UPnj9n6UQPbOjlutTqfZ7J61-62W8WhZrAJmEz4k78wNXUjlz-SFrhn2M8JqvpAepCETaseo1h3zaXGsa8GdA7AWRATF0YZQbtxDHTOw7RCqklWC0s3cZznsBse-fY6wD56db_N-9XyVxFPVQj8TYQxbCsuTKac5MdYsoo25js7mHlZz6kX8VvnUeaTUXnwG-46JpPmy9zqqs82KsLnMioA7zNo5yYewbaSTzEPEYKPjsyykgla69ag_X00WjHKnGHQs2DVZ5kiWaOU0di5rb7IrFDBp1IIm-U58J9-RUlSmVxKkk7K5VNHm0uD54pJC5QoIDt2qqJvm3kD8hp0BL4Y28F0R-jkdroFzKRCfJ7olGlMntPMdYFccmru80oNUnBfCGEhJ7Jcb4cxpISaFMJImTaFOwuUSEgb6Pi8BPBihYGepuuWonwP6CQI31_7FMzQ_gzV0bgZJVZCfyxZKfl3wZC-gzBo8N4vEoUNIDS5kfNWzD0WqbTc6B3q0XA2XAszZ-I3EG0i-wFlMUAwaKqD1KWcUxafeH6vc9DfAczG49RyopmAr5OaxjbGLzTNzIW0GwQ2RxHKikvkb8RnxZFsNigJKfHvxCK6_I5xPIRNc1tN31Sc1XLpjXFL_Bu4hUxRsm2IrdvpFQw3J8OrBXQpfWvQd_42IL1eX9RnhAdWA6g7QCSTzVCcO-YjzujVZiLeB84qcnoXgQYxkkeWSes4GjWefUovE2cVGIZTy-MFySQBSr3S4BqhNasb24Cg1PAECQAV1etrpoO7YdRF_NdgE9BjIBU07TY36oEXWUzxNCdl-uvg6flQXnxZSLoPzRuPt7e14SeRCzOg7nEbHtnAbS0ACgY-CF8b5EZJtDODnaj5QP4pQI6Z0ocd7QUN_wk3qM5BZO7mBiiqroyXw4ouQNMA1vBl_uJggqwC86cvP1A2uVrCx7rB62BptRKZE6AmVOkrSOPHc0aEzEnK8_6-QcIaebabvPuoRqSd8N-migBR4FvO_pvi8WqLpB4-PemXAZUQM2cVu1u6MBLKYE7s4uqkmoIO11NeE24GSm3k2Dx3oJ6Kck4QRJ1OUDWe-2As46VlqilLC6NMFyBMBf-ZiSng7RlEexDhes42Gw9DnWnPqYmwMqSQObMLGgwS9GqhcQ3GAq3-C5SWzryCOVLpWewmRNhcUH7x9zUOMaTVfrVu_p2yfiKKkiFYQ5UY7pb6hQSvWYMsGtgg9TcEjbrSlIlEsLUsUh1qD_Y5o_38cUczqqhAJcFioZ7mJ1TcXEqtv3k5bvUo7b3BpVKvxnS8CeQU7fUPd1N1E19S9_5WiioWleHyIpugS9rrKajpv4aWKJwXx4C1Dqchd1l0W2D-m4WyGDzxAC-mrZzi3d3e3188P326jszCNojT94YXuFJ2p_2OcasgJVZW5FYTTQF9e1r8x-qYEuQELMx6gVpyTZUCTw0glpkhyDngZ1BTUPUsej-ymtQYwU7p9pz6cnXNo6WyfUaNcyfoeoTRDbPewdjBRw8cNZkK6o7iGTKHbUYOl1EMeMxV83GJUBxczcKHqINzIOVrdYwmJRxPEKpsxG8uubJfjQaahMuySTMyM_o7aITMN9fzGREAvmpH1MxgTdrSaYVX1_MdoVb1qRr-hNjHqrhfNyMmEQ3hgJhOVBCqD0hfhqSCHTTNgHFsXo2dvOU1AzASf5IL6UYFpojSEHBWDZG4cn01Dad7GKYgMW6lxq8FCuGZG1SNFgw64lpGJNuZsBoOmYcyk9HzKmMiyUHUba7Rf1BRnuCCa_hjMr1czjBAPwAz6R8sZm0Tl38GrYI4ejBi2yxZYVsKA3qE8GTXtKU9me_xTnuIdVKQvRn9Hq2b0r5JhTbODiq5dchHBTVWOAu6tchTG24XEGnecXUIkE4edyPFq1saPBhEHU9DjkoPR1TTnYGyVvqGepaBBZv5OYDLCW4beDRhDZoR2TlJKrN15YK1dIVr6JNupaWGKen9GjwyztrAG2UMIjuL7jGIvH6VkInlPCcf3TQQvR_DDo9FSegoZEM-5wecpJRXFxzHhEojFkj3tqtbXLt2metGI-yg1OsPOJhr4TaSPrfgfQrj_UR0fXkVjnE40uoEa94aBqX0VIjEfBPx3PKy8UM1nNEfC63iMFAZUv9PwnZKl8NTt1IQHQdPTnTF0qXJ1bo0H49sa1GIYvoRb30H12oM7Damjr699MpPUObdQltrIpzP2fm79CTlpTs-bx72_NLuEgjbIk6dvB90EBd-I2_wwgbZyi9ijsAl_8GyfEjC07nVUL9M2QmO3go9-wL7sJXpm0tkLvX7XrFuLhmLnVrtZi4aB59bVEfzWlH_G9Pdzq3cGZgEEm-Fqq_anJPPg3FYT0B-OUvof0T99868U6791Okedk7__hKMarZqlDmtLW6t2ll7RWltK7Vq7nV6Kpbe0spbWtvZz--QnSwpLTwo-QK11rXWbaXJrt2s5rDcmFwl_NRlQ0wPo_ceoi6U0wmfIvXoUS9F8wQjR3gvR2QvR3QvRi3a0mswk4Y7zTPOu2Bx1ciEt6LDc0fTr-BH3qZ5laCwLp51SD4ESlU0oV5RLazBdBQF6QIWT1V7jN_fhxyy3afSK02hXQKNlTd7IcptQvwKF-hUoVITGlYBjYptApwCBewqH_AfftoqIsCM2DjLDLp_0KvBJqwIa3YIGqSomq9hkRWiorqGQ1XdGYLtk_HQKi1zEQXCkvNKgTJjs3jX9whQKq9kqrWYR3w7ckFNZQQh2KkiLndKqdwubu0gcj6EpOWS_6sRXWLmyW7RX2Bjlj5V2aQrlZeiWNVy3qtzeKSSJs7L0MLH6vNWr6rRuVaNRu6yLCldQpVNLvxrNe6UF6RTNWK2yxm5VkNsr21O9avzQL1m_lK9GylZQFW3FTlWpoTJCh7QWh9miqpisyBUH75GSkVTZ6dCuIFFUQaNVlUKVZa2PhPTUR7_QglNX4tCJmrh-p_iKb6DHsmpsqt5zEd6MzePXPm26ENyhfsSaetRdRd-Qjd9cOUl_FWUXfPrLrjFSLxtl8331FK_9nLZROnuki16JF5yr2VlaLyOim0wM8dul1KfORL11gu8aTSifrYm09igap4cEvp0NnzzjjRH6ZpMEbM7400w9oQL51GO2hE88jY-8fdHY_rL5fwE9FQ33
```
