### PR TITLE
Resume failed update feature

### DIFF
--- a/src/UpdateCheck.lua
+++ b/src/UpdateCheck.lua
@@ -78,8 +78,13 @@ end
 
 ConPrintf("Checking for update...")
 
-local scriptPath = "."
-local runtimePath = "."
+local scriptPath
+local runtimePath
+do
+	local currentDir = io.popen("cd"):read() or io.popen("pwd"):read() or "."
+	scriptPath = currentDir
+	runtimePath = currentDir
+end
 
 -- Load and process local manifest
 local localVer


### PR DESCRIPTION
### Description of the problem being solved:
Occasionally, when downloading large updates for PoB, some files would fail.  This would cause the entire update process to have to start over.  This PR identifies files it had previously tried to download and failed that still exist in the Update folder.  If they match what was about to be downloaded, we don't have to download it again.  This means eventually retrying enough times might result in a successful download.
### Steps taken to verify a working solution:
- Update from a super old version, downloading almost every file
- Observe some files failing and the download failing
- On the next attempt, observe files being skipped that were successfully downloaded

### After screenshot:
![image](https://github.com/user-attachments/assets/ad1bdb94-8e6d-42ee-a47d-99d3fa1f782c)
