### PR TITLE
Fix Cleave of Rage area not scaling with Rage effect

### DIFF
--- a/src/Data/Skills/act_str.lua
+++ b/src/Data/Skills/act_str.lua
@@ -1668,7 +1668,7 @@ skills["CleaveAltX"] = {
 			flag("Condition:CanGainRage", { type = "GlobalEffect", effectType = "Buff" }),
 		},
 		["chain_strike_cone_radius_+_per_x_rage"] = {
-			mod("AreaOfEffect", "BASE", nil, 0, 0, { type = "Multiplier", var = "Rage", div = 5 }),
+			mod("AreaOfEffect", "BASE", nil, 0, 0, { type = "Multiplier", var = "RageEffect", div = 5 }),
 			div = 5,
 		},
 		["quality_display_chain_hook_is_gem"] = {

--- a/src/Export/Skills/act_str.txt
+++ b/src/Export/Skills/act_str.txt
@@ -334,7 +334,7 @@ local skills, mod, flag, skill = ...
 			flag("Condition:CanGainRage", { type = "GlobalEffect", effectType = "Buff" }),
 		},
 		["chain_strike_cone_radius_+_per_x_rage"] = {
-			mod("AreaOfEffect", "BASE", nil, 0, 0, { type = "Multiplier", var = "Rage", div = 5 }),
+			mod("AreaOfEffect", "BASE", nil, 0, 0, { type = "Multiplier", var = "RageEffect", div = 5 }),
 			div = 5,
 		},
 		["quality_display_chain_hook_is_gem"] = {


### PR DESCRIPTION
Fixes #7795
Hope I didn't break anything, I just mimicked your changes to other 'per x rage' stats. 

POB for posterity: https://pobb.in/IM7VlUeN5ZoY
has 100 rage (+25 max in custom to simulate new warcry)
and 100% rage effect from lvl 11 berserk + rite of ruin


Before: 
![image](https://github.com/user-attachments/assets/6ef1695f-a77c-4f52-87b4-4127c734ab9c)

After:
![image](https://github.com/user-attachments/assets/212d94d6-8386-4b18-add2-e4f510ae02ee)


