### PR TITLE
Fix impale not using enemy damage taken

### DIFF
--- a/spec/System/TestImpale_spec.lua
+++ b/spec/System/TestImpale_spec.lua
@@ -1,0 +1,254 @@
+describe("TestAttacks", function()
+	before_each(function()
+		newBuild()
+		-- exactly 200 damage
+		build.itemsTab:CreateDisplayItemFromRaw("New Item\nVaal Greatsword\nQuality: 0\nAdds 132 to 58 physical damage\n150% chance to Impale Enemies on Hit with Attacks")
+		build.itemsTab:AddDisplayItem()
+		build.itemsTab:CreateDisplayItemFromRaw("New Item\nPaua Amulet\nYour hits can't be evaded\n-20 strength\n")
+		build.itemsTab:AddDisplayItem()
+	end)
+
+	teardown(function()
+		-- newBuild() takes care of resetting everything in setup()
+	end)
+
+	it("basic impale", function()
+		-- 0% crit
+		build.configTab.input.customMods = "\z
+		never deal critical strikes\n\z
+		Impale Damage dealt to Enemies Impaled by you Overwhelms 100% Physical Damage Reduction\n\z
+		Overwhelm 100% physical damage reduction\n\z
+		"
+		build.configTab:BuildModList()
+		runCallback("OnFrame")
+
+		assert.are.equals(100, build.calcsTab.mainOutput.MainHand.ImpaleChance)
+		assert.are.equals(100, build.calcsTab.mainOutput.MainHand.ImpaleChanceOnCrit)
+		assert.are.equals(200, build.calcsTab.mainOutput.MainHand.PhysicalHitAverage)
+		assert.are.equals(200, build.calcsTab.mainOutput.MainHand.impaleStoredHitAvg)
+		assert.are.equals(200, build.calcsTab.mainOutput.ImpaleHit)
+		assert.are.equals(100*1.3, build.calcsTab.mainOutput.ImpaleDPS) -- 5 impales * 10% stored damage * 1.3 attacks per second
+
+		-- 50% crit
+		build.configTab.input.customMods = "\z
+		+45% critical strike chance\n\z
+		Impale Damage dealt to Enemies Impaled by you Overwhelms 100% Physical Damage Reduction\n\z
+		Overwhelm 100% physical damage reduction\n\z
+		"
+		build.configTab:BuildModList()
+		runCallback("OnFrame")
+
+		assert.are.equals(200, build.calcsTab.mainOutput.MainHand.PhysicalHitAverage)
+		assert.are.equals(300, build.calcsTab.mainOutput.MainHand.PhysicalCritAverage)
+		assert.are.equals(250, build.calcsTab.mainOutput.MainHand.impaleStoredHitAvg)
+		assert.are.equals(250, build.calcsTab.mainOutput.ImpaleHit)
+		assert.are.equals(125*1.3, build.calcsTab.mainOutput.ImpaleDPS) -- 5 impales * 10% stored damage * 1.3 attacks per second
+
+		-- 100% crit
+		build.configTab.input.customMods = "\z
+		+100% critical strike chance\n\z
+		Impale Damage dealt to Enemies Impaled by you Overwhelms 100% Physical Damage Reduction\n\z
+		Overwhelm 100% physical damage reduction\n\z
+		"
+		build.configTab:BuildModList()
+		runCallback("OnFrame")
+
+		assert.are.equals(300, build.calcsTab.mainOutput.MainHand.PhysicalCritAverage)
+		assert.are.equals(300, build.calcsTab.mainOutput.ImpaleHit)
+		assert.are.equals(150*1.3, build.calcsTab.mainOutput.ImpaleDPS) -- 5 impales * 10% stored damage * 1.3 attacks per second
+	end)
+
+	it("impale with inc damage taken", function()
+		-- 0% crit
+		build.configTab.input.customMods = "\z
+		never deal critical strikes\n\z
+		Impale Damage dealt to Enemies Impaled by you Overwhelms 100% Physical Damage Reduction\n\z
+		Overwhelm 100% physical damage reduction\n\z
+		Nearby enemies take 100% increased physical damage\n\z
+		"
+		build.configTab:BuildModList()
+		runCallback("OnFrame")
+
+		assert.are.equals(400, build.calcsTab.mainOutput.MainHand.PhysicalHitAverage)
+		assert.are.equals(200, build.calcsTab.mainOutput.MainHand.impaleStoredHitAvg)
+		assert.are.equals(200, build.calcsTab.mainOutput.ImpaleHit)
+		assert.are.equals(200*1.3, build.calcsTab.mainOutput.ImpaleDPS) -- 5 impales * 10% stored damage * 1.3 attacks per second
+
+		-- 50% crit
+		build.configTab.input.customMods = "\z
+		+45% critical strike chance\n\z
+		Impale Damage dealt to Enemies Impaled by you Overwhelms 100% Physical Damage Reduction\n\z
+		Overwhelm 100% physical damage reduction\n\z
+		Nearby enemies take 100% increased physical damage\n\z
+		"
+		build.configTab:BuildModList()
+		runCallback("OnFrame")
+
+		assert.are.equals(400, build.calcsTab.mainOutput.MainHand.PhysicalHitAverage)
+		assert.are.equals(600, build.calcsTab.mainOutput.MainHand.PhysicalCritAverage)
+		assert.are.equals(250, build.calcsTab.mainOutput.MainHand.impaleStoredHitAvg)
+		assert.are.equals(250, build.calcsTab.mainOutput.ImpaleHit)
+		assert.are.equals(250*1.3, build.calcsTab.mainOutput.ImpaleDPS) -- 5 impales * 10% stored damage * 1.3 attacks per second
+
+		-- 100% crit
+		build.configTab.input.customMods = "\z
+		+100% critical strike chance\n\z
+		Impale Damage dealt to Enemies Impaled by you Overwhelms 100% Physical Damage Reduction\n\z
+		Overwhelm 100% physical damage reduction\n\z
+		Nearby enemies take 100% increased physical damage\n\z
+		"
+		build.configTab:BuildModList()
+		runCallback("OnFrame")
+
+		assert.are.equals(400, build.calcsTab.mainOutput.MainHand.PhysicalHitAverage)
+		assert.are.equals(600, build.calcsTab.mainOutput.MainHand.PhysicalCritAverage)
+		assert.are.equals(300, build.calcsTab.mainOutput.MainHand.impaleStoredHitAvg)
+		assert.are.equals(300, build.calcsTab.mainOutput.ImpaleHit)
+		assert.are.equals(300*1.3, build.calcsTab.mainOutput.ImpaleDPS) -- 5 impales * 10% stored damage * 1.3 attacks per second
+	end)
+
+	it("impale with physical reduction", function()
+		-- 0% crit
+		build.configTab.input.customMods = "\z
+		never deal critical strikes\n\z
+		"
+		build.configTab.input.enemyPhysicalReduction = 10
+		build.configTab.input.enemyArmour = 1000 -- 50% dr for 200 damage, 66.6% dr for 100 dmg (impale stacks)
+		build.configTab:BuildModList()
+		runCallback("OnFrame")
+
+		-- dam * (1 - (armourDR + additionalDR)
+		assert.are.equals(200 * (1 - (0.5 + 0.1)), build.calcsTab.mainOutput.MainHand.PhysicalHitAverage)
+		assert.are.equals(200, build.calcsTab.mainOutput.MainHand.impaleStoredHitAvg)
+		assert.are.equals(200, build.calcsTab.mainOutput.ImpaleHit)
+		-- [5 impales * 10% stored damage] * 1.3 attacks * (armour mod - phys DR)
+		assert.are.near(100 * 1.3 * (1 - (2/3 + 0.1)), build.calcsTab.mainOutput.ImpaleDPS, 0.0000001) -- floating point math
+
+
+		-- 100% crit
+		build.configTab.input.customMods = "\z
+		+100% critical strike chance\n\z
+		"
+		build.configTab.input.enemyPhysicalReduction = 10
+		build.configTab.input.enemyArmour = 1500 -- 50% dr for 300 damage, 66.6% dr for 150 dmg (impale stacks)
+		build.configTab:BuildModList()
+		runCallback("OnFrame")
+
+		-- dam * (1 - (armourDR + additionalDR)
+		assert.are.equals(300 * (1 - (0.5 + 0.1)), build.calcsTab.mainOutput.MainHand.PhysicalCritAverage)
+		assert.are.equals(300, build.calcsTab.mainOutput.MainHand.impaleStoredHitAvg)
+		assert.are.equals(300, build.calcsTab.mainOutput.ImpaleHit)
+		-- [5 impales * 10% stored damage] * 1.3 attacks * (armour mod - phys DR)
+		assert.are.near(150 * 1.3 * (1 - (2/3 + 0.1)), build.calcsTab.mainOutput.ImpaleDPS, 0.0000001) -- floating point math
+
+	end)
+
+	it("impale with physical reduction and inc damage taken", function()
+		-- 0% crit
+		build.configTab.input.customMods = "\z
+		never deal critical strikes\n\z
+		Nearby enemies take 100% increased physical damage\n\z
+		"
+		build.configTab.input.enemyPhysicalReduction = 10
+		build.configTab.input.enemyArmour = 1000 -- 50% dr for 200 damage, 66.6% dr for 100 dmg (impale stacks) .. damage taken is after armour
+		build.configTab:BuildModList()
+		runCallback("OnFrame")
+
+		-- taken * dam * (1 - (armourDR + additionalDR)
+		assert.are.equals(2 * 200 * (1 - (0.5 + 0.1)), build.calcsTab.mainOutput.MainHand.PhysicalHitAverage)
+		assert.are.equals(200, build.calcsTab.mainOutput.MainHand.impaleStoredHitAvg)
+		assert.are.equals(200, build.calcsTab.mainOutput.ImpaleHit)
+		-- taken * [5 impales * 10% stored damage] * 1.3 attacks * (armour mod - phys DR)
+		assert.are.near(2 * 100 * 1.3 * (1 - (2/3 + 0.1)), build.calcsTab.mainOutput.ImpaleDPS, 0.0000001) -- floating point math
+
+
+		-- 100% crit
+		build.configTab.input.customMods = "\z
+		+100% critical strike chance\n\z
+		Nearby enemies take 100% increased physical damage\n\z
+		"
+		build.configTab.input.enemyPhysicalReduction = 10
+		build.configTab.input.enemyArmour = 1500 -- 50% dr for 300 damage, 66.6% dr for 150 dmg (impale stacks)
+		build.configTab:BuildModList()
+		runCallback("OnFrame")
+
+		-- taken * dam * (1 - (armourDR + additionalDR)
+		assert.are.equals(2 * 300 * (1 - (0.5 + 0.1)), build.calcsTab.mainOutput.MainHand.PhysicalCritAverage)
+		assert.are.equals(300, build.calcsTab.mainOutput.MainHand.impaleStoredHitAvg)
+		assert.are.equals(300, build.calcsTab.mainOutput.ImpaleHit)
+		-- taken * [5 impales * 10% stored damage] * 1.3 attacks * (armour mod - phys DR)
+		assert.are.near(2 * 150 * 1.3 * (1 - (2/3 + 0.1)), build.calcsTab.mainOutput.ImpaleDPS, 0.0000001) -- floating point math
+
+	end)
+
+	it("impale dual wield", function()
+		newBuild()
+		-- exactly 100
+		build.itemsTab:CreateDisplayItemFromRaw("New Item\nVaal Blade\nQuality: 0\nAdds 54 to 14 physical damage\n150% chance to Impale Enemies on Hit with Attacks")
+		build.itemsTab:AddDisplayItem()
+		-- exactly 200 offhand
+		build.itemsTab:CreateDisplayItemFromRaw("New Item\nVaal Blade\nQuality: 0\nAdds 54 to 14 physical damage\n100% increased Physical Damage\n150% chance to Impale Enemies on Hit with Attacks")
+		build.itemsTab:AddDisplayItem()
+		build.itemsTab:CreateDisplayItemFromRaw("New Item\nPaua Amulet\nYour hits can't be evaded\n-20 strength\n")
+		build.itemsTab:AddDisplayItem()
+
+
+		-- 0% crit
+		build.configTab.input.customMods = "\z
+		never deal critical strikes\n\z
+		Impale Damage dealt to Enemies Impaled by you Overwhelms 100% Physical Damage Reduction\n\z
+		Overwhelm 100% physical damage reduction\n\z
+		"
+		build.configTab:BuildModList()
+		runCallback("OnFrame")
+
+		assert.are.equals(100, build.calcsTab.mainOutput.MainHand.ImpaleChance)
+		assert.are.equals(100, build.calcsTab.mainOutput.OffHand.ImpaleChance)
+		assert.are.equals(100, build.calcsTab.mainOutput.MainHand.ImpaleChanceOnCrit)
+		assert.are.equals(100, build.calcsTab.mainOutput.OffHand.ImpaleChanceOnCrit)
+
+		assert.are.equals(100, build.calcsTab.mainOutput.MainHand.PhysicalHitAverage)
+		assert.are.equals(200, build.calcsTab.mainOutput.OffHand.PhysicalHitAverage)
+		assert.are.equals(100, build.calcsTab.mainOutput.MainHand.impaleStoredHitAvg)
+		assert.are.equals(200, build.calcsTab.mainOutput.OffHand.impaleStoredHitAvg)
+
+		assert.are.equals(150, build.calcsTab.mainOutput.ImpaleHit)
+		-- 5 impales * 10% stored damage * 1.3 attacks per second * 1.1 dual wield modifier
+		assert.are.near(75*1.3*1.1, build.calcsTab.mainOutput.ImpaleDPS, 0.0000001)
+
+
+		-- 50% crit
+		build.configTab.input.customMods = "\z
+		+45% critical strike chance\n\z
+		Impale Damage dealt to Enemies Impaled by you Overwhelms 100% Physical Damage Reduction\n\z
+		Overwhelm 100% physical damage reduction\n\z
+		"
+		build.configTab:BuildModList()
+		runCallback("OnFrame")
+
+		assert.are.equals(125, build.calcsTab.mainOutput.MainHand.impaleStoredHitAvg)
+		assert.are.equals(250, build.calcsTab.mainOutput.OffHand.impaleStoredHitAvg)
+
+		assert.are.equals(187.5, build.calcsTab.mainOutput.ImpaleHit)
+		-- 5 impales * 10% stored damage * 1.3 attacks per second * 1.1 dual wield modifier
+		assert.are.near(187.5/2*1.3*1.1, build.calcsTab.mainOutput.ImpaleDPS, 0.0000001)
+
+
+		-- 50% crit
+		build.configTab.input.customMods = "\z
+		+100% critical strike chance\n\z
+		Impale Damage dealt to Enemies Impaled by you Overwhelms 100% Physical Damage Reduction\n\z
+		Overwhelm 100% physical damage reduction\n\z
+		"
+		build.configTab:BuildModList()
+		runCallback("OnFrame")
+
+		assert.are.equals(150, build.calcsTab.mainOutput.MainHand.impaleStoredHitAvg)
+		assert.are.equals(300, build.calcsTab.mainOutput.OffHand.impaleStoredHitAvg)
+
+		assert.are.equals(225, build.calcsTab.mainOutput.ImpaleHit)
+		-- 5 impales * 10% stored damage * 1.3 attacks per second * 1.1 dual wield modifier
+		assert.are.near(225/2*1.3*1.1, build.calcsTab.mainOutput.ImpaleDPS, 0.0000001)
+
+	end)
+end)

--- a/spec/System/TestImpale_spec.lua
+++ b/spec/System/TestImpale_spec.lua
@@ -251,4 +251,37 @@ describe("TestAttacks", function()
 		assert.are.near(225/2*1.3*1.1, build.calcsTab.mainOutput.ImpaleDPS, 0.0000001)
 
 	end)
+
+	it("impale with extra mods", function()
+		-- inc effect
+		build.configTab.input.customMods = "\z
+		never deal critical strikes\n\z
+		Impale Damage dealt to Enemies Impaled by you Overwhelms 100% Physical Damage Reduction\n\z
+		Overwhelm 100% physical damage reduction\n\z
+		50% increased Impale Effect\n\z
+		"
+		build.configTab:BuildModList()
+		runCallback("OnFrame")
+
+		assert.are.equals(200, build.calcsTab.mainOutput.MainHand.PhysicalHitAverage)
+		assert.are.equals(200, build.calcsTab.mainOutput.MainHand.impaleStoredHitAvg)
+		assert.are.equals(200, build.calcsTab.mainOutput.ImpaleHit)
+		assert.are.near(100*1.3*1.5, build.calcsTab.mainOutput.ImpaleDPS, 0.00000001) -- 5 impales * 10% stored damage * 1.3 attacks per second * 1.5 impale effect
+
+		-- last 1 extra hit
+		build.configTab.input.customMods = "\z
+		never deal critical strikes\n\z
+		Impale Damage dealt to Enemies Impaled by you Overwhelms 100% Physical Damage Reduction\n\z
+		Overwhelm 100% physical damage reduction\n\z
+		Impales you inflict last 1 additional Hit\n\z
+		"
+		build.configTab:BuildModList()
+		runCallback("OnFrame")
+
+		assert.are.equals(200, build.calcsTab.mainOutput.MainHand.PhysicalHitAverage)
+		assert.are.equals(200, build.calcsTab.mainOutput.MainHand.impaleStoredHitAvg)
+		assert.are.equals(200, build.calcsTab.mainOutput.ImpaleHit)
+		assert.are.near(120*1.3, build.calcsTab.mainOutput.ImpaleDPS, 0.0000001) -- 6 impales * 10% stored damage * 1.3 attacks per second
+	end)
+
 end)

--- a/src/Modules/CalcOffence.lua
+++ b/src/Modules/CalcOffence.lua
@@ -4905,8 +4905,8 @@ function calcs.offence(env, actor, activeSkill)
 			if skillModList:Flag(cfg, "IgnoreEnemyImpalePhysicalDamageReduction") then
 				impaleResist = 0
 			end
-
-			local impaleDMGModifier = impaleHitDamageMod * (1 - impaleResist / 100) * impaleChance
+			local impaleTaken = (1 + enemyDB:Sum("INC", nil, "DamageTaken", "PhysicalDamageTaken") / 100) * enemyDB:More(nil, "DamageTaken", "PhysicalDamageTaken")
+			local impaleDMGModifier = impaleHitDamageMod * (1 - impaleResist / 100) * impaleChance * impaleTaken
 
 			globalOutput.ImpaleStacksMax = maxStacks
 			globalOutput.ImpaleStacks = impaleStacks
@@ -4926,6 +4926,9 @@ function calcs.offence(env, actor, activeSkill)
 				t_insert(breakdown.ImpaleModifier, s_format("x %.3f ^8(stored damage)", impaleStoredDamage))
 				t_insert(breakdown.ImpaleModifier, s_format("x %.2f ^8(impale chance)", impaleChance))
 				t_insert(breakdown.ImpaleModifier, s_format("x %.2f ^8(impale enemy physical damage reduction)", (1 - impaleResist / 100)))
+				if impaleTaken ~= 1 then
+					t_insert(breakdown.ImpaleModifier, s_format("x %.2f ^8(impale enemy damage taken)", impaleTaken))
+				end
 				t_insert(breakdown.ImpaleModifier, s_format("= %.3f ^8(impale damage multiplier)", impaleDMGModifier))
 			end
 		end
@@ -5393,7 +5396,7 @@ function calcs.offence(env, actor, activeSkill)
 		output.CombinedDPS = output.CombinedDPS + output.ImpaleDPS
 		if breakdown then
 			breakdown.ImpaleDPS = {}
-			t_insert(breakdown.ImpaleDPS, s_format("%.2f ^8(average physical hit)", output.ImpaleHit))
+			t_insert(breakdown.ImpaleDPS, s_format("%.2f ^8(average physical hit before mitigation)", output.ImpaleHit))
 			t_insert(breakdown.ImpaleDPS, s_format("x %.2f ^8(chance to hit)", output.HitChance / 100))
 			if skillFlags.notAverage then
 				t_insert(breakdown.ImpaleDPS, output.HitSpeed and s_format("x %.2f ^8(hit rate)", output.HitSpeed) or s_format("x %.2f ^8(%s rate)", output.Speed, skillFlags.attack and "attack" or "cast"))

--- a/src/Modules/CalcOffence.lua
+++ b/src/Modules/CalcOffence.lua
@@ -5374,12 +5374,12 @@ function calcs.offence(env, actor, activeSkill)
 	end
 	if skillFlags.impale then
 		if skillFlags.attack then
-			output.ImpaleHit = ((output.MainHand.impaleStoredHitAvg or output.OffHand.impaleStoredHitAvg) + (output.OffHand.impaleStoredHitAvg or output.MainHand.impaleStoredHitAvg)) / 2 * (1-output.CritChance/100) + ((output.MainHand.PhysicalCritAverage or output.OffHand.PhysicalCritAverage) + (output.OffHand.PhysicalCritAverage or output.MainHand.PhysicalCritAverage)) / 2 * (output.CritChance/100)
+			output.ImpaleHit = ((output.MainHand.impaleStoredHitAvg or output.OffHand.impaleStoredHitAvg) + (output.OffHand.impaleStoredHitAvg or output.MainHand.impaleStoredHitAvg)) / 2
 			if skillData.doubleHitsWhenDualWielding and skillFlags.bothWeaponAttack then
 				output.ImpaleHit = output.ImpaleHit * 2
 			end
 		else
-			output.ImpaleHit = output.impaleStoredHitAvg * (1-output.CritChance/100) + output.PhysicalCritAverage * (output.CritChance/100)
+			output.ImpaleHit = output.impaleStoredHitAvg
 		end
 		output.ImpaleDPS = output.ImpaleHit * ((output.ImpaleModifier or 1) - 1) * output.HitChance / 100 * skillData.dpsMultiplier
 		if skillData.showAverage then


### PR DESCRIPTION
Fixes #7787 .

### Description of the problem being solved:

Impale damage did not respect enemy damage taken modifiers. This bug is a result of fixing impale armour application recently.

Clarify "average physical hit" in impale breakdown as "average physical hit before mitigation".

### Steps taken to verify a working solution:
- Checked changes to impale dps with different "enemies take % more physical damage" modifiers and Pride/Vulnerability
- Tested with minimal example and real build

### Link to a build that showcases this PR:
https://pobb.in/wFfb1O9sTa5M

Change first line in Custom Modifiers and watch dps change. 1000 Hit DPS, 100% impale, 10% more damage taken, ignore all armour.

### Before screenshot:
![image](https://github.com/user-attachments/assets/8952e59d-fa3d-4950-ab3d-d601212c9642)

### After screenshot:
![image](https://github.com/user-attachments/assets/4d15a288-c603-4af7-bf8b-f82442e8578a)


----

As far as I can tell, the only relevant modifiers are `DamageTaken` and `PhysicalDamageTaken` (Physical reduction and Armour works already), Other modifiers affecting impale, like reflected damage or flat subtractions seem not relevant to enemy calculations. 

Impale damage is still not affected by attack damage taken, like Intimidate. Which I think is correct, but not 100%.

Also my first contribution, hope this is right.