### PR TITLE
Add support for unholy might on block staff mastery

### DIFF
--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -3609,6 +3609,7 @@ local specialModList = {
 	["curses are inflicted on you instead of linked targets"] = { mod("ExtraLinkEffect", "LIST", { mod = flag("CurseImmune"), }), },
 	["elemental ailments are inflicted on you instead of linked targets"] = { mod("ExtraLinkEffect", "LIST", { mod = flag("ElementalAilmentImmune") }) },
 	["non%-unique utility flasks you use apply to linked targets"] = { mod("ExtraLinkEffect", "LIST", { mod = mod("ParentNonUniqueFlasksAppliedToYou", "FLAG", true, { type = "GlobalEffect", effectType = "Global", unscalable = true } ), }) },
+	["gain unholy might on block for (%d) seconds"] = { flag("Condition:UnholyMight", { type = "Condition", var = "BlockedRecently"}), flag("Condition:CanWither", { type = "Condition", var = "BlockedRecently"}), },
 	-- Traps, Mines and Totems
 	["traps and mines deal (%d+)%-(%d+) additional physical damage"] = function(_, min, max) return { mod("PhysicalMin", "BASE", tonumber(min), nil, 0, bor(KeywordFlag.Trap, KeywordFlag.Mine)), mod("PhysicalMax", "BASE", tonumber(max), nil, 0, bor(KeywordFlag.Trap, KeywordFlag.Mine)) } end,
 	["traps and mines deal (%d+) to (%d+) additional physical damage"] = function(_, min, max) return { mod("PhysicalMin", "BASE", tonumber(min), nil, 0, bor(KeywordFlag.Trap, KeywordFlag.Mine)), mod("PhysicalMax", "BASE", tonumber(max), nil, 0, bor(KeywordFlag.Trap, KeywordFlag.Mine)) } end,


### PR DESCRIPTION
### Description of the problem being solved:
Adds support for the "Gain unholy might on block for 3 seconds" staff mastery.

### Steps taken to verify a working solution:
1. Spec the mastery
2. Equip a skill that does physical damage
3. In the config enable "Have you blocked recently?"
4. DPS should increase and the wither config line should appear.

### Link to a build that showcases this PR:
https://pobb.in/O0-W82zpKG5V

### Before screenshot:
![image](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/28728694/d690e277-2604-4e6b-9852-91a4f2ea0a05)

### After screenshot:
![image](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/28728694/8a13d4eb-e855-4abb-96c7-ce1b1fbd187f)
