### PR TITLE
General Exporter improvements

### DIFF
--- a/src/Export/Classes/GGPKData.lua
+++ b/src/Export/Classes/GGPKData.lua
@@ -36,8 +36,8 @@ local GGPKClass = newClass("GGPKData", function(self, path, datPath)
 		self.oozPath = datPath:match("\\$") and datPath or (datPath .. "\\")
 	else
 		self.path = path
-		self.temp = io.popen("cd"):read('*l'):gsub('\r?', '')
-		self.oozPath = self.temp .. "\\ggpk\\"
+		self.oozPath = io.popen("cd"):read('*l'):gsub('\r?', '') .. "\\ggpk\\"
+		self:CleanDir()
 		self:ExtractFiles()
 	end
 
@@ -51,6 +51,11 @@ local GGPKClass = newClass("GGPKData", function(self, path, datPath)
 	end
 end)
 
+function GGPKClass:CleanDir()
+	local cmd = 'del ' .. self.oozPath .. 'Data ' .. self.oozPath .. 'Metadata /Q /S'
+	ConPrintf(cmd)
+	os.execute(cmd)
+end
 
 function GGPKClass:ExtractFilesWithBun(fileListStr)
 	local cmd = 'cd ' .. self.oozPath .. ' && bun_extract_file.exe extract-files "' .. self.path .. '" . ' .. fileListStr
@@ -268,7 +273,8 @@ function GGPKClass:GetNeededFiles()
 		"Data/Commands.dat",
 		"Data/ModEquivalencies.dat",
 		"Data/InfluenceTags.dat",
-		"Data/InfluenceTypes.dat"
+		"Data/InfluenceTypes.dat",
+		"Data/leaguenames.dat"
 	}
 	local txtFiles = {
 		"Metadata/StatDescriptions/passive_skill_aura_stat_descriptions.txt",

--- a/src/Export/Classes/GGPKData.lua
+++ b/src/Export/Classes/GGPKData.lua
@@ -11,6 +11,7 @@ local function scanDir(directory, extension)
 	local t = { }
 	local pFile = io.popen('dir "'..directory..'" /b')
 	for filename in pFile:lines() do
+		filename = filename:gsub('\r?$', '')
 		--ConPrintf("%s\n", filename)
 		if extension then
 			if filename:match(extension) then
@@ -35,7 +36,7 @@ local GGPKClass = newClass("GGPKData", function(self, path, datPath)
 		self.oozPath = datPath:match("\\$") and datPath or (datPath .. "\\")
 	else
 		self.path = path
-		self.temp = io.popen("cd"):read('*l')
+		self.temp = io.popen("cd"):read('*l'):gsub('\r?', '')
 		self.oozPath = self.temp .. "\\ggpk\\"
 		self:ExtractFiles()
 	end

--- a/src/Export/Classes/GGPKSourceListControl.lua
+++ b/src/Export/Classes/GGPKSourceListControl.lua
@@ -43,6 +43,7 @@ function GGPKSourceListClass:EditDATSource(datSource, newSource)
 		controls.save.enabled = (controls.dat.buf:match("%S") or controls.ggpk.buf:match("%S")) and controls.label.buf:match("%S") and buf:match("%S")
 	end)
 	controls.save = new("ButtonControl", {"TOP",controls.spec,"TOP"}, -45, 22, 80, 20, "Save", function()
+		local reload = datSource.label == main.datSource.label
 		datSource.label = controls.label.buf
 		datSource.ggpkPath = controls.ggpk.buf or ""
 		datSource.datFilePath = controls.dat.buf or ""
@@ -52,7 +53,7 @@ function GGPKSourceListClass:EditDATSource(datSource, newSource)
 			self.selIndex = #self.list
 			self.selValue = datSource
 		end
-		if datSource.label == main.datSource.label then
+		if reload then
 			main:LoadDatSource(datSource)
 		end
 		main:ClosePopup()

--- a/src/Export/Classes/GGPKSourceListControl.lua
+++ b/src/Export/Classes/GGPKSourceListControl.lua
@@ -28,14 +28,16 @@ function GGPKSourceListClass:EditDATSource(datSource, newSource)
 	controls.label = new("EditControl", nil, 85, 20, 180, 20, datSource.label, nil, nil, nil, function(buf)
 		controls.save.enabled = (controls.dat.buf:match("%S") or controls.ggpk.buf:match("%S")) and buf:match("%S")
 	end)
-	controls.ggpkLabel = new("LabelControl", nil, 0, 40, 0, 16, "^7GGPK/Steam PoE path:")
+	controls.ggpkLabel = new("LabelControl", nil, 0, 40, 0, 16, "^7Source from GGPK/Steam PoE path:")
 	controls.ggpk = new("EditControl", {"TOP",controls.ggpkLabel,"TOP"}, 0, 20, 350, 20, datSource.ggpkPath, nil, nil, nil, function(buf)
 		controls.save.enabled = (buf:match("%S") or controls.dat.buf:match("%S")) and controls.label.buf:match("%S") and controls.spec.buf:match("%S")
 	end)
-	controls.datLabel = new("LabelControl", {"TOP",controls.ggpk,"TOP"}, 0, 22, 0, 16, "^7DAT File location:")
+	controls.ggpk.enabled = function() return not controls.dat.buf:match("%S") end
+	controls.datLabel = new("LabelControl", {"TOP",controls.ggpk,"TOP"}, 0, 22, 0, 16, "^7Source from DAT files:")
 	controls.dat = new("EditControl", {"TOP",controls.datLabel,"TOP"}, 0, 20, 350, 20, datSource.datFilePath, nil, nil, nil, function(buf)
 		controls.save.enabled = (buf:match("%S") or controls.ggpk.buf:match("%S")) and controls.label.buf:match("%S") and controls.spec.buf:match("%S")
 	end)
+	controls.dat.enabled = function() return not controls.ggpk.buf:match("%S") end
 	controls.specLabel = new("LabelControl", {"TOP",controls.dat,"TOP"}, 0, 22, 0, 16, "^7Spec File location:")
 	controls.spec = new("EditControl", {"TOP",controls.specLabel,"TOP"}, 0, 20, 350, 20, datSource.spec or "spec.lua", nil, nil, nil, function(buf)
 		controls.save.enabled = (controls.dat.buf:match("%S") or controls.ggpk.buf:match("%S")) and controls.label.buf:match("%S") and buf:match("%S")
@@ -49,6 +51,9 @@ function GGPKSourceListClass:EditDATSource(datSource, newSource)
 			table.insert(self.list, datSource)
 			self.selIndex = #self.list
 			self.selValue = datSource
+		end
+		if datSource.label == main.datSource.label then
+			main:LoadDatSource(datSource)
 		end
 		main:ClosePopup()
 	end)

--- a/src/Export/Main.lua
+++ b/src/Export/Main.lua
@@ -82,6 +82,9 @@ function main:Init()
 		else
 			self:LoadDatFiles()
 		end
+		if self.datFileByName["leaguenames"] then
+			self.leagueLabel = self.datFileByName["leaguenames"]:ReadValueText({ type = "String" }, self.datFileByName["leaguenames"].rows[2] + 8)
+		end
 	end
 
 	self.scriptList = { }
@@ -153,7 +156,7 @@ function main:Init()
 	self.colList = { }
 
 	self.controls.shownLeagueLabel = new("LabelControl", nil, 10, 10, 100, 16, "^7Data from:")
-	self.controls.leagueLabel = new("LabelControl", { "LEFT", self.controls.shownLeagueLabel, "RIGHT"}, 10, 0, 100, 16, function() return self.leagueLabel or "Unknown" end)
+	self.controls.leagueLabel = new("LabelControl", { "LEFT", self.controls.shownLeagueLabel, "RIGHT"}, 10, 0, 100, 16, function() return "^7" .. (self.leagueLabel or "Unknown") end)
 	self.controls.addSource = new("ButtonControl", nil, 10, 30, 100, 18, "Edit Sources...", function()
 		self.OpenPathPopup()
 	end)
@@ -343,6 +346,9 @@ function main:LoadDatSource(value)
 	else
 		self:LoadDatFiles()
 	end
+	if self.datFileByName["leaguenames"] then
+		self.leagueLabel = self.datFileByName["leaguenames"]:ReadValueText({ type = "String" }, self.datFileByName["leaguenames"].rows[2] + 8)
+	end
 end
 
 function main:OpenPathPopup()
@@ -441,19 +447,6 @@ function main:LoadDatFiles()
 			now = GetTime()
 		end
 		local datFile = new("DatFile", record.name:gsub("%.dat$",""), record.data)
-		if record.name:match("leaguenames%.dat") then
-			if not datFile.spec[2] or not datFile.spec[2].type then
-				datFile.spec = {
-					{
-						type = "String"
-					},
-					{
-						type = "String"
-					}
-				}
-			end
-			self.leagueLabel = datFile:ReadCellText(2, 2)
-		end
 		t_insert(self.datFileList, datFile)
 		self.datFileByName[datFile.name] = datFile
 	end
@@ -468,19 +461,6 @@ function main:LoadDat64Files()
 			now = GetTime()
 		end
 		local datFile = new("Dat64File", record.name:gsub("%.dat64$",""), record.data)
-		if record.name:match("leaguenames%.dat64") then
-			if not datFile.spec[2] or not datFile.spec[2].type then
-				datFile.spec = {
-					{
-						type = "String"
-					},
-					{
-						type = "String"
-					}
-				}
-			end
-			self.leagueLabel = datFile:ReadCellText(2, 2)
-		end
 		t_insert(self.datFileList, datFile)
 		self.datFileByName[datFile.name] = datFile
 	end

--- a/src/Export/Main.lua
+++ b/src/Export/Main.lua
@@ -416,7 +416,7 @@ function main:InitGGPK()
 		return
 	else
 		local now = GetTime()
-		local ggpkPath = self.datSource.ggpkPath or self.datSource.datFilePath
+		local ggpkPath = self.datSource.ggpkPath
 		if ggpkPath then
 			self.ggpk = new("GGPKData", ggpkPath)
 			ConPrintf("GGPK: %d ms", GetTime() - now)


### PR DESCRIPTION
Dat files stopped appearing in my exporter due to `\r` appearing when Lua used `cd`.  Not sure if anyone else has this bug, but this fix should be relatively safe for everyone.

This also fixes:

- a dead branch that I believe was causing issues loading a saved spec
- Unclear wording and ability to enter both a DAT file location and a GGPK location
- Editing the current DatSource doesn't reload the data
- Old DAT files were sticking around even if the newly parsed ggpk didn't contain them