### PR TITLE
Fix Trade Query Stat Weight Crash

### DIFF
--- a/src/Classes/TradeQuery.lua
+++ b/src/Classes/TradeQuery.lua
@@ -529,10 +529,10 @@ end
 -- Popup to set stat weight multipliers for sorting
 function TradeQueryClass:SetStatWeights(previousSelectionList)
 	previousSelectionList = previousSelectionList or {}
-    local controls = { }
-    local statList = { }
+	local controls = { }
+	local statList = { }
 	local sliderController = { index = 1 }
-    local popupHeight = 285
+	local popupHeight = 285
 
 	controls.ListControl = new("TradeStatWeightMultiplierListControl", { "TOPLEFT", nil, "TOPRIGHT" }, -410, 45, 400, 200, statList, sliderController)
 

--- a/src/Classes/TradeQuery.lua
+++ b/src/Classes/TradeQuery.lua
@@ -528,6 +528,7 @@ end
 
 -- Popup to set stat weight multipliers for sorting
 function TradeQueryClass:SetStatWeights(previousSelectionList)
+	previousSelectionList = previousSelectionList or {}
     local controls = { }
     local statList = { }
 	local sliderController = { index = 1 }


### PR DESCRIPTION
Fixes crash when resetting stat weight multipliers with no previous selection