### PR TITLE
Add support for adrenaline on stun mastery

### DIFF
--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -3174,6 +3174,7 @@ local specialModList = {
 	["take (%d+) fire damage per second while flame%-touched"] = function(num) return { mod("FireDegen", "BASE", num, { type = "Condition", var = "AffectedByApproachingFlames" }) } end,
 	["gain adrenaline when you become flame%-touched"] = { flag("Condition:Adrenaline", { type = "Condition", var = "AffectedByApproachingFlames" }) },
 	["lose adrenaline when you cease to be flame%-touched"] = { },
+	["gain adrenaline when stunned, for 2 seconds per 100ms of stun duration"] = { flag("Condition:Adrenaline", {type = "Condition", var = "StunnedRecently"})},
 	["modifiers to ignite duration on you apply to all elemental ailments"] = { flag("IgniteDurationAppliesToElementalAilments") },
 	["chance to avoid being shocked applies to all elemental ailments"] = { flag("ShockAvoidAppliesToElementalAilments") }, -- typo / old wording change
 	["modifiers to chance to avoid being shocked apply to all elemental ailments"] = { flag("ShockAvoidAppliesToElementalAilments") },


### PR DESCRIPTION
### Description of the problem being solved:
Adds support for the "Gain Adrenaline when Stunned, for 2 seconds per 100ms of Stun Duration" stun mastery mod.

Only active if the "Have you been stunned recently" config is ticked.

Technically small improvement would be to check if the stun duration is longer than 100ms (mastery doesn't do anything ingame if it's lower than that), but I couldn't figure out how to set a condition in the calcsDefence that is then respected by the mod parser. Not really an issue tho, no real build has the 300%+ stun recovery needed where this case would apply.

### Steps taken to verify a working solution:
- Spec the mastery
- Enable the config for "Have you been stunned recently"
- DPS should change since you now have adrenaline.

### Link to a build that showcases this PR:
https://pobb.in/bVtxVL8hQwg9

### Before screenshot:
![image](https://github.com/user-attachments/assets/e6f70f56-db6a-465c-8b7b-60158b5a98c3)

### After screenshot:
![image](https://github.com/user-attachments/assets/3dbfaed2-9b34-460e-9687-b532dd8fe1f6)
![image](https://github.com/user-attachments/assets/b6429ba3-6a03-454f-a0d5-25c788120f01)

