### PR TITLE
Fix blasphemy auras triggering mana cost warning

### DIFF
--- a/src/Modules/Build.lua
+++ b/src/Modules/Build.lua
@@ -1735,19 +1735,8 @@ function buildMode:AddDisplayStatList(statList, actor)
 						end
 					elseif not (statData.hideStat) then
 						-- Change the color of the stat label to red if cost exceeds pool
-						local output = actor.output
-						local poolVal = output[statData.pool]
 						local colorOverride = nil
-						if statData.stat:match("Cost$") and not statData.stat:match("PerSecondCost$") and statVal and poolVal then
-							if statData.stat == "ManaCost" and output.EnergyShieldProtectsMana then
-								if statVal > output.ManaUnreserved + output.EnergyShield then
-									colorOverride = colorCodes.NEGATIVE
-								end
-							elseif statVal > poolVal then
-								colorOverride = colorCodes.NEGATIVE
-							end
-						end
-						if statData.warnFunc and statData.warnFunc(statVal, actor.output) and statData.warnColor then
+						if actor.output[statData.stat.."Warning"] or (statData.warnFunc and statData.warnFunc(statVal, actor.output) and statData.warnColor) then
 							colorOverride = colorCodes.NEGATIVE
 						end
 						t_insert(statBoxList, {

--- a/src/Modules/Calcs.lua
+++ b/src/Modules/Calcs.lua
@@ -8,6 +8,7 @@ local ipairs = ipairs
 local t_insert = table.insert
 local s_format = string.format
 local m_min = math.min
+local m_ceil = math.ceil
 
 local calcs = { }
 calcs.breakdownModule = "Modules/CalcBreakdown"
@@ -441,8 +442,13 @@ function calcs.buildOutput(build, mode)
 					if cachedCost then
 						local totalPool = (output.EnergyShieldProtectsMana and costResource == "ManaCost" and output["EnergyShield"] or 0) + (output[pool] or 0)
 						if totalPool < cachedCost then
-							output[costResource.."Warning"] = output[costResource.."Warning"] or {}
-							t_insert(output[costResource.."Warning"], skill.activeEffect.grantedEffect.name)
+							local rawPool = pool:gsub("Unreserved$", "")
+							local reservation = GlobalCache.cachedData[mode][uuid].Env.player.mainSkill and GlobalCache.cachedData[mode][uuid].Env.player.mainSkill.skillData[rawPool .. "ReservedPercent"]
+							-- Skill has both cost and reservation check if there's avilable pool for raw cost before reservation
+							if not reservation or (reservation and (totalPool + m_ceil((output[rawPool] or 0) * reservation / 100)) < cachedCost) then
+								output[costResource.."Warning"] = output[costResource.."Warning"] or {}
+								t_insert(output[costResource.."Warning"], skill.activeEffect.grantedEffect.name)
+							end
 						end
 					end
 				end

--- a/src/Modules/Calcs.lua
+++ b/src/Modules/Calcs.lua
@@ -444,7 +444,7 @@ function calcs.buildOutput(build, mode)
 						if totalPool < cachedCost then
 							local rawPool = pool:gsub("Unreserved$", "")
 							local reservation = GlobalCache.cachedData[mode][uuid].Env.player.mainSkill and GlobalCache.cachedData[mode][uuid].Env.player.mainSkill.skillData[rawPool .. "ReservedPercent"]
-							-- Skill has both cost and reservation check if there's avilable pool for raw cost before reservation
+							-- Skill has both cost and reservation check if there's available pool for raw cost before reservation
 							if not reservation or (reservation and (totalPool + m_ceil((output[rawPool] or 0) * reservation / 100)) < cachedCost) then
 								output[costResource.."Warning"] = output[costResource.."Warning"] or {}
 								t_insert(output[costResource.."Warning"], skill.activeEffect.grantedEffect.name)


### PR DESCRIPTION
Fixes #8319

### Description of the problem being solved:
The warning calculations did not consdier the case of a skill having both reservation and mana costs. Mana cost would be checked after applying reservation and not before causing the warning to show up in some cases.

This pr adds a check and handling for such cases, as well as using the warnings from output to determine color override for cost labels instead of re-checking pool availability.

### Link to a build that showcases this PR:
```
eNq1W1132jgTvm5_hQ_3DQECTXtI9xAgTc4hDS-k7b5XPcIWoK0ssZachP31q5FsYwhyZOzNRWvQPPMlzWg0Mv0_XkLqPeFIEM6uGq2z84aHmc8DwlZXje-PNx8uG398ed-fIrl-WF7HhMLIl_fv-vrZo_gJU4VreBJFKyx_pJw6vxSnDWJyjTm7R3_x6CsPrhrfOMMNb4FYQGT6yadIiG8oxFeNua_ADQ8JH7NguPs-IVyjCPkSRxOQOoglv-eBGl0iKtRwiAibc_83ll8jHm-0Vk8EPxuiu_vpw-wxpxNheZ2USe_6U4q2OJpLJD2h_rlqDJRn0ArfEqlYIRorPueNZiHtdRwJOUKhenwbM99gHGRkbRvZNMLj5RL7kjzhYUTkcI2Y78C-LO19TCXZUIKjjL511rUhbl8xb51b2T9yiehoOn9bEUPJHTz-k8j1NVUedOIL1HcrRiR2Jp9yIjgrpbUT8TCmVIWRE-0MCxw9IUkcFRnycEGYo08GEUYPS7O2ZiggsbjHMsIiQ16cXdqw94ihIRe7eeqdF5FOcaSCWu4h3gLMsc9VHshDWm0XKcexVuSELLE7ZSlLEkBZbU6zYzx3pSvN-DSFZioLulHOeUwdKeUuO9kXwwi_OFDN8N95wla7Z6O8Y9KNX56wgN8IP3GpNzunzDK-nWaU3U9nrVanc35-8anda7Wsm8Z6K4iP6D16IWEcqmz9iH5j5hCuE7JaS6YSlA3asSaFGxLh8qghp8EJqDXiojwMwsvBCWpr9j8D7R3z3WL2O4t0rs7t6L1CwExFEhQNC4odETsRSTy6bL1G1AqzRN7WzZwJxv76q6qpZkhit5S9W6LFbgVaJ7cC4RG3ti7dAIdO6vSKcBYfnX0qApX00pjhaLWdrwmmQTnqVLEh2jjVlf7nPNrJ2_viSi2YPLSkS36iKHDbScrq9IREPsO2esXuMuRu6xKrslMBAuxaXk8j_hcU8LQcbBCFPI4cJ9wQOxmQbg7moDLDQey77UbZOeSaqqOWqxkZSulJaSnoQErk_x7xYOXsNC2kFGJfv3m82agUAqvBlQHse6pSJ7kC5kPPgfpBLWWniIYt0l3AjtpZQLbpu0s5gLjbAht3CWN25M4isgm9V8kiVHuAPmnf89weYp0cdThzOjxpQscT35Q_K83X0CMR5ahVgbPbv6yqRJj9s3Xmv0fuJGDMgjiCUHCWcYg4JuaRhCqRCjFCEnlBUhH_QBFBTLZ1_0ZgFPnriZr6G0TpQmWCq0b-W_h0AGylc9tv6h4VPN2FGx5JD7_Af1MUyW3aNdKE-hvFR0jC9ElbpR1KG958zZ8HwRNY8cg5FVmrCW02mAV7PB4jjD2UJhEflNA2wgcvREKqPcusSgFK51pcdwG40WNcKaBKp8vLTgdMhFMWiraDfUJGlF7qiI5znbZ2N2miGU4g9l3_-2yiH96tpdyIz83m8_Pz2QbJNV_iF7UNnfk8bG4USCn8QfwmlH4Ats2B-rteDfSfZtRMOfVNc000zSeIxYgonc1cNsFQ7XXwBDx84xILGIMv0w_9OYgSnlAT8RWH4nqr4ucGyoaD1kXiSqCeY2kWQx5z1ZBRjGH2lyim8P3_YkQJzOx5_tuJ6VAyHoXZWUixUjMLad5wfNxuwPWDycSMDKhMmIG4dJrNdCYKeSRIpzj5UvcfBzuth4j6QutNmE_jQB0kktSSzCJFC9AMGq5wBAhSiw74ZGLe9ZU2CfFXyheItlNI0oZVB1NvhUNYBvdYokCFVfNOKhOaYEdTs1NPP2LK4NhBwEIISh03gBphsUFE1Rt6Qex983fOu8mzGdeObuzp1Ur1OrDM5zEzU8lQmIRJKqBZk43ZpF6riNiscbhvYTKeG8xMfT2Ut1mTQaLQ-tfpgZ1AVx90HF0wCAIC6QzRP6fHvDBmFLZwODYfeiE3VG3mk4x5zPCdDFfDu46Gqxo4wkjgIN_gnNJYHPPC4Bk6BzjYA_EE9Nozb5D_V3GSivUyuR4I9vjSS0TX7cT5M1nKwXJJiT4bvOW-A3K7414R_ucu0xK9nMhkCzMZMdm-ksSutzCzScGjzuKa4o5tYqm5XzVCIvxfi3i5hLslZamM9H3Z-OZmPHy8-zFO6ps8RHvjF4vDBdyumP93Vegca8U8ES-Eebxq_CD4WSsyUtNEqAAjKUUbkQsr2IUSzWm2Bo5y01S3JLuaOs5rR2DnNH7BkSqUVurg7kcEW_XKxt9QygiEQz3UgzZucCNkZ2ROiUNVZpmmg8VT-rrNzgXuwKzmwGABVpWYiFolJ6NveEJCHaKWLlkSH0rp4imHqsVQFfjF91UV7m8L5js54tp56Cs2GwMzaAebKzQbOhkt8Kq-sLN61Yza4SPsI6vtZtAOzvpYnOkL4ONcMqoCTt8404tcBc2AUDiOWmd2THFGYmf4INc4Sk4TNk73KkelJIWBE5FFLO1hnKMo8JVuqls8BGN2qGkcW2yAsYJMtNdNtTg0T2NnZbqQ1kRWBDWtCav_kkZHwRQkPT6L-81ogRPSNqfF_mS4IEh0_h08cRKYZpclXA7IihKGOihWZ6M7eNXZHLb0qnO8UQX7b-t8J6N2-HepD15HuJhSxokJBFU1DhBb1Tg8qoOtjCN8MoPZYSWyw86Ka5CsDXUUnI4WZY6kO3UyB9NDOxmuW3wno3X-V_UxVhYUbgAZTUF8yJiNlDNkQWw4stJqHU8kO-tK8TJb4VFLS3M0AZ5cExflAEPyBiO1l98WVItunLI29S1GFN434rQaw1fX4VWYwVVbvEEsSNk9HKvRd_Pg6D0uheKpe7MjuNGr6kOGw-0RRna9-s30VKe7tnDOSlrKcxlBQ-4fzsP_6-MoPE2ypovuGqqKe0TUvEV6vaVygPDPtB3e1-fppIUJz1kH084gFti8WfMTow1nGgFtQnOQNDysRPvdSMqlp-ricLr4PpuAPeYEqg7QTxBDMGQ6xc1igBHitUpArrmaXW-w2AqBqGcaxl63DANM5SG-XQKv9xyvc4KV3vwZbQ5FX5zCqIL5CY92DTyOG9SrwaBeDQadxOOYQZVXZ6cGj7TrsqbMervFanOUlfxxJNh6lTVol-ZQWWSnLv93a1gMrRrCo1WDHhclV0JdKaZdNSIvanBg-T2jthTbqWp_u2IIl1Mg2Hqmx1BlDZraogqH44HdrcyhV9e0turKMeWXZnU_XlSey249i6qM8YMwpljWkAk7NSSUTsWgvKiIb9Xj_5N3ytKL9qI04pQqqqJXu1VzdU3TclFXcqmtrj75CFUCNyNsVWoKj6emdj1zUNtOUceB7-I0m8o6v_oeX1Ox0a2sSPUtrlc2GVRNHq8F9ptJq0e3qXQbSb-FwNmSrJKGkvmQtJQ0KPtmrw80pcjHa04DHCVKYGiVJb85Td9A-Hie6W4BwMV3-tZAiuq4gNKXp1NQ146Zr5VH5nCHL169HHGMPsx-qQq_08QRDjR4CG-BzDFd5pgUSfW5bvo5ixVkRejDUjfvFUzfQDjAtEfSAM3o228AknfzOaUzxPLO__iW87MrwRTR-_gGYv_3ADlR6bLMlpjpn-pPX973m4c_DP8XYw4Tyw==
```
