### PR TITLE
Validate mode before saving settings

### DIFF
--- a/src/Modules/Main.lua
+++ b/src/Modules/Main.lua
@@ -680,7 +680,7 @@ function main:SaveSettings()
 		t_insert(mode, child)
 	end
 
-	-- if setting save is attempted and mode if nil something has gone very wrong
+	-- if setting save is attempted and mode is nil something has gone very wrong
 	if not mode.attrib.mode or not mode[1] then
 		launch:ShowErrMsg("^1Error saving 'Settings.xml': mode element is invalid")
 		return true

--- a/src/Modules/Main.lua
+++ b/src/Modules/Main.lua
@@ -679,6 +679,12 @@ function main:SaveSettings()
 		end
 		t_insert(mode, child)
 	end
+
+	-- if setting save is attempted and mode if nil something has gone very wrong
+	if not mode.attrib.mode or not mode[1] then
+		launch:ShowErrMsg("^1Error saving 'Settings.xml': mode element is invalid")
+		return true
+	end
 	t_insert(setXML, mode)
 	local accounts = { elem = "Accounts", attrib = { lastAccountName = self.lastAccountName, lastRealm = self.lastRealm } }
 	for accountName, account in pairs(self.gameAccounts) do


### PR DESCRIPTION
Fixes #7523

### Description of the problem being solved:
If a crash occurs during the loading of a build opened through the `pob://` protocol the mode element in settings.xml is corrupted causing a crash upon restarting POB.

This pr attempts to prevent mangling of settings.xml by validating the mode before saving.