### PR TITLE
Change wording for "Base Damage Reduction" on Hit taken mult. section…

### DIFF
--- a/src/Modules/CalcDefence.lua
+++ b/src/Modules/CalcDefence.lua
@@ -1955,7 +1955,7 @@ function calcs.buildDefenceEstimations(env, actor)
 				t_insert(breakdown[damageType.."TakenHitMult"], s_format("= %.2f", resMult))
 			end
 			if reduction ~= 0 then
-				t_insert(breakdown[damageType.."TakenHitMult"], s_format("Base %s Damage Reduction: %.2f", damageType, 1 - reduction / 100))
+				t_insert(breakdown[damageType.."TakenHitMult"], s_format("Base %s Damage Taken: %.2f", damageType, 1 - reduction / 100))
 			end
 			if armourReduct ~= 0 then
 				if resMult ~= 1 then


### PR DESCRIPTION
… of Calcs

This affects tooltips for all types of damage, not just Cold.

Fixes # .

### Description of the problem being solved:

https://github.com/PathOfBuildingCommunity/PathOfBuilding/issues/8378

Saying "# Damage Reduction" can be misleading when, if the reduction is 35%, the shown value is 0.65 (or 65%), which is the value _after_ the reduction.

### Steps taken to verify a working solution:
- Use the build provided and check the tooltip text on Calcs>Damaging Hits>Hit taken Mult.

### Link to a build that showcases this PR:
```
https://pobb.in/avrPMV5OETPF
```

### Before screenshot:
![image](https://github.com/user-attachments/assets/e06232a1-c8ea-403e-8f1f-cb7dc3f6b1f3)

### After screenshot:
![image](https://github.com/user-attachments/assets/541ace45-1f7f-4877-b5fe-1fc92de740e3)