### PR TITLE
Add platform dropdown option to issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/accuracy_bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/accuracy_bug_report.yaml
@@ -29,7 +29,7 @@ body:
         - Native
         - Wine
         - pobfrontend
-      default: 1
+      default: 0
     validations:
       required: true
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/accuracy_bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/accuracy_bug_report.yaml
@@ -21,6 +21,17 @@ body:
       options:
         - label: I've checked for duplicate open **and closed** issues by using the search function of the [issue tracker](https://github.com/PathOfBuildingCommunity/PathOfBuilding/issues?q=is%3Aissue)
           required: true
+  - type: dropdown
+    id: platform
+    attributes:
+      label: What platform are you running Path of Building on?
+      options: 
+        - Native
+        - Wine
+        - pobfrontend
+      default: 1
+    validations:
+      required: true
   - type: textarea
     id: expected
     attributes:

--- a/.github/ISSUE_TEMPLATE/accuracy_bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/accuracy_bug_report.yaml
@@ -27,7 +27,8 @@ body:
       label: What platform are you running Path of Building on?
       options: 
         - Windows
-        - Linux
+        - Linux - Wine
+        - Linux - PoB Frontend
         - MacOS
       default: 0
     validations:

--- a/.github/ISSUE_TEMPLATE/accuracy_bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/accuracy_bug_report.yaml
@@ -26,9 +26,9 @@ body:
     attributes:
       label: What platform are you running Path of Building on?
       options: 
-        - Native
-        - Wine
-        - pobfrontend
+        - Windows
+        - Linux
+        - MacOS
       default: 0
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/application_bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/application_bug_report.yaml
@@ -27,7 +27,8 @@ body:
       label: What platform are you running Path of Building on?
       options: 
         - Windows
-        - Linux
+        - Linux - Wine
+        - Linux - PoB Frontend
         - MacOS
       default: 0
     validations:

--- a/.github/ISSUE_TEMPLATE/application_bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/application_bug_report.yaml
@@ -21,6 +21,17 @@ body:
       options:
         - label: I've checked for duplicate open **and closed** issues by using the search function of the [issue tracker](https://github.com/PathOfBuildingCommunity/PathOfBuilding/issues?q=is%3Aissue)
           required: true
+  - type: dropdown
+    id: platform
+    attributes:
+      label: What platform are you running Path of Building on?
+      options: 
+        - Native
+        - Wine
+        - pobfrontend
+      default: 0
+    validations:
+      required: true
   - type: textarea
     id: expected
     attributes:

--- a/.github/ISSUE_TEMPLATE/application_bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/application_bug_report.yaml
@@ -26,9 +26,9 @@ body:
     attributes:
       label: What platform are you running Path of Building on?
       options: 
-        - Native
-        - Wine
-        - pobfrontend
+        - Windows
+        - Linux
+        - MacOS
       default: 0
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/behaviour_bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/behaviour_bug_report.yaml
@@ -33,9 +33,9 @@ body:
     attributes:
       label: What platform are you running Path of Building on?
       options: 
-        - Native
-        - Wine
-        - pobfrontend
+        - Windows
+        - Linux
+        - MacOS
       default: 0
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/behaviour_bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/behaviour_bug_report.yaml
@@ -28,6 +28,17 @@ body:
       options: 
         - label: I've checked that the behaviour is supposed to be supported. If it isn't please open a feature request instead (Red text is a feature request).
           required: true
+  - type: dropdown
+    id: platform
+    attributes:
+      label: What platform are you running Path of Building on?
+      options: 
+        - Native
+        - Wine
+        - pobfrontend
+      default: 0
+    validations:
+      required: true
   - type: textarea
     id: expected
     attributes:

--- a/.github/ISSUE_TEMPLATE/behaviour_bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/behaviour_bug_report.yaml
@@ -34,7 +34,8 @@ body:
       label: What platform are you running Path of Building on?
       options: 
         - Windows
-        - Linux
+        - Linux - Wine
+        - Linux - PoB Frontend
         - MacOS
       default: 0
     validations:

