### PR TITLE
Fix infinitely nested XML stored as importLink

### DIFF
--- a/src/Classes/ImportTab.lua
+++ b/src/Classes/ImportTab.lua
@@ -297,12 +297,12 @@ You can get this from your web browser's cookies while logged into the Path of E
 		if self.controls.importCodeMode.selIndex == 1 then
 			main:OpenConfirmPopup("Build Import", colorCodes.WARNING.."Warning:^7 Importing to the current build will erase ALL existing data for this build.", "Import", function()
 				self.build:Shutdown()
-				self.build:Init(self.build.dbFileName, self.build.buildName, self.importCodeXML, false, self.controls.importCodeIn.buf)
+				self.build:Init(self.build.dbFileName, self.build.buildName, self.importCodeXML, false, self.importCodeSite and self.controls.importCodeIn.buf or nil)
 				self.build.viewMode = "TREE"
 			end)
 		else
 			self.build:Shutdown()
-			self.build:Init(false, "Imported build", self.importCodeXML, false, self.controls.importCodeIn.buf)
+			self.build:Init(false, "Imported build", self.importCodeXML, false, self.importCodeSite and self.controls.importCodeIn.buf or nil)
 			self.build.viewMode = "TREE"
 		end
 	end
@@ -382,6 +382,8 @@ function ImportTabClass:Save(xml)
 	if self.build.importLink then
 		xml.attrib.importLink = self.build.importLink
 	end
+	-- Gets rid of erroneous, potentially infinitely nested full base64 XML stored as an import link
+	xml.attrib.importLink = (xml.attrib.importLink and xml.attrib.importLink:len() < 100) and xml.attrib.importLink or nil 
 end
 
 function ImportTabClass:Draw(viewPort, inputEvents)


### PR DESCRIPTION
We were seeing large build codes being stored in the XML, as they weren't being differentiated from external build links.  Other than the obvious unintended use case, this could also result in ballooning build file sizes as builds kept building on each other and nesting infinitely deeper.
