### PR TITLE
Use pre-armour physical damage as base damage for impale damage calculation

### DIFF
--- a/src/Modules/CalcOffence.lua
+++ b/src/Modules/CalcOffence.lua
@@ -5355,12 +5355,12 @@ function calcs.offence(env, actor, activeSkill)
 	end
 	if skillFlags.impale then
 		if skillFlags.attack then
-			output.ImpaleHit = ((output.MainHand.PhysicalHitAverage or output.OffHand.PhysicalHitAverage) + (output.OffHand.PhysicalHitAverage or output.MainHand.PhysicalHitAverage)) / 2 * (1-output.CritChance/100) + ((output.MainHand.PhysicalCritAverage or output.OffHand.PhysicalCritAverage) + (output.OffHand.PhysicalCritAverage or output.MainHand.PhysicalCritAverage)) / 2 * (output.CritChance/100)
+			output.ImpaleHit = ((output.MainHand.impaleStoredHitAvg or output.OffHand.impaleStoredHitAvg) + (output.OffHand.impaleStoredHitAvg or output.MainHand.impaleStoredHitAvg)) / 2 * (1-output.CritChance/100) + ((output.MainHand.PhysicalCritAverage or output.OffHand.PhysicalCritAverage) + (output.OffHand.PhysicalCritAverage or output.MainHand.PhysicalCritAverage)) / 2 * (output.CritChance/100)
 			if skillData.doubleHitsWhenDualWielding and skillFlags.bothWeaponAttack then
 				output.ImpaleHit = output.ImpaleHit * 2
 			end
 		else
-			output.ImpaleHit = output.PhysicalHitAverage * (1-output.CritChance/100) + output.PhysicalCritAverage * (output.CritChance/100)
+			output.ImpaleHit = output.impaleStoredHitAvg * (1-output.CritChance/100) + output.PhysicalCritAverage * (output.CritChance/100)
 		end
 		output.ImpaleDPS = output.ImpaleHit * ((output.ImpaleModifier or 1) - 1) * output.HitChance / 100 * skillData.dpsMultiplier
 		if skillData.showAverage then


### PR DESCRIPTION
This will now take the pre-determined "pre-armour physical damage" as base damage for impale damage calculation

Fixes #7726 and #7727.

### Description of the problem being solved:

It was previously taking into account the already mitigated (through enemy armour/pdr) physical hit.


### Steps taken to verify a working solution:
- Checked POE Wiki (I know, this might not be up to date) but there it states indeed 
_"impale records hit damage before the defender's [mitigation](https://www.poewiki.net/wiki/Receiving_damage)"_
- Checked the Wiki on PoeDB
_"When a hit applies impale to a target, 10% of that hit's [physical damage](https://poedb.tw/us/Physical_damage) is recorded before any [damage mitigation](https://poedb.tw/us/Receiving_damage) is applied."_
- Used the use cases of #7726 to verify if the damage is indeed correct in all cases.

### Link to a build that showcases this PR:
See #7726
```
https://pobb.in/KBIVH-a04Pk1
``` 

### Before screenshot:
See #7726

### After screenshot:

- No overwhelm, 0% enemy pdr:
![image](https://github.com/user-attachments/assets/84ac6e92-f51c-4ec6-a826-4f29fea8b0b9)

- No overwhelm, 50% enemy pdr:
![image](https://github.com/user-attachments/assets/f6c07376-3911-42cc-8ea3-a4b2c90c97fa)

- 100% normal overwhelm (only), 50% enemy pdr:
![image](https://github.com/user-attachments/assets/9b0f9abe-07ee-40f9-9b15-d76434e36331)

- 100% impale overwhelm (only), 50% enemy pdr:
![image](https://github.com/user-attachments/assets/12b9423a-9d70-47b8-b03e-97480e20838f)

- 100% normal overwhelm + 100% impale overwhelm, 50% enemy pdr:
![image](https://github.com/user-attachments/assets/7e0d5d56-6355-4dd1-8019-7ff54a22f8eb)
