### PR TITLE
Added ignore mirrored items checkbox to trade query options.

### DIFF
--- a/src/Classes/TradeQueryGenerator.lua
+++ b/src/Classes/TradeQueryGenerator.lua
@@ -1027,6 +1027,10 @@ function TradeQueryGeneratorClass:RequestQuery(slot, context, statWeights, callb
 		options.special = { itemName = context.slotTbl.slotName }
 	end
 
+	controls.includeMirrored = new("CheckBoxControl", {"TOPRIGHT",lastItemAnchor,"BOTTOMRIGHT"}, 0, 5, 18, "Mirrored items:", function(state) end)
+	controls.includeMirrored.state = (self.lastIncludeMirrored == nil or self.lastIncludeMirrored == true)
+	updateLastAnchor(controls.includeMirrored)
+
 	if not isJewelSlot and not isAbyssalJewelSlot and includeScourge then
 		controls.includeScourge = new("CheckBoxControl", {"TOPRIGHT",lastItemAnchor,"BOTTOMRIGHT"}, 0, 5, 18, "Scourge Mods:", function(state) end)
 		controls.includeScourge.state = (self.lastIncludeScourge == nil or self.lastIncludeScourge == true)
@@ -1138,6 +1142,9 @@ function TradeQueryGeneratorClass:RequestQuery(slot, context, statWeights, callb
 	controls.generateQuery = new("ButtonControl", { "BOTTOM", nil, "BOTTOM" }, -45, -10, 80, 20, "Execute", function()
 		main:ClosePopup()
 
+		if controls.includeMirrored then
+			self.lastIncludeMirrored, options.includeMirrored = controls.includeMirrored.state, controls.includeMirrored.state
+		end
 		if controls.includeCorrupted then
 			self.lastIncludeCorrupted, options.includeCorrupted = controls.includeCorrupted.state, controls.includeCorrupted.state
 		end

--- a/src/Classes/TradeQueryGenerator.lua
+++ b/src/Classes/TradeQueryGenerator.lua
@@ -924,6 +924,14 @@ function TradeQueryGeneratorClass:FinishQuery()
 			break
 		end
 	end
+	if not options.includeMirrored then
+	    queryTable.query.filters.misc_filters = {
+	    	disabled = false,
+	    	filters = {
+	    		mirrored = false,
+	    	}
+	    }
+	end
 
 	if options.maxPrice and options.maxPrice > 0 then
 		queryTable.query.filters.trade_filters = {


### PR DESCRIPTION
Fixes #8127 .

### Description of the problem being solved:
Added feature to exclude mirrored items from trade query.
### Steps taken to verify a working solution:
- Go to "Items"
- Click "Trade for these items"
- Try the checkbox "Mirrored items"

### Before screenshot:
![image](https://github.com/user-attachments/assets/70f9b357-d8e5-4aad-88ae-aeebaffd8a20)

### After screenshot:
![image](https://github.com/user-attachments/assets/4a4ac302-3931-427e-92a6-b00f04bbbdd6)
