### PR TITLE
Add support for Rejuvenation Totem helm enchant

### DIFF
--- a/src/Data/Skills/act_str.lua
+++ b/src/Data/Skills/act_str.lua
@@ -8498,10 +8498,10 @@ skills["RejuvenationTotem"] = {
 	castTime = 0.6,
 	statMap = {
 		["base_life_regeneration_rate_per_minute"] = {
-			{mod("LifeRegen", "BASE", nil, 0, 0, { type = "GlobalEffect", effectType = "Aura" }),
-			div = 60},
-			{mod("ManaRegen", "BASE", nil, 0, 0, { type = "GlobalEffect", effectType = "Aura" }, { type = "Condition", var = "RejuvenationTotemManaRegen" }),
-			div = 400},
+			{ mod("LifeRegen", "BASE", nil, 0, 0, { type = "GlobalEffect", effectType = "Aura" }),
+			div = 60 },
+			{ mod("ManaRegen", "BASE", nil, 0, 0, { type = "GlobalEffect", effectType = "Aura" }, { type = "Condition", var = "RejuvenationTotemManaRegen" }),
+			div = 400 },
 		},
 	},
 	baseFlags = {

--- a/src/Data/Skills/act_str.lua
+++ b/src/Data/Skills/act_str.lua
@@ -8498,8 +8498,10 @@ skills["RejuvenationTotem"] = {
 	castTime = 0.6,
 	statMap = {
 		["base_life_regeneration_rate_per_minute"] = {
-			mod("LifeRegen", "BASE", nil, 0, 0, { type = "GlobalEffect", effectType = "Aura" }),
-			div = 60,
+			{mod("LifeRegen", "BASE", nil, 0, 0, { type = "GlobalEffect", effectType = "Aura" }),
+			div = 60},
+			{mod("ManaRegen", "BASE", nil, 0, 0, { type = "GlobalEffect", effectType = "Aura" }, { type = "Condition", var = "RejuvenationTotemManaRegen" }),
+			div = 400},
 		},
 	},
 	baseFlags = {

--- a/src/Export/Skills/act_str.txt
+++ b/src/Export/Skills/act_str.txt
@@ -1668,10 +1668,10 @@ local skills, mod, flag, skill = ...
 #flags spell aura totem area duration
 	statMap = {
 		["base_life_regeneration_rate_per_minute"] = {
-			{mod("LifeRegen", "BASE", nil, 0, 0, { type = "GlobalEffect", effectType = "Aura" }),
-			div = 60},
-			{mod("ManaRegen", "BASE", nil, 0, 0, { type = "GlobalEffect", effectType = "Aura" }, { type = "Condition", var = "RejuvenationTotemManaRegen" }),
-			div = 400},
+			{ mod("LifeRegen", "BASE", nil, 0, 0, { type = "GlobalEffect", effectType = "Aura" }),
+			div = 60 },
+			{ mod("ManaRegen", "BASE", nil, 0, 0, { type = "GlobalEffect", effectType = "Aura" }, { type = "Condition", var = "RejuvenationTotemManaRegen" }),
+			div = 400 },
 		},
 	},
 #baseMod skill("radius", 40)

--- a/src/Export/Skills/act_str.txt
+++ b/src/Export/Skills/act_str.txt
@@ -1668,8 +1668,10 @@ local skills, mod, flag, skill = ...
 #flags spell aura totem area duration
 	statMap = {
 		["base_life_regeneration_rate_per_minute"] = {
-			mod("LifeRegen", "BASE", nil, 0, 0, { type = "GlobalEffect", effectType = "Aura" }),
-			div = 60,
+			{mod("LifeRegen", "BASE", nil, 0, 0, { type = "GlobalEffect", effectType = "Aura" }),
+			div = 60},
+			{mod("ManaRegen", "BASE", nil, 0, 0, { type = "GlobalEffect", effectType = "Aura" }, { type = "Condition", var = "RejuvenationTotemManaRegen" }),
+			div = 400},
 		},
 	},
 #baseMod skill("radius", 40)

--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -3834,6 +3834,7 @@ local specialModList = {
 	["each totem applies (%d+)%% increased damage taken to enemies near it"] = function(num) return { mod("EnemyModifier", "LIST", { mod = mod("DamageTaken", "INC", num, { type = "Multiplier", var = "TotemsSummoned" }) }) } end,
 	["totems gain %+(%d+)%% to (%w+) resistance"] = function(num, _, resistance) return { mod("Totem"..firstToUpper(resistance).."Resist", "BASE", num) } end,
 	["totems gain %+(%d+)%% to all elemental resistances"] = function(num) return { mod("TotemElementalResist", "BASE", num) } end,
+	["rejuvenation totem also grants mana regeneration equal to 15%% of its life regeneration"] = { flag("Condition:RejuvenationTotemManaRegen") },
 	-- Minions
 	["your strength is added to your minions"] = { flag("StrengthAddedToMinions") },
 	["half of your strength is added to your minions"] = { flag("HalfStrengthAddedToMinions") },


### PR DESCRIPTION
Fixes #5644 

### Description of the problem being solved:
Labyrinth helm enchant didn't work. I couldn't think of a way to grab the regen total from the totem other than the skill in act_str.lua. For what it is, probably doesn't matter. Helm enchants have been gone for a while now. It's hard coded to 15%, so if they do add a similar mod down the road, it won't accidentally be parsed through this stuff. So it'll be red text, and then we (aka someone smarter) can worry about doing a better job then.

EDIT: Also, the wording was changed at one point. So the issue linked has old wording, which I didn't bother supporting as it would only be relevant for older builds, which at that point they can just replace the old worded mod with the current enchant.

### Link to a build that showcases this PR:
https://pobb.in/Aqrym-Kd-LaU
### After screenshot:
![image](https://github.com/user-attachments/assets/481e6e39-d4cf-4722-938c-ac74c27e65a1)
