### PR TITLE
Add toggle for node search vieport edge highlight

### DIFF
--- a/src/Classes/PassiveTreeView.lua
+++ b/src/Classes/PassiveTreeView.lua
@@ -689,20 +689,25 @@ function PassiveTreeViewClass:Draw(build, viewPort, inputEvents)
 			SetDrawColor(rgbColor[1], rgbColor[2], rgbColor[3])
 			local size = 175 * scale / self.zoom ^ 0.4
 
-			-- Snap node matches to the edge of the viewPort
-			local peekaboo_ratio = 1.15
-			local scaled_down_ratio = 0.6667
-			local wide_cull = {viewPort.x - size / peekaboo_ratio, viewPort.x + viewPort.width - size * peekaboo_ratio}
-			local high_cull = {viewPort.y - size / peekaboo_ratio, viewPort.y + viewPort.height - size * peekaboo_ratio}
-			local newX = m_min(m_max(scrX - size, wide_cull[1]), wide_cull[2])
-			local newY = m_min(m_max(scrY - size, high_cull[1]), high_cull[2])
+			if main.edgeSearchHighlight then
+				-- Snap node matches to the edge of the viewPort
+				local peekaboo_ratio = 1.15
+				local scaled_down_ratio = 0.6667
+				local wide_cull = {viewPort.x - size / peekaboo_ratio, viewPort.x + viewPort.width - size * peekaboo_ratio}
+				local high_cull = {viewPort.y - size / peekaboo_ratio, viewPort.y + viewPort.height - size * peekaboo_ratio}
+				local newX = m_min(m_max(scrX - size, wide_cull[1]), wide_cull[2])
+				local newY = m_min(m_max(scrY - size, high_cull[1]), high_cull[2])
 
-			if newX ~= scrX - size or newY ~= scrY - size then
-			  size = size * scaled_down_ratio
-			  newX = newX + size / 2
-			  newY = newY + size / 2
+				if newX ~= scrX - size or newY ~= scrY - size then
+				size = size * scaled_down_ratio
+				newX = newX + size / 2
+				newY = newY + size / 2
+				end
+				DrawImage(self.highlightRing, newX, newY, size * 2, size * 2)
+			else
+				DrawImage(self.highlightRing, scrX - size, scrY - size, size * 2, size * 2)
 			end
-			DrawImage(self.highlightRing, newX, newY, size * 2, size * 2)
+
 		end
 		if node == hoverNode and (node.type ~= "Socket" or not IsKeyDown("SHIFT")) and (node.type ~= "Mastery" or node.masteryEffects) and not IsKeyDown("CTRL") and not main.popups[1] then
 			-- Draw tooltip

--- a/src/Modules/Main.lua
+++ b/src/Modules/Main.lua
@@ -93,6 +93,7 @@ function main:Init()
 	self.colorNegative = defaultColorCodes.NEGATIVE
 	self.colorHighlight = defaultColorCodes.HIGHLIGHT
 	self.showThousandsSeparators = true
+	self.edgeSearchHighlight = true
 	self.thousandsSeparator = ","
 	self.decimalSeparator = "."
 	self.defaultItemAffixQuality = 0.5
@@ -581,6 +582,9 @@ function main:LoadSettings(ignoreBuild)
 				if node.attrib.betaTest then
 					self.betaTest = node.attrib.betaTest == "true"
 				end
+				if node.attrib.edgeSearchHighlight then
+					self.edgeSearchHighlight = node.attrib.edgeSearchHighlight == "true"
+				end
 				if node.attrib.defaultGemQuality then
 					self.defaultGemQuality = m_min(tonumber(node.attrib.defaultGemQuality) or 0, 23)
 				end
@@ -702,6 +706,7 @@ function main:SaveSettings()
 		decimalSeparator = self.decimalSeparator,
 		showTitlebarName = tostring(self.showTitlebarName),
 		betaTest = tostring(self.betaTest),
+		edgeSearchHighlight = tostring(self.edgeSearchHighlight),
 		defaultGemQuality = tostring(self.defaultGemQuality or 0),
 		defaultCharLevel = tostring(self.defaultCharLevel or 1),
 		defaultItemAffixQuality = tostring(self.defaultItemAffixQuality or 0.5),
@@ -880,6 +885,11 @@ function main:OpenOptionsPopup()
 	end)
 
 	nextRow()
+	controls.edgeSearchHighlight = new("CheckBoxControl", { "TOPLEFT", nil, "TOPLEFT" }, defaultLabelPlacementX, currentY, 20, "^7Show search circles at viewport edge", function(state)
+		self.edgeSearchHighlight = state
+	end)
+
+	nextRow()
 	drawSectionHeader("build", "Build-related options")
 
 	controls.showThousandsSeparators = new("CheckBoxControl", { "TOPLEFT", nil, "TOPLEFT"}, defaultLabelPlacementX, currentY, 20, "^7Show thousands separators:", function(state)
@@ -957,6 +967,7 @@ function main:OpenOptionsPopup()
 	end
 
 	controls.betaTest.state = self.betaTest
+	controls.edgeSearchHighlight.state = self.edgeSearchHighlight
 	controls.titlebarName.state = self.showTitlebarName
 	local initialNodePowerTheme = self.nodePowerTheme
 	local initialColorPositive = self.colorPositive
@@ -967,6 +978,7 @@ function main:OpenOptionsPopup()
 	local initialThousandsSeparator = self.thousandsSeparator
 	local initialDecimalSeparator = self.decimalSeparator
 	local initialBetaTest = self.betaTest
+	local initialedgeSearchHighlight = self.edgeSearchHighlight
 	local initialDefaultGemQuality = self.defaultGemQuality or 0
 	local initialDefaultCharLevel = self.defaultCharLevel or 1
 	local initialDefaultItemAffixQuality = self.defaultItemAffixQuality or 0.5
@@ -1015,6 +1027,7 @@ function main:OpenOptionsPopup()
 		self.decimalSeparator = initialDecimalSeparator
 		self.showTitlebarName = initialTitlebarName
 		self.betaTest = initialBetaTest
+		self.edgeSearchHighlight = initialedgeSearchHighlight
 		self.defaultGemQuality = initialDefaultGemQuality
 		self.defaultCharLevel = initialDefaultCharLevel
 		self.defaultItemAffixQuality = initialDefaultItemAffixQuality


### PR DESCRIPTION
Fixes https://www.reddit.com/r/pathofexile/comments/1e9kh0w/path_of_building_community_2430_325_tree_build/lef5dcc/

### Description of the problem being solved:
Adds an option to disable PoE Planner inspired node search highlight. Highlighting is enabled by default.