### PR TITLE
Fixes Cinderswallow Urn mod missing in current version.

### DIFF
--- a/src/Data/Uniques/flask.lua
+++ b/src/Data/Uniques/flask.lua
@@ -183,7 +183,7 @@ Implicits: 0
 {variant:7}Recharges 1 Charge when you Consume an Ignited corpse
 {variant:9}Recharges 5 Charges when you Consume an Ignited corpse
 {variant:7}Enemies Ignited by you during Effect take 10% increased Damage
-{variant:8}Enemies Ignited by you during Effect take (7-10)% increased Damage
+{variant:8,9}Enemies Ignited by you during Effect take (7-10)% increased Damage
 {variant:7,9}Recover (1-3)% of Life when you Kill an Enemy during Effect
 {variant:7,9}Recover (1-3)% of Mana when you Kill an Enemy during Effect
 {variant:7,9}Recover (1-3)% of Energy Shield when you Kill an Enemy during Effect


### PR DESCRIPTION
Fixes #8418 .

### Description of the problem being solved:
Cinderswallow Urn mod missing in current version: `Enemies Ignited by you during Effect take (7-10)% increased Damage`

### Steps taken to verify a working solution:
- Check Cinderswallow Urn mods list.

### Before screenshot:
![image](https://github.com/user-attachments/assets/6940e07c-438f-4b7e-bb08-5a03850b855a)

### After screenshot:
![image](https://github.com/user-attachments/assets/b3236085-5eb4-4731-bd77-4c69602f708e)
