### PR TITLE
Color mastery differences blue when comparing trees

### DIFF
--- a/src/Classes/PassiveTreeView.lua
+++ b/src/Classes/PassiveTreeView.lua
@@ -589,6 +589,9 @@ function PassiveTreeViewClass:Draw(build, viewPort, inputEvents)
 					elseif not compareNode.alloc and node.alloc then
 						-- Base has not, current has, color red (Remove nodes to match)
 						SetDrawColor(1, 0, 0)
+					elseif node.type == "Mastery" and compareNode.alloc and node.alloc and node.sd ~= compareNode.sd then
+						-- Node is a mastery, both have it allocated, but mastery changed, color it blue
+						SetDrawColor(0, 0, 1)
 					else
 						-- Both have or both have not, use white
 						SetDrawColor(1, 1, 1)
@@ -614,6 +617,9 @@ function PassiveTreeViewClass:Draw(build, viewPort, inputEvents)
 				elseif not compareNode.alloc and node.alloc then
 					-- Base has not, current has, color red (Remove nodes to match)
 					SetDrawColor(1, 0, 0)
+				elseif node.type == "Mastery" and compareNode.alloc and node.alloc and node.sd ~= compareNode.sd then
+					-- Node is a mastery, both have it allocated, but mastery changed, color it blue
+					SetDrawColor(0, 0, 1)
 				else
 					-- Both have or both have not, use white
 					SetDrawColor(1, 1, 1)


### PR DESCRIPTION
Fixes #7958 .

### Description of the problem being solved:
Compare passive tree doesn't visually show changed mastery

### Link to a build that showcases this PR:

