### PR TITLE
Create workflows for porting changes

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -1,0 +1,22 @@
+name: Port changes to PoB2
+
+on:
+    pull_request:
+        types: [closed]
+
+env:
+    LABEL_STRING: ${{ join(github.event.pull_request.labels.*.name, ',') }}
+
+jobs:
+    backport:
+        if: github.event.pull_request.merged == true && contains(github.event.pull_request.labels.*.name, 'pob2')
+        runs-on: ubuntu-latest
+        steps:
+            - name: Notify PathOfBuilding repo
+              uses: peter-evans/repository-dispatch@v3
+              with:
+                token: ${{ secrets.WIRES77_PAT }}
+                repository: ${{ github.repository_owner }}/PathOfBuilding-PoE2
+                event-type: port-changes
+                client-payload: '{"patch_url": "${{ github.event.pull_request.patch_url }}", "msg": "Apply changes from ${{ github.event.pull_request.html_url }}", "id": ${{ github.event.pull_request.number }}, "title": "${{ github.event.pull_request.title }}", "labels": "${{ env.LABEL_STRING }}", "name": "${{ github.event.pull_request.user.name }}", "user": "${{ github.event.pull_request.user.login }}"}'
+

--- a/.github/workflows/backport_receive.yml
+++ b/.github/workflows/backport_receive.yml
@@ -1,0 +1,28 @@
+name: Update code with code from PoB2
+
+on:
+    repository_dispatch:
+        types:
+            - port-changes
+
+jobs:
+    apply-patch:
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v3
+              with:
+                ref: 'dev'
+            - name: Apply patch
+              run: |
+                curl -L ${{ github.event.client_payload.patch_url }} | git apply -v --index
+            - name: Create Pull Request
+              uses: peter-evans/create-pull-request@v5
+              with:
+                title: "[pob2-port] ${{ github.event.client_payload.title }}"
+                branch: pob2-pr-${{ github.event.client_payload.id }}
+                body: |
+                  ${{ github.event.client_payload.msg }}
+                author: ${{ github.event.client_payload.name || github.event.client_payload.user }} <${{ github.event.client_payload.user }}@users.noreply.github.com>
+                commit-message: ${{ github.event.client_payload.msg }}
+                labels: ${{ github.event.client_payload.labels }}


### PR DESCRIPTION
This pair of workflows does two things:
- Accepts payloads from PathOfBuilding-PoE2 PRs that get merged with the `pob1` label
- Sends payloads to the PathOfBuilding-PoE2 repo when PRs get merged with the `pob2` label