### PR TITLE
Add support for additional strike targets mod & Ancestral Call Support

### DIFF
--- a/src/Data/SkillStatMap.lua
+++ b/src/Data/SkillStatMap.lua
@@ -1653,6 +1653,10 @@ return {
 --
 -- Skill type modifier
 --
+-- MeleeSingleTarget
+["melee_attack_number_of_spirit_strikes"] = {
+	mod("AdditionalStrikeTarget", "BASE", nil)
+},
 -- Trap
 ["support_trap_damage_+%_final"] = {
 	mod("Damage", "MORE", nil, 0, KeywordFlag.Trap),

--- a/src/Modules/CalcOffence.lua
+++ b/src/Modules/CalcOffence.lua
@@ -1075,6 +1075,9 @@ function calcs.offence(env, actor, activeSkill)
 					radius = output.WeaponRange
 				}
 			end
+
+			local baseStrikeCount = 1
+			output.StrikeTargets = baseStrikeCount + skillModList:Sum("BASE", skillCfg, "AdditionalStrikeTarget")
 		end
 	end
 	if skillFlags.area or skillData.radius or (skillFlags.mine and activeSkill.skillTypes[SkillType.Aura]) then

--- a/src/Modules/CalcSections.lua
+++ b/src/Modules/CalcSections.lua
@@ -695,6 +695,10 @@ return {
 		{ label = "Area of Effect modifiers", modName = "AreaOfEffectTertiary", cfg = "skill" },
 	}, },
 	{ label = "Weapon Range", haveOutput = "WeaponRange", { format = "{1:output:WeaponRangeMetre}m", { breakdown = "WeaponRange" }, }, },
+	{ label = "Strike Targets", haveOutput = "StrikeTargets", { format = "{1:output:StrikeTargets}",
+		{ breakdown = "StrikeTargets" }, 
+		{ modName = "AdditionalStrikeTarget", cfg = "skill" }
+	}, },
 	{ label = "Attachment Range", flag = "brand", { format = "{1:output:BrandAttachmentRangeMetre}m",
 		{ breakdown = "BrandAttachmentRange" },
 		{ modName = "BrandAttachmentRange", cfg = "skill"},

--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -3866,6 +3866,8 @@ local specialModList = {
 	["projectiles deal (%d+)%% increased damage with hits and ailments for each time they have chained"] = function(num) return { mod("Damage", "INC", num, nil, 0, bor(KeywordFlag.Hit, KeywordFlag.Ailment), { type = "PerStat", stat = "Chain" }, { type = "SkillType", skillType = SkillType.Projectile }) } end,
 	["projectiles deal (%d+)%% increased damage with hits and ailments for each enemy pierced"] = function(num) return { mod("Damage", "INC", num, nil, 0, bor(KeywordFlag.Hit, KeywordFlag.Ailment), { type = "PerStat", stat = "PiercedCount" }, { type = "SkillType", skillType = SkillType.Projectile }) } end,
 	["(%d+)%% increased bonuses gained from equipped quiver"] = function(num) return {mod("EffectOfBonusesFromQuiver", "INC", num)} end,
+	-- Strike Skills
+	["non%-vaal strike skills target (%d+) additional nearby enem[yi]e?s?"] = function(num) return { mod("AdditionalStrikeTarget", "BASE", num, { type = "SkillType", skillType = SkillType.MeleeSingleTarget}, { type = "SkillType", skillType = SkillType.Vaal, neg = true}) } end,
 	-- Leech/Gain on Hit/Kill
 	["cannot leech life"] = { flag("CannotLeechLife") },
 	["cannot leech mana"] = { flag("CannotLeechMana") },


### PR DESCRIPTION
### Description of the problem being solved:
Adds support for the "non-vaal strike skills target 1/2 additional nearby enem[yi]e?s?" mod.
Adds support for Ancestral Call additional strike targets.

### Steps taken to verify a working solution:
- Select any non-vaal strike skill (e.g. flicker strike)
- Equip a suitable weapon
- You should already see the Strike Targets: 1 in the calcs tab under Skill type-specific Stats.
- Spec the attack mastery for +1 additional nearby enemy strike
- Strike Targets should now be 2.
- Add ancestral call
- Strike Targets should now be 4 (5 if awakened).

### Link to a build that showcases this PR:
https://pobb.in/x3kzZbZIk5J1

### Before screenshot:
![image](https://github.com/user-attachments/assets/fe93661e-fab5-464e-802c-40cc46a9f41b)
![image](https://github.com/user-attachments/assets/ecdc574c-b3f5-4137-b9fc-53f2d119c476)

### After screenshot:
![image](https://github.com/user-attachments/assets/b7b725f8-0302-472c-8d6f-298ab56385be)
![image](https://github.com/user-attachments/assets/d299999f-4afe-4696-8ce7-539cd8773759)
![image](https://github.com/user-attachments/assets/c3403ac7-f631-474c-b0d9-24fb69e046ee)
