### PR TITLE
Seething Fury incorrectly has a Medium Radius Modifier set

### DIFF
--- a/src/Data/Uniques/jewel.lua
+++ b/src/Data/Uniques/jewel.lua
@@ -1561,7 +1561,6 @@ Variant: Current
 League: Legion
 Requires Level: 20
 Limited to: 1
-Radius: Medium
 (10-15)% increased Attack Damage while holding a Shield
 {variant:1}+0.2% to Off Hand Critical Strike Chance per 10 Maximum Energy Shield on Shield
 {variant:2,3}+0.15% to Off Hand Critical Strike Chance per 10 Maximum Energy Shield on Shield


### PR DESCRIPTION
Seething Fury incorrectly has a Medium Radius Modifier set

Fixes #7711  .

### Description of the problem being solved:

Seething Fury incorrectly has a Medium Radius Modifier set

### Steps taken to verify a working solution:
- Create a new build
- Add the Seething Fury jewel to any jewel slot
- Verify that the Jewel doesn't have a radius

### Link to a build that showcases this PR:

Not possible since the fixed item needs to be added via the item tab

### Before screenshot:

![image](https://github.com/user-attachments/assets/b96d5aff-45f3-4e94-97b3-42afacb0a994)

### After screenshot:

![image](https://github.com/user-attachments/assets/178ca4ea-5d66-4bf1-a5a5-6e8a6585b613)
