### PR TITLE
Fix Abyss jewels not working in weapon swap

### DIFF
--- a/src/Modules/CalcSetup.lua
+++ b/src/Modules/CalcSetup.lua
@@ -647,7 +647,7 @@ function calcs.initEnv(build, mode, override, specEnv)
 			elseif override.repItem and override.repSlotName:match("^Weapon 1") and slotName:match("^Weapon 2") and
 			(override.repItem.base.type == "Staff" or override.repItem.base.type == "Two Handed Sword" or override.repItem.base.type == "Two Handed Axe" or override.repItem.base.type == "Two Handed Mace"
 			or (override.repItem.base.type == "Bow" and item and item.base.type ~= "Quiver")) then
-				item = nil
+				goto continue
 			elseif slot.nodeId and override.spec then
 				item = build.itemsTab.items[env.spec.jewels[slot.nodeId]]
 			else
@@ -668,7 +668,7 @@ function calcs.initEnv(build, mode, override, specEnv)
 				t_insert(env.explodeSources, item)
 			end
 			if slot.weaponSet and slot.weaponSet ~= (build.itemsTab.activeItemSet.useSecondWeaponSet and 2 or 1) then
-				item = nil
+				goto continue
 			end
 			if slot.weaponSet == 2 and build.itemsTab.activeItemSet.useSecondWeaponSet then
 				slotName = slotName:gsub(" Swap","")
@@ -676,7 +676,7 @@ function calcs.initEnv(build, mode, override, specEnv)
 			if slot.nodeId then
 				-- Slot is a jewel socket, check if socket is allocated
 				if not env.allocNodes[slot.nodeId] then
-					item = nil
+					goto continue
 				elseif item then
 					if item.jewelData then
 						item.jewelData.limitDisabled = nil
@@ -692,7 +692,7 @@ function calcs.initEnv(build, mode, override, specEnv)
 							end
 							env.itemWarnings.jewelLimitWarning = env.itemWarnings.jewelLimitWarning or { }
 							t_insert(env.itemWarnings.jewelLimitWarning, limitKey)
-							item = nil
+							goto continue
 						else
 							jewelLimits[limitKey] = (jewelLimits[limitKey] or 0) + 1
 						end
@@ -758,6 +758,7 @@ function calcs.initEnv(build, mode, override, specEnv)
 				end
 			end
 			items[slotName] = item
+			::continue::
 		end
 
 		if not env.configInput.ignoreItemDisablers then


### PR DESCRIPTION
Fixes #7644

### Description of the problem being solved:
When using `weaponSet` 2 some items with `slotName`s containing swap would get clobbered depending on order in `build.itemsTab.orderedSlots`.

https://github.com/PathOfBuildingCommunity/PathOfBuilding/blob/ad60a7a1a3d50ea88c0ba20394a0c618a3fc58af/src/Modules/CalcSetup.lua#L670-L675

If the correct item was added it had the swap stripped. When the non swap counterpart is iterated over item is set to nil which is later assigned to the map with effectively the same key as the existing element removing it from the table.

Additionally this pr uses goto to skip iterations where item is explicitly set to nil. I can't think of any other cases where this change could affect things other than the issue being solved.

### Steps taken to verify a working solution:
- Test build from issue

### Link to a build that showcases this PR:
```
https://pobb.in/QH3ki1iuOi4L
```

### Before screenshot:
![obraz](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/91493239/8c60163a-2aea-44c4-b0b8-958818d543ec)
![obraz](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/91493239/93180842-d211-4d53-ae27-0fff9b2196fa)

### After screenshot:
![obraz](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/91493239/1be48ccf-8b08-4883-8cbb-799ae3bebc71)

![obraz](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/91493239/8a1f2147-8717-4342-ba51-fd83a45c7732)
