### PR TITLE
Generate keystone items from tree data

### DIFF
--- a/src/Data/Uniques/Special/Generated.lua
+++ b/src/Data/Uniques/Special/Generated.lua
@@ -460,71 +460,6 @@ end
 
 table.insert(data.uniques.generated, table.concat(balanceOfTerror, "\n"))
 
-local skinOfTheLords = {
-	"Skin of the Lords",
-	"Simple Robe",
-	"League: Breach",
-	"Source: Upgraded from unique{Skin of the Loyal} using currency{Blessing of Chayula}",
-}
-local excludedItemKeystones = {
-	"Corrupted Soul", -- exclusive to specific unique
-	"Divine Flesh", -- exclusive to specific unique
-	"Hollow Palm Technique", -- exclusive to specific unique
-	"Immortal Ambition", -- exclusive to specific unique
-	"Secrets of Suffering", -- exclusive to specific items
-	"Inner Conviction", -- exclusive to specific items
-	"Phase Acrobatics", -- removed from game
-	"Mortal Conviction", -- removed from game
-}
-local excludedPassiveKeystones = {
-	"Chaos Inoculation", -- to prevent infinite loop
-	"Necromantic Aegis", -- to prevent infinite loop
-}
-local skinOfTheLordsKeystones = {}
-for _, name in ipairs(data.keystones) do
-	if not isValueInArray(excludedItemKeystones, name) and not isValueInArray(excludedPassiveKeystones, name) then
-		table.insert(skinOfTheLordsKeystones, name)
-	end
-end
-for _, name in ipairs(skinOfTheLordsKeystones) do
-	table.insert(skinOfTheLords, "Variant: "..name)
-end
-table.insert(skinOfTheLords, "Implicits: 0")
-table.insert(skinOfTheLords, "Sockets cannot be modified")
-table.insert(skinOfTheLords, "+2 to Level of Socketed Gems")
-table.insert(skinOfTheLords, "100% increased Global Defences")
-table.insert(skinOfTheLords, "You can only Socket Corrupted Gems in this item")
-for index, name in ipairs(skinOfTheLordsKeystones) do
-	table.insert(skinOfTheLords, "{variant:"..index.."}"..name)
-end
-table.insert(skinOfTheLords, "Corrupted")
-table.insert(data.uniques.generated, table.concat(skinOfTheLords, "\n"))
-
-local impossibleEscapeKeystones = {}
-for _, name in ipairs(data.keystones) do
-	if not isValueInArray(excludedItemKeystones, name) then
-		table.insert(impossibleEscapeKeystones, name)
-	end
-end
-local impossibleEscape = {
-	"Impossible Escape",
-	"Viridian Jewel",
-	"League: Sentinel",
-	"Source: Drops from unique{The Maven} (Uber)",
-	"Limited to: 1",
-	"Radius: Small"
-}
-for _, name in ipairs(impossibleEscapeKeystones) do
-	table.insert(impossibleEscape, "Variant: "..name)
-end
-table.insert(impossibleEscape, "Variant: Everything (QoL Test Variant)")
-local variantCount = #impossibleEscapeKeystones + 1
-for index, name in ipairs(impossibleEscapeKeystones) do
-	table.insert(impossibleEscape, "{variant:"..index..","..variantCount.."}Passives in radius of "..name.." can be allocated without being connected to your tree")
-end
-table.insert(impossibleEscape, "Corrupted")
-table.insert(data.uniques.generated, table.concat(impossibleEscape, "\n"))
-
 --[[ 3 scenarios exist for legacy mods
 	- Mod changed, but kept the same mod Id
 		-- Has legacyMod
@@ -721,6 +656,7 @@ table.insert(data.uniques.generated, table.concat(voranasMarch, "\n"))
 
 function buildTreeDependentUniques(tree)
 	buildForbidden(tree.classNotables)
+	buildKeystoneItems(tree.keystoneMap)
 end
 
 function buildForbidden(classNotables)
@@ -760,6 +696,75 @@ function buildForbidden(classNotables)
 	end
 	table.insert(data.uniques.generated, table.concat(forbidden["Flame"], "\n"))
 	table.insert(data.uniques.generated, table.concat(forbidden["Flesh"], "\n"))
+end
+
+function buildKeystoneItems(keystoneMap)
+	local skinOfTheLords = {
+		"Skin of the Lords",
+		"Simple Robe",
+		"League: Breach",
+		"Source: Upgraded from unique{Skin of the Loyal} using currency{Blessing of Chayula}",
+	}
+	local excludedPassiveKeystones = {
+		"Chaos Inoculation", -- to prevent infinite loop
+		"Necromantic Aegis", -- to prevent infinite loop
+	}
+
+	-- Keystones added by jewels don't have a position set in the tree data
+	local isKeystoneNative = function(node) return node.isKeystone and not node.isBlighted and node.x ~= nil end
+
+	local skinOfTheLordsKeystones = {}
+	local seen = {}
+	for _, node in pairs(keystoneMap) do		
+		if isKeystoneNative(node) and not isValueInArray(excludedPassiveKeystones, node.name) and not seen[node] then
+			table.insert(skinOfTheLordsKeystones, node.name)
+			seen[node] = true
+		end
+	end
+	table.sort(skinOfTheLordsKeystones)
+	
+	for _, name in ipairs(skinOfTheLordsKeystones) do
+		table.insert(skinOfTheLords, "Variant: "..name)
+	end
+	table.insert(skinOfTheLords, "Implicits: 0")
+	table.insert(skinOfTheLords, "Sockets cannot be modified")
+	table.insert(skinOfTheLords, "+2 to Level of Socketed Gems")
+	table.insert(skinOfTheLords, "100% increased Global Defences")
+	table.insert(skinOfTheLords, "You can only Socket Corrupted Gems in this item")
+
+	for index, name in ipairs(skinOfTheLordsKeystones) do
+		table.insert(skinOfTheLords, "{variant:"..index.."}"..name)
+	end
+	table.insert(skinOfTheLords, "Corrupted")
+	table.insert(data.uniques.generated, table.concat(skinOfTheLords, "\n"))
+	
+	local impossibleEscapeKeystones = {}
+	seen = {}
+	for _, node in pairs(keystoneMap) do
+		if isKeystoneNative(node) and not seen[node] then
+			table.insert(impossibleEscapeKeystones, node.name)
+			seen[node] = true
+		end
+	end
+	table.sort(impossibleEscapeKeystones)
+	local impossibleEscape = {
+		"Impossible Escape",
+		"Viridian Jewel",
+		"League: Sentinel",
+		"Source: Drops from unique{The Maven} (Uber)",
+		"Limited to: 1",
+		"Radius: Small"
+	}
+	for _, name in ipairs(impossibleEscapeKeystones) do
+		table.insert(impossibleEscape, "Variant: "..name)
+	end
+	table.insert(impossibleEscape, "Variant: Everything (QoL Test Variant)")
+	local variantCount = #impossibleEscapeKeystones + 1
+	for index, name in ipairs(impossibleEscapeKeystones) do
+		table.insert(impossibleEscape, "{variant:"..index..","..variantCount.."}Passives in radius of "..name.." can be allocated without being connected to your tree")
+	end
+	table.insert(impossibleEscape, "Corrupted")
+	table.insert(data.uniques.generated, table.concat(impossibleEscape, "\n"))
 end
 
 -- That Which Was Taken


### PR DESCRIPTION
Generates Skin of the Lords and Impossible Escape variants from tree data, using only keystones that are natively on the tree. 
Previously was generating invalid variants with conquered keystones that had been missed on the exclusion list.