### PR TITLE
Update functionality of Shepherd of Souls, add Config for Vaal Skills used in the past 8 Seconds

### DIFF
--- a/src/Data/ModCache.lua
+++ b/src/Data/ModCache.lua
@@ -10352,6 +10352,7 @@ c["Share Endurance Charges with nearby party members Your nearby party members m
 c["Share Endurance, Frenzy and Power Charges with nearby party members"]={nil,"Share Endurance, Frenzy and Power Charges with nearby party members "}
 c["Share Endurance, Frenzy and Power Charges with nearby party members Limited to 1 Keystone Tattoo"]={nil,"Share Endurance, Frenzy and Power Charges with nearby party members Limited to 1 Keystone Tattoo "}
 c["Shared Suffering"]={nil,"Shared Suffering "}
+c["Shepherd of Souls"]={{[1]={[1]={skillType=42,type="SkillType"},[2]={neg=true,skillType=43,type="SkillType"},flags=0,keywordFlags=0,name="SoulCost",type="MORE",value=-80},[2]={[1]={type="Multiplier",var="VaalSkillsUsedInPast8Seconds"},flags=0,keywordFlags=0,name="SoulCost",type="INC",value=80}},nil}
 c["Shock Attackers for 4 seconds on Block"]={{[1]={[1]={type="Condition",var="BlockedRecently"},flags=0,keywordFlags=0,name="ShockBase",type="BASE",value=15},[2]={[1]={type="Condition",var="BlockedRecently"},flags=0,keywordFlags=0,name="EnemyModifier",type="LIST",value={mod={flags=0,keywordFlags=0,name="Condition:Shocked",type="FLAG",value=true}}}},nil}
 c["Shock Reflection"]={nil,"Shock Reflection "}
 c["Shock a nearby Enemy for 2 seconds on Killing a Shocked Enemy"]={nil,"Shock a nearby Enemy for 2 seconds on Killing a Shocked Enemy "}

--- a/src/Data/ModCache.lua
+++ b/src/Data/ModCache.lua
@@ -10352,7 +10352,6 @@ c["Share Endurance Charges with nearby party members Your nearby party members m
 c["Share Endurance, Frenzy and Power Charges with nearby party members"]={nil,"Share Endurance, Frenzy and Power Charges with nearby party members "}
 c["Share Endurance, Frenzy and Power Charges with nearby party members Limited to 1 Keystone Tattoo"]={nil,"Share Endurance, Frenzy and Power Charges with nearby party members Limited to 1 Keystone Tattoo "}
 c["Shared Suffering"]={nil,"Shared Suffering "}
-c["Shepherd of Souls"]={{[1]={[1]={neg=true,skillType=42,type="SkillType"},flags=0,keywordFlags=0,name="Damage",type="MORE",value=-30}},nil}
 c["Shock Attackers for 4 seconds on Block"]={{[1]={[1]={type="Condition",var="BlockedRecently"},flags=0,keywordFlags=0,name="ShockBase",type="BASE",value=15},[2]={[1]={type="Condition",var="BlockedRecently"},flags=0,keywordFlags=0,name="EnemyModifier",type="LIST",value={mod={flags=0,keywordFlags=0,name="Condition:Shocked",type="FLAG",value=true}}}},nil}
 c["Shock Reflection"]={nil,"Shock Reflection "}
 c["Shock a nearby Enemy for 2 seconds on Killing a Shocked Enemy"]={nil,"Shock a nearby Enemy for 2 seconds on Killing a Shocked Enemy "}

--- a/src/Modules/ConfigOptions.lua
+++ b/src/Modules/ConfigOptions.lua
@@ -1378,6 +1378,9 @@ Huge sets the radius to 11.
 		modList:NewMod("Condition:UsedVaalSkillRecently", "FLAG", true, "Config", { type = "Condition", var = "Combat" })
 		modList:NewMod("Condition:UsedSkillRecently", "FLAG", true, "Config", { type = "Condition", var = "Combat" })
 	end },
+		{ var = "multiplierUsedVaalSkillInPast8Seconds", type = "count", label = "# of Vaal Skills used in the past 8 Seconds:", ifMult = "VaalSkillsUsedInPast8Seconds", apply = function(val, modList, enemyModList)
+		modList:NewMod("Multiplier:VaalSkillsUsedInPast8Seconds", "BASE", val, "Config", { type = "Condition", var = "Combat" })
+	end },
 	{ var = "conditionSoulGainPrevention", type = "check", label = "Do you have Soul Gain Prevention?", ifCond = "SoulGainPrevention", apply = function(val, modList, enemyModList)
 		modList:NewMod("Condition:SoulGainPrevention", "FLAG", true, "Config", { type = "Condition", var = "Combat" })
 	end },

--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -2187,7 +2187,8 @@ local specialModList = {
 	["life recovery from flasks also applies to energy shield"] = { flag("LifeFlaskAppliesToEnergyShield") },
 	["non%-instant mana recovery from flasks is also recovered as life"] = { flag("ManaFlaskAppliesToLife") },
 	["life leech effects recover energy shield instead while on full life"] = { flag("ImmortalAmbition", { type = "Condition", var = "FullLife" }, { type = "Condition", var = "LeechingLife" }) },
-	["shepherd of souls"] = { mod("Damage", "MORE", -30, { type = "SkillType", skillType = SkillType.Vaal, neg = true }) },
+	["shepherd of souls wrong"] = { flag("vaal non-aura skills have 80% less soul cost"), flag("vaal non-aura skills have 100% increased soul cost per vaal skill used in the past 8 seconds") },
+	["shepherd of souls"] = { mod("SoulCost", "MORE", -80, { type = "SkillType", skillType = SkillType.Vaal }, { type = "SkillType", skillType = SkillType.Aura, neg = true }), mod("SoulCost", "INC", 80, { type = "Multiplier", var = "VaalSkillsUsedInPast8Seconds" })},
 	["adds (%d+) to (%d+) attack physical damage to melee skills per (%d+) dexterity while you are unencumbered"] = function(_, min, max, dex) return { -- Hollow Palm 3 suffixes
 		mod("PhysicalMin", "BASE", tonumber(min), nil, ModFlag.Melee, KeywordFlag.Attack, { type = "PerStat", stat = "Dex", div = tonumber(dex) }, { type = "Condition", var = "Unencumbered" }),
 		mod("PhysicalMax", "BASE", tonumber(max), nil, ModFlag.Melee, KeywordFlag.Attack, { type = "PerStat", stat = "Dex", div = tonumber(dex) }, { type = "Condition", var = "Unencumbered" }),


### PR DESCRIPTION
Fixes #7691 .

### Description of the problem being solved:

Shepherd of Souls still has the old Mod Description and Functionality prior to version 3.23 (https://www.poewiki.net/wiki/Shepherd_of_Souls), namely lessening the damage of Non-Vaal Skills by 30% and regaining 50% souls on use. Since 3.23 the Keystone instead grants:
Vaal Non-Aura Skills have 80% less Soul Cost
Vaal Non-Aura Skills have 100% increased Soul Cost per Vaal Skill used in the past 8 seconds

To fix this issue, i added parsing for these lines, and added configuration to set the number of Vaal Skills used in the past 8 seconds.
### Steps taken to verify a working solution:
- Created a build with a Vaal Skill and Yaomac's Accord (or the "Forbidden Secrets" Node of the "Architect of Chaos" Ascendancy)
- Checked if the 80% less Soul Cost applies correctly
- Changed the configuration number of Vaal Skills used in the past 8 seconds to see if the Soul Cost adjusts accordingly

### Link to a build that showcases this PR:
https://pobb.in/EDLX0C_GmD1g
### Before screenshot:
![image](https://github.com/user-attachments/assets/cf1eb51b-2817-4bfd-b6e0-b95b71cfce1a)

### After screenshot:
![image](https://github.com/user-attachments/assets/deb9dfd5-ffbf-4922-89c1-df30b8d6902a)
![image](https://github.com/user-attachments/assets/42c457c2-235b-4f3f-82af-b52f4e48cc37)
