### PR TITLE
Fix abyss socket items with no selectableSocketCount (eg Wraithlord)

### DIFF
--- a/src/Classes/Item.lua
+++ b/src/Classes/Item.lua
@@ -1708,11 +1708,11 @@ function ItemClass:BuildModList()
 		if self.sockets then
 			for i, socket in ipairs(self.sockets) do
 				if socket.color ~= "A" then
-					t_insert(newSockets, socket)
-					group = socket.group
 					if #newSockets >= self.selectableSocketCount then
 						break
 					end
+					t_insert(newSockets, socket)
+					group = socket.group
 				end
 			end
 		end


### PR DESCRIPTION
This fixed items such as `Wraithlord` and `Replica Shroud of the Lightless` still having 1 non-abyss socket

Before
![image](https://github.com/user-attachments/assets/cffdc7e5-d363-48c6-984a-5a974310f1ba)

After
![image](https://github.com/user-attachments/assets/a7884cc0-6d93-45f7-abfd-edad7bd25998)
