### PR TITLE
Fix Snipe for Assailum not working

### DIFF
--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -2814,7 +2814,7 @@ local specialModList = {
 	["socketed non%-channelling bow skills are triggered by snipe"] = {
 	},
 	["grants level (%d+) snipe skill"] = function(num) return {
-		mod("ExtraSkill", "LIST", { skillId = "ChannelledSnipe", level = num }),
+		mod("ExtraSkill", "LIST", { skillId = "Snipe", level = num }),
 		mod("ExtraSupport", "LIST", { skillId = "ChannelledSnipeSupport", level = num }, { type = "SocketedIn", slotName = "{SlotName}" }),
 	} end,
 	["socketed triggered bow skills deal (%d+)%% less damage"] = function(num) return { mod("ExtraSkillMod", "LIST", { mod = mod("Damage", "MORE", -num) }, { type = "SocketedIn", slotName = "{SlotName}", keyword = "bow" }, { type = "SkillType", skillType = SkillType.Triggerable }) } end,


### PR DESCRIPTION
Fixes #8194

### Description of the problem being solved:
Snipe's skillid appears to have changed at some point causing the mod to no longer function correctly.

Note that this pr requires regeneration of modcache to function.

### Steps taken to verify a working solution:
- Test snipe as standalone skill
- Test snipe as support
