### PR TITLE
Fix broken base types on some items

### DIFF
--- a/src/Data/Rares.lua
+++ b/src/Data/Rares.lua
@@ -83,7 +83,7 @@ Prefix: IncreasedLife7
 -- Gloves
 [[
 Evasion Gloves
-Sinistral Gloves
+Trapsetter Gloves
 Crafted: true
 Prefix: LocalIncreasedPhysicalDamageReductionRating2
 Prefix: LocalIncreasedPhysicalDamageReductionRatingPercent5
@@ -97,7 +97,7 @@ Prefix: LocalIncreasedEnergyShieldPercent5
 Prefix: LocalIncreasedEnergyShield6
 ]],[[
 Armour Gloves
-Debilitation Gauntlets
+Thwarting Gauntlets
 Crafted: true
 Prefix: LocalIncreasedPhysicalDamageReductionRating2
 Prefix: LocalIncreasedPhysicalDamageReductionRatingPercent5

--- a/src/Data/Uniques/jewel.lua
+++ b/src/Data/Uniques/jewel.lua
@@ -470,7 +470,6 @@ Source: Drops from unique Delirium bosses in maps
 Adds Hollow Palm Technique
 ]],[[
 The Perandus Pact
-The Light of Meaning
 Prismatic Jewel
 Variant: Life
 Variant: Energy Shield


### PR DESCRIPTION
Perandus pact was given the wrong base due to a copy/paste error, and the other 2 rare templates have old bases that have been removed (I set them to what the std bases were converted to)

I think the rare templates likely need an overhaul with the new top bases added, but leaving that for a separate PR