### PR TITLE
Fix The Apostate not working with Life Mastery

### DIFF
--- a/src/Modules/Data.lua
+++ b/src/Modules/Data.lua
@@ -608,6 +608,7 @@ data.itemTagSpecialExclusionPattern = {
 			"maximum Life as Fire Damage",
 			"when on Full Life",
 			"when on Low Life",
+			"Gain Maximum Life instead of Maximum Energy Shield",
 			"^Socketed Gems are Supported by Level",
 			"^Allocates",
 		},


### PR DESCRIPTION
Fixes #7621

The mod was not added in the special exclude list