### PR TITLE
Scale Warcry buffs by Warcry Power earlier in Calc

### DIFF
--- a/src/Data/Skills/act_str.lua
+++ b/src/Data/Skills/act_str.lua
@@ -287,12 +287,10 @@ skills["AncestralCry"] = {
 			mod("AncestralExertedAttacks", "BASE", nil),
 		},
 		["ancestral_cry_elemental_resist_%_per_5_power_up_to_cap"] = {
-			mod("ElementalResist", "BASE", nil, 0, 0, { type = "GlobalEffect", effectType = "Warcry" }, { type = "Multiplier", var = "WarcryPower", div = 5, limit = 5 }),
-			mod("ElementalResist", "BASE", nil, 0, 0, { type = "GlobalEffect", effectType = "Warcry" }, { type = "Multiplier", var = "WarcryPower", actor = "parent", div = 5, limit = 5 }),
+			mod("ElementalResist", "BASE", nil, 0, 0, { type = "GlobalEffect", effectType = "Warcry", div = 5, limit = 30 }),
 		},
 		["ancestral_cry_maximum_elemental_resist_%_per_10_power_up_to_cap"] = {
-			mod("ElementalResistMax", "BASE", nil, 0, 0, { type = "GlobalEffect", effectType = "Warcry" }, { type = "Multiplier", var = "WarcryPower", div = 10, limit = 3 }),
-			mod("ElementalResistMax", "BASE", nil, 0, 0, { type = "GlobalEffect", effectType = "Warcry" }, { type = "Multiplier", var = "WarcryPower", actor = "parent", div = 10, limit = 3 }),
+			mod("ElementalResistMax", "BASE", nil, 0, 0, { type = "GlobalEffect", effectType = "Warcry", div = 10, limit = 30 }),
 		},
 		["skill_empower_limitation_specifier_for_stat_description"] = {
 			-- Display only
@@ -782,8 +780,7 @@ skills["BattlemagesCry"] = {
 			mod("BattlemageExertedAttacks", "BASE", nil),
 		},
 		["divine_cry_additional_base_critical_strike_chance_per_5_power_up_to_cap"] = {
-			mod("CritChance", "BASE", nil, 0, 0, { type = "GlobalEffect", effectType = "Warcry" }, { type = "Multiplier", var = "WarcryPower", div = 5, limit = 5 }),
-			mod("CritChance", "BASE", nil, 0, 0, { type = "GlobalEffect", effectType = "Warcry" }, { type = "Multiplier", var = "WarcryPower", actor = "parent", div = 5, limit = 5 }),
+			mod("CritChance", "BASE", nil, 0, 0, { type = "GlobalEffect", effectType = "Warcry", div = 5, limit = 25 }),
 			div = 100,
 		},
 		["display_battlemage_cry_exerted_attacks_trigger_supported_spell"] ={
@@ -3672,8 +3669,7 @@ skills["EnduringCry"] = {
 	castTime = 0.8,
 	statMap = {
 		["enduring_cry_life_regeneration_rate_per_minute_%_per_5_power_up_to_cap"] = {
-			mod("LifeRegenPercent", "BASE", nil, 0, 0, { type = "GlobalEffect", effectType = "Warcry" }, { type = "Multiplier", var = "WarcryPower", div = 5, limit = 5 }),
-			mod("LifeRegenPercent", "BASE", nil, 0, 0, { type = "GlobalEffect", effectType = "Warcry" }, { type = "Multiplier", var = "WarcryPower", actor = "parent", div = 5, limit = 5 }),
+			mod("LifeRegenPercent", "BASE", nil, 0, 0, { type = "GlobalEffect", effectType = "Warcry", div = 5, limit = 25 }),
 			div = 60,
 		},
 	},
@@ -6068,8 +6064,7 @@ skills["InfernalCry"] = {
 			mod("InfernalExertedAttacks", "BASE", nil),
 		},
 		["infernal_cry_physical_damage_%_to_add_as_fire_per_5_power_up_to_cap"] = {
-			mod("PhysicalDamageGainAsFire", "BASE", nil, 0, 0, { type = "GlobalEffect", effectType = "Warcry" }, { type = "Multiplier", var = "WarcryPower", div = 5, limit = 5 }),
-			mod("PhysicalDamageGainAsFire", "BASE", nil, 0, 0, { type = "GlobalEffect", effectType = "Warcry" }, { type = "Multiplier", var = "WarcryPower", actor = "parent", div = 5, limit = 5 }),
+			mod("PhysicalDamageGainAsFire", "BASE", nil, 0, 0, { type = "GlobalEffect", effectType = "Warcry", div = 5, limit = 25 }),
 		},
 		["infernal_cry_empowered_attacks_trigger_combust_display"] = {
 			-- Display only
@@ -6497,8 +6492,7 @@ skills["IntimidatingCry"] = {
 			mod("IntimidatingExertedAttacks", "BASE", nil),
 		},
 		["intimidating_cry_movement_speed_+%_per_5_power_up_to_cap"] = {
-			mod("MovementSpeed", "INC", nil, 0, 0, { type = "GlobalEffect", effectType = "Warcry" }, { type = "Multiplier", var = "WarcryPower", div = 5, limit = 6 }),
-			mod("MovementSpeed", "INC", nil, 0, 0, { type = "GlobalEffect", effectType = "Warcry" }, { type = "Multiplier", var = "WarcryPower", actor = "parent", div = 5, limit = 6 }),
+			mod("MovementSpeed", "INC", nil, 0, 0, { type = "GlobalEffect", effectType = "Warcry", div = 5, limit = 30 }),
 		},
 		["intimidating_cry_empowerd_attacks_deal_double_damage_display"] = {
 		},
@@ -8663,12 +8657,10 @@ skills["SeismicCry"] = {
 			mod("SeismicAoEMoreMultiplier", "BASE", nil),
 		},
 		["seismic_cry_stun_threshold_+%_per_5_power_up_to_cap"] = {
-			mod("StunThreshold", "INC", nil, 0, 0, { type = "GlobalEffect", effectType = "Warcry" }, { type = "Multiplier", var = "WarcryPower", div = 5, limit = 5 }),
-			mod("StunThreshold", "INC", nil, 0, 0, { type = "GlobalEffect", effectType = "Warcry" }, { type = "Multiplier", var = "WarcryPower", actor = "parent", div = 5, limit = 5 }),
+			mod("StunThreshold", "INC", nil, 0, 0, { type = "GlobalEffect", effectType = "Warcry", div = 5, limit = 25 }),
 		},
 		["seismic_cry_armour_+%_final_per_5_power_up_to_cap"] = {
-			mod("Armour", "MORE", nil, 0, 0, { type = "GlobalEffect", effectType = "Warcry" }, { type = "Multiplier", var = "WarcryPower", div = 5, limit = 5 }),
-			mod("Armour", "MORE", nil, 0, 0, { type = "GlobalEffect", effectType = "Warcry" }, { type = "Multiplier", var = "WarcryPower", actor = "parent", div = 5, limit = 5 }),
+			mod("Armour", "MORE", nil, 0, 0, { type = "GlobalEffect", effectType = "Warcry", div = 5, limit = 25 }),
 		},
 		["skill_empower_limitation_specifier_for_stat_description"] = {
 			-- Display only
@@ -10911,8 +10903,7 @@ skills["VengefulCry"] = {
 	castTime = 0.8,
 	statMap = {
 		["rage_warcry_gain_X_rage_per_minute_per_5_monster_power_max_25_power"] = {
-			mod("RageRegen", "BASE", nil, 0, 0, { type = "GlobalEffect", effectType = "Warcry" }, { type = "Multiplier", var = "WarcryPower", div = 5, limit = 5 }),
-			mod("RageRegen", "BASE", nil, 0, 0, { type = "GlobalEffect", effectType = "Warcry" }, { type = "Multiplier", var = "WarcryPower", actor = "parent", div = 5, limit = 5 }),
+			mod("RageRegen", "BASE", nil, 0, 0, { type = "GlobalEffect", effectType = "Warcry", div = 5, limit = 25 }),
 			flag("Condition:CanGainRage", { type = "GlobalEffect", effectType = "Warcry"} ),
 			div = 60,
 		},

--- a/src/Export/Skills/act_str.txt
+++ b/src/Export/Skills/act_str.txt
@@ -54,12 +54,10 @@ local skills, mod, flag, skill = ...
 			mod("AncestralExertedAttacks", "BASE", nil),
 		},
 		["ancestral_cry_elemental_resist_%_per_5_power_up_to_cap"] = {
-			mod("ElementalResist", "BASE", nil, 0, 0, { type = "GlobalEffect", effectType = "Warcry" }, { type = "Multiplier", var = "WarcryPower", div = 5, limit = 5 }),
-			mod("ElementalResist", "BASE", nil, 0, 0, { type = "GlobalEffect", effectType = "Warcry" }, { type = "Multiplier", var = "WarcryPower", actor = "parent", div = 5, limit = 5 }),
+			mod("ElementalResist", "BASE", nil, 0, 0, { type = "GlobalEffect", effectType = "Warcry", div = 5, limit = 30 }),
 		},
 		["ancestral_cry_maximum_elemental_resist_%_per_10_power_up_to_cap"] = {
-			mod("ElementalResistMax", "BASE", nil, 0, 0, { type = "GlobalEffect", effectType = "Warcry" }, { type = "Multiplier", var = "WarcryPower", div = 10, limit = 3 }),
-			mod("ElementalResistMax", "BASE", nil, 0, 0, { type = "GlobalEffect", effectType = "Warcry" }, { type = "Multiplier", var = "WarcryPower", actor = "parent", div = 10, limit = 3 }),
+			mod("ElementalResistMax", "BASE", nil, 0, 0, { type = "GlobalEffect", effectType = "Warcry", div = 10, limit = 30 }),
 		},
 		["skill_empower_limitation_specifier_for_stat_description"] = {
 			-- Display only
@@ -149,8 +147,7 @@ local skills, mod, flag, skill = ...
 			mod("BattlemageExertedAttacks", "BASE", nil),
 		},
 		["divine_cry_additional_base_critical_strike_chance_per_5_power_up_to_cap"] = {
-			mod("CritChance", "BASE", nil, 0, 0, { type = "GlobalEffect", effectType = "Warcry" }, { type = "Multiplier", var = "WarcryPower", div = 5, limit = 5 }),
-			mod("CritChance", "BASE", nil, 0, 0, { type = "GlobalEffect", effectType = "Warcry" }, { type = "Multiplier", var = "WarcryPower", actor = "parent", div = 5, limit = 5 }),
+			mod("CritChance", "BASE", nil, 0, 0, { type = "GlobalEffect", effectType = "Warcry", div = 5, limit = 25 }),
 			div = 100,
 		},
 		["display_battlemage_cry_exerted_attacks_trigger_supported_spell"] ={
@@ -662,8 +659,7 @@ local skills, mod, flag, skill = ...
 #flags warcry area duration
 	statMap = {
 		["enduring_cry_life_regeneration_rate_per_minute_%_per_5_power_up_to_cap"] = {
-			mod("LifeRegenPercent", "BASE", nil, 0, 0, { type = "GlobalEffect", effectType = "Warcry" }, { type = "Multiplier", var = "WarcryPower", div = 5, limit = 5 }),
-			mod("LifeRegenPercent", "BASE", nil, 0, 0, { type = "GlobalEffect", effectType = "Warcry" }, { type = "Multiplier", var = "WarcryPower", actor = "parent", div = 5, limit = 5 }),
+			mod("LifeRegenPercent", "BASE", nil, 0, 0, { type = "GlobalEffect", effectType = "Warcry", div = 5, limit = 25 }),
 			div = 60,
 		},
 	},
@@ -1054,8 +1050,7 @@ local skills, mod, flag, skill = ...
 			mod("InfernalExertedAttacks", "BASE", nil),
 		},
 		["infernal_cry_physical_damage_%_to_add_as_fire_per_5_power_up_to_cap"] = {
-			mod("PhysicalDamageGainAsFire", "BASE", nil, 0, 0, { type = "GlobalEffect", effectType = "Warcry" }, { type = "Multiplier", var = "WarcryPower", div = 5, limit = 5 }),
-			mod("PhysicalDamageGainAsFire", "BASE", nil, 0, 0, { type = "GlobalEffect", effectType = "Warcry" }, { type = "Multiplier", var = "WarcryPower", actor = "parent", div = 5, limit = 5 }),
+			mod("PhysicalDamageGainAsFire", "BASE", nil, 0, 0, { type = "GlobalEffect", effectType = "Warcry", div = 5, limit = 25 }),
 		},
 		["infernal_cry_empowered_attacks_trigger_combust_display"] = {
 			-- Display only
@@ -1164,8 +1159,7 @@ local skills, mod, flag, skill = ...
 			mod("IntimidatingExertedAttacks", "BASE", nil),
 		},
 		["intimidating_cry_movement_speed_+%_per_5_power_up_to_cap"] = {
-			mod("MovementSpeed", "INC", nil, 0, 0, { type = "GlobalEffect", effectType = "Warcry" }, { type = "Multiplier", var = "WarcryPower", div = 5, limit = 6 }),
-			mod("MovementSpeed", "INC", nil, 0, 0, { type = "GlobalEffect", effectType = "Warcry" }, { type = "Multiplier", var = "WarcryPower", actor = "parent", div = 5, limit = 6 }),
+			mod("MovementSpeed", "INC", nil, 0, 0, { type = "GlobalEffect", effectType = "Warcry", div = 5, limit = 30 }),
 		},
 		["intimidating_cry_empowerd_attacks_deal_double_damage_display"] = {
 		},
@@ -1610,12 +1604,10 @@ local skills, mod, flag, skill = ...
 			mod("SeismicAoEMoreMultiplier", "BASE", nil),
 		},
 		["seismic_cry_stun_threshold_+%_per_5_power_up_to_cap"] = {
-			mod("StunThreshold", "INC", nil, 0, 0, { type = "GlobalEffect", effectType = "Warcry" }, { type = "Multiplier", var = "WarcryPower", div = 5, limit = 5 }),
-			mod("StunThreshold", "INC", nil, 0, 0, { type = "GlobalEffect", effectType = "Warcry" }, { type = "Multiplier", var = "WarcryPower", actor = "parent", div = 5, limit = 5 }),
+			mod("StunThreshold", "INC", nil, 0, 0, { type = "GlobalEffect", effectType = "Warcry", div = 5, limit = 25 }),
 		},
 		["seismic_cry_armour_+%_final_per_5_power_up_to_cap"] = {
-			mod("Armour", "MORE", nil, 0, 0, { type = "GlobalEffect", effectType = "Warcry" }, { type = "Multiplier", var = "WarcryPower", div = 5, limit = 5 }),
-			mod("Armour", "MORE", nil, 0, 0, { type = "GlobalEffect", effectType = "Warcry" }, { type = "Multiplier", var = "WarcryPower", actor = "parent", div = 5, limit = 5 }),
+			mod("Armour", "MORE", nil, 0, 0, { type = "GlobalEffect", effectType = "Warcry", div = 5, limit = 25 }),
 		},
 		["skill_empower_limitation_specifier_for_stat_description"] = {
 			-- Display only
@@ -1996,8 +1988,7 @@ local skills, mod, flag, skill = ...
 #flags warcry area duration
 	statMap = {
 		["rage_warcry_gain_X_rage_per_minute_per_5_monster_power_max_25_power"] = {
-			mod("RageRegen", "BASE", nil, 0, 0, { type = "GlobalEffect", effectType = "Warcry" }, { type = "Multiplier", var = "WarcryPower", div = 5, limit = 5 }),
-			mod("RageRegen", "BASE", nil, 0, 0, { type = "GlobalEffect", effectType = "Warcry" }, { type = "Multiplier", var = "WarcryPower", actor = "parent", div = 5, limit = 5 }),
+			mod("RageRegen", "BASE", nil, 0, 0, { type = "GlobalEffect", effectType = "Warcry", div = 5, limit = 25 }),
 			flag("Condition:CanGainRage", { type = "GlobalEffect", effectType = "Warcry"} ),
 			div = 60,
 		},

--- a/src/Modules/CalcPerform.lua
+++ b/src/Modules/CalcPerform.lua
@@ -3103,7 +3103,7 @@ function calcs.perform(env, skipEHP)
 			buffExports.PlayerMods["EnduranceChargesMax="..tostring(output["EnduranceChargesMax"])] = true
 		end
 
-		buffExports.PlayerMods["MovementSpeedMod|percent|max="..tostring(m_floor(output["MovementSpeedMod"] * 100))] = true
+		buffExports.PlayerMods["MovementSpeedMod|percent|max="..tostring(output["MovementSpeedMod"] * 100)] = true
 		
 		for _, mod in ipairs(buffExports["Aura"]["extraAura"].modList) do
 			-- leaving comment to make it easier for future similar mods

--- a/src/Modules/Data.lua
+++ b/src/Modules/Data.lua
@@ -443,9 +443,6 @@ data.highPrecisionMods = {
 	["SupportManaMultiplier"] = {
 		["MORE"] = 4,
 	},
-	["MovementSpeed"] = {
-		["INC"] = 1,
-	},
 }
 
 data.weaponTypeInfo = {


### PR DESCRIPTION
Warcry Buffs are scaled and floored before warcry power is taken into account, this causes the numbers to be wrong, especially when also scaled by uptime, tested all warcries ingame except rallying cry and all were wrong and are fixed by this change except for infernal cry (will talk later about it)

This change also removed duplicate buff code for minions to check parents warcry power, and makes it easier to implement party tab support for warcries

The downside of this change is the buff notes are less informative, but that can be changed by changing the notes if we want it to show there
### Before screenshot:
![image](https://github.com/user-attachments/assets/7426a511-ecce-4a7e-bb21-16a6f935ee49)

### After screenshot:
![image](https://github.com/user-attachments/assets/39d4a371-7a09-4f2d-9de3-097d6a398a50)


All of them tested on multiple builds but here is an example of a minimum test setup: https://pobb.in/2qs_Nsh4BIBy

As for infernal cry, it seems it is not scaled by warcry effect?
![image](https://github.com/user-attachments/assets/d1ee81de-51d1-4268-9088-d8c30a278056)

The values now line up correctly for 0% increased warcry effect at varying power levels from 0 power to infinite power, but ingame does not seem to scale with warcry effect, it applies the same 7-13 at 0% inc effect as it does at 200% increased effect (tested on 5 different builds and had the same results) (*edit already reported here https://www.pathofexile.com/forum/view-thread/3541517*)