### PR TITLE
Fix Herald of Ask damage showing negative values

### DIFF
--- a/src/Data/Skills/act_str.lua
+++ b/src/Data/Skills/act_str.lua
@@ -5363,8 +5363,6 @@ skills["HeraldOfAsh"] = {
 		},
 	},
 	baseFlags = {
-		spell = true,
-		area = true,
 	},
 	baseMods = {
 		skill("radius", 10),

--- a/src/Export/Skills/act_str.txt
+++ b/src/Export/Skills/act_str.txt
@@ -940,7 +940,6 @@ local skills, mod, flag, skill = ...
 #mods
 
 #skill HeraldOfAsh
-#flags spell area
 	preDamageFunc = function(activeSkill, output)
 		activeSkill.skillData.FireDot = (activeSkill.skillData.hoaOverkill or 0) * (1 + activeSkill.skillData.hoaMoreBurn / 100) * activeSkill.skillData.hoaOverkillPercent
 	end,

--- a/src/Modules/CalcOffence.lua
+++ b/src/Modules/CalcOffence.lua
@@ -5244,7 +5244,7 @@ function calcs.offence(env, actor, activeSkill)
 			--Variables below calculate DOT damage
 			local inc = skillModList:Sum("INC", dotTypeCfg, "Damage", damageType.."Damage", isElemental[damageType] and "ElementalDamage" or nil)
 			if skillModList:Flag(nil, "dotIsHeraldOfAsh") then
-				inc = inc - skillModList:Sum("INC", skillCfg, "Damage", damageType.."Damage", isElemental[damageType] and "ElementalDamage" or nil)
+				inc = m_max(inc - skillModList:Sum("INC", skillCfg, "Damage", damageType.."Damage", isElemental[damageType] and "ElementalDamage" or nil), 0)
 			end
 			local more = skillModList:More(dotTypeCfg, "Damage", damageType.."Damage", isElemental[damageType] and "ElementalDamage" or nil)
 			local mult = skillModList:Override(dotTypeCfg, "DotMultiplier") or skillModList:Sum("BASE", dotTypeCfg, "DotMultiplier") + skillModList:Sum("BASE", dotTypeCfg, damageType.."DotMultiplier")


### PR DESCRIPTION
Herald of Ash was previously scaling with area and spell damage mods which it shouldn't it was also possible for the increased damage values to be negative which is not correct.
Fixes #8538