### PR TITLE
Dark seer missing global chance to blind on hit

### DIFF
--- a/src/Data/Uniques/mace.lua
+++ b/src/Data/Uniques/mace.lua
@@ -375,7 +375,7 @@ Implicits: 2
 {variant:6,7,8}(40-60)% increased Global Damage
 {variant:9,10,11}+2 to Level of All Spell Skill Gems
 {variant:1,2,3,4,5}7% Global chance to Blind Enemies on hit
-{variant:6,7,8}10% Global chance to Blind Enemies on hit
+{variant:6,7,8,9,10,11}10% Global chance to Blind Enemies on hit
 Blind does not affect your Chance to Hit
 Enemies Blinded by you have Malediction
 {variant:1,2}Gain 1 Mana on Kill per Level


### PR DESCRIPTION
Fixes #7933.

### Description of the problem being solved:
Dark Seer is missing global chance to blind on hit

### Before screenshot:
![image](https://github.com/user-attachments/assets/a02bda2e-7e8b-483b-93f2-69eb3ecc57fd)

### After screenshot:
![image](https://github.com/user-attachments/assets/02ef7bcf-5a86-4400-b8a4-a0f2130ce1d1)
