### PR TITLE
Add automatic calculation for Rage sacrificed when using Rage Vortex

### DIFF
--- a/src/Data/Skills/act_str.lua
+++ b/src/Data/Skills/act_str.lua
@@ -7789,6 +7789,16 @@ skills["RageVortex"] = {
 	},
 	statDescriptionScope = "skill_stat_descriptions",
 	castTime = 1,
+	preDamageFunc = function(activeSkill, output)
+		if activeSkill.skillPart == 2 then
+			local maxRage = activeSkill.skillModList:Sum("BASE", activeSkill.skillCfg, "MaximumRage")
+			local rageVortexSacrificePercentage = activeSkill.skillData.MaxRageVortexSacrificePercentage / 100
+			local configOverride= activeSkill.skillModList:Sum("BASE", activeSkill.skillCfg, "Multiplier:RageSacrificedStacks")
+			local maxSacrificedRage = math.floor(rageVortexSacrificePercentage * maxRage)
+			local stacks = math.min((configOverride > 0 and configOverride) or maxSacrificedRage, maxSacrificedRage)
+			activeSkill.skillModList:NewMod("Multiplier:RageSacrificed", "BASE", stacks, "Skill:RageVortex")
+		end
+	end,
 	parts = {
 		{
 			name = "Melee",
@@ -7815,7 +7825,7 @@ skills["RageVortex"] = {
 			mod("Speed", "MORE", nil, 0, 0, { type = "SkillPart", skillPart = 2 }),
 		},
 		["rage_slash_sacrifice_rage_%"] = {
-			mod("Multiplier:MaxRageVortexSacrificePercentage", "BASE", nil),
+			skill("MaxRageVortexSacrificePercentage", nil),
 		},
 		["quality_display_rage_vortex_is_gem"] = {
 			-- Display only

--- a/src/Export/Skills/act_str.txt
+++ b/src/Export/Skills/act_str.txt
@@ -1446,6 +1446,16 @@ local skills, mod, flag, skill = ...
 
 #skill RageVortex
 #flags attack melee area duration
+	preDamageFunc = function(activeSkill, output)
+		if activeSkill.skillPart == 2 then
+			local maxRage = activeSkill.skillModList:Sum("BASE", activeSkill.skillCfg, "MaximumRage")
+			local rageVortexSacrificePercentage = activeSkill.skillData.MaxRageVortexSacrificePercentage / 100
+			local configOverride= activeSkill.skillModList:Sum("BASE", activeSkill.skillCfg, "Multiplier:RageSacrificedStacks")
+			local maxSacrificedRage = math.floor(rageVortexSacrificePercentage * maxRage)
+			local stacks = math.min((configOverride > 0 and configOverride) or maxSacrificedRage, maxSacrificedRage)
+			activeSkill.skillModList:NewMod("Multiplier:RageSacrificed", "BASE", stacks, "Skill:RageVortex")
+		end
+	end,
 	parts = {
 		{
 			name = "Melee",
@@ -1472,7 +1482,7 @@ local skills, mod, flag, skill = ...
 			mod("Speed", "MORE", nil, 0, 0, { type = "SkillPart", skillPart = 2 }),
 		},
 		["rage_slash_sacrifice_rage_%"] = {
-			mod("Multiplier:MaxRageVortexSacrificePercentage", "BASE", nil),
+			skill("MaxRageVortexSacrificePercentage", nil),
 		},
 		["quality_display_rage_vortex_is_gem"] = {
 			-- Display only

--- a/src/Modules/ConfigOptions.lua
+++ b/src/Modules/ConfigOptions.lua
@@ -486,8 +486,8 @@ return {
 		end
 	end },
 	{ label = "Rage Vortex:", ifSkill = "Rage Vortex" },
-	{ var = "sacrificedRageCount", type = "count", label = "Amount of Rage Sacrificed?", ifSkill = "Rage Vortex", apply = function(val, modList, enemyModList)
-		modList:NewMod("Multiplier:RageSacrificed", "BASE", val, "Config")
+	{ var = "sacrificedRageCount", type = "count", label = "Amount of ^xFF9922Rage ^7Sacrificed (if not maximum):", ifSkill = "Rage Vortex", apply = function(val, modList, enemyModList)
+		modList:NewMod("Multiplier:RageSacrificedStacks", "BASE", val, "Config")
 	end },
 	{ label = "Raise Spectre:", ifSkill = "Raise Spectre", includeTransfigured = true },
 	{ var = "raiseSpectreEnableBuffs", type = "check", defaultState = true, label = "Enable buffs:", ifSkill = "Raise Spectre", includeTransfigured = true, tooltip = "Enable any buff skills that your spectres have.", apply = function(val, modList, enemyModList)


### PR DESCRIPTION
Adds support for Automatic calc of maximum Rage sacrificed by Rage Vortex
Also allows you to overwrite the value with a config if needed
Fixes #7148