### PR TITLE
Fix first explicit mod missing when it has no parsing

### DIFF
--- a/src/Classes/Item.lua
+++ b/src/Classes/Item.lua
@@ -813,7 +813,7 @@ function ItemClass:ParseRaw(raw, rarity, highQuality)
 					elseif gameModeStage == "FINDEXPLICIT" then
 						gameModeStage = "DONE"
 					end
-				elseif foundExplicit then
+				elseif foundExplicit or (not foundExplicit and gameModeStage == "EXPLICIT") then
 					modLine.modList = { }
 					modLine.extra = line
 					t_insert(modLines, modLine)


### PR DESCRIPTION
Fixes #8408

### Description of the problem being solved:

The item parsing logic in WIKI mode seems to rely on finding a mod that produces a modList to set the foundExplicit variable to true which then allows mods that do not produce a modList to be added to lineList. This causes issues with items such as Dialla's Malefaction where the first explicit line does not have any parsing which causes it to not be added to linesList. Interestingly enough other mods which are parsed piece-wise work fine here as they produce and empty modList with the extras parameter.

This pr attempts to fix the problem while being the least invasive and lowering the chance of some parsing edge case failing. There could totally be a much nicer solution to this problem.
