### PR TITLE
Check for empty build file on load.

### DIFF
--- a/src/Modules/Build.lua
+++ b/src/Modules/Build.lua
@@ -1956,6 +1956,9 @@ function buildMode:LoadDB(xmlText, fileName)
 	if not dbXML then
 		launch:ShowErrMsg("^1Error loading '%s': %s", fileName, errMsg)
 		return true
+	elseif #dbXML == 0 then
+		launch:ShowErrMsg("^1Build file empty '%s'", fileName)
+		return true
 	elseif dbXML[1].elem ~= "PathOfBuilding" then
 		launch:ShowErrMsg("^1Error parsing '%s': 'PathOfBuilding' root element missing", fileName)
 		return true


### PR DESCRIPTION
Throws a recoverable error with informative message on zero-length dbXML:

![image](https://github.com/user-attachments/assets/0d602600-1b1c-4433-bfd5-d00b9dcfe4f3)
