### PR TITLE
Fix Blood Price Unique stats

### DIFF
--- a/src/Data/Uniques/helmet.lua
+++ b/src/Data/Uniques/helmet.lua
@@ -148,7 +148,7 @@ Onslaught
 ]],[[
 Blood Price
 Reaver Helmet
-(20-30)% reduced maximum Life
+24% reduced maximum Life
 Regenerate (200-250) Life per second
 100% increased Stun and Block Recovery
 Nearby Enemy Monsters have at least 8% of Life Reserved


### PR DESCRIPTION
Fixes #7743

### Description of the problem being solved:
Fixes the Life roll on the Blood Price unique helm. Previously was added wrong (couldn't find the previous rolls ever on the wiki)
https://www.poewiki.net/wiki/Blood_Price

### Steps taken to verify a working solution:
- select blood price from items
- check life roll not configurable

### Link to a build that showcases this PR:
https://pobb.in/af92Pa-2TY8K

### Before screenshot:
![image](https://github.com/user-attachments/assets/9a490e9f-d93d-4362-9bf0-a91057345ad4)

### After screenshot:
![image](https://github.com/user-attachments/assets/dc51a3de-fea4-4aa2-bf53-17ec016f7605)
