### PR TITLE
Fix enemy level not updating in sync with player level when in auto mode

### DIFF
--- a/src/Modules/Build.lua
+++ b/src/Modules/Build.lua
@@ -774,6 +774,7 @@ function buildMode:EstimatePlayerProgress()
 	if self.characterLevelAutoMode and self.characterLevel ~= level then
 		self.characterLevel = level
 		self.controls.characterLevel:SetText(self.characterLevel)
+		self.configTab:BuildModList()
 	end
 
 	-- Ascendancy points for lab


### PR DESCRIPTION
### Description of the problem being solved:
Fixes enemy level not updating when player level updates automatically.

### Before video:

https://github.com/user-attachments/assets/064e25c0-a83b-4345-ab5c-05ad35f58f4a

### After video:

https://github.com/user-attachments/assets/9f34a0bb-fb54-471b-b643-65abb6b86e4f

