### PR TITLE
Fix Cooldown breakdown showing overrides for other skills (eg flicker)

### DIFF
--- a/src/Classes/ModDB.lua
+++ b/src/Classes/ModDB.lua
@@ -239,8 +239,9 @@ function ModDBClass:TabulateInternal(context, result, modType, cfg, flags, keywo
 				if (mod.type == modType or not modType) and band(flags, mod.flags) == mod.flags and MatchKeywordFlags(keywordFlags, mod.keywordFlags) and (not source or mod.source:match("[^:]+") == source) then
 					local value
 					if mod[1] then
-						value = context:EvalMod(mod, cfg) or 0
+						value = context:EvalMod(mod, cfg)
 						if mod[1].globalLimit and mod[1].globalLimitKey then
+							value = value or 0
 							globalLimits[mod[1].globalLimitKey] = globalLimits[mod[1].globalLimitKey] or 0
 							if globalLimits[mod[1].globalLimitKey] + value > mod[1].globalLimit then
 								value = mod[1].globalLimit - globalLimits[mod[1].globalLimitKey]


### PR DESCRIPTION
Fix overrides 0 showing up when eval mod fails
(these 3)
![image](https://github.com/user-attachments/assets/82395708-4395-4bce-9dc6-29695dd8c99d)


This is likely caused by https://github.com/PathOfBuildingCommunity/PathOfBuilding/commit/8fe92a53602489e67d6584789dd4380b193539ee where it was copied from `SumInternal` and should not have been an "or 0" case