### PR TITLE
Fix Scorch on Ignite Crit Chance

### DIFF
--- a/src/Modules/CalcOffence.lua
+++ b/src/Modules/CalcOffence.lua
@@ -3645,7 +3645,11 @@ function calcs.offence(env, actor, activeSkill)
 				output[ailment.."ChanceOnHit"] = m_min(100, chance)
 				if skillModList:Flag(cfg, "CritsDontAlways"..ailment) -- e.g. Painseeker
 				or (ailmentData[ailment] and ailmentData[ailment].alt and not skillModList:Flag(cfg, "CritAlwaysAltAilments")) then -- e.g. Secrets of Suffering
-					output[ailment.."ChanceOnCrit"] = output[ailment.."ChanceOnHit"]
+					if ailment == "Scorch" and env.modDB:Flag(nil, "IgniteCanScorch") then
+						output["ScorchChanceOnCrit"] = 100
+					else
+						output[ailment.."ChanceOnCrit"] = output[ailment.."ChanceOnHit"]
+					end
 				else
 					output[ailment.."ChanceOnCrit"] = 100
 				end


### PR DESCRIPTION
Fixes #7900 .
Corrected the calculation for Scorch chance on critical hits when Ignite can trigger Scorch. This ensures Scorch gets a 100% chance in such scenarios.

### Description of the problem being solved:
When Ignite was converted to Scorch, the Scorch chance on crit was not updated in Calcs to reflect that Scorch now applies on crit.

### Steps taken to verify a working solution:
- Verify current state, Scorch does not have 100% chance to apply on crit according to Calcs
- Make changes
- Compare pre and post calculations for Scorch and other ailments/alt-ailments
- Deallocate Oath of Summer and gain Scorch from another source to ensure that values are as expected

### Link to a build that showcases this PR:

Provided in original issue:
https://pobb.in/_wT1ioEzlZ-e

Test Build (Remove Oath of Summer node, add Flamesight helmet):
https://pobb.in/_LPrC81NR2su

### Before screenshot:

Provided build:

![](https://i.imgur.com/M2mpogR.png)

![](https://i.imgur.com/jJuNq39.png)


### After screenshot:

Provided build:

![](https://i.imgur.com/MX98rvM.png)

![](https://i.imgur.com/qi9EomM.png)


Test Build (Ensure Chance on Crit for Scorch maintains original functionality when not interacting with Scorch on Ignite):

![](https://i.imgur.com/Y9wQ1S5.png)