### PR TITLE
Fix Breathstealer's unique modifier

### DIFF
--- a/src/Data/Uniques/gloves.lua
+++ b/src/Data/Uniques/gloves.lua
@@ -482,7 +482,7 @@ Source: Drops in Blighted Maps
 +(30-50) to maximum Mana
 +(10-16)% to all Elemental Resistances
 (5-10)% increased Attack and Cast Speed
-Create a Blighted Spore when you Kill a Rare Monster
+Create a Blighted Spore when your Skills or Minions Kill a Rare Monster
 This item can be anointed by Cassia
 ]],[[
 Farrul's Pounce


### PR DESCRIPTION
Fixes #8388.

### Description of the problem being solved:
Breathstealer's unique modifier is not correct.

### Steps taken to verify a working solution:
- Check out Breathstealer unique modifiers.

### Before screenshot:
![image](https://github.com/user-attachments/assets/0e09b8fc-5b5d-47ce-805d-555685a2a40e)

### After screenshot:
![image](https://github.com/user-attachments/assets/193bc359-41f9-477d-a00e-3b6d460b780e)
