### PR TITLE
Fix Foxshade life modifiers preventing life mastery

### DIFF
--- a/src/Modules/Data.lua
+++ b/src/Modules/Data.lua
@@ -633,6 +633,8 @@ data.itemTagSpecialExclusionPattern = {
 			"Life as Physical Damage",
 			"Life as Extra Maximum Energy Shield",
 			"maximum Life as Fire Damage",
+			"while on Full Life", -- foxshade
+			"while you are on Full Life", -- foxshade
 			"when on Full Life",
 			"when on Low Life",
 			"Gain Maximum Life instead of Maximum Energy Shield",


### PR DESCRIPTION
Fixes #8255 

### Description of the problem being solved:
Foxshade has 2 other "life" mods that shouldn't have the life tag. This excludes the life tag from those few lines, letting the life mastery properly apply. Note that I did not check the function in game myself, but poedb shows no life tags on the mods too.

### Link to a build that showcases this PR:
https://pobb.in/yVpcJzFQ6LgQ
### After screenshot:
![image](https://github.com/user-attachments/assets/f4d1421e-7311-4d2a-9c7d-724f8f81d493)