### PR TITLE
- Update skill gem description for Puncture

### DIFF
--- a/src/Data/Skills/act_dex.lua
+++ b/src/Data/Skills/act_dex.lua
@@ -11455,7 +11455,7 @@ skills["Puncture"] = {
 	color = 2,
 	baseEffectiveness = 0.6700000166893,
 	incrementalEffectiveness = 0.023299999535084,
-	description = "Punctures enemies, causing a bleeding debuff, which will be affected by modifiers to skill duration. Puncture works with bows, daggers, claws or swords.",
+	description = "Punctures enemies with your Bow, causing a bleeding debuff, which will be affected by modifiers to skill duration.",
 	skillTypes = { [SkillType.Attack] = true, [SkillType.RangedAttack] = true, [SkillType.MirageArcherCanUse] = true, [SkillType.Projectile] = true, [SkillType.ProjectilesFromUser] = true, [SkillType.Duration] = true, [SkillType.Trappable] = true, [SkillType.Mineable] = true, [SkillType.Totemable] = true, [SkillType.MeleeSingleTarget] = true, [SkillType.Multistrikeable] = true, [SkillType.Melee] = true, [SkillType.DamageOverTime] = true, [SkillType.Triggerable] = true, [SkillType.Physical] = true, },
 	weaponTypes = {
 		["Bow"] = true,


### PR DESCRIPTION
Fixes # .

### Description of the problem being solved:
Updating the Skill gem description for Puncture, so it matches the new description announced by GGG. Also makes it match the actual weapon requirement already changed for the skill gem.

### Steps taken to verify a working solution:
-
-
-

### Link to a build that showcases this PR:

### Before screenshot:

### After screenshot:
