### PR TITLE
Fix Add 'Cast Time' to Calcs page for Warcries 

### DIFF
--- a/src/Modules/CalcSections.lua
+++ b/src/Modules/CalcSections.lua
@@ -505,6 +505,7 @@ return {
 	{ label = "Hit Rate", haveOutput = "HitSpeed", { format = "{2:output:HitSpeed}", { breakdown = "HitSpeed" } }, },
 	{ label = "Inc. Warcry Speed", flag = "warcry", { format = "{0:mod:2}%", { breakdown = "WarcrySpeed" }, { modName = "WarcrySpeed", modType = "INC", cfg = "skill", }, }, },
 	{ label = "More Warcry Speed", flag = "warcry", { format = "{0:mod:2}%", { breakdown = "WarcrySpeed" }, { modName = "WarcrySpeed", modType = "MORE", cfg = "skill", }, }, },
+	{ label = "Uses per second", flag = "warcry", {format = "{2:output:Speed}"}, },
 } }
 } },
 { 1, "Crit", 1, colorCodes.OFFENCE, {{ defaultCollapsed = false, label = "Crits", data = {

--- a/src/Modules/CalcSections.lua
+++ b/src/Modules/CalcSections.lua
@@ -503,6 +503,8 @@ return {
 	{ label = "CWDT Threshold", haveOutput = "CWDTThreshold", flag = "triggered", { format = "{2:output:CWDTThreshold}", { breakdown = "CWDTThreshold" }, }, },
 	{ label = "Channel time", flag = "channelRelease", haveOutput = "HitTime", { format = "{2:output:HitTime}s", { breakdown = "HitTime" } }, },
 	{ label = "Hit Rate", haveOutput = "HitSpeed", { format = "{2:output:HitSpeed}", { breakdown = "HitSpeed" } }, },
+	{ label = "Inc. Warcry Speed", flag = "warcry", { format = "{0:mod:2}%", { breakdown = "WarcrySpeed" }, { modName = "WarcrySpeed", modType = "INC", cfg = "skill", }, }, },
+	{ label = "More Warcry Speed", flag = "warcry", { format = "{0:mod:2}%", { breakdown = "WarcrySpeed" }, { modName = "WarcrySpeed", modType = "MORE", cfg = "skill", }, }, },
 } }
 } },
 { 1, "Crit", 1, colorCodes.OFFENCE, {{ defaultCollapsed = false, label = "Crits", data = {

--- a/src/Modules/CalcSections.lua
+++ b/src/Modules/CalcSections.lua
@@ -506,6 +506,7 @@ return {
 	{ label = "Inc. Warcry Speed", flag = "warcry", { format = "{0:mod:2}%", { breakdown = "WarcrySpeed" }, { modName = "WarcrySpeed", modType = "INC", cfg = "skill", }, }, },
 	{ label = "More Warcry Speed", flag = "warcry", { format = "{0:mod:2}%", { breakdown = "WarcrySpeed" }, { modName = "WarcrySpeed", modType = "MORE", cfg = "skill", }, }, },
 	{ label = "Uses per second", flag = "warcry", {format = "{2:output:Speed}"}, },
+	{ label = "Warcry Cast Time", flag = "warcry", {format = "{2:output:WarcryCastTime}s"}, },
 } }
 } },
 { 1, "Crit", 1, colorCodes.OFFENCE, {{ defaultCollapsed = false, label = "Crits", data = {


### PR DESCRIPTION
Fixes #8079 .

### Description of the problem being solved:
Currently there's no way to see warcries cast speed.
### Steps taken to verify a working solution:
- Add warcry skill gem.
- Select it in 'Calcs'.
- Check 'Attack/Cast Rate' section

### Before screenshot:
![image](https://github.com/user-attachments/assets/99a1b1ae-b6b0-4f8d-b0c4-9785140e3380)

### After screenshot:
![image](https://github.com/user-attachments/assets/8c930d1b-5f0e-497e-9483-c3ddcca50170)

