### PR TITLE
Disable Tree download if file is missing

### DIFF
--- a/src/Classes/PassiveTree.lua
+++ b/src/Classes/PassiveTree.lua
@@ -34,6 +34,8 @@ local legacySkillsPerOrbit = { 1, 6, 12, 12, 40 }
 local legacyOrbitRadii = { 0, 82, 162, 335, 493 }
 
 -- Retrieve the file at the given URL
+-- This is currently disabled as it does not work due to issues
+-- its possible to fix this but its never used due to us performing preprocessing on tree
 local function getFile(URL)
 	local page = ""
 	local easy = common.curl.easy()
@@ -63,13 +65,14 @@ local PassiveTreeClass = newClass("PassiveTree", function(self, treeVersion)
 		treeText = treeFile:read("*a")
 		treeFile:close()
 	else
-		ConPrintf("Downloading passive tree data...")
 		local page
 		local pageFile = io.open("TreeData/"..treeVersion.."/data.json", "r")
 		if pageFile then
+			ConPrintf("Converting passive tree data json")
 			page = pageFile:read("*a")
 			pageFile:close()
-		else
+		elseif main.allowTreeDownload then  -- Enable downloading with Ctrl+Shift+F5 (currently disabled)
+			ConPrintf("Downloading passive tree data...")
 			page = getFile("https://www.pathofexile.com/passive-skill-tree")
 		end
 		local treeData = page:match("var passiveSkillTreeData = (%b{})")
@@ -694,7 +697,7 @@ function PassiveTreeClass:LoadImage(imgName, url, data, ...)
 		if imgFile then
 			imgFile:close()
 			imgName = self.treeVersion.."/"..imgName
-		elseif main.allowTreeDownload then -- Enable downloading with Ctrl+Shift+F5
+		elseif main.allowTreeDownload then -- Enable downloading with Ctrl+Shift+F5 (currently disabled)
 			ConPrintf("Downloading '%s'...", imgName)
 			local data = getFile(url)
 			if data and not data:match("<!DOCTYPE html>") then

--- a/src/Modules/Main.lua
+++ b/src/Modules/Main.lua
@@ -114,7 +114,7 @@ function main:Init()
 		LoadModule("Data/ModCache", modLib.parseModCache)
 	end
 
-	--[[ this doesnt work properly anymore see PR #7675
+	--[[ this does not work properly anymore see PR #7675
 	if launch.devMode and IsKeyDown("CTRL") and IsKeyDown("SHIFT") then
 		self.allowTreeDownload = true
 	end

--- a/src/Modules/Main.lua
+++ b/src/Modules/Main.lua
@@ -114,9 +114,11 @@ function main:Init()
 		LoadModule("Data/ModCache", modLib.parseModCache)
 	end
 
+	--[[ this doesnt work properly anymore see PR #7675
 	if launch.devMode and IsKeyDown("CTRL") and IsKeyDown("SHIFT") then
 		self.allowTreeDownload = true
 	end
+	--]]
 
 	self.inputEvents = { }
 	self.tooltipLines = { }


### PR DESCRIPTION
Downloading directly was broken recently with enforcement of user agent policies

This was never used anyway as we download the tree files directly from GGG (or their github) and perform preprocessing on them

This will cause issues if it tries to open a tree file and both the lua and the data.json are missing, however the download currently fails anyway so there should be no change