### PR TITLE
Implement lua side hotkey for screenshots

### DIFF
--- a/src/Launch.lua
+++ b/src/Launch.lua
@@ -153,6 +153,8 @@ function launch:OnKeyDown(key, doubleClick)
 		if not self.devMode then
 			self:CheckForUpdate()
 		end
+	elseif key == "PRINTSCREEN" and IsKeyDown("CTRL") then
+		TakeScreenshot()
 	elseif self.promptMsg then
 		self:RunPromptFunc(key)
 	else


### PR DESCRIPTION
### Description of the problem being solved:

Lua side code for https://github.com/PathOfBuildingCommunity/PathOfBuilding-SimpleGraphic/pull/65

Changes the hotkey from just (print screen) to (control + print screen) in an attempt to prevent potential conflicts with other screen capture programs.