### PR TITLE
Fix full dps visual bug on gem dropdown

### DIFF
--- a/src/Modules/Build.lua
+++ b/src/Modules/Build.lua
@@ -1861,7 +1861,7 @@ function buildMode:CompareStatList(tooltip, statList, actor, baseOutput, compare
 			local statVal1 = compareOutput[statData.stat] or 0
 			local statVal2 = baseOutput[statData.stat] or 0
 			local diff = statVal1 - statVal2
-			if statData.stat == "FullDPS" and not GlobalCache.useFullDPS and not self.viewMode == "TREE" then
+			if statData.stat == "FullDPS" and not GlobalCache.useFullDPS and self.viewMode ~= "TREE" then
 				diff = 0
 			end
 			if (diff > 0.001 or diff < -0.001) and (not statData.condFunc or statData.condFunc(statVal1,compareOutput) or statData.condFunc(statVal2,baseOutput)) then


### PR DESCRIPTION
### Description of the problem being solved:
When hovering over a gem in the gem selection dropdown while having anything other than full dps selected in the sort gems by dropdown the tooltip would show that the player loses all full dps (see screen shots). This was caused by a funky lua behaviour here:

https://github.com/PathOfBuildingCommunity/PathOfBuilding/blob/c76a5fea58a8ccfc7421cb34e2f614808a8246ae/src/Modules/Build.lua#L1864-L1866

The above condition would return false even though self.viewMode was not `"TREE"` see below minimal repro:

```lua
test1 = "test1"
test2 = false
test3 = "justtest"

print(test1 == "test1" and not test2 and not test3 == "test3") -- false -- the condition currently
print((test1 == "test1" and not test2 and not test3) == "test3") -- false
print(test1 == "test1" and not test2 and not (test3 == "test3")) -- true
print(test1 == "test1" and not test2 and test3 ~= "test3") -- true -- the condition this pr changes it to
```

### Before screenshot:
![obraz](https://github.com/user-attachments/assets/b0937b60-b868-43f0-8fc9-a3405fa653a8)

### After screenshot:
![obraz](https://github.com/user-attachments/assets/ea1c8b4c-e897-4378-913d-6fc895b899af)
