### PR TITLE
Fixed interaction between block replacement effect from Determined Survivor and Necromantic Aegis

### DIFF
--- a/src/Modules/CalcDefence.lua
+++ b/src/Modules/CalcDefence.lua
@@ -521,7 +521,7 @@ function calcs.defence(env, actor)
 	if actor.itemList["Weapon 3"] and actor.itemList["Weapon 3"].armourData then
 		baseBlockChance = baseBlockChance + actor.itemList["Weapon 3"].armourData.BlockChance
 	end
-	output.ShieldBlockChance = modDB:Override(nil, "ReplaceShieldBlock") or baseBlockChance
+	baseBlockChance = modDB:Override(nil, "ReplaceShieldBlock") or baseBlockChance
 
 	-- Apply player block overrides if Necromantic Aegis allocated
 	baseBlockChance = actor == env.minion and env.keystonesAdded["Necromantic Aegis"] and env.player.modDB:Override(nil, "ReplaceShieldBlock") or output.ShieldBlockChance

--- a/src/Modules/CalcDefence.lua
+++ b/src/Modules/CalcDefence.lua
@@ -516,12 +516,19 @@ function calcs.defence(env, actor)
 	local baseBlockChance = 0
 	if actor.itemList["Weapon 2"] and actor.itemList["Weapon 2"].armourData then
 		baseBlockChance = baseBlockChance + actor.itemList["Weapon 2"].armourData.BlockChance
+		
 	end
 	if actor.itemList["Weapon 3"] and actor.itemList["Weapon 3"].armourData then
 		baseBlockChance = baseBlockChance + actor.itemList["Weapon 3"].armourData.BlockChance
-	end
+	end	
 	output.ShieldBlockChance = baseBlockChance
+	-- Override from Ascendancy or other sources
 	baseBlockChance = modDB:Override(nil, "ReplaceShieldBlock") or baseBlockChance
+	-- Bandage fix for interaction of block replacement effects with Necromantic Aegis
+	if actor == env.minion and env.player.modDB:Override(nil, "ReplaceShieldBlock") and env.allocNodes[45175] then
+		baseBlockChance = env.player.modDB:Override(nil, "ReplaceShieldBlock")
+	end
+
 	if modDB:Flag(nil, "BlockAttackChanceIsEqualToParent") then
 		output.BlockChance = m_min(actor.parent.output.BlockChance, output.BlockChanceMax)
 	elseif modDB:Flag(nil, "BlockAttackChanceIsEqualToPartyMember") then
@@ -533,6 +540,7 @@ function calcs.defence(env, actor)
 		output.BlockChance = m_min(totalBlockChance, output.BlockChanceMax)
 		output.BlockChanceOverCap = m_max(0, totalBlockChance - output.BlockChanceMax)
 	end
+
 	output.ProjectileBlockChance = m_min(output.BlockChance + modDB:Sum("BASE", nil, "ProjectileBlockChance") * calcLib.mod(modDB, nil, "BlockChance"), output.BlockChanceMax)
 	if modDB:Flag(nil, "SpellBlockChanceMaxIsBlockChanceMax") then
 		output.SpellBlockChanceMax = output.BlockChanceMax

--- a/src/Modules/CalcDefence.lua
+++ b/src/Modules/CalcDefence.lua
@@ -520,14 +520,11 @@ function calcs.defence(env, actor)
 	end
 	if actor.itemList["Weapon 3"] and actor.itemList["Weapon 3"].armourData then
 		baseBlockChance = baseBlockChance + actor.itemList["Weapon 3"].armourData.BlockChance
-	end	
-	output.ShieldBlockChance = baseBlockChance
-	-- Override from Ascendancy or other sources
-	baseBlockChance = modDB:Override(nil, "ReplaceShieldBlock") or baseBlockChance
-	-- Bandage fix for interaction of block replacement effects with Necromantic Aegis
-	if actor == env.minion and env.player.modDB:Override(nil, "ReplaceShieldBlock") and env.allocNodes[45175] then
-		baseBlockChance = env.player.modDB:Override(nil, "ReplaceShieldBlock")
 	end
