### PR TITLE
3 25 unique changes

### DIFF
--- a/src/Data/Uniques/amulet.lua
+++ b/src/Data/Uniques/amulet.lua
@@ -197,6 +197,8 @@ Implicits: 1
 ]],[[
 Eternal Damnation
 Agate Amulet
+Variant: Pre 3.25.0
+Variant: Current
 League: Sanctum
 Source: Drops from unique{Lycia, Herald of the Scourge} in normal{The Beyond}
 LevelReq: 52
@@ -206,6 +208,8 @@ Implicits: 1
 {tags:jewellery_resistance}+(-13-13)% to Chaos Resistance
 {tags:jewellery_resistance}-5% to all maximum Resistances
 Gain additional Elemental Damage Reduction equal to half your Chaos Resistance
+{variant:2}Cannot gain Endurance Charges
+{variant:2}Cannot gain Power Charges
 ]],[[
 Badge of the Brotherhood
 Turquoise Amulet
@@ -336,6 +340,8 @@ Implicits: 1
 ]],[[
 Defiance of Destiny
 Paua Amulet
+Variant: Pre 3.25.0
+Variant: Current
 LevelReq: 49
 Implicits: 1
 {tags:mana}(20-30)% increased Mana Regeneration Rate
@@ -343,7 +349,8 @@ Implicits: 1
 {tags:jewellery_resistance}+(10-40)% to Fire Resistance
 {tags:jewellery_resistance}+(10-40)% to Cold Resistance
 {tags:jewellery_resistance}+(10-40)% to Lightning Resistance
-{tags:life}Gain (25-35)% of Missing Unreserved Life before being Hit by an Enemy
+{variant:1}{tags:life}Gain (25-35)% of Missing Unreserved Life before being Hit by an Enemy
+{variant:2}{tags:life}Gain (10-20)% of Missing Unreserved Life before being Hit by an Enemy
 ]],[[
 The Ephemeral Bond
 Lapis Amulet

--- a/src/Data/Uniques/amulet.lua
+++ b/src/Data/Uniques/amulet.lua
@@ -454,7 +454,7 @@ Variant: Chance to Freeze, Shock and Ignite
 Variant: Crit Chance
 Variant: Area of Effect
 Variant: Attack/Cast Speed
-Variant: Item Quantity
+Variant: Item Quantity (Pre 3.25.0)
 Variant: Life
 Variant: Crit Multiplier
 Variant: Maximum number of Raised Zombies
@@ -470,6 +470,7 @@ Variant: Lightning taken as Cold
 Variant: Lightning taken as Fire
 Variant: Gain Physical as random Element
 Variant: Extra Pierces
+Variant: Damage over Time Multiplier
 Implicits: 32
 {variant:1}(24-32)% increased Attributes
 {variant:2}(30-50)% increased Global Defences
@@ -503,6 +504,7 @@ Implicits: 32
 {variant:30}100% of Lightning Damage from Hits taken as Fire Damage
 {variant:31}Gain (12-24)% of Physical Damage as Extra Damage of a random Element
 {variant:32}Projectiles Pierce (4-6) additional Targets
+{variant:33}(24-36)% Damage over Time Multiplier
 Implicit Modifier magnitudes are doubled
 ]],[[
 The Felbog Fang

--- a/src/Data/Uniques/amulet.lua
+++ b/src/Data/Uniques/amulet.lua
@@ -68,6 +68,7 @@ Implicits: 1
 ]],[[
 The Ascetic
 Gold Amulet
+Source: No longer obtainable
 Requires Level 8
 Implicits: 1
 (12-20)% increased Rarity of Items found
@@ -242,6 +243,7 @@ Gold Amulet
 Variant: Pre 3.0.0
 Variant: Pre 3.2.0
 Variant: Current
+Source: No longer obtainable
 Requires Level 30
 Implicits: 1
 (12-20)% increased Rarity of Items found

--- a/src/Data/Uniques/axe.lua
+++ b/src/Data/Uniques/axe.lua
@@ -127,6 +127,7 @@ Royal Axe
 League: Talisman Standard, Talisman Hardcore
 Source: Drops from unique{Rigwald, the Wolven King} (Level 75+)
 Variant: Pre 3.11.0
+Variant: Pre 3.25.0
 Variant: Current
 Implicits: 0
 Adds (50-70) to (135-165) Physical Damage
@@ -135,6 +136,7 @@ Adds (50-70) to (135-165) Physical Damage
 {variant:1}35% increased Attack Speed with Swords
 {variant:1}25% chance to cause Bleeding on Hit
 {variant:2}+25 to Maximum Rage while wielding a Sword
+{variant:3}+10 to Maximum Rage while wielding a Sword
 ]],[[
 Soul Taker
 Siege Axe
@@ -246,17 +248,19 @@ League: Legion
 Variant: Pre 1.0.0
 Variant: Pre 3.7.0
 Variant: Pre 3.11.0
+Variant: Pre 3.25.0
 Variant: Current
 Implicits: 0
 {variant:1}(120-150)% increased Physical Damage
 {variant:2,3}(160-220)% increased Physical Damage
-{variant:4}(100-140)% increased Physical Damage
+{variant:4,5}(100-140)% increased Physical Damage
 {variant:1,2}Adds (16-21) to (32-38) Fire Damage
 Gain 20 Life per Enemy Killed
 +(150-250) to Accuracy Rating
 Culling Strike
 {variant:3,4}Gain 1 Rage on Critical Hit with attacks, no more than once every 0.5 seconds
-{variant:3,4}Gain 1% of Physical Damage as Extra Fire Damage per 1 Rage
+{variant:5}Gain 5 Rage on Melee Hit
+{variant:3,4,5}Gain 1% of Physical Damage as Extra Fire Damage per 1 Rage
 ]],[[
 Kingmaker
 Despot Axe

--- a/src/Data/Uniques/belt.lua
+++ b/src/Data/Uniques/belt.lua
@@ -98,6 +98,8 @@ Implicits: 1
 ]],[[
 Bear's Girdle
 Leather Belt
+Variant: Pre 3.25.0
+Variant: Current
 League: Harvest
 Source: Drops from unique{Ersi, Mother of Thorns} in normal{The Sacred Grove}
 LevelReq: 68
@@ -106,8 +108,9 @@ Implicits: 1
 {tags:attack,physical_damage}Adds (5-7) to (11-12) Physical Damage to Attacks
 (20-30)% increased Stun Duration on Enemies
 Nearby Enemies are Crushed while you have at least 25 Rage
-{tags:physical_damage}(4-6)% increased Physical Damage per 10 Rage
-+20 to Maximum Rage
+{variant:1}{tags:physical_damage}(4-6)% increased Physical Damage per 10 Rage
+{variant:1}+20 to Maximum Rage
+{variant:2}+10 to Maximum Rage
 ]],[[
 Belt of the Deceiver
 Heavy Belt

--- a/src/Data/Uniques/belt.lua
+++ b/src/Data/Uniques/belt.lua
@@ -126,10 +126,13 @@ Implicits: 1
 ]],[[
 Bisco's Leash
 Heavy Belt
+Variant: Pre 3.25.0
+Variant: Current
 LevelReq: 30
 Implicits: 1
 {tags:jewellery_attribute}+(25-35) to Strength
-5% increased Quantity of Items found
+{variant:1}5% increased Quantity of Items found
+{variant:2}{tags:jewellery_attribute}+(10-15) to all Attributes
 {tags:jewellery_resistance}+(20-40)% to Cold Resistance
 1% increased Rarity of Items found per 15 Rampage Kills
 Rampage
@@ -603,12 +606,14 @@ Gain Affliction Charges instead of Frenzy Charges
 Perandus Blazon
 Cloth Belt
 Variant: Pre 1.1.0
+Variant: Pre 3.25.0
 Variant: Current
 Implicits: 1
 (15-25)% increased Stun and Block Recovery
 {tags:jewellery_attribute}+(20-30) to all Attributes
 {variant:1}(8-12)% increased Quantity of Items found
 {variant:2}(6-8)% increased Quantity of Items found
+{variant:3}(10-12)% increased Rarity of Items found
 {tags:jewellery_resistance}+20% to Fire Resistance
 20% increased Flask Effect Duration
 {tags:physical_damage}-2 Physical Damage taken from Attack Hits

--- a/src/Data/Uniques/body.lua
+++ b/src/Data/Uniques/body.lua
@@ -113,11 +113,12 @@ Implicits: 0
 Kaom's Heart
 Glorious Plate
 Variant: Pre 1.0.0
+Variant: Pre 3.25.0
 Variant: Current
 Implicits: 0
 Has no Sockets
 {variant:2}(20-40)% increased Fire Damage
-{variant:1}+1000 to maximum Life
+{variant:1,3}+1000 to maximum Life
 {variant:2}+500 to maximum Life
 ]],[[
 Replica Kaom's Heart

--- a/src/Data/Uniques/body.lua
+++ b/src/Data/Uniques/body.lua
@@ -101,12 +101,16 @@ Regenerate 10% Life over one second when Hit while Sane
 ]],[[
 Greed's Embrace
 Golden Plate
+Variant: Pre 3.25.0
+Variant: Current
 Implicits: 0
-(10-15)% increased Quantity of Items found
-(30-50)% increased Rarity of Items found
+{variant:1}(10-15)% increased Quantity of Items found
+{variant:1}(30-50)% increased Rarity of Items found
+{variant:2}100% increased Rarity of Items found
 -10% to Fire Resistance
 +(20-30)% to Cold Resistance
--20% to Lightning Resistance
+{variant:1}-20% to Lightning Resistance
+{variant:2}(-20--10)% to Lightning Resistance
 20% reduced Movement Speed
 30% reduced Strength Requirement
 ]],[[

--- a/src/Data/Uniques/boots.lua
+++ b/src/Data/Uniques/boots.lua
@@ -300,11 +300,13 @@ Trigger Level 20 Intimidating Cry when you lose Cat's Stealth
 Goldwyrm
 Nubuck Boots
 Variant: Pre 1.1.0
+Variant: Pre 3.25.0
 Variant: Current
 Requires Level 34, 62 Dex
 60% increased Mana Regeneration Rate
 {variant:1}(20-30)% increased Quantity of Items Found
 {variant:2}(14-20)% increased Quantity of Items Found
+{variant:3}(20-40)% increased Rarity of Items Found
 +(40-50)% to Fire Resistance
 10% increased Movement Speed
 ]],[[

--- a/src/Data/Uniques/boots.lua
+++ b/src/Data/Uniques/boots.lua
@@ -186,12 +186,17 @@ You can apply an additional Curse
 ]],[[
 Dawnstrider
 Vaal Greaves
+Variant: Pre 3.25.0
+Variant: Current
 Source: Drops from unique{The Searing Exarch}
 +(80-100) to maximum Life
 30% increased Movement Speed
-100% increased Effect of Buffs your Ancestor Totems grant while Active
-Buffs from Active Ancestor Totems Linger for 4 seconds
-Maximum 1 Buff from an Active Ancestor Totem at a time
+{variant:1}100% increased Effect of Buffs your Ancestor Totems grant while Active
+{variant:1}Buffs from Active Ancestor Totems Linger for 4 seconds
+{variant:1}Maximum 1 Buff from an Active Ancestor Totem at a time
+{variant:2}Socketed Slam Gems are Supported by Level 25 Earthbreaker
+{variant:2}Ancestral Bond
+{variant:2}(3-5)% of Damage from hits is taken from your nearest Totem's Life before you
 ]],
 -- Boots: Evasion
 [[

--- a/src/Data/Uniques/bow.lua
+++ b/src/Data/Uniques/bow.lua
@@ -549,25 +549,27 @@ Variant: Pre 1.1.2
 Variant: Pre 2.0.0
 Variant: Pre 2.6.0
 Variant: Pre 3.5.0
+Variant: Pre 3.25.0
 Variant: Current
 Requires Level 66, 212 Dex
 Implicits: 2
 {variant:3}(6-12)% increased Elemental Damage with Attack Skills
-{variant:4,5}(20-24)% increased Elemental Damage with Attack Skills
+{variant:4,5,6}(20-24)% increased Elemental Damage with Attack Skills
 {variant:1}Adds 40 to 60 Cold Damage
 {variant:2,3,4}Adds (32-40) to (48-60) Cold Damage
-{variant:5}Adds (48-60) to (72-90) Cold Damage
+{variant:5,6}Adds (48-60) to (72-90) Cold Damage
 {variant:1}Adds 1 to 100 Lightning Damage
 {variant:2,3,4}Adds 1 to (80-100) Lightning Damage
-{variant:5}Adds 1 to (120-150) Lightning Damage
+{variant:5,6}Adds 1 to (120-150) Lightning Damage
 (10-15)% increased Attack Speed
 {variant:1,2}(80-100)% increased Critical Strike Chance
 {variant:3,4}(60-80)% increased Critical Strike Chance
-{variant:5}(30-40)% increased Critical Strike Chance
+{variant:5,6}(30-40)% increased Critical Strike Chance
 {variant:1,2}25% increased Quantity of Items Dropped by Slain Frozen enemies
 {variant:3,4,5}15% increased Quantity of Items Dropped by Slain Frozen Enemies
+{variant:6}30% increased Rarity of Items Dropped by Slain Frozen Enemies
 {variant:1,2}50% increased Rarity of Items Dropped by Slain Shocked enemies
-{variant:3,4,5}30% increased Rarity of Items Dropped by Slain Shocked Enemies
+{variant:3,4,5,6}30% increased Rarity of Items Dropped by Slain Shocked Enemies
 ]],[[
 Replica Windripper
 Imperial Bow

--- a/src/Data/Uniques/flask.lua
+++ b/src/Data/Uniques/flask.lua
@@ -75,6 +75,7 @@ Variant: Pre 1.1.0
 Variant: Pre 2.2.0
 Variant: Pre 3.5.0
 Variant: Pre 3.15.0
+Variant: Pre 3.25.0
 Variant: Current
 {variant:1,2}+6% to all maximum Elemental Resistances during Effect
 {variant:3}+4% to all maximum Elemental Resistances during Effect
@@ -83,8 +84,10 @@ Variant: Current
 {variant:1,2,3,4}(40-60)% increased Rarity of Items found during Effect
 {variant:5}(20-30)% increased Rarity of Items found during Effect
 {variant:5}(8-12)% increased Quantity of Items found during Effect
+{variant:6}(30-50)% increased Rarity of Items found during Effect
 25% increased Light Radius during Effect
 {variant:4,5}+50% to Elemental Resistances during Effect
+{variant:6}+10% to Elemental Resistances during Effect
 ]],[[
 The Writhing Jar
 Hallowed Hybrid Flask

--- a/src/Data/Uniques/flask.lua
+++ b/src/Data/Uniques/flask.lua
@@ -364,13 +364,15 @@ Sapphire Flask
 Variant: Pre 2.2.0
 Variant: Pre 3.0.0
 Variant: Pre 3.15.0
+Variant: Pre 3.25.0
 Variant: Current
 {variant:1}30% of Physical Damage from Hits taken as Cold Damage during Effect
 {variant:2,3}20% of Physical Damage from Hits taken as Cold Damage during Effect
 {variant:4}(10-15)% of Physical Damage from Hits taken as Cold Damage during Effect
+{variant:5}(20-30)% of Fire and Lightning Damage from Hits taken as Cold Damage during Effect
 {variant:1,2}Gain (20-30)% of Physical Damage as Extra Cold Damage during effect
 {variant:3}Gain (15-20)% of Physical Damage as Extra Cold Damage during effect
-{variant:4}Gain (10-15)% of Physical Damage as Extra Cold Damage during effect
+{variant:4,5}Gain (10-15)% of Physical Damage as Extra Cold Damage during effect
 30% chance to Avoid being Chilled during Effect
 30% chance to Avoid being Frozen during Effect
 ]],[[
@@ -474,24 +476,30 @@ Grants Level 21 Vulnerability Curse Aura during Effect
 [[
 Elixir of the Unbroken Circle
 Iron Flask
+Variant: Pre 3.25.0
+Variant: Current
 League: Expedition
 Source: Drops from unique{Medved, Feller of Heroes} in normal{Expedition Logbook}
 Implicits: 1
 Restores Ward on use
-(20-40)% increased Duration
+{variant:1}(20-40)% increased Duration
+{variant:2}(50-80)% increased Duration
 Recover 4% of Life per Endurance Charge on use
 Lose all Endurance Charges on use
 Gain 1 Endurance Charge per Second during Effect
 ]],[[
 Olroth's Resolve
 Iron Flask
+Variant: Pre 3.25.0
+Variant: Current
 League: Expedition
 Source: Drops from unique{Olroth, Origin of the Fall} in normal{Expedition Logbook}
 Implicits: 1
 Restores Ward on use
 (50-40)% increased Charges per use
 Ward does not Break during Effect
-70% less Ward during Effect
+{variant:1}70% less Ward during Effect
+{variant:2}85% less Ward during Effect
 ]],[[
 Starlight Chalice
 Iron Flask

--- a/src/Data/Uniques/gloves.lua
+++ b/src/Data/Uniques/gloves.lua
@@ -426,6 +426,7 @@ Sadima's Touch
 Wool Gloves
 Variant: Pre 1.1.0
 Variant: Pre 3.5.0
+Variant: Pre 3.25.0
 Variant: Current
 Requires Level 11
 Adds 4 to 8 Fire Damage to Attacks
@@ -434,6 +435,7 @@ Adds 1 to 13 Lightning Damage to Attacks
 {variant:1}(18-24)% increased Quantity of Items found
 {variant:2}(12-16)% increased Quantity of Items found
 {variant:3}(5-10)% increased Quantity of Items found
+{variant:4}(10-15)% increased Rarity of Items found
 ]],[[
 Voidbringer
 Conjurer Gloves

--- a/src/Data/Uniques/gloves.lua
+++ b/src/Data/Uniques/gloves.lua
@@ -638,13 +638,16 @@ With a Hypnotic Eye Jewel Socketed, gain Arcane Surge on Hit with Spells
 ]],[[
 Hand of the Fervent
 Zealot Gloves
+Variant: Pre 3.25.0
+Variant: Current
 League: Ritual
 Source: Purchase from Ritual Reward
 Requires Level 43, 34 Str, 34 Int
 (70-130)% increased Armour and Energy Shield
 +(50-70) to maximum Life
 Gain Sacrificial Zeal when you use a Skill, dealing you 150% of the Skill's Mana Cost as Physical Damage per Second
-Hits Overwhelm (10-15)% of Physical Damage Reduction while you have Sacrificial Zeal
+{variant:1}Hits Overwhelm (10-15)% of Physical Damage Reduction while you have Sacrificial Zeal
+{variant:2}(35-50)% chance for Hits to ignore Enemy Physical Damage Reduction while you have Sacrificial Zeal
 ]],[[
 Hands of the High Templar
 Crusader Gloves
@@ -1054,6 +1057,7 @@ Flasks gain 1 Charge per second if you've Hit a Unique Enemy Recently
 Nightgrip
 Runic Gages
 Variant: Pre 3.16.0
+Variant: Pre 3.25.0
 Variant: Current
 League: Expedition
 Requires Level 48, 31 Str, 31 Dex, 31 Int
@@ -1061,6 +1065,7 @@ Requires Level 48, 31 Str, 31 Dex, 31 Int
 +(17-23)% to Chaos Resistance
 {variant:1}Gain Added Chaos Damage equal to 25% of Ward
 {variant:2}Gain Added Chaos Damage equal to 20% of Ward
+{variant:3}Gain Added Chaos Damage equal to 10% of Ward
 75% of Damage taken bypasses Ward
 ]],
 }

--- a/src/Data/Uniques/jewel.lua
+++ b/src/Data/Uniques/jewel.lua
@@ -545,9 +545,13 @@ Scion: 30% increased Damage
 ]],[[
 Replica Reckless Defence
 Cobalt Jewel
+Variant: Pre 3.25.0
+Variant: Current
 League: Heist
-+(2-4)% Chance to Block Spell Damage
-+(2-4)% Chance to Block Attack Damage
+{variant:1}+(2-4)% Chance to Block Spell Damage
+{variant:2}+(2-6)% Chance to Block Spell Damage
+{variant:1}+(2-4)% Chance to Block Attack Damage
+{variant:2}+(2-6)% Chance to Block Attack Damage
 +10% chance to be Frozen, Shocked and Ignited
 ]],[[
 The Red Dream
@@ -1496,10 +1500,13 @@ Cobalt Jewel
 Source: Use currency{Vaal Orb} on normal{Cobalt Jewel}
 Variant: Pre 3.4.0
 Variant: Pre 3.20.0
+Variant: Pre 3.25.0
 Variant: Current
 {variant:1}+6% Chance to Block Spell Damage
 {variant:2,3}+(2-4)% Chance to Block Spell Damage
-(2-4)% Chance to Block Attack Damage
+{variant:4}+(2-6)% Chance to Block Spell Damage
+{variant:1,2,3}(2-4)% Chance to Block Attack Damage
+{variant:4}(2-6)% Chance to Block Attack Damage
 Hits have (140-200)% increased Critical Strike Chance against you
 {variant:3}Corrupted
 ]],[[
@@ -1689,8 +1696,12 @@ Limited to: 1
 ]],[[
 The Adorned
 Crimson Jewel
+Variant: Pre 3.25.0
+Variant: Current
 League: Affliction
-(50–150)% increased Effect of Jewel Socket Passive Skills containing Corrupted Magic Jewels
+Source: Vaal Aspect Combination
+{variant:1}(50–150)% increased Effect of Jewel Socket Passive Skills containing Corrupted Magic Jewels
+{variant:2}(0–100)% increased Effect of Jewel Socket Passive Skills containing Corrupted Magic Jewels
 ]],
 -- Jewel: Labyrinth rewards
 [[

--- a/src/Data/Uniques/ring.lua
+++ b/src/Data/Uniques/ring.lua
@@ -833,6 +833,8 @@ Implicits: 1
 ]],[[
 The Pariah
 Unset Ring
+Variant: Pre 3.25.0
+Variant: Current
 League: Warbands
 Requires Level 60
 Implicits: 1
@@ -842,7 +844,8 @@ Has 1 Socket
 {tags:life}+100 to Maximum Life per Red Socket
 {tags:jewellery_defense}+100 to Maximum Energy Shield per Blue Socket
 {tags:mana}+100 to Maximum Mana per Green Socket
-15% increased Item Quantity per White Socket
+{variant:1}15% increased Item Quantity per White Socket
+{variant:2}60% increased Item Rarity of Items found per White Socket
 ]],[[
 Perandus Signet
 Paua Ring
@@ -1161,21 +1164,23 @@ Variant: Pre 1.0.0
 Variant: Pre 1.1.0
 Variant: Pre 2.6.0
 Variant: Pre 3.19.0
+Variant: Pre 3.25.0
 Variant: Current
 Requires Level 30
 Implicits: 2
 {variant:1}{tags:jewellery_resistance}+(8-12) to all Elemental Resistances
-{variant:2,3,4,5}{tags:jewellery_resistance}+(8-10)% to all Elemental Resistances
+{variant:2,3,4,5,6}{tags:jewellery_resistance}+(8-10)% to all Elemental Resistances
 {variant:1,2}(15-25)% increased Quantity of Items found
 {variant:3,4,5}(10-16)% increased Quantity of Items found
+{variant:6}(20-30)% increased Rarity of Items found
 Can't use other Rings
 {variant:1,2,3}{tags:jewellery_resistance}+(8-12)% to all Elemental Resistances
 {variant:4}{tags:jewellery_resistance}+(16-24)% to all Elemental Resistances
-{variant:5}{tags:jewellery_resistance}+(25-40)% to all Elemental Resistances
+{variant:5,6}{tags:jewellery_resistance}+(25-40)% to all Elemental Resistances
 {variant:1,2,3}{tags:attack,life}Gain (20-30) Life per Enemy Hit with Attacks
-{variant:4,5}{tags:attack,life}Gain (40-60) Life per Enemy Hit with Attacks
+{variant:4,5,6}{tags:attack,life}Gain (40-60) Life per Enemy Hit with Attacks
 {variant:1,2,3}{tags:attack,mana}Gain 15 Mana per Enemy Hit with Attacks
-{variant:4,5}{tags:attack,mana}Gain 30 Mana per Enemy Hit with Attacks
+{variant:4,5,6}{tags:attack,mana}Gain 30 Mana per Enemy Hit with Attacks
 {tags:caster}50% reduced Effect of Curses on you
 ]],[[
 Timeclasp
@@ -1341,15 +1346,18 @@ Bleeding Enemies you Kill with Hits Shatter
 ]],[[
 Ventor's Gamble
 Gold Ring
+Variant: Pre 3.25.0
+Variant: Current
 Requires Level 65
 Implicits: 1
 (6-15)% increased Rarity of Items found
 {tags:life}+(0-60) to maximum Life
-(-10-10)% increased Quantity of Items found
+{variant:1}(-10-10)% increased Quantity of Items found
 (-40-40)% increased Rarity of Items found
 {tags:jewellery_resistance}+(-25-50)% to Fire Resistance
 {tags:jewellery_resistance}+(-25-50)% to Cold Resistance
 {tags:jewellery_resistance}+(-25-50)% to Lightning Resistance
+{variant:2}{tags:mana}(-15-15)% increased Mana Reservation Efficiency of Skills
 ]],[[
 Vivinsect
 Unset Ring

--- a/src/Data/Uniques/ring.lua
+++ b/src/Data/Uniques/ring.lua
@@ -845,7 +845,7 @@ Has 1 Socket
 {tags:jewellery_defense}+100 to Maximum Energy Shield per Blue Socket
 {tags:mana}+100 to Maximum Mana per Green Socket
 {variant:1}15% increased Item Quantity per White Socket
-{variant:2}60% increased Item Rarity of Items found per White Socket
+{variant:2}60% increased Rarity of Items found per White Socket
 ]],[[
 Perandus Signet
 Paua Ring

--- a/src/Data/Uniques/shield.lua
+++ b/src/Data/Uniques/shield.lua
@@ -703,12 +703,13 @@ Unaffected by Ignite or Shock if Maximum Life and Maximum Mana are within 500
 Sentari's Answer
 Brass Spirit Shield
 Variant: Pre 3.4.0
+Variant: Pre 3.25.0
 Variant: Current
 Implicits: 0
 {variant:1}7% Chance to Block Spell Damage
-{variant:2}10% Chance to Block Spell Damage
+{variant:2,3}10% Chance to Block Spell Damage
 +(20-30) to Intelligence
-(4-8)% increased Quantity of Items found
+{variant:1,2}(4-8)% increased Quantity of Items found
 +5% Chance to Block
 Curse Enemies with Punishment when you Block their Melee Damage, ignoring Curse Limit
 Curse Enemies with Temporal Chains when you Block their Projectile Attack Damage, ignoring Curse Limit

--- a/src/Data/Uniques/shield.lua
+++ b/src/Data/Uniques/shield.lua
@@ -43,15 +43,16 @@ League: Breach
 Source: Upgraded from unique{The Anticipation} using currency{Blessing of Uul-Netol}
 Variant: Pre 3.0.0
 Variant: Pre 3.21.0
+Variant: Pre 3.25.0
 Variant: Current
 Implicits: 1
-{variant:2,3}+(30-40) to maximum Life
-Grants Level 30 Reckoning Skill
+{variant:2,3,4}+(30-40) to maximum Life
+{variant:1,2,3}Grants Level 30 Reckoning Skill
 {variant:1,2}(130-170)% increased Armour
-{variant:3}(165-205)% increased Armour
+{variant:3,4}(165-205)% increased Armour
 +(65-80) to maximum Life
 {variant:1,2}Recover 250 Life when you Block
-{variant:3}Recover (250-500) Life when you Block
+{variant:3,4}Recover (250-500) Life when you Block
 +6% Chance to Block
 {variant:1,2}+1500 Armour if you've Blocked Recently
 ]],[[
@@ -106,14 +107,16 @@ Implicits: 1
 Lycosidae
 Rawhide Tower Shield
 Variant: Pre 3.0.0
+Variant: Pre 3.25.0
 Variant: Current
 Implicits: 1
-{variant:2}+(10-20) to maximum Life
+{variant:2,3}+(10-20) to maximum Life
 +(120-160) to Armour
 +(30-40) to maximum Life
 Your hits can't be Evaded
 +(3-5)% Chance to Block
-Adds 250 to 300 Cold Damage to Counterattacks
+{variant:1,2}Adds 250 to 300 Cold Damage to Counterattacks
+{variant:3}Adds 250 to 300 Cold Damage to Retaliation Skills
 ]],[[
 Magna Eclipsis
 Pinnacle Tower Shield

--- a/src/Data/Uniques/staff.lua
+++ b/src/Data/Uniques/staff.lua
@@ -372,19 +372,20 @@ Martyr of Innocence
 Highborn Staff
 Variant: Pre 3.5.0
 Variant: Pre 3.13.0
+Variant: Pre 3.25.0
 Variant: Current
 Requires Level 52, 89 Str, 89 Int
 Implicits: 1
 18% Chance to Block Attack Damage while wielding a Staff
 (12-16)% Chance to Block Attack Damage while wielding a Staff
 {variant:1,2}Adds (350-400) to (500-600) Fire Damage
-{variant:3}Adds (315-360) to (450-540) Fire Damage
+{variant:3,4}Adds (315-360) to (450-540) Fire Damage
 {variant:1}Adds (130-150) to (200-250) Fire Damage to Spells
 {variant:2}Adds (230-250) to (300-350) Fire Damage to Spells
-{variant:3}Battlemage
-Grants Level 15 Vengeance Skill
+{variant:3,4}Battlemage
+{variant:1,2,3}Grants Level 15 Vengeance Skill
 {variant:1}100% increased Fire Damage if you have been Hit Recently
-{variant:2,3}100% increased Fire Damage
+{variant:2,3,4}100% increased Fire Damage
 Immune to Freeze and Chill while Ignited
 Damage Penetrates 15% of Fire Resistance if you have Blocked Recently
 ]],[[

--- a/src/Data/Uniques/sword.lua
+++ b/src/Data/Uniques/sword.lua
@@ -188,6 +188,8 @@ Attacks with this Weapon Maim on hit
 ]],[[
 Replica Innsbury Edge
 Elder Sword
+Variant: Pre 3.25.0
+Variant: Current
 League: Heist
 Source: Steal from a unique{Curio Display} during a Grand Heist
 Implicits: 1
@@ -195,7 +197,7 @@ Implicits: 1
 (100-140)% increased Physical Damage
 0.2% of Chaos Damage Leeched as Life
 50% of Physical Damage Converted to Chaos Damage
-10% of Physical Damage from Hits taken as Chaos Damage
+{variant:1}10% of Physical Damage from Hits taken as Chaos Damage
 Inflict Withered for 2 seconds on Hit with this Weapon
 ]],[[
 The Iron Mass
@@ -357,16 +359,18 @@ League: Talisman Standard, Talisman Hardcore
 Source: Drops from unique{Rigwald, the Wolven King} (Level 75+)
 Variant: Pre 2.6.0
 Variant: Pre 3.11.0
+Variant: Pre 3.25.0
 Variant: Current
 Implicits: 2
 {variant:1}18% increased Global Accuracy Rating
-{variant:2,3}40% increased Global Accuracy Rating
+{variant:2,3,4}40% increased Global Accuracy Rating
 +10% Chance to Block Attack Damage while Dual Wielding
 Adds (60-80) to (150-180) Physical Damage
 {variant:1,2}80% increased Physical Damage with Axes
 +(350-400) to Accuracy Rating
 {variant:1,2}15% chance to gain a Frenzy Charge on Kill
 {variant:3}+1% to Damage over Time Multiplier for Bleeding per Rage while wielding an Axe
+{variant:4}+2% to Damage over Time Multiplier for Bleeding per Rage while wielding an Axe
 ]],[[
 The Rippling Thoughts
 Legion Sword
@@ -695,17 +699,19 @@ Reaver Sword
 Variant: Pre 2.6.0
 Variant: Pre 3.11.0
 Variant: Pre 3.17.0
+Variant: Pre 3.25.0
 Variant: Current
 Implicits: 3
 {variant:1}18% increased Global Accuracy Rating
 {variant:2}40% increased Global Accuracy Rating
-{variant:3,4}60% increased Global Accuracy Rating
+{variant:3,4,5}60% increased Global Accuracy Rating
 {variant:1,2}(160-190)% increased Physical Damage
-{variant:3,4}(130-160)% increased Physical Damage
+{variant:3,4,5}(130-160)% increased Physical Damage
 (25-30)% increased Attack Speed
 5% increased Movement Speed
 Triggers Level 15 Manifest Dancing Dervishes on Rampage
-Manifested Dancing Dervishes disables both weapon slots
+{variant:1,2,3,4}Manifested Dancing Dervishes disables both weapon slots
+{variant:5}Cannot be used while Manifested
 Manifested Dancing Dervishes die when Rampage ends
 Melee Hits count as Rampage Kills
 Rampage

--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -4464,6 +4464,10 @@ local specialModList = {
 	["reserves (%d+)%% of life"] = function(num) return { mod("ExtraLifeReserved", "BASE", num) } end,
 	["(%d+)%% of cold damage taken as lightning"] = function(num) return { mod("ColdDamageTakenAsLightning", "BASE", num) } end,
 	["(%d+)%% of fire damage taken as lightning"] = function(num) return { mod("FireDamageTakenAsLightning", "BASE", num) } end,
+	["(%d+)%% of fire and lightning damage from hits taken as cold damage during effect"] = function(num) return { 
+		mod("FireDamageFromHitsTakenAsCold", "BASE", num, { type = "Condition", var = "UsingFlask" }), 
+		mod("LightningDamageFromHitsTakenAsCold", "BASE", num, { type = "Condition", var = "UsingFlask" }), 
+	} end,
 	["items and gems have (%d+)%% reduced attribute requirements"] = function(num) return { mod("GlobalAttributeRequirements", "INC", -num) } end,
 	["items and gems have (%d+)%% increased attribute requirements"] = function(num) return { mod("GlobalAttributeRequirements", "INC", num) } end,
 	["mana reservation of herald skills is always (%d+)%%"] = function(num) return { mod("SkillData", "LIST", { key = "ManaReservationPercentForced", value = num }, { type = "SkillType", skillType = SkillType.Herald }) } end,


### PR DESCRIPTION
Contains most of the unique changes listed in the 3.25 patch notes, 


Only ones missing (at the moment) are `The Perfidy` and `The Ravenous Passion` which will be handled by other PRs
`Forbidden Shako` which is auto generated, `Replica Dragonfang's Flight` which should be auto generated

`Hand of the Fervent` and `Lycosidae` are not fully handled, those will be handled in other PRs without needing to directly address them

`The Dancing Dervish` changes are not handled at all