### PR TITLE
Update how Influences are handled

### DIFF
--- a/src/Classes/Item.lua
+++ b/src/Classes/Item.lua
@@ -48,7 +48,7 @@ local function getCatalystScalar(catalystId, tags, quality)
 	return 1
 end
 
-local influenceInfo = itemLib.influenceInfo
+local influenceInfo = itemLib.influenceInfo.all
 
 local ItemClass = newClass("Item", function(self, raw, rarity, highQuality)
 	if raw then
@@ -752,6 +752,13 @@ function ItemClass:ParseRaw(raw, rarity, highQuality)
 					self.canHaveTwoEnchants = true
 					self.canHaveThreeEnchants = true
 					self.canHaveFourEnchants = true
+				elseif lineLower == "has elder, shaper and all conqueror influences" then
+					self.HasElderShaperAndAllConquerorInfluences = true
+					for _, curInfluenceInfo in ipairs(itemLib.influenceInfo.default) do
+						self[curInfluenceInfo.key] = true
+					end
+				elseif lineLower:match("if the eater of worlds is dominant") then
+					self.canHaveEldritchInfluence = true
 				elseif lineLower == "has a crucible passive skill tree with only support passive skills" then
 					self.canHaveOnlySupportSkillsCrucibleTree = true
 				elseif lineLower == "has a crucible passive skill tree" then

--- a/src/Classes/ItemsTab.lua
+++ b/src/Classes/ItemsTab.lua
@@ -32,7 +32,7 @@ local socketDropList = {
 
 local baseSlots = { "Weapon 1", "Weapon 2", "Helmet", "Body Armour", "Gloves", "Boots", "Amulet", "Ring 1", "Ring 2", "Belt", "Flask 1", "Flask 2", "Flask 3", "Flask 4", "Flask 5" }
 
-local influenceInfo = itemLib.influenceInfo
+local influenceInfo = itemLib.influenceInfo.all
 
 local catalystQualityFormat = {
 	"^x7F7F7FQuality (Attack Modifiers): "..colorCodes.MAGIC.."+%d%% (augmented)",
@@ -502,9 +502,15 @@ holding Shift will put it in the second.]])
 	end
 	local function setDisplayItemInfluence(influenceIndexList)
 		self.displayItem:ResetInfluence()
-		for _, index in ipairs(influenceIndexList) do
-			if index > 0 then
-				self.displayItem[influenceInfo[index].key] = true;
+		if self.displayItem.HasElderShaperAndAllConquerorInfluences then
+			for i, curInfluenceInfo in ipairs(itemLib.influenceInfo.default) do
+				self.displayItem[influenceInfo[i].key] = true
+			end
+		else
+			for _, index in ipairs(influenceIndexList) do
+				if index > 0 then
+					self.displayItem[influenceInfo[index].key] = true
+				end
 			end
 		end
 
@@ -1559,6 +1565,12 @@ function ItemsTabClass:SetDisplayItem(item)
 		-- Set both influence dropdowns
 		local influence1 = 1
 		local influence2 = 1
+		local influenceDisplayList = { "Influence" }
+		for i, curInfluenceInfo in ipairs((item.canHaveEldritchInfluence or item.type == "Helmet" or item.type == "Body Armour" or item.type == "Gloves" or item.type == "Boots") and itemLib.influenceInfo.all or itemLib.influenceInfo.default) do
+			influenceDisplayList[i + 1] = curInfluenceInfo.display
+		end
+		self.controls.displayItemInfluence.list = influenceDisplayList
+		self.controls.displayItemInfluence2.list = influenceDisplayList
 		for i, curInfluenceInfo in ipairs(influenceInfo) do
 			if item[curInfluenceInfo.key] then
 				if influence1 == 1 then

