### PR TITLE
Fixes the GGPK export of ChainHook Enchantment description

### DIFF
--- a/src/Export/statdesc.lua
+++ b/src/Export/statdesc.lua
@@ -274,6 +274,8 @@ function describeStats(stats)
 					return string.format("(%"..v.fmt.."-%"..v.fmt..")", v.min, v.max)
 				end
 			end):gsub("{(%d?):(%+?)d?}", function(n, fmt)
+				-- Most forms are {0:1}, however Chain Hook enchantment is {0:}
+				-- the above pattern supports both cases.
 				n = n ~= "" and n or "0"
 				local v = val[tonumber(n)+1]
 				if v.min == v.max then

--- a/src/Export/statdesc.lua
+++ b/src/Export/statdesc.lua
@@ -273,7 +273,7 @@ function describeStats(stats)
 				else
 					return string.format("(%"..v.fmt.."-%"..v.fmt..")", v.min, v.max)
 				end
-			end):gsub("{(%d?):(%+?)d}", function(n, fmt)
+			end):gsub("{(%d?):(%+?)d?}", function(n, fmt)
 				n = n ~= "" and n or "0"
 				local v = val[tonumber(n)+1]
 				if v.min == v.max then


### PR DESCRIPTION
Eliminates the need for manually fixing the `Chain Hook` endgame enhancement that GGG has as `{0:+}` whereas we assumed there would always be a second digit post the `:`.

Export Before:
`"Chain Hook has {0:+} metres to radius per 12 Rage",`

Export After:
`"Chain Hook has +0.1 metres to radius per 12 Rage",`