### PR TITLE
Fix Tawhoa's Chosen crash when no active skill is enabled

### DIFF
--- a/src/Modules/CalcActiveSkill.lua
+++ b/src/Modules/CalcActiveSkill.lua
@@ -156,14 +156,20 @@ end
 
 -- Copy an Active Skill
 function calcs.copyActiveSkill(env, mode, skill)
-	local activeEffect = {
-		grantedEffect = skill.activeEffect.grantedEffect,
-		level = skill.activeEffect.srcInstance.level,
-		quality = skill.activeEffect.srcInstance.quality,
-		qualityId = skill.activeEffect.srcInstance.qualityId,
-		srcInstance = skill.activeEffect.srcInstance,
-		gemData = skill.activeEffect.srcInstance.gemData,
+    local activeEffect = {
+        grantedEffect = skill.activeEffect.grantedEffect,
+		level = skill.activeEffect.level,
+		quality = skill.activeEffect.quality
 	}
+
+	if skill.activeEffect.srcInstance then
+		activeEffect.level = skill.activeEffect.srcInstance.level
+		activeEffect.quality = skill.activeEffect.srcInstance.quality
+		activeEffect.qualityId = skill.activeEffect.srcInstance.qualityId
+		activeEffect.srcInstance = skill.activeEffect.srcInstance
+		activeEffect.gemData = skill.activeEffect.srcInstance.gemDat
+	end
+
 	local newSkill = calcs.createActiveSkill(activeEffect, skill.supportList, skill.actor, skill.socketGroup, skill.summonSkill)
 	local newEnv, _, _, _ = calcs.initEnv(env.build, mode, env.override)
 	calcs.buildActiveSkillModList(newEnv, newSkill)


### PR DESCRIPTION
Closes #8478

### Description of the problem being solved:

Some active skills such do not have a `srcInstance` property due to their non-gem origin. This would cause a nil deref when trying to use such as skill as a trigger source for Tawhoa's Chosen.

This pr adds an if check to handle this properly.