### PR TITLE
Fix Tree Management Keyboard Shortcut #7406

### DIFF
--- a/help.txt
+++ b/help.txt
@@ -57,7 +57,7 @@ PgUp/PgDn/MWheel	Zoom in / out (hold with shift to increase the amount of zoom x
 Ctrl + LMB	Zoom in on mouse cursor position
 Hold Shift	Enable "path trace mode" 
 	(highlighted nodes will stay highlighted, and will be allocated when a node is clicked on the tree)
-
+Up/Down arrow	Select previous/next tree respectively
 Developer Use
 
 General Shortcuts:

--- a/help.txt
+++ b/help.txt
@@ -58,6 +58,7 @@ Ctrl + LMB	Zoom in on mouse cursor position
 Hold Shift	Enable "path trace mode" 
 	(highlighted nodes will stay highlighted, and will be allocated when a node is clicked on the tree)
 Up/Down arrow	Select previous/next tree respectively
+
 Developer Use
 
 General Shortcuts:

--- a/src/Classes/TreeTab.lua
+++ b/src/Classes/TreeTab.lua
@@ -258,6 +258,18 @@ function TreeTabClass:Draw(viewPort, inputEvents)
 				self.build.spec:Redo()
 				self.build.buildFlag = true
 				inputEvents[id] = nil
+			elseif event.key == "UP" then
+				index = self.activeSpec - 1
+				if self.specList[index] then
+					self.build.modFlag = true
+					self:SetActiveSpec(index)
+				end
+			elseif event.key == "DOWN" then
+				index = self.activeSpec + 1
+				if self.specList[index] then
+					self.build.modFlag = true
+					self:SetActiveSpec(index)
+				end
 			elseif event.key == "f" and IsKeyDown("CTRL") then
 				self:SelectControl(self.controls.treeSearch)
 			elseif event.key == "m" and IsKeyDown("CTRL") then


### PR DESCRIPTION
Fixes #7406.

### Description of the problem being solved:
Pressing Up or Down arrow keys on my keyboard moves through the Tree Management.