### PR TITLE
Fix Reset 'Enemy Damage Type' after 'Boss Skill Preset'

### DIFF
--- a/src/Modules/ConfigOptions.lua
+++ b/src/Modules/ConfigOptions.lua
@@ -2026,6 +2026,8 @@ Huge sets the radius to 11.
 				end
 			end
 		else
+			build.configTab.varControls['enemyDamageType']:SelByValue("Average", "val")
+			build.configTab.input['enemyDamageType'] = "Average"
 			build.configTab.varControls['enemyDamageType'].enabled = true
 		end
 	end },


### PR DESCRIPTION
Fixes #7870 .

### Description of the problem being solved:
When you set the 'Boss Skill Preset' back to 'None' to see the normal EHP/Max Hit values the 'Enemy Damage Type' stays the same as whatever the Boss Skill was.
### Steps taken to verify a working solution:
- Select any boss skill preset.
- Select preset to None.
- Chech damage type.
- Must be "Average".

### Before screenshot:
![image](https://github.com/user-attachments/assets/270ef5fb-9287-40e8-8517-5bca39707e7e)

### After screenshot:
![image](https://github.com/user-attachments/assets/7bcbe196-f751-4c31-b8e7-d0f19c5c8350)
