### PR TITLE
Added shield condition to Determined survivor (Gladiator)

### DIFF
--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -2442,7 +2442,7 @@ local specialModList = {
 		mod("MovementSpeed", "MORE", num, { type = "Multiplier", var = "ChallengerCharge" }),
 	} end,
 	["gain (%d+)%% chance to block from equipped shield instead of the shield's value"] = function(num) return {
-		mod("ReplaceShieldBlock", "OVERRIDE", num)
+		mod("ReplaceShieldBlock", "OVERRIDE", num, {type = "Condition", var = "UsingShield"})
 	} end,
 	["deal (%d+)%% more damage with hits and ailments to rare and unique enemies for each second they've ever been in your presence, up to a maximum of (%d+)%%"] = function(num, _, limit) return {
 		mod("Damage", "MORE", num, nil, 0, bor(KeywordFlag.Hit, KeywordFlag.Ailment), { type = "Multiplier", var = "EnemyPresenceSeconds", actor = "enemy", limit = tonumber(limit) }, { type = "ActorCondition", actor = "enemy", var = "RareOrUnique" }),


### PR DESCRIPTION
Fixes # .

### Description of the problem being solved:
Bug with gladiator ascendency Determined Survivor, it gave a flat 50% block chance even when you did not wear a shield.

### Steps taken to verify a working solution:
- Tested the block chance was correct while dual wielding, wearing shield, and two handed
-
-

### Link to a build that showcases this PR:
https://pobb.in/HtQSxX4B1sIR

### Before screenshot:

### After screenshot:
