### PR TITLE
Fix 3.1 xp multiplier calc for levels 95-99

### DIFF
--- a/src/Modules/Build.lua
+++ b/src/Modules/Build.lua
@@ -191,7 +191,8 @@ function buildMode:Init(dbFileName, buildName, buildXML, convertBuild, importLin
 					mult = ((playerLevel + 5) / (playerLevel + 5 + diff ^ 2.5)) ^ 1.5
 				end
 				if playerLevel >= 95 then
-					mult = mult * (1 / (1 + 0.1 * (playerLevel - 94)))
+					local xpPenalty = ({0.935, 0.885, 0.8125, 0.7175, 0.6})[playerLevel - 94] or 0
+					mult = mult * (1 / (1 + 0.1 * (playerLevel - 94))) * xpPenalty
 				end
 				if mult > 0.01 then
 					local line = level

--- a/src/Modules/Build.lua
+++ b/src/Modules/Build.lua
@@ -191,7 +191,7 @@ function buildMode:Init(dbFileName, buildName, buildXML, convertBuild, importLin
 					mult = ((playerLevel + 5) / (playerLevel + 5 + diff ^ 2.5)) ^ 1.5
 				end
 				if playerLevel >= 95 then
-					local xpPenalty = ({0.935, 0.885, 0.8125, 0.7175, 0.6})[playerLevel - 94] or 0
+					local xpPenalty = ({0.935, 0.885, 0.813, 0.7175, 0.6})[playerLevel - 94] or 0
 					mult = mult * (1 / (1 + 0.1 * (playerLevel - 94))) * xpPenalty
 				end
 				if mult > 0.01 then


### PR DESCRIPTION
### Description of the problem being solved:
PoB doesn't currently take into account the experience penalty for levels 95-99 that GGG applied in [patch 3.1](https://www.pathofexile.com/forum/view-thread/2035872) and the experience multipliers shown in PoB are higher than they should be when you hover the level at top center of the window.

### An explanation of the numbers:
I initially was going to follow the formula shown on [poewiki.net](https://www.poewiki.net/wiki/Experience#Experience_penalties)  `1/(1+[number from patch notes])`. However after reading a couple of reddit posts ([reddit post 1](https://www.reddit.com/r/pathofexile/comments/ypswyu/about_experience_penalty_31_and_experience/), [reddit post 2](https://www.reddit.com/r/pathofexile/comments/8jqm2o/experience_multiplier_changes_from_310/)) of people experiencing less experience gained than you would expect from reading the patch notes. People were experiencing ~66% less experience gained rather than the stated 40% less. As the second post points out the patch notes used `1-[in-game multiplier]` to describe the increase of experience needed. 

Player level | Patch notes % | PoeWiki Penalty | Actual Penalty 
----------- | --------------- | ---------------- |-----
95 | 6.5% | 1/(1+0.065) = 0.939 | 1-0.065 = 0.935
96 | 11.5% | 1/(1+0.115)= 0.8969 | 1-0.115 = 0.885
97 | 18.7% | 1/(1+0187) = 0.8425 | 1-0.187 = 0.813
98 | 28.25% | 1/(1+0.2825) = 0.7797 | 1-0.2825 = 0.7175
99 | 40%| 1/(1+0.4) = 0.7143 | 1-0.4 = 0.6

### Steps taken to verify a working solution:
- Open a new or existing build
- Set the level anywhere from 95-99 at the top middle of the screen
- Hover the the level box
- Compare to expected output

I have generated these numbers using Google Sheets to use as a reference for verifying the values
Area level → <br /> Player level ↓ | 80 | 81 | 82 | 83 | 84 | 
---------------------------- | --- | --- | -- | --- | --- | 
95 | 9.19% | 10.12% | 10.97% | 11.69% | 12.25%
96 | 8.07% | 8.88% | 9.63% | 10.26% | 10.75%
97 | 5.26% | 5.77% | 6.23% | 6.62% | 6.92%
98 | 3.36% | 3.67% | 3.94% | 4.18% | 4.36%
99 | 2.07% | 2.25% | 2.41% | 2.55% | 2.65%

[Full sheet](https://docs.google.com/spreadsheets/d/1Hvrtufp45-Sg-MyGXJcZZ6Osy-OBFrvIOBha5DjNoDY/edit?usp=sharing) of experience numbers.

This [site](https://www.i-volve.net/jol/poe_xpdrop_en.php) applies the 3.1 experience penalty in its calculations so this can be used as a 3rd party to verify the correct numbers. 
[Level 95 Area Level 83](https://www.i-volve.net/jol/poe_xpdrop_en.php?lvl=95&lvlzone=83)
![image](https://github.com/user-attachments/assets/2935d48f-59b2-4853-b863-458952750bbc)
[Level 99 Area Level 83](https://www.i-volve.net/jol/poe_xpdrop_en.php?lvl=99&lvlzone=83)
![image](https://github.com/user-attachments/assets/9da5f8c6-0836-40bc-ba43-84cc20d8b105)
It shows the penalty number so to convert that into a multiplier as with pob you'll have to do a little math.
`100-xp penalty = experience multiplier`

### Link to a build that showcases this PR:
This is build agnostic, only the character level has relevance and can just create a new empty pob and set the level

### Before screenshot:
#### Level 95
![image](https://github.com/user-attachments/assets/e31961de-29bb-4902-b6bd-ab7909e49341)
#### Level 99
![image](https://github.com/user-attachments/assets/53fe7b19-17fa-4900-96fc-1f6a8b12646d)

### After screenshot:
#### Level 95
![image](https://github.com/user-attachments/assets/f072ce19-5c85-4794-baef-a8361661865e)
#### Level 99
![image](https://github.com/user-attachments/assets/a7fdc39b-48ee-44c7-99d0-5c5423ba7f19)

Verified co-conspirator:  @Nightblade