### PR TITLE
Fix Ynda's Stand not working correctly with Trickster's Escape Artist

### DIFF
--- a/src/Modules/CalcDefence.lua
+++ b/src/Modules/CalcDefence.lua
@@ -358,9 +358,6 @@ function calcs.defence(env, actor)
 					if modDB:Flag(nil, "Unbreakable") then
 						armourBase = armourBase * 2
 					end
-					if modDB:Flag(nil, "ConvertBodyArmourArmourEvasionToWard") then
-						armourBase = armourBase * (1 - ((modDB:Sum("BASE", nil, "BodyArmourArmourEvasionToWardPercent") or 0) / 100))
-					end
 				end
 				output["ArmourOn"..slot] = armourBase
 			end
@@ -372,9 +369,6 @@ function calcs.defence(env, actor)
 					end
 				 	if modDB:Flag(nil, "Unbreakable") and modDB:Flag(nil, "IronReflexes") then
 						evasionBase = evasionBase * 2
-					end
-					if modDB:Flag(nil, "ConvertBodyArmourArmourEvasionToWard") then
-						evasionBase = evasionBase * (1 - ((modDB:Sum("BASE", nil, "BodyArmourArmourEvasionToWardPercent") or 0) / 100))
 					end
 				end
 				output["EvasionOn"..slot] = evasionBase


### PR DESCRIPTION
The Belt mod does not affect the amount of evasion on the body armour for the purpose of Trickster's Escape artist node
This is also verified on the wiki https://www.poewiki.net/wiki/Ynda%27s_Stand
