### PR TITLE
Add support for Tornado Shot legacy Helm Enchant

### DIFF
--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -4022,6 +4022,7 @@ local specialModList = {
 	["essence drain and soulrend fire (%d+) additional projectiles"] = function(num) return { mod("ProjectileCount", "BASE", num, nil, { type = "SkillName", skillNameList = { "Essence Drain", "Soulrend" }, includeTransfigured = true }) } end,
 	["(%d+)%% reduced essence drain and soulrend projectile speed"] = function(num) return { mod("ProjectileSpeed", "INC", -num, nil, { type = "SkillName", skillNameList = { "Essence Drain", "Soulrend" }, includeTransfigured = true }) } end,
 	["tornado shot fires an additional secondary projectile"] = { mod("tornadoShotSecondaryProjectiles", "BASE", 1, nil, { type = "SkillName", skillNameList = { "Tornado Shot" } }) },
+	["tornado shot fires 2 additional secondary projectiles"] = { mod("tornadoShotSecondaryProjectiles", "BASE", 2, nil, { type = "SkillName", skillNameList = { "Tornado Shot" } }) },
 	["projectiles pierce an additional target"] = { mod("PierceCount", "BASE", 1) },
 	["projectiles pierce (%d+) targets?"] = function(num) return { mod("PierceCount", "BASE", num) } end,
 	["projectiles pierce (%d+) additional targets?"] = function(num) return { mod("PierceCount", "BASE", num) } end,


### PR DESCRIPTION
Fixes # 8566.

### Description of the problem being solved:
There's a legacy mod for Tornado Shot helmet enchant, confirmed on wiki.
![image](https://github.com/user-attachments/assets/5df7ed47-71c8-403b-80f0-e2e064f3f764)

### Link to a build that showcases this PR:
https://pobb.in/k0QD3Oli3TWV

### After screenshot:
![image](https://github.com/user-attachments/assets/4f1d9dfd-58f6-4cd1-902f-e39b45d88523)