### PR TITLE
Fix PartyTab Crash with thresholds

### DIFF
--- a/src/Modules/ModTools.lua
+++ b/src/Modules/ModTools.lua
@@ -59,6 +59,10 @@ function modLib.parseTags(line)
 				if tag ~= "" then
 					local tagName, tagValue = tag:match("^(%a+)=(.+)")
 					if tagName then
+						-- list of all the tag parts that should be numbers
+						if ({threshold = true})[tagName] then
+							tagValue = tonumber(tagValue)
+						end
 						tagSet[tagName] = tagValue == "true" and true or tagValue
 					else
 						ConPrintf("Error tag invalid: "..tag)


### PR DESCRIPTION
Party tab is currently the only thing using mod tools to parse strings directly into mod tags, its not automatically turning them into numbers, this is fine in most cases, but the modstore doesnt turn thresholds into numbers and so causes a crash

![image](https://github.com/user-attachments/assets/0b47a507-fc80-4c02-a3f4-2a39c981b905)


I made it use a lookup array, this is slower, but makes it easier to add others in future if other tags also need to be numbers and not strings