### PR TITLE
Fix incorrect skillId for elder staff power charge on crit

### DIFF
--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -1822,7 +1822,7 @@ local function flag(name, ...)
 end
 
 local gemIdLookup = {
-	["power charge on critical strike"] = "SupportPowerChargeOnCrit",
+	["power charge on critical strike"] = "SupportPowerChargeOnCritical",
 }
 for name, grantedEffect in pairs(data.skills) do
 	if not grantedEffect.hidden or grantedEffect.fromItem or grantedEffect.fromTree then


### PR DESCRIPTION
Fixes #8046.

### Description of the problem being solved:
This mod is the only mod that manually has a skillId mapped, so when all the granted effect IDs changed, this needed to change too.
### Steps taken to verify a working solution:
- No crash when hovering the mod