--- a/src/Data/ModCache.lua
+++ b/src/Data/ModCache.lua
@@ -8603,7 +8603,7 @@ c["Has 3 Sockets"]={{[1]={flags=0,keywordFlags=0,name="SocketCount",type="BASE",
 c["Has 4 Abyssal Sockets"]={{[1]={flags=0,keywordFlags=0,name="AbyssalSocketCount",type="BASE",value=4}},nil}
 c["Has 6 Abyssal Sockets"]={{[1]={flags=0,keywordFlags=0,name="AbyssalSocketCount",type="BASE",value=6}},nil}
 c["Has 6 Sockets"]={{[1]={flags=0,keywordFlags=0,name="SocketCount",type="BASE",value=6}},nil}
-c["Has Elder, Shaper and all Conqueror Influences"]={nil,"Has Elder, Shaper and all Conqueror Influences "}
+c["Has Elder, Shaper and all Conqueror Influences"]={{},nil}
 c["Has a Crucible Passive Skill Tree"]={{},nil}
 c["Has a Crucible Passive Skill Tree with only Support Passive Skills"]={{},nil}
 c["Has a Two Handed Sword Crucible Passive Skill Tree"]={{},nil}

--- a/src/Modules/ItemTools.lua
+++ b/src/Modules/ItemTools.lua
@@ -13,14 +13,24 @@ itemLib = { }
 
 -- Info table for all types of item influence
 itemLib.influenceInfo = {
-	{ key="shaper", display="Shaper", color=colorCodes.SHAPER },
-	{ key="elder", display="Elder", color=colorCodes.ELDER },
-	{ key="adjudicator", display="Warlord", color=colorCodes.ADJUDICATOR },
-	{ key="basilisk", display="Hunter", color=colorCodes.BASILISK },
-	{ key="crusader", display="Crusader", color=colorCodes.CRUSADER },
-	{ key="eyrie", display="Redeemer", color=colorCodes.EYRIE },
-	{ key="cleansing", display="Searing Exarch", color=colorCodes.CLEANSING },
-	{ key="tangle", display="Eater of Worlds", color=colorCodes.TANGLE },
+	["all"] = {
+		{ key="shaper", display="Shaper", color=colorCodes.SHAPER },
+		{ key="elder", display="Elder", color=colorCodes.ELDER },
+		{ key="adjudicator", display="Warlord", color=colorCodes.ADJUDICATOR },
+		{ key="basilisk", display="Hunter", color=colorCodes.BASILISK },
+		{ key="crusader", display="Crusader", color=colorCodes.CRUSADER },
+		{ key="eyrie", display="Redeemer", color=colorCodes.EYRIE },
+		{ key="cleansing", display="Searing Exarch", color=colorCodes.CLEANSING },
+		{ key="tangle", display="Eater of Worlds", color=colorCodes.TANGLE },
+	},
+	["default"] = {
+		{ key="shaper", display="Shaper", color=colorCodes.SHAPER },
+		{ key="elder", display="Elder", color=colorCodes.ELDER },
+		{ key="adjudicator", display="Warlord", color=colorCodes.ADJUDICATOR },
+		{ key="basilisk", display="Hunter", color=colorCodes.BASILISK },
+		{ key="crusader", display="Crusader", color=colorCodes.CRUSADER },
+		{ key="eyrie", display="Redeemer", color=colorCodes.EYRIE },
+	}
 }
 
 -- Apply a value scalar to the first n of any numbers present

--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -5089,6 +5089,7 @@ local specialModList = {
 	["can have (%d+) additional enchantment modifiers"] = { },
 	["this item can be anointed by cassia"] = { },
 	["has a crucible passive skill tree"] = { },
+	["has elder, shaper and all conqueror influences"] = { },
 	["has a two handed sword crucible passive skill tree"] = { },
 	["has a crucible passive skill tree with only support passive skills"] = { },
 	["crucible passive skill tree is removed if this modifier is removed"] = { },


### PR DESCRIPTION
This prevents you setting eldritch influences (eater/exarch) onto items that it cannot go on (with the exception of eternal struggle)

This also adds support for `Astrolabe Amulet`'s `Has Elder, Shaper and all Conqueror Influences` implict

I may extend this to allow all eater/exarch mods onto amulets now that the influence cant be applied, which would make it so eternal struggle wouldnt need variants generated, or I might generate all the variants, depending on what maintainer prefers