### PR TITLE
Fix many unique staves with Attack block instead of Spell block implicit

### DIFF
--- a/src/Data/Uniques/staff.lua
+++ b/src/Data/Uniques/staff.lua
@@ -83,7 +83,7 @@ Source: Drops from unique{The Searing Exarch} (Uber)
 Requires Level 68, 78 Str, 78 Int
 Implicits: 2
 {variant:1}+18% Chance to Block Attack Damage while wielding a Staff
-{variant:2}+22% Chance to Block Attack Damage while wielding a Staff
+{variant:2}+22% Chance to Block Spell Damage while wielding a Staff
 (60-70)% reduced Elemental Resistances
 Deal Triple Damage with Elemental Skills
 ]],[[

--- a/src/Data/Uniques/staff.lua
+++ b/src/Data/Uniques/staff.lua
@@ -12,7 +12,7 @@ Requires Level 66, 158 Str, 113 Int
 Implicits: 3
 {variant:1}+12% Chance to Block Attack Damage while wielding a Staff
 {variant:2}+18% Chance to Block Attack Damage while wielding a Staff
-{variant:3}+25% Chance to Block Attack Damage while wielding a Staff
+{variant:3}+25% Chance to Block Spell Damage while wielding a Staff
 40% increased Strength Requirement
 +(80-120) to Intelligence
 (30-50)% increased Lightning Damage
@@ -30,7 +30,7 @@ Requires Level 66, 158 Str, 113 Int
 Implicits: 3
 {variant:1}+12% Chance to Block Attack Damage while wielding a Staff
 {variant:2}+18% Chance to Block Attack Damage while wielding a Staff
-{variant:3}+25% Chance to Block Attack Damage while wielding a Staff
+{variant:3}+25% Chance to Block Spell Damage while wielding a Staff
 {variant:1}+1 to Level of all Lightning Spell Skill Gems
 {variant:2,3}+2 to Level of all Lightning Spell Skill Gems
 +(80-120) to Intelligence
@@ -48,7 +48,7 @@ Requires Level 66, 158 Str, 113 Int
 Implicits: 3
 {variant:1}+12% Chance to Block Attack Damage while wielding a Staff
 {variant:2}+18% Chance to Block Attack Damage while wielding a Staff
-{variant:3}+25% Chance to Block Attack Damage while wielding a Staff
+{variant:3}+25% Chance to Block Spell Damage while wielding a Staff
 {variant:1}+1 to Level of all Lightning Spell Skill Gems
 {variant:2,3}+2 to Level of all Lightning Spell Skill Gems
 +(80-120) to Intelligence
@@ -66,7 +66,7 @@ Requires Level 66, 158 Str, 113 Int
 Implicits: 3
 {variant:1}+12% Chance to Block Attack Damage while wielding a Staff
 {variant:2}+18% Chance to Block Attack Damage while wielding a Staff
-{variant:3}+25% Chance to Block Attack Damage while wielding a Staff
+{variant:3}+25% Chance to Block Spell Damage while wielding a Staff
 {variant:1}+1 to Level of all Lightning Spell Skill Gems
 {variant:2,3}+2 to Level of all Lightning Spell Skill Gems
 +(80-120) to Intelligence
@@ -126,7 +126,7 @@ Variant: Current
 Implicits: 3
 {variant:1}+12% Chance to Block Attack Damage while wielding a Staff
 {variant:2}+18% Chance to Block Attack Damage while wielding a Staff
-{variant:3}+20% Chance to Block Attack Damage while wielding a Staff
+{variant:3}+20% Chance to Block Spell Damage while wielding a Staff
 +12% Chance to Block Attack Damage while wielding a Staff
 100% increased Physical Damage
 (5-10)% increased Attack Speed
@@ -141,7 +141,7 @@ League: Heist
 Source: Steal from a unique{Curio Display} during a Grand Heist
 Implicits: 2
 {variant:1}+18% Chance to Block Attack Damage while wielding a Staff
-{variant:2}+20% Chance to Block Attack Damage while wielding a Staff
+{variant:2}+20% Chance to Block Spell Damage while wielding a Staff
 +12% Chance to Block Attack Damage while wielding a Staff
 100% increased Fire Damage
 (5-10)% increased Attack Speed
@@ -256,7 +256,7 @@ Variant: Current
 Requires Level 66, 113 Str, 113 Int
 Implicits: 2
 {variant:2}18% Chance to Block Attack Damage while wielding a Staff
-{variant:3}+25% Chance to Block Attack Damage while wielding a Staff
+{variant:3}+25% Chance to Block Spell Damage while wielding a Staff
 {variant:1}Socketed Gems are supported by Level 10 Life Leech
 {variant:2,3}Socketed Gems are supported by Level 1 Chance to Bleed
 Grants Summon Harbinger of Brutality Skill
@@ -274,7 +274,7 @@ Source: Upgraded from unique{The Enmity Divine} via currency{Haemocombustion Scr
 Requires Level 66, 113 Str, 113 Int
 Implicits: 2
 {variant:1}+18% Chance to Block Attack Damage while wielding a Staff
-{variant:2}+25% Chance to Block Attack Damage while wielding a Staff
+{variant:2}+25% Chance to Block Spell Damage while wielding a Staff
 Socketed Gems are supported by Level 1 Chance to Bleed
 Grants Summon Greater Harbinger of Brutality Skill
 +5% Chance to Block Attack Damage while wielding a Staff
@@ -292,7 +292,7 @@ Requires Level 58, 99 Str, 99 Int
 Implicits: 3
 {variant:1}+12% Chance to Block Attack Damage while wielding a Staff
 {variant:2,3}+18% Chance to Block Attack Damage while wielding a Staff
-{variant:4}+25% Chance to Block Attack Damage while wielding a Staff
+{variant:4}+25% Chance to Block Spell Damage while wielding a Staff
 +2 to Level of Socketed Minion Gems
 {variant:3,4}Minions deal (60-80)% increased Damage
 {variant:3,4}+1% Chance to Block Attack Damage per Summoned Skeleton
@@ -312,7 +312,7 @@ Variant: Current
 Implicits: 3
 {variant:1}+12% Chance to Block Attack Damage while wielding a Staff
 {variant:2}+18% Chance to Block Attack Damage while wielding a Staff
-{variant:3}+20% Chance to Block Attack Damage while wielding a Staff
+{variant:3}+20% Chance to Block Spell Damage while wielding a Staff
 Socketed Gems are Supported by Level 8 Trap
 (40-50)% increased Damage
 (10-20)% increased maximum Life
@@ -326,7 +326,7 @@ League: Heist
 Source: Steal from a unique{Curio Display} during a Grand Heist
 Implicits: 2
 {variant:1}+18% Chance to Block Attack Damage while wielding a Staff
-{variant:2}+20% Chance to Block Attack Damage while wielding a Staff
+{variant:2}+20% Chance to Block Spell Damage while wielding a Staff
 Socketed Gems are Supported by Level 1 Multiple Totems
 (40-50)% increased Global Damage
 (10-20)% increased maximum Life
@@ -340,7 +340,7 @@ League: Affliction
 Requires Level 58, 99 Str, 99 Int
 Implicits: 2
 {variant:1}+18% Chance to Block Attack Damage while wielding a Staff
-{variant:2}+25% Chance to Block Attack Damage while wielding a Staff
+{variant:2}+25% Chance to Block Spell Damage while wielding a Staff
 Socketed Gems are Supported by Level 1 Lifetap
 (20-30)% increased Cast Speed
 Lose 500 Life per second
@@ -373,7 +373,7 @@ Source: No longer obtainable
 Requires Level 32
 Implicits: 2
 {variant:1}+18% Chance to Block Attack Damage while wielding a Staff
-{variant:2}+20% Chance to Block Attack Damage while wielding a Staff
+{variant:2}+20% Chance to Block Spell Damage while wielding a Staff
 Socketed Gems are Supported by Level 16 Trap
 Socketed Gems are Supported by Level 16 Cluster Trap
 Socketed Gems are Supported by Level 16 Trap and Mine Damage
@@ -428,7 +428,7 @@ Variant: Current
 Requires Level 52, 89 Str, 89 Int
 Implicits: 2
 {variant:1,2,3}+18% Chance to Block Attack Damage while wielding a Staff
-{variant:4}+22% Chance to Block Attack Damage while wielding a Staff
+{variant:4}+22% Chance to Block Spell Damage while wielding a Staff
 (12-16)% Chance to Block Attack Damage while wielding a Staff
 {variant:1,2}Adds (350-400) to (500-600) Fire Damage
 {variant:3,4}Adds (315-360) to (450-540) Fire Damage
@@ -522,7 +522,7 @@ Variant: Current
 Implicits: 3
 {variant:1,2}+12% Chance to Block Attack Damage while wielding a Staff
 {variant:3,4,5}+18% Chance to Block Attack Damage while wielding a Staff
-{variant:6}+25% Chance to Block Attack Damage while wielding a Staff
+{variant:6}+25% Chance to Block Spell Damage while wielding a Staff
 {variant:5,6}+(40-60)% to Fire Damage over Time Multiplier
 {variant:1,2,3}(30-50)% increased Spell Damage
 {variant:1,2,3}(20-40)% increased Fire Damage
@@ -575,7 +575,7 @@ Requires Level 28, 51 Str, 51 Int
 Implicits: 3
 {variant:1}+12% Chance to Block Attack Damage while wielding a Staff
 {variant:2}+18% Chance to Block Attack Damage while wielding a Staff
-{variant:3}+20% Chance to Block Attack Damage while wielding a Staff
+{variant:3}+20% Chance to Block Spell Damage while wielding a Staff
 (80-100)% increased Physical Damage
 Adds (25-35) to (45-60) Cold Damage
 Adds (1-10) to (70-90) Lightning Damage
@@ -592,7 +592,7 @@ Source: No longer obtainable
 Requires Level 60, 51 Str, 51 Int
 Implicits: 2
 {variant:1}+18% Chance to Block Attack Damage while wielding a Staff
-{variant:2}+20% Chance to Block Attack Damage while wielding a Staff
+{variant:2}+20% Chance to Block Spell Damage while wielding a Staff
 15% Chance to Block Attack Damage while wielding a Staff
 Adds (242-260) to (268-285) Physical Damage
 (20-35)% increased Critical Strike Chance
@@ -667,7 +667,7 @@ Source: Drops from unique{Oshabi, Avatar of the Grove}
 Requires Level 68, 89 Str, 89 Int
 Implicits: 2
 {variant:1}+18% Chance to Block Attack Damage while wielding a Staff
-{variant:2}+22% Chance to Block Attack Damage while wielding a Staff
+{variant:2}+22% Chance to Block Spell Damage while wielding a Staff
 Grants Level 20 Brandsurge Skill
 Brand Skills have (50-100)% increased Duration
 ]],[[
@@ -678,7 +678,7 @@ Variant: Current
 League: Crucible
 Implicits: 2
 {variant:1}+18% Chance to Block Attack Damage while wielding a Staff
-{variant:2}+22% Chance to Block Attack Damage while wielding a Staff
+{variant:2}+22% Chance to Block Spell Damage while wielding a Staff
 Has 1 Socket
 (150-200)% increased Spell Damage
 (80-120)% increased Critical Strike Chance for Spells


### PR DESCRIPTION
Fixes #8579 

### Description of the problem being solved:
The base type "Quarterstaff" for annihilating light was changed from 18% attack block to 22% spell block, but the current variant for the unique was using 22% attack block. Quick fix.
### Steps taken to verify a working solution:

### After screenshot:
![image](https://github.com/user-attachments/assets/449a690c-e612-4569-bc06-9bba2c516f2d)
