### PR TITLE
Implement a docker container for tests

### DIFF
--- a/.github/workflows/builddocker.yml
+++ b/.github/workflows/builddocker.yml
@@ -1,0 +1,42 @@
+name: Build and publish busted tests docker image
+on:
+ workflow_dispatch:
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Generate docker image metadata
+        uses: docker/metadata-action@v5
+        id: meta
+        with:
+          images: |
+            ghcr.io/${{ github.repository_owner }}/pathofbuilding-tests
+          labels: |
+            org.opencontainers.image.description=A docker image packaged with the correct verions of tools to run PathOfBuilding busted tests. Includes emmylua debugger files. Refer to https://github.com/PathOfBuildingCommunity/PathOfBuilding/blob/dev/CONTRIBUTING.md for usage instructions.
+            org.opencontainers.image.licenses=https://opensource.org/licenses/MIT
+          tags: |
+            type=sha
+            type=raw,value=latest
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          platforms: linux/amd64
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/builddocker.yml
+++ b/.github/workflows/builddocker.yml
@@ -25,7 +25,7 @@ jobs:
           images: |
             ghcr.io/${{ github.repository_owner }}/pathofbuilding-tests
           labels: |
-            org.opencontainers.image.description=A docker image packaged with the correct verions of tools to run PathOfBuilding busted tests. Includes emmylua debugger files. Refer to https://github.com/PathOfBuildingCommunity/PathOfBuilding/blob/dev/CONTRIBUTING.md for usage instructions.
+            org.opencontainers.image.description=A docker image packaged with the correct versions of tools to run PathOfBuilding busted tests. Includes emmylua debugger files. Refer to https://github.com/PathOfBuildingCommunity/PathOfBuilding/blob/dev/CONTRIBUTING.md for usage instructions.
             org.opencontainers.image.licenses=https://opensource.org/licenses/MIT
           tags: |
             type=sha

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   run_tests:
     runs-on: ubuntu-latest
-    container: ghcr.io/paliak/busted-tests:latest
+    container: ghcr.io/paliak/pathofbuilding-tests:latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,22 +7,11 @@ on:
 jobs:
   run_tests:
     runs-on: ubuntu-latest
+    container: ghcr.io/paliak/busted-tests:latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
-      - name: Install Lua/LuaJIT
-        uses: leafo/gh-actions-lua@v8.0.0
-        with:
-          luaVersion: "luajit-2.0.5"
-      - name: Install LuaRocks
-        uses: leafo/gh-actions-luarocks@v4.0.0
-      - name: Install busted
-        run: luarocks install busted
-      - name: Install cluacov
-        run: luarocks install cluacov 0.1.2-1
-      - name: Install coveralls integration
-        run: luarocks install luacov-coveralls
+        uses: actions/checkout@v4
       - name: Run tests
-        run: busted --lua=/home/runner/work/PathOfBuilding/PathOfBuilding/.lua/bin/luajit
+        run: busted --lua=luajit
       - name: Report coverage
         run: cd src; luacov-coveralls --repo-token=${{ secrets.github_token }} -e TestData -e Data -e runtime

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN wget https://luarocks.org/releases/luarocks-3.7.0.tar.gz && tar xf luarocks-
 RUN cd luarocks-3.7.0 && ./configure && make
 
 FROM buildbase AS luajit
-RUN git clone --depth 1 --branch v2.1.0-beta3 https://github.com/LuaJIT/LuaJIT
+RUN git clone https://github.com/LuaJIT/LuaJIT && cd LuaJIT && git checkout c7db8255e1eb59f933fac7bc9322f0e4f8ddc6e6
 RUN cd LuaJIT && make
 
 FROM buildbase AS emmyluadebugger
@@ -34,6 +34,6 @@ RUN luarocks install busted 2.2.0-1;\
 	luarocks install luacov-coveralls 0.2.3-1
 
 RUN --mount=type=cache,from=emmyluadebugger,source=/opt,target=/opt make -C /opt/EmmyLuaDebugger/build/ install
