### PR TITLE
Issue #8478 fix: Error loop when active skill disabled with Tawhoa's Chosen mirage skill

### DIFF
--- a/src/Modules/CalcActiveSkill.lua
+++ b/src/Modules/CalcActiveSkill.lua
@@ -156,6 +156,9 @@ end
 
 -- Copy an Active Skill
 function calcs.copyActiveSkill(env, mode, skill)
+	if not skill.activeEffect.srcInstance then 
+		return skill, env
+	end
 	local activeEffect = {
 		grantedEffect = skill.activeEffect.grantedEffect,
 		level = skill.activeEffect.srcInstance.level,

--- a/src/Modules/CalcMirages.lua
+++ b/src/Modules/CalcMirages.lua
@@ -37,6 +37,10 @@ local function calculateMirage(env, config)
 	if mirageSkill then
 		local newSkill, newEnv = calcs.copyActiveSkill(env, env.mode, mirageSkill)
 		newSkill.skillCfg.skillCond["usedByMirage"] = true
+		if not newSkill.activeEffect.srcInstance then
+			config.mirageSkillNotFoundFunc(env, config)
+			return not config.calcMainSkillOffence
+		end
 		newEnv.limitedSkills = newEnv.limitedSkills or {}
 		newEnv.limitedSkills[cacheSkillUUID(newSkill, newEnv)] = true
 		newSkill.skillData.mirageUses = env.player.mainSkill.skillData.storedUses


### PR DESCRIPTION
Fixes # 8478

### Description of the problem being solved:
see https://github.com/PathOfBuildingCommunity/PathOfBuilding/issues/8478
### Steps taken to verify a working solution:
- Tested that I could import the build string from issue 8478 without errors
- Opened a few other builds and tested that mirage skills were not broken or causing new errors
-

### Link to a build that showcases this PR:
https://pobb.in/IjlXE2-NbvaG
### Before screenshot:
![image](https://github.com/user-attachments/assets/419fad8c-17e0-4b3a-9e45-c62a0e3fcaea)
### After screenshot:
![image](https://github.com/user-attachments/assets/0707f49e-0446-4735-878b-4f8a9de30f13)
