### PR TITLE
Default "Enemy Damage Type" to "Average"

### DIFF
--- a/src/Modules/ConfigOptions.lua
+++ b/src/Modules/ConfigOptions.lua
@@ -2035,6 +2035,10 @@ Huge sets the radius to 11.
 				end
 			end
 		else
+			if build.configTab.varControls['enemyDamageType'].enabled == false then
+				build.configTab.input['enemyDamageType'] = "Average"
+				build.configTab.varControls['enemyDamageType']:SelByValue("Average", "val")
+			end
 			build.configTab.varControls['enemyDamageType'].enabled = true
 		end
 	end },


### PR DESCRIPTION
Fixes #7870 .
Implement Enemy Damage Type defaulting to "Average" after user swaps off of a Boss Skill Preset other than None.

### Description of the problem being solved:
When users set "Boss Skill Preset" to a boss specific skill, returning to "None" would leave "Enemy Damage Type" as the type associated with that boss. This changes reverts "Enemy Damage Type" to "Average" when the user switches back to "None" from a "Boss Skill Preset" other than "None".

### Steps taken to verify a working solution:
- Gathered stats for test build in several settings before change.
- Gathered stats for test build in several settings post change.
- Compared before/after stats to confirm that settings were being applied correctly, both manually and automatically.

### Link to a build that showcases this PR:
https://pobb.in/kYuRwhP1-Sm0
https://poe.ninja/builds/settlersssf/character/LPBird/Lotus_KANYQR?type=exp&i=0

### Before screenshot:
Boss Skill Preset/Enemy Damage Type:

None/Average:
![image](https://github.com/user-attachments/assets/c3dd68bf-b895-4247-a087-137b271c091a)

None/Spell:
![image](https://github.com/user-attachments/assets/8d4732f4-27e9-48cd-9995-f1302ad50017)

Atziri Flameblast/Spell:
![image](https://github.com/user-attachments/assets/c18ca246-bc94-4fd7-842e-9149d96ff1fe)

Stays on "Spell" after switching back from Atziri Flameblast:
![image](https://github.com/user-attachments/assets/2551a36e-1c64-4e72-8bb5-4ed327394f31)

### After screenshot:
Boss Skill Preset/Enemy Damage Type:

None/Average
![image](https://github.com/user-attachments/assets/1550552b-707f-4535-a5b9-39bbf6669551)

None/Spell
![image](https://github.com/user-attachments/assets/58cedd1e-e9a9-4db0-88c7-3b3a380b399f)

Atziri Flameblast/Spell:
![image](https://github.com/user-attachments/assets/3d50669f-b41d-4a43-9fc3-1b7708755365)

Switches back to "Average" after switching back to "None" from "Atziri Flameblast"
![image](https://github.com/user-attachments/assets/fcb3efd5-d14a-45f7-a31d-391809bdc0b1)

None/Average applied correctly after automatic switch from "Spell"
![image](https://github.com/user-attachments/assets/8747e9dd-954c-4847-8199-9a94d6cc7026)


Additional Note:
After working on this I decided not to pursue the option of setting "Enemy Damage Type" to a previous value set by the user, as defaulting to "Average" encapsulated most of the use cases I could imagine.
