### PR TITLE
Add ability to search in the spectre library

### DIFF
--- a/src/Classes/ListControl.lua
+++ b/src/Classes/ListControl.lua
@@ -70,6 +70,7 @@ local ListClass = newClass("ListControl", "Control", "ControlHost", function(sel
 		self.controls.scrollBarH.shown = false
 		self.controls.scrollBarV.shown = false
 	end
+	self.labelPositionOffset = {0, 0}
 end)
 
 function ListClass:SelectIndex(index)
@@ -176,7 +177,7 @@ function ListClass:Draw(viewPort, noTooltip)
 
 	local label = self:GetProperty("label") 
 	if label then
-		DrawString(x, y - 20, "LEFT", 16, self.font, label)
+		DrawString(x + self.labelPositionOffset[1], y - 20 + self.labelPositionOffset[2], "LEFT", 16, self.font, label)
 	end
 	if self.otherDragSource and not self.CanDragToValue then
 		SetDrawColor(0.2, 0.6, 0.2)

--- a/src/Classes/MinionListControl.lua
+++ b/src/Classes/MinionListControl.lua
@@ -12,7 +12,6 @@ local MinionListClass = newClass("MinionListControl", "ListControl", function(se
 	self.ListControl(anchor, x, y, width, height, 16, "VERTICAL", not dest, list)
 	self.data = data
 	self.dest = dest
-	self.unfilteredList = copyTable(list)
 	if dest then
 		self.dragTargetList = { dest }
 		self.label = "^7Available Spectres:"
@@ -30,13 +29,12 @@ local MinionListClass = newClass("MinionListControl", "ListControl", function(se
 		self.controls.delete.enabled = function()
 			return self.selValue ~= nil
 		end
-	end		
+	end
 end)
 
 function MinionListClass:AddSel()
 	if self.dest and not isValueInArray(self.dest.list, self.selValue) then
 		t_insert(self.dest.list, self.selValue)
-		t_insert(self.dest.unfilteredList, self.selValue)
 	end
 end
 
@@ -88,7 +86,6 @@ end
 
 function MinionListClass:ReceiveDrag(type, value, source)
 	t_insert(self.list, self.selDragIndex or #self.list + 1, value)
-	t_insert(self.unfilteredList, self.selDragIndex or #self.list + 1, value)
 end
 
 function MinionListClass:OnSelClick(index, minionId, doubleClick)
@@ -100,44 +97,7 @@ end
 function MinionListClass:OnSelDelete(index, minionId)
 	if not self.dest then
 		t_remove(self.list, index)
-		t_remove(self.unfilteredList, index)
 		self.selIndex = nil
 		self.selValue = nil
-	end
-end
-
-function MinionListClass:DoesEntryMatchFilters(searchStr, minionId, filterMode)
-	if filterMode == 1 or filterMode == 3 then
-		local err, match = PCall(string.matchOrPattern, self.data.minions[minionId].name:lower(), searchStr)
-		if not err and match then
-			return true
-		end
-	end
-	if filterMode == 2 or filterMode == 3 then
-		for _, skillId in ipairs(self.data.minions[minionId].skillList) do
-			if self.data.skills[skillId] then
-				local err, match = PCall(string.matchOrPattern, self.data.skills[skillId].name:lower(), searchStr)
-				if not err and match then
-					return true
-				end
-			end
-		end
-	end
-	return false
-end
-
-function MinionListClass:ListFilterChanged(buf, filterMode)
-	local searchStr = buf:lower():gsub("[%-%.%+%[%]%$%^%%%?%*]", "%%%0")
-	if searchStr:match("%S") then
-		local filteredList = { }
-		for _, minionId in pairs(self.unfilteredList) do
-			if self:DoesEntryMatchFilters(searchStr, minionId, filterMode) then
-				t_insert(filteredList, minionId)
-			end
-		end
-		self.list = filteredList
-		self:SelectIndex(1)
-	else
-		self.list = self.unfilteredList
 	end
 end

--- a/src/Classes/MinionListControl.lua
+++ b/src/Classes/MinionListControl.lua
@@ -106,20 +106,32 @@ function MinionListClass:OnSelDelete(index, minionId)
 	end
 end
 
-function MinionListClass:DoesEntryMatchFilters(searchStr, minionId)
-	local err, match = PCall(string.matchOrPattern, self.data.minions[minionId].name:lower(), searchStr)
-	if not err and match then
-		return true
+function MinionListClass:DoesEntryMatchFilters(searchStr, minionId, filterMode)
+	if filterMode == 1 or filterMode == 3 then
+		local err, match = PCall(string.matchOrPattern, self.data.minions[minionId].name:lower(), searchStr)
+		if not err and match then
+			return true
+		end
+	end
+	if filterMode == 2 or filterMode == 3 then
+		for _, skillId in ipairs(self.data.minions[minionId].skillList) do
+			if self.data.skills[skillId] then
+				local err, match = PCall(string.matchOrPattern, self.data.skills[skillId].name:lower(), searchStr)
+				if not err and match then
+					return true
+				end
+			end
+		end
 	end
 	return false
 end
 
-function MinionListClass:ListFilterChanged(buf)
+function MinionListClass:ListFilterChanged(buf, filterMode)
 	local searchStr = buf:lower():gsub("[%-%.%+%[%]%$%^%%%?%*]", "%%%0")
 	if searchStr:match("%S") then
 		local filteredList = { }
 		for _, minionId in pairs(self.unfilteredList) do
-			if self:DoesEntryMatchFilters(searchStr, minionId) then
+			if self:DoesEntryMatchFilters(searchStr, minionId, filterMode) then
 				t_insert(filteredList, minionId)
 			end
 		end

--- a/src/Classes/MinionSearchListControl.lua
+++ b/src/Classes/MinionSearchListControl.lua
@@ -1,0 +1,67 @@
+-- Path of Building
+--
+-- Class: Minion Search List
+-- Minion list control with search field. Cannot be mutable.
+--
+local ipairs = ipairs
+local t_insert = table.insert
+local t_remove = table.remove
+local s_format = string.format
+
+local MinionSearchListClass = newClass("MinionSearchListControl", "MinionListControl", function(self, anchor, x, y, width, height, data, list, dest)
+	self.MinionListControl(anchor, x, y, width, height, data, list, dest)	
+	self.unfilteredList = copyTable(list)
+	self.isMutable = false
+
+	self.controls.searchText = new("EditControl", {"BOTTOMLEFT",self,"TOPLEFT"}, 0, -2, 128, 18, "", "Search", "%c", 100, function(buf)
+		self:ListFilterChanged(buf, self.controls.searchModeDropDown.selIndex)
+	end, nil, nil, true)	
+	
+	self.controls.searchModeDropDown = new("DropDownControl", {"LEFT",self.controls.searchText,"RIGHT"}, 2, 0, 60, 18, { "Names", "Skills", "Both"}, function(index, value)
+		self:ListFilterChanged(self.controls.searchText.buf, index)
+	end)
+
+	self.labelPositionOffset = {0, -20}
+	if dest then
+		self.controls.add.y = self.controls.add.y - 20
+	else
+		self.controls.delete.y = self.controls.add.y - 20
+	end
+
+end)
+
+function MinionSearchListClass:DoesEntryMatchFilters(searchStr, minionId, filterMode)
+	if filterMode == 1 or filterMode == 3 then
+		local err, match = PCall(string.matchOrPattern, self.data.minions[minionId].name:lower(), searchStr)
+		if not err and match then
+			return true
+		end
+	end
+	if filterMode == 2 or filterMode == 3 then
+		for _, skillId in ipairs(self.data.minions[minionId].skillList) do
+			if self.data.skills[skillId] then
+				local err, match = PCall(string.matchOrPattern, self.data.skills[skillId].name:lower(), searchStr)
+				if not err and match then
+					return true
+				end
+			end
+		end
+	end
+	return false
+end
+
+function MinionSearchListClass:ListFilterChanged(buf, filterMode)
+	local searchStr = buf:lower():gsub("[%-%.%+%[%]%$%^%%%?%*]", "%%%0")
+	if searchStr:match("%S") then
+		local filteredList = { }
+		for _, minionId in pairs(self.unfilteredList) do
+			if self:DoesEntryMatchFilters(searchStr, minionId, filterMode) then
+				t_insert(filteredList, minionId)
+			end
+		end
+		self.list = filteredList
+		self:SelectIndex(1)
+	else
+		self.list = self.unfilteredList
+	end
+end

--- a/src/Modules/Build.lua
+++ b/src/Modules/Build.lua
@@ -1502,27 +1502,20 @@ function buildMode:OpenSpectreLibrary()
 		end
 	end)
 	local controls = { }
-	controls.searchText = new("EditControl", nil, -61, 18, 268, 18, "", "Search", "%c", 100, function(buf)
-		controls.source:ListFilterChanged(buf, controls.searchModeDropDown.selIndex)
-		--controls.list:ListFilterChanged(buf) -- filter left list
-	end, nil, nil, true)	
-	controls.list = new("MinionListControl", nil, -100, 60, 190, 250, self.data, destList)
-	controls.source = new("MinionListControl", nil, 100, 60, 190, 250, self.data, sourceList, controls.list)
-	controls.save = new("ButtonControl", nil, -45, 350, 80, 20, "Save", function()
+	controls.list = new("MinionListControl", nil, -100, 40, 190, 250, self.data, destList)
+	controls.source = new("MinionSearchListControl", nil, 100, 60, 190, 230, self.data, sourceList, controls.list)
+	controls.save = new("ButtonControl", nil, -45, 330, 80, 20, "Save", function()
 		self.spectreList = destList
 		self.modFlag = true
 		self.buildFlag = true
 		main:ClosePopup()
 	end)
-	controls.cancel = new("ButtonControl", nil, 45, 350, 80, 20, "Cancel", function()
+	controls.cancel = new("ButtonControl", nil, 45, 330, 80, 20, "Cancel", function()
 		main:ClosePopup()
 	end)
 	controls.noteLine1 = new("LabelControl", {"TOPLEFT",controls.list,"BOTTOMLEFT"}, 24, 2, 0, 16, "Spectres in your Library must be assigned to an active")
 	controls.noteLine2 = new("LabelControl", {"TOPLEFT",controls.list,"BOTTOMLEFT"}, 20, 18, 0, 16, "Raise Spectre gem for their buffs and curses to activate")
-	controls.searchModeDropDown = new("DropDownControl", {"LEFT",controls.searchText,"RIGHT"}, 2, 0, 120, 18, { "Names", "Skills", "Names & Skills"}, function(index, value)
-		controls.source:ListFilterChanged(controls.searchText.buf, index)
-	end)
-	main:OpenPopup(410, 380, "Spectre Library", controls)
+	main:OpenPopup(410, 360, "Spectre Library", controls)
 end
 
 function buildMode:OpenSimilarPopup()

--- a/src/Modules/Build.lua
+++ b/src/Modules/Build.lua
@@ -1515,7 +1515,8 @@ function buildMode:OpenSpectreLibrary()
 	end)
 	controls.noteLine1 = new("LabelControl", {"TOPLEFT",controls.list,"BOTTOMLEFT"}, 24, 2, 0, 16, "Spectres in your Library must be assigned to an active")
 	controls.noteLine2 = new("LabelControl", {"TOPLEFT",controls.list,"BOTTOMLEFT"}, 20, 18, 0, 16, "Raise Spectre gem for their buffs and curses to activate")
-	main:OpenPopup(410, 360, "Spectre Library", controls)
+	local spectrePopup = main:OpenPopup(410, 360, "Spectre Library", controls)
+	spectrePopup:SelectControl(spectrePopup.controls.source.controls.searchText)
 end
 
 function buildMode:OpenSimilarPopup()

--- a/src/Modules/Build.lua
+++ b/src/Modules/Build.lua
@@ -1502,20 +1502,38 @@ function buildMode:OpenSpectreLibrary()
 		end
 	end)
 	local controls = { }
-	controls.list = new("MinionListControl", nil, -100, 40, 190, 250, self.data, destList)
-	controls.source = new("MinionListControl", nil, 100, 40, 190, 250, self.data, sourceList, controls.list)
-	controls.save = new("ButtonControl", nil, -45, 330, 80, 20, "Save", function()
+	controls.searchText = new("EditControl", nil, 0, 25, 390, 20, "", "Search", "%c", 100, function(buf)
+		local searchStr = buf:lower():gsub("[%-%.%+%[%]%$%^%%%?%*]", "%%%0")
+		if searchStr:match("%S") then
+			local sourceListFiltered = { }
+			for _, minionId in pairs(sourceList) do
+				local err, match = PCall(string.matchOrPattern, self.data.minions[minionId].name:lower(), searchStr)
+				if not err and match then
+					t_insert(sourceListFiltered, minionId)
+				end
+				--if string.find( self.data.minions[minionId].name:lower(), buf:lower()) then
+				--	t_insert(sourceListFiltered, minionId)
+				--end
+			end
+			controls.source.list = sourceListFiltered
+		else
+			controls.source.list = sourceList
+		end
+	end, nil, nil, true)
+	controls.list = new("MinionListControl", nil, -100, 70, 190, 250, self.data, destList)
+	controls.source = new("MinionListControl", nil, 100, 70, 190, 250, self.data, sourceList, controls.list)
+	controls.save = new("ButtonControl", nil, -45, 360, 80, 20, "Save", function()
 		self.spectreList = destList
 		self.modFlag = true
 		self.buildFlag = true
 		main:ClosePopup()
 	end)
-	controls.cancel = new("ButtonControl", nil, 45, 330, 80, 20, "Cancel", function()
+	controls.cancel = new("ButtonControl", nil, 45, 360, 80, 20, "Cancel", function()
 		main:ClosePopup()
 	end)
 	controls.noteLine1 = new("LabelControl", {"TOPLEFT",controls.list,"BOTTOMLEFT"}, 24, 2, 0, 16, "Spectres in your Library must be assigned to an active")
 	controls.noteLine2 = new("LabelControl", {"TOPLEFT",controls.list,"BOTTOMLEFT"}, 20, 18, 0, 16, "Raise Spectre gem for their buffs and curses to activate")
-	main:OpenPopup(410, 360, "Spectre Library", controls)
+	main:OpenPopup(410, 390, "Spectre Library", controls)
 end
 
 function buildMode:OpenSimilarPopup()

--- a/src/Modules/Build.lua
+++ b/src/Modules/Build.lua
@@ -1503,22 +1503,8 @@ function buildMode:OpenSpectreLibrary()
 	end)
 	local controls = { }
 	controls.searchText = new("EditControl", nil, 0, 25, 390, 20, "", "Search", "%c", 100, function(buf)
-		local searchStr = buf:lower():gsub("[%-%.%+%[%]%$%^%%%?%*]", "%%%0")
-		if searchStr:match("%S") then
-			local sourceListFiltered = { }
-			for _, minionId in pairs(sourceList) do
-				local err, match = PCall(string.matchOrPattern, self.data.minions[minionId].name:lower(), searchStr)
-				if not err and match then
-					t_insert(sourceListFiltered, minionId)
-				end
-				--if string.find( self.data.minions[minionId].name:lower(), buf:lower()) then
-				--	t_insert(sourceListFiltered, minionId)
-				--end
-			end
-			controls.source.list = sourceListFiltered
-		else
-			controls.source.list = sourceList
-		end
+		controls.source:ListFilterChanged(buf)
+		--controls.list:ListFilterChanged(buf) -- filter left list
 	end, nil, nil, true)
 	controls.list = new("MinionListControl", nil, -100, 70, 190, 250, self.data, destList)
 	controls.source = new("MinionListControl", nil, 100, 70, 190, 250, self.data, sourceList, controls.list)

--- a/src/Modules/Build.lua
+++ b/src/Modules/Build.lua
@@ -1502,8 +1502,8 @@ function buildMode:OpenSpectreLibrary()
 		end
 	end)
 	local controls = { }
-	controls.searchText = new("EditControl", nil, 0, 18, 390, 18, "", "Search", "%c", 100, function(buf)
-		controls.source:ListFilterChanged(buf)
+	controls.searchText = new("EditControl", nil, -61, 18, 268, 18, "", "Search", "%c", 100, function(buf)
+		controls.source:ListFilterChanged(buf, controls.searchModeDropDown.selIndex)
 		--controls.list:ListFilterChanged(buf) -- filter left list
 	end, nil, nil, true)	
 	controls.list = new("MinionListControl", nil, -100, 60, 190, 250, self.data, destList)
@@ -1519,6 +1519,9 @@ function buildMode:OpenSpectreLibrary()
 	end)
 	controls.noteLine1 = new("LabelControl", {"TOPLEFT",controls.list,"BOTTOMLEFT"}, 24, 2, 0, 16, "Spectres in your Library must be assigned to an active")
 	controls.noteLine2 = new("LabelControl", {"TOPLEFT",controls.list,"BOTTOMLEFT"}, 20, 18, 0, 16, "Raise Spectre gem for their buffs and curses to activate")
+	controls.searchModeDropDown = new("DropDownControl", {"LEFT",controls.searchText,"RIGHT"}, 2, 0, 120, 18, { "Names", "Skills", "Names & Skills"}, function(index, value)
+		controls.source:ListFilterChanged(controls.searchText.buf, index)
+	end)
 	main:OpenPopup(410, 380, "Spectre Library", controls)
 end
 

--- a/src/Modules/Build.lua
+++ b/src/Modules/Build.lua
@@ -1502,24 +1502,24 @@ function buildMode:OpenSpectreLibrary()
 		end
 	end)
 	local controls = { }
-	controls.searchText = new("EditControl", nil, 0, 25, 390, 20, "", "Search", "%c", 100, function(buf)
+	controls.searchText = new("EditControl", nil, 0, 18, 390, 18, "", "Search", "%c", 100, function(buf)
 		controls.source:ListFilterChanged(buf)
 		--controls.list:ListFilterChanged(buf) -- filter left list
-	end, nil, nil, true)
-	controls.list = new("MinionListControl", nil, -100, 70, 190, 250, self.data, destList)
-	controls.source = new("MinionListControl", nil, 100, 70, 190, 250, self.data, sourceList, controls.list)
-	controls.save = new("ButtonControl", nil, -45, 360, 80, 20, "Save", function()
+	end, nil, nil, true)	
+	controls.list = new("MinionListControl", nil, -100, 60, 190, 250, self.data, destList)
+	controls.source = new("MinionListControl", nil, 100, 60, 190, 250, self.data, sourceList, controls.list)
+	controls.save = new("ButtonControl", nil, -45, 350, 80, 20, "Save", function()
 		self.spectreList = destList
 		self.modFlag = true
 		self.buildFlag = true
 		main:ClosePopup()
 	end)
-	controls.cancel = new("ButtonControl", nil, 45, 360, 80, 20, "Cancel", function()
+	controls.cancel = new("ButtonControl", nil, 45, 350, 80, 20, "Cancel", function()
 		main:ClosePopup()
 	end)
 	controls.noteLine1 = new("LabelControl", {"TOPLEFT",controls.list,"BOTTOMLEFT"}, 24, 2, 0, 16, "Spectres in your Library must be assigned to an active")
 	controls.noteLine2 = new("LabelControl", {"TOPLEFT",controls.list,"BOTTOMLEFT"}, 20, 18, 0, 16, "Raise Spectre gem for their buffs and curses to activate")
-	main:OpenPopup(410, 390, "Spectre Library", controls)
+	main:OpenPopup(410, 380, "Spectre Library", controls)
 end
 
 function buildMode:OpenSimilarPopup()


### PR DESCRIPTION
Fixes #8054 .

### Description of the problem being solved:

> The list of added spectres is long and continues to grow; it can be tedious and time consuming to find the particular one you wish to use in your build.

Now you can search the list of available spectres by name or by skill. Default is to only search by name, but in a dropdown menu you can choose to search by skill or even name and skill.

Search for skills is just an added bonus i found neat.

The search field only filters the list of available spectres(on the right), not the list of spectres added to the build (on the left).

todo:
- add ctrl + F shortcut to be in line with all other search bars

### Steps taken to verify a working solution:
- open spectre library and search a few different spectre

### Link to a build that showcases this PR:#
```
eNqtW1t32roSfm5_hRfvDXeadpHuRSBpslbScCBpz3nqErYA7coWW5aTsH_9GV1sDEGOjJ2H1lgz31ykGWnG9vCv15B6z5jHhEUXjfZZq-HhyGcBiVYXjafH60_njb--fRxOkVg_LC8TQuXIt48fhurao_gZU-BreALxFRY_U6Tub0DaoEisMYvu0d-Mf2fBReMHi3DDW6AoICL95VMUxz9QiC8acx-YGx6KfRwF4919Q7hGHPkC8zspdZQIds8CGBU8gdEQkWjO_D9YfOcs2Silngl-0TS399OH2WNOJRLlVQKLPgynFG0xnwskvBj-uWiMwDFohW-IAChEE8BpNZqFtJcJj8UEhXD5Ps98g3GQkbXP2p8Hvc-t_vl5p9vv2pimHF8tl9gX5BmPORHjNYp8B2Flae8TKsiGEsxzGvZtHDdvwNstK_wjE4hOpvP3FdGUzMH_v4hYX1LwpxOupL5dRURgZ_IpIzGLSmntRDxOKIWYcqKd4RjzZySIoyJjFi5I5OiTexShMYt3vu6cF5FOMYcoFXscrXcY5thnENh5lm7n7Euvna18B4nHcayi78gSu1OWssowlNXmNDuu5q50pYFPU2gGOc6Ncs4S6kgpdtmmY6Wa4FcHqttIOFDN8D95wna_b5f6zITan5zi_-pmmlH2v5y1291uq9X70hm029bUvt7GxEf0Hr2SMAkhpz6iP3gncFCwrFZrEUEasbF2rZF1TTguzzVmNDiBa41YXJ5NBo2DE2A79b9K2tvId4vEp4irjJrbhQeFDDOID7nRLyh25NiJMFHmskFqUSscGXlbN3PuMPbX3-EcNEMCuyXl3RItdqukdXKrJDzi1r4jQwknSUaLk86-FDGVdNNVhPlqO18TTINy1KliY7RxOgz6X_PcTu7eF1dqxeRZS7rkF-KB2wZRVqdnFOdTbHtQ7C5N7rYwMZwOgSHArqfgKWd_y3M2Lcc24iFLuOOEa2InA9LdQVcXMxwkvtt2lJULlxTqI1czMi7Qk9JSrCMhkP9nwoKVs9OUkFIc-_rNk80GcohcDa4AcuODAzXJnUs-DRyoH2ApO0W03CPdBeyonQVku767lAMWd1vkzl3CmB25s4hsQu8hWYSwCajyGMr3XTawTg7UUE41jiJ0LMym7AU0X8u-RlyOGk44u1ONVRWOo3-3zvh75E4CrqIg4TIUnGUcchwT80hCSKRxPEECeYE5Ev9EnKBIdFTTJcaI--s7mPprROkCMsFFI39X_VKNmmtCBeYTuCeFSsUOEdvppA-bquEkr27DDePCw6_yvyniYnvRWCIaY02o7gBOLEikKmXIR5Q2vPmavYyCZynpkTEap0we2mxwFOxhPHKMPZRmF18qoYyXP7wQxaD1Vi_XWFqT61fdBsqMiIECcOo5P-92pe2yqkJ8O9onjAjoJUBWrm3W6ZuOmEaSYj8Mn2Z36uLDWohN_LXZfHl5OdsgsWZL_Ar705nPwuYGmEDhT_EfQuknCdscwd_laqT-FFAzRRrqVlnc1L9kkHICOutJbkpDldelJ-TFDyZwLMfkzfTHcC5FxTCbXHzHYXy5hcC6lueJg9aDcaWknmOhV0meJ-3hBXiJEirv_ydBlMiZbeXv3ul2Y8R4mFVJAAUzK_O_RnzcbqTrR3d3emREhQGT4tJp1tNpFPJIkE6xuam6iaOd1mNE_VjpTSKfJgGUGCbnZMuIooXUTfZPZXkQ5PuSOaRM0Ich6GOIv1O2QLSTspiuKhSt3gqHciHcY4ECiLjmrQAjmtKSpoKDqxkisVqmMOUyXFXgSKb9AbUs3t7-J-docy2JJtrnjT0F26mCByb6LIn0rEYoNBGjpHipGLPMtM5miRnnq2WmF5K8VJ5WFLfRJhEK8aIRktj_vUiWS9nNBVsEVw3qq-vrq_Hj7c8rk5zyLMre31ESLmQHU_-_20LmWB2evDhZxPryovGT4BelyAS8TWgsDaMUbWKcZQe1UozmFPgK0BQVFLlpM_g41o7AjnT1ijkksxWcun1OsFWvbPwdpbRAeSKXydyGJruudiB9xBtDKtQVg8VTqsFtR5F9Zqs5crCAF7YBRK2Szeg7nhAyV8ASJUviy32weMplZtFUBX7xfdhC_W3BfJvzqR1DtbFtAHrQzqzb1DZuM1rgVdUUt3pVj9rZJ9hHVtv1oJ05K0JZpB65HEfJqAqQfrBILXIImhGh8ixpndkrijMSO-CDWGNudnwb0j3kqJSkMHA4WSTCHsY5igJfqZaYxUNyzM6q2z4WG-RYQSbaa4VYHJqnsUPpFoI1kRWx6rrC6j9TpRRMgSnQLe7XowVOSHsUFvvNcEGQqPw7emYk0JWqJVwOyIoSBhzmqsOo8rs6zGE9Xh3xGs7Df6zzbUbt7E-CyGPNERR9fHECkUFVDUHGVjWERzh8ioTjkwFmhyeRHe-s-AyS1ZBHmdPRosxhSsuTEXQBfDK7qs9P5lb5H87EGCwo3AAymoL4EEk0AWeIgthwhFJqHU8kO-tKYemt8KilpRF1gJuHPEU5QJO8AwR7-U3BadENKesx3WBE5TN9RqsBvnmYVQVM9smTDYqCFO7h2Bl9Nw-O3mMiBkzVP5nIdnxVH0Y43B4Bsus1bKZVneqsyDrL9IPmgsuS-V_Gwv-pElRemSq_ayp7OHFPCMwbV-stlSMJ_5v2soaqLDZtBnmddRnsAAkUwaov8wujDYsUR643YFAKyPa7BpQJD87G4XTxNLuTNukqFArnZxlHckh3dJrFDFqM1y7Bcslghr3RYhvHiHq6seP1ywBgKg75OyX41b7jdU-w0pu_oM2h6N4pQBXMNxidGjCOGzSowaBBDQadhHHMoMqrs1uDRzp1WVNmvd1g2CBFJX8cCbZBZQ06pREqi-zW5f9-DYuhXUN4tGvQo1dyJdSVYjpVI7JXgwPL7xm1pdhuVfs7FUO4nALB1tN9hiprUJ8tqiAcD-x-ZYRBXdParivHlF-a1f3YqzyX_XoWVRnjR2FCsaghE3ZrSCjdikHZq8jfrsf_J--UpRdtrzTHKaeoil7tV83VNU1Lr67kUtu5-uQSqgTfjESrUlN4PDV16pmD2naKOgq-3mk2lXV-9T2-psNGv7Ii1be4QdlkUDV5vBU4bJpmj37BiaMAz1V36heWb8vFRoh8T-pF3ZGfRqmP5VrZax_ybRBPveuy_0Za08LcOuvvmLOupHdDhKebkgdfEhhFjyqn9ddvT7BoSVamEaZ_mFaY4s_ueIIIinOveeR7WVOKfLxmNMDcOBLLlp_5Wi19k-JzK_O_hSH_xVnK1bfzzNcwQXP5WkH85n0Nq4z9l2Jz2hXI8ZnqPJYTJI05FNJ9zwNpfsiEdOwMMVkR-rBUzylAOfWwxUG5MPtMT36khjkOlGVj-UrOHNNlDqT_jrbZg82UY_D5HQ7zKjKjdIaiPfdnoZUtOd0HVr--fRw2D78o_T_xN7yR
```

### Before screenshot:
![grafik](https://github.com/user-attachments/assets/f85b37fa-24e1-470b-a25e-940e50e9f841)

### After screenshot:
![grafik](https://github.com/user-attachments/assets/ab8ac347-3b8e-46e7-8ccb-d410783ef2ef)
