### PR TITLE
fix Ghost Reaver and Brutal Fervour Interaction

### DIFF
--- a/src/Modules/CalcPerform.lua
+++ b/src/Modules/CalcPerform.lua
@@ -706,7 +706,7 @@ local function doActorMisc(env, actor)
 			local effect = m_max(m_floor(70 * calcLib.mod(modDB, nil, "SelfChillEffect")), 0)
 			modDB:NewMod("ActionSpeed", "INC", -effect, "Freeze")
 		end
-		if modDB:Flag(nil, "CanLeechLifeOnFullLife") then
+		if modDB:Flag(nil, "CanLeechLifeOnFullLife") and not modDB:Flag(nil, "GhostReaver") then
 			condList["Leeching"] = true
 			condList["LeechingLife"] = true
 		end


### PR DESCRIPTION
Fixes #8208 .

This just doesnt automatically count you as leeching if you have both, all the other interactions still work, and lets you use config to count as leeching