### PR TITLE
Split Tree sprites data from tree.lua

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -54,7 +54,7 @@ Steps:
    according to the file's format. This is important, otherwise the JSON data converter
    won't trigger.
 7. Restart Path of Building Community. This should result in a new file `tree.lua`.
-8. Remove `data.json` from the new directory. Do not commit this file.
+8. Remove `data.json` and `sprites.json` from the new directory. Do not commit these files.
 
 ## Installer creation
 

--- a/fix_ascendancy_positions.py
+++ b/fix_ascendancy_positions.py
@@ -120,6 +120,13 @@ def fix_ascendancy_positions(path: os.PathLike) -> None:
             if node["Node"]["name"] in EXTRA_NODES_STATS:
                 data["nodes"][node["Node"]["skill"]]["stats"] = EXTRA_NODES_STATS[node["Node"]["name"]]["stats"]
                 data["nodes"][node["Node"]["skill"]]["reminderText"] = EXTRA_NODES_STATS[node["Node"]["name"]]["reminderText"]
+    # Remove unused image zoom levels and data around them
+    for sprite in data["sprites"]:
+        if "1" in data["sprites"][sprite]:
+            data["sprites"][sprite] = data["sprites"][sprite]["1"]
+        elif "0.3835" in data["sprites"][sprite]:
+            data["sprites"][sprite] = data["sprites"][sprite]["0.3835"]
+    del data["imageZoomLevels"]
     with open(path, "w", encoding="utf-8") as o:
         json.dump(data, o, indent=4)
 

--- a/fix_ascendancy_positions.py
+++ b/fix_ascendancy_positions.py
@@ -120,13 +120,20 @@ def fix_ascendancy_positions(path: os.PathLike) -> None:
             if node["Node"]["name"] in EXTRA_NODES_STATS:
                 data["nodes"][node["Node"]["skill"]]["stats"] = EXTRA_NODES_STATS[node["Node"]["name"]]["stats"]
                 data["nodes"][node["Node"]["skill"]]["reminderText"] = EXTRA_NODES_STATS[node["Node"]["name"]]["reminderText"]
+    
     # Remove unused image zoom levels and data around them
     for sprite in data["sprites"]:
         if "1" in data["sprites"][sprite]:
             data["sprites"][sprite] = data["sprites"][sprite]["1"]
         elif "0.3835" in data["sprites"][sprite]:
             data["sprites"][sprite] = data["sprites"][sprite]["0.3835"]
+    spritesPath = os.path.join(os.path.dirname(path), "sprites.json")
+    with open(spritesPath, "w", encoding="utf-8") as o:
+        json.dump({"extraImages": data["extraImages"],"sprites": data["sprites"]}, o, indent=4)
+    del data["extraImages"]
+    del data["sprites"]
     del data["imageZoomLevels"]
+    
     with open(path, "w", encoding="utf-8") as o:
         json.dump(data, o, indent=4)
 

