### PR TITLE
Nicer check-empty-build popup

### DIFF
--- a/src/Modules/Build.lua
+++ b/src/Modules/Build.lua
@@ -1957,7 +1957,7 @@ function buildMode:LoadDB(xmlText, fileName)
 		launch:ShowErrMsg("^1Error loading '%s': %s", fileName, errMsg)
 		return true
 	elseif #dbXML == 0 then
-		launch:ShowErrMsg("^1Build file empty '%s'", fileName)
+		main:OpenMessagePopup("Error", "Build file is empty, or error parsing xml.\n\n"..fileName)
 		return true
 	elseif dbXML[1].elem ~= "PathOfBuilding" then
 		launch:ShowErrMsg("^1Error parsing '%s': 'PathOfBuilding' root element missing", fileName)


### PR DESCRIPTION
Clicking OK takes the user to the build list screen.  Also works for the auto-build-load at startup.

![image](https://github.com/user-attachments/assets/df66e3bb-1490-4db2-806c-2fd8af854c0e)