```
eNrNXFlz6rgSfp75FRTP5sSW5W0qmVuELQsEAmR9SRkjwImxiReWMzX__bYks2SxYwNV985DDka9t_qT1DJz-p_l1CnMiR_YnntWlH6JxQJxLW9ou-Oz4l2_XtKL__n7z9OOGU7ao_PIdujI33_-cco-FxwyJ85ZUUPFQmj6YxLer0XJLyBqZrrhhHhuy3z1_IY3PCveeC4pFgamO7TD9ZPlmEFwY07JWbFl-mY0JH6xYAYWcYeV7VBMOwEKKyR-k2ouR6HX8oYwGvoRjE5N2-151hsJG74XzcChYmFukwWnuWx12t3-jlW2u2sVePXHaccxV8TvhWZYCODPWbEMwTHHpGpO4S9IM50IRIm_kFQ8SeU4j_wgzMHWmxEy3FBKv7CkJpF2fFIbjYgV2nNS8e2wMjFda0dLEl9e2lbkhPbMsWk-NnYpSRwXX4TLidL7Xmg61U5vNzKGJqvp9F74s90Pdjg5dyCUOaRTnsuxa4ckJ1PHswPP3cOPDyyJKYgcB6otE22XBMSfm6H9yZxE2d50YLu5otQyXbPiBRlyQCk7xIcCDnMx9IjlQc3n1ZGTs2mPSHbKXH7EDHmt2c-PWi8rXW7B-xnUBajLRtnzIicjZbjFHiSiJLIqWW4hCidRXbpbjZKCk4XNPVpIP1vHyrl20dnRrVLkRpIiiaomJwL4ZBXYlum0zKU9jaaAnH3zjbg7YhQlecKMJ6ELuJDErBuJ9tZtn-zBVvGc4T5sE9MLkvgMWUsubdu9gB1C2bIiWOxX27BoqWW0Ez6EU5ZZ6y9Kfela25mlpcm9c32GrrvLc4oGytKFsqHbgIFDMvNs1cTlt-UUxXRlY-LGGlfZEKdJiDVpQJy7Zri7PRFFzRANTUtdBDJULQ0yJd0NsiylCf3eCSWNJcGJRFhziT9e9SY2cYb5qNdmVcxZRt93uXdjIKFs-nIldJc1Z0weTH-YDdizUeW1fG4Gu0ArKelR5eS7AU3eHxDYBALDkGTd8XZ875XuqZ18bGV_6kU7G2Q1fWZw8g91gX5aJvgpokuGkfVhXUqEk83p4NyB01BWTzZcYKjj5GIth6FpvVW94Thz3JiSXBwf7etFsxkAJp0QWQXQ5Q82yvbOxqOkZqBuw2zOVPt0ocyuYEudWcFm8c-u5RNLdl_o6v1ZjYIykGdWsUloC_BiCiseOwPDYX1bTYnJgbNRpoMOI8x44Op4C7B8QhsZQT5q2OVs6znRFJ-4v1eZ5X8gz6Sg5g5hwwSlkFnHZ47v1PTtKWBpEFTN0CwM473xvenbphsi1mIJiOlbkyakvm46zgCQ4Ky4-y17Ym2Zuu2ExK_Cd1QpNeyzRGmd9NMT1mKiny6nM88PC2RJ_-mYfrg6K45MJyCckH0DcoLQdtkJGPDIcYqF3sRblIdzqqnveU6wZiqYsxlxhx9k9H1CCuYaXSzYEvJ-EH0oTM0ArF7x6Qpi_pE0LEmCLIu68a_wD9J1FQkK0jUVnmSEsCSoWNYlOoawLgoY61iEJ1VEkijIWFFleFIUbIAUoKRPSBFlSUAykDCZIAQZIoLPuqKoIFCR6AAQI1EAFToViLGCRUGSkaLRJ00yNBChMhEYrMSCrMmi9u-HftrlkAXe9SBkkGaDqgJSLEiqhmVBQ7oigIWKwazRBEM2kABkEqZfy6KgykgHhyVJ1AXQqSmCrCrAKemqSsMiS5QGY01QDFkB7yXwUzEwkgVsqCKQI0MGkRiLYDw2QKRkKKJEKUUkIFEHLjhEgUhZxLIhcFdAEVgDEdVAuYY0Q1DBKEERDdUQJEkDKyWqS-BxUJChgmHAqCBZhmDKiizwmEM-EAYyjCiFrugCDyvYoFMjdCwgXYYUIxVp4IvIVBoG0sEvDdzgaQUfETUF7IQ5APGSkayp8AUEUjAwuMJShw04EQoIjGKiaMLgJAN_2SxSZM0AP1VVAyuwpsBsEVVqqY4knc0VapcMAWdzAnILUZdoFIBEhDBKEmRQkJhjEhapQiSKqsCnpQy50sAnODwL8dREoqTBfKJTUVHAWBpBETxWNPCVT0MF0k256OzCMnij6xqNK0xIgU1iWt60M2D6q_LHmeXaUHohlNNOKxgpcZeXEkissv44ves22Yc_JmE4C_46OVksFr9mZjjxRmQJu7Bfljc9mQET1GQpeLMdp0TFnpThv_Nxrfx0FU0uut3z5-VSkivDZ33VW0zxwKrMrdVS7bXn4qsznmiytLTm_tWLd6Ff1MfXvcZTddbrV1DQdeqvTWQgRW3ddi-Gj6ub0ktDfLxo9PBtu97Gj93eovq6uLMer2eo1Z43mk7l9eX9Pjhvm_7VJHKQSbTq63uj8-rfG1V5PnmeW82wRG6MzlXTmwxatZr5OggaFSR2y53e5ZPRmGgq-U1u3ieLau33OHjWZ4u5VLpeNMOyPv498Gbnz4u5d3nhX88MfXR1XgqbzzV98PR8PZssjearP1p0q6vrebTU_Na4fPM2iF5r9WU9qqNG33itPrq9--Ba98Ae7WVVD8Z39Vp5ET5Ulm779aJSKskwWe7d8Mmyfq9MWZ8sOiDn7Iwl5GSdkVPeQw9O-BNdz30bwIKvBycUE38ERww1rG_B0TAUiniARjpUoqRusVGBotuiIdJVWd-gIRyZRYqpUMQwobG6Bj0D62tw_IiHUOIIEEiXJLzBwzXAxiBiSArAYWiHDqw_c5QNGXl5M2TkYPC_QUZezFmQkUMAh4MYGmVNlHehEQFk6AJPyReE5Dj1FSG_giPWNLpeMHCMM0oBkUEpTwfP1w4q8sXlAywyJGVwzqcPh7NdVOQ4-RUVOZDtwiLDfI5yfD3gCMknEUc8juIcFfliwLGUQ288ZxNQkYP8Z1Rka-f_ASo-KgwVFxGgolad5EdFQJ_PqDg7f0JqBd_ePBGGiveV31110l1a7-7TorR4iu6uO6XZw2KNitG7-96oj27rU70_9VzFV_qj_qqnypXR-XnDQ4aGB92722rnst3peqQk2hevpmeVly1NFefXVtOw2p3O1Xm73orETvSAuh2sqqt3f_lqB1fajdXUGqjRe3-yRj0sK7h2q9u-FpDbB6tcLQ81b1lp9LXJEDLQVacvBLVuyPDqYSFF94_iVd-2R2_N-_fS3bz9XCtr3beS8vRoypXSjaxMlov90PD0hG4h6YcbLyQBHaNfrh9OezRVAWyD_bBBpsH5Ck4kddqx-XQXE-9BKXWPhHx7vcuzvuockpEZOfT728h0bLolFne_bfKbWdfzp5s-M4iCLTE9OHOJ_dWM4ly52eQjZSeMhVF16_0xh_rYoII93G7QuU_0Y8V0LObz6aU7i8KCy65sp3ZgvQyi0Yjev4KK0GfXyrV6vVbpX97X4gPGLgub0S9uNB3QS0f-7_YY2COsAVIIokHAP54V722yYIZUSWjaDhx6LM9xzFlANjt8ZnTsgQN8KdIY1YW9ubj9XtaWIFlSbUl8OJCMH-AU5Nsk0a7N-A9GcYW0sUYPZEnS6B1psiDepqnAis3bgwmRYjfRyVLo1XCiO3QwhReOcqaTqDke_SESIZ22UHX2yLboWTY95XSSc6qUuGxuGhLzHfeYkmWwS-ckAXwwmZlfJCdxx6MpUWWX14lR5aPJ7FVimYm-88Fk5k3H2XMhTElSNlQpkm48l01yKJqy7dB-UGJmaw7ZkCQLbIcT4scb0yRJLcCoNUlq4fj2IAqTy3iHIiVW7JYqIUJ0LJmVX7wk-EDHUpDow8VHQkB3aZJF8fuCRCBLY-W9wcT4xZ3GlBTEffaE8PPRlCCsrxoS_I-HU4qE4W957tlD3m1OKJdPZGmAAfuKw8WwFvrhYj731A-XWIet7VtivuPRZPa70KY7kW-k8A1QJiG0qA6TQGvrMAl927XCyCd7C-h-3olsebvpe5BNH_hb5vVoGnLE7eG9JfAm9t7srMe-NzfD_yoZEfAgdQHY0KTURxi5VQhGmFIbGUUxs74Hkq13uWTxpfBbT3NL5AUev6yRhgGc5AdBsJZfpOwWs0na3BNdENOhb915zmECv7yUcogwet0dzUx3uBbX_m6Pvs1Dxuh5YQAy2R1Ild6qHxpDl0xX3whKtuv0ZH2qY7cj9JwV3-n0Qp9e6fz2vOkTvRQ0tF-08yLqqq5g_n18_NTjIyfsv6s2ZNFns2-tlRI-nhWxhn8hRVQQVnRV5ddOp5chHEHj0zD9vDkMJ4uLAsJfV3sg5sxzGcfOETaWkkIWH27jU7_jwWkXeDqDu26T-stPqA0HzmAQQzrE-4Un6QxcTUHKwXLuQfYL5cEqCEynwPsPBSWPAOKEn_lRDn62JhXkPbws9Bbm7LNqvI-gA9yPZaAjyPjeIfUIDqlHcGgvGd85dPDslI8QEXQsb_LMtwsCi2d4UDy-KTb1YAtQbgkHq5SPFX_lCJNBOkJ5SEewA-ecCceCGHRoReIjBDD_mnE0iJUP9R8dWML5DBiuCrwHccgc5HuLQyR8X9jKwRLUY6VVOhbG5J-ah8cRH5xL5TiTKo_z5WnkkPAISCgfAVDkA4sSH8gvHSf-e6-UuSctzs2xzy7qwKgqh2L1kdKCjwUuR9tX732EysHXtd1xrhR-D03oODk42kpxjAMf3s-nvME_fI0_0mZDOdiQw5c4NS8YHAoeXxWensTNHv4Cs28OSY91rh4IfRs-4O0t1mJiby947sgex80m_hC3mxj_5pv1W2NV_pbFx35RxzEtMvGcIfFjYwltucU_616_yaCJGx8TGHZ_pL3mUpJ5ehMIQo9e6wdf3pdI1PHxhyVbPlVP02R5rPeXTxV157Ma-acYrKtwo0TFkpHME9hj22mP2GUB2MduPDLYN938vJ3-lpv4ZMicq3iRG_aIM9oRovxg8OZ2cZMxjPEPPPGvejzH6Zrubng2v3I82cw83o5lT3__eXry-X_H8F_-_2QC
``` 

### Before screenshot:
![grafik](https://github.com/user-attachments/assets/5a8ac222-26e5-44d6-9ccf-1ed377f51736)

### After screenshot:
![grafik](https://github.com/user-attachments/assets/cf7846db-3de3-45dc-8aea-790b7a75bf3b)

### Before screenshot:
![grafik](https://github.com/user-attachments/assets/9c3257fe-8f24-4daa-8fb0-15e8c7e760f2)

### After screenshot:
![grafik](https://github.com/user-attachments/assets/a04a7b80-3b82-4762-b8b6-949d79d4079f)

