### PR TITLE
Fix damage calculation when using both Autoexertion and Echoes of Creation

### DIFF
--- a/src/Data/ModCache.lua
+++ b/src/Data/ModCache.lua
@@ -10484,8 +10484,8 @@ c["Skills Supported by Nightblade have 40% increased Effect of Elusive"]={{[1]={
 c["Skills Supported by Unleash have 30% increased Seal gain frequency"]={{[1]={flags=0,keywordFlags=0,name="SealGainFrequency",type="INC",value=30}},nil}
 c["Skills Supported by Unleash have 40% increased Seal gain frequency"]={{[1]={flags=0,keywordFlags=0,name="SealGainFrequency",type="INC",value=40}},nil}
 c["Skills Supported by Unleash have 50% increased Seal gain frequency"]={{[1]={flags=0,keywordFlags=0,name="SealGainFrequency",type="INC",value=50}},nil}
-c["Skills deal 13% more Damage for each Warcry Exerting them"]={{[1]={flags=0,keywordFlags=0,name="ExertAverageIncrease",type="MORE",value=13}},nil}
-c["Skills deal 15% more Damage for each Warcry Exerting them"]={{[1]={flags=0,keywordFlags=0,name="ExertAverageIncrease",type="MORE",value=15}},nil}
+c["Skills deal 13% more Damage for each Warcry Exerting them"]={{[1]={flags=0,keywordFlags=0,name="EchoesExertAverageIncrease",type="MORE",value=13}},nil}
+c["Skills deal 15% more Damage for each Warcry Exerting them"]={{[1]={flags=0,keywordFlags=0,name="EchoesExertAverageIncrease",type="MORE",value=15}},nil}
 c["Skills fire 2 additional Projectiles"]={{[1]={flags=0,keywordFlags=0,name="ProjectileCount",type="BASE",value=2}},nil}
 c["Skills fire 2 additional Projectiles during Effect"]={{[1]={[1]={type="Condition",var="UsingFlask"},flags=0,keywordFlags=0,name="ProjectileCount",type="BASE",value=2}},nil}
 c["Skills fire 2 additional Projectiles if you've been Hit Recently"]={{[1]={[1]={type="Condition",var="BeenHitRecently"},flags=0,keywordFlags=0,name="ProjectileCount",type="BASE",value=2}},nil}

--- a/src/Data/Skills/sup_str.lua
+++ b/src/Data/Skills/sup_str.lua
@@ -4496,7 +4496,7 @@ skills["SupportOverexertion"] = {
 			mod("ExertIncrease", "INC", nil)
 		},
 		["support_overexertion_damage_+%_final_per_warcry_exerting_action"] = {
-			mod("ExertAverageIncrease", "MORE", nil)
+			mod("AutoexertionExertAverageIncrease", "MORE", nil)
 		},
 	},
 	qualityStats = {

--- a/src/Export/Skills/sup_str.txt
+++ b/src/Export/Skills/sup_str.txt
@@ -632,7 +632,7 @@ local skills, mod, flag, skill = ...
 			mod("ExertIncrease", "INC", nil)
 		},
 		["support_overexertion_damage_+%_final_per_warcry_exerting_action"] = {
-			mod("ExertAverageIncrease", "MORE", nil)
+			mod("AutoexertionExertAverageIncrease", "MORE", nil)
 		},
 	},
 #mods

--- a/src/Modules/CalcOffence.lua
+++ b/src/Modules/CalcOffence.lua
@@ -2585,20 +2585,23 @@ function calcs.offence(env, actor, activeSkill)
 					local incExertedAttacks = skillModList:Sum("INC", cfg, "ExertIncrease")
 					local moreExertedAttacks = skillModList:Sum("MORE", cfg, "ExertIncrease")
 					local moreExertedAttackDamage = skillModList:Sum("MORE", cfg, "ExertAttackIncrease")
-					local moreAverageExertedDamage = skillModList:Sum("MORE", cfg, "ExertAverageIncrease")
+					local autoExertionExertedDamage = skillModList:Sum("MORE", cfg, "AutoexertionExertAverageIncrease")
+					local echoesOfCreationExertedDamage = skillModList:Sum("MORE", cfg, "EchoesExertAverageIncrease")
 					if activeSkill.skillModList:Flag(nil, "Condition:WarcryMaxHit") then
 						skillModList:NewMod("Damage", "INC", incExertedAttacks, "Exerted Attacks")
 						skillModList:NewMod("Damage", "MORE", moreExertedAttacks, "Exerted Attacks")
 						skillModList:NewMod("Damage", "MORE", moreExertedAttackDamage, "Exerted Attack Damage", ModFlag.Attack)
-						skillModList:NewMod("Damage", "MORE", moreAverageExertedDamage * warcryCount, "# Warcry Exerting Damage")
+						skillModList:NewMod("Damage", "MORE", autoExertionExertedDamage * warcryCount, "Max Autoexertion Support")
+						skillModList:NewMod("Damage", "MORE", echoesOfCreationExertedDamage * warcryCount, "Max Echoes of Creation")
 					else
 						skillModList:NewMod("Damage", "INC", incExertedAttacks * globalOutput.ExertedAttackUptimeRatio / 100, "Uptime Scaled Exerted Attacks")
 						skillModList:NewMod("Damage", "MORE", moreExertedAttacks * globalOutput.ExertedAttackUptimeRatio / 100, "Uptime Scaled Exerted Attacks")
 						skillModList:NewMod("Damage", "MORE", moreExertedAttackDamage * globalOutput.ExertedAttackUptimeRatio / 100, "Uptime Scaled Exerted Attack Damage", ModFlag.Attack)
-						skillModList:NewMod("Damage", "MORE", moreAverageExertedDamage * globalOutput.GlobalWarcryUptimeRatio / 100, "Uptime Scaled # Warcry Exerting Damage")
+						skillModList:NewMod("Damage", "MORE", autoExertionExertedDamage * globalOutput.GlobalWarcryUptimeRatio / 100, "Uptime Scaled Autoexertion Support")
+						skillModList:NewMod("Damage", "MORE", echoesOfCreationExertedDamage * globalOutput.GlobalWarcryUptimeRatio / 100, "Uptime Scaled Echoes of Creation")
 					end
 					globalOutput.ExertedAttackAvgDmg = calcLib.mod(skillModList, skillCfg, "ExertIncrease")
-					globalOutput.ExertedAttackAvgDmg = globalOutput.ExertedAttackAvgDmg * calcLib.mod(skillModList, skillCfg, "ExertAttackIncrease", "ExertAverageIncrease")
+					globalOutput.ExertedAttackAvgDmg = globalOutput.ExertedAttackAvgDmg * calcLib.mod(skillModList, skillCfg, "ExertAttackIncrease", "AutoexertionExertAverageIncrease", "EchoesExertAverageIncrease")
 					globalOutput.ExertedAttackHitEffect = globalOutput.ExertedAttackAvgDmg * globalOutput.ExertedAttackUptimeRatio / 100
 					globalOutput.ExertedAttackMaxHitEffect = globalOutput.ExertedAttackAvgDmg
 					if globalBreakdown then

--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -4569,7 +4569,7 @@ local specialModList = {
 	["cannot recover energy shield to above evasion rating"] = { flag("EvasionESRecoveryCap") },
 	["warcries exert (%d+) additional attacks?"] = function(num) return { mod("ExtraExertedAttacks", "BASE", num) } end,
 	["warcries have (%d+)%% chance to exert (%d+) additional attacks?"] = function(num, _, var) return { mod("ExtraExertedAttacks", "BASE", (num*var/100)) } end,
-	["skills deal (%d+)%% more damage for each warcry exerting them"] = function(num) return { mod("ExertAverageIncrease", "MORE", num, nil) } end,
+	["skills deal (%d+)%% more damage for each warcry exerting them"] = function(num) return { mod("EchoesExertAverageIncrease", "MORE", num, nil) } end,
 	["iron will"] = { flag("IronWill") },
 	["iron reflexes while stationary"] = { mod("Keystone", "LIST", "Iron Reflexes", { type = "Condition", var = "Stationary" }) },
 	["you have iron reflexes while at maximum frenzy charges"] = { mod("Keystone", "LIST", "Iron Reflexes", { type = "StatThreshold", stat = "FrenzyCharges", thresholdStat = "FrenzyChargesMax" }) },


### PR DESCRIPTION
The More mods were being summed together before being multiplier. This also fixes the terrible breakdown names I previously used
Fixes #8005