### PR TITLE
Filter for only poe1 realms and fix sorting

### DIFF
--- a/src/Classes/TradeQuery.lua
+++ b/src/Classes/TradeQuery.lua
@@ -1118,7 +1118,10 @@ function TradeQueryClass:UpdateRealms()
 			end
 			self.realmIds = {}
 			for _, value in pairs(data.realms) do
-				self.realmIds[value.text] = value.id
+				-- filter out only Path of Exile one realms, as poe2 is not supported yet
+				if value.text:match("PoE 1 ") then
+					self.realmIds[value.text:gsub("PoE 1 ", "")] = value.id
+				end
 			end
 			setRealmDropList()
 


### PR DESCRIPTION
The realm names got updated to include poe1 infront, which breaks sorting, as this PoB only supports poe1 atm anyway, we can just filter to only poe1 realms and remove the "PoE 1" from the front to fix sorting.

This still creates valid searches for now, but might not if trade site updates their URLS.