### PR TITLE
Add support for spark maximum hits mode

### DIFF
--- a/src/Data/Skills/act_int.lua
+++ b/src/Data/Skills/act_int.lua
@@ -14987,7 +14987,7 @@ skills["Spark"] = {
 		local skillData = activeSkill.skillData
 		if activeSkill.skillPart == 2 then
 			skillData.dpsMultiplier = ( skillData.dpsMultiplier or 1 ) * math.floor( output.Duration / 0.66 )
-			output.SkillDPSMultiplier = ( skillData.dpsMultiplier or 1 )
+			output.SkillDPSMultiplier = skillData.dpsMultiplier
 		end
 	end,
 	baseFlags = {
@@ -15075,7 +15075,7 @@ skills["SparkAltX"] = {
 		local skillData = activeSkill.skillData
 		if activeSkill.skillPart == 2 then
 			skillData.dpsMultiplier = ( skillData.dpsMultiplier or 1 ) * math.floor( output.Duration / 0.66 )
-			output.SkillDPSMultiplier = ( skillData.dpsMultiplier or 1 )
+			output.SkillDPSMultiplier = skillData.dpsMultiplier
 		end
 	end,
 	baseFlags = {
@@ -15165,7 +15165,7 @@ skills["SparkAltY"] = {
 		local skillData = activeSkill.skillData
 		if activeSkill.skillPart == 2 then
 			skillData.dpsMultiplier = ( skillData.dpsMultiplier or 1 ) * math.floor( output.Duration / 0.66 )
-			output.SkillDPSMultiplier = ( skillData.dpsMultiplier or 1 )
+			output.SkillDPSMultiplier = skillData.dpsMultiplier
 		end
 	end,
 	baseFlags = {

--- a/src/Data/Skills/act_int.lua
+++ b/src/Data/Skills/act_int.lua
@@ -18575,7 +18575,7 @@ skills["FrostBoltNova"] = {
 	baseEffectiveness = 1.2086000442505,
 	incrementalEffectiveness = 0.049499999731779,
 	description = "An icy blast explodes around the caster, dealing cold damage to enemies, and leaving behind a whirling vortex which deals cold damage over time and chills enemies caught in it.",
-	skillTypes = { [SkillType.Spell] = true, [SkillType.Damage] = true, [SkillType.Area] = true, [SkillType.Trappable] = true, [SkillType.Totemable] = true, [SkillType.Mineable] = true, [SkillType.Multicastable] = true, [SkillType.Cold] = true, [SkillType.Triggerable] = true, [SkillType.Duration] = true, [SkillType.ChillingArea] = true, [SkillType.AreaSpell] = true, [SkillType.Nova] = true, [SkillType.CanRapidFire] = true, },
+	skillTypes = { [SkillType.Spell] = true, [SkillType.Damage] = true, [SkillType.Area] = true, [SkillType.Trappable] = true, [SkillType.Totemable] = true, [SkillType.Mineable] = true, [SkillType.Multicastable] = true, [SkillType.Cold] = true, [SkillType.Triggerable] = true, [SkillType.Duration] = true, [SkillType.ChillingArea] = true, [SkillType.AreaSpell] = true, [SkillType.Nova] = true, },
 	statDescriptionScope = "skill_stat_descriptions",
 	castTime = 0.75,
 	preDamageFunc = function(activeSkill, output)
@@ -18659,7 +18659,7 @@ skills["FrostBoltNovaAltX"] = {
 	baseEffectiveness = 1.2086000442505,
 	incrementalEffectiveness = 0.049499999731779,
 	description = "An icy blast explodes around the caster, dealing cold damage to enemies, and leaving behind a whirling vortex which deals cold damage over time and chills enemies caught in it. If the caster targets near their Frostbolt projectiles, it will explode from a number of those projectiles instead, destroying them.",
-	skillTypes = { [SkillType.Spell] = true, [SkillType.Damage] = true, [SkillType.Area] = true, [SkillType.Trappable] = true, [SkillType.Totemable] = true, [SkillType.Mineable] = true, [SkillType.Multicastable] = true, [SkillType.Cold] = true, [SkillType.Triggerable] = true, [SkillType.Duration] = true, [SkillType.ChillingArea] = true, [SkillType.AreaSpell] = true, [SkillType.Nova] = true, [SkillType.CanRapidFire] = true, },
+	skillTypes = { [SkillType.Spell] = true, [SkillType.Damage] = true, [SkillType.Area] = true, [SkillType.Trappable] = true, [SkillType.Totemable] = true, [SkillType.Mineable] = true, [SkillType.Multicastable] = true, [SkillType.Cold] = true, [SkillType.Triggerable] = true, [SkillType.Duration] = true, [SkillType.ChillingArea] = true, [SkillType.AreaSpell] = true, [SkillType.Nova] = true, },
 	statDescriptionScope = "skill_stat_descriptions",
 	castTime = 0.75,
 	preDamageFunc = function(activeSkill, output)

--- a/src/Data/Skills/act_int.lua
+++ b/src/Data/Skills/act_int.lua
@@ -14987,7 +14987,7 @@ skills["Spark"] = {
 		local skillData = activeSkill.skillData
 		if activeSkill.skillPart == 2 then
 			skillData.dpsMultiplier = ( skillData.dpsMultiplier or 1 ) * math.floor( output.Duration / 0.66 )
-			output.SkillDPSMultiplier = ( skillData.dpsMultiplier or 1 ) * math.floor( output.Duration / 0.66 )
+			output.SkillDPSMultiplier = ( skillData.dpsMultiplier or 1 )
 		end
 	end,
 	baseFlags = {
@@ -15075,7 +15075,7 @@ skills["SparkAltX"] = {
 		local skillData = activeSkill.skillData
 		if activeSkill.skillPart == 2 then
 			skillData.dpsMultiplier = ( skillData.dpsMultiplier or 1 ) * math.floor( output.Duration / 0.66 )
-			output.SkillDPSMultiplier = ( skillData.dpsMultiplier or 1 ) * math.floor( output.Duration / 0.66 )
+			output.SkillDPSMultiplier = ( skillData.dpsMultiplier or 1 )
 		end
 	end,
 	baseFlags = {
@@ -15165,7 +15165,7 @@ skills["SparkAltY"] = {
 		local skillData = activeSkill.skillData
 		if activeSkill.skillPart == 2 then
 			skillData.dpsMultiplier = ( skillData.dpsMultiplier or 1 ) * math.floor( output.Duration / 0.66 )
-			output.SkillDPSMultiplier = ( skillData.dpsMultiplier or 1 ) * math.floor( output.Duration / 0.66 )
+			output.SkillDPSMultiplier = ( skillData.dpsMultiplier or 1 )
 		end
 	end,
 	baseFlags = {

--- a/src/Data/Skills/act_int.lua
+++ b/src/Data/Skills/act_int.lua
@@ -14975,6 +14975,21 @@ skills["Spark"] = {
 	skillTypes = { [SkillType.Spell] = true, [SkillType.Projectile] = true, [SkillType.ProjectilesFromUser] = true, [SkillType.Damage] = true, [SkillType.Duration] = true, [SkillType.Trappable] = true, [SkillType.Totemable] = true, [SkillType.Mineable] = true, [SkillType.Multicastable] = true, [SkillType.Triggerable] = true, [SkillType.Lightning] = true, [SkillType.CanRapidFire] = true, },
 	statDescriptionScope = "skill_stat_descriptions",
 	castTime = 0.65,
+	parts = {
+		{
+			name = "1 Hit",
+		},
+		{
+			name = "Maximum Hits",
+		},
+	},
+	preDamageFunc = function(activeSkill, output)
+		local skillData = activeSkill.skillData
+		if activeSkill.skillPart == 2 then
+			skillData.dpsMultiplier = ( skillData.dpsMultiplier or 1 ) * math.floor( output.Duration / 0.66 )
+			output.SkillDPSMultiplier = ( skillData.dpsMultiplier or 1 ) * math.floor( output.Duration / 0.66 )
+		end
+	end,
 	baseFlags = {
 		spell = true,
 		projectile = true,
@@ -15048,6 +15063,21 @@ skills["SparkAltX"] = {
 	skillTypes = { [SkillType.Spell] = true, [SkillType.Projectile] = true, [SkillType.ProjectilesFromUser] = true, [SkillType.Damage] = true, [SkillType.Duration] = true, [SkillType.Trappable] = true, [SkillType.Totemable] = true, [SkillType.Mineable] = true, [SkillType.Multicastable] = true, [SkillType.Triggerable] = true, [SkillType.Lightning] = true, [SkillType.CanRapidFire] = true, },
 	statDescriptionScope = "skill_stat_descriptions",
 	castTime = 0.75,
+	parts = {
+		{
+			name = "1 Hit",
+		},
+		{
+			name = "Maximum Hits",
+		},
+	},
+	preDamageFunc = function(activeSkill, output) 
+		local skillData = activeSkill.skillData
+		if activeSkill.skillPart == 2 then
+			skillData.dpsMultiplier = ( skillData.dpsMultiplier or 1 ) * math.floor( output.Duration / 0.66 )
+			output.SkillDPSMultiplier = ( skillData.dpsMultiplier or 1 ) * math.floor( output.Duration / 0.66 )
+		end
+	end,
 	baseFlags = {
 		spell = true,
 		projectile = true,
@@ -15123,6 +15153,21 @@ skills["SparkAltY"] = {
 	skillTypes = { [SkillType.Spell] = true, [SkillType.Projectile] = true, [SkillType.ProjectilesFromUser] = true, [SkillType.Damage] = true, [SkillType.Duration] = true, [SkillType.Trappable] = true, [SkillType.Totemable] = true, [SkillType.Mineable] = true, [SkillType.Multicastable] = true, [SkillType.Triggerable] = true, [SkillType.Lightning] = true, [SkillType.CanRapidFire] = true, },
 	statDescriptionScope = "skill_stat_descriptions",
 	castTime = 0.65,
+	parts = {
+		{
+			name = "1 Hit",
+		},
+		{
+			name = "Maximum Hits",
+		},
+	},
+	preDamageFunc = function(activeSkill, output)
+		local skillData = activeSkill.skillData
+		if activeSkill.skillPart == 2 then
+			skillData.dpsMultiplier = ( skillData.dpsMultiplier or 1 ) * math.floor( output.Duration / 0.66 )
+			output.SkillDPSMultiplier = ( skillData.dpsMultiplier or 1 ) * math.floor( output.Duration / 0.66 )
+		end
+	end,
 	baseFlags = {
 		spell = true,
 		projectile = true,
@@ -18530,7 +18575,7 @@ skills["FrostBoltNova"] = {
 	baseEffectiveness = 1.2086000442505,
 	incrementalEffectiveness = 0.049499999731779,
 	description = "An icy blast explodes around the caster, dealing cold damage to enemies, and leaving behind a whirling vortex which deals cold damage over time and chills enemies caught in it.",
-	skillTypes = { [SkillType.Spell] = true, [SkillType.Damage] = true, [SkillType.Area] = true, [SkillType.Trappable] = true, [SkillType.Totemable] = true, [SkillType.Mineable] = true, [SkillType.Multicastable] = true, [SkillType.Cold] = true, [SkillType.Triggerable] = true, [SkillType.Duration] = true, [SkillType.ChillingArea] = true, [SkillType.AreaSpell] = true, [SkillType.Nova] = true, },
+	skillTypes = { [SkillType.Spell] = true, [SkillType.Damage] = true, [SkillType.Area] = true, [SkillType.Trappable] = true, [SkillType.Totemable] = true, [SkillType.Mineable] = true, [SkillType.Multicastable] = true, [SkillType.Cold] = true, [SkillType.Triggerable] = true, [SkillType.Duration] = true, [SkillType.ChillingArea] = true, [SkillType.AreaSpell] = true, [SkillType.Nova] = true, [SkillType.CanRapidFire] = true, },
 	statDescriptionScope = "skill_stat_descriptions",
 	castTime = 0.75,
 	preDamageFunc = function(activeSkill, output)
@@ -18614,7 +18659,7 @@ skills["FrostBoltNovaAltX"] = {
 	baseEffectiveness = 1.2086000442505,
 	incrementalEffectiveness = 0.049499999731779,
 	description = "An icy blast explodes around the caster, dealing cold damage to enemies, and leaving behind a whirling vortex which deals cold damage over time and chills enemies caught in it. If the caster targets near their Frostbolt projectiles, it will explode from a number of those projectiles instead, destroying them.",
-	skillTypes = { [SkillType.Spell] = true, [SkillType.Damage] = true, [SkillType.Area] = true, [SkillType.Trappable] = true, [SkillType.Totemable] = true, [SkillType.Mineable] = true, [SkillType.Multicastable] = true, [SkillType.Cold] = true, [SkillType.Triggerable] = true, [SkillType.Duration] = true, [SkillType.ChillingArea] = true, [SkillType.AreaSpell] = true, [SkillType.Nova] = true, },
+	skillTypes = { [SkillType.Spell] = true, [SkillType.Damage] = true, [SkillType.Area] = true, [SkillType.Trappable] = true, [SkillType.Totemable] = true, [SkillType.Mineable] = true, [SkillType.Multicastable] = true, [SkillType.Cold] = true, [SkillType.Triggerable] = true, [SkillType.Duration] = true, [SkillType.ChillingArea] = true, [SkillType.AreaSpell] = true, [SkillType.Nova] = true, [SkillType.CanRapidFire] = true, },
 	statDescriptionScope = "skill_stat_descriptions",
 	castTime = 0.75,
 	preDamageFunc = function(activeSkill, output)

--- a/src/Export/Skills/act_int.txt
+++ b/src/Export/Skills/act_int.txt
@@ -3372,14 +3372,59 @@ local skills, mod, flag, skill = ...
 
 #skill Spark
 #flags spell projectile duration
+	parts = {
+		{
+			name = "1 Hit",
+		},
+		{
+			name = "Maximum Hits",
+		},
+	},
+	preDamageFunc = function(activeSkill, output)
+		local skillData = activeSkill.skillData
+		if activeSkill.skillPart == 2 then
+			skillData.dpsMultiplier = ( skillData.dpsMultiplier or 1 ) * math.floor( output.Duration / 0.66 )
+			output.SkillDPSMultiplier = ( skillData.dpsMultiplier or 1 ) * math.floor( output.Duration / 0.66 )
+		end
+	end,
 #mods
 
 #skill SparkAltX
 #flags spell projectile duration
+	parts = {
+		{
+			name = "1 Hit",
+		},
+		{
+			name = "Maximum Hits",
+		},
+	},
+	preDamageFunc = function(activeSkill, output) 
+		local skillData = activeSkill.skillData
+		if activeSkill.skillPart == 2 then
+			skillData.dpsMultiplier = ( skillData.dpsMultiplier or 1 ) * math.floor( output.Duration / 0.66 )
+			output.SkillDPSMultiplier = ( skillData.dpsMultiplier or 1 ) * math.floor( output.Duration / 0.66 )
+		end
+	end,
 #mods
 
 #skill SparkAltY
 #flags spell projectile duration
+	parts = {
+		{
+			name = "1 Hit",
+		},
+		{
+			name = "Maximum Hits",
+		},
+	},
+	preDamageFunc = function(activeSkill, output)
+		local skillData = activeSkill.skillData
+		if activeSkill.skillPart == 2 then
+			skillData.dpsMultiplier = ( skillData.dpsMultiplier or 1 ) * math.floor( output.Duration / 0.66 )
+			output.SkillDPSMultiplier = ( skillData.dpsMultiplier or 1 ) * math.floor( output.Duration / 0.66 )
+		end
+	end,
 #mods
 
 #skill VaalSparkSpiralNova

--- a/src/Export/Skills/act_int.txt
+++ b/src/Export/Skills/act_int.txt
@@ -3384,7 +3384,7 @@ local skills, mod, flag, skill = ...
 		local skillData = activeSkill.skillData
 		if activeSkill.skillPart == 2 then
 			skillData.dpsMultiplier = ( skillData.dpsMultiplier or 1 ) * math.floor( output.Duration / 0.66 )
-			output.SkillDPSMultiplier = ( skillData.dpsMultiplier or 1 ) * math.floor( output.Duration / 0.66 )
+			output.SkillDPSMultiplier = ( skillData.dpsMultiplier or 1 )
 		end
 	end,
 #mods
@@ -3403,7 +3403,7 @@ local skills, mod, flag, skill = ...
 		local skillData = activeSkill.skillData
 		if activeSkill.skillPart == 2 then
 			skillData.dpsMultiplier = ( skillData.dpsMultiplier or 1 ) * math.floor( output.Duration / 0.66 )
-			output.SkillDPSMultiplier = ( skillData.dpsMultiplier or 1 ) * math.floor( output.Duration / 0.66 )
+			output.SkillDPSMultiplier = ( skillData.dpsMultiplier or 1 )
 		end
 	end,
 #mods
@@ -3422,7 +3422,7 @@ local skills, mod, flag, skill = ...
 		local skillData = activeSkill.skillData
 		if activeSkill.skillPart == 2 then
 			skillData.dpsMultiplier = ( skillData.dpsMultiplier or 1 ) * math.floor( output.Duration / 0.66 )
-			output.SkillDPSMultiplier = ( skillData.dpsMultiplier or 1 ) * math.floor( output.Duration / 0.66 )
+			output.SkillDPSMultiplier = ( skillData.dpsMultiplier or 1 )
 		end
 	end,
 #mods

--- a/src/Export/Skills/act_int.txt
+++ b/src/Export/Skills/act_int.txt
@@ -3384,7 +3384,7 @@ local skills, mod, flag, skill = ...
 		local skillData = activeSkill.skillData
 		if activeSkill.skillPart == 2 then
 			skillData.dpsMultiplier = ( skillData.dpsMultiplier or 1 ) * math.floor( output.Duration / 0.66 )
-			output.SkillDPSMultiplier = ( skillData.dpsMultiplier or 1 )
+			output.SkillDPSMultiplier = skillData.dpsMultiplier
 		end
 	end,
 #mods
@@ -3403,7 +3403,7 @@ local skills, mod, flag, skill = ...
 		local skillData = activeSkill.skillData
 		if activeSkill.skillPart == 2 then
 			skillData.dpsMultiplier = ( skillData.dpsMultiplier or 1 ) * math.floor( output.Duration / 0.66 )
-			output.SkillDPSMultiplier = ( skillData.dpsMultiplier or 1 )
+			output.SkillDPSMultiplier = skillData.dpsMultiplier
 		end
 	end,
 #mods
@@ -3422,7 +3422,7 @@ local skills, mod, flag, skill = ...
 		local skillData = activeSkill.skillData
 		if activeSkill.skillPart == 2 then
 			skillData.dpsMultiplier = ( skillData.dpsMultiplier or 1 ) * math.floor( output.Duration / 0.66 )
-			output.SkillDPSMultiplier = ( skillData.dpsMultiplier or 1 )
+			output.SkillDPSMultiplier = skillData.dpsMultiplier
 		end
 	end,
 #mods


### PR DESCRIPTION
Fixes #7612 (at least the intention behind it).

### Description of the problem being solved:
Adds a new mode for Spark & Spark alt qualities that uses the maximum amount of possible hits with the given spark duration assuming a 100% hitrate after each 0.66s cooldown period.

Didn't add the mode to Vaal Spark, as its mechanics are different to normal Spark & a DPS number is useless for it anyways.

### Steps taken to verify a working solution:
- Add spark gem
- Select "Maximum Hits" mode
- DPS should go up (baseline x3 without any duration)
- spec some duration on the tree -> DPS should go up as soon as you hit a breakpoint.

### Link to a build that showcases this PR:
https://pobb.in/18bN-kP4WaPe

### Before screenshot:
![image](https://github.com/user-attachments/assets/04fb4959-8293-4e51-bde1-bb5adf60e77a)

### After screenshot:
![image](https://github.com/user-attachments/assets/b83fc3f4-b1a6-447b-bf88-24e93f345f24)
![image](https://github.com/user-attachments/assets/a5441609-d4fc-4bfd-9e94-9600842cdb68)
![image](https://github.com/user-attachments/assets/5d5f8467-e4e4-4df5-90f9-e3a2808b070a)
