### PR TITLE
Add Ctrl+Alt+c error popup

### DIFF
--- a/src/Classes/Item.lua
+++ b/src/Classes/Item.lua
@@ -298,7 +298,11 @@ function ItemClass:ParseRaw(raw, rarity, highQuality)
 	self.rawLines = { }
 	-- Find non-blank lines and trim whitespace
 	for line in raw:gmatch("%s*([^\n]*%S)") do
-	 	t_insert(self.rawLines, line)
+		if line:match("^{ ") then
+			main:OpenMessagePopup("Error", "\"Advanced Item Description\" (Ctrl+Alt+c) is currently unsupported.\nPlease try again using Ctrl+c only.")
+			return
+		end
+		t_insert(self.rawLines, line)
 	end
 	local mode = rarity and "GAME" or "WIKI"
 	local l = 1


### PR DESCRIPTION
### Description of the problem being solved:

Currently some item mods are parsed incorrectly if the user tries to paste an item into PoB after using <kbd>Ctrl</kbd>+<kbd>Alt</kbd>+<kbd>c</kbd> (Advanced Item Description).

This PR adds an error popup to inform the user of the incompatibility, and provides a remedy.

### Before screenshot:

![image](https://github.com/user-attachments/assets/cf5eec3e-171a-498b-88f3-b0b28a6ea436)

### After screenshot:

![image](https://github.com/user-attachments/assets/29525787-4352-4ba4-92f7-4a7fff6bb5b8)
