### PR TITLE
Fixed monster explosion ignite divide by 0 calculation error

### DIFF
--- a/src/Modules/CalcOffence.lua
+++ b/src/Modules/CalcOffence.lua
@@ -4354,7 +4354,7 @@ function calcs.offence(env, actor, activeSkill)
 				if output.Cooldown then
 					igniteStacks = ((output.HitChance / 100) * globalOutput.IgniteDuration / m_max(output.Cooldown, (output.HitTime or output.Time)) * skillData.dpsMultiplier) / maxStacks
 				else
-					igniteStacks = ((output.HitChance / 100) * globalOutput.IgniteDuration / (globalOutput.HitTime or output.Time) * skillData.dpsMultiplier) / maxStacks
+					igniteStacks = m_min(((output.HitChance / 100) * globalOutput.IgniteDuration / (globalOutput.HitTime or output.Time) * skillData.dpsMultiplier), 0) / maxStacks
 				end
 			end
 			igniteStacks = overrideStackPotential or igniteStacks or 1
@@ -4518,7 +4518,7 @@ function calcs.offence(env, actor, activeSkill)
 				local effectMod = calcLib.mod(skillModList, dotCfg, "AilmentEffect")
 				igniteStacks = 1
 				if not skillData.triggeredOnDeath then
-					igniteStacks = m_min(maxStacks, skillModList:Override(nil, "IgniteStackPotentialOverride") or (output.HitChance / 100) * globalOutput.IgniteDuration / (globalOutput.HitTime or output.Time))
+					igniteStacks = m_min(maxStacks, skillModList:Override(nil, "IgniteStackPotentialOverride") or m_max((output.HitChance / 100) * globalOutput.IgniteDuration / (globalOutput.HitTime or output.Time), 0))
 				end
 				local IgniteDPSUncapped = baseVal * effectMod * rateMod * igniteStacks * effMult
 				local IgniteDPSCapped = m_min(IgniteDPSUncapped, data.misc.DotDpsCap)


### PR DESCRIPTION
Fixes #7912.

### Description of the problem being solved:
There are some divisible-by-0 calculation errors for monster explosions (such as chieftain, occultist, and gladiator ascendency). The "On Kill Monster Explosion" skill seems to have a cast time of 0, and causes some stats to be `nan` or `inf`.
When the ignite duration is 0 seconds, the ignite DPS becomes `inf`, thus reaching dot cap.

I'm worried that the 0 cast speed for monster explosions would cause any other existing or future issues, but here's the bandage fix for the ignite problem caused by it.

### Steps taken to verify a working solution:
- Any explosion effect (from gear or ascendency) that has fire damage 
- See Calc tab for ignite details

### Link to a build that showcases this PR:
https://pobb.in/dbGiJENwcvZX
### Before screenshot:
![image](https://github.com/user-attachments/assets/0c99f178-a07f-4a59-adca-b12988b0c7f5)

### After screenshot:
![image](https://github.com/user-attachments/assets/3425bf3c-e98e-4fc0-970e-e1b69e1f572c)