--- a/.github/ISSUE_TEMPLATE/calculation_bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/calculation_bug_report.yaml
@@ -33,9 +33,9 @@ body:
     attributes:
       label: What platform are you running Path of Building on?
       options: 
-        - Native
-        - Wine
-        - pobfrontend
+        - Windows
+        - Linux
+        - MacOS
       default: 0
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/calculation_bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/calculation_bug_report.yaml
@@ -28,6 +28,17 @@ body:
       options:
         - label: I've checked that the calculation is supposed to be supported. If it isn't please open a feature request instead (Red text is a feature request).
           required: true
+  - type: dropdown
+    id: platform
+    attributes:
+      label: What platform are you running Path of Building on?
+      options: 
+        - Native
+        - Wine
+        - pobfrontend
+      default: 0
+    validations:
+      required: true
   - type: textarea
     id: expected
     attributes:

--- a/.github/ISSUE_TEMPLATE/calculation_bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/calculation_bug_report.yaml
@@ -34,7 +34,8 @@ body:
       label: What platform are you running Path of Building on?
       options: 
         - Windows
-        - Linux
+        - Linux - Wine
+        - Linux - PoB Frontend
         - MacOS
       default: 0
     validations:

--- a/.github/ISSUE_TEMPLATE/crash_report.yaml
+++ b/.github/ISSUE_TEMPLATE/crash_report.yaml
@@ -27,7 +27,8 @@ body:
       label: What platform are you running Path of Building on?
       options: 
         - Windows
-        - Linux
+        - Linux - Wine
+        - Linux - PoB Frontend
         - MacOS
       default: 0
     validations:

--- a/.github/ISSUE_TEMPLATE/crash_report.yaml
+++ b/.github/ISSUE_TEMPLATE/crash_report.yaml
@@ -21,6 +21,17 @@ body:
       options:
         - label: I've checked for duplicate open **and closed** issues by using the search function of the [issue tracker](https://github.com/PathOfBuildingCommunity/PathOfBuilding/issues?q=is%3Aissue)
           required: true
+  - type: dropdown
+    id: platform
+    attributes:
+      label: What platform are you running Path of Building on?
+      options: 
+        - Native
+        - Wine
+        - pobfrontend
+      default: 0
+    validations:
+      required: true
   - type: textarea
     id: context
     attributes:

--- a/.github/ISSUE_TEMPLATE/crash_report.yaml
+++ b/.github/ISSUE_TEMPLATE/crash_report.yaml
@@ -26,9 +26,9 @@ body:
     attributes:
       label: What platform are you running Path of Building on?
       options: 
-        - Native
-        - Wine
-        - pobfrontend
+        - Windows
+        - Linux
+        - MacOS
       default: 0
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yaml
@@ -20,7 +20,8 @@ body:
       label: What platform are you running Path of Building on?
       options: 
         - Windows
-        - Linux
+        - Linux - Wine
+        - Linux - PoB Frontend
         - MacOS
       default: 0
     validations:

--- a/.github/ISSUE_TEMPLATE/feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yaml
@@ -19,9 +19,9 @@ body:
     attributes:
       label: What platform are you running Path of Building on?
       options: 
-        - Native
-        - Wine
-        - pobfrontend
+        - Windows
+        - Linux
+        - MacOS
       default: 0
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yaml
@@ -14,6 +14,17 @@ body:
       options:
         - label: I've checked for duplicate open **and closed** issues by using the search function of the [issue tracker](https://github.com/PathOfBuildingCommunity/PathOfBuilding/issues?q=is%3Aissue)
           required: true
+  - type: dropdown
+    id: platform
+    attributes:
+      label: What platform are you running Path of Building on?
+      options: 
+        - Native
+        - Wine
+        - pobfrontend
+      default: 0
+    validations:
+      required: true
   - type: textarea
     id: problem
     attributes:


### PR DESCRIPTION
Per discussion on discord about reported issues without platform/package disclaimer, adding a dropdown option in the issues templates so users can select the platform that they're using. Defaults to windows as that appears to be the majority of the user base. 

![image](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/42928828/bea7029d-9297-4828-947e-c97ffcddbd05)