### PR TITLE
Rage Vortex Config Changes (#7148)

### DIFF
--- a/src/Modules/ConfigOptions.lua
+++ b/src/Modules/ConfigOptions.lua
@@ -485,10 +485,13 @@ return {
 			modList:NewMod("Condition:PrideMaxEffect", "FLAG", true, "Config")
 		end
 	end },
+
 	{ label = "Rage Vortex:", ifSkill = "Rage Vortex" },
-	{ var = "sacrificedRageCount", type = "count", label = "Amount of Rage Sacrificed?", ifSkill = "Rage Vortex", apply = function(val, modList, enemyModList)
+	{ var = "sacrificedRageCount", type = "count", label = "Amount of Rage Sacrificed (if not maximum):", ifSkill = "Rage Vortex", apply = function(val, modList, enemyModList)
 		modList:NewMod("Multiplier:RageSacrificed", "BASE", val, "Config")
+		modList:NewMod("OverrideSacrificedRage", "FLAG", true, "")
 	end },
+
 	{ label = "Raise Spectre:", ifSkill = "Raise Spectre", includeTransfigured = true },
 	{ var = "raiseSpectreEnableBuffs", type = "check", defaultState = true, label = "Enable buffs:", ifSkill = "Raise Spectre", includeTransfigured = true, tooltip = "Enable any buff skills that your spectres have.", apply = function(val, modList, enemyModList)
 		modList:NewMod("SkillData", "LIST", { key = "enable", value = true }, "Config", { type = "SkillType", skillType = SkillType.Buff }, { type = "SkillName", skillName = "Raise Spectre", includeTransfigured = true, summonSkill = true })

--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -2260,6 +2260,9 @@ local specialModList = {
 	["gain %d+ rage on hit with axes"] = {
 		flag("Condition:CanGainRage"),
 	},
+	["gain %d+ rage on hit with axes or swords"] = {
+		flag("Condition:CanGainRage"),
+	},
 	["gain %d+ rage when hit by an enemy"] = {
 		flag("Condition:CanGainRage"),
 	},


### PR DESCRIPTION
Fixes #7148 .

### Description of the problem being solved:
Previously Rage Vortex config did not default to maximum value if no value was entered.

- Added default value relative to character's maximum rage and rage vortex quality
- Updated rage vortex config label

### Steps taken to verify a working solution:
- Checked correct values at multiple values of maximum rage and gem quality
- Tested with minimalist build example (below) and build without rage vortex equipped


### Link to a build that showcases this PR:
https://pobb.in/B-dn7h3HSJog
Changing maximum rage, gem quality, and amount of rage sacrificed will show correct calculations.
e.g.
Max rage at 45, no value given, at 20% quality (25% sacrificed): 11 sacrificed
is equal to if value were manually input as 11
Changing quality to 0% (20% sacrificed) at 45 max rage: 9 sacrificed
is equivalent to inputting 9 sacrificed

### Before screenshot:
![image](https://github.com/user-attachments/assets/b2e886d6-12ba-4a73-81d9-6364ba4a284a)


### After screenshot:
![image](https://github.com/user-attachments/assets/54c156fd-08b6-44a2-b03e-eb4e8b37a501)

