### PR TITLE
Fix Minion supports not scaling Siegebreaker ground DoT

### DIFF
--- a/src/Data/Skills/minion.lua
+++ b/src/Data/Skills/minion.lua
@@ -1561,11 +1561,10 @@ skills["SiegebreakerCausticGround"] = {
 	hidden = true,
 	color = 4,
 	baseFlags = {
-		cast = true,
 		area = true,
-		chaos = true,
+		duration = true,
 	},
-	skillTypes = { },
+	skillTypes = { [SkillType.Spell] = true, [SkillType.Duration] = true, [SkillType.Damage] = true, [SkillType.Area] = true, [SkillType.DamageOverTime] = true, [SkillType.Triggerable] = true, [SkillType.Chaos] = true, [SkillType.AreaSpell] = true, },
 	baseMods = {
 		skill("ChaosDot", 1, { type = "PercentStat", stat = "Life", percentVar = "SiegebreakerCausticGroundPercent" }),
 		skill("dotIsArea", true),
@@ -1584,11 +1583,10 @@ skills["ReplicaSiegebreakerBurningGround"] = {
 	hidden = true,
 	color = 4,
 	baseFlags = {
-		cast = true,
 		area = true,
-		fire = true,
+		duration = true,
 	},
-	skillTypes = { },
+	skillTypes = { [SkillType.Spell] = true, [SkillType.Duration] = true, [SkillType.Damage] = true, [SkillType.Area] = true, [SkillType.DamageOverTime] = true, [SkillType.Triggerable] = true, [SkillType.Fire] = true, [SkillType.AreaSpell] = true, [SkillType.CausesBurning] = true, },
 	baseMods = {
 		skill("FireDot", 1, { type = "PercentStat", stat = "Life", percentVar = "SiegebreakerBurningGroundPercent" }),
 		skill("dotIsArea", true),

--- a/src/Export/Skills/minion.txt
+++ b/src/Export/Skills/minion.txt
@@ -289,13 +289,12 @@ skills["SiegebreakerCausticGround"] = {
 	hidden = true,
 	color = 4,
 	baseFlags = {
-		cast = true,
 		area = true,
-		chaos = true,
+		duration = true,
 	},
-	skillTypes = { },
+	skillTypes = { [SkillType.Spell] = true, [SkillType.Duration] = true, [SkillType.Damage] = true, [SkillType.Area] = true, [SkillType.DamageOverTime] = true, [SkillType.Triggerable] = true, [SkillType.Chaos] = true, [SkillType.AreaSpell] = true, },
 	baseMods = {
-		skill("ChaosDot", 1, { type = "PercentStat", stat = "Life", percentVar = "CausticGroundPercent" }),
+		skill("ChaosDot", 1, { type = "PercentStat", stat = "Life", percentVar = "SiegebreakerCausticGroundPercent" }),
 		skill("dotIsArea", true),
 		flag("dotIsCausticGround"),
 	},
@@ -312,13 +311,12 @@ skills["ReplicaSiegebreakerBurningGround"] = {
 	hidden = true,
 	color = 4,
 	baseFlags = {
-		cast = true,
 		area = true,
-		fire = true,
+		duration = true,
 	},
-	skillTypes = { },
+	skillTypes = { [SkillType.Spell] = true, [SkillType.Duration] = true, [SkillType.Damage] = true, [SkillType.Area] = true, [SkillType.DamageOverTime] = true, [SkillType.Triggerable] = true, [SkillType.Fire] = true, [SkillType.AreaSpell] = true, [SkillType.CausesBurning] = true, },
 	baseMods = {
-		skill("FireDot", 1, { type = "PercentStat", stat = "Life", percentVar = "BurningGroundPercent" }),
+		skill("FireDot", 1, { type = "PercentStat", stat = "Life", percentVar = "SiegebreakerBurningGroundPercent" }),
 		skill("dotIsArea", true),
 		flag("dotIsBurningGround"),
 	},


### PR DESCRIPTION
Skill gems should scale the damage from the ground DoT but were not as we did not add any skill tags to the effect
Fixes #5790