### PR TITLE
Update Claw base Critical Strike Chance for 3.25

### DIFF
--- a/src/Data/Bases/claw.lua
+++ b/src/Data/Bases/claw.lua
@@ -9,7 +9,7 @@ itemBases["Nailed Fist"] = {
 	influenceTags = { shaper = "claw_shaper", elder = "claw_elder", adjudicator = "claw_adjudicator", basilisk = "claw_basilisk", crusader = "claw_crusader", eyrie = "claw_eyrie", cleansing = "claw_cleansing", tangle = "claw_tangle" },
 	implicit = "Grants 3 Life per Enemy Hit",
 	implicitModTypes = { { "resource", "life", "attack" }, },
-	weapon = { PhysicalMin = 4, PhysicalMax = 11, CritChanceBase = 6.2, AttackRateBase = 1.6, Range = 11, },
+	weapon = { PhysicalMin = 4, PhysicalMax = 11, CritChanceBase = 7.3, AttackRateBase = 1.6, Range = 11, },
 	req = { dex = 11, int = 11, },
 }
 itemBases["Sharktooth Claw"] = {
@@ -19,7 +19,7 @@ itemBases["Sharktooth Claw"] = {
 	influenceTags = { shaper = "claw_shaper", elder = "claw_elder", adjudicator = "claw_adjudicator", basilisk = "claw_basilisk", crusader = "claw_crusader", eyrie = "claw_eyrie", cleansing = "claw_cleansing", tangle = "claw_tangle" },
 	implicit = "Grants 6 Life per Enemy Hit",
 	implicitModTypes = { { "resource", "life", "attack" }, },
-	weapon = { PhysicalMin = 6, PhysicalMax = 17, CritChanceBase = 6.5, AttackRateBase = 1.5, Range = 11, },
+	weapon = { PhysicalMin = 6, PhysicalMax = 17, CritChanceBase = 8, AttackRateBase = 1.5, Range = 11, },
 	req = { level = 7, dex = 14, int = 20, },
 }
 itemBases["Awl"] = {
@@ -29,7 +29,7 @@ itemBases["Awl"] = {
 	influenceTags = { shaper = "claw_shaper", elder = "claw_elder", adjudicator = "claw_adjudicator", basilisk = "claw_basilisk", crusader = "claw_crusader", eyrie = "claw_eyrie", cleansing = "claw_cleansing", tangle = "claw_tangle" },
 	implicit = "Grants 7 Life per Enemy Hit",
 	implicitModTypes = { { "resource", "life", "attack" }, },
-	weapon = { PhysicalMin = 7, PhysicalMax = 23, CritChanceBase = 6.3, AttackRateBase = 1.55, Range = 11, },
+	weapon = { PhysicalMin = 7, PhysicalMax = 23, CritChanceBase = 7.5, AttackRateBase = 1.55, Range = 11, },
 	req = { level = 12, dex = 25, int = 25, },
 }
 itemBases["Cat's Paw"] = {
@@ -39,7 +39,7 @@ itemBases["Cat's Paw"] = {
 	influenceTags = { shaper = "claw_shaper", elder = "claw_elder", adjudicator = "claw_adjudicator", basilisk = "claw_basilisk", crusader = "claw_crusader", eyrie = "claw_eyrie", cleansing = "claw_cleansing", tangle = "claw_tangle" },
 	implicit = "Grants 8 Life per Enemy Hit",
 	implicitModTypes = { { "resource", "life", "attack" }, },
-	weapon = { PhysicalMin = 12, PhysicalMax = 22, CritChanceBase = 6, AttackRateBase = 1.6, Range = 11, },
+	weapon = { PhysicalMin = 12, PhysicalMax = 22, CritChanceBase = 7, AttackRateBase = 1.6, Range = 11, },
 	req = { level = 17, dex = 39, int = 27, },
 }
 itemBases["Blinder"] = {
@@ -49,7 +49,7 @@ itemBases["Blinder"] = {
 	influenceTags = { shaper = "claw_shaper", elder = "claw_elder", adjudicator = "claw_adjudicator", basilisk = "claw_basilisk", crusader = "claw_crusader", eyrie = "claw_eyrie", cleansing = "claw_cleansing", tangle = "claw_tangle" },
 	implicit = "Grants 12 Life per Enemy Hit",
 	implicitModTypes = { { "resource", "life", "attack" }, },
-	weapon = { PhysicalMin = 12, PhysicalMax = 31, CritChanceBase = 6.3, AttackRateBase = 1.55, Range = 11, },
+	weapon = { PhysicalMin = 12, PhysicalMax = 31, CritChanceBase = 7.5, AttackRateBase = 1.55, Range = 11, },
 	req = { level = 22, dex = 41, int = 41, },
 }
 itemBases["Timeworn Claw"] = {
@@ -59,7 +59,7 @@ itemBases["Timeworn Claw"] = {
 	influenceTags = { shaper = "claw_shaper", elder = "claw_elder", adjudicator = "claw_adjudicator", basilisk = "claw_basilisk", crusader = "claw_crusader", eyrie = "claw_eyrie", cleansing = "claw_cleansing", tangle = "claw_tangle" },
 	implicit = "Grants 19 Life per Enemy Hit",
 	implicitModTypes = { { "resource", "life", "attack" }, },
-	weapon = { PhysicalMin = 16, PhysicalMax = 43, CritChanceBase = 6.5, AttackRateBase = 1.3, Range = 11, },
+	weapon = { PhysicalMin = 16, PhysicalMax = 43, CritChanceBase = 8, AttackRateBase = 1.3, Range = 11, },
 	req = { level = 26, dex = 39, int = 56, },
 }
 itemBases["Sparkling Claw"] = {
@@ -69,7 +69,7 @@ itemBases["Sparkling Claw"] = {
 	influenceTags = { shaper = "claw_shaper", elder = "claw_elder", adjudicator = "claw_adjudicator", basilisk = "claw_basilisk", crusader = "claw_crusader", eyrie = "claw_eyrie", cleansing = "claw_cleansing", tangle = "claw_tangle" },
 	implicit = "Grants 15 Life per Enemy Hit",
 	implicitModTypes = { { "resource", "life", "attack" }, },
-	weapon = { PhysicalMin = 14, PhysicalMax = 38, CritChanceBase = 6, AttackRateBase = 1.6, Range = 11, },
+	weapon = { PhysicalMin = 14, PhysicalMax = 38, CritChanceBase = 7, AttackRateBase = 1.6, Range = 11, },
 	req = { level = 30, dex = 64, int = 44, },
 }
 itemBases["Fright Claw"] = {
@@ -79,7 +79,7 @@ itemBases["Fright Claw"] = {
 	influenceTags = { shaper = "claw_shaper", elder = "claw_elder", adjudicator = "claw_adjudicator", basilisk = "claw_basilisk", crusader = "claw_crusader", eyrie = "claw_eyrie", cleansing = "claw_cleansing", tangle = "claw_tangle" },
 	implicit = "Grants 20 Life per Enemy Hit",
 	implicitModTypes = { { "resource", "life", "attack" }, },
-	weapon = { PhysicalMin = 12, PhysicalMax = 46, CritChanceBase = 6.3, AttackRateBase = 1.5, Range = 11, },
+	weapon = { PhysicalMin = 12, PhysicalMax = 46, CritChanceBase = 7.5, AttackRateBase = 1.5, Range = 11, },
 	req = { level = 34, dex = 61, int = 61, },
 }
 itemBases["Double Claw"] = {
@@ -89,7 +89,7 @@ itemBases["Double Claw"] = {
 	influenceTags = { shaper = "claw_shaper", elder = "claw_elder", adjudicator = "claw_adjudicator", basilisk = "claw_basilisk", crusader = "claw_crusader", eyrie = "claw_eyrie", cleansing = "claw_cleansing", tangle = "claw_tangle" },
 	implicit = "Grants 15 Life per Enemy Hit\nGrants 6 Mana per Enemy Hit",
 	implicitModTypes = { { "resource", "life", "mana", "attack" }, { "resource", "life", "mana", "attack" }, },
-	weapon = { PhysicalMin = 15, PhysicalMax = 44, CritChanceBase = 6.3, AttackRateBase = 1.5, Range = 11, },
+	weapon = { PhysicalMin = 15, PhysicalMax = 44, CritChanceBase = 7.5, AttackRateBase = 1.5, Range = 11, },
 	req = { level = 36, dex = 67, int = 67, },
 }
 itemBases["Thresher Claw"] = {
@@ -99,7 +99,7 @@ itemBases["Thresher Claw"] = {
 	influenceTags = { shaper = "claw_shaper", elder = "claw_elder", adjudicator = "claw_adjudicator", basilisk = "claw_basilisk", crusader = "claw_crusader", eyrie = "claw_eyrie", cleansing = "claw_cleansing", tangle = "claw_tangle" },
 	implicit = "Grants 25 Life per Enemy Hit",
 	implicitModTypes = { { "resource", "life", "attack" }, },
-	weapon = { PhysicalMin = 20, PhysicalMax = 53, CritChanceBase = 6.5, AttackRateBase = 1.3, Range = 11, },
+	weapon = { PhysicalMin = 20, PhysicalMax = 53, CritChanceBase = 8, AttackRateBase = 1.3, Range = 11, },
 	req = { level = 37, dex = 53, int = 77, },
 }
 itemBases["Gouger"] = {
@@ -109,7 +109,7 @@ itemBases["Gouger"] = {
 	influenceTags = { shaper = "claw_shaper", elder = "claw_elder", adjudicator = "claw_adjudicator", basilisk = "claw_basilisk", crusader = "claw_crusader", eyrie = "claw_eyrie", cleansing = "claw_cleansing", tangle = "claw_tangle" },
 	implicit = "Grants 24 Life per Enemy Hit",
 	implicitModTypes = { { "resource", "life", "attack" }, },
-	weapon = { PhysicalMin = 15, PhysicalMax = 51, CritChanceBase = 6.3, AttackRateBase = 1.5, Range = 11, },
+	weapon = { PhysicalMin = 15, PhysicalMax = 51, CritChanceBase = 7.5, AttackRateBase = 1.5, Range = 11, },
 	req = { level = 40, dex = 70, int = 70, },
 }
 itemBases["Tiger's Paw"] = {
@@ -119,7 +119,7 @@ itemBases["Tiger's Paw"] = {
 	influenceTags = { shaper = "claw_shaper", elder = "claw_elder", adjudicator = "claw_adjudicator", basilisk = "claw_basilisk", crusader = "claw_crusader", eyrie = "claw_eyrie", cleansing = "claw_cleansing", tangle = "claw_tangle" },
 	implicit = "1.6% of Physical Attack Damage Leeched as Life",
 	implicitModTypes = { { "resource", "life", "physical", "attack" }, },
-	weapon = { PhysicalMin = 23, PhysicalMax = 43, CritChanceBase = 6, AttackRateBase = 1.6, Range = 11, },
+	weapon = { PhysicalMin = 23, PhysicalMax = 43, CritChanceBase = 7, AttackRateBase = 1.6, Range = 11, },
 	req = { level = 43, dex = 88, int = 61, },
 }
 itemBases["Gut Ripper"] = {
@@ -129,7 +129,7 @@ itemBases["Gut Ripper"] = {
 	influenceTags = { shaper = "claw_shaper", elder = "claw_elder", adjudicator = "claw_adjudicator", basilisk = "claw_basilisk", crusader = "claw_crusader", eyrie = "claw_eyrie", cleansing = "claw_cleansing", tangle = "claw_tangle" },
 	implicit = "Grants 44 Life per Enemy Hit",
 	implicitModTypes = { { "resource", "life", "attack" }, },
-	weapon = { PhysicalMin = 20, PhysicalMax = 53, CritChanceBase = 6.3, AttackRateBase = 1.5, Range = 11, },
+	weapon = { PhysicalMin = 20, PhysicalMax = 53, CritChanceBase = 7.5, AttackRateBase = 1.5, Range = 11, },
 	req = { level = 46, dex = 80, int = 80, },
 }
 itemBases["Prehistoric Claw"] = {
@@ -139,7 +139,7 @@ itemBases["Prehistoric Claw"] = {
 	influenceTags = { shaper = "claw_shaper", elder = "claw_elder", adjudicator = "claw_adjudicator", basilisk = "claw_basilisk", crusader = "claw_crusader", eyrie = "claw_eyrie", cleansing = "claw_cleansing", tangle = "claw_tangle" },
 	implicit = "2% of Physical Attack Damage Leeched as Life",
 	implicitModTypes = { { "resource", "life", "physical", "attack" }, },
-	weapon = { PhysicalMin = 26, PhysicalMax = 68, CritChanceBase = 6.5, AttackRateBase = 1.3, Range = 11, },
+	weapon = { PhysicalMin = 26, PhysicalMax = 68, CritChanceBase = 8, AttackRateBase = 1.3, Range = 11, },
 	req = { level = 49, dex = 69, int = 100, },
 }
 itemBases["Noble Claw"] = {
@@ -149,7 +149,7 @@ itemBases["Noble Claw"] = {
 	influenceTags = { shaper = "claw_shaper", elder = "claw_elder", adjudicator = "claw_adjudicator", basilisk = "claw_basilisk", crusader = "claw_crusader", eyrie = "claw_eyrie", cleansing = "claw_cleansing", tangle = "claw_tangle" },
 	implicit = "Grants 40 Life per Enemy Hit",
 	implicitModTypes = { { "resource", "life", "attack" }, },
-	weapon = { PhysicalMin = 21, PhysicalMax = 56, CritChanceBase = 6, AttackRateBase = 1.6, Range = 11, },
+	weapon = { PhysicalMin = 21, PhysicalMax = 56, CritChanceBase = 7, AttackRateBase = 1.6, Range = 11, },
 	req = { level = 52, dex = 105, int = 73, },
 }
 itemBases["Eagle Claw"] = {
@@ -159,7 +159,7 @@ itemBases["Eagle Claw"] = {
 	influenceTags = { shaper = "claw_shaper", elder = "claw_elder", adjudicator = "claw_adjudicator", basilisk = "claw_basilisk", crusader = "claw_crusader", eyrie = "claw_eyrie", cleansing = "claw_cleansing", tangle = "claw_tangle" },
 	implicit = "2% of Physical Attack Damage Leeched as Life",
 	implicitModTypes = { { "resource", "life", "physical", "attack" }, },
-	weapon = { PhysicalMin = 17, PhysicalMax = 69, CritChanceBase = 6.3, AttackRateBase = 1.5, Range = 11, },
+	weapon = { PhysicalMin = 17, PhysicalMax = 69, CritChanceBase = 7.5, AttackRateBase = 1.5, Range = 11, },
 	req = { level = 55, dex = 94, int = 94, },
 }
 itemBases["Twin Claw"] = {
@@ -169,7 +169,7 @@ itemBases["Twin Claw"] = {
 	influenceTags = { shaper = "claw_shaper", elder = "claw_elder", adjudicator = "claw_adjudicator", basilisk = "claw_basilisk", crusader = "claw_crusader", eyrie = "claw_eyrie", cleansing = "claw_cleansing", tangle = "claw_tangle" },
 	implicit = "Grants 28 Life per Enemy Hit\nGrants 10 Mana per Enemy Hit",
 	implicitModTypes = { { "resource", "life", "mana", "attack" }, { "resource", "life", "mana", "attack" }, },
-	weapon = { PhysicalMin = 21, PhysicalMax = 64, CritChanceBase = 6.3, AttackRateBase = 1.5, Range = 11, },
+	weapon = { PhysicalMin = 21, PhysicalMax = 64, CritChanceBase = 7.5, AttackRateBase = 1.5, Range = 11, },
 	req = { level = 57, dex = 103, int = 103, },
 }
 itemBases["Great White Claw"] = {
@@ -179,7 +179,7 @@ itemBases["Great White Claw"] = {
 	influenceTags = { shaper = "claw_shaper", elder = "claw_elder", adjudicator = "claw_adjudicator", basilisk = "claw_basilisk", crusader = "claw_crusader", eyrie = "claw_eyrie", cleansing = "claw_cleansing", tangle = "claw_tangle" },
 	implicit = "Grants 46 Life per Enemy Hit",
 	implicitModTypes = { { "resource", "life", "attack" }, },
-	weapon = { PhysicalMin = 30, PhysicalMax = 78, CritChanceBase = 6.5, AttackRateBase = 1.3, Range = 11, },
+	weapon = { PhysicalMin = 30, PhysicalMax = 78, CritChanceBase = 8, AttackRateBase = 1.3, Range = 11, },
 	req = { level = 58, dex = 81, int = 117, },
 }
 itemBases["Throat Stabber"] = {
@@ -189,7 +189,7 @@ itemBases["Throat Stabber"] = {
 	influenceTags = { shaper = "claw_shaper", elder = "claw_elder", adjudicator = "claw_adjudicator", basilisk = "claw_basilisk", crusader = "claw_crusader", eyrie = "claw_eyrie", cleansing = "claw_cleansing", tangle = "claw_tangle" },
 	implicit = "Grants 40 Life per Enemy Hit",
 	implicitModTypes = { { "resource", "life", "attack" }, },
-	weapon = { PhysicalMin = 21, PhysicalMax = 73, CritChanceBase = 6.3, AttackRateBase = 1.5, Range = 11, },
+	weapon = { PhysicalMin = 21, PhysicalMax = 73, CritChanceBase = 7.5, AttackRateBase = 1.5, Range = 11, },
 	req = { level = 60, dex = 113, int = 113, },
 }
 itemBases["Hellion's Paw"] = {
@@ -199,7 +199,7 @@ itemBases["Hellion's Paw"] = {
 	influenceTags = { shaper = "claw_shaper", elder = "claw_elder", adjudicator = "claw_adjudicator", basilisk = "claw_basilisk", crusader = "claw_crusader", eyrie = "claw_eyrie", cleansing = "claw_cleansing", tangle = "claw_tangle" },
 	implicit = "1.6% of Physical Attack Damage Leeched as Life",
 	implicitModTypes = { { "resource", "life", "physical", "attack" }, },
-	weapon = { PhysicalMin = 29, PhysicalMax = 55, CritChanceBase = 6, AttackRateBase = 1.6, Range = 11, },
+	weapon = { PhysicalMin = 29, PhysicalMax = 55, CritChanceBase = 7, AttackRateBase = 1.6, Range = 11, },
 	req = { level = 62, dex = 131, int = 95, },
 }
 itemBases["Eye Gouger"] = {
@@ -209,7 +209,7 @@ itemBases["Eye Gouger"] = {
 	influenceTags = { shaper = "claw_shaper", elder = "claw_elder", adjudicator = "claw_adjudicator", basilisk = "claw_basilisk", crusader = "claw_crusader", eyrie = "claw_eyrie", cleansing = "claw_cleansing", tangle = "claw_tangle" },
 	implicit = "Grants 50 Life per Enemy Hit",
 	implicitModTypes = { { "resource", "life", "attack" }, },
-	weapon = { PhysicalMin = 26, PhysicalMax = 68, CritChanceBase = 6.3, AttackRateBase = 1.5, Range = 11, },
+	weapon = { PhysicalMin = 26, PhysicalMax = 68, CritChanceBase = 7.5, AttackRateBase = 1.5, Range = 11, },
 	req = { level = 64, dex = 113, int = 113, },
 }
 itemBases["Vaal Claw"] = {
@@ -219,7 +219,7 @@ itemBases["Vaal Claw"] = {
 	influenceTags = { shaper = "claw_shaper", elder = "claw_elder", adjudicator = "claw_adjudicator", basilisk = "claw_basilisk", crusader = "claw_crusader", eyrie = "claw_eyrie", cleansing = "claw_cleansing", tangle = "claw_tangle" },
 	implicit = "2% of Physical Attack Damage Leeched as Life",
 	implicitModTypes = { { "resource", "life", "physical", "attack" }, },
-	weapon = { PhysicalMin = 29, PhysicalMax = 76, CritChanceBase = 6.5, AttackRateBase = 1.3, Range = 11, },
+	weapon = { PhysicalMin = 29, PhysicalMax = 76, CritChanceBase = 8, AttackRateBase = 1.3, Range = 11, },
 	req = { level = 66, dex = 95, int = 131, },
 }
 itemBases["Imperial Claw"] = {
@@ -229,7 +229,7 @@ itemBases["Imperial Claw"] = {
 	influenceTags = { shaper = "claw_shaper", elder = "claw_elder", adjudicator = "claw_adjudicator", basilisk = "claw_basilisk", crusader = "claw_crusader", eyrie = "claw_eyrie", cleansing = "claw_cleansing", tangle = "claw_tangle" },
 	implicit = "Grants 46 Life per Enemy Hit",
 	implicitModTypes = { { "resource", "life", "attack" }, },
-	weapon = { PhysicalMin = 25, PhysicalMax = 65, CritChanceBase = 6, AttackRateBase = 1.6, Range = 11, },
+	weapon = { PhysicalMin = 25, PhysicalMax = 65, CritChanceBase = 7, AttackRateBase = 1.6, Range = 11, },
 	req = { level = 68, dex = 131, int = 95, },
 }
 itemBases["Terror Claw"] = {
@@ -239,7 +239,7 @@ itemBases["Terror Claw"] = {
 	influenceTags = { shaper = "claw_shaper", elder = "claw_elder", adjudicator = "claw_adjudicator", basilisk = "claw_basilisk", crusader = "claw_crusader", eyrie = "claw_eyrie", cleansing = "claw_cleansing", tangle = "claw_tangle" },
 	implicit = "2% of Physical Attack Damage Leeched as Life",
 	implicitModTypes = { { "resource", "life", "physical", "attack" }, },
-	weapon = { PhysicalMin = 18, PhysicalMax = 71, CritChanceBase = 6.3, AttackRateBase = 1.5, Range = 11, },
+	weapon = { PhysicalMin = 18, PhysicalMax = 71, CritChanceBase = 7.5, AttackRateBase = 1.5, Range = 11, },
 	req = { level = 70, dex = 113, int = 113, },
 }
 itemBases["Gemini Claw"] = {
@@ -249,7 +249,7 @@ itemBases["Gemini Claw"] = {
 	influenceTags = { shaper = "claw_shaper", elder = "claw_elder", adjudicator = "claw_adjudicator", basilisk = "claw_basilisk", crusader = "claw_crusader", eyrie = "claw_eyrie", cleansing = "claw_cleansing", tangle = "claw_tangle" },
 	implicit = "Grants 38 Life per Enemy Hit\nGrants 14 Mana per Enemy Hit",
 	implicitModTypes = { { "resource", "life", "mana", "attack" }, { "resource", "life", "mana", "attack" }, },
-	weapon = { PhysicalMin = 23, PhysicalMax = 68, CritChanceBase = 6.3, AttackRateBase = 1.5, Range = 11, },
+	weapon = { PhysicalMin = 23, PhysicalMax = 68, CritChanceBase = 7.5, AttackRateBase = 1.5, Range = 11, },
 	req = { level = 72, dex = 121, int = 121, },
 }
 itemBases["Shadow Fangs"] = {
@@ -259,7 +259,7 @@ itemBases["Shadow Fangs"] = {
 	influenceTags = { shaper = "claw_shaper", elder = "claw_elder", adjudicator = "claw_adjudicator", basilisk = "claw_basilisk", crusader = "claw_crusader", eyrie = "claw_eyrie", cleansing = "claw_cleansing", tangle = "claw_tangle" },
 	implicit = "Adds (26-38) to (52-70) Chaos Damage",
 	implicitModTypes = { { "chaos_damage", "damage", "chaos", "attack" }, },
-	weapon = { PhysicalMin = 13, PhysicalMax = 24, CritChanceBase = 6, AttackRateBase = 1.6, Range = 11, },
+	weapon = { PhysicalMin = 13, PhysicalMax = 24, CritChanceBase = 7, AttackRateBase = 1.6, Range = 11, },
 	req = { level = 30, dex = 54, int = 54, },
 }
 itemBases["Malign Fangs"] = {
@@ -269,7 +269,7 @@ itemBases["Malign Fangs"] = {
 	influenceTags = { shaper = "claw_shaper", elder = "claw_elder", adjudicator = "claw_adjudicator", basilisk = "claw_basilisk", crusader = "claw_crusader", eyrie = "claw_eyrie", cleansing = "claw_cleansing", tangle = "claw_tangle" },
 	implicit = "Adds (43-55) to (81-104) Chaos Damage",
 	implicitModTypes = { { "chaos_damage", "damage", "chaos", "attack" }, },
-	weapon = { PhysicalMin = 20, PhysicalMax = 37, CritChanceBase = 6, AttackRateBase = 1.6, Range = 11, },
+	weapon = { PhysicalMin = 20, PhysicalMax = 37, CritChanceBase = 7, AttackRateBase = 1.6, Range = 11, },
 	req = { level = 50, dex = 86, int = 86, },
 }
 itemBases["Void Fangs"] = {
@@ -279,6 +279,6 @@ itemBases["Void Fangs"] = {
 	influenceTags = { shaper = "claw_shaper", elder = "claw_elder", adjudicator = "claw_adjudicator", basilisk = "claw_basilisk", crusader = "claw_crusader", eyrie = "claw_eyrie", cleansing = "claw_cleansing", tangle = "claw_tangle" },
 	implicit = "Adds (46-63) to (92-113) Chaos Damage",
 	implicitModTypes = { { "chaos_damage", "damage", "chaos", "attack" }, },
-	weapon = { PhysicalMin = 22, PhysicalMax = 41, CritChanceBase = 6, AttackRateBase = 1.6, Range = 11, },
+	weapon = { PhysicalMin = 22, PhysicalMax = 41, CritChanceBase = 7, AttackRateBase = 1.6, Range = 11, },
 	req = { level = 70, dex = 113, int = 113, },
 }


### PR DESCRIPTION
Fixes # .

### Description of the problem being solved:
Updates values based on information from patch notes for 3.25. As seen here: https://www.pathofexile.com/forum/view-thread/3531661#itemchanges

### Steps taken to verify a working solution:
- Open PoB
- Items > Craft Item > Rarity: Rare > Type: Claw > Base: pick any wand that had their value changed > Create
- Critical strike chance should match 3.25 patch notes


### Link to a build that showcases this PR:
Build with a claw that had crit chance changed from 6.3% to 7.5%:
https://pobb.in/WaogEe45sptt

### Before screenshot:
![old base crit chance](https://github.com/user-attachments/assets/52c04c0d-ec1f-4abe-9e10-3a70ebf1ad9e)

### After screenshot:
![new base crit chance](https://github.com/user-attachments/assets/eeaedad4-5b4a-4b25-bcab-32d70e1c0438)

