### PR TITLE
Fix Ynda's Stand ward conversion mod not taking catalysts into consideration

### DIFF
--- a/src/Modules/CalcDefence.lua
+++ b/src/Modules/CalcDefence.lua
@@ -359,7 +359,7 @@ function calcs.defence(env, actor)
 						armourBase = armourBase * 2
 					end
 					if modDB:Flag(nil, "ConvertBodyArmourArmourEvasionToWard") then
-						armourBase = armourBase / 2
+						armourBase = armourBase * (1 - ((modDB:Sum("BASE", nil, "BodyArmourArmourEvasionToWardPercent") or 0) / 100))
 					end
 				end
 				output["ArmourOn"..slot] = armourBase
@@ -374,7 +374,7 @@ function calcs.defence(env, actor)
 						evasionBase = evasionBase * 2
 					end
 					if modDB:Flag(nil, "ConvertBodyArmourArmourEvasionToWard") then
-						evasionBase = evasionBase / 2
+						evasionBase = evasionBase * (1 - ((modDB:Sum("BASE", nil, "BodyArmourArmourEvasionToWardPercent") or 0) / 100))
 					end
 				end
 				output["EvasionOn"..slot] = evasionBase
@@ -731,7 +731,7 @@ function calcs.defence(env, actor)
 							armourBase = armourBase * 2
 						end
 						if modDB:Flag(nil, "ConvertBodyArmourArmourEvasionToWard") then
-							armourBase = armourBase / 2
+							armourBase = armourBase * (1 - ((modDB:Sum("BASE", nil, "BodyArmourArmourEvasionToWardPercent") or 0) / 100))
 						end
 					end
 					armour = armour + armourBase * calcLib.mod(modDB, slotCfg, "Armour", "ArmourAndEvasion", "Defences", slot.."ESAndArmour")
@@ -750,7 +750,7 @@ function calcs.defence(env, actor)
 							evasionBase = evasionBase * 2
 						end
 						if modDB:Flag(nil, "ConvertBodyArmourArmourEvasionToWard") then
-							evasionBase = evasionBase / 2
+							evasionBase = evasionBase * (1 - ((modDB:Sum("BASE", nil, "BodyArmourArmourEvasionToWardPercent") or 0) / 100))
 						end
 					end
 					gearEvasion = gearEvasion + evasionBase

--- a/src/Modules/CalcPerform.lua
+++ b/src/Modules/CalcPerform.lua
@@ -1194,7 +1194,8 @@ function calcs.perform(env, skipEHP)
 		if armourData then
 			ward = armourData.Evasion + armourData.Armour
 			if ward > 0 then
-				modDB:NewMod("Ward", "BASE", ward * 0.5 , "Body Armour Armour And Evasion Rating to Ward Conversion")
+				local wardMult = ((modDB:Sum("BASE", nil,"BodyArmourArmourEvasionToWardPercent") or 0) / 100)
+				modDB:NewMod("Ward", "BASE", ward * wardMult , "Body Armour Armour And Evasion Rating to Ward Conversion")
 			end
 		end
 	end

--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -4211,7 +4211,7 @@ local specialModList = {
 	["reflects (%d+) physical damage to melee attackers"] = { },
 	["ignore all movement penalties from armour"] = { flag("Condition:IgnoreMovementPenalties") },
 	["gain armour equal to your reserved mana"] = { mod("Armour", "BASE", 1, { type = "PerStat", stat = "ManaReserved", div = 1 }) },
-	["gain ward instead of (%d+)%% of armour and evasion rating from equipped body armour"] = {flag("ConvertBodyArmourArmourEvasionToWard")},
+	["gain ward instead of (%d+)%% of armour and evasion rating from equipped body armour"] = function(num) return {flag("ConvertBodyArmourArmourEvasionToWard"), mod("BodyArmourArmourEvasionToWardPercent", "BASE", num)} end,
 	["(%d+)%% increased armour per (%d+) reserved mana"] = function(num, _, mana) return { mod("Armour", "INC", num, { type = "PerStat", stat = "ManaReserved", div = tonumber(mana) }) } end,
 	["cannot be stunned"] = { flag("StunImmune"), },
 	["cannot be stunned while bleeding"] = { flag("StunImmune", { type = "Condition", var = "Bleeding" }), },


### PR DESCRIPTION
### Description of the problem being solved:
The calculation for the Armour/Evasion to ward conversion didn't take Tempering catalysts into consideration. This fixes it.

### Steps taken to verify a working solution:
- added the code to make it work
- used the PoB below
- switched the values and the calculations are correct now

### Link to a build that showcases this PR:
https://pobb.in/sF-bEns2KZiF
### Before screenshot:
![image](https://github.com/user-attachments/assets/a38f54cf-dd7b-4e39-b2f9-3c48fd10240b)

### After screenshot:
![image](https://github.com/user-attachments/assets/47b1cde4-6def-4802-9fd5-23efff4686b3)
