### PR TITLE
Mana cost raw not being set to 0 when using lifetap

### DIFF
--- a/src/Modules/CalcOffence.lua
+++ b/src/Modules/CalcOffence.lua
@@ -1608,8 +1608,9 @@ function calcs.offence(env, actor, activeSkill)
 					val.baseCostNoMult = val.baseCostNoMult + costs[manaType].baseCostNoMult
 					val.finalBaseCost = val.finalBaseCost + costs[manaType].finalBaseCost
 					costs[manaType].baseCost = 0
-					costs[manaType].baseCostNoMult = 0
+					costs[manaType].baseCostRaw = 0
 					costs[manaType].finalBaseCost = 0
+					costs[manaType].baseCostNoMult = 0
 				elseif additionalLifeCost > 0 or hybridLifeCost > 0 then
 					val.baseCost = costs[manaType].baseCost
 					val.finalBaseCost = val.finalBaseCost + round(costs[manaType].finalBaseCost * (hybridLifeCost + additionalLifeCost))

--- a/src/Modules/CalcTriggers.lua
+++ b/src/Modules/CalcTriggers.lua
@@ -535,6 +535,9 @@ local function defaultTriggerHandler(env, config)
 						end
 						trigRate = trigRate / m_ceil(manaSpentThreshold / sourceManaCost)
 					else
+						if breakdown then
+							t_insert(breakdown.EffectiveSourceRate, s_format("Source skill has no mana cost", output.EffectiveSourceRate))
+						end
 						trigRate = 0
 					end
 				end


### PR DESCRIPTION
Fixes #8228

### Description of the problem being solved:
Fix `ManaCostRaw` not being set to 0 when mana cost is converted to life cost fully. Adds a breakdown line to inform the user that the source skill has no mana cost.

![obraz](https://github.com/user-attachments/assets/c0c937f2-d9d2-4ea9-ad24-5997feee9944)
