### PR TITLE
Fix invalid skill ids in party tab source

### DIFF
--- a/src/Classes/PartyTab.lua
+++ b/src/Classes/PartyTab.lua
@@ -857,8 +857,20 @@ function PartyTabClass:ParseBuffs(list, buf, buffType, label)
 						end
 						if currentName ~= "SKIP" then
 							if mod.source:match("Item") then
-								_, mod.source = mod.source:match("Item:(%d+):(.+)")
+								local oldItem
+								oldItem, mod.source = mod.source:match("Item:(%d+):(.+)")
 								mod.source = "Party - "..mod.source
+							end
+							if mod.source:match("Skill") then
+								local skillId = mod.source:match("Skill:(.+)")
+								if not data.skills[skillId] then
+									local minimisedName = currentName:gsub(" %l",string.upper):gsub(" ","")
+									if data.skills[minimisedName] then
+										mod.source = "Skill:"..minimisedName
+									else
+										mod.source = skillId
+									end
+								end
 							end
 							if buffType == "Link" then
 								mod.name = mod.name:gsub("Parent", "PartyMember")


### PR DESCRIPTION
Fixes #8060

Sorry for now seeing this when the issue was made, this now checks if a skill is a valid skill, if not it replaces it with the name of the aura applying it if valid, otherwise replaces it with a text source to prevent crashes (note this makes source show up as empty instead of crashing, eg malformed purity of lightning)
![image](https://github.com/user-attachments/assets/2ae4b68e-a415-45e5-917e-f30a75fddc0e)


This shouldnt be an issue for any current exports but is for older exports, and likely will be an issue in future (also helps with user edits xmls)
