### PR TITLE
add spectre WRETCHED DEFILERS

### DIFF
--- a/src/Data/Skills/spectre.lua
+++ b/src/Data/Skills/spectre.lua
@@ -10548,3 +10548,34 @@ skills["AzmeriGolemRotateZap"] = {
 		[1] = { 0.80000001192093, 1.2000000476837, critChance = 5, levelRequirement = 0, statInterpolation = { 3, 3, }, },
 	},
 }
+
+skills["RevenantBossSpellProjectile"] = {
+    name = "Lightning Projectile",
+    hidden = true,
+    color = 4,
+    baseEffectiveness = 1,
+    incrementalEffectiveness = 0.059477807555838,
+    skillTypes = { [SkillType.Spell] = true, [SkillType.Projectile] = true, [SkillType.ProjectilesFromUser] = true, [SkillType.Triggerable] = true, [SkillType.Multicastable] = true, },
+    statDescriptionScope = "skill_stat_descriptions",
+    castTime = 1,
+    baseFlags = {
+        spell = true,
+        projectile = true,
+    },
+    constantStats = {
+        { "monster_projectile_variation", 7 },
+        { "base_number_of_projectiles_in_spiral_nova", 9 },
+        { "projectile_spiral_nova_time_ms", 750 },
+        { "projectile_spiral_nova_angle", 50 },
+        { "projectile_spiral_nova_starting_angle_offset", -20 },
+        { "monster_reverse_point_blank_damage_-%_at_minimum_range", 80 },
+    },
+    stats = {
+        "spell_minimum_base_lightning_damage",
+        "spell_maximum_base_lightning_damage",
+        "base_is_projectile",
+    },
+    levels = {
+        [1] = {0.60000002384186, 1.3999999761581, levelRequirement = 3, statInterpolation = {3, 3}, },
+    },
+}

--- a/src/Data/Spectres.lua
+++ b/src/Data/Spectres.lua
@@ -6789,7 +6789,6 @@ minions["Metadata/Monsters/Revenant/RevenantMapBossStandalone_AtlasUber"] = {
         "standalone_map_boss",
     },
     life = 3.9,
-    evasion = 0.5,
     fireResist = 40,
     coldResist = 40,
     lightningResist = 40,
@@ -6800,6 +6799,10 @@ minions["Metadata/Monsters/Revenant/RevenantMapBossStandalone_AtlasUber"] = {
     attackRange = 10,
     accuracy = 1,
     skillList = {
+        "MeleeAtAnimationSpeed",
+        "RevenantMapBossSummon1",
+        "RevenantMapBossSummon2",
+        "RevenantReviveUndead",
         "RevenantBossSpellProjectile",
     },
     modList = {

--- a/src/Data/Spectres.lua
+++ b/src/Data/Spectres.lua
@@ -6766,3 +6766,42 @@ minions["Metadata/Monsters/LeagueAzmeri/SpecialCorpses/SynthesisGolemHigh"] = {
 		mod("PlayerModifier", "LIST", { mod = mod("Duration", "INC", 20, 0, 0, { type = "GlobalEffect", effectType = "Buff", effectName = "HalfRememberedGoliath", unscaleable = true })}),
 	},
 }
+
+minions["Metadata/Monsters/Revenant/RevenantMapBossStandalone_AtlasUber"] = {
+    name = "Wretched Defiler",
+    monsterTags = {
+        "caster",
+        "demon",
+        "fast_movement",
+        "flesh_armour",
+        "is_unarmed",
+        "large_model",
+        "lightning_affinity",
+        "melee",
+        "not_int",
+        "not_str",
+        "physical_affinity",
+        "raises_dead",
+        "ranged",
+        "red_blood",
+        "slashing_weapon",
+        "small_height",
+        "standalone_map_boss",
+    },
+    life = 3.9,
+    evasion = 0.5,
+    fireResist = 40,
+    coldResist = 40,
+    lightningResist = 40,
+    chaosResist = 25,
+    damage = 3,
+    damageSpread = 0.2,
+    attackTime = 1.5,
+    attackRange = 10,
+    accuracy = 1,
+    skillList = {
+        "RevenantBossSpellProjectile",
+    },
+    modList = {
+    },
+}

--- a/src/Export/Minions/Spectres.txt
+++ b/src/Export/Minions/Spectres.txt
@@ -429,3 +429,5 @@ local minions, mod, flag = ...
 #monster Metadata/Monsters/LeagueAzmeri/SpecialCorpses/SynthesisGolemHigh
 #mod mod("PlayerModifier", "LIST", { mod = mod("Duration", "INC", 20, 0, 0, { type = "GlobalEffect", effectType = "Buff", effectName = "HalfRememberedGoliath", unscaleable = true })})
 #emit
+-- Wretched Defiler
+#spectre Metadata/Monsters/Revenant/RevenantMapBossStandalone_AtlasUber

--- a/src/Export/Skills/spectre.txt
+++ b/src/Export/Skills/spectre.txt
@@ -2167,3 +2167,7 @@ skills["DarkMarionetteExplodePerfect"] = {
 #skill AzmeriGolemRotateZap Spinning Zap
 #flags spell area hit
 #mods
+
+#skill RevenantBossSpellProjectile Lightning Projectile
+#flags spell projectile triggerable
+#mods


### PR DESCRIPTION
Fixes #8226 .

### Description of the problem being solved:
add spectre WRETCHED DEFILERS info
### Steps taken to verify a working solution:
-  add skills to Data\Skills\spectre.lua
-  add minions to Data\Spectres.lua
- add skill to Export\Skills\spectre.txt
- add -- Wretched Defiler to Export\Minions\Spectres.txt

### Link to a build that showcases this PR:
https://pobb.in/kZojnrDg29Ht
### Before screenshot:
![image](https://github.com/user-attachments/assets/2b56745e-bd8a-4794-ba69-e6e5d7491a65)

### After screenshot:
![image](https://github.com/user-attachments/assets/8d54a16b-295d-444c-a95e-c4ee95f9bcd3)

![image](https://github.com/user-attachments/assets/ed5d19eb-d7a1-414a-9222-09323964382d)
