### PR TITLE
Disable Non-Instant Life Leech with Strength of Blood

### DIFF
--- a/src/Modules/CalcOffence.lua
+++ b/src/Modules/CalcOffence.lua
@@ -3535,6 +3535,12 @@ function calcs.offence(env, actor, activeSkill)
 		output.LifeLeechRate = 0
 		output.LifeLeechPerHit = 0
 	end
+	-- Disable non-instant life leech
+	if skillModList:Flag(nil, "UnaffectedByNonInstantLifeLeech") then
+		output.LifeLeechRate = 0
+		output.LifeLeechPerHit = 0
+		output.LifeLeechInstances = 0
+	end
 	output.LifeLeechRate = output.LifeLeechInstantRate + m_min(output.LifeLeechRate, output.MaxLifeLeechRate) * output.LifeRecoveryRateMod
 	output.LifeLeechPerHit = output.LifeLeechInstant + m_min(output.LifeLeechPerHit, output.MaxLifeLeechRate) * output.LifeLeechDuration * output.LifeRecoveryRateMod
 	output.EnergyShieldLeechRate = output.EnergyShieldLeechInstantRate + m_min(output.EnergyShieldLeechRate, output.MaxEnergyShieldLeechRate) * output.EnergyShieldRecoveryRateMod

--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -1970,6 +1970,7 @@ local specialModList = {
 	["(%d+)%% less damage taken for every (%d+)%% life recovery per second from leech"] = function(num, _, div)
 		return { mod("DamageTaken", "MORE", -num, { type = "PerStat", stat = "MaxLifeLeechRatePercent", div = tonumber(div) }) }
 	end,
+	["(%w+) recovery from non%-instant leech is not applied"] = function(_, type) return { flag("UnaffectedByNonInstant" .. firstToUpper(type) .. "Leech") } end,
 	["(%d+)%% additional physical damage reduction for every (%d+)%% life recovery per second from leech"] = function(num, _, div)
 		return { mod("PhysicalDamageReduction", "BASE", num, { type = "PerStat", stat = "MaxLifeLeechRatePercent", div = tonumber(div) }, { type = "Condition", var = "Leeching"}) }
 	end,


### PR DESCRIPTION
Fixes # .

### Description of the problem being solved:
Adds support for the line "Life Recovery from Non-Instant Leech is not applied" from the Strength of Blood keystone

### Steps taken to verify a working solution:
- Add source of life leech and source of instant life leech
- Add Strength of Blood of blood to a build
- Verify only Instant Life Leech is part of Life Leech Rate in calcs

### Link to a build that showcases this PR:
https://pobb.in/7kckh4cytUcH
Disabled imperial claws life gain on hit to make instant leech easier to identify

### Without Strength of Blood:
![image](https://github.com/user-attachments/assets/0c97355d-6b37-492b-850f-930939f20e4b)


### With Strength of Blood:
![image](https://github.com/user-attachments/assets/6d5e83d9-d9e5-450e-a53b-ec16f6985741)

