### PR TITLE
hide alternate_ascendancies as they are unobtainable but still in tree data

### DIFF
--- a/src/Classes/PassiveTree.lua
+++ b/src/Classes/PassiveTree.lua
@@ -121,6 +121,26 @@ local PassiveTreeClass = newClass("PassiveTree", function(self, treeVersion)
 		end
 	end
 	
+	-- hide alternate_ascendancies as they are unobtainable but still in tree data
+	if self.alternate_ascendancies then
+		local tempMap = {}
+		local temp_groups = {}
+		for ascendClassId, ascendClass in pairs(self.alternate_ascendancies) do
+			tempMap[ascendClass.id] = true
+		end
+		for i, node in pairs(self.nodes) do
+			if node.ascendancyName and tempMap[node.ascendancyName] then
+				self.nodes[i] = nil
+				temp_groups[node.group] = true
+			end
+		end
+		for i, group in pairs(temp_groups) do
+			self.groups[i] = nil
+		end
+			
+		self.alternate_ascendancies = nil
+	end
+	
 	if self.alternate_ascendancies then
 		self.secondaryAscendNameMap = { }
 		local alternate_ascendancies_class = { 

--- a/src/Classes/PassiveTree.lua
+++ b/src/Classes/PassiveTree.lua
@@ -123,6 +123,9 @@ local PassiveTreeClass = newClass("PassiveTree", function(self, treeVersion)
 	
 	-- hide alternate_ascendancies as they are unobtainable but still in tree data
 	if self.alternate_ascendancies then
+		if launch.devMode then
+			ConPrintf("WARNING! alternate_ascendancies exist but are being hidden")
+		end
 		local tempMap = {}
 		local temp_groups = {}
 		for ascendClassId, ascendClass in pairs(self.alternate_ascendancies) do


### PR DESCRIPTION
This is just a temp fix until they add another source of secondary ascendencies or remove the current ones from tree data

note this just removes them from tree data, their selection is still possible, but is being removed in #7672 so didnt want to make merge conflicts
