### PR TITLE
Fix autoexertion not triggering supported skills

### DIFF
--- a/src/Data/Skills/sup_str.lua
+++ b/src/Data/Skills/sup_str.lua
@@ -4496,7 +4496,7 @@ skills["SupportOverexertion"] = {
 			mod("ExertIncrease", "INC", nil)
 		},
 		["support_overexertion_damage_+%_final_per_warcry_exerting_action"] = {
-			mod("AutoexertionExertAverageIncrease", "MORE", nil)
+			mod("OverexertionExertAverageIncrease", "MORE", nil)
 		},
 	},
 	qualityStats = {

--- a/src/Export/Skills/sup_str.txt
+++ b/src/Export/Skills/sup_str.txt
@@ -632,7 +632,7 @@ local skills, mod, flag, skill = ...
 			mod("ExertIncrease", "INC", nil)
 		},
 		["support_overexertion_damage_+%_final_per_warcry_exerting_action"] = {
-			mod("AutoexertionExertAverageIncrease", "MORE", nil)
+			mod("OverexertionExertAverageIncrease", "MORE", nil)
 		},
 	},
 #mods

--- a/src/Modules/CalcOffence.lua
+++ b/src/Modules/CalcOffence.lua
@@ -2585,7 +2585,7 @@ function calcs.offence(env, actor, activeSkill)
 					local incExertedAttacks = skillModList:Sum("INC", cfg, "ExertIncrease")
 					local moreExertedAttacks = skillModList:Sum("MORE", cfg, "ExertIncrease")
 					local moreExertedAttackDamage = skillModList:Sum("MORE", cfg, "ExertAttackIncrease")
-					local autoExertionExertedDamage = skillModList:Sum("MORE", cfg, "AutoexertionExertAverageIncrease")
+					local autoExertionExertedDamage = skillModList:Sum("MORE", cfg, "OverexertionExertAverageIncrease")
 					local echoesOfCreationExertedDamage = skillModList:Sum("MORE", cfg, "EchoesExertAverageIncrease")
 					if activeSkill.skillModList:Flag(nil, "Condition:WarcryMaxHit") then
 						skillModList:NewMod("Damage", "INC", incExertedAttacks, "Exerted Attacks")
@@ -2601,7 +2601,7 @@ function calcs.offence(env, actor, activeSkill)
 						skillModList:NewMod("Damage", "MORE", echoesOfCreationExertedDamage * globalOutput.GlobalWarcryUptimeRatio / 100, "Uptime Scaled Echoes of Creation")
 					end
 					globalOutput.ExertedAttackAvgDmg = calcLib.mod(skillModList, skillCfg, "ExertIncrease")
-					globalOutput.ExertedAttackAvgDmg = globalOutput.ExertedAttackAvgDmg * calcLib.mod(skillModList, skillCfg, "ExertAttackIncrease", "AutoexertionExertAverageIncrease", "EchoesExertAverageIncrease")
+					globalOutput.ExertedAttackAvgDmg = globalOutput.ExertedAttackAvgDmg * calcLib.mod(skillModList, skillCfg, "ExertAttackIncrease", "OverexertionExertAverageIncrease", "EchoesExertAverageIncrease")
 					globalOutput.ExertedAttackHitEffect = globalOutput.ExertedAttackAvgDmg * globalOutput.ExertedAttackUptimeRatio / 100
 					globalOutput.ExertedAttackMaxHitEffect = globalOutput.ExertedAttackAvgDmg
 					if globalBreakdown then

--- a/src/Modules/CalcTriggers.lua
+++ b/src/Modules/CalcTriggers.lua
@@ -1152,6 +1152,19 @@ local configTable = {
 					return skill.activeEffect.grantedEffect.name == "Call to Arms"
 				end}
 	end,
+	["autoexertion"] = function(env)
+		if env.player.mainSkill.activeEffect.grantedEffect.name == "Autoexertion" then
+			env.player.mainSkill.skillFlags.globalTrigger = true
+			return {source = env.player.mainSkill}
+		end
+		env.player.mainSkill.skillData.sourceRateIsFinal = true
+		env.player.mainSkill.skillData.ignoresTickRate = true
+		return {triggerOnUse = true,
+				useCastRate = true,
+				triggerSkillCond = function(env, skill)
+					return skill.activeEffect.grantedEffect.name == "Autoexertion"
+				end}
+	end,
 	["mark on hit"] = function()
 		return {triggerSkillCond = function(env, skill) return skill.skillTypes[SkillType.Attack] end}
 	end,


### PR DESCRIPTION
Fixes #8017

### Description of the problem being solved:
Fixes autoexertion not triggering supported skills.

~~This does not currently fix the support effect not causing warcries to reserve mana. This issue is caused by missing `SkillType.HasReservation` flag causing the reservation calculations to be skipped here~~:

https://github.com/PathOfBuildingCommunity/PathOfBuilding/blob/0904a877041149b757a30738005a3403f9838745/src/Modules/CalcPerform.lua#L1532

~~Problem is there's no good way to add the the flag without also making the skill incompatible with the support effect as it excludes skills with that flag.~~


Requires https://github.com/PathOfBuildingCommunity/PathOfBuilding/pull/8029 to solve mana reservation issue.