### PR TITLE
Fix issues around importing to the wrong tree

### DIFF
--- a/src/Classes/ImportTab.lua
+++ b/src/Classes/ImportTab.lua
@@ -707,6 +707,8 @@ function ImportTabClass:ImportPassiveTreeAndJewels(json, charData)
 		charPassiveData.mastery_effects or {}, 
 		latestTreeVersion .. (charData.league:match("Ruthless") and "_ruthless" or "") .. (isAscendancyInTree(charData.class, latestTreeVersion) and "" or "_alternate")
 	)
+	self.build.treeTab:SetActiveSpec(self.build.treeTab.activeSpec)
+	self.build.spec:BuildClusterJewelGraphs()
 	self.build.spec:AddUndoState()
 	self.build.characterLevel = charData.level
 	self.build.characterLevelAutoMode = false
@@ -723,7 +725,6 @@ function ImportTabClass:ImportPassiveTreeAndJewels(json, charData)
 		end
 	end
 	self.build.configTab.varControls["resistancePenalty"]:SetSel(resistancePenaltyIndex)
-	self.build.buildFlag = true
 	main:SetWindowTitleSubtext(string.format("%s (%s, %s, %s)", self.build.buildName, charData.name, charData.class, charData.league))
 end
 


### PR DESCRIPTION
### Description of the problem being solved:
When importing a character from Phrecia league, sometimes the ascendancy dropdown would be wrong and cluster jewel nodes would not be allocated
### Steps taken to verify a working solution:
- Started on 3.25 tree
- Imported nikidino8#2454 -> Phrecia -> Manikio
- Saw ascendancy dropdowns properly updated
- Saw cluster jewel nodes filled in

### Link to a build that showcases this PR:
N/A
### Before screenshot:
![image](https://github.com/user-attachments/assets/21fb85c5-3332-4fa3-a58c-0c184f93274e)

### After screenshot:
![image](https://github.com/user-attachments/assets/865bb3b5-89d0-4e4c-abdc-46fcfacc4a2e)
