### PR TITLE
Remove non-existant stat from Cadigan's Crown

### DIFF
--- a/src/Data/Uniques/helmet.lua
+++ b/src/Data/Uniques/helmet.lua
@@ -1562,7 +1562,6 @@ League: Expedition
 Source: Drops from unique{Olroth, Origin of the Fall} in normal{Expedition Logbook}
 Requires Level 68, 66 Str, 66 Dex, 66 Int
 Never deal Critical Strikes
-Nearby Enemies cannot deal Critical Strikes
 Battlemage
 ]],
 }


### PR DESCRIPTION
Im not sure how this got there:

Nearby Enemies cannot deal Critical Strikes

The item does not have that line:

![image](https://github.com/user-attachments/assets/f005801b-35c0-4779-a4c2-e59b23d68daf)
