### PR TITLE
Add black background to detail text in character dropdown

### DIFF
--- a/src/Classes/DropDownControl.lua
+++ b/src/Classes/DropDownControl.lua
@@ -319,6 +319,14 @@ function DropDownClass:Draw(viewPort, noTooltip)
 	DrawString(0, 0, "LEFT", lineHeight, "VAR", selLabel or "")
 	if selDetail ~= nil then
 		local dx = DrawStringWidth(lineHeight, "VAR", selDetail)
+		if not enabled or self.dropped then
+			SetDrawColor(0, 0, 0)
+		elseif mOver then
+			SetDrawColor(0.33, 0.33, 0.33)
+		else
+			SetDrawColor(0, 0, 0)
+		end
+		DrawImage(nil, width - dx - 4 - 22, 0, width - 4, lineHeight)
 		DrawString(width - dx - 22, 0, "LEFT", lineHeight, "VAR", selDetail)
 	end
 	SetViewport()
@@ -378,7 +386,13 @@ function DropDownClass:Draw(viewPort, noTooltip)
 				DrawString(0, y, "LEFT", lineHeight, "VAR", label)
 				if detail ~= nil then
 					local detail = listVal.detail
-					dx = DrawStringWidth(lineHeight, "VAR", detail)
+					local dx = DrawStringWidth(lineHeight, "VAR", detail)
+					if index == self.hoverSel then
+						SetDrawColor(0.33, 0.33, 0.33)
+					else
+						SetDrawColor(0, 0, 0)
+					end
+					DrawImage(nil, width - dx - 8 - 22, y, width - 4, lineHeight)
 					DrawString(width - dx - 4 - 22, y, "LEFT", lineHeight, "VAR", detail)
 				end
 				self:DrawSearchHighlights(label, searchInfo, 0, y, width - 4, lineHeight)

--- a/src/Classes/DropDownControl.lua
+++ b/src/Classes/DropDownControl.lua
@@ -327,6 +327,11 @@ function DropDownClass:Draw(viewPort, noTooltip)
 			SetDrawColor(0, 0, 0)
 		end
 		DrawImage(nil, width - dx - 4 - 22, 0, width - 4, lineHeight)
+		if enabled then
+			SetDrawColor(1, 1, 1)
+		else
+			SetDrawColor(0.66, 0.66, 0.66)
+		end
 		DrawString(width - dx - 22, 0, "LEFT", lineHeight, "VAR", selDetail)
 	end
 	SetViewport()
@@ -393,6 +398,12 @@ function DropDownClass:Draw(viewPort, noTooltip)
 						SetDrawColor(0, 0, 0)
 					end
 					DrawImage(nil, width - dx - 8 - 22, y, width - 4, lineHeight)
+					-- highlight font color if hovered or selected
+					if index == self.hoverSel or index == self.selIndex then
+						SetDrawColor(1, 1, 1)
+					else
+						SetDrawColor(0.66, 0.66, 0.66)
+					end
 					DrawString(width - dx - 4 - 22, y, "LEFT", lineHeight, "VAR", detail)
 				end
 				self:DrawSearchHighlights(label, searchInfo, 0, y, width - 4, lineHeight)


### PR DESCRIPTION
Closes https://github.com/PathOfBuildingCommunity/PathOfBuilding/issues/8486

### Description of the problem being solved:

Character names are currently drawn over the top of the details on the right of the dropdown. If a name happens to be very long (often happens when using tofu for utf-8) the details stop being legible. This adds a black background behind the detail text to make it more readable.

### Steps taken to verify a working solution:
- Tested by importing pjsdevil#2432 account and previewing characters from Necro Settlers league
- Make sure the mouse over hlighlight works correctly

### Before screenshot:
![obraz](https://github.com/user-attachments/assets/a8efdb22-2cdb-410f-a975-e69b80a72676)
![obraz](https://github.com/user-attachments/assets/77303ae9-237b-48fb-8813-5019c7030f10)

### After screenshot:
![obraz](https://github.com/user-attachments/assets/077e82eb-0ced-4372-b430-a463c88c595c)
![obraz](https://github.com/user-attachments/assets/67fd4a09-36d6-4f45-910d-ff71cf3e253a)
