### PR TITLE
Removed action speed calculation and breakdown display for Explosive Arrow

### DIFF
--- a/src/Data/Skills/act_dex.lua
+++ b/src/Data/Skills/act_dex.lua
@@ -6249,7 +6249,7 @@ skills["ExplosiveArrow"] = {
 			activeSkill.skillData.dpsMultiplier = activeSkill.skillData.dpsMultiplier / barrageProjectiles  -- cancel out the normal dps multiplier from barrage that applies to most other skills
 		end
 
-		local fuseApplicationRate = (output.HitChance / 100) * globalOutput.Speed * globalOutput.ActionSpeedMod * activeSkill.skillData.dpsMultiplier * (barrageProjectiles or 1)
+		local fuseApplicationRate = (output.HitChance / 100) * globalOutput.Speed * activeSkill.skillData.dpsMultiplier * (barrageProjectiles or 1)
 		local initialApplicationRate = fuseApplicationRate
 		if activeSkill.skillFlags.totem then
 			fuseApplicationRate = fuseApplicationRate * activeTotems
@@ -6283,7 +6283,6 @@ skills["ExplosiveArrow"] = {
 			if output.HitChance < 100 then
 				t_insert(globalBreakdown.MaxExplosiveArrowFuseCalculated, s_format("x %.2f ^8(hit chance)", output.HitChance / 100))
 			end
-			t_insert(globalBreakdown.MaxExplosiveArrowFuseCalculated, s_format("x %.2f ^8(action speed)", globalOutput.ActionSpeedMod))
 			t_insert(globalBreakdown.MaxExplosiveArrowFuseCalculated, s_format("x %.2f ^8(projectiles)", barrageProjectiles or 1))
 			if activeSkill.skillFlags.totem then
 				t_insert(globalBreakdown.MaxExplosiveArrowFuseCalculated, s_format("= %.2f ^8(fuse rate)", initialApplicationRate))


### PR DESCRIPTION
Fixes #8310.

### Description of the problem being solved:

EA max fuse calculation was getting double dip from action speed.
I don't think action speed affects fuse detonation speed or fuse duration.

### Link to a build that showcases this PR:
https://pobb.in/Z23AeT76xtdf

In this extreme example, a `3.00 APS` bow with `100% increased action speed` should only be able to have `(6 + 1)` max fuse instead of 13.

### Before screenshot:
![image](https://github.com/user-attachments/assets/67a362ec-1b50-448b-a96a-ef24a50e99e7)

### After screenshot:
![image](https://github.com/user-attachments/assets/ca47de33-b507-48f4-83ae-2f1c96d4b089)

