### PR TITLE
Fix issue where PoB did not detect changes when selecting gems via keyboard shortcuts

### DIFF
--- a/src/Classes/SkillsTab.lua
+++ b/src/Classes/SkillsTab.lua
@@ -664,6 +664,9 @@ function SkillsTabClass:CreateGemSlot(index)
 			slot.enableGlobal2.state = true
 			slot.count:SetText(gemInstance.count)
 		elseif gemId == gemInstance.gemId then
+			if addUndo then
+				self:AddUndoState()
+			end
 			return
 		end
 		gemInstance.gemId = gemId


### PR DESCRIPTION
Fixes #8067 .

### Description of the problem being solved:
The bug was not specific to overexertion (like the issue states), and rather is present with all gems.

Fixes selecting skills with the keyboard by properly creating an undostate when one should be created.

Also fixes not creating an undostate when first a skill was selected with the keyboard(up, down), but then clicked with the mouse.