### PR TITLE
Fix Herald of Ash overkill damage incorrectly scaling with global damage increases

### DIFF
--- a/src/Data/Skills/act_str.lua
+++ b/src/Data/Skills/act_str.lua
@@ -5368,6 +5368,7 @@ skills["HeraldOfAsh"] = {
 	},
 	baseMods = {
 		skill("radius", 10),
+		flag("dotIsHeraldOfAsh"),
 	},
 	qualityStats = {
 		Default = {

--- a/src/Export/Skills/act_str.txt
+++ b/src/Export/Skills/act_str.txt
@@ -960,6 +960,7 @@ local skills, mod, flag, skill = ...
 		},
 	},
 #baseMod skill("radius", 10)
+#baseMod flag("dotIsHeraldOfAsh")
 #mods
 
 #skill HeraldOfPurity

--- a/src/Modules/CalcOffence.lua
+++ b/src/Modules/CalcOffence.lua
@@ -5144,6 +5144,7 @@ function calcs.offence(env, actor, activeSkill)
 
 	runSkillFunc("preDotFunc")
 
+	---Section Handles Generic Damage over time [DOT]
 	for _, damageType in ipairs(dmgTypeList) do
 		local dotTypeCfg = copyTable(dotCfg, true)
 		dotTypeCfg.keywordFlags = bor(dotTypeCfg.keywordFlags, KeywordFlag[damageType.."Dot"])
@@ -5157,6 +5158,7 @@ function calcs.offence(env, actor, activeSkill)
 		if baseVal > 0 or (output[damageType.."Dot"] or 0) > 0 then
 			skillFlags.dot = true
 			local effMult = 1
+			--Section handles Enemy Damage Taken based on Configs
 			if env.mode_effective then
 				local resist = 0
 				local takenInc = enemyDB:Sum("INC", dotTakenCfg, "DamageTaken", "DamageTakenOverTime", damageType.."DamageTaken", damageType.."DamageTakenOverTime") + (isElemental[damageType] and enemyDB:Sum("INC", dotTakenCfg, "ElementalDamageTaken") or 0)
@@ -5173,7 +5175,11 @@ function calcs.offence(env, actor, activeSkill)
 					breakdown[damageType.."DotEffMult"] = breakdown.effMult(damageType, resist, 0, takenInc, effMult, takenMore, sourceRes, true)
 				end
 			end
+			--Variables below calculate DOT damage
 			local inc = skillModList:Sum("INC", dotTypeCfg, "Damage", damageType.."Damage", isElemental[damageType] and "ElementalDamage" or nil)
+			if skillModList:Flag(nil, "dotIsHeraldOfAsh") then
+				inc = inc - skillModList:Sum("INC", skillCfg, "Damage", damageType.."Damage", isElemental[damageType] and "ElementalDamage" or nil)
+			end
 			local more = skillModList:More(dotTypeCfg, "Damage", damageType.."Damage", isElemental[damageType] and "ElementalDamage" or nil)
 			local mult = skillModList:Override(dotTypeCfg, "DotMultiplier") or skillModList:Sum("BASE", dotTypeCfg, "DotMultiplier") + skillModList:Sum("BASE", dotTypeCfg, damageType.."DotMultiplier")
 			local aura = activeSkill.skillTypes[SkillType.Aura] and not activeSkill.skillTypes[SkillType.RemoteMined] and calcLib.mod(skillModList, dotTypeCfg, "AuraEffect")
@@ -5190,6 +5196,7 @@ function calcs.offence(env, actor, activeSkill)
 			end
 		end
 	end
+	
 	if skillModList:Flag(nil, "DotCanStack") then
 		skillFlags.DotCanStack = true
 		local speed = output.Speed


### PR DESCRIPTION
Calculations fixed, mod inc display edge case issue.

Fixes #8261  .

### Description of the problem being solved:
Calculations of Herald of Ash pulled from all sources of Fire damage over time increases, including but not limited to Global Fire damage increases when not supposed to.
### Steps taken to verify a working solution:
- Testing with two equipments granting 10% Global Fire Damage and 70% Burning Damage increases and calculated with 40 overkill damage. 
- Manual Calculations to confirm number matches changes.
- Only Issue Remains as Inc mods are not filtered. Should open a new issue with this edge case as it far exceeds scope of current issue.

### Link to a build that showcases this PR:
https://pobb.in/vwANN9PgixQd
### Before screenshot:
![image](https://github.com/user-attachments/assets/11988447-cec5-4ee0-b2dc-ca2ad6d9694d)

### After screenshot:
![image](https://github.com/user-attachments/assets/c9665144-4c3e-47e3-b9e7-6be739eca40e)
