### PR TITLE
Change Sacrificial Zeal to be opt in rather than opt out

### DIFF
--- a/src/Modules/ConfigOptions.lua
+++ b/src/Modules/ConfigOptions.lua
@@ -894,7 +894,7 @@ Huge sets the radius to 11.
 	{ var = "buffChaoticMight", type = "check", label = "Do you have Chaotic Might?", tooltip = "This will enable the Chaotic Might buff.\n(Grants 30% of Physical Damage as Extra ^xD02090Chaos ^7Damage)", apply = function(val, modList, enemyModList)
 		modList:NewMod("Condition:ChaoticMight", "FLAG", true, "Config", { type = "Condition", var = "Combat" })
 	end },
-	{ var = "buffSacrificialZeal", type = "check", label = "Do you have Sacrificial Zeal?", defaultState = true, ifFlag = "SacrificialZeal", tooltip = "This will enable the Sacrificial Zeal buff.\n(Grants 25% of the skill's mana cost as Physical Damage and causes you to take physical damage over time equal to a percentage of the skill's mana cost.)", apply = function(val, modList, enemyModList)
+	{ var = "buffSacrificialZeal", type = "check", label = "Do you have Sacrificial Zeal?", ifFlag = "SacrificialZeal", tooltip = "This will enable the Sacrificial Zeal buff.\n(Grants 25% of the skill's mana cost as Physical Damage and causes you to take physical damage over time equal to a percentage of the skill's mana cost.)", apply = function(val, modList, enemyModList)
 		modList:NewMod("Condition:SacrificialZeal", "FLAG", true, "Config", { type = "Condition", var = "Combat" })
 	end },
 	{ var = "minionbuffChaoticMight", type = "check", label = "Do your minions have Chaotic Might?", ifFlag = "haveMinion", tooltip = "This will enable the Chaotic Might buff on your minions.\n(Grants 30% of Physical Damage as Extra ^xD02090Chaos ^7Damage)", apply = function(val, modList, enemyModList)


### PR DESCRIPTION
Closes https://github.com/PathOfBuildingCommunity/PathOfBuilding/issues/8541

### Description of the problem being solved:
Initially when trying to fix issue https://github.com/PathOfBuildingCommunity/PathOfBuilding/issues/8421 i made the config default enabled to maintain current behaviour of it being on the moment Hand of the Fervent was equipped. I was under the impression that the ifFlag would prevent the config application function from running but that doesn't not seem to be the case. I've tried a few different ways of fixing this but i've decided that the best course of action would be to simply make the effect opt in rather than opt out.
