### PR TITLE
Enable recursive copyTable for ConfigSet Fix #7852

### DIFF
--- a/src/Classes/ConfigSetListControl.lua
+++ b/src/Classes/ConfigSetListControl.lua
@@ -12,7 +12,7 @@ local ConfigSetListClass = newClass("ConfigSetListControl", "ListControl", funct
 	self.configTab = configTab
 	self.controls.copy = new("ButtonControl", {"BOTTOMLEFT",self,"TOP"}, 2, -4, 60, 18, "Copy", function()
 		local configSet = configTab.configSets[self.selValue]
-		local newConfigSet = copyTable(configSet, true)
+		local newConfigSet = copyTable(configSet)
 		newConfigSet.id = 1
 		while configTab.configSets[newConfigSet.id] do
 			newConfigSet.id = newConfigSet.id + 1


### PR DESCRIPTION
Fixes #7852 .

When you select a config set and hit the copy button, that action copy the top object but keep reference for internal tables.
![image](https://github.com/user-attachments/assets/7bf45295-b326-4cf2-b467-cab4f9f36db8)

This MR allow to do copyTable in deep mode
![image](https://github.com/user-attachments/assets/5316506f-90f5-4ecf-9e7f-2dc0a0c08c92)
