### PR TITLE
Fix import with discriminators

### DIFF
--- a/src/Classes/ImportTab.lua
+++ b/src/Classes/ImportTab.lua
@@ -455,8 +455,9 @@ function ImportTabClass:DownloadCharacterList()
 				self.charImportMode = "GETSESSIONID"
 				return
 			end
-			self.controls.accountName:SetText(realAccountName:gsub("-", "#"))
-			accountName = realAccountName:gsub("-", "#")
+			realAccountName = realAccountName:gsub("-", "#")
+			self.controls.accountName:SetText(realAccountName)
+			accountName = realAccountName
 			self.charImportStatus = "Character list successfully retrieved."
 			self.charImportMode = "SELECTCHAR"
 			self.lastRealm = realm.id

--- a/src/Classes/ImportTab.lua
+++ b/src/Classes/ImportTab.lua
@@ -406,9 +406,9 @@ function ImportTabClass:DownloadCharacterList()
 	local accountName
 	-- Handle spaces in the account name
 	if realm.realmCode == "pc" then
-		accountName = self.controls.accountName.buf:gsub("%s+", "")
+		accountName = self.controls.accountName.buf:gsub("%s+", ""):gsub("-", "%%23"):gsub("#", "%%23")
 	else
-		accountName = self.controls.accountName.buf:gsub("^[%s?]+", ""):gsub("[%s?]+$", ""):gsub("%s", "+")
+		accountName = self.controls.accountName.buf:gsub("^[%s?]+", ""):gsub("[%s?]+$", ""):gsub("%s", "+"):gsub("-", "%%23"):gsub("#", "%%23")
 	end
 	local sessionID = #self.controls.sessionInput.buf == 32 and self.controls.sessionInput.buf or (main.gameAccounts[accountName] and main.gameAccounts[accountName].sessionID)
 	launch:DownloadPage(realm.hostName.."character-window/get-characters?accountName="..accountName.."&realm="..realm.realmCode, function(response, errMsg)
@@ -456,6 +456,7 @@ function ImportTabClass:DownloadCharacterList()
 				return
 			end
 			self.controls.accountName:SetText(realAccountName)
+			realAccountName = realAccountName:gsub("-", "%%23"):gsub("#", "%%23")
 			accountName = realAccountName
 			self.charImportStatus = "Character list successfully retrieved."
 			self.charImportMode = "SELECTCHAR"
@@ -570,7 +571,7 @@ function ImportTabClass:DownloadPassiveTree()
 	self.charImportMode = "IMPORTING"
 	self.charImportStatus = "Retrieving character passive tree..."
 	local realm = realmList[self.controls.accountRealm.selIndex]
-	local accountName = self.controls.accountName.buf
+	local accountName = self.controls.accountName.buf:gsub("-", "%%23"):gsub("#", "%%23")
 	local sessionID = #self.controls.sessionInput.buf == 32 and self.controls.sessionInput.buf or (main.gameAccounts[accountName] and main.gameAccounts[accountName].sessionID)
 	local charSelect = self.controls.charSelect
 	local charData = charSelect.list[charSelect.selIndex].char
@@ -592,7 +593,7 @@ function ImportTabClass:DownloadItems()
 	self.charImportMode = "IMPORTING"
 	self.charImportStatus = "Retrieving character items..."
 	local realm = realmList[self.controls.accountRealm.selIndex]
-	local accountName = self.controls.accountName.buf
+	local accountName = self.controls.accountName.buf:gsub("-", "%%23"):gsub("#", "%%23")
 	local sessionID = #self.controls.sessionInput.buf == 32 and self.controls.sessionInput.buf or (main.gameAccounts[accountName] and main.gameAccounts[accountName].sessionID)
 	local charSelect = self.controls.charSelect
 	local charData = charSelect.list[charSelect.selIndex].char

--- a/src/Classes/ImportTab.lua
+++ b/src/Classes/ImportTab.lua
@@ -406,12 +406,12 @@ function ImportTabClass:DownloadCharacterList()
 	local accountName
 	-- Handle spaces in the account name
 	if realm.realmCode == "pc" then
-		accountName = self.controls.accountName.buf:gsub("%s+", ""):gsub("-", "%%23"):gsub("#", "%%23")
+		accountName = self.controls.accountName.buf:gsub("%s+", "")
 	else
-		accountName = self.controls.accountName.buf:gsub("^[%s?]+", ""):gsub("[%s?]+$", ""):gsub("%s", "+"):gsub("-", "%%23"):gsub("#", "%%23")
+		accountName = self.controls.accountName.buf:gsub("^[%s?]+", ""):gsub("[%s?]+$", ""):gsub("%s", "+")
 	end
 	local sessionID = #self.controls.sessionInput.buf == 32 and self.controls.sessionInput.buf or (main.gameAccounts[accountName] and main.gameAccounts[accountName].sessionID)
-	launch:DownloadPage(realm.hostName.."character-window/get-characters?accountName="..accountName.."&realm="..realm.realmCode, function(response, errMsg)
+	launch:DownloadPage(realm.hostName.."character-window/get-characters?accountName="..accountName:gsub("-", "%%23"):gsub("#", "%%23").."&realm="..realm.realmCode, function(response, errMsg)
 		if errMsg == "Response code: 401" then
 			self.charImportStatus = colorCodes.NEGATIVE.."Sign-in is required."
 			self.charImportMode = "GETSESSIONID"
@@ -443,7 +443,7 @@ function ImportTabClass:DownloadCharacterList()
 		end
 		-- GGG's character API has an issue where for /get-characters the account name is not case-sensitive, but for /get-passive-skills and /get-items it is.
 		-- This workaround grabs the profile page and extracts the correct account name from one of the URLs.
-		launch:DownloadPage(realm.hostName..realm.profileURL..accountName, function(response, errMsg)
+		launch:DownloadPage(realm.hostName..realm.profileURL..accountName:gsub("#", "%%23"), function(response, errMsg)
 			if errMsg then
 				self.charImportStatus = colorCodes.NEGATIVE.."Error retrieving character list, try again ("..errMsg:gsub("\n"," ")..")"
 				self.charImportMode = "GETACCOUNTNAME"
@@ -456,7 +456,6 @@ function ImportTabClass:DownloadCharacterList()
 				return
 			end
 			self.controls.accountName:SetText(realAccountName:gsub("-", "#"))
-			realAccountName = realAccountName:gsub("-", "%%23"):gsub("#", "%%23")
 			accountName = realAccountName
 			self.charImportStatus = "Character list successfully retrieved."
 			self.charImportMode = "SELECTCHAR"
@@ -559,11 +558,11 @@ function ImportTabClass:SaveAccountHistory()
 	if not historyList[self.controls.accountName.buf] then
 		t_insert(historyList, self.controls.accountName.buf)
 		historyList[self.controls.accountName.buf] = true
-		self.controls.accountHistory:SelByValue(self.controls.accountName.buf)
 		table.sort(historyList, function(a,b)
 			return a:lower() < b:lower()
 		end)
 		self.controls.accountHistory:CheckDroppedWidth(true)
+		self.controls.accountHistory:SelByValue(self.controls.accountName.buf)
 	end
 end
 
@@ -571,11 +570,11 @@ function ImportTabClass:DownloadPassiveTree()
 	self.charImportMode = "IMPORTING"
 	self.charImportStatus = "Retrieving character passive tree..."
 	local realm = realmList[self.controls.accountRealm.selIndex]
-	local accountName = self.controls.accountName.buf:gsub("-", "%%23"):gsub("#", "%%23")
+	local accountName = self.controls.accountName.buf
 	local sessionID = #self.controls.sessionInput.buf == 32 and self.controls.sessionInput.buf or (main.gameAccounts[accountName] and main.gameAccounts[accountName].sessionID)
 	local charSelect = self.controls.charSelect
 	local charData = charSelect.list[charSelect.selIndex].char
-	launch:DownloadPage(realm.hostName.."character-window/get-passive-skills?accountName="..accountName.."&character="..charData.name.."&realm="..realm.realmCode, function(response, errMsg)
+	launch:DownloadPage(realm.hostName.."character-window/get-passive-skills?accountName="..accountName:gsub("#", "%%23").."&character="..charData.name.."&realm="..realm.realmCode, function(response, errMsg)
 		self.charImportMode = "SELECTCHAR"
 		if errMsg then
 			self.charImportStatus = colorCodes.NEGATIVE.."Error importing character data, try again ("..errMsg:gsub("\n"," ")..")"
@@ -593,11 +592,11 @@ function ImportTabClass:DownloadItems()
 	self.charImportMode = "IMPORTING"
 	self.charImportStatus = "Retrieving character items..."
 	local realm = realmList[self.controls.accountRealm.selIndex]
-	local accountName = self.controls.accountName.buf:gsub("-", "%%23"):gsub("#", "%%23")
+	local accountName = self.controls.accountName.buf
 	local sessionID = #self.controls.sessionInput.buf == 32 and self.controls.sessionInput.buf or (main.gameAccounts[accountName] and main.gameAccounts[accountName].sessionID)
 	local charSelect = self.controls.charSelect
 	local charData = charSelect.list[charSelect.selIndex].char
-	launch:DownloadPage(realm.hostName.."character-window/get-items?accountName="..accountName.."&character="..charData.name.."&realm="..realm.realmCode, function(response, errMsg)
+	launch:DownloadPage(realm.hostName.."character-window/get-items?accountName="..accountName:gsub("#", "%%23").."&character="..charData.name.."&realm="..realm.realmCode, function(response, errMsg)
 		self.charImportMode = "SELECTCHAR"
 		if errMsg then
 			self.charImportStatus = colorCodes.NEGATIVE.."Error importing character data, try again ("..errMsg:gsub("\n"," ")..")"

--- a/src/Classes/ImportTab.lua
+++ b/src/Classes/ImportTab.lua
@@ -456,7 +456,7 @@ function ImportTabClass:DownloadCharacterList()
 				return
 			end
 			self.controls.accountName:SetText(realAccountName:gsub("-", "#"))
-			accountName = realAccountName
+			accountName = realAccountName:gsub("-", "#")
 			self.charImportStatus = "Character list successfully retrieved."
 			self.charImportMode = "SELECTCHAR"
 			self.lastRealm = realm.id

--- a/src/Classes/ImportTab.lua
+++ b/src/Classes/ImportTab.lua
@@ -455,7 +455,7 @@ function ImportTabClass:DownloadCharacterList()
 				self.charImportMode = "GETSESSIONID"
 				return
 			end
-			self.controls.accountName:SetText(realAccountName)
+			self.controls.accountName:SetText(realAccountName:gsub("-", "#"))
 			realAccountName = realAccountName:gsub("-", "%%23"):gsub("#", "%%23")
 			accountName = realAccountName
 			self.charImportStatus = "Character list successfully retrieved."


### PR DESCRIPTION
The new PoE patch requires accounts to also have a discriminator, this automatically url encodes them, including the "real account name" retrieved from the website, allowing characters to be imported again.

![image](https://github.com/user-attachments/assets/76af4fe5-0e92-48dd-ad4c-56eac3903e0a)


This saves the account name with the un-encoded value into the list, ~~but currently selects the wrong index from the list~~ edit: fixed that, was an old issue, we sorted the account order after selecting, so it would always have the last value selected.

fixes  #8359 and #8360