### PR TITLE
Sort loadouts dropdown based on name + number

### DIFF
--- a/src/Modules/Build.lua
+++ b/src/Modules/Build.lua
@@ -973,6 +973,21 @@ function buildMode:SyncLoadouts(reset)
 		end
 	end
 
+	table.sort(filteredList, function(a, b)
+		local aText, aNum = a:match("^(.+) {%d+}$"), tonumber(a:match("{(%d+)}"))
+		local bText, bNum = b:match("^(.+) {%d+}$"), tonumber(b:match("{(%d+)}"))
+		if not aText then
+			aText, aNum = a, 0
+		end
+		if not bText then
+			bText, bNum = b, 0
+		end
+		if aText ~= bText then
+			return aText < bText
+		end
+		return aNum < bNum
+	end)
+
 	t_insert(filteredList, "-----")
 	t_insert(filteredList, "New Loadout")
 	t_insert(filteredList, "Sync")


### PR DESCRIPTION
Currently the loadout order is kind of a mess so sort it by name and number if present so the order is at least consistent.

### Link to a build that showcases this PR:

https://pobb.in/u/thedeathbeam/pf-poison-scourge-arrow

### Before screenshot:

![image](https://github.com/user-attachments/assets/e9fc15ee-7dd8-4171-9a34-0979172a4582)

### After screenshot:

![image](https://github.com/user-attachments/assets/3aec7574-dc5b-42df-8981-f172e960f980)

