### PR TITLE
Fix quality check condition for item types

### DIFF
--- a/src/Classes/ItemsTab.lua
+++ b/src/Classes/ItemsTab.lua
@@ -1955,7 +1955,7 @@ function ItemsTabClass:CraftItem()
 		item.implicitModLines = { }
 		item.explicitModLines = { }
 		item.crucibleModLines = { }
-		if base.base.type ~= "Amulet" or base.base.type ~= "Belt" or base.base.type ~= "Jewel" or base.base.type ~= "Quiver" or base.base.type ~= "Ring" then
+		if base.base.type == "Amulet" or base.base.type == "Belt" or base.base.type == "Jewel" or base.base.type == "Quiver" or base.base.type == "Ring" then
 			item.quality = nil
 		else
 			item.quality = 0


### PR DESCRIPTION
Fixes #7966 .

### Description of the problem being solved:
Due to an incorrect If statement regarding setting quality to nil for Amulets, Belts, etc, items that should have quality set to 20 by default were going into NormaliseQuality() with a nil value for quality, causing it to get set to 0 by default.

### Steps taken to verify a working solution:
- Verify current state, non-quality items had no option for quality, quality items had their default set to 0
- Make changes
- Check a non-quality item such as an Amulet, no option to set quality and no visible quality as expected.
- Check a quality item such as Body Armour, quality is set to 20 as a default.
- Check several other examples of both cases, behavior as expected for both non-quality and quality items that were tested

### Link to a build that showcases this PR:
NA

### Before screenshot:
Amulet Example:

![](https://i.imgur.com/mIPgwr3.png)

Body Armour Example:

![](https://i.imgur.com/pN6PbMs.png)

### After screenshot:
Amulet Example:

![](https://i.imgur.com/dOPN2ZD.png)

Body Armour Example:

![](https://i.imgur.com/dTZj4i4.png)

Additional Note:
This code still relies on NormalizeQuality() to properly set the default value from 0 to 20 in cases where a default quality is expected. I think it would be pertinent to remove the reliance CraftItem() has on NormalizeQuality() to properly set the default values, unless this behavior is intentional. I can look into this decoupling further if desired. 
