### PR TITLE
Fix Life/Mana/Hybrid flasks allowing enchantments when crafting

### DIFF
--- a/src/Classes/ItemsTab.lua
+++ b/src/Classes/ItemsTab.lua
@@ -433,7 +433,7 @@ holding Shift will put it in the second.]])
 		self:EnchantDisplayItem(1)
 	end)
 	self.controls.displayItemEnchant.shown = function()
-		return self.displayItem and self.displayItem.enchantments
+		return self.displayItem and self.displayItem.enchantments and not ({ Life = true, Mana = true, Hybrid = true })[self.displayItem.base.subType]
 	end
 	self.controls.displayItemEnchant2 = new("ButtonControl", {"TOPLEFT",self.controls.displayItemEnchant,"TOPRIGHT",true}, {8, 0, 160, 20}, "Apply Enchantment 2...", function()
 		self:EnchantDisplayItem(2)


### PR DESCRIPTION
Fixes #6127

EDIT: No good, Harvest enchants for all flasks exist.
See #8224

### Description of the problem being solved:
All Flasks showed the Apply Enchantment button. Only Hybrid flasks can have enchantments at this moment.
### Before screenshot:
![image](https://github.com/user-attachments/assets/e5d16d4e-043a-4350-b283-4505870a25e5)
### After screenshot:
![image](https://github.com/user-attachments/assets/b4c834fa-6d84-4bb3-95af-afbbcd57b437)