### PR TITLE
Fixes Rupture using the wrong stat for damage taken and Bleed duration

### DIFF
--- a/src/Data/Skills/sup_dex.lua
+++ b/src/Data/Skills/sup_dex.lua
@@ -3133,10 +3133,10 @@ skills["SupportRupture"] = {
 	excludeSkillTypes = { },
 	statDescriptionScope = "gem_stat_descriptions",
 	statMap = {
-		["support_rupture_bleeding_time_passed_+%_final"] = {
+		["support_rupture_bleeding_damage_taken_+%_final"] = {
 			mod("DamageTaken", "MORE", nil, 0, KeywordFlag.Bleed, { type = "GlobalEffect", effectType = "Debuff" }, { type = "Multiplier", var = "RuptureStack", limit = 3 })
 		},
-		["support_rupture_bleeding_damage_taken_+%_final"] = {
+		["support_rupture_bleeding_time_passed_+%_final"] = {
 			mod("BleedExpireRate", "MORE", nil, 0, KeywordFlag.Bleed, { type = "GlobalEffect", effectType = "Debuff" }, { type = "Multiplier", var = "RuptureStack", limit = 3 })
 		},
 		["critical_strikes_that_inflict_bleeding_also_rupture"] = {

--- a/src/Data/Skills/sup_dex.lua
+++ b/src/Data/Skills/sup_dex.lua
@@ -3137,7 +3137,7 @@ skills["SupportRupture"] = {
 			mod("DamageTaken", "MORE", nil, 0, KeywordFlag.Bleed, { type = "GlobalEffect", effectType = "Debuff" }, { type = "Multiplier", var = "RuptureStack", limit = 3 })
 		},
 		["support_rupture_bleeding_time_passed_+%_final"] = {
-			mod("BleedExpireRate", "INC", nil, 0, KeywordFlag.Bleed, { type = "GlobalEffect", effectType = "Debuff" }, { type = "Multiplier", var = "RuptureStack", limit = 3 })
+			mod("BleedExpireRate", "MORE", nil, 0, KeywordFlag.Bleed, { type = "GlobalEffect", effectType = "Debuff" }, { type = "Multiplier", var = "RuptureStack", limit = 3 })
 		},
 		["critical_strikes_that_inflict_bleeding_also_rupture"] = {
 			flag("Condition:CanInflictRupture", { type = "GlobalEffect", effectType = "Buff" }),

--- a/src/Data/Skills/sup_dex.lua
+++ b/src/Data/Skills/sup_dex.lua
@@ -3137,7 +3137,7 @@ skills["SupportRupture"] = {
 			mod("DamageTaken", "MORE", nil, 0, KeywordFlag.Bleed, { type = "GlobalEffect", effectType = "Debuff" }, { type = "Multiplier", var = "RuptureStack", limit = 3 })
 		},
 		["support_rupture_bleeding_time_passed_+%_final"] = {
-			mod("BleedExpireRate", "MORE", nil, 0, KeywordFlag.Bleed, { type = "GlobalEffect", effectType = "Debuff" }, { type = "Multiplier", var = "RuptureStack", limit = 3 })
+			mod("BleedExpireRate", "INC", nil, 0, KeywordFlag.Bleed, { type = "GlobalEffect", effectType = "Debuff" }, { type = "Multiplier", var = "RuptureStack", limit = 3 })
 		},
 		["critical_strikes_that_inflict_bleeding_also_rupture"] = {
 			flag("Condition:CanInflictRupture", { type = "GlobalEffect", effectType = "Buff" }),

--- a/src/Export/Skills/sup_dex.txt
+++ b/src/Export/Skills/sup_dex.txt
@@ -376,10 +376,10 @@ local skills, mod, flag, skill = ...
 
 #skill SupportRupture
 	statMap = {
-		["support_rupture_bleeding_time_passed_+%_final"] = {
+		["support_rupture_bleeding_damage_taken_+%_final"] = {
 			mod("DamageTaken", "MORE", nil, 0, KeywordFlag.Bleed, { type = "GlobalEffect", effectType = "Debuff" }, { type = "Multiplier", var = "RuptureStack", limit = 3 })
 		},
-		["support_rupture_bleeding_damage_taken_+%_final"] = {
+		["support_rupture_bleeding_time_passed_+%_final"] = {
 			mod("BleedExpireRate", "MORE", nil, 0, KeywordFlag.Bleed, { type = "GlobalEffect", effectType = "Debuff" }, { type = "Multiplier", var = "RuptureStack", limit = 3 })
 		},
 		["critical_strikes_that_inflict_bleeding_also_rupture"] = {

--- a/src/Modules/CalcOffence.lua
+++ b/src/Modules/CalcOffence.lua
@@ -3850,10 +3850,9 @@ function calcs.offence(env, actor, activeSkill)
 			local overrideStackPotential = skillModList:Override(nil, "BleedStackPotentialOverride") and skillModList:Override(nil, "BleedStackPotentialOverride") / maxStacks
 			globalOutput.BleedStacksMax = maxStacks
 			local durationBase = skillData.bleedDurationIsSkillDuration and skillData.duration or data.misc.BleedDurationBase
-			local durationMod = calcLib.mod(skillModList, dotCfg, "EnemyBleedDuration", "EnemyAilmentDuration", "SkillAndDamagingAilmentDuration", skillData.bleedIsSkillEffect and "Duration" or nil) * calcLib.mod(enemyDB, nil, "SelfBleedDuration", "SelfAilmentDuration")
+			local durationMod = calcLib.mod(skillModList, dotCfg, "EnemyBleedDuration", "EnemyAilmentDuration", "SkillAndDamagingAilmentDuration", skillData.bleedIsSkillEffect and "Duration" or nil) * calcLib.mod(enemyDB, nil, "SelfBleedDuration", "SelfAilmentDuration") / calcLib.mod(enemyDB, dotCfg, "BleedExpireRate")
 			durationMod = m_max(durationMod, 0)
 			local rateMod = calcLib.mod(skillModList, cfg, "BleedFaster") + enemyDB:Sum("INC", nil, "SelfBleedFaster")  / 100
-			rateMod = (calcLib.mod(enemyDB, dotCfg, "BleedExpireRate") / 2) + 0.5
 			globalOutput.BleedDuration = durationBase * durationMod / rateMod * debuffDurationMult
 
 			-- The chance any given hit applies bleed

--- a/src/Modules/CalcOffence.lua
+++ b/src/Modules/CalcOffence.lua
@@ -3850,9 +3850,10 @@ function calcs.offence(env, actor, activeSkill)
 			local overrideStackPotential = skillModList:Override(nil, "BleedStackPotentialOverride") and skillModList:Override(nil, "BleedStackPotentialOverride") / maxStacks
 			globalOutput.BleedStacksMax = maxStacks
 			local durationBase = skillData.bleedDurationIsSkillDuration and skillData.duration or data.misc.BleedDurationBase
-			local durationMod = calcLib.mod(skillModList, dotCfg, "EnemyBleedDuration", "EnemyAilmentDuration", "SkillAndDamagingAilmentDuration", skillData.bleedIsSkillEffect and "Duration" or nil) * calcLib.mod(enemyDB, nil, "SelfBleedDuration", "SelfAilmentDuration") / calcLib.mod(enemyDB, dotCfg, "BleedExpireRate")
+			local durationMod = calcLib.mod(skillModList, dotCfg, "EnemyBleedDuration", "EnemyAilmentDuration", "SkillAndDamagingAilmentDuration", skillData.bleedIsSkillEffect and "Duration" or nil) * calcLib.mod(enemyDB, nil, "SelfBleedDuration", "SelfAilmentDuration")
 			durationMod = m_max(durationMod, 0)
 			local rateMod = calcLib.mod(skillModList, cfg, "BleedFaster") + enemyDB:Sum("INC", nil, "SelfBleedFaster")  / 100
+			rateMod = (calcLib.mod(enemyDB, dotCfg, "BleedExpireRate") / 2) + 0.5
 			globalOutput.BleedDuration = durationBase * durationMod / rateMod * debuffDurationMult
 
 			-- The chance any given hit applies bleed


### PR DESCRIPTION
### Description of the problem being solved:

Rupture support has 2 mods: 
- up to 29% more dmg taken per Rupture stack
- 25% quicker bleed on enemy per Rupture

Currently, the "more dmg taken" mod is inversed with the "quicker bleed" numerically, and only goes up to 75%. 

For the quicker bleed, I'm not sure where exactly this is calculated but 75% quicker shouldn't mean a 29% duration as this is the case in POB

### Steps taken to verify a working solution:
- Opened the same build and checked that both the more damage taken and duration matched the proper calculation

### Link to a build that showcases this PR:
https://pobb.in/91FAzNjlHslt

### Before screenshot:
![image](https://github.com/user-attachments/assets/884875f8-674a-499f-88a7-f3e61c20f9bd)

![image](https://github.com/user-attachments/assets/2ea5e54f-3990-437f-8960-db7b07c8f172)


### After screenshot:
![image](https://github.com/user-attachments/assets/209b05df-5c80-456e-90d3-0e9c859cb73e)

![image](https://github.com/user-attachments/assets/53293325-bc69-44ee-9ae1-35ff213ce7cf)
