### PR TITLE
Fix Rupture sometimes applying multiple times

### DIFF
--- a/src/Data/Skills/sup_dex.lua
+++ b/src/Data/Skills/sup_dex.lua
@@ -3134,10 +3134,10 @@ skills["SupportRupture"] = {
 	statDescriptionScope = "gem_stat_descriptions",
 	statMap = {
 		["support_rupture_bleeding_damage_taken_+%_final"] = {
-			mod("DamageTaken", "MORE", nil, 0, KeywordFlag.Bleed, { type = "GlobalEffect", effectType = "Debuff" }, { type = "Multiplier", var = "RuptureStack", limit = 3 })
+			mod("DamageTaken", "MORE", nil, 0, KeywordFlag.Bleed, { type = "GlobalEffect", effectType = "Debuff", effectName = "Rupture" }, { type = "Multiplier", var = "RuptureStack", limit = 3 })
 		},
 		["support_rupture_bleeding_time_passed_+%_final"] = {
-			mod("BleedExpireRate", "MORE", nil, 0, KeywordFlag.Bleed, { type = "GlobalEffect", effectType = "Debuff" }, { type = "Multiplier", var = "RuptureStack", limit = 3 })
+			mod("BleedExpireRate", "MORE", nil, 0, KeywordFlag.Bleed, { type = "GlobalEffect", effectType = "Debuff", effectName = "Rupture" }, { type = "Multiplier", var = "RuptureStack", limit = 3 })
 		},
 		["critical_strikes_that_inflict_bleeding_also_rupture"] = {
 			flag("Condition:CanInflictRupture", { type = "GlobalEffect", effectType = "Buff" }),

--- a/src/Export/Skills/sup_dex.txt
+++ b/src/Export/Skills/sup_dex.txt
@@ -377,10 +377,10 @@ local skills, mod, flag, skill = ...
 #skill SupportRupture
 	statMap = {
 		["support_rupture_bleeding_damage_taken_+%_final"] = {
-			mod("DamageTaken", "MORE", nil, 0, KeywordFlag.Bleed, { type = "GlobalEffect", effectType = "Debuff" }, { type = "Multiplier", var = "RuptureStack", limit = 3 })
+			mod("DamageTaken", "MORE", nil, 0, KeywordFlag.Bleed, { type = "GlobalEffect", effectType = "Debuff", effectName = "Rupture" }, { type = "Multiplier", var = "RuptureStack", limit = 3 })
 		},
 		["support_rupture_bleeding_time_passed_+%_final"] = {
-			mod("BleedExpireRate", "MORE", nil, 0, KeywordFlag.Bleed, { type = "GlobalEffect", effectType = "Debuff" }, { type = "Multiplier", var = "RuptureStack", limit = 3 })
+			mod("BleedExpireRate", "MORE", nil, 0, KeywordFlag.Bleed, { type = "GlobalEffect", effectType = "Debuff", effectName = "Rupture" }, { type = "Multiplier", var = "RuptureStack", limit = 3 })
 		},
 		["critical_strikes_that_inflict_bleeding_also_rupture"] = {
 			flag("Condition:CanInflictRupture", { type = "GlobalEffect", effectType = "Buff" }),


### PR DESCRIPTION
Fixes #8259  .

### Description of the problem being solved:
The global Rupture debuff was not previously not assigned an effect name. Because of that, multiple instances were allowed to apply, as they had different active skills as their source.

I just assigned an effect name, which caused the standard mergeBuff / match functions to be able to properly identify duplicates and only apply the highest values instead. 

### Steps taken to verify a working solution:
- Checked number of applied stacks, effect on duration and damage for correctness
- Checked that different magnitudes from support gem level work correctly
- Checked that behavior is consistent across different skills

### Link to a build that showcases this PR:
https://pobb.in/70IX7nLOCxOZ

### Before screenshot:
![CalcTooltip_Before](https://github.com/user-attachments/assets/cbbbd7a9-d60e-458d-a8a8-1531991a999d)
![SkillTooltip_Before](https://github.com/user-attachments/assets/4236c20f-ec97-4f7b-876a-85603d73254a)

### After screenshot:
![CalcTooltip_After](https://github.com/user-attachments/assets/2669cbf9-6ee4-4721-b0ab-37134f755f39)
![SkillTooltip_After](https://github.com/user-attachments/assets/65c5f330-cf22-468c-93fd-9c6e9969f309)
