### PR TITLE
Fixed Off hand detection regarding Necromantic Aegis

### DIFF
--- a/src/Modules/CalcPerform.lua
+++ b/src/Modules/CalcPerform.lua
@@ -153,8 +153,7 @@ local function doActorAttribsConditions(env, actor)
 	-- Set conditions
 	if (actor.itemList["Weapon 2"] and actor.itemList["Weapon 2"].type == "Shield") or (actor == env.player and env.aegisModList) then
 		condList["UsingShield"] = true
-	end
-	if not actor.itemList["Weapon 2"] then
+	elseif not actor.itemList["Weapon 2"] then
 		condList["OffHandIsEmpty"] = true
 	end
 	if actor.weaponData1.type == "None" then


### PR DESCRIPTION
Fixes #8288  .

### Description of the problem being solved:
With KEYSTONE: Necromantic Aegis noded and equipment / effects that check for empty offhand, Shields in the offhand slot [Weapon 2] will always be considered empty handed during calculations.
### Steps taken to verify a working solution:
-Load build that both allocates Necromantic Aegis, and has any shield with mods that affect player with any source that checks for an empty offhand; White Wind, Imperial Skean used in this case.
-Check Calculations for presence of White Wind Inc when shield is equiped and unequiped on any non-complex cold damage skill.
-Check Calculations for presence of White Wind Inc when shield is equiped and unequiped with no skill group active to see Minion Hit average changes.

NOTE: Freezing Pulse is set to level 1 and 0 quality for testing. Default settings applied on config section.

### Link to a build that showcases this PR:
https://pobb.in/KtsIqbfE2Pxx

### Before screenshot:
Freezing Pulse Before
![image](https://github.com/user-attachments/assets/665a35d2-d00f-447a-acec-06b2009ebbe1)
MH Hit Damage Before
![image](https://github.com/user-attachments/assets/471a414b-6058-491e-955d-79d5987927ec)

### After screenshot:
Freezing Pulse After
![image](https://github.com/user-attachments/assets/660c29c9-3500-41d1-a6e2-f62df208106f)
MH Hit Damage After
![image](https://github.com/user-attachments/assets/0d5493f8-13b1-411f-9e14-f8e767e01c5e)
