### PR TITLE
Fix Perfect Agony not including on enemy effects

### DIFF
--- a/src/Modules/CalcOffence.lua
+++ b/src/Modules/CalcOffence.lua
@@ -863,7 +863,8 @@ function calcs.offence(env, actor, activeSkill)
 		end
 	end
 	if skillModList:Flag(nil, "DotMultiplierIsCritMultiplier") then
-		skillModList:NewMod("DotMultiplier", "OVERRIDE", skillModList:Sum("BASE", skillCfg, "CritMultiplier"), "Perfect Agony", ModFlag.Ailment)
+		-- On enemy crit multiplier effects also apply for Perfect Agony: https://www.pathofexile.com/forum/view-thread/3532389#13
+		skillModList:NewMod("DotMultiplier", "OVERRIDE", skillModList:Sum("BASE", skillCfg, "CritMultiplier") + enemyDB:Sum("BASE", skillCfg, "SelfCritMultiplier"), "Perfect Agony", ModFlag.Ailment)
 	end
 
 	if skillModList:Flag(nil, "HasSeals") and activeSkill.skillTypes[SkillType.CanRapidFire] and not skillModList:Flag(nil, "NoRepeatBonuses") then


### PR DESCRIPTION
Fixes https://www.reddit.com/r/pathofexile/comments/1e9kh0w/path_of_building_community_2430_325_tree_build/lef48np/

### Description of the problem being solved:
Perfect agony did not include on enemy effects that increase critical strike multiplier.