### PR TITLE
Fix crash caused by intuitive leap-like being socketed in cluster socket

### DIFF
--- a/src/Classes/PassiveSpec.lua
+++ b/src/Classes/PassiveSpec.lua
@@ -887,7 +887,7 @@ function PassiveSpecClass:NodesInIntuitiveLeapLikeRadius(node)
 		local radiusIndex = item.jewelRadiusIndex
 		if item and item.jewelData and item.jewelData.intuitiveLeapLike then
 			local inRadius = self.nodes[node.id].nodesInRadius and self.nodes[node.id].nodesInRadius[radiusIndex]
-			for affectedNodeId, affectedNode in pairs(inRadius) do
+			for affectedNodeId, affectedNode in pairs(inRadius or {}) do
 				if self.nodes[affectedNodeId].alloc then
 					t_insert(result, self.nodes[affectedNodeId])
 				end


### PR DESCRIPTION
Fixes #7876

Accounts for Intuitive Leap-like jewels which have no radius due to being socketed in a cluster socket.
