### PR TITLE
update Taming

### DIFF
--- a/src/Data/Uniques/ring.lua
+++ b/src/Data/Uniques/ring.lua
@@ -1181,6 +1181,7 @@ Prismatic Ring
 League: Domination, Nemesis
 Source: Vendor Recipe
 Variant: Pre 3.0.0
+Variant: Pre 3.25.0
 Variant: Current
 Requires Level 30
 Implicits: 1
@@ -1188,13 +1189,14 @@ Implicits: 1
 {variant:1}{tags:jewellery_elemental,attack}15% increased Elemental Damage with Attack Skills
 {variant:2}{tags:jewellery_elemental,attack}30% increased Elemental Damage with Attack Skills
 {variant:1}{tags:jewellery_resistance}+(10-15)% to all Elemental Resistances
-{variant:2}{tags:jewellery_resistance}+(20-30)% to all Elemental Resistances
+{variant:2,3}{tags:jewellery_resistance}+(20-30)% to all Elemental Resistances
 {variant:1}{tags:jewellery_elemental}15% increased Elemental Damage
 {variant:2}{tags:jewellery_elemental}30% increased Elemental Damage
 {variant:1}5% chance to Freeze, Shock and Ignite
-{variant:2}10% chance to Freeze, Shock and Ignite
+{variant:2,3}10% chance to Freeze, Shock and Ignite
 {variant:1}10% increased Damage per Freeze, Shock and Ignite on Enemy
 {variant:2}20% increased Damage with Hits and Ailments per Freeze, Shock and Ignite on Enemy
+{variant:3}(30-40)% increased Elemental Damage with Hits and Ailments for each type of Elemental Ailment on Enemy
 ]],[[
 Tasalio's Sign
 Sapphire Ring

--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -3077,6 +3077,15 @@ local specialModList = {
 		mod("EnemyModifier", "LIST", { mod = mod("DamageTaken", "INC", num) }, { type = "ActorCondition", actor = "enemy", var = "Poisoned" }),
 	} end,
 	-- Elemental Ailments
+	["(%d+)%% increased elemental damage with hits and ailments for each type of elemental ailment on enemy"] = function(num) return {
+		mod("ElementalDamage", "INC", num, { type = "ActorCondition", actor = "enemy", var = "Frozen" }),
+		mod("ElementalDamage", "INC", num, { type = "ActorCondition", actor = "enemy", var = "Chilled" }),
+		mod("ElementalDamage", "INC", num, { type = "ActorCondition", actor = "enemy", var = "Ignited" }),
+		mod("ElementalDamage", "INC", num, { type = "ActorCondition", actor = "enemy", var = "Shocked" }),
+		mod("ElementalDamage", "INC", num, { type = "ActorCondition", actor = "enemy", var = "Scorched" }),
+		mod("ElementalDamage", "INC", num, { type = "ActorCondition", actor = "enemy", var = "Brittle" }),
+		mod("ElementalDamage", "INC", num, { type = "ActorCondition", actor = "enemy", var = "Sapped" }),
+	} end,
 	["your shocks can increase damage taken by up to a maximum of (%d+)%%"] = function(num) return { mod("ShockMax", "OVERRIDE", num) } end,
 	["%+(%d+)%% to maximum effect of shock"] = function(num) return { mod("ShockMax", "BASE", num) } end,
 	["your elemental damage can shock"] = { flag("ColdCanShock"), flag("FireCanShock") },


### PR DESCRIPTION
updates it to the new patch notes

> The Taming now has 30-40% increased Elemental Damage with Hits and Ailments for each type of Elemental Ailment on Enemy (from 20% increased Damage with Hits and Ailments per Freeze, Shock or Ignite on Enemy). This change affects existing items, though you will need to use a Divine Orb to obtain the new values. It no longer has 30% increased Elemental Damage with Attack Skills or 30% increased Elemental Damage, and using a Divine Orb on existing versions will remove these two modifiers. 