### PR TITLE
Fix 3.1 xp multiplier calc for levels 95-99

### DIFF
--- a/src/Modules/Build.lua
+++ b/src/Modules/Build.lua
@@ -191,7 +191,8 @@ function buildMode:Init(dbFileName, buildName, buildXML, convertBuild, importLin
 					mult = ((playerLevel + 5) / (playerLevel + 5 + diff ^ 2.5)) ^ 1.5
 				end
 				if playerLevel >= 95 then
-					mult = mult * (1 / (1 + 0.1 * (playerLevel - 94)))
+					local xpPenalty = ({0.935, 0.885, 0.8125, 0.7175, 0.6})[playerLevel - 94] or 0
+					mult = mult * (1 / (1 + 0.1 * (playerLevel - 94))) * xpPenalty
 				end
 				if mult > 0.01 then
 					local line = level


### PR DESCRIPTION
Fixes # .

### Description of the problem being solved:
GGG applied a experience penalty to experience for levels 95-99 in patch 3.1. https://www.pathofexile.com/forum/view-thread/2035872

Currently PoB doesn't take these penalties into account when calculating the experience multiplier.


### Steps taken to verify a working solution:
- 
-
-

### Link to a build that showcases this PR:

### Before screenshot:
#### Level 95
![image](https://github.com/user-attachments/assets/e31961de-29bb-4902-b6bd-ab7909e49341)
#### Level 99
![image](https://github.com/user-attachments/assets/53fe7b19-17fa-4900-96fc-1f6a8b12646d)

### After screenshot:
#### Level 95
![image](https://github.com/user-attachments/assets/f072ce19-5c85-4794-baef-a8361661865e)
#### Level 99
![image](https://github.com/user-attachments/assets/a7fdc39b-48ee-44c7-99d0-5c5423ba7f19)
