### PR TITLE
fix pathing behavior for nodes affected by intuitive leap-like mechanics

### DIFF
--- a/src/Classes/PassiveTreeView.lua
+++ b/src/Classes/PassiveTreeView.lua
@@ -252,7 +252,7 @@ function PassiveTreeViewClass:Draw(build, viewPort, inputEvents)
 	elseif hoverNode and hoverNode.path then
 		-- Use the node's own path and dependence list
 		hoverPath = { }
-		if not hoverNode.dependsOnIntuitiveLeapLike then
+		if not hoverNode.affectedByIntuitiveLeapLike then
 			for _, pathNode in pairs(hoverNode.path) do
 				hoverPath[pathNode] = true
 			end
@@ -1062,7 +1062,7 @@ function PassiveTreeViewClass:AddNodeTooltip(tooltip, node, build)
 		elseif node.alloc then
 			-- Calculate the differences caused by deallocating this node and its dependent nodes
 			nodeOutput = calcFunc({ removeNodes = { [node] = true } })
-			if not node.dependsOnIntuitiveLeapLike and pathLength > 1 then
+			if not node.affectedByIntuitiveLeapLike and pathLength > 1 then
 				pathOutput = calcFunc({ removeNodes = pathNodes })
 			end
 		elseif isGranted then
@@ -1076,19 +1076,19 @@ function PassiveTreeViewClass:AddNodeTooltip(tooltip, node, build)
 			else
 				nodeOutput = calcFunc({ addNodes = { [node] = true } })
 			end
-			if not node.dependsOnIntuitiveLeapLike and pathLength > 1 then
+			if not node.affectedByIntuitiveLeapLike and pathLength > 1 then
 				pathOutput = calcFunc({ addNodes = pathNodes })
 			end
 		end
 		local count = build:AddStatComparesToTooltip(tooltip, calcBase, nodeOutput, realloc and "^7Reallocating this node will give you:" or node.alloc and "^7Unallocating this node will give you:" or isGranted and "^7This node is granted by an item. Removing it will give you:" or "^7Allocating this node will give you:")
-		if not node.dependsOnIntuitiveLeapLike and pathLength > 1 and not isGranted then
+		if not node.affectedByIntuitiveLeapLike and pathLength > 1 and not isGranted then
 			count = count + build:AddStatComparesToTooltip(tooltip, calcBase, pathOutput, node.alloc and "^7Unallocating this node and all nodes depending on it will give you:" or "^7Allocating this node and all nodes leading to it will give you:", pathLength)
 		end
 		if count == 0 then
 			if isGranted then
 				tooltip:AddLine(14, string.format("^7This node is granted by an item. Removing it will cause no changes"))
 			else
-				tooltip:AddLine(14, string.format("^7No changes from %s this node%s.", node.alloc and "unallocating" or "allocating", not node.dependsOnIntuitiveLeapLike and pathLength > 1 and " or the nodes leading to it" or ""))
+				tooltip:AddLine(14, string.format("^7No changes from %s this node%s.", node.alloc and "unallocating" or "allocating", not node.affectedByIntuitiveLeapLike and pathLength > 1 and " or the nodes leading to it" or ""))
 			end
 		end
 		tooltip:AddLine(14, colorCodes.TIP.."Tip: Press Ctrl+D to disable the display of stat differences.")
@@ -1104,7 +1104,7 @@ function PassiveTreeViewClass:AddNodeTooltip(tooltip, node, build)
 			tooltip:AddLine(14, "^7"..#self.tracePath .. " nodes in trace path")
 			tooltip:AddLine(14, colorCodes.TIP)
 		else
-			tooltip:AddLine(14, "^7"..#node.path .. " points to node" .. (node.dependsOnIntuitiveLeapLike and " ^8(Can be allocated without pathing to it)" or ""))
+			tooltip:AddLine(14, "^7"..node.pathDist .. " points to node" .. (node.affectedByIntuitiveLeapLike and " ^8(Can be allocated without pathing to it)" or ""))
 			tooltip:AddLine(14, colorCodes.TIP)
 			if #node.path > 1 then
 				-- Handy hint!


### PR DESCRIPTION
Fixes #7642

### Description of the problem being solved:
Restrictions on pathing around nodes affected by Intuitive Leap-like mechanics was too strict and didn't account for cases where the node was also connected to the tree. Additionally, fixes path distance calculations for paths going through nodes that are allocated but not connected. 

### Steps taken to verify a working solution:
- Verified scenario showcased in issue correctly finds the shortest path
- Verified path distance displays correctly when pathing through `affectedByIntuitiveLeapLike` nodes

### Link to a build that showcases this PR:
https://pobb.in/LBRXZb7F14NJ

### Before screenshot:
![image](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/19672127/3d483e97-437e-44a5-a795-c06d5cb7ed3f)

### After screenshot:
![image](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/19672127/9c29d5b1-08b8-46d3-a2a0-8e5e4d04cf88)


