### PR TITLE
Fix crash caused by lack of envirement override propagation

### DIFF
--- a/src/Modules/CalcSetup.lua
+++ b/src/Modules/CalcSetup.lua
@@ -366,6 +366,7 @@ function calcs.initEnv(build, mode, override, specEnv)
 		env.calcsInput = build.calcsTab.input
 		env.mode = mode
 		env.spec = override.spec or build.spec
+		env.override = override
 		env.classId = env.spec.curClassId
 
 		modDB = new("ModDB")

--- a/src/Modules/Calcs.lua
+++ b/src/Modules/Calcs.lua
@@ -133,8 +133,6 @@ function calcs.getMiscCalculator(build)
 	end
 	return function(override, useFullDPS)
 		local env, cachedPlayerDB, cachedEnemyDB, cachedMinionDB = calcs.initEnv(build, "CALCULATOR", override)
-		-- we need to preserve the override somewhere for use by possible trigger-based build-outs with overrides
-		env.override = override
 		calcs.perform(env)
 		if (useFullDPS ~= false or build.viewMode == "TREE") and usedFullDPS then
 			-- prevent upcoming calculation from using Cached Data and thus forcing it to re-calculate new FullDPS roll-up 


### PR DESCRIPTION
Fixes #8389

### Description of the problem being solved:
Environment overrides needed to correctly handle recursive trigger rate calculations were being lost in `calcs.calcFullDPS` causing a crash. This pr causes overrides to be saved unconditionally in `calcs.initEnv` fixing the issue.

### Link to a build that showcases this PR:
See issue

