### PR TITLE
Add support for Impale avoidance in calcs tab

### DIFF
--- a/src/Modules/CalcDefence.lua
+++ b/src/Modules/CalcDefence.lua
@@ -1288,6 +1288,7 @@ function calcs.defence(env, actor)
 	output.AvoidAllDamageFromHitsChance = m_min(modDB:Sum("BASE", nil, "AvoidAllDamageFromHitsChance"), data.misc.AvoidChanceCap)
 	-- other avoidances etc
 	output.BlindAvoidChance = m_min(modDB:Sum("BASE", nil, "AvoidBlind"), 100)
+	output.ImpaleAvoidChance = m_min(modDB:Sum("BASE", nil, "AvoidImpale"), 100)
 
 	if modDB:Flag(nil, "SpellSuppressionAppliesToAilmentAvoidance") then
 		local spellSuppressionToAilmentPercent = (modDB:Sum("BASE", nil, "SpellSuppressionAppliesToAilmentAvoidancePercent") or 0) / 100

--- a/src/Modules/CalcSections.lua
+++ b/src/Modules/CalcSections.lua
@@ -1698,6 +1698,7 @@ return {
 	{ label = "Scorch Avoid Ch.", haveOutput = "ScorchAvoidChance", { format = "{0:output:ScorchAvoidChance}%", { modName = { "AvoidScorch", "AvoidElementalAilments", "AvoidAilments", "AvoidShockAppliesToElementalAilments", "ScorchImmune", "ElementalAilmentImmune" } }, }, },
 	{ label = "Bleed Avoid Ch.", haveOutput = "BleedAvoidChance", { format = "{0:output:BleedAvoidChance}%", { modName = { "AvoidBleed", "AvoidAilments", "BleedImmune" } }, }, },
 	{ label = "Poison Avoid Ch.", haveOutput = "PoisonAvoidChance", { format = "{0:output:PoisonAvoidChance}%", { modName = { "AvoidPoison", "AvoidAilments", "PoisonImmune" } }, }, },
+	{ label = "Impale Avoid Ch.", haveOutput = "ImpaleAvoidChance", { format = "{0:output:ImpaleAvoidChance}%", { modName = "AvoidImpale" }, }, },
 	{ label = "Curse Avoid Ch.", haveOutput = "CurseAvoidChance", { format = "{0:output:CurseAvoidChance}%", { modName = { "AvoidCurse", "CurseImmune" } }, }, },
 	{ label = "Crit Reduction", haveOutput = "CritExtraDamageReduction", { format = "{0:output:CritExtraDamageReduction}%", { modName = "ReduceCritExtraDamage" }, }, },
 	{ label = "Blind Duration", haveOutput = "SelfBlindDuration", { format = "{0:output:SelfBlindDuration}%", { modName = "SelfBlindDuration" }, }, },

--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -356,6 +356,7 @@ local modNameList = {
 	["to avoid status ailments"] = "AvoidAilments",
 	["to avoid bleeding"] = "AvoidBleed",
 	["to avoid being poisoned"] = "AvoidPoison",
+	["to avoid being impaled"] = "AvoidImpale",
 	["damage is taken from mana before life"] = "DamageTakenFromManaBeforeLife",
 	["lightning damage is taken from mana before life"] = "LightningDamageTakenFromManaBeforeLife",
 	["damage taken from mana before life"] = "DamageTakenFromManaBeforeLife",


### PR DESCRIPTION
### Description of the problem being solved:
Adds support for Impale Avoidance in the calcs tab under "Other Avoidance".

### Steps taken to verify a working solution:
- Spec either the evasion mastery with 30% Impale avoidance or add a cluster with the "readiness" node.
- Check the calcs tab under "Other Avoidance" for the correct value.

### Link to a build that showcases this PR:
https://pobb.in/qGxdsl_rJBG4

### Before screenshot:
![image](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/28728694/916b76b8-b160-433a-8560-a3a74d68a8f1)

### After screenshot:
![image](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/28728694/9c932eca-8cff-4a4c-863a-185b50c72ec8)
![image](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/28728694/9b21b80a-edbb-4a7e-8169-22933f49e13a)
