### PR TITLE
Added modType to CalcSections config for DotMultiplier

### DIFF
--- a/src/Modules/CalcSections.lua
+++ b/src/Modules/CalcSections.lua
@@ -438,7 +438,7 @@ return {
 		{ format = "{0:mod:1}%", { modName = "ChaosDamage", modType = "MORE", cfg = "dotChaos" }, },
 	},
 	{ label = "Total Multiplier",
-		{ format = "{0:mod:1}%", { modName = "DotMultiplier", cfg = "dot" }, },
+		{ format = "{0:mod:1}%", { modName = "DotMultiplier", modType = "BASE", cfg = "dot" }, },
 		{ format = "{0:mod:1}%", { modName = "PhysicalDotMultiplier", modType = "BASE", cfg = "dotPhysical" }, },
 		{ format = "{0:mod:1}%", { modName = "LightningDotMultiplier", modType = "BASE", cfg = "dotLightning" }, },
 		{ format = "{0:mod:1}%", { modName = "ColdDotMultiplier", modType = "BASE", cfg = "dotCold" }, },


### PR DESCRIPTION
Fixes #7956.

### Description of the problem being solved:

Damage over time calc section was not showing a value for the Dot Multiplier total despite calculating the damage correctly.

### Steps taken to verify a working solution:
- Created a test build that includes the Blight of Contagion skill and a few damage over time multiplier passives.

### Link to a build that showcases this PR:

https://pobb.in/W2bTRwTfLHG2

### Before screenshot:
![image](https://github.com/user-attachments/assets/bf68e7e2-312a-4b1f-8d46-7986d817649f)


### After screenshot:
![image](https://github.com/user-attachments/assets/c8a2af39-03e5-43df-a86f-64fd29268d36)

