### PR TITLE
Add Shaper influence to Tides of Time unique belt

### DIFF
--- a/src/Data/Uniques/belt.lua
+++ b/src/Data/Uniques/belt.lua
@@ -890,6 +890,7 @@ Imbalanced Guard
 ]],[[
 The Tides of Time
 Vanguard Belt
+Shaper Item
 Source: Drops from unique{The Shaper} (Uber)
 Requires Level 78
 Implicits: 1


### PR DESCRIPTION
Fixes #8568.

### Description of the problem being solved:
Adds Shaper influence to Tides of Time

### Steps taken to verify a working solution:
- Added Tides of Time from the unique item selection and verified it has Shaper influence by default
- Checked if it interacts correctly with Eternity Shroud's "gain as elemental" per shaper item
-

### Link to a build that showcases this PR:
https://pobb.in/gMEVo5IIByfJ

### Before screenshot:
![image](https://github.com/user-attachments/assets/82cec66d-7540-4594-b4db-efe55c6f3ddd)


### After screenshot:
![image](https://github.com/user-attachments/assets/96e9d366-1364-4de1-9369-955f4679a662)
