### PR TITLE
fix: allow xbox and sony realms characters import

### DIFF
--- a/src/Classes/ImportTab.lua
+++ b/src/Classes/ImportTab.lua
@@ -11,8 +11,8 @@ local band = bit.band
 
 local realmList = {
 	{ label = "PC", id = "PC", realmCode = "pc", hostName = "https://www.pathofexile.com/", profileURL = "account/view-profile/" },
-	{ label = "Xbox", id = "XBOX", realmCode = "xbox", hostName = "https://www.pathofexile.com/", profileURL = "account/xbox/view-profile/" },
-	{ label = "PS4", id = "SONY", realmCode = "sony", hostName = "https://www.pathofexile.com/", profileURL = "account/sony/view-profile/" },
+	{ label = "Xbox", id = "XBOX", realmCode = "xbox", hostName = "https://www.pathofexile.com/", profileURL = "account/view-profile/" },
+	{ label = "PS4", id = "SONY", realmCode = "sony", hostName = "https://www.pathofexile.com/", profileURL = "account/view-profile/" },
 	{ label = "Hotcool", id = "PC", realmCode = "pc", hostName = "https://pathofexile.tw/", profileURL = "account/view-profile/" },
 	{ label = "Tencent", id = "PC", realmCode = "pc", hostName = "https://poe.game.qq.com/", profileURL = "account/view-profile/" },
 }


### PR DESCRIPTION
Fixes this Reddit thread: https://www.reddit.com/r/pathofexile/comments/1gu6skw/pob_version_249_still_having_issues_importing/

### Description of the problem being solved:
With new account naming the realms use the same `profileURL`.

### Steps taken to verify a working solution:
- Open Pob and go to Import part
- Select Xbox
- Account is `Roooost#8989`
- Import
- Characters will be there and importable

### Link to a build that showcases this PR:
Since it's an import problem, I don't think a build link would help here.


### Before screenshot:
![image](https://github.com/user-attachments/assets/a1dbeb3a-0bd5-4c03-ad31-ae7c2d1db10f)

### After screenshot:
![image](https://github.com/user-attachments/assets/7e2af889-e691-454c-a9cb-d8323af88af8)
