### PR TITLE
Use less whitespace in the PlayerProgress box

### DIFF
--- a/src/Modules/Build.lua
+++ b/src/Modules/Build.lua
@@ -1049,7 +1049,7 @@ function buildMode:EstimatePlayerProgress()
 	if SecondaryAscUsed > secondaryAscMax then InsertIfNew(self.controls.warnings.lines, "You have too many secondary ascendancy points allocated") end
 	self.Act = level < 90 and act <= 10 and act or "Endgame"
 	
-	return string.format("%s%3d / %3d   %s%d / %d", PointsUsed > usedMax and colorCodes.NEGATIVE or "^7", PointsUsed, usedMax, AscUsed > ascMax and colorCodes.NEGATIVE or "^7", AscUsed, ascMax),
+	return string.format("%s%d/%d %s%d/%d", PointsUsed > usedMax and colorCodes.NEGATIVE or "^7", PointsUsed, usedMax, AscUsed > ascMax and colorCodes.NEGATIVE or "^7", AscUsed, ascMax),
 		"Required Level: "..level.."\nEstimated Progress:\nAct: "..self.Act.."\nQuestpoints: "..acts[act].questPoints.."\nExtra Skillpoints: "..actExtra(act, extra)..labSuggest
 end
 


### PR DESCRIPTION

### Before screenshots:
![image](https://github.com/user-attachments/assets/a40bb588-ccf7-47b5-a1fb-cdde7148a20e)
![image](https://github.com/user-attachments/assets/ad6e51c1-6bd6-4a80-b26f-528f271a2053)

### After screenshots:
![image](https://github.com/user-attachments/assets/18a2cf89-7ba5-4474-8794-a940af9b0838)
![image](https://github.com/user-attachments/assets/c3bddab2-55d6-4432-afac-6f5e0d387b78)



### Note
The padding between "Save As" and this box can probably be trimmed down a little.