### PR TITLE
Hide recovery information if recovery is 0 on mana flasks

### DIFF
--- a/src/Classes/ItemsTab.lua
+++ b/src/Classes/ItemsTab.lua
@@ -3269,13 +3269,13 @@ function ItemsTabClass:AddItemTooltip(tooltip, item, slot, dbMode)
 			end
 		end
 		if flaskData.manaTotal then
-			if flaskData.manaGradual then
+			if flaskData.manaGradual ~= 0 then
 				tooltip:AddLine(16, s_format("^x7F7F7FRecovers %s%d ^x7F7F7FMana over %s%.1f0 ^x7F7F7FSeconds",
 					main:StatColor(flaskData.manaTotal, base.flask.mana), flaskData.manaGradual,
 					main:StatColor(flaskData.duration, base.flask.duration), flaskData.duration
 					))
 			end
-			if flaskData.manaInstant then
+			if flaskData.manaInstant ~= 0 then
 				tooltip:AddLine(16, s_format("^x7F7F7FRecovers %s%d ^x7F7F7FMana instantly", main:StatColor(flaskData.manaTotal, base.flask.mana), flaskData.manaInstant))
 			end
 		end


### PR DESCRIPTION
### Description of the problem being solved:
Mana flasks unlike life flasks always show both instant and non instant recovery lines even when the recovery is 0. This pr adds a zero check to make the description work just like for life flasks.


### Before screenshot:
![before](https://github.com/user-attachments/assets/44b81624-c9c2-4c1c-8e50-370e289f62c4)

### After screenshot:
![after](https://github.com/user-attachments/assets/845869ad-3b6b-4d45-8bf5-1d30fdc99cab)
