### PR TITLE
Add editorconfig configuration

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,4 @@
+[*.lua]
+trim_trailing_whitespace = false
+indent_style = tab
+max_line_length = 120


### PR DESCRIPTION
Most editors support editorconfig or have plugins for it, its universal config for specifying whitespace/line-length rules. Especially useful for editors like Neovim who support it out of the box and dont have other concepts of per project whitespace configuration.

https://editorconfig.org/