### PR TITLE
Remove url encoding check, as it was broken

### DIFF
--- a/src/Classes/ImportTab.lua
+++ b/src/Classes/ImportTab.lua
@@ -63,11 +63,11 @@ local ImportTabClass = newClass("ImportTab", "ControlHost", "Control", function(
 		self:DownloadCharacterList()
 	end)
 	self.controls.accountNameGo.enabled = function()
-		return self.controls.accountName.buf:match("%S[#%-(%%23)]%d%d%d%d$")
+		return self.controls.accountName.buf:match("%S[#%-]%d%d%d%d$")
 	end
 	self.controls.accountNameGo.tooltipFunc = function(tooltip)
 		tooltip:Clear()
-		if not self.controls.accountName.buf:match("[#%-(%%23)]%d%d%d%d$") then
+		if not self.controls.accountName.buf:match("[#%-]%d%d%d%d$") then
 			tooltip:AddLine(16, "^7Missing discriminator e.g. " .. self.controls.accountName.buf .. "#1234")
 		end
 	end
@@ -99,7 +99,7 @@ local ImportTabClass = newClass("ImportTab", "ControlHost", "Control", function(
 	
 	self.controls.accountNameMissingDiscriminator = new("LabelControl", {"BOTTOMLEFT",self.controls.accountNameUnicode,"TOPLEFT"}, {0, -4, 0, 18}, "^1Missing discriminator e.g. #1234")
 	self.controls.accountNameMissingDiscriminator.shown = function()
-		return not self.controls.accountName.buf:match("[#%-(%%23)]%d%d%d%d$")
+		return not self.controls.accountName.buf:match("[#%-]%d%d%d%d$")
 	end
 	
 
@@ -423,8 +423,8 @@ function ImportTabClass:DownloadCharacterList()
 	else
 		accountName = self.controls.accountName.buf:gsub("^[%s?]+", ""):gsub("[%s?]+$", ""):gsub("%s", "+")
 	end
+	accountName = accountName:gsub("(.*)[#%-]", "%1#")
 	local sessionID = #self.controls.sessionInput.buf == 32 and self.controls.sessionInput.buf or (main.gameAccounts[accountName] and main.gameAccounts[accountName].sessionID)
-	accountName = ReplaceDiscriminatorSafely(accountName)
 	launch:DownloadPage(realm.hostName.."character-window/get-characters?accountName="..accountName:gsub("#", "%%23").."&realm="..realm.realmCode, function(response, errMsg)
 		if errMsg == "Response code: 401" then
 			self.charImportStatus = colorCodes.NEGATIVE.."Sign-in is required."
@@ -469,7 +469,7 @@ function ImportTabClass:DownloadCharacterList()
 				self.charImportMode = "GETSESSIONID"
 				return
 			end
-			realAccountName = ReplaceDiscriminatorSafely(realAccountName)
+			realAccountName = realAccountName:gsub("(.*)[#%-]", "%1#")
 			accountName = realAccountName
 			self.controls.accountName:SetText(realAccountName)
 			self.charImportStatus = "Character list successfully retrieved."
@@ -1137,10 +1137,6 @@ end
 
 function HexToChar(x)
 	return string.char(tonumber(x, 16))
-end
-
-function ReplaceDiscriminatorSafely(accountName)
-	return accountName:gsub("(.*)[#%-]", "%1#")
 end
 
 function UrlDecode(url)


### PR DESCRIPTION
Lua patterns dont support `alternations`, and the capture group I used doesnt "group" the things together within a `[ ]` unlike normal, so this removes the functionality, we can support it in future, but it was deemed as not a worthwhile usecase

This also fixes an issue with the `sessionID` on line 426 if `-` was used instead of `#`, due to account name being changed after and saved with `#`.