### PR TITLE
Fix the stats of "The Dark Seer" unique sceptre

### DIFF
--- a/src/Data/Uniques/mace.lua
+++ b/src/Data/Uniques/mace.lua
@@ -380,7 +380,8 @@ Blind does not affect your Chance to Hit
 Enemies Blinded by you have Malediction
 {variant:1,2}Gain 1 Mana on Kill per Level
 {variant:1,2}Gain 1 Energy Shield on Kill per Level
-{variant:3,4,6,7,9,10}+1 to maximum Life per Level
+{variant:3,4,6,7}+1 to maximum Life per Level
+{variant:9,10}+(1-2) to maximum Life per Level
 {variant:3,5,6,8}+1 to maximum Mana per Level
 {variant:9,11}+(1-2) to maximum Mana per Level
 {variant:4,5,7,8}+1 to maximum Energy Shield per Level


### PR DESCRIPTION
### Description of the problem being solved:
Current implementation of The Dark Seer does not have a slider for +1-2 maximum life per level for the current variants. I assume this is because it was incorrectly not mentioned on the patch notes by GGG but can be verified on the wiki and ingame.

https://www.poewiki.net/wiki/The_Dark_Seer

![image](https://github.com/user-attachments/assets/14e857a7-450d-4293-ab69-e6edafd35bc0)

### Steps taken to verify a working solution:
- Add "The Dark Seer" unique sceptre.
- Select variant 9/10 (Life/ES or Life/mana)
- Slider for 1-2 Life should appear in the drop down.

### Link to a build that showcases this PR:
https://pobb.in/ZeywqjufeIon (kinda useless)

### Before screenshot:
![image](https://github.com/user-attachments/assets/2f71bf8b-265b-4328-9045-c2caed4d5bff)

### After screenshot:
![image](https://github.com/user-attachments/assets/5f9c9b26-6c46-41ad-b52a-ae85c1f376f4)
