### PR TITLE
fix: update wand crit chance and attack speed

### DIFF
--- a/src/Data/Bases/wand.lua
+++ b/src/Data/Bases/wand.lua
@@ -9,7 +9,7 @@ itemBases["Driftwood Wand"] = {
 	influenceTags = { shaper = "wand_shaper", elder = "wand_elder", adjudicator = "wand_adjudicator", basilisk = "wand_basilisk", crusader = "wand_crusader", eyrie = "wand_eyrie", cleansing = "wand_cleansing", tangle = "wand_tangle" },
 	implicit = "(8-12)% increased Spell Damage",
 	implicitModTypes = { { "caster_damage", "damage", "caster" }, },
-	weapon = { PhysicalMin = 5, PhysicalMax = 9, CritChanceBase = 7, AttackRateBase = 1.4, Range = 120, },
+	weapon = { PhysicalMin = 5, PhysicalMax = 9, CritChanceBase = 8.3, AttackRateBase = 1.5, Range = 120, },
 	req = { int = 14, },
 }
 itemBases["Goat's Horn"] = {
@@ -19,7 +19,7 @@ itemBases["Goat's Horn"] = {
 	influenceTags = { shaper = "wand_shaper", elder = "wand_elder", adjudicator = "wand_adjudicator", basilisk = "wand_basilisk", crusader = "wand_crusader", eyrie = "wand_eyrie", cleansing = "wand_cleansing", tangle = "wand_tangle" },
 	implicit = "Adds (1-2) to (3-4) Fire Damage to Spells and Attacks",
 	implicitModTypes = { { "elemental_damage", "caster_damage", "damage", "elemental", "fire", "attack", "caster" }, },
-	weapon = { PhysicalMin = 9, PhysicalMax = 16, CritChanceBase = 7, AttackRateBase = 1.2, Range = 120, },
+	weapon = { PhysicalMin = 9, PhysicalMax = 16, CritChanceBase = 9, AttackRateBase = 1.4, Range = 120, },
 	req = { level = 6, int = 29, },
 }
 itemBases["Carved Wand"] = {
@@ -29,7 +29,7 @@ itemBases["Carved Wand"] = {
 	influenceTags = { shaper = "wand_shaper", elder = "wand_elder", adjudicator = "wand_adjudicator", basilisk = "wand_basilisk", crusader = "wand_crusader", eyrie = "wand_eyrie", cleansing = "wand_cleansing", tangle = "wand_tangle" },
 	implicit = "(11-15)% increased Spell Damage",
 	implicitModTypes = { { "caster_damage", "damage", "caster" }, },
-	weapon = { PhysicalMin = 9, PhysicalMax = 17, CritChanceBase = 7, AttackRateBase = 1.5, Range = 120, },
+	weapon = { PhysicalMin = 9, PhysicalMax = 17, CritChanceBase = 8, AttackRateBase = 1.6, Range = 120, },
 	req = { level = 12, int = 47, },
 }
 itemBases["Quartz Wand"] = {
@@ -39,7 +39,7 @@ itemBases["Quartz Wand"] = {
 	influenceTags = { shaper = "wand_shaper", elder = "wand_elder", adjudicator = "wand_adjudicator", basilisk = "wand_basilisk", crusader = "wand_crusader", eyrie = "wand_eyrie", cleansing = "wand_cleansing", tangle = "wand_tangle" },
 	implicit = "Adds (2-3) to (4-7) Cold Damage to Spells and Attacks",
 	implicitModTypes = { { "elemental_damage", "caster_damage", "damage", "elemental", "cold", "attack", "caster" }, },
-	weapon = { PhysicalMin = 14, PhysicalMax = 27, CritChanceBase = 7, AttackRateBase = 1.3, Range = 120, },
+	weapon = { PhysicalMin = 14, PhysicalMax = 27, CritChanceBase = 9, AttackRateBase = 1.45, Range = 120, },
 	req = { level = 18, int = 65, },
 }
 itemBases["Spiraled Wand"] = {
@@ -49,7 +49,7 @@ itemBases["Spiraled Wand"] = {
 	influenceTags = { shaper = "wand_shaper", elder = "wand_elder", adjudicator = "wand_adjudicator", basilisk = "wand_basilisk", crusader = "wand_crusader", eyrie = "wand_eyrie", cleansing = "wand_cleansing", tangle = "wand_tangle" },
 	implicit = "Adds (1-2) to (9-11) Lightning Damage to Spells and Attacks",
 	implicitModTypes = { { "elemental_damage", "caster_damage", "damage", "elemental", "lightning", "attack", "caster" }, },
-	weapon = { PhysicalMin = 12, PhysicalMax = 37, CritChanceBase = 7, AttackRateBase = 1.3, Range = 120, },
+	weapon = { PhysicalMin = 12, PhysicalMax = 37, CritChanceBase = 9, AttackRateBase = 1.45, Range = 120, },
 	req = { level = 24, int = 83, },
 }
 itemBases["Sage Wand"] = {
@@ -59,7 +59,7 @@ itemBases["Sage Wand"] = {
 	influenceTags = { shaper = "wand_shaper", elder = "wand_elder", adjudicator = "wand_adjudicator", basilisk = "wand_basilisk", crusader = "wand_crusader", eyrie = "wand_eyrie", cleansing = "wand_cleansing", tangle = "wand_tangle" },
 	implicit = "(17-21)% increased Spell Damage",
 	implicitModTypes = { { "caster_damage", "damage", "caster" }, },
-	weapon = { PhysicalMin = 23, PhysicalMax = 42, CritChanceBase = 8, AttackRateBase = 1.2, Range = 120, },
+	weapon = { PhysicalMin = 23, PhysicalMax = 42, CritChanceBase = 10, AttackRateBase = 1.4, Range = 120, },
 	req = { level = 30, int = 119, },
 }
 itemBases["Pagan Wand"] = {
@@ -69,7 +69,7 @@ itemBases["Pagan Wand"] = {
 	influenceTags = { shaper = "wand_shaper", elder = "wand_elder", adjudicator = "wand_adjudicator", basilisk = "wand_basilisk", crusader = "wand_crusader", eyrie = "wand_eyrie", cleansing = "wand_cleansing", tangle = "wand_tangle" },
 	implicit = "10% increased Cast Speed",
 	implicitModTypes = { { "caster", "speed" }, },
-	weapon = { PhysicalMin = 22, PhysicalMax = 40, CritChanceBase = 7, AttackRateBase = 1.35, Range = 120, },
+	weapon = { PhysicalMin = 22, PhysicalMax = 40, CritChanceBase = 8.5, AttackRateBase = 1.45, Range = 120, },
 	req = { level = 34, int = 118, },
 }
 itemBases["Faun's Horn"] = {
@@ -79,7 +79,7 @@ itemBases["Faun's Horn"] = {
 	influenceTags = { shaper = "wand_shaper", elder = "wand_elder", adjudicator = "wand_adjudicator", basilisk = "wand_basilisk", crusader = "wand_crusader", eyrie = "wand_eyrie", cleansing = "wand_cleansing", tangle = "wand_tangle" },
 	implicit = "Adds (5-10) to (11-13) Fire Damage to Spells and Attacks",
 	implicitModTypes = { { "elemental_damage", "caster_damage", "damage", "elemental", "fire", "attack", "caster" }, },
-	weapon = { PhysicalMin = 26, PhysicalMax = 48, CritChanceBase = 7, AttackRateBase = 1.2, Range = 120, },
+	weapon = { PhysicalMin = 26, PhysicalMax = 48, CritChanceBase = 8.5, AttackRateBase = 1.4, Range = 120, },
 	req = { level = 35, int = 116, },
 }
 itemBases["Engraved Wand"] = {
@@ -89,7 +89,7 @@ itemBases["Engraved Wand"] = {
 	influenceTags = { shaper = "wand_shaper", elder = "wand_elder", adjudicator = "wand_adjudicator", basilisk = "wand_basilisk", crusader = "wand_crusader", eyrie = "wand_eyrie", cleansing = "wand_cleansing", tangle = "wand_tangle" },
 	implicit = "(22-26)% increased Spell Damage",
 	implicitModTypes = { { "caster_damage", "damage", "caster" }, },
-	weapon = { PhysicalMin = 21, PhysicalMax = 38, CritChanceBase = 7, AttackRateBase = 1.5, Range = 120, },
+	weapon = { PhysicalMin = 21, PhysicalMax = 38, CritChanceBase = 8, AttackRateBase = 1.6, Range = 120, },
 	req = { level = 40, int = 131, },
 }
 itemBases["Crystal Wand"] = {
@@ -99,7 +99,7 @@ itemBases["Crystal Wand"] = {
 	influenceTags = { shaper = "wand_shaper", elder = "wand_elder", adjudicator = "wand_adjudicator", basilisk = "wand_basilisk", crusader = "wand_crusader", eyrie = "wand_eyrie", cleansing = "wand_cleansing", tangle = "wand_tangle" },
 	implicit = "Adds (4-8) to (10-12) Cold Damage to Spells and Attacks",
 	implicitModTypes = { { "elemental_damage", "caster_damage", "damage", "elemental", "cold", "attack", "caster" }, },
-	weapon = { PhysicalMin = 28, PhysicalMax = 52, CritChanceBase = 7, AttackRateBase = 1.3, Range = 120, },
+	weapon = { PhysicalMin = 28, PhysicalMax = 52, CritChanceBase = 9, AttackRateBase = 1.45, Range = 120, },
 	req = { level = 45, int = 146, },
 }
 itemBases["Coiled Wand"] = {
@@ -109,7 +109,7 @@ itemBases["Coiled Wand"] = {
 	influenceTags = { shaper = "wand_shaper", elder = "wand_elder", adjudicator = "wand_adjudicator", basilisk = "wand_basilisk", crusader = "wand_crusader", eyrie = "wand_eyrie", cleansing = "wand_cleansing", tangle = "wand_tangle" },
 	implicit = "Adds (1-2) to (22-24) Lightning Damage to Spells and Attacks",
 	implicitModTypes = { { "elemental_damage", "caster_damage", "damage", "elemental", "lightning", "attack", "caster" }, },
-	weapon = { PhysicalMin = 21, PhysicalMax = 64, CritChanceBase = 7, AttackRateBase = 1.3, Range = 120, },
+	weapon = { PhysicalMin = 21, PhysicalMax = 64, CritChanceBase = 9, AttackRateBase = 1.45, Range = 120, },
 	req = { level = 49, int = 158, },
 }
 itemBases["Omen Wand"] = {
@@ -119,7 +119,7 @@ itemBases["Omen Wand"] = {
 	influenceTags = { shaper = "wand_shaper", elder = "wand_elder", adjudicator = "wand_adjudicator", basilisk = "wand_basilisk", crusader = "wand_crusader", eyrie = "wand_eyrie", cleansing = "wand_cleansing", tangle = "wand_tangle" },
 	implicit = "(27-31)% increased Spell Damage",
 	implicitModTypes = { { "caster_damage", "damage", "caster" }, },
-	weapon = { PhysicalMin = 33, PhysicalMax = 61, CritChanceBase = 8, AttackRateBase = 1.2, Range = 120, },
+	weapon = { PhysicalMin = 33, PhysicalMax = 61, CritChanceBase = 10, AttackRateBase = 1.4, Range = 120, },
 	req = { level = 53, int = 200, },
 }
 itemBases["Heathen Wand"] = {
@@ -129,7 +129,7 @@ itemBases["Heathen Wand"] = {
 	influenceTags = { shaper = "wand_shaper", elder = "wand_elder", adjudicator = "wand_adjudicator", basilisk = "wand_basilisk", crusader = "wand_crusader", eyrie = "wand_eyrie", cleansing = "wand_cleansing", tangle = "wand_tangle" },
 	implicit = "10% increased Cast Speed",
 	implicitModTypes = { { "caster", "speed" }, },
-	weapon = { PhysicalMin = 31, PhysicalMax = 57, CritChanceBase = 7, AttackRateBase = 1.35, Range = 120, },
+	weapon = { PhysicalMin = 31, PhysicalMax = 57, CritChanceBase = 8, AttackRateBase = 1.45, Range = 120, },
 	req = { level = 55, int = 184, },
 }
 itemBases["Demon's Horn"] = {
@@ -139,7 +139,7 @@ itemBases["Demon's Horn"] = {
 	influenceTags = { shaper = "wand_shaper", elder = "wand_elder", adjudicator = "wand_adjudicator", basilisk = "wand_basilisk", crusader = "wand_crusader", eyrie = "wand_eyrie", cleansing = "wand_cleansing", tangle = "wand_tangle" },
 	implicit = "Adds (18-36) to (53-59) Fire Damage to Spells and Attacks",
 	implicitModTypes = { { "elemental_damage", "caster_damage", "damage", "elemental", "fire", "attack", "caster" }, },
-	weapon = { PhysicalMin = 38, PhysicalMax = 71, CritChanceBase = 7, AttackRateBase = 1.2, Range = 120, },
+	weapon = { PhysicalMin = 38, PhysicalMax = 71, CritChanceBase = 9.5, AttackRateBase = 1.4, Range = 120, },
 	req = { level = 56, int = 179, },
 }
 itemBases["Imbued Wand"] = {
@@ -149,7 +149,7 @@ itemBases["Imbued Wand"] = {
 	influenceTags = { shaper = "wand_shaper", elder = "wand_elder", adjudicator = "wand_adjudicator", basilisk = "wand_basilisk", crusader = "wand_crusader", eyrie = "wand_eyrie", cleansing = "wand_cleansing", tangle = "wand_tangle" },
 	implicit = "(33-37)% increased Spell Damage",
 	implicitModTypes = { { "caster_damage", "damage", "caster" }, },
-	weapon = { PhysicalMin = 29, PhysicalMax = 53, CritChanceBase = 7, AttackRateBase = 1.5, Range = 120, },
+	weapon = { PhysicalMin = 29, PhysicalMax = 53, CritChanceBase = 8, AttackRateBase = 1.6, Range = 120, },
 	req = { level = 59, int = 188, },
 }
 itemBases["Opal Wand"] = {
@@ -159,7 +159,7 @@ itemBases["Opal Wand"] = {
 	influenceTags = { shaper = "wand_shaper", elder = "wand_elder", adjudicator = "wand_adjudicator", basilisk = "wand_basilisk", crusader = "wand_crusader", eyrie = "wand_eyrie", cleansing = "wand_cleansing", tangle = "wand_tangle" },
 	implicit = "Adds (14-29) to (42-47) Cold Damage to Spells and Attacks",
 	implicitModTypes = { { "elemental_damage", "caster_damage", "damage", "elemental", "cold", "attack", "caster" }, },
-	weapon = { PhysicalMin = 35, PhysicalMax = 65, CritChanceBase = 7, AttackRateBase = 1.3, Range = 120, },
+	weapon = { PhysicalMin = 35, PhysicalMax = 65, CritChanceBase = 9, AttackRateBase = 1.45, Range = 120, },
 	req = { level = 62, int = 212, },
 }
 itemBases["Tornado Wand"] = {
@@ -169,7 +169,7 @@ itemBases["Tornado Wand"] = {
 	influenceTags = { shaper = "wand_shaper", elder = "wand_elder", adjudicator = "wand_adjudicator", basilisk = "wand_basilisk", crusader = "wand_crusader", eyrie = "wand_eyrie", cleansing = "wand_cleansing", tangle = "wand_tangle" },
 	implicit = "Adds (3-5) to (70-82) Lightning Damage to Spells and Attacks",
 	implicitModTypes = { { "elemental_damage", "caster_damage", "damage", "elemental", "lightning", "attack", "caster" }, },
-	weapon = { PhysicalMin = 25, PhysicalMax = 75, CritChanceBase = 7, AttackRateBase = 1.3, Range = 120, },
+	weapon = { PhysicalMin = 25, PhysicalMax = 75, CritChanceBase = 9, AttackRateBase = 1.45, Range = 120, },
 	req = { level = 65, int = 212, },
 }
 itemBases["Prophecy Wand"] = {
@@ -179,7 +179,7 @@ itemBases["Prophecy Wand"] = {
 	influenceTags = { shaper = "wand_shaper", elder = "wand_elder", adjudicator = "wand_adjudicator", basilisk = "wand_basilisk", crusader = "wand_crusader", eyrie = "wand_eyrie", cleansing = "wand_cleansing", tangle = "wand_tangle" },
 	implicit = "(36-40)% increased Spell Damage",
 	implicitModTypes = { { "caster_damage", "damage", "caster" }, },
-	weapon = { PhysicalMin = 35, PhysicalMax = 64, CritChanceBase = 8, AttackRateBase = 1.2, Range = 120, },
+	weapon = { PhysicalMin = 35, PhysicalMax = 64, CritChanceBase = 10, AttackRateBase = 1.4, Range = 120, },
 	req = { level = 68, int = 245, },
 }
 itemBases["Profane Wand"] = {
@@ -189,7 +189,7 @@ itemBases["Profane Wand"] = {
 	influenceTags = { shaper = "wand_shaper", elder = "wand_elder", adjudicator = "wand_adjudicator", basilisk = "wand_basilisk", crusader = "wand_crusader", eyrie = "wand_eyrie", cleansing = "wand_cleansing", tangle = "wand_tangle" },
 	implicit = "14% increased Cast Speed",
 	implicitModTypes = { { "caster", "speed" }, },
-	weapon = { PhysicalMin = 33, PhysicalMax = 61, CritChanceBase = 7, AttackRateBase = 1.35, Range = 120, },
+	weapon = { PhysicalMin = 33, PhysicalMax = 61, CritChanceBase = 8.5, AttackRateBase = 1.45, Range = 120, },
 	req = { level = 70, int = 237, },
 }
 itemBases["Assembler Wand"] = {
@@ -199,7 +199,7 @@ itemBases["Assembler Wand"] = {
 	influenceTags = { shaper = "wand_shaper", elder = "wand_elder", adjudicator = "wand_adjudicator", basilisk = "wand_basilisk", crusader = "wand_crusader", eyrie = "wand_eyrie", cleansing = "wand_cleansing", tangle = "wand_tangle" },
 	implicit = "Gain an Endurance, Frenzy or Power Charge every 6 seconds",
 	implicitModTypes = { {  }, },
-	weapon = { PhysicalMin = 16, PhysicalMax = 30, CritChanceBase = 7.5, AttackRateBase = 1.4, Range = 120, },
+	weapon = { PhysicalMin = 16, PhysicalMax = 30, CritChanceBase = 9, AttackRateBase = 1.5, Range = 120, },
 	req = { level = 30, int = 101, },
 }
 itemBases["Congregator Wand"] = {
@@ -209,7 +209,7 @@ itemBases["Congregator Wand"] = {
 	influenceTags = { shaper = "wand_shaper", elder = "wand_elder", adjudicator = "wand_adjudicator", basilisk = "wand_basilisk", crusader = "wand_crusader", eyrie = "wand_eyrie", cleansing = "wand_cleansing", tangle = "wand_tangle" },
 	implicit = "Gain an Endurance, Frenzy or Power Charge every 6 seconds",
 	implicitModTypes = { {  }, },
-	weapon = { PhysicalMin = 25, PhysicalMax = 46, CritChanceBase = 7.5, AttackRateBase = 1.4, Range = 120, },
+	weapon = { PhysicalMin = 25, PhysicalMax = 46, CritChanceBase = 9, AttackRateBase = 1.5, Range = 120, },
 	req = { level = 50, int = 168, },
 }
 itemBases["Accumulator Wand"] = {
@@ -219,7 +219,7 @@ itemBases["Accumulator Wand"] = {
 	influenceTags = { shaper = "wand_shaper", elder = "wand_elder", adjudicator = "wand_adjudicator", basilisk = "wand_basilisk", crusader = "wand_crusader", eyrie = "wand_eyrie", cleansing = "wand_cleansing", tangle = "wand_tangle" },
 	implicit = "Gain 2 Endurance, Frenzy or Power Charges every 6 seconds",
 	implicitModTypes = { {  }, },
-	weapon = { PhysicalMin = 29, PhysicalMax = 54, CritChanceBase = 7.5, AttackRateBase = 1.4, Range = 120, },
+	weapon = { PhysicalMin = 29, PhysicalMax = 54, CritChanceBase = 9.5, AttackRateBase = 1.5, Range = 120, },
 	req = { level = 70, int = 237, },
 }
 
@@ -230,7 +230,7 @@ itemBases["Convoking Wand"] = {
 	influenceTags = { shaper = "wand_shaper", elder = "wand_elder", adjudicator = "wand_adjudicator", basilisk = "wand_basilisk", crusader = "wand_crusader", eyrie = "wand_eyrie", cleansing = "wand_cleansing", tangle = "wand_tangle" },
 	implicit = "Minions deal (26-30)% increased Damage",
 	implicitModTypes = { { "damage", "minion" }, },
-	weapon = { PhysicalMin = 30, PhysicalMax = 55, CritChanceBase = 7, AttackRateBase = 1.4, Range = 120, },
+	weapon = { PhysicalMin = 30, PhysicalMax = 55, CritChanceBase = 8.3, AttackRateBase = 1.5, Range = 120, },
 	req = { level = 72, int = 242, },
 }
 
@@ -241,7 +241,7 @@ itemBases["Calling Wand"] = {
 	influenceTags = { shaper = "wand_shaper", elder = "wand_elder", adjudicator = "wand_adjudicator", basilisk = "wand_basilisk", crusader = "wand_crusader", eyrie = "wand_eyrie", cleansing = "wand_cleansing", tangle = "wand_tangle" },
 	implicit = "Minions deal (12-16)% increased Damage",
 	implicitModTypes = { { "damage", "minion" }, },
-	weapon = { PhysicalMin = 13, PhysicalMax = 25, CritChanceBase = 7, AttackRateBase = 1.4, Range = 120, },
+	weapon = { PhysicalMin = 13, PhysicalMax = 25, CritChanceBase = 8.3, AttackRateBase = 1.5, Range = 120, },
 	req = { level = 20, int = 81, },
 }
 
@@ -252,6 +252,6 @@ itemBases["Convening Wand"] = {
 	influenceTags = { shaper = "wand_shaper", elder = "wand_elder", adjudicator = "wand_adjudicator", basilisk = "wand_basilisk", crusader = "wand_crusader", eyrie = "wand_eyrie", cleansing = "wand_cleansing", tangle = "wand_tangle" },
 	implicit = "Minions deal (20-24)% increased Damage",
 	implicitModTypes = { { "damage", "minion" }, },
-	weapon = { PhysicalMin = 27, PhysicalMax = 50, CritChanceBase = 7, AttackRateBase = 1.4, Range = 120, },
+	weapon = { PhysicalMin = 27, PhysicalMax = 50, CritChanceBase = 8.3, AttackRateBase = 1.5, Range = 120, },
 	req = { level = 50, int = 183, },
 }


### PR DESCRIPTION
### Description of the problem being solved:
Updates values based on information from patch notes for 3.25. As seen here: https://www.pathofexile.com/forum/view-thread/3531661#itemchanges

### Steps taken to verify a working solution:
- Open PoB
- Items > Craft Item > Rarity: Rare > Type: Wand > Base: pick any wand that had their value changed > Create
- Values should be there updated

### Link to a build that showcases this PR:
https://pobb.in/a2pxLf2d_SFJ -- It only has one wand there just to show

### Before screenshot:
![image](https://github.com/user-attachments/assets/db47a50d-7a23-41a6-91dc-cda171bcdb6c)

### After screenshot:
![image](https://github.com/user-attachments/assets/a3b6f602-a5f5-459b-b4c3-483dfedeb165)
