### PR TITLE
Fix Curtain Call PoB description does not match with in-game.

### DIFF
--- a/src/Data/Uniques/helmet.lua
+++ b/src/Data/Uniques/helmet.lua
@@ -1253,8 +1253,8 @@ Requires Level 20
 +23 to maximum Life
 (15-10)% reduced Mine Throwing Speed
 Mines have (40-50)% increased Detonation Speed
-Skills which Place Mines place up to 1 additional Mine if you have at least 800 Dexterity
-Skills which Place Mines place up to 1 additional Mine if you have at least 800 Intelligence
+Skills which throw Mines throw up to 1 additional Mine if you have at least 800 Dexterity
+Skills which throw Mines throw up to 1 additional Mine if you have at least 800 Intelligence
 ]],[[
 Eye of Malice
 Callous Mask


### PR DESCRIPTION
Fixes #7658.

### Description of the problem being solved:
Curtain Call PoB description does not match with in-game.
### Steps taken to verify a working solution:
- Check the item desctiption

### Before screenshot:
![image](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/36129181/d57ad01c-d80f-49d4-afda-155e8fc8bb74)

### After screenshot:
![image](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/36129181/f38bbc70-cce1-45d3-8a07-dd27978ff90a)
