### PR TITLE
Automate creating PR for SimpleGraphic releases

### DIFF
--- a/.github/workflows/update-simple-graphic.yml
+++ b/.github/workflows/update-simple-graphic.yml
@@ -13,7 +13,7 @@ jobs:
             - name: Download DLLs
               uses: robinraju/release-downloader@v1
               with:
-                repository: ${{ github.repository.owner }}/PathOfBuilding-SimpleGraphic
+                repository: ${{ github.repository_owner }}/PathOfBuilding-SimpleGraphic
                 tag: ${{ github.event.client_payload.tag }}
                 fileName: SimpleGraphicDLLs-x64-windows.tar
                 extract: true

--- a/.github/workflows/update-simple-graphic.yml
+++ b/.github/workflows/update-simple-graphic.yml
@@ -13,7 +13,7 @@ jobs:
             - name: Download DLLs
               uses: robinraju/release-downloader@v1
               with:
-                repository: ${{ github.repository.owner }}/SimpleGraphic
+                repository: ${{ github.repository.owner }}/PathOfBuilding-SimpleGraphic
                 tag: ${{ github.event.client_payload.tag }}
                 fileName: SimpleGraphicDLLs-x64-windows.tar
                 extract: true

--- a/.github/workflows/update-simple-graphic.yml
+++ b/.github/workflows/update-simple-graphic.yml
@@ -1,0 +1,29 @@
+name: Update SimpleGraphic DLLs
+on:
+    repository_dispatch:
+        types: [update-simple-graphic]
+jobs:
+    update:
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v3
+              with:
+                ref: 'dev'
+            - name: Download DLLs
+              uses: robinraju/release-downloader@v1
+              with:
+                repository: ${{ github.repository.owner }}/SimpleGraphic
+                tag: ${{ github.event.client_payload.tag }}
+                fileName: SimpleGraphicDLLs-x64-windows.tar
+                extract: true
+                out-file-path: runtime
+            - name: Create Pull Request
+              uses: peter-evans/create-pull-request@v5
+              with:
+                title: Update to SimpleGraphic ${{ github.event.client_payload.tag }}
+                branch: simple-graphic-${{ github.event.client_payload.tag }}
+                body: |
+                    Update DLLs to SimpleGraphic-${{ github.event.client_payload.tag }} from ${{ github.event.client_payload.release_link }}
+                commit-message: Update DLLs to SimpleGraphic-${{ github.event.client_payload.tag }}
+              


### PR DESCRIPTION
While not a hard task, downloading the SimpleGraphic artifacts and manually pushing them to each PoB repo is just one more thing that can be automated off of a release task list and ensures it's not forgotten.

https://github.com/PathOfBuildingCommunity/PathOfBuilding-SimpleGraphic/pull/69 notifies this action when the artifacts have been uploaded to the release and creates a PR in this repo updating the DLLs.