### PR TITLE
Dynamically expand some dropdowns that were too narrow to read

### DIFF
--- a/src/Classes/TreeTab.lua
+++ b/src/Classes/TreeTab.lua
@@ -158,6 +158,7 @@ local TreeTabClass = newClass("TreeTab", "ControlHost", function(self, build)
 	self.controls.versionSelect.maxDroppedWidth = 1000
 	self.controls.versionSelect.enableDroppedWidth = true
 	self.controls.versionSelect.enableChangeBoxWidth = true
+	self.controls.versionSelect:CheckDroppedWidth(true)
 	self.controls.versionSelect.selIndex = #self.treeVersions
 
 	-- Tree Search Textbox

--- a/src/Modules/Build.lua
+++ b/src/Modules/Build.lua
@@ -1066,6 +1066,7 @@ function buildMode:OnFrame(inputEvents)
 	self.controls.classDrop:SelByValue(self.spec.curClassId, "classId")
 	self.controls.ascendDrop.list = self.controls.classDrop:GetSelValueByKey("ascendancies")
 	self.controls.ascendDrop:SelByValue(self.spec.curAscendClassId, "ascendClassId")
+	self.controls.ascendDrop:CheckDroppedWidth(true)
 	-- // secondaryAscend dropdown hidden away until we learn more
 	--self.controls.secondaryAscendDrop.list = {{label = "None", ascendClassId = 0}, {label = "Warden", ascendClassId = 1}, {label = "Warlock", ascendClassId = 2}, {label = "Primalist", ascendClassId = 3}}
 	--self.controls.secondaryAscendDrop:SelByValue(self.spec.curSecondaryAscendClassId, "ascendClassId")


### PR DESCRIPTION
### Description of the problem being solved:
The alternate tree names made the tree version select too narrow to read, same with the new ascendancy names.

### Before screenshot:
![image](https://github.com/user-attachments/assets/787f3360-ee1c-41e2-aa09-b1bc52236576)
![image](https://github.com/user-attachments/assets/c0fd5661-fb2b-46b0-9114-d55a349d1ac7)

### After screenshot:
![image](https://github.com/user-attachments/assets/2fd74cbf-e4ec-41e3-a368-c79214b8d8e0)
![image](https://github.com/user-attachments/assets/7f54598d-f356-48a6-a14d-26afc4dbd6f3)

