### PR TITLE
enhance passive tree search with sticky edges

### DIFF
--- a/src/Classes/PassiveTreeView.lua
+++ b/src/Classes/PassiveTreeView.lua
@@ -682,7 +682,21 @@ function PassiveTreeViewClass:Draw(build, viewPort, inputEvents)
 			local rgbColor = rgbColor or {1, 0, 0}
 			SetDrawColor(rgbColor[1], rgbColor[2], rgbColor[3])
 			local size = 175 * scale / self.zoom ^ 0.4
-			DrawImage(self.highlightRing, scrX - size, scrY - size, size * 2, size * 2)
+
+			-- Snap node matches to the edge of the viewPort
+			local peekaboo_ratio = 1.15
+			local scaled_down_ratio = 0.6667
+			local wide_cull = {viewPort.x - size / peekaboo_ratio, viewPort.x + viewPort.width - size * peekaboo_ratio}
+			local high_cull = {viewPort.y - size / peekaboo_ratio, viewPort.y + viewPort.height - size * peekaboo_ratio}
+			local newX = m_min(m_max(scrX - size, wide_cull[1]), wide_cull[2])
+			local newY = m_min(m_max(scrY - size, high_cull[1]), high_cull[2])
+
+			if newX ~= scrX - size or newY ~= scrY - size then
+			  size = size * scaled_down_ratio
+			  newX = newX + size / 2
+			  newY = newY + size / 2
+			end
+			DrawImage(self.highlightRing, newX, newY, size * 2, size * 2)
 		end
 		if node == hoverNode and (node.type ~= "Socket" or not IsKeyDown("SHIFT")) and (node.type ~= "Mastery" or node.masteryEffects) and not IsKeyDown("CTRL") and not main.popups[1] then
 			-- Draw tooltip


### PR DESCRIPTION
hi, this is my first contribution to pob.

I was inspired by [PoEPlanner](poeplanner.com) and how passive skills that you search for are highlighted along the border of the viewable area. This is great for folks with smaller screens so they dont have to zoom out a ton (and lose all visibility) or pan around frantically looking for the passive they searched for.

anyways, here's what I cooked up:

![sticky-edges-opt-1](https://github.com/user-attachments/assets/e1fc1a2e-91b0-4095-9463-3568b4f6bc93)

(the red circle shrinks in size and snaps to the edge of the viewport)