### PR TITLE
Disable "gain when hit" for builds which cannot survive unlucky hits

### DIFF
--- a/src/Modules/CalcDefence.lua
+++ b/src/Modules/CalcDefence.lua
@@ -2524,7 +2524,7 @@ function calcs.buildDefenceEstimations(env, actor)
 			local suppressionEffect = 1
 			local ExtraAvoidChance = 0
 			local averageAvoidChance = 0
-			if not env.configInput.DisableEHPGainOnBlock then
+			if not env.configInput.DisableEHPGainOnBlock and (output["NumberOfDamagingHits"] > 1) then
 				DamageIn.LifeWhenHit = output.LifeOnBlock * BlockChance
 				DamageIn.ManaWhenHit = output.ManaOnBlock * BlockChance
 				DamageIn.EnergyShieldWhenHit = output.EnergyShieldOnBlock * BlockChance
@@ -2557,7 +2557,7 @@ function calcs.buildDefenceEstimations(env, actor)
 				ExtraAvoidChance = ExtraAvoidChance + output.AvoidProjectilesChance / 2
 			end
 			-- gain when hit (currently just gain on block/suppress)
-			if not env.configInput.DisableEHPGainOnBlock then
+			if not env.configInput.DisableEHPGainOnBlock and (output["NumberOfDamagingHits"] > 1) then
 				if (DamageIn.LifeWhenHit or 0) ~= 0 or (DamageIn.ManaWhenHit or 0) ~= 0 or DamageIn.EnergyShieldWhenHit ~= 0 then
 					DamageIn.GainWhenHit = true
 				end


### PR DESCRIPTION
Disables "gain when hit" (eg gain on block) regardless of config, if the build cannot survive a hit from the enemy.

Not the biggest fan of this solution, as it causes a huge spike in EHP for certain builds once they cross that threshold, there is also debate if this number should be higher to incentivise people to get higher max hit, or even if we should add a ramping function to the amount of gain on block depending on how likely they are to survive, eg if they can survive a normal hit but not a crit, only apply 70% gain on block, and if they can also survive a crit then apply 100%, and between those do a ramp function.

Out of 100 builds I have looked at for this, it applies to 6 anyway (vs guardian boss config).