### PR TITLE
Fix Mine and Trap Throw Count

### DIFF
--- a/src/Modules/CalcOffence.lua
+++ b/src/Modules/CalcOffence.lua
@@ -1138,6 +1138,9 @@ function calcs.offence(env, actor, activeSkill)
 		end
 		output.TrapThrowingSpeed = baseSpeed * calcLib.mod(skillModList, skillCfg, "TrapThrowingSpeed") * output.ActionSpeedMod
 		local trapThrowCount = calcLib.val(skillModList, "TrapThrowCount", skillCfg)
+		if skillData.trapCooldown or skillData.cooldown then
+			trapThrowCount = 1
+		end
 		output.TrapThrowCount = trapThrowCount
 		output.TrapThrowingSpeed = m_min(output.TrapThrowingSpeed, data.misc.ServerTickRate)
 		output.TrapThrowingTime = 1 / output.TrapThrowingSpeed
@@ -1224,6 +1227,9 @@ function calcs.offence(env, actor, activeSkill)
 		output.MineLayingSpeed = baseSpeed * calcLib.mod(skillModList, skillCfg, "MineLayingSpeed") * output.ActionSpeedMod
 		-- Calculate additional mine throw
 		local mineThrowCount = calcLib.val(skillModList, "MineThrowCount", skillCfg)
+		if skillData.trapCooldown or skillData.cooldown then
+			mineThrowCount = 1
+		end
 		output.MineThrowCount = mineThrowCount
 		if mineThrowCount >= 1 then
 			-- Throwing Mines takes 10% more time for each *additional* Mine thrown


### PR DESCRIPTION
#7662 introduced multiple trap/mine throws, this doesnt take into account cooldown skills, maximum stored uses, or trap/mine limits

giving it many more throws than is possible 
![image](https://github.com/user-attachments/assets/fd9e6498-5493-4554-bebc-31bef85b78b9)


For now this PR just disables it on cooldown skills, but will update the PR to properly calculate the amount thrown based on cooldowns, throw speed, and limits if it hasnt been merged by the time I get around to it