### PR TITLE
Allow quality to be set on item copy/paste

### DIFF
--- a/src/Classes/ItemsTab.lua
+++ b/src/Classes/ItemsTab.lua
@@ -1493,7 +1493,7 @@ end
 function ItemsTabClass:CreateDisplayItemFromRaw(itemRaw, normalise)
 	local newItem = new("Item", itemRaw)
 	if newItem.base then
-		if normalise then
+		if normalise and not newItem.quality then
 			newItem:NormaliseQuality()
 			newItem:BuildModList()
 		end


### PR DESCRIPTION
### Description of the problem being solved:
Before this change, copy/pasting an item, even with "Quality: 0" as one of the lines, would result in 20% quality on it when saving the item.  This made it difficult to test exact numbers, as you'd have to work backward from 20% quality.
