### PR TITLE
Add Scorch chance on crit for Warden's Oath of Summer

### DIFF
--- a/src/Modules/CalcOffence.lua
+++ b/src/Modules/CalcOffence.lua
@@ -3653,6 +3653,10 @@ function calcs.offence(env, actor, activeSkill)
 				output[ailment.."ChanceOnHit"] = 0
 				output[ailment.."ChanceOnCrit"] = 0
 			end
+			-- Warden's Oath of Summer Scorch on Crit Chance
+			if ailment == "Scorch" and env.modDB:Flag(nil, "IgniteCanScorch") then
+				output["ScorchChanceOnCrit"] = 100
+			end
 			if (output[ailment.."ChanceOnHit"] + (skillModList:Flag(cfg, "NeverCrit") and 0 or output[ailment.."ChanceOnCrit"])) > 0 then
 				skillFlags["inflict"..ailment] = true
 			end


### PR DESCRIPTION
Fixes #7900 .
Implemented a condition to set "ScorchChanceOnCrit" to 100% when "IgniteCanScorch" flag is active. This ensures the Scorch ailment is applied on critical hits when using the Warden's Oath of Summer.

### Description of the problem being solved:
When Ignite was converted to Scorch, the Scorch chance on crit was not updated in Calcs to reflect that Scorch now applies on crit.

### Steps taken to verify a working solution:
- Verify current state, Scorch does not have 100% chance to apply on crit according to Calcs
- Make changes
- Compare pre and post calculations for Scorch and other ailments/alt-ailments
- Deallocate Oath of Summer and gain Scorch from another source to ensure that values are as expected

### Link to a build that showcases this PR:

Provided in original issue:
https://pobb.in/_wT1ioEzlZ-e

Test Build (Remove Oath of Summer node, add Flamesight helmet):
https://pobb.in/_LPrC81NR2su

### Before screenshot:

Provided build:

![](https://i.imgur.com/M2mpogR.png)

![](https://i.imgur.com/jJuNq39.png)


### After screenshot:

Provided build:

![](https://i.imgur.com/MX98rvM.png)

![](https://i.imgur.com/qi9EomM.png)


Test Build (Ensure Chance on Crit for Scorch maintains original functionality when not interacting with Scorch on Ignite):

![](https://i.imgur.com/Y9wQ1S5.png)