### PR TITLE
Added support for Ambush skill

### DIFF
--- a/src/Data/Skills/act_dex.lua
+++ b/src/Data/Skills/act_dex.lua
@@ -106,6 +106,16 @@ skills["Ambush"] = {
 	skillTypes = { [SkillType.Spell] = true, [SkillType.Movement] = true, [SkillType.Duration] = true, [SkillType.Travel] = true, [SkillType.Triggerable] = true, [SkillType.Cooldown] = true, [SkillType.LateConsumeCooldown] = true, },
 	statDescriptionScope = "secondary_debuff_skill_stat_descriptions",
 	castTime = 0.3,
+	statMap = {
+		["ambush_additional_critical_strike_chance_permyriad"] = {
+			mod("CritChance", "BASE", nil, ModFlag.Melee, 0, { type = "GlobalEffect", effectType = "Buff", effectName = "Ambush" }),
+			div = 100,
+		},
+		["vanishing_ambush_critical_strike_multiplier_+"] = {
+			mod("CritMultiplier", "BASE", nil, ModFlag.Melee, 0, { type = "GlobalEffect", effectType = "Buff", effectName = "Ambush" }),
+		},
+		-- not excluding Exert for Two-Handed weapons, to simulate a potential weapon swap for skills with a duration ( Rage Vortex )
+	},
 	baseFlags = {
 		spell = true,
 		movement = true,

--- a/src/Export/Skills/act_dex.txt
+++ b/src/Export/Skills/act_dex.txt
@@ -28,6 +28,16 @@ local skills, mod, flag, skill = ...
 
 #skill Ambush
 #flags spell movement duration travel
+	statMap = {
+		["ambush_additional_critical_strike_chance_permyriad"] = {
+			mod("CritChance", "BASE", nil, ModFlag.Melee, 0, { type = "GlobalEffect", effectType = "Buff", effectName = "Ambush" }),
+			div = 100,
+		},
+		["vanishing_ambush_critical_strike_multiplier_+"] = {
+			mod("CritMultiplier", "BASE", nil, ModFlag.Melee, 0, { type = "GlobalEffect", effectType = "Buff", effectName = "Ambush" }),
+		},
+		-- not excluding Exert for Two-Handed weapons, to simulate a potential weapon swap for skills with a duration ( Rage Vortex )
+	},
 #mods
 
 #skill AnimateWeapon


### PR DESCRIPTION
Fixes #3035  .

### Description of the problem being solved:
creating a statMap in /src/Export/Skills/act_dex.txt that creates a GlobalEffect "Ambush", with the Melee ModFlag.
Using the already defined Export names for crit chance and crit multi; "vanishing_ambush_critical_strike_multiplier_+" and "ambush_additional_critical_strike_chance_permyriad".

Two-Handed weapons are not excluded on purpose, to still support weapon swapping for skills with duration (Rage Vortex)

### Steps taken to verify a working solution:
-  Tried various skills that don't match the ModFlag to ensure they don't work
-  supported ambush with enhance and checked quality increases to ensure correct scaling

### Link to a build that showcases this PR:
https://pobb.in/WHBCnFfCHtUJ
### Before screenshot:
![image](https://github.com/user-attachments/assets/808a72b1-6cc2-4fd6-9d2b-5cfecb34ca89)
### After screenshot:
![image](https://github.com/user-attachments/assets/2f09ff4d-814c-40e3-a126-0a4db4ed1697)