### PR TITLE
Allow children of PopupDialogs to process input events first

### DIFF
--- a/src/Classes/PopupDialog.lua
+++ b/src/Classes/PopupDialog.lua
@@ -60,6 +60,7 @@ function PopupDialogClass:Draw(viewPort)
 end
 
 function PopupDialogClass:ProcessInput(inputEvents, viewPort)
+	self:ProcessControlsInput(inputEvents, viewPort)
 	for id, event in ipairs(inputEvents) do
 		if event.type == "KeyDown" then
 			if event.key == "ESCAPE" then
@@ -83,5 +84,4 @@ function PopupDialogClass:ProcessInput(inputEvents, viewPort)
 			end
 		end
 	end
-	self:ProcessControlsInput(inputEvents, viewPort)
 end


### PR DESCRIPTION
Fixes #7635

### Description of the problem being solved:
Input events are handled by `PopupDialog` before being passed to its child controls, allowing an input to be handled twice. Now allows child controls to handle/consume events first. 
 
### Steps taken to verify a working solution:
- Using a build with at least 7 sockets, open the item trader dialog and scroll while hovering a dropdown. The dropdown should scroll without the item slot view scrolling. 

### Link to a build that showcases this PR:
https://pobb.in/ZCKPLQT3VO6d

