### PR TITLE
Fix "# of warcries used recently" configuration option unavailable.

### DIFF
--- a/src/Modules/ConfigOptions.lua
+++ b/src/Modules/ConfigOptions.lua
@@ -1369,7 +1369,7 @@ Huge sets the radius to 11.
 	{ var = "conditionSoulGainPrevention", type = "check", label = "Do you have Soul Gain Prevention?", ifCond = "SoulGainPrevention", apply = function(val, modList, enemyModList)
 		modList:NewMod("Condition:SoulGainPrevention", "FLAG", true, "Config", { type = "Condition", var = "Combat" })
 	end },
-	{ var = "conditionUsedWarcryRecently", type = "check", label = "Have you used a Warcry Recently?", ifFlag = "warcry", implyCondList = {"UsedWarcryInPast8Seconds", "UsedSkillRecently"}, tooltip = "This also implies that you have used a Skill Recently.", apply = function(val, modList, enemyModList)
+	{ var = "conditionUsedWarcryRecently", type = "check", label = "Have you used a Warcry Recently?", {ifFlag = "warcry", ifCond = "UsedWarcryRecently"}, implyCondList = {"UsedWarcryInPast8Seconds", "UsedSkillRecently"}, tooltip = "This also implies that you have used a Skill Recently.", apply = function(val, modList, enemyModList)
 		modList:NewMod("Condition:UsedWarcryRecently", "FLAG", true, "Config", { type = "Condition", var = "Combat" })
 		modList:NewMod("Condition:UsedWarcryInPast8Seconds", "FLAG", true, "Config", { type = "Condition", var = "Combat" })
 		modList:NewMod("Condition:UsedSkillRecently", "FLAG", true, "Config", { type = "Condition", var = "Combat" })
@@ -1423,7 +1423,7 @@ Huge sets the radius to 11.
 	{ var = "conditionRavenousCorpseConsumed", type = "check", label = "Has Ravenous consumed a corpse?", ifSkill = "Ravenous", implyCond = "ConsumedCorpseRecently", tooltip = "Corpse must be the same type as the monster you're fighting.\nThis also implies you have 'Consumed a corpse Recently'", apply = function(val, modList, enemyModList)
 		modList:NewMod("Condition:RavenousCorpseConsumed", "FLAG", true, "Config", { type = "Condition", var = "Combat" })
 	end },
-	{ var = "multiplierWarcryUsedRecently", type = "count", label = "# of Warcries Used Recently:", ifFlag = "warcry", implyCondList = {"UsedWarcryRecently", "UsedWarcryInPast8Seconds", "UsedSkillRecently"}, tooltip = "This also implies you have 'Used a Warcry Recently', 'Used a Warcry in the past 8 seconds', and 'Used a Skill Recently'", apply = function(val, modList, enemyModList)
+	{ var = "multiplierWarcryUsedRecently", type = "count", label = "# of Warcries Used Recently:", {ifFlag = "warcry", ifMult = "WarcryUsedRecently"}, implyCondList = {"UsedWarcryRecently", "UsedWarcryInPast8Seconds", "UsedSkillRecently"}, tooltip = "This also implies you have 'Used a Warcry Recently', 'Used a Warcry in the past 8 seconds', and 'Used a Skill Recently'", apply = function(val, modList, enemyModList)
 		modList:NewMod("Multiplier:WarcryUsedRecently", "BASE", m_min(val, 100), "Config", { type = "Condition", var = "Combat" })
 		modList:NewMod("Condition:UsedWarcryRecently", "FLAG", true, "Config", { type = "Condition", var = "Combat" })
 		modList:NewMod("Condition:UsedWarcryInPast8Seconds", "FLAG", true, "Config", { type = "Condition", var = "Combat" })


### PR DESCRIPTION
Fixes #8216 .

### Description of the problem being solved:
The "# of Warcries Used Recently" option (to configure the damage that Admonisher should give) has disappeared and is appearing in red (saying it's invalid) when importing characters that had already checked it.
### Steps taken to verify a working solution:
- Path to the Admonisher Notable
- Check the Configurations tab to input the number of warcries used recently

### Link to a build that showcases this PR:
Minimal:
```
eNqtW1132jgTvm5_hQ_XacAffO0h3UNC0mTfpGFD2u5e9QhbgFohUVtOwv76dyTZxqHIsbF7kYI1z3xJM5oZYPTny5paTziMCGdnLfu007Iw83lA2PKs9eXx6sOg9efH96MpEqv7xXlMqFz5-P7dSL22KH7CFHBuyxIoXGLxNWXlfgdWG8TECnN2h37w8BMPzlqfOcMta45YQET6zqcoij6jNT5rzXwAtywU-ZgFF7vnCeEKhcgXOLyVYsex4Hc8gFURxrC6RoTNuP8Ti08hjzegVct6IvhZ09zcTe8fHnMqEZZXCUx6N5pStMXhTCBhRfDnrDUGz6AlnqA1_AVuiMbAqnPa9wbd_sAeDjtdB2xvF6LP4zASR7KYbTAOMpR96pgIpyG-XCywL8gTvgiJuFgh5ufkmXBVae9iKsiGEhzmtOqaENe_Me8PTLSPXCA6mc5yPhoMB87QHbiDQc_p9oqBXLxtwDciVucUPHqMGAm-WTIi8LHoKScRZ3VMfIU1blNMKQRpKdoHHOHwCQmyp5eRN1_PCTvOgXeIoQseldgnSTnFIeQAUQkwwz6HtFFVRkXkLVng8pSV7EgAVbU5zo7LWVm6yoyPU-gBMmQ5yhmPaUlKsUtUAyPVBL9kVI4xm92wnUCngNcTF-oWe0s3FdWX19MdU7dz2vXsQd8eOrZtzJTT1TYiPqJ36IWs4zUk2Uf0E7McG898WpYrwSA7mLC2OX6vSIiPgF1wGhwDWyEeGXFeQZYh7BrKi7Hvx1AsbHc3j1cUQmWcB5ex_4ckvmF-ucD8wkKVYHN3eOHmLPADxIssG-YUl4XshCRht3NTp1Msa4lZInBbzqBbjP3VJ3DxAxK4XJLdaeM4hZ6VxKU8KwkPeLaA_2tEBTdJ4GE3Oad2Eaiioy4ZDpfb2YpgGlSjThW7QJsS2VD6OY8u5e_X4iqdmTy0oku-oTAod2dU1ekJRfn8bA-L3aXJ855yjPF4h6G8BESAyxbV05D_kGU7rQYbh2sehyV3XBOXsyC9XHTD8oCD2C93m2XtxzmFJqysHRkKFKW0EnQsBPJ_TniwLO01JaQS4rV-s3izgSwiz0NZBvLWhCqb5IqVD90S1PdwmEvFtLxfywvYUZcWkNUM5aXsQcrbIi_9fTG9MuSlRWQbegfpYg3XgGqx73juHjFuDjRWpbokRViyW5vyZ9B8JYcnUTVqKI4ygHGAcBVi9t-2NP9X5KUEXLIA6iwIhdIy9hGHxDySNWTSKJoggawgqai_opAgJhw12YkwCv3VLWz9FaJ0DpngrJV_Kt_tAe10b0dtNb2Sr27WGx4KC7_I_6YoFNuz1gLRCGtC9QT4RIIw1SVD2qG0Zc1W_HkcPEkrHjmnUQqy0GaDWfCKx2OIsYXSJOJLJZSN8o21RpGAW0ufykgqnZt93QTSjRbjoIAslr2ufdKzex3npOfYHffEHfb77okzcN3OieNC_XPiDe3-4KQ7gEcn9tD2vBPPtXvOSbcz6A5OvF4XVh2nL7GdPtB4rgt1MbhNdmko3I5fC2cEbBWgf26sB_2Rnthp7aQp70ZfHm7Vi3crITbRH-328_Pz6QaJFV_gF7jbTn2-bm8ABE74EP0klH6QbNtj-He-HI8nP17mg__dbmlXBPNfG_QlGqMZSFxH6JdY_PVv6C4___rmAfXZmRLYTiWO9Mgvaut3Mg-EBPylz1FbOlntuNwF-eIzFziSa_Jh-mY0kypFVgSH4BNeR-dbiN0rWbTsjTySbZTUMyz0Qcxj0llkgBcopvL53zGiRJ6qTv7prZ6bMh6usz4OWMGpkleM5vi43chtH9_e6pUxFQkzKS49YvooJQpZJNidcW2TfHmBqK9sHt2wTSwspmaqaxL53-fxYiEHpCBChGroe3l1dXnxePP1MgnFPETt3HcWr-dy_qf_3yXMGValghXF80i_PGt9JfhZKTLBAhEK6cHnlKJNhLMgUUonFlDAFXBTVNANptPUw7x2BGZOly84hJheQpXphwQb9crW31BKC5QVqExdJm5ySmlmpAuaC8gIukI2eEqNhM1c5JTWaI5cLMBCNkTUKDlZfcMTQh5biDqyIL7M-sVbLg-5pirwS9bKG_c7qcbMPNTY18RAL5rBenBrQierBV5VU2OjV_WqGT7BPjLarhfN4Kzp4gzcZOKSURVw-syZOuQQNGNCZeVk3NlLijMSM8N7scJhcvGZON1BjkpJCgMnJPNYmMM4R1HgKzUHMnhIrpmhetBhsEGuFWSiV62_waF5GjMr3TIbE1kRVFfRRv8lNXnBFiT9qMH9erXACWlPbrA_WS4IEpV_x0-cBLovM4TLHllRwoC6oj4b1WzWZ7PffdbneAUl3E_jfierZvgXQWQlcoCLLoBKMZFBVY-DjK16HB4J80Uc4qMZPOxXIjvsQ3ENknVMB8HpalHmSBqpoznodu9ouOpGj0ar_D_BCwwWFF4AGU1BfIiYTcAZoiA2SrJSah1OJDvrKvHSV-FBSytz1AGefBpSlAM0yRuM4C6_LqgWy3HKJirXGFH5KTen9Rj-9qlPHWZyLhxvEAtSdveHavTdPpT0HhcR8FRjhIkcP9f1IcPr7QFGZr1G7bSrUwMG2Wcl04-ZCOUc4T_O1__K8ZndPx163kA_SRrPftJsQuU9IbB_oTp3qTxJ-I_8QKV7OuwO9Kh4dCOg60waYPk663_NfOII689_v2G04Uwh5EhB95Wah5Eo6WWTJp9yaG4BMZ1D4y_N0w3pJwotF7hMLul5RLsYoIVYdgXIOYfNtsbzbRQhaulxg9WtwgBTsY93KuDVFWS5R1hpzZ7RZl-0dwyjGuYnPJwGeBw2qNeAQb0GDDqKxyGDap9OtwGPOE1ZU-W8XWO4K0UtfxwItl5tDZzKHGqLdJvyf7eBw2A3EB52A3p4FU9CUynGqRuRXgMOrH5nNJZi3br2OzVDuJoCwdbSI4c6Z1DXFnU4HA7sbm0Ovaa21W4qx1Q_mvX96NXey24zh6qK8eN1TLFoIBO6DSQUt2ZQejXxdjP-P_qmrHxovcqIY6qoml7t1s3VDW2L11RyaayuPrqFqoB7IGxZaQsPpyanmT1o7KZoouHzjrOpqvPr3_ENFRvd2orUv-J6VZNB3eTxu8BROxn1qKmVGiOpLyVwtiDLZKCk3yQjJQXKnryaA00p8vGK0wCHiRJYTs6Sn0mlX0jodzLdDYD8z55SVPcNzOtvRu5w6deODwFnK_DKTH6sH_32fYmD9D5XE7zSAKVZ8l1NTukDYnnV-m_5IY2wFDBwzYCILAm9X6ihP2ioPrkooeE6-8WY_A0UDnGgzLvgMRMzTBc5Jm_tQPYpYYpw3WGJjd7fMDc7mNkh0wNV9e7j-1F7_-eO_weToTMl
```
### Before screenshot:
![image](https://github.com/user-attachments/assets/ab07bd7b-5ebb-4bb8-9eb6-aea8d596852e)

### After screenshot:
![image](https://github.com/user-attachments/assets/b1e0c1f5-7ba6-45a6-a51b-5d47568dd0d2)
