### PR TITLE
Fix incorrect modflags for weaponcfg

### DIFF
--- a/src/Modules/CalcDefence.lua
+++ b/src/Modules/CalcDefence.lua
@@ -922,21 +922,6 @@ function calcs.defence(env, actor)
 		end
 	end
 
-	local weaponsCfg = {
-		flags = env.player.weaponData1.countsAsAll1H and bit.bor( ModFlag.Sword, ModFlag.Axe, ModFlag.Claw, ModFlag.Dagger, ModFlag.Mace ) or
-				bit.bor(env.player.weaponData1 and env.player.weaponData1.type and ModFlag[env.data.weaponTypeInfo[actor.weaponData1.type].flag] or 0,
-						 env.player.weaponData2 and env.player.weaponData2.type and ModFlag[env.data.weaponTypeInfo[actor.weaponData2.type].flag] or 0)
-	}
-
-	-- Add weapon dependent mods as unflagged mods if the correct weapons are equipped
-	for _, value in ipairs(modDB:Tabulate("BASE",  weaponsCfg, "SpellSuppressionChance")) do
-		if value.mod.flags ~= 0 and bit.band(value.mod.flags and weaponsCfg.flags) == value.mod.flags then
-			local mod = copyTable(value.mod)
-			mod.flags = 0
-			modDB:AddMod(mod)
-		end
-	end
-
 	local spellSuppressionChance =  modDB:Sum("BASE", nil, "SpellSuppressionChance")
 	local totalSpellSuppressionChance = modDB:Override(nil, "SpellSuppressionChance") or spellSuppressionChance
 

--- a/src/Modules/CalcDefence.lua
+++ b/src/Modules/CalcDefence.lua
@@ -922,9 +922,10 @@ function calcs.defence(env, actor)
 		end
 	end
 
-	-- Spell Suppression
 	local weaponsCfg = {
-		flags = bit.bor(env.player.weaponData1 and env.player.weaponData1.type and ModFlag[env.player.weaponData1.type] or 0, env.player.weaponData2 and env.player.weaponData2.type and ModFlag[env.player.weaponData2.type] or 0)
+		flags = env.player.weaponData1.countsAsAll1H and bit.bor( ModFlag.Sword, ModFlag.Axe, ModFlag.Claw, ModFlag.Dagger, ModFlag.Mace ) or
+				bit.bor(env.player.weaponData1 and env.player.weaponData1.type and ModFlag[env.data.weaponTypeInfo[actor.weaponData1.type].flag] or 0,
+						 env.player.weaponData2 and env.player.weaponData2.type and ModFlag[env.data.weaponTypeInfo[actor.weaponData2.type].flag] or 0)
 	}
 
 	-- Add weapon dependent mods as unflagged mods if the correct weapons are equipped

--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -3333,8 +3333,8 @@ local specialModList = {
 	["evasion rating is doubled against projectile attacks"] = { mod("ProjectileEvasion", "MORE", 100) },
 	["evasion rating is doubled against melee attacks"] = { mod("MeleeEvasion", "MORE", 100) },
 	["+(%d+)%% chance to suppress spell damage for each dagger you're wielding"] = function(num) return {
-		mod("SpellSuppressionChance", "BASE", num, nil, ModFlag.Dagger ),
-		mod("SpellSuppressionChance", "BASE", num, nil, ModFlag.Dagger, { type = "Condition", var = "DualWieldingDaggers" })
+		mod("SpellSuppressionChance", "BASE", num, { type = "Condition", var = "UsingDagger" } ),
+		mod("SpellSuppressionChance", "BASE", num, { type = "Condition", var = "DualWieldingDaggers" }),
 	} end,
 	-- Buffs/debuffs
 	["phasing"] = { flag("Condition:Phasing") },


### PR DESCRIPTION
Fixes #7737

### Description of the problem being solved:
Varunastra was setting incorrect mod flags for weaponcfg used for spell suppression. 