### PR TITLE
Fix EHP and Maximum Hit taken with negative Unreserved Life

### DIFF
--- a/src/Modules/CalcDefence.lua
+++ b/src/Modules/CalcDefence.lua
@@ -1982,6 +1982,8 @@ function calcs.buildDefenceEstimations(env, actor)
 		output.LifeRecoverable = (output.LifeCancellableReservation / 100) * output.Life
 	end
 	
+	output.LifeRecoverable = m_max(output.LifeRecoverable, 1)
+	
 	-- Prevented life loss taken over 4 seconds (and Petrified Blood)
 	do
 		local halfLife = output.Life * 0.5


### PR DESCRIPTION
Fixes #7955 .

With negative unreserved life your life recoverable was negative, and thus EHP and Maximum Hit Taken made no sense (if you didnt have other pool to cancel it out), this caps life recoverable to have a minimum value of 1 (the minimum possible ingame) so that it doesnt break sorting or sidebar values, this still warns the user to fix their life reserved and life costs