### PR TITLE
Fix Enduring Cry having incorrect duration

### DIFF
--- a/src/Data/Skills/act_str.lua
+++ b/src/Data/Skills/act_str.lua
@@ -3465,7 +3465,6 @@ skills["EnduringCry"] = {
 	},
 	constantStats = {
 		{ "enduring_cry_life_regenerated_percentage_per_5_power", 2 },
-		{ "base_skill_effect_duration", 2000 },
 	},
 	stats = {
 		"warcry_speed_+%",


### PR DESCRIPTION
The skill had a constant stat that was adding +2 seconds to it