--- a/src/Classes/PassiveTree.lua
+++ b/src/Classes/PassiveTree.lua
@@ -170,17 +170,8 @@ local PassiveTreeClass = newClass("PassiveTree", function(self, treeVersion)
 	end
 
 	if not self.assets then
-		local treeTextOLD
-		local treeFileOLD = io.open("TreeData/".. "3_18" .."/tree.lua", "r")
-		if treeFileOLD then
-			treeTextOLD = treeFileOLD:read("*a")
-			treeFileOLD:close()
-		end
-		local temp = {}
-		for k, v in pairs(assert(loadstring(treeTextOLD))()) do
-			temp[k] = v
-		end
-		self.assets = temp.assets
+		self.assets = LoadModule("TreeData/3_19/Assets.lua")
+		self.assets = self.assets.assets
 		if self.alternate_ascendancies then
 			-- backgrounds
 			self.assets["ClassesPrimalist"] = {[0.3835]="https://web.poecdn.com/gen/image/WzIyLCJlMzIwYTYwYmNiZTY4ZmQ5YTc2NmE1ZmY4MzhjMDMyNCIseyJ0IjoyNywic3AiOjAuMzgzNX1d/3d68393250/ClassesPrimalist.png"}

--- a/src/Classes/PassiveTree.lua
+++ b/src/Classes/PassiveTree.lua
@@ -215,9 +215,13 @@ local PassiveTreeClass = newClass("PassiveTree", function(self, treeVersion)
 	self.spriteMap = { }
 	local spriteSheets = { }
 	for type, data in pairs(self.skillSprites) do
-		local maxZoom = data[#data]
-		if versionNum >= 3.19 then
+		local maxZoom
+		if not self.imageZoomLevels then
+			maxZoom = data
+		elseif versionNum >= 3.19 then
 			maxZoom = data[0.3835] or data[1]
+		else
+			maxZoom = data[#data]
 		end
 		local sheet = spriteSheets[maxZoom.filename]
 		if not sheet then

--- a/src/Classes/PassiveTree.lua
+++ b/src/Classes/PassiveTree.lua
@@ -90,8 +90,6 @@ local PassiveTreeClass = newClass("PassiveTree", function(self, treeVersion)
 		self[k] = v
 	end
 
-	local cdnRoot = versionNum >= 3.08 and versionNum <= 3.09 and "https://web.poecdn.com" or ""
-
 	self.size = m_min(self.max_x - self.min_x, self.max_y - self.min_y) * 1.1
 
 	if versionNum >= 3.10 then
@@ -171,7 +169,7 @@ local PassiveTreeClass = newClass("PassiveTree", function(self, treeVersion)
 		self.orbitAnglesByOrbit[orbit] = self:CalcOrbitAngles(skillsInOrbit)
 	end
 
-	if versionNum >= 3.19 then
+	if not self.assets then
 		local treeTextOLD
 		local treeFileOLD = io.open("TreeData/".. "3_18" .."/tree.lua", "r")
 		if treeFileOLD then
@@ -183,7 +181,6 @@ local PassiveTreeClass = newClass("PassiveTree", function(self, treeVersion)
 			temp[k] = v
 		end
 		self.assets = temp.assets
-		self.skillSprites = self.sprites
 		if self.alternate_ascendancies then
 			-- backgrounds
 			self.assets["ClassesPrimalist"] = {[0.3835]="https://web.poecdn.com/gen/image/WzIyLCJlMzIwYTYwYmNiZTY4ZmQ5YTc2NmE1ZmY4MzhjMDMyNCIseyJ0IjoyNywic3AiOjAuMzgzNX1d/3d68393250/ClassesPrimalist.png"}
@@ -206,6 +203,8 @@ local PassiveTreeClass = newClass("PassiveTree", function(self, treeVersion)
 			self.assets["CharmSocketActiveDex"] = {[0.3835]="https://web.poecdn.com/gen/image/WzIyLCJlMzIwYTYwYmNiZTY4ZmQ5YTc2NmE1ZmY4MzhjMDMyNCIseyJ0IjoyNywic3AiOjAuMzgzNX1d/3d68393250/CharmSocketActiveDex.png"}
 		end
 	end
+
+	local cdnRoot = versionNum >= 3.08 and versionNum <= 3.09 and "https://web.poecdn.com" or ""
 	ConPrintf("Loading passive tree assets...")
 	for name, data in pairs(self.assets) do
 		self:LoadImage(name..".png", cdnRoot..(data[0.3835] or data[1]), data, not name:match("[OL][ri][bn][ie][tC]") and "ASYNC" or nil)--, not name:match("[OL][ri][bn][ie][tC]") and "MIPMAP" or nil)
@@ -214,6 +213,33 @@ local PassiveTreeClass = newClass("PassiveTree", function(self, treeVersion)
 	-- Load sprite sheets and build sprite map
 	self.spriteMap = { }
 	local spriteSheets = { }
+	if not self.skillSprites then
+		if not self.sprites then
+			ConPrintf("Loading passive tree sprite data for version '%s'...", treeVersions[treeVersion].display)
+			local spriteText
+			local spriteFile = io.open("TreeData/"..treeVersion.."/sprites.lua", "r")
+			if spriteFile then
+				spriteText = spriteFile:read("*a")
+				spriteFile:close()
+			else
+				local page
+				local pageFile = io.open("TreeData/"..treeVersion.."/sprites.json", "r")
+				if pageFile then
+					ConPrintf("Converting passive tree sprites json")
+					page = pageFile:read("*a")
+					pageFile:close()
+					spriteText = "return " .. jsonToLua(page)
+				end
+				spriteFile = io.open("TreeData/"..treeVersion.."/sprites.lua", "w")
+				spriteFile:write(spriteText)
+				spriteFile:close()
+			end
+			for k, v in pairs(assert(loadstring(spriteText))()) do
+				self[k] = v
+			end
+		end
+		self.skillSprites = self.sprites
+	end
 	for type, data in pairs(self.skillSprites) do
 		local maxZoom
 		if not self.imageZoomLevels then

--- a/src/TreeData/3_19/Assets.lua
+++ b/src/TreeData/3_19/Assets.lua
@@ -1,0 +1,727 @@
+return {
+	["assets"]= {
+        ["PSSkillFrame"]= {
+            [0.1246]= "https://web.poecdn.com/gen/image/WzIyLCJjOTk3MTkyODgzMjUyYWZlNzZkZGE3Yzc1MjNhNGMwOCIseyJ0IjowLCJzcCI6MC4xMjQ2fV0/b09afb1b33/Skill_Frame_Unallocated.png",
+            [0.2109]= "https://web.poecdn.com/gen/image/WzIyLCJjOTk3MTkyODgzMjUyYWZlNzZkZGE3Yzc1MjNhNGMwOCIseyJ0IjowLCJzcCI6MC4yMTA5fV0/f5a8a049af/Skill_Frame_Unallocated.png",
+            [0.2972]= "https://web.poecdn.com/gen/image/WzIyLCJjOTk3MTkyODgzMjUyYWZlNzZkZGE3Yzc1MjNhNGMwOCIseyJ0IjowLCJzcCI6MC4yOTcyfV0/eddadb07ed/Skill_Frame_Unallocated.png",
+            [0.3835]= "https://web.poecdn.com/gen/image/WzIyLCJjOTk3MTkyODgzMjUyYWZlNzZkZGE3Yzc1MjNhNGMwOCIseyJ0IjowLCJzcCI6MC4zODM1fV0/9b61a3a2d4/Skill_Frame_Unallocated.png"
+        },
+        ["PSSkillFrameHighlighted"]= {
+            [0.1246]= "https://web.poecdn.com/gen/image/WzIyLCI5Y2I0ZDcwMzZhYzU0MzNlMzA3MmFkNWEyMWE2YWNkZCIseyJ0IjoyLCJzcCI6MC4xMjQ2fV0/8fda9ea666/Skill_Frame_CanAllocate.png",
+            [0.2109]= "https://web.poecdn.com/gen/image/WzIyLCI5Y2I0ZDcwMzZhYzU0MzNlMzA3MmFkNWEyMWE2YWNkZCIseyJ0IjoyLCJzcCI6MC4yMTA5fV0/f40d36962e/Skill_Frame_CanAllocate.png",
+            [0.2972]= "https://web.poecdn.com/gen/image/WzIyLCI5Y2I0ZDcwMzZhYzU0MzNlMzA3MmFkNWEyMWE2YWNkZCIseyJ0IjoyLCJzcCI6MC4yOTcyfV0/b1256ffc6f/Skill_Frame_CanAllocate.png",
+            [0.3835]= "https://web.poecdn.com/gen/image/WzIyLCI5Y2I0ZDcwMzZhYzU0MzNlMzA3MmFkNWEyMWE2YWNkZCIseyJ0IjoyLCJzcCI6MC4zODM1fV0/865766cbc3/Skill_Frame_CanAllocate.png"
+        },
+        ["PSSkillFrameActive"]= {
+            [0.1246]= "https://web.poecdn.com/gen/image/WzIyLCI1ZjU5YTE1MzQxYmFlNWUwZmQ3MjhmZDY3NjZjNzhmYSIseyJ0IjoxLCJzcCI6MC4xMjQ2fV0/0a16d802f9/Skill_Frame_Allocated.png",
+            [0.2109]= "https://web.poecdn.com/gen/image/WzIyLCI1ZjU5YTE1MzQxYmFlNWUwZmQ3MjhmZDY3NjZjNzhmYSIseyJ0IjoxLCJzcCI6MC4yMTA5fV0/415bc0e3ae/Skill_Frame_Allocated.png",
+            [0.2972]= "https://web.poecdn.com/gen/image/WzIyLCI1ZjU5YTE1MzQxYmFlNWUwZmQ3MjhmZDY3NjZjNzhmYSIseyJ0IjoxLCJzcCI6MC4yOTcyfV0/e092a3bc00/Skill_Frame_Allocated.png",
+            [0.3835]= "https://web.poecdn.com/gen/image/WzIyLCI1ZjU5YTE1MzQxYmFlNWUwZmQ3MjhmZDY3NjZjNzhmYSIseyJ0IjoxLCJzcCI6MC4zODM1fV0/eb03e31dcb/Skill_Frame_Allocated.png"
+        },
+        ["PSGroupBackground1"]= {
+            [0.1246]= "https://web.poecdn.com/gen/image/WzIxLDE0LHsiayI6IjJEQXJ0L1VJSW1hZ2VzL0luR2FtZS9QYXNzaXZlU2tpbGxTY3JlZW5Hcm91cEJhY2tncm91bmRTbWFsbCIsInNwIjowLjEyNDZ9XQ/fa0f03d1f4/Group_Background_1.png",
+            [0.2109]= "https://web.poecdn.com/gen/image/WzIxLDE0LHsiayI6IjJEQXJ0L1VJSW1hZ2VzL0luR2FtZS9QYXNzaXZlU2tpbGxTY3JlZW5Hcm91cEJhY2tncm91bmRTbWFsbCIsInNwIjowLjIxMDl9XQ/9183d552f2/Group_Background_1.png",
+            [0.2972]= "https://web.poecdn.com/gen/image/WzIxLDE0LHsiayI6IjJEQXJ0L1VJSW1hZ2VzL0luR2FtZS9QYXNzaXZlU2tpbGxTY3JlZW5Hcm91cEJhY2tncm91bmRTbWFsbCIsInNwIjowLjI5NzJ9XQ/ddb0a06e73/Group_Background_1.png",
+            [0.3835]= "https://web.poecdn.com/gen/image/WzIxLDE0LHsiayI6IjJEQXJ0L1VJSW1hZ2VzL0luR2FtZS9QYXNzaXZlU2tpbGxTY3JlZW5Hcm91cEJhY2tncm91bmRTbWFsbCIsInNwIjowLjM4MzV9XQ/dd73ce340e/Group_Background_1.png"
+        },
+        ["PSGroupBackground2"]= {
+            [0.1246]= "https://web.poecdn.com/gen/image/WzIxLDE0LHsiayI6IjJEQXJ0L1VJSW1hZ2VzL0luR2FtZS9QYXNzaXZlU2tpbGxTY3JlZW5Hcm91cEJhY2tncm91bmRNZWRpdW0iLCJzcCI6MC4xMjQ2fV0/0b38c31c41/Group_Background_2.png",
+            [0.2109]= "https://web.poecdn.com/gen/image/WzIxLDE0LHsiayI6IjJEQXJ0L1VJSW1hZ2VzL0luR2FtZS9QYXNzaXZlU2tpbGxTY3JlZW5Hcm91cEJhY2tncm91bmRNZWRpdW0iLCJzcCI6MC4yMTA5fV0/ca64c612dd/Group_Background_2.png",
+            [0.2972]= "https://web.poecdn.com/gen/image/WzIxLDE0LHsiayI6IjJEQXJ0L1VJSW1hZ2VzL0luR2FtZS9QYXNzaXZlU2tpbGxTY3JlZW5Hcm91cEJhY2tncm91bmRNZWRpdW0iLCJzcCI6MC4yOTcyfV0/b708e24332/Group_Background_2.png",
+            [0.3835]= "https://web.poecdn.com/gen/image/WzIxLDE0LHsiayI6IjJEQXJ0L1VJSW1hZ2VzL0luR2FtZS9QYXNzaXZlU2tpbGxTY3JlZW5Hcm91cEJhY2tncm91bmRNZWRpdW0iLCJzcCI6MC4zODM1fV0/3c3a726e87/Group_Background_2.png"
+        },
+        ["PSGroupBackground3"]= {
+            [0.1246]= "https://web.poecdn.com/gen/image/WzIxLDE0LHsiayI6IjJEQXJ0L1VJSW1hZ2VzL0luR2FtZS9QYXNzaXZlU2tpbGxTY3JlZW5Hcm91cEJhY2tncm91bmRMYXJnZUhhbGYiLCJzcCI6MC4xMjQ2fV0/b9083d15e9/Group_Background_3.png",
+            [0.2109]= "https://web.poecdn.com/gen/image/WzIxLDE0LHsiayI6IjJEQXJ0L1VJSW1hZ2VzL0luR2FtZS9QYXNzaXZlU2tpbGxTY3JlZW5Hcm91cEJhY2tncm91bmRMYXJnZUhhbGYiLCJzcCI6MC4yMTA5fV0/cfb667a158/Group_Background_3.png",
+            [0.2972]= "https://web.poecdn.com/gen/image/WzIxLDE0LHsiayI6IjJEQXJ0L1VJSW1hZ2VzL0luR2FtZS9QYXNzaXZlU2tpbGxTY3JlZW5Hcm91cEJhY2tncm91bmRMYXJnZUhhbGYiLCJzcCI6MC4yOTcyfV0/b388d137e7/Group_Background_3.png",
+            [0.3835]= "https://web.poecdn.com/gen/image/WzIxLDE0LHsiayI6IjJEQXJ0L1VJSW1hZ2VzL0luR2FtZS9QYXNzaXZlU2tpbGxTY3JlZW5Hcm91cEJhY2tncm91bmRMYXJnZUhhbGYiLCJzcCI6MC4zODM1fV0/ddf32c5faf/Group_Background_3.png"
+        },
+        ["NotableFrameUnallocated"]= {
+            [0.1246]= "https://web.poecdn.com/gen/image/WzIyLCIxOTE0YzZhNTUxMWJmNjhlOTM5OTJjZTQxMmQwMjZlOCIseyJ0Ijo2LCJzcCI6MC4xMjQ2fV0/ad65502a05/NotableFrameUnallocated.png",
+            [0.2109]= "https://web.poecdn.com/gen/image/WzIyLCIxOTE0YzZhNTUxMWJmNjhlOTM5OTJjZTQxMmQwMjZlOCIseyJ0Ijo2LCJzcCI6MC4yMTA5fV0/7929af8f5d/NotableFrameUnallocated.png",
+            [0.2972]= "https://web.poecdn.com/gen/image/WzIyLCIxOTE0YzZhNTUxMWJmNjhlOTM5OTJjZTQxMmQwMjZlOCIseyJ0Ijo2LCJzcCI6MC4yOTcyfV0/5d1be4166d/NotableFrameUnallocated.png",
+            [0.3835]= "https://web.poecdn.com/gen/image/WzIyLCIxOTE0YzZhNTUxMWJmNjhlOTM5OTJjZTQxMmQwMjZlOCIseyJ0Ijo2LCJzcCI6MC4zODM1fV0/e10e419f16/NotableFrameUnallocated.png"
+        },
+        ["NotableFrameCanAllocate"]= {
+            [0.1246]= "https://web.poecdn.com/gen/image/WzIyLCI4NWQwYjI5YzA0MzUwYTYyM2NlMjkyMmY4ODhhNTNkMSIseyJ0Ijo4LCJzcCI6MC4xMjQ2fV0/5d4566b4ca/NotableFrameCanAllocate.png",
+            [0.2109]= "https://web.poecdn.com/gen/image/WzIyLCI4NWQwYjI5YzA0MzUwYTYyM2NlMjkyMmY4ODhhNTNkMSIseyJ0Ijo4LCJzcCI6MC4yMTA5fV0/2b55b40fbe/NotableFrameCanAllocate.png",
+            [0.2972]= "https://web.poecdn.com/gen/image/WzIyLCI4NWQwYjI5YzA0MzUwYTYyM2NlMjkyMmY4ODhhNTNkMSIseyJ0Ijo4LCJzcCI6MC4yOTcyfV0/7698b83bc9/NotableFrameCanAllocate.png",
+            [0.3835]= "https://web.poecdn.com/gen/image/WzIyLCI4NWQwYjI5YzA0MzUwYTYyM2NlMjkyMmY4ODhhNTNkMSIseyJ0Ijo4LCJzcCI6MC4zODM1fV0/017c29909a/NotableFrameCanAllocate.png"
+        },
+        ["NotableFrameAllocated"]= {
+            [0.1246]= "https://web.poecdn.com/gen/image/WzIyLCI1YjQyZDcxYzA5ZTA5ZjExZTdiMDk5MjAwYzM1ZTliYSIseyJ0Ijo3LCJzcCI6MC4xMjQ2fV0/8b9a795d9a/NotableFrameAllocated.png",
+            [0.2109]= "https://web.poecdn.com/gen/image/WzIyLCI1YjQyZDcxYzA5ZTA5ZjExZTdiMDk5MjAwYzM1ZTliYSIseyJ0Ijo3LCJzcCI6MC4yMTA5fV0/2b08e07ea4/NotableFrameAllocated.png",
+            [0.2972]= "https://web.poecdn.com/gen/image/WzIyLCI1YjQyZDcxYzA5ZTA5ZjExZTdiMDk5MjAwYzM1ZTliYSIseyJ0Ijo3LCJzcCI6MC4yOTcyfV0/fdb57d91cd/NotableFrameAllocated.png",
+            [0.3835]= "https://web.poecdn.com/gen/image/WzIyLCI1YjQyZDcxYzA5ZTA5ZjExZTdiMDk5MjAwYzM1ZTliYSIseyJ0Ijo3LCJzcCI6MC4zODM1fV0/c9804cce8b/NotableFrameAllocated.png"
+        },
+        ["KeystoneFrameUnallocated"]= {
+            [0.1246]= "https://web.poecdn.com/gen/image/WzIyLCIyMGE3MTc1NzBlNWY4Y2FkYjM2MWVjNmNlNjU2Mjk5OCIseyJ0IjozLCJzcCI6MC4xMjQ2fV0/a7e298dbf9/KeystoneFrameUnallocated.png",
+            [0.2109]= "https://web.poecdn.com/gen/image/WzIyLCIyMGE3MTc1NzBlNWY4Y2FkYjM2MWVjNmNlNjU2Mjk5OCIseyJ0IjozLCJzcCI6MC4yMTA5fV0/7425630c32/KeystoneFrameUnallocated.png",
+            [0.2972]= "https://web.poecdn.com/gen/image/WzIyLCIyMGE3MTc1NzBlNWY4Y2FkYjM2MWVjNmNlNjU2Mjk5OCIseyJ0IjozLCJzcCI6MC4yOTcyfV0/ae870b174d/KeystoneFrameUnallocated.png",
+            [0.3835]= "https://web.poecdn.com/gen/image/WzIyLCIyMGE3MTc1NzBlNWY4Y2FkYjM2MWVjNmNlNjU2Mjk5OCIseyJ0IjozLCJzcCI6MC4zODM1fV0/903d5d56d2/KeystoneFrameUnallocated.png"
+        },
+        ["KeystoneFrameCanAllocate"]= {
+            [0.1246]= "https://web.poecdn.com/gen/image/WzIyLCJmN2FmMjU5NGI1NDg3ZDY3OTk4NWQwNWQxOGRjN2U5ZCIseyJ0Ijo1LCJzcCI6MC4xMjQ2fV0/af957d5e68/KeystoneFrameCanAllocate.png",
+            [0.2109]= "https://web.poecdn.com/gen/image/WzIyLCJmN2FmMjU5NGI1NDg3ZDY3OTk4NWQwNWQxOGRjN2U5ZCIseyJ0Ijo1LCJzcCI6MC4yMTA5fV0/37d7d3f978/KeystoneFrameCanAllocate.png",
+            [0.2972]= "https://web.poecdn.com/gen/image/WzIyLCJmN2FmMjU5NGI1NDg3ZDY3OTk4NWQwNWQxOGRjN2U5ZCIseyJ0Ijo1LCJzcCI6MC4yOTcyfV0/c155f72c0f/KeystoneFrameCanAllocate.png",
+            [0.3835]= "https://web.poecdn.com/gen/image/WzIyLCJmN2FmMjU5NGI1NDg3ZDY3OTk4NWQwNWQxOGRjN2U5ZCIseyJ0Ijo1LCJzcCI6MC4zODM1fV0/48bc70d163/KeystoneFrameCanAllocate.png"
+        },
+        ["KeystoneFrameAllocated"]= {
+            [0.1246]= "https://web.poecdn.com/gen/image/WzIyLCJmZDFhOWMwNDA0NmY2ZmY0MzY4Njc5NDg1NDBkYmJhZiIseyJ0Ijo0LCJzcCI6MC4xMjQ2fV0/50d48310a1/KeystoneFrameAllocated.png",
+            [0.2109]= "https://web.poecdn.com/gen/image/WzIyLCJmZDFhOWMwNDA0NmY2ZmY0MzY4Njc5NDg1NDBkYmJhZiIseyJ0Ijo0LCJzcCI6MC4yMTA5fV0/a3f161032d/KeystoneFrameAllocated.png",
+            [0.2972]= "https://web.poecdn.com/gen/image/WzIyLCJmZDFhOWMwNDA0NmY2ZmY0MzY4Njc5NDg1NDBkYmJhZiIseyJ0Ijo0LCJzcCI6MC4yOTcyfV0/26eb320cd5/KeystoneFrameAllocated.png",
+            [0.3835]= "https://web.poecdn.com/gen/image/WzIyLCJmZDFhOWMwNDA0NmY2ZmY0MzY4Njc5NDg1NDBkYmJhZiIseyJ0Ijo0LCJzcCI6MC4zODM1fV0/40dc9a16c5/KeystoneFrameAllocated.png"
+        },
+        ["Orbit1Normal"]= {
+            [0.1246]= "https://web.poecdn.com/gen/image/WzIyLCI5MzdhOWQyNGEyOGRkYWRhMGUxMWZmNTY5ZThjOWQwOSIseyJ0Ijo5LCJvIjoxLCJzcCI6MC4xMjQ2fV0/9ad9b57a9b/Orbit1Normal.png",
+            [0.2109]= "https://web.poecdn.com/gen/image/WzIyLCI5MzdhOWQyNGEyOGRkYWRhMGUxMWZmNTY5ZThjOWQwOSIseyJ0Ijo5LCJvIjoxLCJzcCI6MC4yMTA5fV0/3ccb4ff7c7/Orbit1Normal.png",
+            [0.2972]= "https://web.poecdn.com/gen/image/WzIyLCI5MzdhOWQyNGEyOGRkYWRhMGUxMWZmNTY5ZThjOWQwOSIseyJ0Ijo5LCJvIjoxLCJzcCI6MC4yOTcyfV0/b78c57fe44/Orbit1Normal.png",
+            [0.3835]= "https://web.poecdn.com/gen/image/WzIyLCI5MzdhOWQyNGEyOGRkYWRhMGUxMWZmNTY5ZThjOWQwOSIseyJ0Ijo5LCJvIjoxLCJzcCI6MC4zODM1fV0/8473628bbe/Orbit1Normal.png"
+        },
+        ["Orbit1Intermediate"]= {
+            [0.1246]= "https://web.poecdn.com/gen/image/WzIyLCI5ZDhjYjk5MzA1MGUyNjBhZWQ1YzAyODE4OThjMGFhNiIseyJ0IjoxMCwibyI6MSwic3AiOjAuMTI0Nn1d/0282d9605e/Orbit1Intermediate.png",
+            [0.2109]= "https://web.poecdn.com/gen/image/WzIyLCI5ZDhjYjk5MzA1MGUyNjBhZWQ1YzAyODE4OThjMGFhNiIseyJ0IjoxMCwibyI6MSwic3AiOjAuMjEwOX1d/b115b9949f/Orbit1Intermediate.png",
+            [0.2972]= "https://web.poecdn.com/gen/image/WzIyLCI5ZDhjYjk5MzA1MGUyNjBhZWQ1YzAyODE4OThjMGFhNiIseyJ0IjoxMCwibyI6MSwic3AiOjAuMjk3Mn1d/b2b5225ae3/Orbit1Intermediate.png",
+            [0.3835]= "https://web.poecdn.com/gen/image/WzIyLCI5ZDhjYjk5MzA1MGUyNjBhZWQ1YzAyODE4OThjMGFhNiIseyJ0IjoxMCwibyI6MSwic3AiOjAuMzgzNX1d/728e38a58b/Orbit1Intermediate.png"
+        },
+        ["Orbit1Active"]= {
+            [0.1246]= "https://web.poecdn.com/gen/image/WzIyLCJjNzYzNTdkOGE1ZjQ5YzIyNjYyNjhhZTU1M2FhZjBiZCIseyJ0IjoxMSwibyI6MSwic3AiOjAuMTI0Nn1d/1002ed727c/Orbit1Active.png",
+            [0.2109]= "https://web.poecdn.com/gen/image/WzIyLCJjNzYzNTdkOGE1ZjQ5YzIyNjYyNjhhZTU1M2FhZjBiZCIseyJ0IjoxMSwibyI6MSwic3AiOjAuMjEwOX1d/a940d5deee/Orbit1Active.png",
+            [0.2972]= "https://web.poecdn.com/gen/image/WzIyLCJjNzYzNTdkOGE1ZjQ5YzIyNjYyNjhhZTU1M2FhZjBiZCIseyJ0IjoxMSwibyI6MSwic3AiOjAuMjk3Mn1d/08eac63d7d/Orbit1Active.png",
+            [0.3835]= "https://web.poecdn.com/gen/image/WzIyLCJjNzYzNTdkOGE1ZjQ5YzIyNjYyNjhhZTU1M2FhZjBiZCIseyJ0IjoxMSwibyI6MSwic3AiOjAuMzgzNX1d/e20f9b2f56/Orbit1Active.png"
+        },
+        ["Orbit2Normal"]= {
+            [0.1246]= "https://web.poecdn.com/gen/image/WzIyLCJkZmI3YTBiMzljMWU0MTY4OWVjOWNhNGVlZTc1Y2MwOCIseyJ0Ijo5LCJvIjoyLCJzcCI6MC4xMjQ2fV0/24cfd57c84/Orbit2Normal.png",
+            [0.2109]= "https://web.poecdn.com/gen/image/WzIyLCJkZmI3YTBiMzljMWU0MTY4OWVjOWNhNGVlZTc1Y2MwOCIseyJ0Ijo5LCJvIjoyLCJzcCI6MC4yMTA5fV0/2f4acb5b91/Orbit2Normal.png",
+            [0.2972]= "https://web.poecdn.com/gen/image/WzIyLCJkZmI3YTBiMzljMWU0MTY4OWVjOWNhNGVlZTc1Y2MwOCIseyJ0Ijo5LCJvIjoyLCJzcCI6MC4yOTcyfV0/380b16fc09/Orbit2Normal.png",
+            [0.3835]= "https://web.poecdn.com/gen/image/WzIyLCJkZmI3YTBiMzljMWU0MTY4OWVjOWNhNGVlZTc1Y2MwOCIseyJ0Ijo5LCJvIjoyLCJzcCI6MC4zODM1fV0/1fedcde7d0/Orbit2Normal.png"
+        },
+        ["Orbit2Intermediate"]= {
+            [0.1246]= "https://web.poecdn.com/gen/image/WzIyLCJjMzEzZGU5MDkxYTMxNWI5MzM0NTllODk2MTViMDRhZCIseyJ0IjoxMCwibyI6Miwic3AiOjAuMTI0Nn1d/a8292bd5d2/Orbit2Intermediate.png",
+            [0.2109]= "https://web.poecdn.com/gen/image/WzIyLCJjMzEzZGU5MDkxYTMxNWI5MzM0NTllODk2MTViMDRhZCIseyJ0IjoxMCwibyI6Miwic3AiOjAuMjEwOX1d/81fd4a754a/Orbit2Intermediate.png",
+            [0.2972]= "https://web.poecdn.com/gen/image/WzIyLCJjMzEzZGU5MDkxYTMxNWI5MzM0NTllODk2MTViMDRhZCIseyJ0IjoxMCwibyI6Miwic3AiOjAuMjk3Mn1d/93a330504f/Orbit2Intermediate.png",
+            [0.3835]= "https://web.poecdn.com/gen/image/WzIyLCJjMzEzZGU5MDkxYTMxNWI5MzM0NTllODk2MTViMDRhZCIseyJ0IjoxMCwibyI6Miwic3AiOjAuMzgzNX1d/296b9fe7df/Orbit2Intermediate.png"
+        },
+        ["Orbit2Active"]= {
+            [0.1246]= "https://web.poecdn.com/gen/image/WzIyLCJhNmFhYWU1YjMzYTI0ZjBiYzFiODRmY2VkNWU5MDUzYSIseyJ0IjoxMSwibyI6Miwic3AiOjAuMTI0Nn1d/2068a14974/Orbit2Active.png",
+            [0.2109]= "https://web.poecdn.com/gen/image/WzIyLCJhNmFhYWU1YjMzYTI0ZjBiYzFiODRmY2VkNWU5MDUzYSIseyJ0IjoxMSwibyI6Miwic3AiOjAuMjEwOX1d/550987375d/Orbit2Active.png",
+            [0.2972]= "https://web.poecdn.com/gen/image/WzIyLCJhNmFhYWU1YjMzYTI0ZjBiYzFiODRmY2VkNWU5MDUzYSIseyJ0IjoxMSwibyI6Miwic3AiOjAuMjk3Mn1d/c90967df00/Orbit2Active.png",
+            [0.3835]= "https://web.poecdn.com/gen/image/WzIyLCJhNmFhYWU1YjMzYTI0ZjBiYzFiODRmY2VkNWU5MDUzYSIseyJ0IjoxMSwibyI6Miwic3AiOjAuMzgzNX1d/d2e48d8707/Orbit2Active.png"
+        },
+        ["Orbit3Normal"]= {
+            [0.1246]= "https://web.poecdn.com/gen/image/WzIyLCIwMjAyZmIzZjY2MjY5MWY4ZjI0ZTBhOWM4NTcwZDAyMiIseyJ0Ijo5LCJvIjozLCJzcCI6MC4xMjQ2fV0/f195b91678/Orbit3Normal.png",
+            [0.2109]= "https://web.poecdn.com/gen/image/WzIyLCIwMjAyZmIzZjY2MjY5MWY4ZjI0ZTBhOWM4NTcwZDAyMiIseyJ0Ijo5LCJvIjozLCJzcCI6MC4yMTA5fV0/d0783d3a3a/Orbit3Normal.png",
+            [0.2972]= "https://web.poecdn.com/gen/image/WzIyLCIwMjAyZmIzZjY2MjY5MWY4ZjI0ZTBhOWM4NTcwZDAyMiIseyJ0Ijo5LCJvIjozLCJzcCI6MC4yOTcyfV0/715aeaeff9/Orbit3Normal.png",
+            [0.3835]= "https://web.poecdn.com/gen/image/WzIyLCIwMjAyZmIzZjY2MjY5MWY4ZjI0ZTBhOWM4NTcwZDAyMiIseyJ0Ijo5LCJvIjozLCJzcCI6MC4zODM1fV0/32abc3d2c0/Orbit3Normal.png"
+        },
+        ["Orbit3Intermediate"]= {
+            [0.1246]= "https://web.poecdn.com/gen/image/WzIyLCI5MmZiNTdlMGQyMTk4MjQ1MDAyMDQwOTIxZGQ3ZmNlZCIseyJ0IjoxMCwibyI6Mywic3AiOjAuMTI0Nn1d/fdfa0c6e4b/Orbit3Intermediate.png",
+            [0.2109]= "https://web.poecdn.com/gen/image/WzIyLCI5MmZiNTdlMGQyMTk4MjQ1MDAyMDQwOTIxZGQ3ZmNlZCIseyJ0IjoxMCwibyI6Mywic3AiOjAuMjEwOX1d/e16e3c6b17/Orbit3Intermediate.png",
+            [0.2972]= "https://web.poecdn.com/gen/image/WzIyLCI5MmZiNTdlMGQyMTk4MjQ1MDAyMDQwOTIxZGQ3ZmNlZCIseyJ0IjoxMCwibyI6Mywic3AiOjAuMjk3Mn1d/7ad81a3e64/Orbit3Intermediate.png",
+            [0.3835]= "https://web.poecdn.com/gen/image/WzIyLCI5MmZiNTdlMGQyMTk4MjQ1MDAyMDQwOTIxZGQ3ZmNlZCIseyJ0IjoxMCwibyI6Mywic3AiOjAuMzgzNX1d/916204f272/Orbit3Intermediate.png"
+        },
+        ["Orbit3Active"]= {
+            [0.1246]= "https://web.poecdn.com/gen/image/WzIyLCI1MTcwZWMzOTI0YTRmMzUwNTdhMWUwZGIxNTliOTczZSIseyJ0IjoxMSwibyI6Mywic3AiOjAuMTI0Nn1d/86b2d1b864/Orbit3Active.png",
+            [0.2109]= "https://web.poecdn.com/gen/image/WzIyLCI1MTcwZWMzOTI0YTRmMzUwNTdhMWUwZGIxNTliOTczZSIseyJ0IjoxMSwibyI6Mywic3AiOjAuMjEwOX1d/e7bc7886bb/Orbit3Active.png",
+            [0.2972]= "https://web.poecdn.com/gen/image/WzIyLCI1MTcwZWMzOTI0YTRmMzUwNTdhMWUwZGIxNTliOTczZSIseyJ0IjoxMSwibyI6Mywic3AiOjAuMjk3Mn1d/91ca42f66c/Orbit3Active.png",
+            [0.3835]= "https://web.poecdn.com/gen/image/WzIyLCI1MTcwZWMzOTI0YTRmMzUwNTdhMWUwZGIxNTliOTczZSIseyJ0IjoxMSwibyI6Mywic3AiOjAuMzgzNX1d/e18a85f3c6/Orbit3Active.png"
+        },
+        ["Orbit4Normal"]= {
+            [0.1246]= "https://web.poecdn.com/gen/image/WzIyLCIxY2Y0NDc3MDAxN2NjNjQxYzhmNjgwZjc0M2JhMjllZCIseyJ0Ijo5LCJvIjo0LCJzcCI6MC4xMjQ2fV0/dcaa0aa2e0/Orbit4Normal.png",
+            [0.2109]= "https://web.poecdn.com/gen/image/WzIyLCIxY2Y0NDc3MDAxN2NjNjQxYzhmNjgwZjc0M2JhMjllZCIseyJ0Ijo5LCJvIjo0LCJzcCI6MC4yMTA5fV0/44bd74eff3/Orbit4Normal.png",
+            [0.2972]= "https://web.poecdn.com/gen/image/WzIyLCIxY2Y0NDc3MDAxN2NjNjQxYzhmNjgwZjc0M2JhMjllZCIseyJ0Ijo5LCJvIjo0LCJzcCI6MC4yOTcyfV0/5c7dbdb570/Orbit4Normal.png",
+            [0.3835]= "https://web.poecdn.com/gen/image/WzIyLCIxY2Y0NDc3MDAxN2NjNjQxYzhmNjgwZjc0M2JhMjllZCIseyJ0Ijo5LCJvIjo0LCJzcCI6MC4zODM1fV0/0c0f891840/Orbit4Normal.png"
+        },
+        ["Orbit4Intermediate"]= {
+            [0.1246]= "https://web.poecdn.com/gen/image/WzIyLCI4NmZjYjIzNDQwM2NhM2E2YzEwNDBmNTY0OTVlNDlkMiIseyJ0IjoxMCwibyI6NCwic3AiOjAuMTI0Nn1d/bdcc10393a/Orbit4Intermediate.png",
+            [0.2109]= "https://web.poecdn.com/gen/image/WzIyLCI4NmZjYjIzNDQwM2NhM2E2YzEwNDBmNTY0OTVlNDlkMiIseyJ0IjoxMCwibyI6NCwic3AiOjAuMjEwOX1d/59f768ee30/Orbit4Intermediate.png",
+            [0.2972]= "https://web.poecdn.com/gen/image/WzIyLCI4NmZjYjIzNDQwM2NhM2E2YzEwNDBmNTY0OTVlNDlkMiIseyJ0IjoxMCwibyI6NCwic3AiOjAuMjk3Mn1d/eff5135d02/Orbit4Intermediate.png",
+            [0.3835]= "https://web.poecdn.com/gen/image/WzIyLCI4NmZjYjIzNDQwM2NhM2E2YzEwNDBmNTY0OTVlNDlkMiIseyJ0IjoxMCwibyI6NCwic3AiOjAuMzgzNX1d/2a562ae2a2/Orbit4Intermediate.png"
+        },
+        ["Orbit4Active"]= {
+            [0.1246]= "https://web.poecdn.com/gen/image/WzIyLCIwMDdhMzlkODY5NDgzZGY4YzhiYzZhNjgyMjk3MzNiZCIseyJ0IjoxMSwibyI6NCwic3AiOjAuMTI0Nn1d/1d7d1b7b00/Orbit4Active.png",
+            [0.2109]= "https://web.poecdn.com/gen/image/WzIyLCIwMDdhMzlkODY5NDgzZGY4YzhiYzZhNjgyMjk3MzNiZCIseyJ0IjoxMSwibyI6NCwic3AiOjAuMjEwOX1d/8f5f095c33/Orbit4Active.png",
+            [0.2972]= "https://web.poecdn.com/gen/image/WzIyLCIwMDdhMzlkODY5NDgzZGY4YzhiYzZhNjgyMjk3MzNiZCIseyJ0IjoxMSwibyI6NCwic3AiOjAuMjk3Mn1d/e8d4451762/Orbit4Active.png",
+            [0.3835]= "https://web.poecdn.com/gen/image/WzIyLCIwMDdhMzlkODY5NDgzZGY4YzhiYzZhNjgyMjk3MzNiZCIseyJ0IjoxMSwibyI6NCwic3AiOjAuMzgzNX1d/358e71694f/Orbit4Active.png"
+        },
+        ["Orbit5Normal"]= {
+            [0.1246]= "https://web.poecdn.com/gen/image/WzIyLCI3ODE5ZGNkZDJkZTcyMDI5NzNkOGJiZmI2ODRhZTM5ZCIseyJ0Ijo5LCJvIjo1LCJzcCI6MC4xMjQ2fV0/c47e994790/Orbit5Normal.png",
+            [0.2109]= "https://web.poecdn.com/gen/image/WzIyLCI3ODE5ZGNkZDJkZTcyMDI5NzNkOGJiZmI2ODRhZTM5ZCIseyJ0Ijo5LCJvIjo1LCJzcCI6MC4yMTA5fV0/9972d988eb/Orbit5Normal.png",
+            [0.2972]= "https://web.poecdn.com/gen/image/WzIyLCI3ODE5ZGNkZDJkZTcyMDI5NzNkOGJiZmI2ODRhZTM5ZCIseyJ0Ijo5LCJvIjo1LCJzcCI6MC4yOTcyfV0/d675987380/Orbit5Normal.png",
+            [0.3835]= "https://web.poecdn.com/gen/image/WzIyLCI3ODE5ZGNkZDJkZTcyMDI5NzNkOGJiZmI2ODRhZTM5ZCIseyJ0Ijo5LCJvIjo1LCJzcCI6MC4zODM1fV0/7fb760c1ec/Orbit5Normal.png"
+        },
+        ["Orbit5Intermediate"]= {
+            [0.1246]= "https://web.poecdn.com/gen/image/WzIyLCI2MDBlOGQ2Y2YzNzYwZjAzMTYxNjJjMTMwZWNmNDU3NiIseyJ0IjoxMCwibyI6NSwic3AiOjAuMTI0Nn1d/d42bf4dc77/Orbit5Intermediate.png",
+            [0.2109]= "https://web.poecdn.com/gen/image/WzIyLCI2MDBlOGQ2Y2YzNzYwZjAzMTYxNjJjMTMwZWNmNDU3NiIseyJ0IjoxMCwibyI6NSwic3AiOjAuMjEwOX1d/aa6b7be5d1/Orbit5Intermediate.png",
+            [0.2972]= "https://web.poecdn.com/gen/image/WzIyLCI2MDBlOGQ2Y2YzNzYwZjAzMTYxNjJjMTMwZWNmNDU3NiIseyJ0IjoxMCwibyI6NSwic3AiOjAuMjk3Mn1d/6beacce2ab/Orbit5Intermediate.png",
+            [0.3835]= "https://web.poecdn.com/gen/image/WzIyLCI2MDBlOGQ2Y2YzNzYwZjAzMTYxNjJjMTMwZWNmNDU3NiIseyJ0IjoxMCwibyI6NSwic3AiOjAuMzgzNX1d/5408b6d38f/Orbit5Intermediate.png"
+        },
+        ["Orbit5Active"]= {
+            [0.1246]= "https://web.poecdn.com/gen/image/WzIyLCJhY2NjYzYxNDUzOTg4MzJiN2I3ODRmZjg4Y2VlMWNhNCIseyJ0IjoxMSwibyI6NSwic3AiOjAuMTI0Nn1d/89b1c727c8/Orbit5Active.png",
+            [0.2109]= "https://web.poecdn.com/gen/image/WzIyLCJhY2NjYzYxNDUzOTg4MzJiN2I3ODRmZjg4Y2VlMWNhNCIseyJ0IjoxMSwibyI6NSwic3AiOjAuMjEwOX1d/982d8707de/Orbit5Active.png",
+            [0.2972]= "https://web.poecdn.com/gen/image/WzIyLCJhY2NjYzYxNDUzOTg4MzJiN2I3ODRmZjg4Y2VlMWNhNCIseyJ0IjoxMSwibyI6NSwic3AiOjAuMjk3Mn1d/a613a355c5/Orbit5Active.png",
+            [0.3835]= "https://web.poecdn.com/gen/image/WzIyLCJhY2NjYzYxNDUzOTg4MzJiN2I3ODRmZjg4Y2VlMWNhNCIseyJ0IjoxMSwibyI6NSwic3AiOjAuMzgzNX1d/2e40fab72a/Orbit5Active.png"
+        },
+        ["Orbit6Normal"]= {
+            [0.1246]= "https://web.poecdn.com/gen/image/WzIyLCIyMDg5MzYxMDgxMzRkYzNhNzQwM2E0YmYxYjBiMTNmYyIseyJ0Ijo5LCJvIjo2LCJzcCI6MC4xMjQ2fV0/a1c93ef19d/Orbit6Normal.png",
+            [0.2109]= "https://web.poecdn.com/gen/image/WzIyLCIyMDg5MzYxMDgxMzRkYzNhNzQwM2E0YmYxYjBiMTNmYyIseyJ0Ijo5LCJvIjo2LCJzcCI6MC4yMTA5fV0/a8fd525bd6/Orbit6Normal.png",
+            [0.2972]= "https://web.poecdn.com/gen/image/WzIyLCIyMDg5MzYxMDgxMzRkYzNhNzQwM2E0YmYxYjBiMTNmYyIseyJ0Ijo5LCJvIjo2LCJzcCI6MC4yOTcyfV0/3f90e0b902/Orbit6Normal.png",
+            [0.3835]= "https://web.poecdn.com/gen/image/WzIyLCIyMDg5MzYxMDgxMzRkYzNhNzQwM2E0YmYxYjBiMTNmYyIseyJ0Ijo5LCJvIjo2LCJzcCI6MC4zODM1fV0/142302a3c9/Orbit6Normal.png"
+        },
+        ["Orbit6Intermediate"]= {
+            [0.1246]= "https://web.poecdn.com/gen/image/WzIyLCIxZmExMWQyYzA4YmU1MmE5NGQ1MmYzYzExMzY4NmNmZCIseyJ0IjoxMCwibyI6Niwic3AiOjAuMTI0Nn1d/89011c4382/Orbit6Intermediate.png",
+            [0.2109]= "https://web.poecdn.com/gen/image/WzIyLCIxZmExMWQyYzA4YmU1MmE5NGQ1MmYzYzExMzY4NmNmZCIseyJ0IjoxMCwibyI6Niwic3AiOjAuMjEwOX1d/334b347d41/Orbit6Intermediate.png",
+            [0.2972]= "https://web.poecdn.com/gen/image/WzIyLCIxZmExMWQyYzA4YmU1MmE5NGQ1MmYzYzExMzY4NmNmZCIseyJ0IjoxMCwibyI6Niwic3AiOjAuMjk3Mn1d/113440961a/Orbit6Intermediate.png",
+            [0.3835]= "https://web.poecdn.com/gen/image/WzIyLCIxZmExMWQyYzA4YmU1MmE5NGQ1MmYzYzExMzY4NmNmZCIseyJ0IjoxMCwibyI6Niwic3AiOjAuMzgzNX1d/168a4dc858/Orbit6Intermediate.png"
+        },
+        ["Orbit6Active"]= {
+            [0.1246]= "https://web.poecdn.com/gen/image/WzIyLCIwMWFlMDlkODA4ODc5Y2Q2Njc3YzZhZjhkNWY1Y2NlMyIseyJ0IjoxMSwibyI6Niwic3AiOjAuMTI0Nn1d/1f2ac8f56c/Orbit6Active.png",
+            [0.2109]= "https://web.poecdn.com/gen/image/WzIyLCIwMWFlMDlkODA4ODc5Y2Q2Njc3YzZhZjhkNWY1Y2NlMyIseyJ0IjoxMSwibyI6Niwic3AiOjAuMjEwOX1d/4863acaddd/Orbit6Active.png",
+            [0.2972]= "https://web.poecdn.com/gen/image/WzIyLCIwMWFlMDlkODA4ODc5Y2Q2Njc3YzZhZjhkNWY1Y2NlMyIseyJ0IjoxMSwibyI6Niwic3AiOjAuMjk3Mn1d/a59c4a2177/Orbit6Active.png",
+            [0.3835]= "https://web.poecdn.com/gen/image/WzIyLCIwMWFlMDlkODA4ODc5Y2Q2Njc3YzZhZjhkNWY1Y2NlMyIseyJ0IjoxMSwibyI6Niwic3AiOjAuMzgzNX1d/b34c2805ce/Orbit6Active.png"
+        },
+        ["LineConnectorNormal"]= {
+            [0.1246]= "https://web.poecdn.com/gen/image/WzIyLCI0ZWY1YzAwYWExOGI2NDUzYThhYmVjZDE5ZDY4NDc1ZCIseyJ0IjoxMiwic3AiOjAuMTI0Nn1d/38ccf19045/LineConnectorNormal.png",
+            [0.2109]= "https://web.poecdn.com/gen/image/WzIyLCI0ZWY1YzAwYWExOGI2NDUzYThhYmVjZDE5ZDY4NDc1ZCIseyJ0IjoxMiwic3AiOjAuMjEwOX1d/8a893aeab2/LineConnectorNormal.png",
+            [0.2972]= "https://web.poecdn.com/gen/image/WzIyLCI0ZWY1YzAwYWExOGI2NDUzYThhYmVjZDE5ZDY4NDc1ZCIseyJ0IjoxMiwic3AiOjAuMjk3Mn1d/7b29ac491d/LineConnectorNormal.png",
+            [0.3835]= "https://web.poecdn.com/gen/image/WzIyLCI0ZWY1YzAwYWExOGI2NDUzYThhYmVjZDE5ZDY4NDc1ZCIseyJ0IjoxMiwic3AiOjAuMzgzNX1d/725f80798b/LineConnectorNormal.png"
+        },
+        ["LineConnectorIntermediate"]= {
+            [0.1246]= "https://web.poecdn.com/gen/image/WzIyLCJkYjM1NzQwZTQ5MTc3MGYxZTNlMGM1ZmVhMTEzOGIwMCIseyJ0IjoxMywic3AiOjAuMTI0Nn1d/8479abda51/LineConnectorIntermediate.png",
+            [0.2109]= "https://web.poecdn.com/gen/image/WzIyLCJkYjM1NzQwZTQ5MTc3MGYxZTNlMGM1ZmVhMTEzOGIwMCIseyJ0IjoxMywic3AiOjAuMjEwOX1d/9a12a87f1b/LineConnectorIntermediate.png",
+            [0.2972]= "https://web.poecdn.com/gen/image/WzIyLCJkYjM1NzQwZTQ5MTc3MGYxZTNlMGM1ZmVhMTEzOGIwMCIseyJ0IjoxMywic3AiOjAuMjk3Mn1d/f84400d814/LineConnectorIntermediate.png",
+            [0.3835]= "https://web.poecdn.com/gen/image/WzIyLCJkYjM1NzQwZTQ5MTc3MGYxZTNlMGM1ZmVhMTEzOGIwMCIseyJ0IjoxMywic3AiOjAuMzgzNX1d/5a0be0174b/LineConnectorIntermediate.png"
+        },
+        ["LineConnectorActive"]= {
+            [0.1246]= "https://web.poecdn.com/gen/image/WzIyLCIyMjkxMGYxY2JjOWExOWRiZmY3ZGQ4NGNjM2NiY2Y1YSIseyJ0IjoxNCwic3AiOjAuMTI0Nn1d/c2a77dd98e/LineConnectorActive.png",
+            [0.2109]= "https://web.poecdn.com/gen/image/WzIyLCIyMjkxMGYxY2JjOWExOWRiZmY3ZGQ4NGNjM2NiY2Y1YSIseyJ0IjoxNCwic3AiOjAuMjEwOX1d/89f42e19ff/LineConnectorActive.png",
+            [0.2972]= "https://web.poecdn.com/gen/image/WzIyLCIyMjkxMGYxY2JjOWExOWRiZmY3ZGQ4NGNjM2NiY2Y1YSIseyJ0IjoxNCwic3AiOjAuMjk3Mn1d/813a19abeb/LineConnectorActive.png",
+            [0.3835]= "https://web.poecdn.com/gen/image/WzIyLCIyMjkxMGYxY2JjOWExOWRiZmY3ZGQ4NGNjM2NiY2Y1YSIseyJ0IjoxNCwic3AiOjAuMzgzNX1d/06f72908a7/LineConnectorActive.png"
+        },
+        ["PSLineDeco"]= {
+            [0.1246]= "https://web.poecdn.com/gen/image/WzIwLDE0LHsiaCI6ZmFsc2UsInNwIjowLjEyNDZ9XQ/f5f36d1cea/Line_Deco.png",
+            [0.2109]= "https://web.poecdn.com/gen/image/WzIwLDE0LHsiaCI6ZmFsc2UsInNwIjowLjIxMDl9XQ/2489b0afd1/Line_Deco.png",
+            [0.2972]= "https://web.poecdn.com/gen/image/WzIwLDE0LHsiaCI6ZmFsc2UsInNwIjowLjI5NzJ9XQ/190e462ecb/Line_Deco.png",
+            [0.3835]= "https://web.poecdn.com/gen/image/WzIwLDE0LHsiaCI6ZmFsc2UsInNwIjowLjM4MzV9XQ/ba8f9fc2ea/Line_Deco.png"
+        },
+        ["PSLineDecoHighlighted"]= {
+            [0.1246]= "https://web.poecdn.com/gen/image/WzIwLDE0LHsiaCI6dHJ1ZSwic3AiOjAuMTI0Nn1d/4f9c115f09/Line_Deco_Highlighted.png",
+            [0.2109]= "https://web.poecdn.com/gen/image/WzIwLDE0LHsiaCI6dHJ1ZSwic3AiOjAuMjEwOX1d/525b316df4/Line_Deco_Highlighted.png",
+            [0.2972]= "https://web.poecdn.com/gen/image/WzIwLDE0LHsiaCI6dHJ1ZSwic3AiOjAuMjk3Mn1d/7153e29585/Line_Deco_Highlighted.png",
+            [0.3835]= "https://web.poecdn.com/gen/image/WzIwLDE0LHsiaCI6dHJ1ZSwic3AiOjAuMzgzNX1d/141a3d6daa/Line_Deco_Highlighted.png"
+        },
+        ["PSPointsFrame"]= {
+            [1]= "https://web.poecdn.com/gen/image/WzIxLDE0LHsiayI6IjJEQXJ0L1VJSW1hZ2VzL0luR2FtZS9QYXNzaXZlU2tpbGxTY3JlZW5Qb2ludHNCYWNrZ3JvdW5kIiwic3AiOjF9XQ/2bfde4bf6f/PointsBackground.png"
+        },
+        ["Background2"]= {
+            [0.1246]= "https://web.poecdn.com/gen/image/WzIxLDE0LHsiayI6IjJEQXJ0L1VJSW1hZ2VzL0NvbW1vbi9CYWNrZ3JvdW5kMiIsInNwIjowLjEyNDZ9XQ/2295be05e7/Background2.png",
+            [0.2109]= "https://web.poecdn.com/gen/image/WzIxLDE0LHsiayI6IjJEQXJ0L1VJSW1hZ2VzL0NvbW1vbi9CYWNrZ3JvdW5kMiIsInNwIjowLjIxMDl9XQ/d815d12b6f/Background2.png",
+            [0.2972]= "https://web.poecdn.com/gen/image/WzIxLDE0LHsiayI6IjJEQXJ0L1VJSW1hZ2VzL0NvbW1vbi9CYWNrZ3JvdW5kMiIsInNwIjowLjI5NzJ9XQ/34fe43706f/Background2.png",
+            [0.3835]= "https://web.poecdn.com/gen/image/WzIxLDE0LHsiayI6IjJEQXJ0L1VJSW1hZ2VzL0NvbW1vbi9CYWNrZ3JvdW5kMiIsInNwIjowLjM4MzV9XQ/db55ae5694/Background2.png"
+        },
+        ["imgPSFadeCorner"]= {
+            [1]= "https://web.poecdn.com/gen/image/WzIxLDE0LHsiayI6IjJEQXJ0L1VJSW1hZ2VzL0luR2FtZS9GYWRlQ29ybmVyIiwic3AiOjF9XQ/294320f751/Fade_Corner.png"
+        },
+        ["imgPSFadeSide"]= {
+            [1]= "https://web.poecdn.com/gen/image/WzIxLDE0LHsiayI6IjJEQXJ0L1VJSW1hZ2VzL0luR2FtZS9GYWRlU2lkZSIsInNwIjoxfV0/48ee79851e/Fade_Side.png"
+        },
+        ["GroupBackgroundSmallAlt"]= {
+            [0.1246]= "https://web.poecdn.com/gen/image/WzIxLDE0LHsiayI6IjJEQXJ0L1VJSW1hZ2VzL0luR2FtZS9QYXNzaXZlU2tpbGxTY3JlZW5Hcm91cEJhY2tncm91bmRTbWFsbEFsdCIsInNwIjowLjEyNDZ9XQ/25fc1cd745/GroupBackgroundSmallAlt.png",
+            [0.2109]= "https://web.poecdn.com/gen/image/WzIxLDE0LHsiayI6IjJEQXJ0L1VJSW1hZ2VzL0luR2FtZS9QYXNzaXZlU2tpbGxTY3JlZW5Hcm91cEJhY2tncm91bmRTbWFsbEFsdCIsInNwIjowLjIxMDl9XQ/0a99d13293/GroupBackgroundSmallAlt.png",
+            [0.2972]= "https://web.poecdn.com/gen/image/WzIxLDE0LHsiayI6IjJEQXJ0L1VJSW1hZ2VzL0luR2FtZS9QYXNzaXZlU2tpbGxTY3JlZW5Hcm91cEJhY2tncm91bmRTbWFsbEFsdCIsInNwIjowLjI5NzJ9XQ/025c6144e9/GroupBackgroundSmallAlt.png",
+            [0.3835]= "https://web.poecdn.com/gen/image/WzIxLDE0LHsiayI6IjJEQXJ0L1VJSW1hZ2VzL0luR2FtZS9QYXNzaXZlU2tpbGxTY3JlZW5Hcm91cEJhY2tncm91bmRTbWFsbEFsdCIsInNwIjowLjM4MzV9XQ/cd6f4fd884/GroupBackgroundSmallAlt.png"
+        },
+        ["GroupBackgroundMediumAlt"]= {
+            [0.1246]= "https://web.poecdn.com/gen/image/WzIxLDE0LHsiayI6IjJEQXJ0L1VJSW1hZ2VzL0luR2FtZS9QYXNzaXZlU2tpbGxTY3JlZW5Hcm91cEJhY2tncm91bmRNZWRpdW1BbHQiLCJzcCI6MC4xMjQ2fV0/f3ae6193ab/GroupBackgroundMediumAlt.png",
+            [0.2109]= "https://web.poecdn.com/gen/image/WzIxLDE0LHsiayI6IjJEQXJ0L1VJSW1hZ2VzL0luR2FtZS9QYXNzaXZlU2tpbGxTY3JlZW5Hcm91cEJhY2tncm91bmRNZWRpdW1BbHQiLCJzcCI6MC4yMTA5fV0/05593cbdeb/GroupBackgroundMediumAlt.png",
+            [0.2972]= "https://web.poecdn.com/gen/image/WzIxLDE0LHsiayI6IjJEQXJ0L1VJSW1hZ2VzL0luR2FtZS9QYXNzaXZlU2tpbGxTY3JlZW5Hcm91cEJhY2tncm91bmRNZWRpdW1BbHQiLCJzcCI6MC4yOTcyfV0/c21add1ec7/GroupBackgroundMediumAlt.png",
+            [0.3835]= "https://web.poecdn.com/gen/image/WzIxLDE0LHsiayI6IjJEQXJ0L1VJSW1hZ2VzL0luR2FtZS9QYXNzaXZlU2tpbGxTY3JlZW5Hcm91cEJhY2tncm91bmRNZWRpdW1BbHQiLCJzcCI6MC4zODM1fV0/1a1880aa75/GroupBackgroundMediumAlt.png"
+        },
+        ["GroupBackgroundLargeHalfAlt"]= {
+            [0.1246]= "https://web.poecdn.com/gen/image/WzIxLDE0LHsiayI6IjJEQXJ0L1VJSW1hZ2VzL0luR2FtZS9QYXNzaXZlU2tpbGxTY3JlZW5Hcm91cEJhY2tncm91bmRMYXJnZUhhbGZBbHQiLCJzcCI6MC4xMjQ2fV0/28ed6e5883/GroupBackgroundLargeHalfAlt.png",
+            [0.2109]= "https://web.poecdn.com/gen/image/WzIxLDE0LHsiayI6IjJEQXJ0L1VJSW1hZ2VzL0luR2FtZS9QYXNzaXZlU2tpbGxTY3JlZW5Hcm91cEJhY2tncm91bmRMYXJnZUhhbGZBbHQiLCJzcCI6MC4yMTA5fV0/0f9624ed1d/GroupBackgroundLargeHalfAlt.png",
+            [0.2972]= "https://web.poecdn.com/gen/image/WzIxLDE0LHsiayI6IjJEQXJ0L1VJSW1hZ2VzL0luR2FtZS9QYXNzaXZlU2tpbGxTY3JlZW5Hcm91cEJhY2tncm91bmRMYXJnZUhhbGZBbHQiLCJzcCI6MC4yOTcyfV0/0b776619ea/GroupBackgroundLargeHalfAlt.png",
+            [0.3835]= "https://web.poecdn.com/gen/image/WzIxLDE0LHsiayI6IjJEQXJ0L1VJSW1hZ2VzL0luR2FtZS9QYXNzaXZlU2tpbGxTY3JlZW5Hcm91cEJhY2tncm91bmRMYXJnZUhhbGZBbHQiLCJzcCI6MC4zODM1fV0/ba9dbd8956/GroupBackgroundLargeHalfAlt.png"
+        },
+        ["PSStartNodeBackgroundInactive"]= {
+            [0.1246]= "https://web.poecdn.com/gen/image/WzIxLDE0LHsiayI6IjJEQXJ0L1VJSW1hZ2VzL0luR2FtZS9QYXNzaXZlU2tpbGxTY3JlZW5TdGFydE5vZGVCYWNrZ3JvdW5kSW5hY3RpdmUiLCJzcCI6MC4xMjQ2fV0/2e2dad8148/Start_Node_Background.png",
+            [0.2109]= "https://web.poecdn.com/gen/image/WzIxLDE0LHsiayI6IjJEQXJ0L1VJSW1hZ2VzL0luR2FtZS9QYXNzaXZlU2tpbGxTY3JlZW5TdGFydE5vZGVCYWNrZ3JvdW5kSW5hY3RpdmUiLCJzcCI6MC4yMTA5fV0/739c5e4eca/Start_Node_Background.png",
+            [0.2972]= "https://web.poecdn.com/gen/image/WzIxLDE0LHsiayI6IjJEQXJ0L1VJSW1hZ2VzL0luR2FtZS9QYXNzaXZlU2tpbGxTY3JlZW5TdGFydE5vZGVCYWNrZ3JvdW5kSW5hY3RpdmUiLCJzcCI6MC4yOTcyfV0/58b58c60e8/Start_Node_Background.png",
+            [0.3835]= "https://web.poecdn.com/gen/image/WzIxLDE0LHsiayI6IjJEQXJ0L1VJSW1hZ2VzL0luR2FtZS9QYXNzaXZlU2tpbGxTY3JlZW5TdGFydE5vZGVCYWNrZ3JvdW5kSW5hY3RpdmUiLCJzcCI6MC4zODM1fV0/cea66dd461/Start_Node_Background.png"
+        },
+        ["centerduelist"]= {
+            [0.1246]= "https://web.poecdn.com/gen/image/WzIxLDE0LHsiayI6IjJEQXJ0L1VJSW1hZ2VzL0luR2FtZS9DbGFzc2VzL1N0ckRleC9QYXNzaXZlU2tpbGxTY3JlZW5TdGFydE5vZGVCYWNrZ3JvdW5kIiwic3AiOjAuMTI0Nn1d/a084d659e1/StartNodeBackgroundStrDex.png",
+            [0.2109]= "https://web.poecdn.com/gen/image/WzIxLDE0LHsiayI6IjJEQXJ0L1VJSW1hZ2VzL0luR2FtZS9DbGFzc2VzL1N0ckRleC9QYXNzaXZlU2tpbGxTY3JlZW5TdGFydE5vZGVCYWNrZ3JvdW5kIiwic3AiOjAuMjEwOX1d/9e7e9b9067/StartNodeBackgroundStrDex.png",
+            [0.2972]= "https://web.poecdn.com/gen/image/WzIxLDE0LHsiayI6IjJEQXJ0L1VJSW1hZ2VzL0luR2FtZS9DbGFzc2VzL1N0ckRleC9QYXNzaXZlU2tpbGxTY3JlZW5TdGFydE5vZGVCYWNrZ3JvdW5kIiwic3AiOjAuMjk3Mn1d/4112b5f1c0/StartNodeBackgroundStrDex.png",
+            [0.3835]= "https://web.poecdn.com/gen/image/WzIxLDE0LHsiayI6IjJEQXJ0L1VJSW1hZ2VzL0luR2FtZS9DbGFzc2VzL1N0ckRleC9QYXNzaXZlU2tpbGxTY3JlZW5TdGFydE5vZGVCYWNrZ3JvdW5kIiwic3AiOjAuMzgzNX1d/4c81465fb3/StartNodeBackgroundStrDex.png"
+        },
+        ["centermarauder"]= {
+            [0.1246]= "https://web.poecdn.com/gen/image/WzIxLDE0LHsiayI6IjJEQXJ0L1VJSW1hZ2VzL0luR2FtZS9DbGFzc2VzL1N0ci9QYXNzaXZlU2tpbGxTY3JlZW5TdGFydE5vZGVCYWNrZ3JvdW5kIiwic3AiOjAuMTI0Nn1d/d1ffb53ab3/StartNodeBackgroundStr.png",
+            [0.2109]= "https://web.poecdn.com/gen/image/WzIxLDE0LHsiayI6IjJEQXJ0L1VJSW1hZ2VzL0luR2FtZS9DbGFzc2VzL1N0ci9QYXNzaXZlU2tpbGxTY3JlZW5TdGFydE5vZGVCYWNrZ3JvdW5kIiwic3AiOjAuMjEwOX1d/c372272906/StartNodeBackgroundStr.png",
+            [0.2972]= "https://web.poecdn.com/gen/image/WzIxLDE0LHsiayI6IjJEQXJ0L1VJSW1hZ2VzL0luR2FtZS9DbGFzc2VzL1N0ci9QYXNzaXZlU2tpbGxTY3JlZW5TdGFydE5vZGVCYWNrZ3JvdW5kIiwic3AiOjAuMjk3Mn1d/ac7fc15b19/StartNodeBackgroundStr.png",
+            [0.3835]= "https://web.poecdn.com/gen/image/WzIxLDE0LHsiayI6IjJEQXJ0L1VJSW1hZ2VzL0luR2FtZS9DbGFzc2VzL1N0ci9QYXNzaXZlU2tpbGxTY3JlZW5TdGFydE5vZGVCYWNrZ3JvdW5kIiwic3AiOjAuMzgzNX1d/7ad4e0e8ad/StartNodeBackgroundStr.png"
+        },
+        ["centerranger"]= {
+            [0.1246]= "https://web.poecdn.com/gen/image/WzIxLDE0LHsiayI6IjJEQXJ0L1VJSW1hZ2VzL0luR2FtZS9DbGFzc2VzL0RleC9QYXNzaXZlU2tpbGxTY3JlZW5TdGFydE5vZGVCYWNrZ3JvdW5kIiwic3AiOjAuMTI0Nn1d/dd0003bf97/StartNodeBackgroundDex.png",
+            [0.2109]= "https://web.poecdn.com/gen/image/WzIxLDE0LHsiayI6IjJEQXJ0L1VJSW1hZ2VzL0luR2FtZS9DbGFzc2VzL0RleC9QYXNzaXZlU2tpbGxTY3JlZW5TdGFydE5vZGVCYWNrZ3JvdW5kIiwic3AiOjAuMjEwOX1d/e927ab8b67/StartNodeBackgroundDex.png",
+            [0.2972]= "https://web.poecdn.com/gen/image/WzIxLDE0LHsiayI6IjJEQXJ0L1VJSW1hZ2VzL0luR2FtZS9DbGFzc2VzL0RleC9QYXNzaXZlU2tpbGxTY3JlZW5TdGFydE5vZGVCYWNrZ3JvdW5kIiwic3AiOjAuMjk3Mn1d/c774337d03/StartNodeBackgroundDex.png",
+            [0.3835]= "https://web.poecdn.com/gen/image/WzIxLDE0LHsiayI6IjJEQXJ0L1VJSW1hZ2VzL0luR2FtZS9DbGFzc2VzL0RleC9QYXNzaXZlU2tpbGxTY3JlZW5TdGFydE5vZGVCYWNrZ3JvdW5kIiwic3AiOjAuMzgzNX1d/b6902971ce/StartNodeBackgroundDex.png"
+        },
+        ["centershadow"]= {
+            [0.1246]= "https://web.poecdn.com/gen/image/WzIxLDE0LHsiayI6IjJEQXJ0L1VJSW1hZ2VzL0luR2FtZS9DbGFzc2VzL0RleEludC9QYXNzaXZlU2tpbGxTY3JlZW5TdGFydE5vZGVCYWNrZ3JvdW5kIiwic3AiOjAuMTI0Nn1d/f293c4da60/StartNodeBackgroundDexInt.png",
+            [0.2109]= "https://web.poecdn.com/gen/image/WzIxLDE0LHsiayI6IjJEQXJ0L1VJSW1hZ2VzL0luR2FtZS9DbGFzc2VzL0RleEludC9QYXNzaXZlU2tpbGxTY3JlZW5TdGFydE5vZGVCYWNrZ3JvdW5kIiwic3AiOjAuMjEwOX1d/bc10b67322/StartNodeBackgroundDexInt.png",
+            [0.2972]= "https://web.poecdn.com/gen/image/WzIxLDE0LHsiayI6IjJEQXJ0L1VJSW1hZ2VzL0luR2FtZS9DbGFzc2VzL0RleEludC9QYXNzaXZlU2tpbGxTY3JlZW5TdGFydE5vZGVCYWNrZ3JvdW5kIiwic3AiOjAuMjk3Mn1d/620d8d017f/StartNodeBackgroundDexInt.png",
+            [0.3835]= "https://web.poecdn.com/gen/image/WzIxLDE0LHsiayI6IjJEQXJ0L1VJSW1hZ2VzL0luR2FtZS9DbGFzc2VzL0RleEludC9QYXNzaXZlU2tpbGxTY3JlZW5TdGFydE5vZGVCYWNrZ3JvdW5kIiwic3AiOjAuMzgzNX1d/ac0713485e/StartNodeBackgroundDexInt.png"
+        },
+        ["centertemplar"]= {
+            [0.1246]= "https://web.poecdn.com/gen/image/WzIxLDE0LHsiayI6IjJEQXJ0L1VJSW1hZ2VzL0luR2FtZS9DbGFzc2VzL1N0ckludC9QYXNzaXZlU2tpbGxTY3JlZW5TdGFydE5vZGVCYWNrZ3JvdW5kIiwic3AiOjAuMTI0Nn1d/76b7e38233/StartNodeBackgroundStrInt.png",
+            [0.2109]= "https://web.poecdn.com/gen/image/WzIxLDE0LHsiayI6IjJEQXJ0L1VJSW1hZ2VzL0luR2FtZS9DbGFzc2VzL1N0ckludC9QYXNzaXZlU2tpbGxTY3JlZW5TdGFydE5vZGVCYWNrZ3JvdW5kIiwic3AiOjAuMjEwOX1d/a54bdf614a/StartNodeBackgroundStrInt.png",
+            [0.2972]= "https://web.poecdn.com/gen/image/WzIxLDE0LHsiayI6IjJEQXJ0L1VJSW1hZ2VzL0luR2FtZS9DbGFzc2VzL1N0ckludC9QYXNzaXZlU2tpbGxTY3JlZW5TdGFydE5vZGVCYWNrZ3JvdW5kIiwic3AiOjAuMjk3Mn1d/59d865cdb0/StartNodeBackgroundStrInt.png",
+            [0.3835]= "https://web.poecdn.com/gen/image/WzIxLDE0LHsiayI6IjJEQXJ0L1VJSW1hZ2VzL0luR2FtZS9DbGFzc2VzL1N0ckludC9QYXNzaXZlU2tpbGxTY3JlZW5TdGFydE5vZGVCYWNrZ3JvdW5kIiwic3AiOjAuMzgzNX1d/51b706ad9c/StartNodeBackgroundStrInt.png"
+        },
+        ["centerwitch"]= {
+            [0.1246]= "https://web.poecdn.com/gen/image/WzIxLDE0LHsiayI6IjJEQXJ0L1VJSW1hZ2VzL0luR2FtZS9DbGFzc2VzL0ludC9QYXNzaXZlU2tpbGxTY3JlZW5TdGFydE5vZGVCYWNrZ3JvdW5kIiwic3AiOjAuMTI0Nn1d/551dc45d01/StartNodeBackgroundInt.png",
+            [0.2109]= "https://web.poecdn.com/gen/image/WzIxLDE0LHsiayI6IjJEQXJ0L1VJSW1hZ2VzL0luR2FtZS9DbGFzc2VzL0ludC9QYXNzaXZlU2tpbGxTY3JlZW5TdGFydE5vZGVCYWNrZ3JvdW5kIiwic3AiOjAuMjEwOX1d/805889d05c/StartNodeBackgroundInt.png",
+            [0.2972]= "https://web.poecdn.com/gen/image/WzIxLDE0LHsiayI6IjJEQXJ0L1VJSW1hZ2VzL0luR2FtZS9DbGFzc2VzL0ludC9QYXNzaXZlU2tpbGxTY3JlZW5TdGFydE5vZGVCYWNrZ3JvdW5kIiwic3AiOjAuMjk3Mn1d/9ce2d91f73/StartNodeBackgroundInt.png",
+            [0.3835]= "https://web.poecdn.com/gen/image/WzIxLDE0LHsiayI6IjJEQXJ0L1VJSW1hZ2VzL0luR2FtZS9DbGFzc2VzL0ludC9QYXNzaXZlU2tpbGxTY3JlZW5TdGFydE5vZGVCYWNrZ3JvdW5kIiwic3AiOjAuMzgzNX1d/8b73e64875/StartNodeBackgroundInt.png"
+        },
+        ["centerscion"]= {
+            [0.1246]= "https://web.poecdn.com/gen/image/WzIxLDE0LHsiayI6IjJEQXJ0L1VJSW1hZ2VzL0luR2FtZS9DbGFzc2VzL1N0ckRleEludC9QYXNzaXZlU2tpbGxTY3JlZW5TdGFydE5vZGVCYWNrZ3JvdW5kIiwic3AiOjAuMTI0Nn1d/620cf3a01a/StartNodeBackgroundStrDexInt.png",
+            [0.2109]= "https://web.poecdn.com/gen/image/WzIxLDE0LHsiayI6IjJEQXJ0L1VJSW1hZ2VzL0luR2FtZS9DbGFzc2VzL1N0ckRleEludC9QYXNzaXZlU2tpbGxTY3JlZW5TdGFydE5vZGVCYWNrZ3JvdW5kIiwic3AiOjAuMjEwOX1d/ff02c0d070/StartNodeBackgroundStrDexInt.png",
+            [0.2972]= "https://web.poecdn.com/gen/image/WzIxLDE0LHsiayI6IjJEQXJ0L1VJSW1hZ2VzL0luR2FtZS9DbGFzc2VzL1N0ckRleEludC9QYXNzaXZlU2tpbGxTY3JlZW5TdGFydE5vZGVCYWNrZ3JvdW5kIiwic3AiOjAuMjk3Mn1d/1aafed2581/StartNodeBackgroundStrDexInt.png",
+            [0.3835]= "https://web.poecdn.com/gen/image/WzIxLDE0LHsiayI6IjJEQXJ0L1VJSW1hZ2VzL0luR2FtZS9DbGFzc2VzL1N0ckRleEludC9QYXNzaXZlU2tpbGxTY3JlZW5TdGFydE5vZGVCYWNrZ3JvdW5kIiwic3AiOjAuMzgzNX1d/801737b229/StartNodeBackgroundStrDexInt.png"
+        },
+        ["BlightedNotableFrameUnallocated"]= {
+            [0.1246]= "https://web.poecdn.com/gen/image/WzIyLCIxNTIwNDU5MDc2NWU2MmYyOGU4ZTNiMGJhNGI1NWUyNyIseyJ0Ijo2Mywic3AiOjAuMTI0Nn1d/d40118a397/BlightedNotableFrameUnallocated.png",
+            [0.2109]= "https://web.poecdn.com/gen/image/WzIyLCIxNTIwNDU5MDc2NWU2MmYyOGU4ZTNiMGJhNGI1NWUyNyIseyJ0Ijo2Mywic3AiOjAuMjEwOX1d/218723d1e2/BlightedNotableFrameUnallocated.png",
+            [0.2972]= "https://web.poecdn.com/gen/image/WzIyLCIxNTIwNDU5MDc2NWU2MmYyOGU4ZTNiMGJhNGI1NWUyNyIseyJ0Ijo2Mywic3AiOjAuMjk3Mn1d/4fefb4c324/BlightedNotableFrameUnallocated.png",
+            [0.3835]= "https://web.poecdn.com/gen/image/WzIyLCIxNTIwNDU5MDc2NWU2MmYyOGU4ZTNiMGJhNGI1NWUyNyIseyJ0Ijo2Mywic3AiOjAuMzgzNX1d/a030b6f0fb/BlightedNotableFrameUnallocated.png"
+        },
+        ["BlightedNotableFrameCanAllocate"]= {
+            [0.1246]= "https://web.poecdn.com/gen/image/WzIyLCI4YzUxYTNiMTY0MGMzMjUwNmY5ZGJhMjQwNDMxZjE4NSIseyJ0Ijo2NSwic3AiOjAuMTI0Nn1d/ebf0740e31/BlightedNotableFrameCanAllocate.png",
+            [0.2109]= "https://web.poecdn.com/gen/image/WzIyLCI4YzUxYTNiMTY0MGMzMjUwNmY5ZGJhMjQwNDMxZjE4NSIseyJ0Ijo2NSwic3AiOjAuMjEwOX1d/7cb6b76a0b/BlightedNotableFrameCanAllocate.png",
+            [0.2972]= "https://web.poecdn.com/gen/image/WzIyLCI4YzUxYTNiMTY0MGMzMjUwNmY5ZGJhMjQwNDMxZjE4NSIseyJ0Ijo2NSwic3AiOjAuMjk3Mn1d/2b787a0f3a/BlightedNotableFrameCanAllocate.png",
+            [0.3835]= "https://web.poecdn.com/gen/image/WzIyLCI4YzUxYTNiMTY0MGMzMjUwNmY5ZGJhMjQwNDMxZjE4NSIseyJ0Ijo2NSwic3AiOjAuMzgzNX1d/d9fdeff849/BlightedNotableFrameCanAllocate.png"
+        },
+        ["BlightedNotableFrameAllocated"]= {
+            [0.1246]= "https://web.poecdn.com/gen/image/WzIyLCI4OTFiZTBiOTdkYjAwOTlmOTYyYzllMDE1MDY1ZTllNCIseyJ0Ijo2NCwic3AiOjAuMTI0Nn1d/6c0dd4d251/BlightedNotableFrameAllocated.png",
+            [0.2109]= "https://web.poecdn.com/gen/image/WzIyLCI4OTFiZTBiOTdkYjAwOTlmOTYyYzllMDE1MDY1ZTllNCIseyJ0Ijo2NCwic3AiOjAuMjEwOX1d/8b30f97909/BlightedNotableFrameAllocated.png",
+            [0.2972]= "https://web.poecdn.com/gen/image/WzIyLCI4OTFiZTBiOTdkYjAwOTlmOTYyYzllMDE1MDY1ZTllNCIseyJ0Ijo2NCwic3AiOjAuMjk3Mn1d/fc4b001298/BlightedNotableFrameAllocated.png",
+            [0.3835]= "https://web.poecdn.com/gen/image/WzIyLCI4OTFiZTBiOTdkYjAwOTlmOTYyYzllMDE1MDY1ZTllNCIseyJ0Ijo2NCwic3AiOjAuMzgzNX1d/5711d7a0c3/BlightedNotableFrameAllocated.png"
+        },
+        ["JewelFrameUnallocated"]= {
+            [0.1246]= "https://web.poecdn.com/gen/image/WzIyLCIzZTlkYTEwZTVlNjgwMmVjNzc0ZjJhYTRmNDc5ZDM5MCIseyJ0IjoxNSwic3AiOjAuMTI0Nn1d/26850c3220/JewelFrameUnallocated.png",
+            [0.2109]= "https://web.poecdn.com/gen/image/WzIyLCIzZTlkYTEwZTVlNjgwMmVjNzc0ZjJhYTRmNDc5ZDM5MCIseyJ0IjoxNSwic3AiOjAuMjEwOX1d/146dcc85eb/JewelFrameUnallocated.png",
+            [0.2972]= "https://web.poecdn.com/gen/image/WzIyLCIzZTlkYTEwZTVlNjgwMmVjNzc0ZjJhYTRmNDc5ZDM5MCIseyJ0IjoxNSwic3AiOjAuMjk3Mn1d/65efa526a4/JewelFrameUnallocated.png",
+            [0.3835]= "https://web.poecdn.com/gen/image/WzIyLCIzZTlkYTEwZTVlNjgwMmVjNzc0ZjJhYTRmNDc5ZDM5MCIseyJ0IjoxNSwic3AiOjAuMzgzNX1d/a1363cd145/JewelFrameUnallocated.png"
+        },
+        ["JewelFrameCanAllocate"]= {
+            [0.1246]= "https://web.poecdn.com/gen/image/WzIyLCI1OWFiN2NlZjViYTg1NTJhNWY3MjI3YTYzODg5Nzc3OCIseyJ0IjoxNiwic3AiOjAuMTI0Nn1d/aa414e00d5/JewelFrameCanAllocate.png",
+            [0.2109]= "https://web.poecdn.com/gen/image/WzIyLCI1OWFiN2NlZjViYTg1NTJhNWY3MjI3YTYzODg5Nzc3OCIseyJ0IjoxNiwic3AiOjAuMjEwOX1d/a7e8c9b474/JewelFrameCanAllocate.png",
+            [0.2972]= "https://web.poecdn.com/gen/image/WzIyLCI1OWFiN2NlZjViYTg1NTJhNWY3MjI3YTYzODg5Nzc3OCIseyJ0IjoxNiwic3AiOjAuMjk3Mn1d/c585019069/JewelFrameCanAllocate.png",
+            [0.3835]= "https://web.poecdn.com/gen/image/WzIyLCI1OWFiN2NlZjViYTg1NTJhNWY3MjI3YTYzODg5Nzc3OCIseyJ0IjoxNiwic3AiOjAuMzgzNX1d/62ba748f00/JewelFrameCanAllocate.png"
+        },
+        ["JewelFrameAllocated"]= {
+            [0.1246]= "https://web.poecdn.com/gen/image/WzIyLCI2MDJlNzlmYmRlZGM0OWJmNjc3NGM2Mjk1ODY3OTIyZSIseyJ0IjoxNywic3AiOjAuMTI0Nn1d/239494b58a/JewelFrameAllocated.png",
+            [0.2109]= "https://web.poecdn.com/gen/image/WzIyLCI2MDJlNzlmYmRlZGM0OWJmNjc3NGM2Mjk1ODY3OTIyZSIseyJ0IjoxNywic3AiOjAuMjEwOX1d/95143055fe/JewelFrameAllocated.png",
+            [0.2972]= "https://web.poecdn.com/gen/image/WzIyLCI2MDJlNzlmYmRlZGM0OWJmNjc3NGM2Mjk1ODY3OTIyZSIseyJ0IjoxNywic3AiOjAuMjk3Mn1d/dfafbdc952/JewelFrameAllocated.png",
+            [0.3835]= "https://web.poecdn.com/gen/image/WzIyLCI2MDJlNzlmYmRlZGM0OWJmNjc3NGM2Mjk1ODY3OTIyZSIseyJ0IjoxNywic3AiOjAuMzgzNX1d/55c403d22d/JewelFrameAllocated.png"
+        },
+        ["JewelSocketActiveBlue"]= {
+            [0.1246]= "https://web.poecdn.com/gen/image/WzIyLCIxMDZlZWE5ZmYyOGFiYjJmZGE3M2I1NGZiODgyMzdjYyIseyJ0IjoxOCwic3AiOjAuMTI0Nn1d/7ce91abaae/JewelSocketActiveBlue.png",
+            [0.2109]= "https://web.poecdn.com/gen/image/WzIyLCIxMDZlZWE5ZmYyOGFiYjJmZGE3M2I1NGZiODgyMzdjYyIseyJ0IjoxOCwic3AiOjAuMjEwOX1d/db564a6dfc/JewelSocketActiveBlue.png",
+            [0.2972]= "https://web.poecdn.com/gen/image/WzIyLCIxMDZlZWE5ZmYyOGFiYjJmZGE3M2I1NGZiODgyMzdjYyIseyJ0IjoxOCwic3AiOjAuMjk3Mn1d/f30785a549/JewelSocketActiveBlue.png",
+            [0.3835]= "https://web.poecdn.com/gen/image/WzIyLCIxMDZlZWE5ZmYyOGFiYjJmZGE3M2I1NGZiODgyMzdjYyIseyJ0IjoxOCwic3AiOjAuMzgzNX1d/2eedafcbf9/JewelSocketActiveBlue.png"
+        },
+        ["JewelSocketActiveGreen"]= {
+            [0.1246]= "https://web.poecdn.com/gen/image/WzIyLCJmZGExZjFlYjZjYWFmNTU1MTczNjE1ZGZjZmI3OTZkMSIseyJ0IjoxOSwic3AiOjAuMTI0Nn1d/482a2b76d9/JewelSocketActiveGreen.png",
+            [0.2109]= "https://web.poecdn.com/gen/image/WzIyLCJmZGExZjFlYjZjYWFmNTU1MTczNjE1ZGZjZmI3OTZkMSIseyJ0IjoxOSwic3AiOjAuMjEwOX1d/2364d600a0/JewelSocketActiveGreen.png",
+            [0.2972]= "https://web.poecdn.com/gen/image/WzIyLCJmZGExZjFlYjZjYWFmNTU1MTczNjE1ZGZjZmI3OTZkMSIseyJ0IjoxOSwic3AiOjAuMjk3Mn1d/d57cfb77cc/JewelSocketActiveGreen.png",
+            [0.3835]= "https://web.poecdn.com/gen/image/WzIyLCJmZGExZjFlYjZjYWFmNTU1MTczNjE1ZGZjZmI3OTZkMSIseyJ0IjoxOSwic3AiOjAuMzgzNX1d/ee05c4e2e0/JewelSocketActiveGreen.png"
+        },
+        ["JewelSocketActiveRed"]= {
+            [0.1246]= "https://web.poecdn.com/gen/image/WzIyLCI1ZDhkOTVkZWZmNDc4ZWU4NWFhNGFlZmI1NDhhNDViMyIseyJ0IjoyMCwic3AiOjAuMTI0Nn1d/09e3ef0310/JewelSocketActiveRed.png",
+            [0.2109]= "https://web.poecdn.com/gen/image/WzIyLCI1ZDhkOTVkZWZmNDc4ZWU4NWFhNGFlZmI1NDhhNDViMyIseyJ0IjoyMCwic3AiOjAuMjEwOX1d/c583fe3891/JewelSocketActiveRed.png",
+            [0.2972]= "https://web.poecdn.com/gen/image/WzIyLCI1ZDhkOTVkZWZmNDc4ZWU4NWFhNGFlZmI1NDhhNDViMyIseyJ0IjoyMCwic3AiOjAuMjk3Mn1d/7b9084f578/JewelSocketActiveRed.png",
+            [0.3835]= "https://web.poecdn.com/gen/image/WzIyLCI1ZDhkOTVkZWZmNDc4ZWU4NWFhNGFlZmI1NDhhNDViMyIseyJ0IjoyMCwic3AiOjAuMzgzNX1d/7a79aeb923/JewelSocketActiveRed.png"
+        },
+        ["JewelSocketActivePrismatic"]= {
+            [0.1246]= "https://web.poecdn.com/gen/image/WzIyLCIwNTM5OWY4MmQ3NWQ3ZTQwYjUwZDIzY2JmM2IzYTg1ZSIseyJ0Ijo1MSwic3AiOjAuMTI0Nn1d/ef553c7901/JewelSocketActivePrismatic.png",
+            [0.2109]= "https://web.poecdn.com/gen/image/WzIyLCIwNTM5OWY4MmQ3NWQ3ZTQwYjUwZDIzY2JmM2IzYTg1ZSIseyJ0Ijo1MSwic3AiOjAuMjEwOX1d/bb45573588/JewelSocketActivePrismatic.png",
+            [0.2972]= "https://web.poecdn.com/gen/image/WzIyLCIwNTM5OWY4MmQ3NWQ3ZTQwYjUwZDIzY2JmM2IzYTg1ZSIseyJ0Ijo1MSwic3AiOjAuMjk3Mn1d/6c8eed3e06/JewelSocketActivePrismatic.png",
+            [0.3835]= "https://web.poecdn.com/gen/image/WzIyLCIwNTM5OWY4MmQ3NWQ3ZTQwYjUwZDIzY2JmM2IzYTg1ZSIseyJ0Ijo1MSwic3AiOjAuMzgzNX1d/cc2861313f/JewelSocketActivePrismatic.png"
+        },
+        ["JewelSocketActiveAbyss"]= {
+            [0.1246]= "https://web.poecdn.com/gen/image/WzIyLCIyZjM5NmMzNTU5Nzc4NTJhODE1NGEwOTJlMDBjZThjZCIseyJ0Ijo1MCwic3AiOjAuMTI0Nn1d/148f109011/JewelSocketActiveAbyss.png",
+            [0.2109]= "https://web.poecdn.com/gen/image/WzIyLCIyZjM5NmMzNTU5Nzc4NTJhODE1NGEwOTJlMDBjZThjZCIseyJ0Ijo1MCwic3AiOjAuMjEwOX1d/c489c9179d/JewelSocketActiveAbyss.png",
+            [0.2972]= "https://web.poecdn.com/gen/image/WzIyLCIyZjM5NmMzNTU5Nzc4NTJhODE1NGEwOTJlMDBjZThjZCIseyJ0Ijo1MCwic3AiOjAuMjk3Mn1d/4cb0707b80/JewelSocketActiveAbyss.png",
+            [0.3835]= "https://web.poecdn.com/gen/image/WzIyLCIyZjM5NmMzNTU5Nzc4NTJhODE1NGEwOTJlMDBjZThjZCIseyJ0Ijo1MCwic3AiOjAuMzgzNX1d/72f84e8db6/JewelSocketActiveAbyss.png"
+        },
+        ["JewelSocketActiveLegion"]= {
+            [0.1246]= "https://web.poecdn.com/gen/image/WzIyLCI5NDI5ZTg2NDgyYjRhNWE3NmJkNmNlYmVhZjIzYzA2NyIseyJ0Ijo4MSwic3AiOjAuMTI0Nn1d/101afbb133/JewelSocketActiveLegion.png",
+            [0.2109]= "https://web.poecdn.com/gen/image/WzIyLCI5NDI5ZTg2NDgyYjRhNWE3NmJkNmNlYmVhZjIzYzA2NyIseyJ0Ijo4MSwic3AiOjAuMjEwOX1d/b9af8ef6bc/JewelSocketActiveLegion.png",
+            [0.2972]= "https://web.poecdn.com/gen/image/WzIyLCI5NDI5ZTg2NDgyYjRhNWE3NmJkNmNlYmVhZjIzYzA2NyIseyJ0Ijo4MSwic3AiOjAuMjk3Mn1d/355d7a3bd3/JewelSocketActiveLegion.png",
+            [0.3835]= "https://web.poecdn.com/gen/image/WzIyLCI5NDI5ZTg2NDgyYjRhNWE3NmJkNmNlYmVhZjIzYzA2NyIseyJ0Ijo4MSwic3AiOjAuMzgzNX1d/c6cc223396/JewelSocketActiveLegion.png"
+        },
+        ["JewelSocketActiveAltRed"]= {
+            [0.1246]= "https://web.poecdn.com/gen/image/WzIyLCI0NDE5Njc0NTlmM2Y0ZTMwY2IzM2U4YjgxZDM2OGFlNiIseyJ0Ijo4Mywic3AiOjAuMTI0Nn1d/9b8451d82d/JewelSocketActiveAltRed.png",
+            [0.2109]= "https://web.poecdn.com/gen/image/WzIyLCI0NDE5Njc0NTlmM2Y0ZTMwY2IzM2U4YjgxZDM2OGFlNiIseyJ0Ijo4Mywic3AiOjAuMjEwOX1d/47138dc14d/JewelSocketActiveAltRed.png",
+            [0.2972]= "https://web.poecdn.com/gen/image/WzIyLCI0NDE5Njc0NTlmM2Y0ZTMwY2IzM2U4YjgxZDM2OGFlNiIseyJ0Ijo4Mywic3AiOjAuMjk3Mn1d/52db416738/JewelSocketActiveAltRed.png",
+            [0.3835]= "https://web.poecdn.com/gen/image/WzIyLCI0NDE5Njc0NTlmM2Y0ZTMwY2IzM2U4YjgxZDM2OGFlNiIseyJ0Ijo4Mywic3AiOjAuMzgzNX1d/d55e387ce3/JewelSocketActiveAltRed.png"
+        },
+        ["JewelSocketActiveAltBlue"]= {
+            [0.1246]= "https://web.poecdn.com/gen/image/WzIyLCI4YWNlMmYxY2RmMjc3NTE4MGExOGJmMjExMjY1ZjE3YyIseyJ0Ijo4NCwic3AiOjAuMTI0Nn1d/a02680bbe7/JewelSocketActiveAltBlue.png",
+            [0.2109]= "https://web.poecdn.com/gen/image/WzIyLCI4YWNlMmYxY2RmMjc3NTE4MGExOGJmMjExMjY1ZjE3YyIseyJ0Ijo4NCwic3AiOjAuMjEwOX1d/a1b5208eb2/JewelSocketActiveAltBlue.png",
+            [0.2972]= "https://web.poecdn.com/gen/image/WzIyLCI4YWNlMmYxY2RmMjc3NTE4MGExOGJmMjExMjY1ZjE3YyIseyJ0Ijo4NCwic3AiOjAuMjk3Mn1d/dd9541673c/JewelSocketActiveAltBlue.png",
+            [0.3835]= "https://web.poecdn.com/gen/image/WzIyLCI4YWNlMmYxY2RmMjc3NTE4MGExOGJmMjExMjY1ZjE3YyIseyJ0Ijo4NCwic3AiOjAuMzgzNX1d/6f9c75c8f2/JewelSocketActiveAltBlue.png"
+        },
+        ["JewelSocketActiveAltPurple"]= {
+            [0.1246]= "https://web.poecdn.com/gen/image/WzIyLCIzMzljN2EwMjZkM2VlZjI1OTQ4MDZiY2I0OTQ0MDM1NSIseyJ0Ijo4NSwic3AiOjAuMTI0Nn1d/57911a8927/JewelSocketActiveAltPurple.png",
+            [0.2109]= "https://web.poecdn.com/gen/image/WzIyLCIzMzljN2EwMjZkM2VlZjI1OTQ4MDZiY2I0OTQ0MDM1NSIseyJ0Ijo4NSwic3AiOjAuMjEwOX1d/9370aae212/JewelSocketActiveAltPurple.png",
+            [0.2972]= "https://web.poecdn.com/gen/image/WzIyLCIzMzljN2EwMjZkM2VlZjI1OTQ4MDZiY2I0OTQ0MDM1NSIseyJ0Ijo4NSwic3AiOjAuMjk3Mn1d/5c4723e281/JewelSocketActiveAltPurple.png",
+            [0.3835]= "https://web.poecdn.com/gen/image/WzIyLCIzMzljN2EwMjZkM2VlZjI1OTQ4MDZiY2I0OTQ0MDM1NSIseyJ0Ijo4NSwic3AiOjAuMzgzNX1d/b7cc0d2a93/JewelSocketActiveAltPurple.png"
+        },
+        ["JewelCircle1"]= {
+            [1]= "https://web.poecdn.com/gen/image/WzIyLCIxYWUxNWEyNTUzMjUwNzQyZTMxNWU5NDVkZTYyMmNhMSIseyJ0Ijo1Miwic3AiOjF9XQ/60c1fcf027/JewelCircle1.png"
+        },
+        ["JewelCircle1Inverse"]= {
+            [1]= "https://web.poecdn.com/gen/image/WzIyLCJkZDk4MWY5NTYwYjljY2EyOTRhM2MzNmJjYjlmYzIxMCIseyJ0Ijo2Niwic3AiOjF9XQ/e62a1de951/JewelCircle1inverse.png"
+        },
+        ["VaalJewelCircle1"]= {
+            [1]= "https://web.poecdn.com/gen/image/WzIyLCI1ZWE4YTNjMGY5MmQ2M2NlYjE5ZmVmNzljN2VjZGNlNCIseyJ0Ijo1Mywic3AiOjF9XQ/c1dd9689c0/VaalJewelCircle1.png"
+        },
+        ["VaalJewelCircle2"]= {
+            [1]= "https://web.poecdn.com/gen/image/WzIyLCJiMTUzMWNkYzY3YzQyYjkyNmZkMTU1NmEwMWZkOTQ2ZSIseyJ0Ijo1NCwic3AiOjF9XQ/5cc92a764e/VaalJewelCircle2.png"
+        },
+        ["KaruiJewelCircle1"]= {
+            [1]= "https://web.poecdn.com/gen/image/WzIyLCIwMjYwYzA0NDMyMGJjZGYzMzE2MzQwMjJjMDY0MmExYSIseyJ0Ijo1NSwic3AiOjF9XQ/b9c39c2b6e/KaruiJewelCircle1.png"
+        },
+        ["KaruiJewelCircle2"]= {
+            [1]= "https://web.poecdn.com/gen/image/WzIyLCJjMzdiNmI3MjkxY2JiZTA4MzZhMWQyNzY4MmYzMjdhYSIseyJ0Ijo1Niwic3AiOjF9XQ/30ac5eb33e/KaruiJewelCircle2.png"
+        },
+        ["MarakethJewelCircle1"]= {
+            [1]= "https://web.poecdn.com/gen/image/WzIyLCJlMGNlYmFhMzFhZmRjN2Y2ZDRlYmM5Y2MxZmIwYWNlMyIseyJ0Ijo1Nywic3AiOjF9XQ/8d1faa3f78/MarakethJewelCircle1.png"
+        },
+        ["MarakethJewelCircle2"]= {
+            [1]= "https://web.poecdn.com/gen/image/WzIyLCJkYTJkZWFlNzEyNWYwMTViYzEwNmI5MDAxYWVlOTEzOCIseyJ0Ijo1OCwic3AiOjF9XQ/4ad56d2764/MarakethJewelCircle2.png"
+        },
+        ["TemplarJewelCircle1"]= {
+            [1]= "https://web.poecdn.com/gen/image/WzIyLCJjMWYwMzI4ZTE0OTUxOWViZDU0MDMxYzQyZjM0MzQxMiIseyJ0Ijo1OSwic3AiOjF9XQ/717b270417/TemplarJewelCircle1.png"
+        },
+        ["TemplarJewelCircle2"]= {
+            [1]= "https://web.poecdn.com/gen/image/WzIyLCJiMzY3Y2ZhMTg3YjQwYTBjY2NkNzBiOWMwYzg0N2VjZiIseyJ0Ijo2MCwic3AiOjF9XQ/4d2db3b068/TemplarJewelCircle2.png"
+        },
+        ["EternalEmpireJewelCircle1"]= {
+            [1]= "https://web.poecdn.com/gen/image/WzIyLCJlMDczOGMxZmRjMTQ1M2JiMjkwN2Q2ZTJmMzdkYjIwYSIseyJ0Ijo2MSwic3AiOjF9XQ/bb864f5a58/EternalEmpireJewelCircle1.png"
+        },
+        ["EternalEmpireJewelCircle2"]= {
+            [1]= "https://web.poecdn.com/gen/image/WzIyLCJlMTdlNTVmZWJhMmU4ZWU4NzM4Y2VlZWE0ZTE1OTc5NyIseyJ0Ijo2Miwic3AiOjF9XQ/08f237f07c/EternalEmpireJewelCircle2.png"
+        },
+        ["JewelSocketAltNormal"]= {
+            [0.1246]= "https://web.poecdn.com/gen/image/WzIyLCI2MDU5ZGVlYjE3Nzg2M2YwODdjMmM4MDBlODhlM2MwOSIseyJ0Ijo2Nywic3AiOjAuMTI0Nn1d/06695ddbf6/JewelSocketAltNormal.png",
+            [0.2109]= "https://web.poecdn.com/gen/image/WzIyLCI2MDU5ZGVlYjE3Nzg2M2YwODdjMmM4MDBlODhlM2MwOSIseyJ0Ijo2Nywic3AiOjAuMjEwOX1d/13b480660b/JewelSocketAltNormal.png",
+            [0.2972]= "https://web.poecdn.com/gen/image/WzIyLCI2MDU5ZGVlYjE3Nzg2M2YwODdjMmM4MDBlODhlM2MwOSIseyJ0Ijo2Nywic3AiOjAuMjk3Mn1d/1deb95fb3e/JewelSocketAltNormal.png",
+            [0.3835]= "https://web.poecdn.com/gen/image/WzIyLCI2MDU5ZGVlYjE3Nzg2M2YwODdjMmM4MDBlODhlM2MwOSIseyJ0Ijo2Nywic3AiOjAuMzgzNX1d/45d1574863/JewelSocketAltNormal.png"
+        },
+        ["JewelSocketAltCanAllocate"]= {
+            [0.1246]= "https://web.poecdn.com/gen/image/WzIyLCJlNmJjNWY5NzIwYWEyY2MwMjg4ZjhmNmIzNzk5ZDZhMyIseyJ0Ijo2OCwic3AiOjAuMTI0Nn1d/dcba0366ec/JewelSocketAltCanAllocate.png",
+            [0.2109]= "https://web.poecdn.com/gen/image/WzIyLCJlNmJjNWY5NzIwYWEyY2MwMjg4ZjhmNmIzNzk5ZDZhMyIseyJ0Ijo2OCwic3AiOjAuMjEwOX1d/3a5d49aacf/JewelSocketAltCanAllocate.png",
+            [0.2972]= "https://web.poecdn.com/gen/image/WzIyLCJlNmJjNWY5NzIwYWEyY2MwMjg4ZjhmNmIzNzk5ZDZhMyIseyJ0Ijo2OCwic3AiOjAuMjk3Mn1d/6586c79125/JewelSocketAltCanAllocate.png",
+            [0.3835]= "https://web.poecdn.com/gen/image/WzIyLCJlNmJjNWY5NzIwYWEyY2MwMjg4ZjhmNmIzNzk5ZDZhMyIseyJ0Ijo2OCwic3AiOjAuMzgzNX1d/e703e6377e/JewelSocketAltCanAllocate.png"
+        },
+        ["JewelSocketAltActive"]= {
+            [0.1246]= "https://web.poecdn.com/gen/image/WzIyLCJlNmJkYmI4M2Q3NzliZTUzMDVhYzFhMDU2YmYxNzc3MyIseyJ0Ijo2OSwic3AiOjAuMTI0Nn1d/a4cbe85033/JewelSocketAltActive.png",
+            [0.2109]= "https://web.poecdn.com/gen/image/WzIyLCJlNmJkYmI4M2Q3NzliZTUzMDVhYzFhMDU2YmYxNzc3MyIseyJ0Ijo2OSwic3AiOjAuMjEwOX1d/36d5d38247/JewelSocketAltActive.png",
+            [0.2972]= "https://web.poecdn.com/gen/image/WzIyLCJlNmJkYmI4M2Q3NzliZTUzMDVhYzFhMDU2YmYxNzc3MyIseyJ0Ijo2OSwic3AiOjAuMjk3Mn1d/e7b40b0986/JewelSocketAltActive.png",
+            [0.3835]= "https://web.poecdn.com/gen/image/WzIyLCJlNmJkYmI4M2Q3NzliZTUzMDVhYzFhMDU2YmYxNzc3MyIseyJ0Ijo2OSwic3AiOjAuMzgzNX1d/3b4d4c3066/JewelSocketAltActive.png"
+        },
+        ["JewelSocketActiveBlueAlt"]= {
+            [0.1246]= "https://web.poecdn.com/gen/image/WzIyLCJiNmQ2NmU0NWM0NDljNjc3MDNlMTRiYTkzM2UyYTA4OCIseyJ0Ijo3Niwic3AiOjAuMTI0Nn1d/28f80b76d3/JewelSocketActiveBlueAlt.png",
+            [0.2109]= "https://web.poecdn.com/gen/image/WzIyLCJiNmQ2NmU0NWM0NDljNjc3MDNlMTRiYTkzM2UyYTA4OCIseyJ0Ijo3Niwic3AiOjAuMjEwOX1d/a0c3ce26a7/JewelSocketActiveBlueAlt.png",
+            [0.2972]= "https://web.poecdn.com/gen/image/WzIyLCJiNmQ2NmU0NWM0NDljNjc3MDNlMTRiYTkzM2UyYTA4OCIseyJ0Ijo3Niwic3AiOjAuMjk3Mn1d/091cea0c9d/JewelSocketActiveBlueAlt.png",
+            [0.3835]= "https://web.poecdn.com/gen/image/WzIyLCJiNmQ2NmU0NWM0NDljNjc3MDNlMTRiYTkzM2UyYTA4OCIseyJ0Ijo3Niwic3AiOjAuMzgzNX1d/556440f786/JewelSocketActiveBlueAlt.png"
+        },
+        ["JewelSocketActiveGreenAlt"]= {
+            [0.1246]= "https://web.poecdn.com/gen/image/WzIyLCJiNzJmN2QyMDJlZWViMzcwMGU5YTEyNzUyZjlkOGFiZCIseyJ0Ijo3Nywic3AiOjAuMTI0Nn1d/88faa2adea/JewelSocketActiveGreenAlt.png",
+            [0.2109]= "https://web.poecdn.com/gen/image/WzIyLCJiNzJmN2QyMDJlZWViMzcwMGU5YTEyNzUyZjlkOGFiZCIseyJ0Ijo3Nywic3AiOjAuMjEwOX1d/9a98f00e77/JewelSocketActiveGreenAlt.png",
+            [0.2972]= "https://web.poecdn.com/gen/image/WzIyLCJiNzJmN2QyMDJlZWViMzcwMGU5YTEyNzUyZjlkOGFiZCIseyJ0Ijo3Nywic3AiOjAuMjk3Mn1d/f6a51190ce/JewelSocketActiveGreenAlt.png",
+            [0.3835]= "https://web.poecdn.com/gen/image/WzIyLCJiNzJmN2QyMDJlZWViMzcwMGU5YTEyNzUyZjlkOGFiZCIseyJ0Ijo3Nywic3AiOjAuMzgzNX1d/c4467618ff/JewelSocketActiveGreenAlt.png"
+        },
+        ["JewelSocketActiveRedAlt"]= {
+            [0.1246]= "https://web.poecdn.com/gen/image/WzIyLCIxNmYwZTI2NDRiYjkzOTM3M2NlNDJmZTc2YTIyZWI2OSIseyJ0Ijo3OCwic3AiOjAuMTI0Nn1d/111ded1c53/JewelSocketActiveRedAlt.png",
+            [0.2109]= "https://web.poecdn.com/gen/image/WzIyLCIxNmYwZTI2NDRiYjkzOTM3M2NlNDJmZTc2YTIyZWI2OSIseyJ0Ijo3OCwic3AiOjAuMjEwOX1d/21a9a1cd39/JewelSocketActiveRedAlt.png",
+            [0.2972]= "https://web.poecdn.com/gen/image/WzIyLCIxNmYwZTI2NDRiYjkzOTM3M2NlNDJmZTc2YTIyZWI2OSIseyJ0Ijo3OCwic3AiOjAuMjk3Mn1d/2b8be6756e/JewelSocketActiveRedAlt.png",
+            [0.3835]= "https://web.poecdn.com/gen/image/WzIyLCIxNmYwZTI2NDRiYjkzOTM3M2NlNDJmZTc2YTIyZWI2OSIseyJ0Ijo3OCwic3AiOjAuMzgzNX1d/98f4332215/JewelSocketActiveRedAlt.png"
+        },
+        ["JewelSocketActivePrismaticAlt"]= {
+            [0.1246]= "https://web.poecdn.com/gen/image/WzIyLCJjODE2YzVmYTlkNjQwMWY0MWYxZjY2YWM0NzZhYzVkMSIseyJ0Ijo3OSwic3AiOjAuMTI0Nn1d/36cd0673d2/JewelSocketActivePrismaticAlt.png",
+            [0.2109]= "https://web.poecdn.com/gen/image/WzIyLCJjODE2YzVmYTlkNjQwMWY0MWYxZjY2YWM0NzZhYzVkMSIseyJ0Ijo3OSwic3AiOjAuMjEwOX1d/a83d099066/JewelSocketActivePrismaticAlt.png",
+            [0.2972]= "https://web.poecdn.com/gen/image/WzIyLCJjODE2YzVmYTlkNjQwMWY0MWYxZjY2YWM0NzZhYzVkMSIseyJ0Ijo3OSwic3AiOjAuMjk3Mn1d/d964209d9e/JewelSocketActivePrismaticAlt.png",
+            [0.3835]= "https://web.poecdn.com/gen/image/WzIyLCJjODE2YzVmYTlkNjQwMWY0MWYxZjY2YWM0NzZhYzVkMSIseyJ0Ijo3OSwic3AiOjAuMzgzNX1d/519705d606/JewelSocketActivePrismaticAlt.png"
+        },
+        ["JewelSocketActiveAbyssAlt"]= {
+            [0.1246]= "https://web.poecdn.com/gen/image/WzIyLCJlZTFjZGY1MDJjM2M3OWQ2NzcyOTUwYTgzMjY4Y2M0MyIseyJ0Ijo4MCwic3AiOjAuMTI0Nn1d/64f600a50b/JewelSocketActiveAbyssAlt.png",
+            [0.2109]= "https://web.poecdn.com/gen/image/WzIyLCJlZTFjZGY1MDJjM2M3OWQ2NzcyOTUwYTgzMjY4Y2M0MyIseyJ0Ijo4MCwic3AiOjAuMjEwOX1d/f7a92bf5a4/JewelSocketActiveAbyssAlt.png",
+            [0.2972]= "https://web.poecdn.com/gen/image/WzIyLCJlZTFjZGY1MDJjM2M3OWQ2NzcyOTUwYTgzMjY4Y2M0MyIseyJ0Ijo4MCwic3AiOjAuMjk3Mn1d/d5d4840784/JewelSocketActiveAbyssAlt.png",
+            [0.3835]= "https://web.poecdn.com/gen/image/WzIyLCJlZTFjZGY1MDJjM2M3OWQ2NzcyOTUwYTgzMjY4Y2M0MyIseyJ0Ijo4MCwic3AiOjAuMzgzNX1d/fb3f56f9af/JewelSocketActiveAbyssAlt.png"
+        },
+        ["JewelSocketActiveLegionAlt"]= {
+            [0.1246]= "https://web.poecdn.com/gen/image/WzIyLCJhZjhjM2NjNzZkODc2MjA5YmUwOGY4NDY0YjU2NTZjMCIseyJ0Ijo4Miwic3AiOjAuMTI0Nn1d/3ca52281c4/JewelSocketActiveLegionAlt.png",
+            [0.2109]= "https://web.poecdn.com/gen/image/WzIyLCJhZjhjM2NjNzZkODc2MjA5YmUwOGY4NDY0YjU2NTZjMCIseyJ0Ijo4Miwic3AiOjAuMjEwOX1d/32b7e75acc/JewelSocketActiveLegionAlt.png",
+            [0.2972]= "https://web.poecdn.com/gen/image/WzIyLCJhZjhjM2NjNzZkODc2MjA5YmUwOGY4NDY0YjU2NTZjMCIseyJ0Ijo4Miwic3AiOjAuMjk3Mn1d/1549cd55d5/JewelSocketActiveLegionAlt.png",
+            [0.3835]= "https://web.poecdn.com/gen/image/WzIyLCJhZjhjM2NjNzZkODc2MjA5YmUwOGY4NDY0YjU2NTZjMCIseyJ0Ijo4Miwic3AiOjAuMzgzNX1d/d11101e50e/JewelSocketActiveLegionAlt.png"
+        },
+        ["JewelSocketClusterAltNormal1Small"]= {
+            [0.1246]= "https://web.poecdn.com/gen/image/WzIyLCIzMTM0MjVhMGYxODNmZGEyYzllMGQ4NTVkMjRmYWFlOCIseyJ0Ijo3MCwic3AiOjAuMTI0Nn1d/91fef3b953/JewelSocketClusterAltNormal1Small.png",
+            [0.2109]= "https://web.poecdn.com/gen/image/WzIyLCIzMTM0MjVhMGYxODNmZGEyYzllMGQ4NTVkMjRmYWFlOCIseyJ0Ijo3MCwic3AiOjAuMjEwOX1d/ac04420da1/JewelSocketClusterAltNormal1Small.png",
+            [0.2972]= "https://web.poecdn.com/gen/image/WzIyLCIzMTM0MjVhMGYxODNmZGEyYzllMGQ4NTVkMjRmYWFlOCIseyJ0Ijo3MCwic3AiOjAuMjk3Mn1d/ed4fb17a91/JewelSocketClusterAltNormal1Small.png",
+            [0.3835]= "https://web.poecdn.com/gen/image/WzIyLCIzMTM0MjVhMGYxODNmZGEyYzllMGQ4NTVkMjRmYWFlOCIseyJ0Ijo3MCwic3AiOjAuMzgzNX1d/fb3fe70c44/JewelSocketClusterAltNormal1Small.png"
+        },
+        ["JewelSocketClusterAltCanAllocate1Small"]= {
+            [0.1246]= "https://web.poecdn.com/gen/image/WzIyLCI1ZTBmMzYyZThkNDZlY2EzNDZmYTAyZDRiNWMxNGFmZiIseyJ0Ijo3MSwic3AiOjAuMTI0Nn1d/303745500a/JewelSocketClusterAltCanAllocate1Small.png",
+            [0.2109]= "https://web.poecdn.com/gen/image/WzIyLCI1ZTBmMzYyZThkNDZlY2EzNDZmYTAyZDRiNWMxNGFmZiIseyJ0Ijo3MSwic3AiOjAuMjEwOX1d/63438ae576/JewelSocketClusterAltCanAllocate1Small.png",
+            [0.2972]= "https://web.poecdn.com/gen/image/WzIyLCI1ZTBmMzYyZThkNDZlY2EzNDZmYTAyZDRiNWMxNGFmZiIseyJ0Ijo3MSwic3AiOjAuMjk3Mn1d/2754fb43ec/JewelSocketClusterAltCanAllocate1Small.png",
+            [0.3835]= "https://web.poecdn.com/gen/image/WzIyLCI1ZTBmMzYyZThkNDZlY2EzNDZmYTAyZDRiNWMxNGFmZiIseyJ0Ijo3MSwic3AiOjAuMzgzNX1d/585539e77d/JewelSocketClusterAltCanAllocate1Small.png"
+        },
+        ["JewelSocketClusterAltNormal1Medium"]= {
+            [0.1246]= "https://web.poecdn.com/gen/image/WzIyLCJlYzA1YzY1MDU3NTgzNTZjMmY1NTAxZmY4ZWI5NTY5ZiIseyJ0Ijo3Miwic3AiOjAuMTI0Nn1d/e0964edd0b/JewelSocketClusterAltNormal1Medium.png",
+            [0.2109]= "https://web.poecdn.com/gen/image/WzIyLCJlYzA1YzY1MDU3NTgzNTZjMmY1NTAxZmY4ZWI5NTY5ZiIseyJ0Ijo3Miwic3AiOjAuMjEwOX1d/a737450190/JewelSocketClusterAltNormal1Medium.png",
+            [0.2972]= "https://web.poecdn.com/gen/image/WzIyLCJlYzA1YzY1MDU3NTgzNTZjMmY1NTAxZmY4ZWI5NTY5ZiIseyJ0Ijo3Miwic3AiOjAuMjk3Mn1d/c27a4eb8b7/JewelSocketClusterAltNormal1Medium.png",
+            [0.3835]= "https://web.poecdn.com/gen/image/WzIyLCJlYzA1YzY1MDU3NTgzNTZjMmY1NTAxZmY4ZWI5NTY5ZiIseyJ0Ijo3Miwic3AiOjAuMzgzNX1d/c20b33b411/JewelSocketClusterAltNormal1Medium.png"
+        },
+        ["JewelSocketClusterAltCanAllocate1Medium"]= {
+            [0.1246]= "https://web.poecdn.com/gen/image/WzIyLCIxODNlNzdlYzljYTM0MDY5MjE5ZjkxZGYyMmRhZDZkNiIseyJ0Ijo3Mywic3AiOjAuMTI0Nn1d/a9a3ac5a52/JewelSocketClusterAltCanAllocate1Medium.png",
+            [0.2109]= "https://web.poecdn.com/gen/image/WzIyLCIxODNlNzdlYzljYTM0MDY5MjE5ZjkxZGYyMmRhZDZkNiIseyJ0Ijo3Mywic3AiOjAuMjEwOX1d/4eb5318ccd/JewelSocketClusterAltCanAllocate1Medium.png",
+            [0.2972]= "https://web.poecdn.com/gen/image/WzIyLCIxODNlNzdlYzljYTM0MDY5MjE5ZjkxZGYyMmRhZDZkNiIseyJ0Ijo3Mywic3AiOjAuMjk3Mn1d/52a2bdd2af/JewelSocketClusterAltCanAllocate1Medium.png",
+            [0.3835]= "https://web.poecdn.com/gen/image/WzIyLCIxODNlNzdlYzljYTM0MDY5MjE5ZjkxZGYyMmRhZDZkNiIseyJ0Ijo3Mywic3AiOjAuMzgzNX1d/e117650da2/JewelSocketClusterAltCanAllocate1Medium.png"
+        },
+        ["JewelSocketClusterAltNormal1Large"]= {
+            [0.1246]= "https://web.poecdn.com/gen/image/WzIyLCI3MDdkOWUzZGEyMWU2ZDE0NzZkZjM2YzUxN2U5M2NhOCIseyJ0Ijo3NCwic3AiOjAuMTI0Nn1d/fd8ee269f7/JewelSocketClusterAltNormal1Large.png",
+            [0.2109]= "https://web.poecdn.com/gen/image/WzIyLCI3MDdkOWUzZGEyMWU2ZDE0NzZkZjM2YzUxN2U5M2NhOCIseyJ0Ijo3NCwic3AiOjAuMjEwOX1d/0bd6bb04b9/JewelSocketClusterAltNormal1Large.png",
+            [0.2972]= "https://web.poecdn.com/gen/image/WzIyLCI3MDdkOWUzZGEyMWU2ZDE0NzZkZjM2YzUxN2U5M2NhOCIseyJ0Ijo3NCwic3AiOjAuMjk3Mn1d/7b0766a033/JewelSocketClusterAltNormal1Large.png",
+            [0.3835]= "https://web.poecdn.com/gen/image/WzIyLCI3MDdkOWUzZGEyMWU2ZDE0NzZkZjM2YzUxN2U5M2NhOCIseyJ0Ijo3NCwic3AiOjAuMzgzNX1d/49798096b6/JewelSocketClusterAltNormal1Large.png"
+        },
+        ["JewelSocketClusterAltCanAllocate1Large"]= {
+            [0.1246]= "https://web.poecdn.com/gen/image/WzIyLCIyZTg2MGI2NmQ4YjdhNDExMDg1MDVjNzAzMGY0MWYwYiIseyJ0Ijo3NSwic3AiOjAuMTI0Nn1d/e7ac5bcb71/JewelSocketClusterAltCanAllocate1Large.png",
+            [0.2109]= "https://web.poecdn.com/gen/image/WzIyLCIyZTg2MGI2NmQ4YjdhNDExMDg1MDVjNzAzMGY0MWYwYiIseyJ0Ijo3NSwic3AiOjAuMjEwOX1d/04a29996a7/JewelSocketClusterAltCanAllocate1Large.png",
+            [0.2972]= "https://web.poecdn.com/gen/image/WzIyLCIyZTg2MGI2NmQ4YjdhNDExMDg1MDVjNzAzMGY0MWYwYiIseyJ0Ijo3NSwic3AiOjAuMjk3Mn1d/32f42b2087/JewelSocketClusterAltCanAllocate1Large.png",
+            [0.3835]= "https://web.poecdn.com/gen/image/WzIyLCIyZTg2MGI2NmQ4YjdhNDExMDg1MDVjNzAzMGY0MWYwYiIseyJ0Ijo3NSwic3AiOjAuMzgzNX1d/4958fca20b/JewelSocketClusterAltCanAllocate1Large.png"
+        },
+        ["AscendancyButton"]= {
+            [0.1246]= "https://web.poecdn.com/gen/image/WzIyLCJiYjQ4YzFmOWNmMzE3YmYxODA2NWMwMWFiMTM5YWM1YSIseyJ0IjoyMSwic3AiOjAuMTI0Nn1d/073e039494/AscendancyButton.png",
+            [0.2109]= "https://web.poecdn.com/gen/image/WzIyLCJiYjQ4YzFmOWNmMzE3YmYxODA2NWMwMWFiMTM5YWM1YSIseyJ0IjoyMSwic3AiOjAuMjEwOX1d/79a77956bb/AscendancyButton.png",
+            [0.2972]= "https://web.poecdn.com/gen/image/WzIyLCJiYjQ4YzFmOWNmMzE3YmYxODA2NWMwMWFiMTM5YWM1YSIseyJ0IjoyMSwic3AiOjAuMjk3Mn1d/b031c3894f/AscendancyButton.png",
+            [0.3835]= "https://web.poecdn.com/gen/image/WzIyLCJiYjQ4YzFmOWNmMzE3YmYxODA2NWMwMWFiMTM5YWM1YSIseyJ0IjoyMSwic3AiOjAuMzgzNX1d/811bdbb1e6/AscendancyButton.png"
+        },
+        ["AscendancyButtonHighlight"]= {
+            [0.1246]= "https://web.poecdn.com/gen/image/WzIyLCI1MjYwNTE2NmZmNjIxMDRhOWEyMTQ5ZTJkZjg2MWEzMSIseyJ0IjoyMiwic3AiOjAuMTI0Nn1d/4dd032b01e/AscendancyButtonHighlight.png",
+            [0.2109]= "https://web.poecdn.com/gen/image/WzIyLCI1MjYwNTE2NmZmNjIxMDRhOWEyMTQ5ZTJkZjg2MWEzMSIseyJ0IjoyMiwic3AiOjAuMjEwOX1d/757e0f9131/AscendancyButtonHighlight.png",
+            [0.2972]= "https://web.poecdn.com/gen/image/WzIyLCI1MjYwNTE2NmZmNjIxMDRhOWEyMTQ5ZTJkZjg2MWEzMSIseyJ0IjoyMiwic3AiOjAuMjk3Mn1d/4ce311d71d/AscendancyButtonHighlight.png",
+            [0.3835]= "https://web.poecdn.com/gen/image/WzIyLCI1MjYwNTE2NmZmNjIxMDRhOWEyMTQ5ZTJkZjg2MWEzMSIseyJ0IjoyMiwic3AiOjAuMzgzNX1d/51adb2326b/AscendancyButtonHighlight.png"
+        },
+        ["AscendancyButtonPressed"]= {
+            [0.1246]= "https://web.poecdn.com/gen/image/WzIyLCIxMzJjOWFlMGYyOGI0N2M3YzUzOTUyYTAzMzQzYmY0ZiIseyJ0IjoyMywic3AiOjAuMTI0Nn1d/d9ad4ac1a2/AscendancyButtonPressed.png",
+            [0.2109]= "https://web.poecdn.com/gen/image/WzIyLCIxMzJjOWFlMGYyOGI0N2M3YzUzOTUyYTAzMzQzYmY0ZiIseyJ0IjoyMywic3AiOjAuMjEwOX1d/d1bf590fc3/AscendancyButtonPressed.png",
+            [0.2972]= "https://web.poecdn.com/gen/image/WzIyLCIxMzJjOWFlMGYyOGI0N2M3YzUzOTUyYTAzMzQzYmY0ZiIseyJ0IjoyMywic3AiOjAuMjk3Mn1d/c03da119f5/AscendancyButtonPressed.png",
+            [0.3835]= "https://web.poecdn.com/gen/image/WzIyLCIxMzJjOWFlMGYyOGI0N2M3YzUzOTUyYTAzMzQzYmY0ZiIseyJ0IjoyMywic3AiOjAuMzgzNX1d/5a69262eb3/AscendancyButtonPressed.png"
+        },
+        ["AscendancyFrameLargeAllocated"]= {
+            [0.1246]= "https://web.poecdn.com/gen/image/WzIyLCIwMDUxMzFhZWY2ODcxMzc4ZDI0OWY4YzMwMWNlNDk2YSIseyJ0Ijo0Mywic3AiOjAuMTI0Nn1d/2cf441bd78/AscendancyFrameLargeAllocated.png",
+            [0.2109]= "https://web.poecdn.com/gen/image/WzIyLCIwMDUxMzFhZWY2ODcxMzc4ZDI0OWY4YzMwMWNlNDk2YSIseyJ0Ijo0Mywic3AiOjAuMjEwOX1d/1f4aea7ba8/AscendancyFrameLargeAllocated.png",
+            [0.2972]= "https://web.poecdn.com/gen/image/WzIyLCIwMDUxMzFhZWY2ODcxMzc4ZDI0OWY4YzMwMWNlNDk2YSIseyJ0Ijo0Mywic3AiOjAuMjk3Mn1d/6be3e2c11d/AscendancyFrameLargeAllocated.png",
+            [0.3835]= "https://web.poecdn.com/gen/image/WzIyLCIwMDUxMzFhZWY2ODcxMzc4ZDI0OWY4YzMwMWNlNDk2YSIseyJ0Ijo0Mywic3AiOjAuMzgzNX1d/18b95c46e7/AscendancyFrameLargeAllocated.png"
+        },
+        ["AscendancyFrameLargeCanAllocate"]= {
+            [0.1246]= "https://web.poecdn.com/gen/image/WzIyLCI1M2E0MTQ1OTdmMzgyZWZmMWMzOGQ4MWMzNmE4ZTlhZSIseyJ0Ijo0NCwic3AiOjAuMTI0Nn1d/970352bd07/AscendancyFrameLargeCanAllocate.png",
+            [0.2109]= "https://web.poecdn.com/gen/image/WzIyLCI1M2E0MTQ1OTdmMzgyZWZmMWMzOGQ4MWMzNmE4ZTlhZSIseyJ0Ijo0NCwic3AiOjAuMjEwOX1d/c76e4f66c4/AscendancyFrameLargeCanAllocate.png",
+            [0.2972]= "https://web.poecdn.com/gen/image/WzIyLCI1M2E0MTQ1OTdmMzgyZWZmMWMzOGQ4MWMzNmE4ZTlhZSIseyJ0Ijo0NCwic3AiOjAuMjk3Mn1d/0868c8e30a/AscendancyFrameLargeCanAllocate.png",
+            [0.3835]= "https://web.poecdn.com/gen/image/WzIyLCI1M2E0MTQ1OTdmMzgyZWZmMWMzOGQ4MWMzNmE4ZTlhZSIseyJ0Ijo0NCwic3AiOjAuMzgzNX1d/aa93ca38e8/AscendancyFrameLargeCanAllocate.png"
+        },
+        ["AscendancyFrameLargeNormal"]= {
+            [0.1246]= "https://web.poecdn.com/gen/image/WzIyLCJmZjcxYjJhZDM5NWE3ZWI5NDQ4YWU5YjE5MGY2ZGRjZCIseyJ0Ijo0NSwic3AiOjAuMTI0Nn1d/980b27def3/AscendancyFrameLargeNormal.png",
+            [0.2109]= "https://web.poecdn.com/gen/image/WzIyLCJmZjcxYjJhZDM5NWE3ZWI5NDQ4YWU5YjE5MGY2ZGRjZCIseyJ0Ijo0NSwic3AiOjAuMjEwOX1d/33fa5e0c64/AscendancyFrameLargeNormal.png",
+            [0.2972]= "https://web.poecdn.com/gen/image/WzIyLCJmZjcxYjJhZDM5NWE3ZWI5NDQ4YWU5YjE5MGY2ZGRjZCIseyJ0Ijo0NSwic3AiOjAuMjk3Mn1d/dec24975d7/AscendancyFrameLargeNormal.png",
+            [0.3835]= "https://web.poecdn.com/gen/image/WzIyLCJmZjcxYjJhZDM5NWE3ZWI5NDQ4YWU5YjE5MGY2ZGRjZCIseyJ0Ijo0NSwic3AiOjAuMzgzNX1d/1287300a52/AscendancyFrameLargeNormal.png"
+        },
+        ["AscendancyFrameSmallAllocated"]= {
+            [0.1246]= "https://web.poecdn.com/gen/image/WzIyLCIyYmEwZWNiOGM2NTQxYmIyMTYwNzZkZjQwM2QzZTU3MyIseyJ0Ijo0Niwic3AiOjAuMTI0Nn1d/40dcf56aba/AscendancyFrameSmallAllocated.png",
+            [0.2109]= "https://web.poecdn.com/gen/image/WzIyLCIyYmEwZWNiOGM2NTQxYmIyMTYwNzZkZjQwM2QzZTU3MyIseyJ0Ijo0Niwic3AiOjAuMjEwOX1d/aa5cb2cc77/AscendancyFrameSmallAllocated.png",
+            [0.2972]= "https://web.poecdn.com/gen/image/WzIyLCIyYmEwZWNiOGM2NTQxYmIyMTYwNzZkZjQwM2QzZTU3MyIseyJ0Ijo0Niwic3AiOjAuMjk3Mn1d/fe352c2bb8/AscendancyFrameSmallAllocated.png",
+            [0.3835]= "https://web.poecdn.com/gen/image/WzIyLCIyYmEwZWNiOGM2NTQxYmIyMTYwNzZkZjQwM2QzZTU3MyIseyJ0Ijo0Niwic3AiOjAuMzgzNX1d/41e6a7d0a3/AscendancyFrameSmallAllocated.png"
+        },
+        ["AscendancyFrameSmallCanAllocate"]= {
+            [0.1246]= "https://web.poecdn.com/gen/image/WzIyLCI0YTA4NDA0MWFkYmUxZWY3MWYwNTg5YTMzYWVmZTViYyIseyJ0Ijo0Nywic3AiOjAuMTI0Nn1d/8289ef30d4/AscendancyFrameSmallCanAllocate.png",
+            [0.2109]= "https://web.poecdn.com/gen/image/WzIyLCI0YTA4NDA0MWFkYmUxZWY3MWYwNTg5YTMzYWVmZTViYyIseyJ0Ijo0Nywic3AiOjAuMjEwOX1d/d67c82409b/AscendancyFrameSmallCanAllocate.png",
+            [0.2972]= "https://web.poecdn.com/gen/image/WzIyLCI0YTA4NDA0MWFkYmUxZWY3MWYwNTg5YTMzYWVmZTViYyIseyJ0Ijo0Nywic3AiOjAuMjk3Mn1d/683c8aefcc/AscendancyFrameSmallCanAllocate.png",
+            [0.3835]= "https://web.poecdn.com/gen/image/WzIyLCI0YTA4NDA0MWFkYmUxZWY3MWYwNTg5YTMzYWVmZTViYyIseyJ0Ijo0Nywic3AiOjAuMzgzNX1d/7edc63983a/AscendancyFrameSmallCanAllocate.png"
+        },
+        ["AscendancyFrameSmallNormal"]= {
+            [0.1246]= "https://web.poecdn.com/gen/image/WzIyLCIyZjYzMmU5MzU5NThmZDNlOTBiMjBmZDNhZWYxZWFiZCIseyJ0Ijo0OCwic3AiOjAuMTI0Nn1d/0f8c54732b/AscendancyFrameSmallNormal.png",
+            [0.2109]= "https://web.poecdn.com/gen/image/WzIyLCIyZjYzMmU5MzU5NThmZDNlOTBiMjBmZDNhZWYxZWFiZCIseyJ0Ijo0OCwic3AiOjAuMjEwOX1d/307f041ad5/AscendancyFrameSmallNormal.png",
+            [0.2972]= "https://web.poecdn.com/gen/image/WzIyLCIyZjYzMmU5MzU5NThmZDNlOTBiMjBmZDNhZWYxZWFiZCIseyJ0Ijo0OCwic3AiOjAuMjk3Mn1d/bcece49823/AscendancyFrameSmallNormal.png",
+            [0.3835]= "https://web.poecdn.com/gen/image/WzIyLCIyZjYzMmU5MzU5NThmZDNlOTBiMjBmZDNhZWYxZWFiZCIseyJ0Ijo0OCwic3AiOjAuMzgzNX1d/b53c1d4e71/AscendancyFrameSmallNormal.png"
+        },
+        ["AscendancyMiddle"]= {
+            [0.1246]= "https://web.poecdn.com/gen/image/WzIyLCI5OTJmZTc3NDVlN2RlZTUxMzQyY2EwMDdiYzVlOTMwZSIseyJ0Ijo0OSwic3AiOjAuMTI0Nn1d/c1b1299299/AscendancyMiddle.png",
+            [0.2109]= "https://web.poecdn.com/gen/image/WzIyLCI5OTJmZTc3NDVlN2RlZTUxMzQyY2EwMDdiYzVlOTMwZSIseyJ0Ijo0OSwic3AiOjAuMjEwOX1d/d4ba53b7db/AscendancyMiddle.png",
+            [0.2972]= "https://web.poecdn.com/gen/image/WzIyLCI5OTJmZTc3NDVlN2RlZTUxMzQyY2EwMDdiYzVlOTMwZSIseyJ0Ijo0OSwic3AiOjAuMjk3Mn1d/28f270be35/AscendancyMiddle.png",
+            [0.3835]= "https://web.poecdn.com/gen/image/WzIyLCI5OTJmZTc3NDVlN2RlZTUxMzQyY2EwMDdiYzVlOTMwZSIseyJ0Ijo0OSwic3AiOjAuMzgzNX1d/5a63101b29/AscendancyMiddle.png"
+        },
+        ["ClassesAscendant"]= {
+            [0.1246]= "https://web.poecdn.com/gen/image/WzIyLCIyY2I4NjNjZTllODk2ODExOTNkODIyZTc5NjE1NzY0MSIseyJ0IjoyNCwic3AiOjAuMTI0Nn1d/2789367bc3/ClassesAscendant.png",
+            [0.2109]= "https://web.poecdn.com/gen/image/WzIyLCIyY2I4NjNjZTllODk2ODExOTNkODIyZTc5NjE1NzY0MSIseyJ0IjoyNCwic3AiOjAuMjEwOX1d/9bd9408c61/ClassesAscendant.png",
+            [0.2972]= "https://web.poecdn.com/gen/image/WzIyLCIyY2I4NjNjZTllODk2ODExOTNkODIyZTc5NjE1NzY0MSIseyJ0IjoyNCwic3AiOjAuMjk3Mn1d/0f3681a0b1/ClassesAscendant.png",
+            [0.3835]= "https://web.poecdn.com/gen/image/WzIyLCIyY2I4NjNjZTllODk2ODExOTNkODIyZTc5NjE1NzY0MSIseyJ0IjoyNCwic3AiOjAuMzgzNX1d/8a9067141f/ClassesAscendant.png"
+        },
+        ["ClassesJuggernaut"]= {
+            [0.1246]= "https://web.poecdn.com/gen/image/WzIyLCI3MjE1OTRlNDRiY2IxYzBhZTdkYjEyMzAzNDA1NDkyNyIseyJ0IjoyNSwic3AiOjAuMTI0Nn1d/472ed37c55/ClassesJuggernaut.png",
+            [0.2109]= "https://web.poecdn.com/gen/image/WzIyLCI3MjE1OTRlNDRiY2IxYzBhZTdkYjEyMzAzNDA1NDkyNyIseyJ0IjoyNSwic3AiOjAuMjEwOX1d/1abb978dd4/ClassesJuggernaut.png",
+            [0.2972]= "https://web.poecdn.com/gen/image/WzIyLCI3MjE1OTRlNDRiY2IxYzBhZTdkYjEyMzAzNDA1NDkyNyIseyJ0IjoyNSwic3AiOjAuMjk3Mn1d/d73e0c105c/ClassesJuggernaut.png",
+            [0.3835]= "https://web.poecdn.com/gen/image/WzIyLCI3MjE1OTRlNDRiY2IxYzBhZTdkYjEyMzAzNDA1NDkyNyIseyJ0IjoyNSwic3AiOjAuMzgzNX1d/cee5528d42/ClassesJuggernaut.png"
+        },
+        ["ClassesBerserker"]= {
+            [0.1246]= "https://web.poecdn.com/gen/image/WzIyLCIxM2M0ODNjNWMyODE4NjlhNTY5MGQyYmE0OWQ0Yjk5ZiIseyJ0IjoyNiwic3AiOjAuMTI0Nn1d/eb9162e7e7/ClassesBerserker.png",
+            [0.2109]= "https://web.poecdn.com/gen/image/WzIyLCIxM2M0ODNjNWMyODE4NjlhNTY5MGQyYmE0OWQ0Yjk5ZiIseyJ0IjoyNiwic3AiOjAuMjEwOX1d/1a3de12380/ClassesBerserker.png",
+            [0.2972]= "https://web.poecdn.com/gen/image/WzIyLCIxM2M0ODNjNWMyODE4NjlhNTY5MGQyYmE0OWQ0Yjk5ZiIseyJ0IjoyNiwic3AiOjAuMjk3Mn1d/fccef59e98/ClassesBerserker.png",
+            [0.3835]= "https://web.poecdn.com/gen/image/WzIyLCIxM2M0ODNjNWMyODE4NjlhNTY5MGQyYmE0OWQ0Yjk5ZiIseyJ0IjoyNiwic3AiOjAuMzgzNX1d/7a03bfc562/ClassesBerserker.png"
+        },
+        ["ClassesChieftain"]= {
+            [0.1246]= "https://web.poecdn.com/gen/image/WzIyLCJkOGE5MzM2YjEzMmFlODc0YTNkMzU5NjBkOTUwZTZjOSIseyJ0IjoyNywic3AiOjAuMTI0Nn1d/410d5613ad/ClassesChieftain.png",
+            [0.2109]= "https://web.poecdn.com/gen/image/WzIyLCJkOGE5MzM2YjEzMmFlODc0YTNkMzU5NjBkOTUwZTZjOSIseyJ0IjoyNywic3AiOjAuMjEwOX1d/4d6c91a432/ClassesChieftain.png",
+            [0.2972]= "https://web.poecdn.com/gen/image/WzIyLCJkOGE5MzM2YjEzMmFlODc0YTNkMzU5NjBkOTUwZTZjOSIseyJ0IjoyNywic3AiOjAuMjk3Mn1d/7fefcc4ebb/ClassesChieftain.png",
+            [0.3835]= "https://web.poecdn.com/gen/image/WzIyLCJkOGE5MzM2YjEzMmFlODc0YTNkMzU5NjBkOTUwZTZjOSIseyJ0IjoyNywic3AiOjAuMzgzNX1d/0c54f33e6b/ClassesChieftain.png"
+        },
+        ["ClassesRaider"]= {
+            [0.1246]= "https://web.poecdn.com/gen/image/WzIyLCJkYWVmZDZmNTdhMjllODBmNWEyMGYzMTg2MWZhNTYyNCIseyJ0IjoyOCwic3AiOjAuMTI0Nn1d/b541c5fbe0/ClassesRaider.png",
+            [0.2109]= "https://web.poecdn.com/gen/image/WzIyLCJkYWVmZDZmNTdhMjllODBmNWEyMGYzMTg2MWZhNTYyNCIseyJ0IjoyOCwic3AiOjAuMjEwOX1d/9dde3f8adb/ClassesRaider.png",
+            [0.2972]= "https://web.poecdn.com/gen/image/WzIyLCJkYWVmZDZmNTdhMjllODBmNWEyMGYzMTg2MWZhNTYyNCIseyJ0IjoyOCwic3AiOjAuMjk3Mn1d/7793a00182/ClassesRaider.png",
+            [0.3835]= "https://web.poecdn.com/gen/image/WzIyLCJkYWVmZDZmNTdhMjllODBmNWEyMGYzMTg2MWZhNTYyNCIseyJ0IjoyOCwic3AiOjAuMzgzNX1d/e68715aa10/ClassesRaider.png"
+        },
+        ["ClassesDeadeye"]= {
+            [0.1246]= "https://web.poecdn.com/gen/image/WzIyLCI0ZGQ5NDc4NDIyMGQ4OGNiMDI3NjBhNTUwMDk0NWRhOCIseyJ0IjoyOSwic3AiOjAuMTI0Nn1d/7a7e769c52/ClassesDeadeye.png",
+            [0.2109]= "https://web.poecdn.com/gen/image/WzIyLCI0ZGQ5NDc4NDIyMGQ4OGNiMDI3NjBhNTUwMDk0NWRhOCIseyJ0IjoyOSwic3AiOjAuMjEwOX1d/a70ee4aa60/ClassesDeadeye.png",
+            [0.2972]= "https://web.poecdn.com/gen/image/WzIyLCI0ZGQ5NDc4NDIyMGQ4OGNiMDI3NjBhNTUwMDk0NWRhOCIseyJ0IjoyOSwic3AiOjAuMjk3Mn1d/c41489eaa9/ClassesDeadeye.png",
+            [0.3835]= "https://web.poecdn.com/gen/image/WzIyLCI0ZGQ5NDc4NDIyMGQ4OGNiMDI3NjBhNTUwMDk0NWRhOCIseyJ0IjoyOSwic3AiOjAuMzgzNX1d/47db5dc1d8/ClassesDeadeye.png"
+        },
+        ["ClassesPathfinder"]= {
+            [0.1246]= "https://web.poecdn.com/gen/image/WzIyLCI5ZmQzOGQzMWI1MjliNGJiMmM3NGEzMDZlZmYxNTBiNCIseyJ0IjozMCwic3AiOjAuMTI0Nn1d/1c1eedc7cf/ClassesPathfinder.png",
+            [0.2109]= "https://web.poecdn.com/gen/image/WzIyLCI5ZmQzOGQzMWI1MjliNGJiMmM3NGEzMDZlZmYxNTBiNCIseyJ0IjozMCwic3AiOjAuMjEwOX1d/08475512b5/ClassesPathfinder.png",
+            [0.2972]= "https://web.poecdn.com/gen/image/WzIyLCI5ZmQzOGQzMWI1MjliNGJiMmM3NGEzMDZlZmYxNTBiNCIseyJ0IjozMCwic3AiOjAuMjk3Mn1d/fe863fb836/ClassesPathfinder.png",
+            [0.3835]= "https://web.poecdn.com/gen/image/WzIyLCI5ZmQzOGQzMWI1MjliNGJiMmM3NGEzMDZlZmYxNTBiNCIseyJ0IjozMCwic3AiOjAuMzgzNX1d/9554499c2a/ClassesPathfinder.png"
+        },
+        ["ClassesOccultist"]= {
+            [0.1246]= "https://web.poecdn.com/gen/image/WzIyLCIwOGY2NWYzMTM1YWEyM2YxZjU0ZmRkMWIxZmVlMTE5OSIseyJ0IjozMSwic3AiOjAuMTI0Nn1d/4503a5c85a/ClassesOccultist.png",
+            [0.2109]= "https://web.poecdn.com/gen/image/WzIyLCIwOGY2NWYzMTM1YWEyM2YxZjU0ZmRkMWIxZmVlMTE5OSIseyJ0IjozMSwic3AiOjAuMjEwOX1d/9e2cba2bd9/ClassesOccultist.png",
+            [0.2972]= "https://web.poecdn.com/gen/image/WzIyLCIwOGY2NWYzMTM1YWEyM2YxZjU0ZmRkMWIxZmVlMTE5OSIseyJ0IjozMSwic3AiOjAuMjk3Mn1d/80d6f521b3/ClassesOccultist.png",
+            [0.3835]= "https://web.poecdn.com/gen/image/WzIyLCIwOGY2NWYzMTM1YWEyM2YxZjU0ZmRkMWIxZmVlMTE5OSIseyJ0IjozMSwic3AiOjAuMzgzNX1d/bc15d219cb/ClassesOccultist.png"
+        },
+        ["ClassesElementalist"]= {
+            [0.1246]= "https://web.poecdn.com/gen/image/WzIyLCIyZjAwMTY3ZDYzYTVmMzExODAyMWE1OGZhMmVkOWMwYiIseyJ0IjozMiwic3AiOjAuMTI0Nn1d/2f12d3a83b/ClassesElementalist.png",
+            [0.2109]= "https://web.poecdn.com/gen/image/WzIyLCIyZjAwMTY3ZDYzYTVmMzExODAyMWE1OGZhMmVkOWMwYiIseyJ0IjozMiwic3AiOjAuMjEwOX1d/387d601499/ClassesElementalist.png",
+            [0.2972]= "https://web.poecdn.com/gen/image/WzIyLCIyZjAwMTY3ZDYzYTVmMzExODAyMWE1OGZhMmVkOWMwYiIseyJ0IjozMiwic3AiOjAuMjk3Mn1d/19d1a46696/ClassesElementalist.png",
+            [0.3835]= "https://web.poecdn.com/gen/image/WzIyLCIyZjAwMTY3ZDYzYTVmMzExODAyMWE1OGZhMmVkOWMwYiIseyJ0IjozMiwic3AiOjAuMzgzNX1d/ac396fa640/ClassesElementalist.png"
+        },
+        ["ClassesNecromancer"]= {
+            [0.1246]= "https://web.poecdn.com/gen/image/WzIyLCJmOWIwN2Y5YTU4NzY4ZThiMmFiYjNhZjNmYTY2N2M3NiIseyJ0IjozMywic3AiOjAuMTI0Nn1d/c472229f0f/ClassesNecromancer.png",
+            [0.2109]= "https://web.poecdn.com/gen/image/WzIyLCJmOWIwN2Y5YTU4NzY4ZThiMmFiYjNhZjNmYTY2N2M3NiIseyJ0IjozMywic3AiOjAuMjEwOX1d/ae060ff4fd/ClassesNecromancer.png",
+            [0.2972]= "https://web.poecdn.com/gen/image/WzIyLCJmOWIwN2Y5YTU4NzY4ZThiMmFiYjNhZjNmYTY2N2M3NiIseyJ0IjozMywic3AiOjAuMjk3Mn1d/c504cdf5fd/ClassesNecromancer.png",
+            [0.3835]= "https://web.poecdn.com/gen/image/WzIyLCJmOWIwN2Y5YTU4NzY4ZThiMmFiYjNhZjNmYTY2N2M3NiIseyJ0IjozMywic3AiOjAuMzgzNX1d/9553918242/ClassesNecromancer.png"
+        },
+        ["ClassesSlayer"]= {
+            [0.1246]= "https://web.poecdn.com/gen/image/WzIyLCI2YjNjNWFkYzIyZDNlZDc0YmFmOGY1ZmNhYjI4NDRjNiIseyJ0IjozNCwic3AiOjAuMTI0Nn1d/37fb898a3e/ClassesSlayer.png",
+            [0.2109]= "https://web.poecdn.com/gen/image/WzIyLCI2YjNjNWFkYzIyZDNlZDc0YmFmOGY1ZmNhYjI4NDRjNiIseyJ0IjozNCwic3AiOjAuMjEwOX1d/9e6ef272e0/ClassesSlayer.png",
+            [0.2972]= "https://web.poecdn.com/gen/image/WzIyLCI2YjNjNWFkYzIyZDNlZDc0YmFmOGY1ZmNhYjI4NDRjNiIseyJ0IjozNCwic3AiOjAuMjk3Mn1d/d2a17781e3/ClassesSlayer.png",
+            [0.3835]= "https://web.poecdn.com/gen/image/WzIyLCI2YjNjNWFkYzIyZDNlZDc0YmFmOGY1ZmNhYjI4NDRjNiIseyJ0IjozNCwic3AiOjAuMzgzNX1d/41f1cf5f2a/ClassesSlayer.png"
+        },
+        ["ClassesGladiator"]= {
+            [0.1246]= "https://web.poecdn.com/gen/image/WzIyLCIzYWU0ZThjMmYxMjQ4YjAzYjc1MzI5OTUzZjA5MDdjZCIseyJ0IjozNSwic3AiOjAuMTI0Nn1d/7c26a41597/ClassesGladiator.png",
+            [0.2109]= "https://web.poecdn.com/gen/image/WzIyLCIzYWU0ZThjMmYxMjQ4YjAzYjc1MzI5OTUzZjA5MDdjZCIseyJ0IjozNSwic3AiOjAuMjEwOX1d/d12e49cedb/ClassesGladiator.png",
+            [0.2972]= "https://web.poecdn.com/gen/image/WzIyLCIzYWU0ZThjMmYxMjQ4YjAzYjc1MzI5OTUzZjA5MDdjZCIseyJ0IjozNSwic3AiOjAuMjk3Mn1d/4d969f8f7a/ClassesGladiator.png",
+            [0.3835]= "https://web.poecdn.com/gen/image/WzIyLCIzYWU0ZThjMmYxMjQ4YjAzYjc1MzI5OTUzZjA5MDdjZCIseyJ0IjozNSwic3AiOjAuMzgzNX1d/7d9e577284/ClassesGladiator.png"
+        },
+        ["ClassesChampion"]= {
+            [0.1246]= "https://web.poecdn.com/gen/image/WzIyLCJiM2U2ZTQxNTg5ZmYzZTUwNmJiMjUyZWRiNmQyYWFhMSIseyJ0IjozNiwic3AiOjAuMTI0Nn1d/86aff7f2d4/ClassesChampion.png",
+            [0.2109]= "https://web.poecdn.com/gen/image/WzIyLCJiM2U2ZTQxNTg5ZmYzZTUwNmJiMjUyZWRiNmQyYWFhMSIseyJ0IjozNiwic3AiOjAuMjEwOX1d/25164dd199/ClassesChampion.png",
+            [0.2972]= "https://web.poecdn.com/gen/image/WzIyLCJiM2U2ZTQxNTg5ZmYzZTUwNmJiMjUyZWRiNmQyYWFhMSIseyJ0IjozNiwic3AiOjAuMjk3Mn1d/51ded1fd76/ClassesChampion.png",
+            [0.3835]= "https://web.poecdn.com/gen/image/WzIyLCJiM2U2ZTQxNTg5ZmYzZTUwNmJiMjUyZWRiNmQyYWFhMSIseyJ0IjozNiwic3AiOjAuMzgzNX1d/043559939c/ClassesChampion.png"
+        },
+        ["ClassesInquisitor"]= {
+            [0.1246]= "https://web.poecdn.com/gen/image/WzIyLCJlNDNmMDM0MjUxMGFmYzAwMmM2YWY3ZjNhNTBjZWI1NSIseyJ0IjozNywic3AiOjAuMTI0Nn1d/6d213a38d4/ClassesInquisitor.png",
+            [0.2109]= "https://web.poecdn.com/gen/image/WzIyLCJlNDNmMDM0MjUxMGFmYzAwMmM2YWY3ZjNhNTBjZWI1NSIseyJ0IjozNywic3AiOjAuMjEwOX1d/9c7fccd06e/ClassesInquisitor.png",
+            [0.2972]= "https://web.poecdn.com/gen/image/WzIyLCJlNDNmMDM0MjUxMGFmYzAwMmM2YWY3ZjNhNTBjZWI1NSIseyJ0IjozNywic3AiOjAuMjk3Mn1d/f4c3f247cf/ClassesInquisitor.png",
+            [0.3835]= "https://web.poecdn.com/gen/image/WzIyLCJlNDNmMDM0MjUxMGFmYzAwMmM2YWY3ZjNhNTBjZWI1NSIseyJ0IjozNywic3AiOjAuMzgzNX1d/2c24143b41/ClassesInquisitor.png"
+        },
+        ["ClassesHierophant"]= {
+            [0.1246]= "https://web.poecdn.com/gen/image/WzIyLCI0NTRiOTdhMTNjZWRjMjRkN2EwOTI3MDZkOTk5NjBmMyIseyJ0IjozOCwic3AiOjAuMTI0Nn1d/bcd7232923/ClassesHierophant.png",
+            [0.2109]= "https://web.poecdn.com/gen/image/WzIyLCI0NTRiOTdhMTNjZWRjMjRkN2EwOTI3MDZkOTk5NjBmMyIseyJ0IjozOCwic3AiOjAuMjEwOX1d/90b335b8dd/ClassesHierophant.png",
+            [0.2972]= "https://web.poecdn.com/gen/image/WzIyLCI0NTRiOTdhMTNjZWRjMjRkN2EwOTI3MDZkOTk5NjBmMyIseyJ0IjozOCwic3AiOjAuMjk3Mn1d/7989dc74ff/ClassesHierophant.png",
+            [0.3835]= "https://web.poecdn.com/gen/image/WzIyLCI0NTRiOTdhMTNjZWRjMjRkN2EwOTI3MDZkOTk5NjBmMyIseyJ0IjozOCwic3AiOjAuMzgzNX1d/2b1214e375/ClassesHierophant.png"
+        },
+        ["ClassesGuardian"]= {
+            [0.1246]= "https://web.poecdn.com/gen/image/WzIyLCI4ZDU4YTc5ZjI5MWM1YjQxOWRlMWExMjdiM2U5NzNkMiIseyJ0IjozOSwic3AiOjAuMTI0Nn1d/22c14e9efc/ClassesGuardian.png",
+            [0.2109]= "https://web.poecdn.com/gen/image/WzIyLCI4ZDU4YTc5ZjI5MWM1YjQxOWRlMWExMjdiM2U5NzNkMiIseyJ0IjozOSwic3AiOjAuMjEwOX1d/8fb31c4df2/ClassesGuardian.png",
+            [0.2972]= "https://web.poecdn.com/gen/image/WzIyLCI4ZDU4YTc5ZjI5MWM1YjQxOWRlMWExMjdiM2U5NzNkMiIseyJ0IjozOSwic3AiOjAuMjk3Mn1d/c57dc0aad4/ClassesGuardian.png",
+            [0.3835]= "https://web.poecdn.com/gen/image/WzIyLCI4ZDU4YTc5ZjI5MWM1YjQxOWRlMWExMjdiM2U5NzNkMiIseyJ0IjozOSwic3AiOjAuMzgzNX1d/f01acaa92a/ClassesGuardian.png"
+        },
+        ["ClassesAssassin"]= {
+            [0.1246]= "https://web.poecdn.com/gen/image/WzIyLCI4ZTdjMDAyOWNiODVlNjY4MjVmNjZlNTM1ZDYyZGRjMiIseyJ0Ijo0MCwic3AiOjAuMTI0Nn1d/4a50206cfb/ClassesAssassin.png",
+            [0.2109]= "https://web.poecdn.com/gen/image/WzIyLCI4ZTdjMDAyOWNiODVlNjY4MjVmNjZlNTM1ZDYyZGRjMiIseyJ0Ijo0MCwic3AiOjAuMjEwOX1d/f02a427bf6/ClassesAssassin.png",
+            [0.2972]= "https://web.poecdn.com/gen/image/WzIyLCI4ZTdjMDAyOWNiODVlNjY4MjVmNjZlNTM1ZDYyZGRjMiIseyJ0Ijo0MCwic3AiOjAuMjk3Mn1d/ed36322069/ClassesAssassin.png",
+            [0.3835]= "https://web.poecdn.com/gen/image/WzIyLCI4ZTdjMDAyOWNiODVlNjY4MjVmNjZlNTM1ZDYyZGRjMiIseyJ0Ijo0MCwic3AiOjAuMzgzNX1d/e0131d5bf1/ClassesAssassin.png"
+        },
+        ["ClassesTrickster"]= {
+            [0.1246]= "https://web.poecdn.com/gen/image/WzIyLCI3YjliMzU3ODA1NDI3MzZiZTBmYWY4YjdkMzA4OWZkYiIseyJ0Ijo0Miwic3AiOjAuMTI0Nn1d/712b046ad0/ClassesTrickster.png",
+            [0.2109]= "https://web.poecdn.com/gen/image/WzIyLCI3YjliMzU3ODA1NDI3MzZiZTBmYWY4YjdkMzA4OWZkYiIseyJ0Ijo0Miwic3AiOjAuMjEwOX1d/3259bbdade/ClassesTrickster.png",
+            [0.2972]= "https://web.poecdn.com/gen/image/WzIyLCI3YjliMzU3ODA1NDI3MzZiZTBmYWY4YjdkMzA4OWZkYiIseyJ0Ijo0Miwic3AiOjAuMjk3Mn1d/36151151a8/ClassesTrickster.png",
+            [0.3835]= "https://web.poecdn.com/gen/image/WzIyLCI3YjliMzU3ODA1NDI3MzZiZTBmYWY4YjdkMzA4OWZkYiIseyJ0Ijo0Miwic3AiOjAuMzgzNX1d/75992bd282/ClassesTrickster.png"
+        },
+        ["ClassesSaboteur"]= {
+            [0.1246]= "https://web.poecdn.com/gen/image/WzIyLCI0ZDM0YTY5NDRjMjZlMjVmNzgyMjgwZjU0M2RjYzcyNiIseyJ0Ijo0MSwic3AiOjAuMTI0Nn1d/b5f54c1bb5/ClassesSaboteur.png",
+            [0.2109]= "https://web.poecdn.com/gen/image/WzIyLCI0ZDM0YTY5NDRjMjZlMjVmNzgyMjgwZjU0M2RjYzcyNiIseyJ0Ijo0MSwic3AiOjAuMjEwOX1d/61418d38be/ClassesSaboteur.png",
+            [0.2972]= "https://web.poecdn.com/gen/image/WzIyLCI0ZDM0YTY5NDRjMjZlMjVmNzgyMjgwZjU0M2RjYzcyNiIseyJ0Ijo0MSwic3AiOjAuMjk3Mn1d/4066ed5904/ClassesSaboteur.png",
+            [0.3835]= "https://web.poecdn.com/gen/image/WzIyLCI0ZDM0YTY5NDRjMjZlMjVmNzgyMjgwZjU0M2RjYzcyNiIseyJ0Ijo0MSwic3AiOjAuMzgzNX1d/1ec191f032/ClassesSaboteur.png"
+        },
+        ["BackgroundDex"]= {
+            [0.1246]= "https://web.poecdn.com/gen/image/WzIxLDE0LHsiayI6IjJEQXJ0L0Jhc2VDbGFzc0lsbHVzdHJhdGlvbnMvRGV4Iiwic3AiOjAuMTI0Nn1d/01a067ae84/BackgroundDex.png",
+            [0.2109]= "https://web.poecdn.com/gen/image/WzIxLDE0LHsiayI6IjJEQXJ0L0Jhc2VDbGFzc0lsbHVzdHJhdGlvbnMvRGV4Iiwic3AiOjAuMjEwOX1d/01ffd3bd76/BackgroundDex.png",
+            [0.2972]= "https://web.poecdn.com/gen/image/WzIxLDE0LHsiayI6IjJEQXJ0L0Jhc2VDbGFzc0lsbHVzdHJhdGlvbnMvRGV4Iiwic3AiOjAuMjk3Mn1d/d63fe63d07/BackgroundDex.png",
+            [0.3835]= "https://web.poecdn.com/gen/image/WzIxLDE0LHsiayI6IjJEQXJ0L0Jhc2VDbGFzc0lsbHVzdHJhdGlvbnMvRGV4Iiwic3AiOjAuMzgzNX1d/61afd63943/BackgroundDex.png"
+        },
+        ["BackgroundDexInt"]= {
+            [0.1246]= "https://web.poecdn.com/gen/image/WzIxLDE0LHsiayI6IjJEQXJ0L0Jhc2VDbGFzc0lsbHVzdHJhdGlvbnMvRGV4SW50Iiwic3AiOjAuMTI0Nn1d/90f71e77c1/BackgroundDexInt.png",
+            [0.2109]= "https://web.poecdn.com/gen/image/WzIxLDE0LHsiayI6IjJEQXJ0L0Jhc2VDbGFzc0lsbHVzdHJhdGlvbnMvRGV4SW50Iiwic3AiOjAuMjEwOX1d/96a2cf0458/BackgroundDexInt.png",
+            [0.2972]= "https://web.poecdn.com/gen/image/WzIxLDE0LHsiayI6IjJEQXJ0L0Jhc2VDbGFzc0lsbHVzdHJhdGlvbnMvRGV4SW50Iiwic3AiOjAuMjk3Mn1d/4a4586cbbf/BackgroundDexInt.png",
+            [0.3835]= "https://web.poecdn.com/gen/image/WzIxLDE0LHsiayI6IjJEQXJ0L0Jhc2VDbGFzc0lsbHVzdHJhdGlvbnMvRGV4SW50Iiwic3AiOjAuMzgzNX1d/53d119695d/BackgroundDexInt.png"
+        },
+        ["BackgroundInt"]= {
+            [0.1246]= "https://web.poecdn.com/gen/image/WzIxLDE0LHsiayI6IjJEQXJ0L0Jhc2VDbGFzc0lsbHVzdHJhdGlvbnMvSW50Iiwic3AiOjAuMTI0Nn1d/7de548e229/BackgroundInt.png",
+            [0.2109]= "https://web.poecdn.com/gen/image/WzIxLDE0LHsiayI6IjJEQXJ0L0Jhc2VDbGFzc0lsbHVzdHJhdGlvbnMvSW50Iiwic3AiOjAuMjEwOX1d/c59e7aa61b/BackgroundInt.png",
+            [0.2972]= "https://web.poecdn.com/gen/image/WzIxLDE0LHsiayI6IjJEQXJ0L0Jhc2VDbGFzc0lsbHVzdHJhdGlvbnMvSW50Iiwic3AiOjAuMjk3Mn1d/42fd38880a/BackgroundInt.png",
+            [0.3835]= "https://web.poecdn.com/gen/image/WzIxLDE0LHsiayI6IjJEQXJ0L0Jhc2VDbGFzc0lsbHVzdHJhdGlvbnMvSW50Iiwic3AiOjAuMzgzNX1d/c0bdb77c25/BackgroundInt.png"
+        },
+        ["BackgroundStr"]= {
+            [0.1246]= "https://web.poecdn.com/gen/image/WzIxLDE0LHsiayI6IjJEQXJ0L0Jhc2VDbGFzc0lsbHVzdHJhdGlvbnMvU3RyIiwic3AiOjAuMTI0Nn1d/fce4e02c2d/BackgroundStr.png",
+            [0.2109]= "https://web.poecdn.com/gen/image/WzIxLDE0LHsiayI6IjJEQXJ0L0Jhc2VDbGFzc0lsbHVzdHJhdGlvbnMvU3RyIiwic3AiOjAuMjEwOX1d/c1d3abcdf6/BackgroundStr.png",
+            [0.2972]= "https://web.poecdn.com/gen/image/WzIxLDE0LHsiayI6IjJEQXJ0L0Jhc2VDbGFzc0lsbHVzdHJhdGlvbnMvU3RyIiwic3AiOjAuMjk3Mn1d/330d1179e9/BackgroundStr.png",
+            [0.3835]= "https://web.poecdn.com/gen/image/WzIxLDE0LHsiayI6IjJEQXJ0L0Jhc2VDbGFzc0lsbHVzdHJhdGlvbnMvU3RyIiwic3AiOjAuMzgzNX1d/a3e9c6203c/BackgroundStr.png"
+        },
+        ["BackgroundStrDex"]= {
+            [0.1246]= "https://web.poecdn.com/gen/image/WzIxLDE0LHsiayI6IjJEQXJ0L0Jhc2VDbGFzc0lsbHVzdHJhdGlvbnMvU3RyRGV4Iiwic3AiOjAuMTI0Nn1d/586fbfd6c5/BackgroundStrDex.png",
+            [0.2109]= "https://web.poecdn.com/gen/image/WzIxLDE0LHsiayI6IjJEQXJ0L0Jhc2VDbGFzc0lsbHVzdHJhdGlvbnMvU3RyRGV4Iiwic3AiOjAuMjEwOX1d/6edcc5d20d/BackgroundStrDex.png",
+            [0.2972]= "https://web.poecdn.com/gen/image/WzIxLDE0LHsiayI6IjJEQXJ0L0Jhc2VDbGFzc0lsbHVzdHJhdGlvbnMvU3RyRGV4Iiwic3AiOjAuMjk3Mn1d/6dcad02a9d/BackgroundStrDex.png",
+            [0.3835]= "https://web.poecdn.com/gen/image/WzIxLDE0LHsiayI6IjJEQXJ0L0Jhc2VDbGFzc0lsbHVzdHJhdGlvbnMvU3RyRGV4Iiwic3AiOjAuMzgzNX1d/9087aa6b4f/BackgroundStrDex.png"
+        },
+        ["BackgroundStrInt"]= {
+            [0.1246]= "https://web.poecdn.com/gen/image/WzIxLDE0LHsiayI6IjJEQXJ0L0Jhc2VDbGFzc0lsbHVzdHJhdGlvbnMvU3RySW50Iiwic3AiOjAuMTI0Nn1d/41eadec198/BackgroundStrInt.png",
+            [0.2109]= "https://web.poecdn.com/gen/image/WzIxLDE0LHsiayI6IjJEQXJ0L0Jhc2VDbGFzc0lsbHVzdHJhdGlvbnMvU3RySW50Iiwic3AiOjAuMjEwOX1d/ca89c1a731/BackgroundStrInt.png",
+            [0.2972]= "https://web.poecdn.com/gen/image/WzIxLDE0LHsiayI6IjJEQXJ0L0Jhc2VDbGFzc0lsbHVzdHJhdGlvbnMvU3RySW50Iiwic3AiOjAuMjk3Mn1d/58e11c129f/BackgroundStrInt.png",
+            [0.3835]= "https://web.poecdn.com/gen/image/WzIxLDE0LHsiayI6IjJEQXJ0L0Jhc2VDbGFzc0lsbHVzdHJhdGlvbnMvU3RySW50Iiwic3AiOjAuMzgzNX1d/128a4c7335/BackgroundStrInt.png"
+        },
+        ["PassiveMasteryConnectedButton"]= {
+            [0.1246]= "https://web.poecdn.com/gen/image/WzIyLCIwNTBiOTZlYjdkMzYwMWNkMzUwMGJmNDllYzA3ZjEwNiIseyJ0Ijo4Niwic3AiOjAuMTI0Nn1d/de4ea8fc37/PassiveMasteryConnectedButton.png",
+            [0.2109]= "https://web.poecdn.com/gen/image/WzIyLCIwNTBiOTZlYjdkMzYwMWNkMzUwMGJmNDllYzA3ZjEwNiIseyJ0Ijo4Niwic3AiOjAuMjEwOX1d/e986f98048/PassiveMasteryConnectedButton.png",
+            [0.2972]= "https://web.poecdn.com/gen/image/WzIyLCIwNTBiOTZlYjdkMzYwMWNkMzUwMGJmNDllYzA3ZjEwNiIseyJ0Ijo4Niwic3AiOjAuMjk3Mn1d/f0c3d9a862/PassiveMasteryConnectedButton.png",
+            [0.3835]= "https://web.poecdn.com/gen/image/WzIyLCIwNTBiOTZlYjdkMzYwMWNkMzUwMGJmNDllYzA3ZjEwNiIseyJ0Ijo4Niwic3AiOjAuMzgzNX1d/f865908de7/PassiveMasteryConnectedButton.png"
+        }
+    }
+}


### PR DESCRIPTION
Built ontop of #7675 (merge that first)

This PR is a subset of work done last year but those changes were too broad and so I am committing just a subset that are useful now and can easily be built upon (eg preventing needing to load sprites/assets on headless)

This splits future tree sprites data from tree.lua and removes unused zoom information during preprocessing
Doing this on the 3.24 tree reduces the size of the file from 4.91MB down to 3.03MB a 38.3% reduction
The changes to the 3.24 tree were not committed to avoid people who already have it needing to download it again

This also adds a copy of the 3.18 tree assets data into the 3.19 folder, and loads only that if its missing, this removes the need to load the whole 3.18 tree.lua every time