### PR TITLE
Add search to the Calcs tab

### DIFF
--- a/src/Classes/CalcSectionControl.lua
+++ b/src/Classes/CalcSectionControl.lua
@@ -239,7 +239,7 @@ function CalcSectionClass:Draw(viewPort, noTooltip)
 			DrawString(x + 3, lineY + 3, "LEFT", 16, "VAR BOLD", "^8"..subSec.label)
 		else
 			if self.calcsTab:SearchMatch(subSec.label) then
-				DrawString(x + 3, lineY + 3, "LEFT", 16, "VAR BOLD", colorCodes.SEARCH_HIGHLIGHT..subSec.label..":")
+				DrawString(x + 3, lineY + 3, "LEFT", 16, "VAR BOLD", colorCodes.HIGHLIGHT..subSec.label..":")
 			else
 				DrawString(x + 3, lineY + 3, "LEFT", 16, "VAR BOLD", "^7"..subSec.label..":")
 			end
@@ -276,7 +276,7 @@ function CalcSectionClass:Draw(viewPort, noTooltip)
 						SetDrawColor(rowData.bgCol or "^0")
 						DrawImage(nil, x + 2, lineY + 2, 130, 18)
 						if self.calcsTab:SearchMatch(rowData.label) then
-							DrawString(x + 132, lineY + 2, "RIGHT_X", 16, "VAR", colorCodes.SEARCH_HIGHLIGHT..rowData.label.."^7:")
+							DrawString(x + 132, lineY + 2, "RIGHT_X", 16, "VAR", colorCodes.HIGHLIGHT..rowData.label.."^7:")
 						else
 							DrawString(x + 132, lineY + 2, "RIGHT_X", 16, "VAR", textColor..rowData.label.."^7:")
 						end

--- a/src/Classes/CalcSectionControl.lua
+++ b/src/Classes/CalcSectionControl.lua
@@ -238,11 +238,11 @@ function CalcSectionClass:Draw(viewPort, noTooltip)
 		if not self.enabled then
 			DrawString(x + 3, lineY + 3, "LEFT", 16, "VAR BOLD", "^8"..subSec.label)
 		else
+			local textColor = "^7"
 			if self.calcsTab:SearchMatch(subSec.label) then
-				DrawString(x + 3, lineY + 3, "LEFT", 16, "VAR BOLD", colorCodes.HIGHLIGHT..subSec.label..":")
-			else
-				DrawString(x + 3, lineY + 3, "LEFT", 16, "VAR BOLD", "^7"..subSec.label..":")
+				textColor = colorCodes.HIGHLIGHT
 			end
+			DrawString(x + 3, lineY + 3, "LEFT", 16, "VAR BOLD", textColor..subSec.label..":")
 			if subSec.data.extra then
 				local x = x + 3 + DrawStringWidth(16, "VAR BOLD", subSec.label) + 10
 				DrawString(x, lineY + 3, "LEFT", 16, "VAR", "^7"..self:FormatStr(subSec.data.extra, actor))
@@ -276,10 +276,9 @@ function CalcSectionClass:Draw(viewPort, noTooltip)
 						SetDrawColor(rowData.bgCol or "^0")
 						DrawImage(nil, x + 2, lineY + 2, 130, 18)
 						if self.calcsTab:SearchMatch(rowData.label) then
-							DrawString(x + 132, lineY + 2, "RIGHT_X", 16, "VAR", colorCodes.HIGHLIGHT..rowData.label.."^7:")
-						else
-							DrawString(x + 132, lineY + 2, "RIGHT_X", 16, "VAR", textColor..rowData.label.."^7:")
+							textColor = colorCodes.HIGHLIGHT
 						end
+						DrawString(x + 132, lineY + 2, "RIGHT_X", 16, "VAR", textColor..rowData.label.."^7:")
 					end
 					for colour, colData in ipairs(rowData) do
 						-- Draw column separator at the left end of the cell

--- a/src/Classes/CalcSectionControl.lua
+++ b/src/Classes/CalcSectionControl.lua
@@ -238,10 +238,14 @@ function CalcSectionClass:Draw(viewPort, noTooltip)
 		if not self.enabled then
 			DrawString(x + 3, lineY + 3, "LEFT", 16, "VAR BOLD", "^8"..subSec.label)
 		else
-			DrawString(x + 3, lineY + 3, "LEFT", 16, "VAR BOLD", "^7"..subSec.label..":")
+			if self.calcsTab:SearchMatch(subSec.label) then
+				DrawString(x + 3, lineY + 3, "LEFT", 16, "VAR BOLD", colorCodes.SEARCH_HIGHLIGHT..subSec.label..":")
+			else
+				DrawString(x + 3, lineY + 3, "LEFT", 16, "VAR BOLD", "^7"..subSec.label..":")
+			end
 			if subSec.data.extra then
 				local x = x + 3 + DrawStringWidth(16, "VAR BOLD", subSec.label) + 10
-				DrawString(x, lineY + 3, "LEFT", 16, "VAR", self:FormatStr(subSec.data.extra, actor))
+				DrawString(x, lineY + 3, "LEFT", 16, "VAR", "^7"..self:FormatStr(subSec.data.extra, actor))
 			end
 		end
 		-- Draw line below label
@@ -269,10 +273,13 @@ function CalcSectionClass:Draw(viewPort, noTooltip)
 						textColor = rowData.color
 					end
 					if rowData.label then
