### PR TITLE
Fix missing datSource on new installs

### DIFF
--- a/src/Export/Classes/GGPKSourceListControl.lua
+++ b/src/Export/Classes/GGPKSourceListControl.lua
@@ -43,7 +43,7 @@ function GGPKSourceListClass:EditDATSource(datSource, newSource)
 		controls.save.enabled = (controls.dat.buf:match("%S") or controls.ggpk.buf:match("%S")) and controls.label.buf:match("%S") and buf:match("%S")
 	end)
 	controls.save = new("ButtonControl", {"TOP",controls.spec,"TOP"}, {-45, 22, 80, 20}, "Save", function()
-		local reload = datSource.label == main.datSource.label
+		local reload = not main.datSource or (datSource.label == main.datSource.label)
 		datSource.label = controls.label.buf
 		datSource.ggpkPath = controls.ggpk.buf or ""
 		datSource.datFilePath = controls.dat.buf or ""

--- a/src/Export/Main.lua
+++ b/src/Export/Main.lua
@@ -334,10 +334,12 @@ end
 
 function main:LoadDatSource(value)
 	self.leagueLabel = nil
-	local out = io.open(self.datSource.spec..(self.datSource.spec:match("%.lua$") and "" or ".lua"), "w")
-	out:write('return ')
-	writeLuaTable(out, self.datSpecs, 1)
-	out:close()
+	if self.datSource then
+		local out = io.open(self.datSource.spec..(self.datSource.spec:match("%.lua$") and "" or ".lua"), "w")
+		out:write('return ')
+		writeLuaTable(out, self.datSpecs, 1)
+		out:close()
+	end
 	self.datSource = value
 	self.datSpecs = LoadModule(self.datSource.spec)
 	self:InitGGPK()


### PR DESCRIPTION
A crash would occur when creating a new datSource on a first-time install.  These couple of checks should fix that issue.
