### PR TITLE
Fix Warden Import Colour

### DIFF
--- a/src/Classes/ImportTab.lua
+++ b/src/Classes/ImportTab.lua
@@ -516,7 +516,7 @@ function ImportTabClass:BuildCharacterList(league)
 						classColor = colorCodes["SHADOW"]
 					elseif (charClass == "Gladiator" or charClass == "Slayer" or charClass == "Champion") then
 						classColor = colorCodes["DUELIST"]
-					elseif (charClass == "Raider" or charClass == "Pathfinder" or charClass == "Deadeye") then
+					elseif (charClass == "Raider" or charClass == "Pathfinder" or charClass == "Deadeye" or charClass == "Warden") then
 						classColor = colorCodes["RANGER"]
 					elseif (charClass == "Juggernaut" or charClass == "Berserker" or charClass == "Chieftain") then
 						classColor = colorCodes["MARAUDER"]


### PR DESCRIPTION
Warden was missing from the list as its "new" and so the colour would be `nil`

I would prefer to do somthing like `classColor = colorCodes[charClass:upper()] or (main.tree[latestTreeVersion].ascendNameMap[charClass] and colorCodes[main.tree[latestTreeVersion].ascendNameMap[charClass].class.name:upper()]) or colorCodes.DEFAULT`
instead of the if statements, but the `ascendNameMap` uses the ID not the name, and so raider is the valid class that maps to warden, and requires more extensive changes to work