### PR TITLE
Fix Power Siphon not benefiting from Spell Damage

### DIFF
--- a/src/Data/SkillStatMap.lua
+++ b/src/Data/SkillStatMap.lua
@@ -839,6 +839,10 @@ return {
 	flag("MinionDamageAppliesToPlayer"),
 	mod("ImprovedMinionDamageAppliesToPlayer", "MAX", nil)
 },
+["active_skill_additive_spell_damage_modifiers_apply_to_attack_damage_at_%_value"] = {
+	flag("SpellDamageAppliesToAttacks"),
+	mod("ImprovedSpellDamageAppliesToAttacks", "MAX", nil),
+},
 ["active_skill_main_hand_weapon_damage_+%_final"] = {
 	mod("Damage", "MORE", nil, 0, 0, { type = "Condition", var = "MainHandAttack" }),
 },

--- a/src/Data/Skills/act_int.lua
+++ b/src/Data/Skills/act_int.lua
@@ -10126,12 +10126,6 @@ skills["ClusterBurst"] = {
 			area = true,
 		},
 	},
-	statMap = {
-		["active_skill_additive_spell_damage_modifiers_apply_to_attack_damage_at_%_value"] = {
-			flag("SpellDamageAppliesToAttacks"),
-			mod("ImprovedSpellDamageAppliesToAttacks", "MAX", nil),
-		},
-	},
 	baseFlags = {
 		attack = true,
 		projectile = true,
@@ -10227,10 +10221,6 @@ skills["ClusterBurstAltX"] = {
 		["kinetic_blast_modifiers_to_number_of_projectiles_instead_apply_to_number_of_clusters"] = {
 			flag("NoAdditionalProjectiles"),
 		},
-		["active_skill_additive_spell_damage_modifiers_apply_to_attack_damage_at_%_value"] = {
-			flag("SpellDamageAppliesToAttacks"),
-			mod("ImprovedSpellDamageAppliesToAttacks", "MAX", nil),
-		},
 	},
 	baseFlags = {
 		attack = true,
@@ -10312,10 +10302,6 @@ skills["KineticBolt"] = {
 	statDescriptionScope = "skill_stat_descriptions",
 	castTime = 1,
 	statMap = {
-		["active_skill_additive_spell_damage_modifiers_apply_to_attack_damage_at_%_value"] = {
-			flag("SpellDamageAppliesToAttacks"),
-			mod("ImprovedSpellDamageAppliesToAttacks", "MAX", nil),
-		},
 		["quality_display_spell_damage_to_attack_damage_is_gem"] = {
 			--Display Only
 		},

--- a/src/Export/Skills/act_int.txt
+++ b/src/Export/Skills/act_int.txt
@@ -2201,10 +2201,6 @@ local skills, mod, flag, skill = ...
 #skill KineticBolt
 #flags attack projectile
 	statMap = {
-		["active_skill_additive_spell_damage_modifiers_apply_to_attack_damage_at_%_value"] = {
-			flag("SpellDamageAppliesToAttacks"),
-			mod("ImprovedSpellDamageAppliesToAttacks", "MAX", nil),
-		},
 		["quality_display_spell_damage_to_attack_damage_is_gem"] = {
 			--Display Only
 		},


### PR DESCRIPTION
The mod was not in the stat map. Moved it to the SkillStatMap file as it's used on a bunch of gems now
