### PR TITLE
Fix Ability to delete non-empty folder.

### DIFF
--- a/src/Classes/BuildListControl.lua
+++ b/src/Classes/BuildListControl.lua
@@ -139,11 +139,31 @@ function BuildListClass:RenameBuild(build, copyOnName)
 	main:OpenPopup(370, 100, (copyOnName and "Copy " or "Rename ")..(build.folderName and "Folder" or "Build"), controls, "save", "edit")	
 end
 
+function deleteDirectory(dir)	
+	local search = NewFileSearch(dir..'/*')
+	if search then
+		os.remove(dir..'/'..search:GetFileName())
+		while search:NextFile() do
+			os.remove(dir..'/'..search:GetFileName())
+		end	
+	endsearch
+
+	local search = NewFileSearch(dir..'/*', true)
+	if search then
+		deleteDirectory(dir..'/'..search:GetFileName())
+		while search:NextFile() do
+			deleteDirectory(dir..'/'..search:GetFileName())
+		end
+	end   
+
+    RemoveDir(dir)
+end
+
 function BuildListClass:DeleteBuild(build)
 	if build.folderName then
 		if NewFileSearch(build.fullFileName.."/*") or NewFileSearch(build.fullFileName.."/*", true) then
 			main:OpenConfirmPopup("Confirm Folder Delete", "The folder is not empty.\nAre you sure you want to delete build:\n"..build.folderName.."\nThis cannot be undone.", "Delete", function()				
-				os.execute("rd \""..build.fullFileName:gsub("\\", "/").."\" /S /Q")
+				deleteDirectory(build.fullFileName:gsub("\\", "/"))
 				self.listMode:BuildList()
 				self.selIndex = nil
 				self.selValue = nil

--- a/src/Classes/BuildListControl.lua
+++ b/src/Classes/BuildListControl.lua
@@ -162,7 +162,7 @@ end
 function BuildListClass:DeleteBuild(build)
 	if build.folderName then
 		if NewFileSearch(build.fullFileName.."/*") or NewFileSearch(build.fullFileName.."/*", true) then
-			main:OpenConfirmPopup("Confirm Folder Delete", "The folder is not empty.\nAre you sure you want to delete build:\n"..build.folderName.."\nThis cannot be undone.", "Delete", function()				
+			main:OpenConfirmPopup("Confirm Folder Delete", "The folder is not empty.\nAre you sure you want to delete folder:\n"..build.folderName.."\nThis cannot be undone.", "Delete", function()				
 				deleteDirectory(build.fullFileName:gsub("\\", "/"))
 				self.listMode:BuildList()
 				self.selIndex = nil

--- a/src/Classes/BuildListControl.lua
+++ b/src/Classes/BuildListControl.lua
@@ -146,7 +146,7 @@ function deleteDirectory(dir)
 		while search:NextFile() do
 			os.remove(dir..'/'..search:GetFileName())
 		end	
-	endsearch
+	end
 
 	local search = NewFileSearch(dir..'/*', true)
 	if search then

--- a/src/Classes/BuildListControl.lua
+++ b/src/Classes/BuildListControl.lua
@@ -142,7 +142,12 @@ end
 function BuildListClass:DeleteBuild(build)
 	if build.folderName then
 		if NewFileSearch(build.fullFileName.."/*") or NewFileSearch(build.fullFileName.."/*", true) then
-			main:OpenMessagePopup("Delete Folder", "The folder is not empty.")
+			main:OpenConfirmPopup("Confirm Folder Delete", "The folder is not empty.\nAre you sure you want to delete build:\n"..build.folderName.."\nThis cannot be undone.", "Delete", function()				
+				os.execute("rd \""..build.fullFileName:gsub("\\", "/").."\" /S /Q")
+				self.listMode:BuildList()
+				self.selIndex = nil
+				self.selValue = nil
+			end)	
 		else
 			local res, msg = RemoveDir(build.fullFileName)
 			if not res then

--- a/src/Classes/BuildListControl.lua
+++ b/src/Classes/BuildListControl.lua
@@ -163,7 +163,7 @@ function BuildListClass:DeleteBuild(build)
 	if build.folderName then
 		if NewFileSearch(build.fullFileName.."/*") or NewFileSearch(build.fullFileName.."/*", true) then
 			main:OpenConfirmPopup("Confirm Folder Delete", "The folder is not empty.\nAre you sure you want to delete folder:\n"..build.folderName.."\nThis cannot be undone.", "Delete", function()				
-				deleteDirectory(build.fullFileName:gsub("\\", "/"))
+				deleteDirectory(build.fullFileName)
 				self.listMode:BuildList()
 				self.selIndex = nil
 				self.selValue = nil


### PR DESCRIPTION
Fixes #1823 .

### Description of the problem being solved:
Added the ability to delete a folder, and all builds stored within the folder.
### Steps taken to verify a working solution:
- Create folder
- Create build in folder
- Delete folder

### Before screenshot:
![image](https://github.com/user-attachments/assets/054b0b65-048e-496b-91fb-b687e49bdac2)

### After screenshot:
![image](https://github.com/user-attachments/assets/fc0ed4ec-3db0-4efd-95a1-bb39c1072867)