+	output.ShieldBlockChance = modDB:Override(nil, "ReplaceShieldBlock") or baseBlockChance
+
+	-- Apply player block overrides if Necromantic Aegis allocated
+	output.ShieldBlockChance = actor == env.minion and env.keystonesAdded["Necromantic Aegis"] and env.player.modDB:Override(nil, "ReplaceShieldBlock") or output.ShieldBlockChance
 
 	if modDB:Flag(nil, "BlockAttackChanceIsEqualToParent") then
 		output.BlockChance = m_min(actor.parent.output.BlockChance, output.BlockChanceMax)

--- a/src/Modules/CalcDefence.lua
+++ b/src/Modules/CalcDefence.lua
@@ -524,7 +524,7 @@ function calcs.defence(env, actor)
 	output.ShieldBlockChance = modDB:Override(nil, "ReplaceShieldBlock") or baseBlockChance
 
 	-- Apply player block overrides if Necromantic Aegis allocated
-	output.ShieldBlockChance = actor == env.minion and env.keystonesAdded["Necromantic Aegis"] and env.player.modDB:Override(nil, "ReplaceShieldBlock") or output.ShieldBlockChance
+	baseBlockChance = actor == env.minion and env.keystonesAdded["Necromantic Aegis"] and env.player.modDB:Override(nil, "ReplaceShieldBlock") or output.ShieldBlockChance
 
 	if modDB:Flag(nil, "BlockAttackChanceIsEqualToParent") then
 		output.BlockChance = m_min(actor.parent.output.BlockChance, output.BlockChanceMax)

--- a/src/Modules/CalcDefence.lua
+++ b/src/Modules/CalcDefence.lua
@@ -521,6 +521,7 @@ function calcs.defence(env, actor)
 	if actor.itemList["Weapon 3"] and actor.itemList["Weapon 3"].armourData then
 		baseBlockChance = baseBlockChance + actor.itemList["Weapon 3"].armourData.BlockChance
 	end
+	output.ShieldBlockChance = baseBlockChance
 	baseBlockChance = modDB:Override(nil, "ReplaceShieldBlock") or baseBlockChance
 
 	-- Apply player block overrides if Necromantic Aegis allocated

--- a/src/Modules/CalcDefence.lua
+++ b/src/Modules/CalcDefence.lua
@@ -524,7 +524,7 @@ function calcs.defence(env, actor)
 	baseBlockChance = modDB:Override(nil, "ReplaceShieldBlock") or baseBlockChance
 
 	-- Apply player block overrides if Necromantic Aegis allocated
-	baseBlockChance = actor == env.minion and env.keystonesAdded["Necromantic Aegis"] and env.player.modDB:Override(nil, "ReplaceShieldBlock") or output.ShieldBlockChance
+	baseBlockChance = actor == env.minion and env.keystonesAdded["Necromantic Aegis"] and env.player.modDB:Override(nil, "ReplaceShieldBlock") or baseBlockChance
 
 	if modDB:Flag(nil, "BlockAttackChanceIsEqualToParent") then
 		output.BlockChance = m_min(actor.parent.output.BlockChance, output.BlockChanceMax)


### PR DESCRIPTION
Fixes interaction between Block Replacement effect granted from Gladiator's "Determined Survivor" ascendency with Necromantic Aegis. 
Now grants minion base 50% block chance given from Determined Survivor and Ascendant's Gladiator Ascendency.

Fixes #8358  .

### Description of the problem being solved:
While allocating Determined Survivor or Gladiator Ascendancy, it did not grant minions the replaced 50% block chance when Necromantic Aegis is allocated.
### Steps taken to verify a working solution:
- Create both Duelist and Scion with said ascendancies allocated and have any base block shield equiped. 
- Set active skill to Summon Zombie or any summon, set calc mode to view minion
- See if active block chance is 50% rather than base shield block chance.

### Link to a build that showcases this PR:
Duelist: https://pobb.in/PweoXCGVDI6_
Scion: https://pobb.in/5apC4rtoIUyg

### No Screenshots required for this change.
