### PR TITLE
Properly generate Replica Dragonfangs Flight variants

### DIFF
--- a/src/Data/Uniques/Special/Generated.lua
+++ b/src/Data/Uniques/Special/Generated.lua
@@ -258,6 +258,44 @@ table.insert(replicaForbiddenShako, "+(25-30) to all Attributes")
 table.insert(data.uniques.generated, table.concat(forbiddenShako, "\n"))
 table.insert(data.uniques.generated, table.concat(replicaForbiddenShako, "\n"))
 
+local replicaDragonfangsFlight = {
+	"Replica Dragonfang's Flight",
+	"Onyx Amulet",
+	"Variant: Pre 3.23.0",
+	"Variant: Current"
+}
+local excludedGems = {
+}
+local gems = { }
+for _, gemData in pairs(data.gems) do
+	local grantedEffect = gemData.grantedEffect
+	if not grantedEffect.support and not isValueInArray(excludedGems, grantedEffect.name) and not grantedEffect.id:match("AltX") and not grantedEffect.id:match("AltY") and not grantedEffect.id:match("^Vaal") then
+		table.insert(gems, grantedEffect.name)
+	end
+end
+table.sort(gems)
+for index, name in ipairs(gems) do
+	table.insert(replicaDragonfangsFlight, "Variant: "..name)
+end
+
+	
+table.insert(replicaDragonfangsFlight, "Selected Variant: 2")
+table.insert(replicaDragonfangsFlight, "Has Alt Variant: true")
+table.insert(replicaDragonfangsFlight, "LevelReq: 56")
+table.insert(replicaDragonfangsFlight, "Implicits: 1")
+table.insert(replicaDragonfangsFlight, "{tags: jewellery_attribute}+(10-16) to all Attributes")
+table.insert(replicaDragonfangsFlight, "{variant:1}{tags:jewellery_resistance}+(10-15)% to all Elemental Resistances")
+table.insert(replicaDragonfangsFlight, "{variant:2}{tags:jewellery_resistance}+(5-10)% to all Elemental Resistances")
+for index, name in ipairs(gems) do
+	table.insert(replicaDragonfangsFlight, "{variant:"..(index + 2).."}+3 to Level of all "..name.." Gems")
+end
+table.insert(replicaDragonfangsFlight, "{variant:1}(10-15)% increased Reservation Efficiency of Skills")
+table.insert(replicaDragonfangsFlight, "{variant:2}(5-10)% increased Reservation Efficiency of Skills")
+table.insert(replicaDragonfangsFlight, "{variant:1}Items and Gems have (10-15)% reduced Attribute Requirements")
+table.insert(replicaDragonfangsFlight, "{variant:2}Items and Gems have (5-10)% reduced Attribute Requirements")
+table.insert(data.uniques.generated, table.concat(replicaDragonfangsFlight, "\n"))
+
+
 local enduranceChargeMods = {
 	[3] = {
 		["Up to Max."] = "15% chance that if you would gain Endurance Charges, you instead gain up to your maximum number of Endurance Charges",

--- a/src/Data/Uniques/amulet.lua
+++ b/src/Data/Uniques/amulet.lua
@@ -900,21 +900,6 @@ Implicits: 1
 {variant:2}Always Freeze, Shock and Ignite
 {variant:1}Cannot gain Power Charges
 ]],[[
-Replica Dragonfang's Flight
-Onyx Amulet
-Variant: Pre 3.23.0
-Variant: Current
-LevelReq: 56
-Implicits: 1
-{tags: jewellery_attribute}+(10-16) to all Attributes
-{variant:1}{tags:jewellery_resistance}+(10-15)% to all Elemental Resistances
-{variant:2}{tags:jewellery_resistance}+(5-10)% to all Elemental Resistances
-+3 to Level of all Spark Gems
-{variant:1}(10-15)% increased Reservation Efficiency of Skills
-{variant:2}(5-10)% increased Reservation Efficiency of Skills
-{variant:1}Items and Gems have (10-15)% reduced Attribute Requirements
-{variant:2}Items and Gems have (5-10)% reduced Attribute Requirements
-]],[[
 Retaliation Charm
 Citrine Amulet
 Variant: Pre 3.19.0


### PR DESCRIPTION
This is technically already done in #7245, so if that gets merged first you can close this, but otherwise this generates the item with 2 variant drop downs, one for version and one for gem