### PR TITLE
Fix party tab warcries clearing links instead of warcries

### DIFF
--- a/src/Classes/PartyTab.lua
+++ b/src/Classes/PartyTab.lua
@@ -92,8 +92,8 @@ local PartyTabClass = newClass("PartyTab", "ControlHost", "Control", function(se
 			self.actor["Curse"] = {}
 		end
 		if partyDestinations[self.controls.importCodeDestination.selIndex] == "All" or partyDestinations[self.controls.importCodeDestination.selIndex] == "Warcry Skills" then
-			self.controls.simpleLinks.label = ""
-			self.controls.editLinks:SetText("")
+			self.controls.simpleWarcries.label = ""
+			self.controls.editWarcries:SetText("")
 			wipeTable(self.actor["Warcry"])
 			self.actor["Warcry"] = {}
 		end


### PR DESCRIPTION
This is mostly an issue when importing a support character with no warcries not clearing warcries if import with no "append" and so the warcry buffs still persist