### PR TITLE
Change ArcaneSurge cast speed increase to ModFlag.Cast

### DIFF
--- a/src/Modules/CalcPerform.lua
+++ b/src/Modules/CalcPerform.lua
@@ -598,7 +598,7 @@ local function doActorMisc(env, actor)
 			modDB.conditions["AffectedByArcaneSurge"] = true
 			local effect = 1 + modDB:Sum("INC", nil, "ArcaneSurgeEffect", "BuffEffectOnSelf") / 100
 			modDB:NewMod("ManaRegen", "INC", (modDB:Max(nil, "ArcaneSurgeManaRegen") or 30) * effect, "Arcane Surge")
-			modDB:NewMod("Speed", "INC", (modDB:Max(nil, "ArcaneSurgeCastSpeed") or 10) * effect, "Arcane Surge", ModFlag.Spell)
+			modDB:NewMod("Speed", "INC", (modDB:Max(nil, "ArcaneSurgeCastSpeed") or 10) * effect, "Arcane Surge", ModFlag.Cast)
 			local arcaneSurgeDamage = modDB:Max(nil, "ArcaneSurgeDamage") or 0
 			if arcaneSurgeDamage ~= 0 then modDB:NewMod("Damage", "MORE", arcaneSurgeDamage * effect, "Arcane Surge", ModFlag.Spell) end
 		end


### PR DESCRIPTION
Fixes #7869 .

### Description of the problem being solved:

Arcane Surge cast speed increase was tagged as `ModFlag.Spell`, being the only Speed increase tagged like this.

Changed it to `ModFlag.Cast`, which allows Wilma's Requitals "Increases and Reductions to Cast Speed apply to Attack Speed" to use the Arcane Surge cast speed.


### Link to a build that showcases this PR:

https://pobb.in/vaSKByGO7J4G

Toggling Arcane Surge in config will change the attack speed of Kinetic Bolt after fix.

Tested against an involved Hierophant PoB using Arcane Surge effects, could not find any difference.

