### PR TITLE
Apply Strength of Blood PDR only while leeching

### DIFF
--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -1972,7 +1972,7 @@ local specialModList = {
 		return { mod("DamageTaken", "MORE", -num, { type = "PerStat", stat = "MaxLifeLeechRatePercent", div = tonumber(div) }) }
 	end,
 	["(%d+)%% additional physical damage reduction for every (%d+)%% life recovery per second from leech"] = function(num, _, div)
-		return { mod("PhysicalDamageReduction", "BASE", num, { type = "PerStat", stat = "MaxLifeLeechRatePercent", div = tonumber(div) }) }
+		return { mod("PhysicalDamageReduction", "BASE", num, { type = "PerStat", stat = "MaxLifeLeechRatePercent", div = tonumber(div) }, { type = "Condition", var = "Leeching"}) }
 	end,
 	["modifiers to chance to suppress spell damage instead apply to chance to dodge spell hits at 50%% of their value"] = {
 		flag("ConvertSpellSuppressionToSpellDodge"),


### PR DESCRIPTION
Fixes #7764  

### Description of the problem being solved:
Strength of Blood Physical Damage Reduction was applying even if not leeching / having no leech sources.

### Steps taken to verify a working solution:
- Make a PoB without leech
- Add a legion jewel with strength of blood
- PDR should not be applied.
- Add leech
- PDR should be applied now.

### Link to a build that showcases this PR:
https://pobb.in/TVCpOHP366PS (Strength of blood unselected, gave PDR in tooltip before)

### Before screenshot:
![image](https://github.com/user-attachments/assets/c121b9a8-1cde-46cd-b69b-f6c26983f89e)
![image](https://github.com/user-attachments/assets/8e063d4d-4077-4bea-a2ca-c0cc28f8a70c)

### After screenshot:
![image](https://github.com/user-attachments/assets/48a2871d-a209-4f48-b1a8-fca2162ea115)

