### PR TITLE
Keep Max Price and Max Level between Trade Queries

### DIFF
--- a/src/Classes/TradeQueryGenerator.lua
+++ b/src/Classes/TradeQueryGenerator.lua
@@ -109,7 +109,9 @@ local TradeQueryGeneratorClass = newClass("TradeQueryGenerator", function(self, 
 	self.queryTab = queryTab
 	self.itemsTab = queryTab.itemsTab
 	self.calcContext = { }
-
+	self.lastMaxPrice = nil
+	self.lastMaxPriceTypeIndex = nil
+	self.lastMaxLevel = nil
 end)
 
 local function fetchStats()
@@ -652,7 +654,37 @@ function TradeQueryGeneratorClass:OnFrame()
 	end
 end
 
+local currencyTable = {
+    { name = "Chaos Orb Equivalent", id = nil },
+    { name = "Chaos Orb", id = "chaos" },
+    { name = "Divine Orb", id = "divine" },
+    { name = "Orb of Alchemy", id = "alch" },
+    { name = "Orb of Alteration", id = "alt" },
+    { name = "Chromatic Orb", id = "chrome" },
+    { name = "Exalted Orb", id = "exalted" },
+    { name = "Blessed Orb", id = "blessed" },
+    { name = "Cartographer's Chisel", id = "chisel" },
+    { name = "Gemcutter's Prism", id = "gcp" },
+    { name = "Jeweller's Orb", id = "jewellers" },
+    { name = "Orb of Scouring", id = "scour" },
+    { name = "Orb of Regret", id = "regret" },
+    { name = "Orb of Fusing", id = "fusing" },
+    { name = "Orb of Chance", id = "chance" },
+    { name = "Regal Orb", id = "regal" },
+    { name = "Vaal Orb", id = "vaal" }
+}
+
 function TradeQueryGeneratorClass:StartQuery(slot, options)
+	if self.lastMaxPrice then
+		options.maxPrice = self.lastMaxPrice
+	end
+	if self.lastMaxPriceTypeIndex then
+		options.maxPriceType = currencyTable[self.lastMaxPriceTypeIndex].id
+	end
+	if self.lastMaxLevel then
+		options.maxLevel = self.lastMaxLevel
+	end
+
 	-- Figure out what type of item we're searching for
 	local existingItem = slot and self.itemsTab.items[slot.selItemId]
 	local testItemType = existingItem and existingItem.baseName or "Unset Amulet"
@@ -1072,35 +1104,19 @@ function TradeQueryGeneratorClass:RequestQuery(slot, context, statWeights, callb
 	end
 
 	-- Add max price limit selection dropbox
-	local currencyTable = {
-		{ name = "Chaos Orb Equivalent", id = nil },
-		{ name = "Chaos Orb", id = "chaos" },
-		{ name = "Divine Orb", id = "divine" },
-		{ name = "Orb of Alchemy", id = "alch" },
-		{ name = "Orb of Alteration", id = "alt" },
-		{ name = "Chromatic Orb", id = "chrome" },
-		{ name = "Exalted Orb", id = "exalted" },
-		{ name = "Blessed Orb", id = "blessed" },
-		{ name = "Cartographer's Chisel", id = "chisel" },
-		{ name = "Gemcutter's Prism", id = "gcp" },
-		{ name = "Jeweller's Orb", id = "jewellers" },
-		{ name = "Orb of Scouring", id = "scour" },
-		{ name = "Orb of Regret", id = "regret" },
-		{ name = "Orb of Fusing", id = "fusing" },
-		{ name = "Orb of Chance", id = "chance" },
-		{ name = "Regal Orb", id = "regal" },
-		{ name = "Vaal Orb", id = "vaal" }
-	}
 	local currencyDropdownNames = { }
 	for _, currency in ipairs(currencyTable) do
 		t_insert(currencyDropdownNames, currency.name)
 	end
 	controls.maxPrice = new("EditControl", {"TOPLEFT",lastItemAnchor,"BOTTOMLEFT"}, {0, 5, 70, 18}, nil, nil, "%D")
+	controls.maxPrice.buf = self.lastMaxPrice and tostring(self.lastMaxPrice) or ""
 	controls.maxPriceType = new("DropDownControl", {"LEFT",controls.maxPrice,"RIGHT"}, {5, 0, 150, 18}, currencyDropdownNames, nil)
+	controls.maxPriceType.selIndex = self.lastMaxPriceTypeIndex or 1
 	controls.maxPriceLabel = new("LabelControl", {"RIGHT",controls.maxPrice,"LEFT"}, {-5, 0, 0, 16}, "^7Max Price:")
 	updateLastAnchor(controls.maxPrice)
 
 	controls.maxLevel = new("EditControl", {"TOPLEFT",lastItemAnchor,"BOTTOMLEFT"}, {0, 5, 100, 18}, nil, nil, "%D")
+	controls.maxLevel.buf = self.lastMaxLevel and tostring(self.lastMaxLevel) or ""
 	controls.maxLevelLabel = new("LabelControl", {"RIGHT",controls.maxLevel,"LEFT"}, {-5, 0, 0, 16}, "Max Level:")
 	updateLastAnchor(controls.maxLevel)
 
@@ -1177,10 +1193,13 @@ function TradeQueryGeneratorClass:RequestQuery(slot, context, statWeights, callb
 		end
 		if controls.maxPrice.buf then
 			options.maxPrice = tonumber(controls.maxPrice.buf)
+			self.lastMaxPrice = options.maxPrice
 			options.maxPriceType = currencyTable[controls.maxPriceType.selIndex].id
+			self.lastMaxPriceTypeIndex = controls.maxPriceType.selIndex
 		end
 		if controls.maxLevel.buf then
 			options.maxLevel = tonumber(controls.maxLevel.buf)
+			self.lastMaxLevel = options.maxLevel
 		end
 		if controls.sockets and controls.sockets.buf then
 			options.sockets = tonumber(controls.sockets.buf)


### PR DESCRIPTION
This is my first PR, please let me know if anything needs to be adjusted or clarified.

### Description of the Problem:

Currently, whenever a new search is initiated in the Trader window, the previously set level and price filters are reset.

### Proposed Solution:

This PR implements a simple persistence mechanism by storing the user's chosen level and price values. These stored values will be retained between searches.

### Testing:

Verified persistence of level and price.

Confirmed default values are still empty on initial load.
