### PR TITLE
Hydrosphere damage tooltip

### DIFF
--- a/src/Data/Skills/act_int.lua
+++ b/src/Data/Skills/act_int.lua
@@ -8644,16 +8644,25 @@ skills["Hydrosphere"] = {
 	castTime = 0.6,
 	parts = {
 			{
-                name = "Frozen (Autopulse)",
+                name = "Autopulse (Frozen)",
             },
             {
-                name = "Shocked (Autopulse)",
+                name = "Autopulse (Shocked)",
             },
             {
-                name = "Frozen & Shocked (Autopulse)",
+                name = "Autopulse (Frozen & Shocked)",
             },
             {
-                name = "Cast",
+                name = "Cast (No Ailment)",
+            },
+            {
+                name = "Cast (Frozen)",
+            },
+            {
+                name = "Cast (Shocked)",
+            },
+            {
+                name = "Cast (Frozen & Shocked)",
             }
 	},
 	preDamageFunc = function(activeSkill, output)
@@ -8668,6 +8677,10 @@ skills["Hydrosphere"] = {
 			mod("SkillPhysicalDamageConvertToCold", "BASE", nil, 0, 0, { type = "SkillPart", skillPart = 3 }),
 			mod("SkillPhysicalDamageConvertToLightning", "BASE", nil, 0, 0, { type = "SkillPart", skillPart = 3 }),
 			mod("SkillPhysicalDamageConvertToCold", "BASE", nil, 0, 0, { type = "SkillPart", skillPart = 4 }),
+			mod("SkillPhysicalDamageConvertToCold", "BASE", nil, 0, 0, { type = "SkillPart", skillPart = 5 }),
+			mod("SkillPhysicalDamageConvertToLightning", "BASE", nil, 0, 0, { type = "SkillPart", skillPart = 6 }),
+            mod("SkillPhysicalDamageConvertToCold", "BASE", nil, 0, 0, { type = "SkillPart", skillPart = 7 }),
+            mod("SkillPhysicalDamageConvertToLightning", "BASE", nil, 0, 0, { type = "SkillPart", skillPart = 7 }),
 		},
 		["water_sphere_cold_lightning_exposure_%"] = {
 			mod("ColdExposure", "BASE", nil, 0, 0, { type = "GlobalEffect", effectType = "Debuff" } ),

--- a/src/Data/Skills/act_int.lua
+++ b/src/Data/Skills/act_int.lua
@@ -8643,25 +8643,31 @@ skills["Hydrosphere"] = {
 	statDescriptionScope = "skill_stat_descriptions",
 	castTime = 0.6,
 	parts = {
-		{
-			name = "Frozen",
-		},
-		{
-			name = "Shocked",
-		},
-		{
-			name = "Frozen & Shocked",
-		}
+			{
+                name = "Frozen (Autopulse)",
+            },
+            {
+                name = "Shocked (Autopulse)",
+            },
+            {
+                name = "Frozen & Shocked (Autopulse)",
+            },
+            {
+                name = "Cast",
+            }
 	},
 	preDamageFunc = function(activeSkill, output)
-		activeSkill.skillData.hitTimeOverride = activeSkill.skillData.repeatFrequency / (1 + activeSkill.skillModList:Sum("INC", activeSkill.skillCfg, "HydroSphereFrequency") / 100)
-	end,
+        if activeSkill.skillPart == 1 or activeSkill.skillPart == 2 or activeSkill.skillPart == 3 then
+            activeSkill.skillData.hitTimeOverride = activeSkill.skillData.repeatFrequency / (1 + activeSkill.skillModList:Sum("INC", activeSkill.skillCfg, "HydroSphereFrequency") / 100)
+        end
+    end,
 	statMap = {
 		["skill_physical_damage_%_to_convert_to_cold"] = {
 			mod("SkillPhysicalDamageConvertToCold", "BASE", nil, 0, 0, { type = "SkillPart", skillPart = 1 }),
 			mod("SkillPhysicalDamageConvertToLightning", "BASE", nil, 0, 0, { type = "SkillPart", skillPart = 2 }),
 			mod("SkillPhysicalDamageConvertToCold", "BASE", nil, 0, 0, { type = "SkillPart", skillPart = 3 }),
 			mod("SkillPhysicalDamageConvertToLightning", "BASE", nil, 0, 0, { type = "SkillPart", skillPart = 3 }),
+			mod("SkillPhysicalDamageConvertToCold", "BASE", nil, 0, 0, { type = "SkillPart", skillPart = 4 }),
 		},
 		["water_sphere_cold_lightning_exposure_%"] = {
 			mod("ColdExposure", "BASE", nil, 0, 0, { type = "GlobalEffect", effectType = "Debuff" } ),

--- a/src/Export/Skills/act_int.txt
+++ b/src/Export/Skills/act_int.txt
@@ -1753,25 +1753,31 @@ local skills, mod, flag, skill = ...
 #skill Hydrosphere
 #flags spell duration area
 	parts = {
-		{
-			name = "Frozen",
-		},
-		{
-			name = "Shocked",
-		},
-		{
-			name = "Frozen & Shocked",
-		}
+			{
+                name = "Frozen (Autopulse)",
+            },
+            {
+                name = "Shocked (Autopulse)",
+            },
+            {
+                name = "Frozen & Shocked (Autopulse)",
+            },
+            {
+                name = "Cast",
+            }
 	},
 	preDamageFunc = function(activeSkill, output)
-		activeSkill.skillData.hitTimeOverride = activeSkill.skillData.repeatFrequency / (1 + activeSkill.skillModList:Sum("INC", activeSkill.skillCfg, "HydroSphereFrequency") / 100)
-	end,
+        if activeSkill.skillPart == 1 or activeSkill.skillPart == 2 or activeSkill.skillPart == 3 then
+            activeSkill.skillData.hitTimeOverride = activeSkill.skillData.repeatFrequency / (1 + activeSkill.skillModList:Sum("INC", activeSkill.skillCfg, "HydroSphereFrequency") / 100)
+        end
+    end,
 	statMap = {
 		["skill_physical_damage_%_to_convert_to_cold"] = {
 			mod("SkillPhysicalDamageConvertToCold", "BASE", nil, 0, 0, { type = "SkillPart", skillPart = 1 }),
 			mod("SkillPhysicalDamageConvertToLightning", "BASE", nil, 0, 0, { type = "SkillPart", skillPart = 2 }),
 			mod("SkillPhysicalDamageConvertToCold", "BASE", nil, 0, 0, { type = "SkillPart", skillPart = 3 }),
 			mod("SkillPhysicalDamageConvertToLightning", "BASE", nil, 0, 0, { type = "SkillPart", skillPart = 3 }),
+			mod("SkillPhysicalDamageConvertToCold", "BASE", nil, 0, 0, { type = "SkillPart", skillPart = 4 }),
 		},
 		["water_sphere_cold_lightning_exposure_%"] = {
 			mod("ColdExposure", "BASE", nil, 0, 0, { type = "GlobalEffect", effectType = "Debuff" } ),

--- a/src/Export/Skills/act_int.txt
+++ b/src/Export/Skills/act_int.txt
@@ -1754,16 +1754,25 @@ local skills, mod, flag, skill = ...
 #flags spell duration area
 	parts = {
 			{
-                name = "Frozen (Autopulse)",
+                name = "Autopulse (Frozen)",
             },
             {
-                name = "Shocked (Autopulse)",
+                name = "Autopulse (Shocked)",
             },
             {
-                name = "Frozen & Shocked (Autopulse)",
+                name = "Autopulse (Frozen & Shocked)",
             },
             {
-                name = "Cast",
+                name = "Cast (No Ailment)",
+            },
+            {
+                name = "Cast (Frozen)",
+            },
+            {
+                name = "Cast (Shocked)",
+            },
+            {
+                name = "Cast (Frozen & Shocked)",
             }
 	},
 	preDamageFunc = function(activeSkill, output)
@@ -1778,6 +1787,10 @@ local skills, mod, flag, skill = ...
 			mod("SkillPhysicalDamageConvertToCold", "BASE", nil, 0, 0, { type = "SkillPart", skillPart = 3 }),
 			mod("SkillPhysicalDamageConvertToLightning", "BASE", nil, 0, 0, { type = "SkillPart", skillPart = 3 }),
 			mod("SkillPhysicalDamageConvertToCold", "BASE", nil, 0, 0, { type = "SkillPart", skillPart = 4 }),
+			mod("SkillPhysicalDamageConvertToCold", "BASE", nil, 0, 0, { type = "SkillPart", skillPart = 5 }),
+			mod("SkillPhysicalDamageConvertToLightning", "BASE", nil, 0, 0, { type = "SkillPart", skillPart = 6 }),
+            mod("SkillPhysicalDamageConvertToCold", "BASE", nil, 0, 0, { type = "SkillPart", skillPart = 7 }),
+            mod("SkillPhysicalDamageConvertToLightning", "BASE", nil, 0, 0, { type = "SkillPart", skillPart = 7 }),
 		},
 		["water_sphere_cold_lightning_exposure_%"] = {
 			mod("ColdExposure", "BASE", nil, 0, 0, { type = "GlobalEffect", effectType = "Debuff" } ),


### PR DESCRIPTION
Fixes #1968 

### Description of the problem being solved:
"There is no way of calculating Hydrosphere damage when casting it. Currently, only "auto" pulses are accounted."
Solution:
Added skill part "Cast" for Hydrosphere, for when the Hydrosphere is continuously recast. Adjusted skill part names for Frozen, Shocked and Frozen & Shocked for clarity. Split "Cast" further into Frozen, Shocked and Frozen Shocked skill parts since the damage pulse from casting actually also converts depending on the ailment of the sphere. 

### Steps taken to verify a working solution:
- Tested in PoB
- skills script executed in dat view without related errors


### Link to a build that showcases this PR:
https://pobb.in/ClnxZZVGiH5d
### Before screenshot:
![image](https://github.com/user-attachments/assets/78e7117b-068c-4b96-a2c0-0e9fff41e2d1)

### After screenshot:
![image](https://github.com/user-attachments/assets/9a06e081-d190-477d-928f-a640592dfcfa)
