### PR TITLE
Fix mod missing from current verison. Move mod line

### DIFF
--- a/src/Data/Uniques/body.lua
+++ b/src/Data/Uniques/body.lua
@@ -462,11 +462,11 @@ Implicits: 0
 {variant:2,3}+(70-100) to maximum Life
 -30% to Cold Resistance
 {variant:1}Evasion Rating is increased by Uncapped Cold Resistance
-{variant:2,3}Evasion Rating is increased by Overcapped Cold Resistance
+{variant:4}+20% chance to Block Attack Damage
+{variant:2,3,4}Evasion Rating is increased by Overcapped Cold Resistance
 {variant:3}Flesh and Stone has no Reservation
 {variant:3}Hollow Palm Technique
 {variant:4}Versatile Combatant
-{variant:4}+20% chance to Block Attack Damage
 ]],[[
 Yriel's Fostering
 Exquisite Leather


### PR DESCRIPTION
Fixes #7734

### Description of the problem being solved:
`Evasion Rating is increased by Overcapped Cold Resistance` was missing from current version of [Replica Perfect Form](https://www.poewiki.net/wiki/Replica_Perfect_Form) (3.23) Also moved the block chance line to be inline with where it is in game.