### PR TITLE
Fix Tattoos being removed from list when using Remove All Tattoos button

### DIFF
--- a/src/Classes/TreeTab.lua
+++ b/src/Classes/TreeTab.lua
@@ -125,10 +125,9 @@ local TreeTabClass = newClass("TreeTab", "ControlHost", function(self, build)
 			main:ClosePopup()
 		end)
 		controls.removeTattoo = new("ButtonControl", nil, 0, buttonY, 144, 20, "Remove All Tattoos", function()
-			local hashOverridesCopy = copyTable(self.build.spec.hashOverrides, true) -- updating hashOverrides in RemoveTattooFromNode
-			for _, node in pairs(hashOverridesCopy) do
+			for id, node in pairs(self.build.spec.hashOverrides) do --hashOverrides will contain only the nodes that have been tattoo-ed
 				if node.isTattoo then
-					self:RemoveTattooFromNode(node)
+					self:RemoveTattooFromNode(self.build.spec.nodes[id])
 				end
 			end
 			self.modFlag = true


### PR DESCRIPTION
Fixes #8170

### Description of the problem being solved:
When removing all tattoos, we were passing the hashOverride node to the RemoveTattooFromNode function and this was changing the actual tattoo data instead of resetting the tree node.

### Steps taken to verify a working solution:
- Add a tattoo
- Remove All Tattoos
- Verify tattoo is still in list


"Tattoo of the Kitava Blood Drinker" in before/after

### Before screenshot:
![tattooError](https://github.com/user-attachments/assets/bed57088-5e8b-4005-b078-dc76d1964259)

### After screenshot:
![tattooFix](https://github.com/user-attachments/assets/a56d7c90-fa7e-43cf-b23a-4aaa965a78c6)