-RUN --mount=type=cache,from=luajit,source=/opt,target=/opt make -C /opt/LuaJIT/ install && ln -sf /usr/local/bin/luajit-2.1.0-beta3 /usr/local/bin/luajit
+RUN --mount=type=cache,from=luajit,source=/opt,target=/opt make -C /opt/LuaJIT/ install
 
 CMD [ "echo", "This container is meant to be ran with docker compose. See: https://github.com/PathOfBuildingCommunity/PathOfBuilding/blob/dev/CONTRIBUTING.md" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,39 @@
+FROM alpine:3.18 AS base
+# Common dependencies
+RUN apk add --no-cache cmake readline-dev build-base tar
+
+FROM base AS buildbase
+# Build dependencies
+RUN apk add --no-cache git
+WORKDIR /opt
+RUN wget https://www.lua.org/ftp/lua-5.1.5.tar.gz && tar -xf lua-5.1.5.tar.gz
+RUN cd lua-5.1.5 && make linux && make install
+
+FROM buildbase AS luarocks
+RUN wget https://luarocks.org/releases/luarocks-3.7.0.tar.gz && tar xf luarocks-3.7.0.tar.gz
+RUN cd luarocks-3.7.0 && ./configure && make
+
+FROM buildbase AS luajit
+RUN git clone --depth 1 --branch v2.1.0-beta3 https://github.com/LuaJIT/LuaJIT
+RUN cd LuaJIT && make
+
+FROM buildbase AS emmyluadebugger
+RUN git clone --depth 1 --branch 1.7.1 https://github.com/EmmyLua/EmmyLuaDebugger
+RUN cd EmmyLuaDebugger && mkdir build && cd build && cmake -DCMAKE_BUILD_TYPE=Release ../ && make
+
+FROM base
+# Luarocks packages dependencies
+RUN apk add --no-cache curl unzip openssl
+
+RUN --mount=type=cache,from=buildBase,source=/opt,target=/opt make -C /opt/lua-5.1.5/ install
+RUN --mount=type=cache,from=luarocks,source=/opt,target=/opt make -C /opt/luarocks-3.7.0/ install
+
+# Install here to install lua rocks pkgs in pararell with compilation of emmylua and luajit
+RUN luarocks install busted 2.2.0-1;\
+	luarocks install cluacov 0.1.2-1;\
+	luarocks install luacov-coveralls 0.2.3-1
+
+RUN --mount=type=cache,from=emmyluadebugger,source=/opt,target=/opt make -C /opt/EmmyLuaDebugger/build/ install
+RUN --mount=type=cache,from=luajit,source=/opt,target=/opt make -C /opt/LuaJIT/ install && ln -sf /usr/local/bin/luajit-2.1.0-beta3 /usr/local/bin/luajit
+
+CMD [ "echo", "This container is meant to be ran with docker compose. See: https://github.com/PathOfBuildingCommunity/PathOfBuilding/blob/dev/CONTRIBUTING.md" ]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,19 +1,16 @@
-version: "3.8"
 services:
-
   busted-tests:
-    image: summ1else/poe-busted-image
+    #build: .
+    image: ghcr.io/paliak/busted-tests:latest
+    environment:
+      HOME: /tmp
     container_name: busted-tests
-    command: bash -c "rm -f spec/test_results.log && busted --lua=luajit | tee spec/test_results.log"
+    user: nobody:nobody
+    command: busted --lua=luajit
+    security_opt:
+      - no-new-privileges:true
+    ports:
+      - "9966:9966"
+    working_dir: /workdir
     volumes:
-      - ./:/root
-    depends_on:
-      - busted-generate-build
-
-  busted-generate-build:
-    image: summ1else/poe-busted-image
-    container_name: busted-generate-build
-    command: bash -c "rm -f spec/test_generation.log && busted --lua=luajit -r generate | tee spec/test_generation.log"
-    restart: "no"
-    volumes:
-      - ./:/root
+      - ./:/workdir:ro

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,10 +1,10 @@
 services:
   busted-tests:
     #build: .
-    image: ghcr.io/paliak/busted-tests:latest
+    image: ghcr.io/paliak/pathofbuilding-tests:latest
     environment:
       HOME: /tmp
-    container_name: busted-tests
+    container_name: pathofbuilding-tests
     user: nobody:nobody
     command: busted --lua=luajit
     security_opt:


### PR DESCRIPTION
### Description of the problem being solved:
Implements a docker container with specific versions of tools needed to run tests. Updates current tests workflow to use it fixing luajit missing issue.

Lines containing references to `ghcr.io/paliak/pathofbuilding-tests:latest` will need to be updated after an image is published under POB org.