-						-- Draw row label with background
 						SetDrawColor(rowData.bgCol or "^0")
 						DrawImage(nil, x + 2, lineY + 2, 130, 18)
-						DrawString(x + 132, lineY + 2, "RIGHT_X", 16, "VAR", textColor..rowData.label.."^7:")
+						if self.calcsTab:SearchMatch(rowData.label) then
+							DrawString(x + 132, lineY + 2, "RIGHT_X", 16, "VAR", colorCodes.SEARCH_HIGHLIGHT..rowData.label.."^7:")
+						else
+							DrawString(x + 132, lineY + 2, "RIGHT_X", 16, "VAR", textColor..rowData.label.."^7:")
+						end
 					end
 					for colour, colData in ipairs(rowData) do
 						-- Draw column separator at the left end of the cell

--- a/src/Classes/CalcsTab.lua
+++ b/src/Classes/CalcsTab.lua
@@ -32,6 +32,9 @@ local CalcsTabClass = newClass("CalcsTab", "UndoHandler", "ControlHost", "Contro
 	self.colWidth = 230
 	self.sectionList = { }
 
+	self.controls.search = new("EditControl", {"TOPLEFT",self,"TOPLEFT"}, 4, 5, 260, 20, "", "Search", "%c", 100, nil, nil, nil, true)
+	t_insert(self.controls, self.controls.search)
+
 	-- Special section for skill/mode selection
 	self:NewSection(3, "SkillSelect", 1, colorCodes.NORMAL, {{ defaultCollapsed = false, label = "View Skill Details", data = {
 		{ label = "Socket Group", { controlName = "mainSocketGroup", 
@@ -300,9 +303,11 @@ function CalcsTabClass:Draw(viewPort, inputEvents)
 	self.controls.scrollBar:SetContentDimension(maxY - baseY, viewPort.height)
 	for _, section in ipairs(self.sectionList) do
 		-- Give sections their actual Y position and let them update
-		section.y = section.y - self.controls.scrollBar.offset
+		section.y = section.y - self.controls.scrollBar.offset + 25
 		section:UpdatePos()
 	end
+	
+	self.controls.search.y = 5 - self.controls.scrollBar.offset
 
 	for _, event in ipairs(inputEvents) do
 		if event.type == "KeyDown" then
@@ -312,6 +317,8 @@ function CalcsTabClass:Draw(viewPort, inputEvents)
 			elseif event.key == "y" and IsKeyDown("CTRL") then
 				self:Redo()
 				self.build.buildFlag = true
+			elseif event.key == "f" and IsKeyDown("CTRL") then
+				self:SelectControl(self.controls.search)
 			end
 		end
 	end
@@ -402,6 +409,11 @@ function CalcsTabClass:CheckFlag(obj)
 		end
 	end
 	return true
+end
+
+function CalcsTabClass:SearchMatch(txt)
+	local searchStr = self.controls.search.buf:lower()
+	return string.len(searchStr) > 0 and txt:lower():find(searchStr)
 end
 
 -- Build the calculation output tables

--- a/src/Data/Global.lua
+++ b/src/Data/Global.lua
@@ -55,8 +55,7 @@ colorCodes = {
 	BRITTLEBG = "^x00122b",
 	SAPBG = "^x261500",
 	SCOURGE = "^xFF6E25",
-	CRUCIBLE = "^xFFA500",
-	SEARCH_HIGHLIGHT = "^xf7f723"
+	CRUCIBLE = "^xFFA500"
 }
 colorCodes.STRENGTH = colorCodes.MARAUDER
 colorCodes.DEXTERITY = colorCodes.RANGER

--- a/src/Data/Global.lua
+++ b/src/Data/Global.lua
@@ -56,6 +56,7 @@ colorCodes = {
 	SAPBG = "^x261500",
 	SCOURGE = "^xFF6E25",
 	CRUCIBLE = "^xFFA500",
+	SEARCH_HIGHLIGHT = "^xf7f723"
 }
 colorCodes.STRENGTH = colorCodes.MARAUDER
 colorCodes.DEXTERITY = colorCodes.RANGER


### PR DESCRIPTION
### Description of the problem being solved:
It is sometimes difficult to find what you're looking for in the Calcs tab since there are a lot of sections and calculations.

This PR adds a search input to the Calcs tab. When searching, matching labels on the page are highlighted. Both section titles and individual calculation labels are able to be searched. The search box can be focused with `ctrl + f`, as you'd expect.

### Steps taken to verify a working solution:
No automated testing is added for this feature.

- `ctrl + f` focuses the search input and selects any existing text
- Changing tabs with an active search doesn't cause issues. Returning to the Calcs tab with an active search maintains the search as expected.
- Custom highlighting color codes work (set in Options -> Hex colour for highlight nodes)
- Collapsing and expanding sections works while searching and not searching
- Matches partial searches and is case insensitive
- The page looks and works correctly when scrolling on skinnier viewports
- No issues created by entering the max chars in the input (100)


### Link to a build that showcases this PR:

### Before screenshot:
![image](https://github.com/user-attachments/assets/68562dc5-4550-4dce-ab0e-f07db5cb6b4d)

### After screenshot:
![image](https://github.com/user-attachments/assets/6e34f617-27c2-47a6-9550-1a7da35f50d6)

https://github.com/user-attachments/assets/5d603636-4516-4486-be18-18e63757e7a1


https://github.com/user-attachments/assets/44ca56ef-c736-4a79-9948-343cd4d3e1c4

