### PR TITLE
adding build sorting by level

### DIFF
--- a/src/Modules/BuildList.lua
+++ b/src/Modules/BuildList.lua
@@ -11,6 +11,7 @@ local buildSortDropList = {
 	{ label = "Sort by Name", sortMode = "NAME" },
 	{ label = "Sort by Class", sortMode = "CLASS" },
 	{ label = "Sort by Last Edited", sortMode = "EDITED"},
+	{ label = "Sort by Level", sortMode = "LEVEL"},
 }
 
 local listMode = new("ControlHost")
@@ -216,6 +217,8 @@ function listMode:SortList()
 			elseif a.ascendClassName ~= b.ascendClassName then
 				return a.ascendClassName < b.ascendClassName
 			end
+		elseif main.buildSortMode == "LEVEL" then
+				return a.level < b.level
 		end
 		return naturalSortCompare(a.fileName, b.fileName)
 	end)

--- a/src/Modules/BuildList.lua
+++ b/src/Modules/BuildList.lua
@@ -218,7 +218,13 @@ function listMode:SortList()
 				return a.ascendClassName < b.ascendClassName
 			end
 		elseif main.buildSortMode == "LEVEL" then
+			if a.level and not b.level then
+				return false
+			elseif not a.level and b.level then
+				return true
+			else
 				return a.level < b.level
+			end
 		end
 		return naturalSortCompare(a.fileName, b.fileName)
 	end)


### PR DESCRIPTION
Adding Level Sorting for the BuildList.

### Description of the problem being solved: Adding Level Sorting for the BuildList.

### Steps taken to verify a working solution:
- Implemented then tested
- Tested both in and out of folders
- Set up tests to confirm Level sorting was working unique to other sorts

### Screenshots:

New Level Sorting:

![image](https://github.com/user-attachments/assets/f74740ca-8b6f-4490-9bc5-e616f06050f0)"

In folder -- ![image](https://github.com/user-attachments/assets/6827cc65-6a6f-41e3-8049-03041aa7967f)

Using the other sorting methods, showing Level sorting has unique functionality.

![image](https://github.com/user-attachments/assets/d12b4d51-ec5a-47ec-8f06-f222a8d6fe30)

![image](https://github.com/user-attachments/assets/a96b53a9-428e-4502-aac8-f33896ae2b9a)

![image](https://github.com/user-attachments/assets/bc249405-b1fd-40cd-b125-de9c603c3ef4)
