### PR TITLE
Fix Caustic Arrow of Poison still have Flat Damage

### DIFF
--- a/src/Data/Skills/act_dex.lua
+++ b/src/Data/Skills/act_dex.lua
@@ -3559,8 +3559,6 @@ skills["PoisonArrowAltX"] = {
 		{ "base_chance_to_poison_on_hit_%", 40 },
 	},
 	stats = {
-		"attack_minimum_added_chaos_damage",
-		"attack_maximum_added_chaos_damage",
 		"active_skill_base_radius_+",
 		"skill_can_fire_arrows",
 		"visual_hit_effect_chaos_is_green",


### PR DESCRIPTION
Forgot to remove the 2 lines from the stat list
Fixes #7796