### PR TITLE
fix: allow account names with dashed in them to be imported correctly

### DIFF
--- a/src/Classes/ImportTab.lua
+++ b/src/Classes/ImportTab.lua
@@ -424,7 +424,7 @@ function ImportTabClass:DownloadCharacterList()
 		accountName = self.controls.accountName.buf:gsub("^[%s?]+", ""):gsub("[%s?]+$", ""):gsub("%s", "+")
 	end
 	local sessionID = #self.controls.sessionInput.buf == 32 and self.controls.sessionInput.buf or (main.gameAccounts[accountName] and main.gameAccounts[accountName].sessionID)
-	accountName = ReplaceDiscrimintorSafely(accountName)
+	accountName = ReplaceDiscriminatorSafely(accountName)
 	launch:DownloadPage(realm.hostName.."character-window/get-characters?accountName="..accountName:gsub("#", "%%23").."&realm="..realm.realmCode, function(response, errMsg)
 		if errMsg == "Response code: 401" then
 			self.charImportStatus = colorCodes.NEGATIVE.."Sign-in is required."
@@ -469,7 +469,7 @@ function ImportTabClass:DownloadCharacterList()
 				self.charImportMode = "GETSESSIONID"
 				return
 			end
-			realAccountName = ReplaceDiscrimintorSafely(realAccountName)
+			realAccountName = ReplaceDiscriminatorSafely(realAccountName)
 			accountName = realAccountName
 			self.controls.accountName:SetText(realAccountName)
 			self.charImportStatus = "Character list successfully retrieved."
@@ -1139,18 +1139,8 @@ function HexToChar(x)
 	return string.char(tonumber(x, 16))
 end
 
-function ReplaceDiscrimintorSafely(accountName)
-	reversedAccountName = string.reverse(accountName)
-	discriminatorIndex = 0
-	for i = 1, #reversedAccountName do
-		local c = reversedAccountName:sub(i,i)
-			if c == "#" or c == "-" then
-			discriminatorIndex = i
-			break
-			end
-	end
-	discriminatorIndex = discriminatorIndex * -1
-	return ReplaceCharAtIndex(accountName, discriminatorIndex, "#")
+function ReplaceDiscriminatorSafely(accountName)
+	return accountName:gsub("(.*)[#%-]", "%1#")
 end
 
 function UrlDecode(url)

--- a/src/Classes/ImportTab.lua
+++ b/src/Classes/ImportTab.lua
@@ -1139,10 +1139,6 @@ function HexToChar(x)
 	return string.char(tonumber(x, 16))
 end
 
-function ReplaceCharAtIndex(str, pos, r)
-    return ("%s%s%s"):format(str:sub(1,pos-1), r, str:sub(pos+1))
-end
-
 function ReplaceDiscrimintorSafely(accountName)
 	reversedAccountName = string.reverse(accountName)
 	discriminatorIndex = 0

--- a/src/Modules/Common.lua
+++ b/src/Modules/Common.lua
@@ -948,3 +948,7 @@ function ImportBuild(importLink, callback)
 		callback(Inflate(common.base64.decode(importLink:gsub("-", "+"):gsub("_", "/"))), nil)
 	end
 end
+
+function ReplaceCharAtIndex(str, pos, r)
+	return ("%s%s%s"):format(str:sub(1,pos-1), r, str:sub(pos+1))
+end

--- a/src/Modules/Common.lua
+++ b/src/Modules/Common.lua
@@ -948,7 +948,3 @@ function ImportBuild(importLink, callback)
 		callback(Inflate(common.base64.decode(importLink:gsub("-", "+"):gsub("_", "/"))), nil)
 	end
 end
-
-function ReplaceCharAtIndex(str, pos, r)
-	return ("%s%s%s"):format(str:sub(1,pos-1), r, str:sub(pos+1))
-end


### PR DESCRIPTION
Fixes #8369.

### Description of the problem being solved:
Accounts with dashes in them (e.g. `Dj-Reck1#9507`) could not be imported.
Those accounts are possible because dashes are allowed in account names for consoles.

### Steps taken to verify a working solution:
- Import `Dj-Reck1#9507`
- Import `Dj-Reck1-9507`
- Import `Tarekis#5639`
- Import `Tarekis-5639`

Hope code looks good to yall. Not a lua dev lol
