### PR TITLE
Fix for Determined Survivor Block Chance

### DIFF
--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -2442,7 +2442,7 @@ local specialModList = {
 		mod("MovementSpeed", "MORE", num, { type = "Multiplier", var = "ChallengerCharge" }),
 	} end,
 	["gain (%d+)%% chance to block from equipped shield instead of the shield's value"] = function(num) return {
-		mod("ReplaceShieldBlock", "OVERRIDE", num)
+		mod("ReplaceShieldBlock", "OVERRIDE", num, { type = "Condition", var = "UsingShield" } )
 	} end,
 	["deal (%d+)%% more damage with hits and ailments to rare and unique enemies for each second they've ever been in your presence, up to a maximum of (%d+)%%"] = function(num, _, limit) return {
 		mod("Damage", "MORE", num, nil, 0, bor(KeywordFlag.Hit, KeywordFlag.Ailment), { type = "Multiplier", var = "EnemyPresenceSeconds", actor = "enemy", limit = tonumber(limit) }, { type = "ActorCondition", actor = "enemy", var = "RareOrUnique" }),


### PR DESCRIPTION
Fixes #7729 

### Description of the problem being solved:
Fixed the issue that the Block chance overrride also applied to dual wielding characters

### Steps taken to verify a working solution:
- added condition for using a shield in modparser
		mod("ReplaceShieldBlock", "OVERRIDE", num)
		mod("ReplaceShieldBlock", "OVERRIDE", num, { type = "Condition", var = "UsingShield" } )
### Link to a build that showcases this PR:
https://pobb.in/d2QlOIfFC96w

### Before screenshot:
![image](https://github.com/user-attachments/assets/0293c36e-f54b-4f13-846a-9cc5fc8070e6)



### After screenshot:
![image](https://github.com/user-attachments/assets/3c81c9fc-7abe-448f-bfd9-039f20b5d318)
