### PR TITLE
Add showcased Mercenaries of Trarthus uniques

### DIFF
--- a/src/Data/Uniques/Special/New.lua
+++ b/src/Data/Uniques/Special/New.lua
@@ -3,6 +3,70 @@
 --
 
 data.uniques.new = {
-
 -- New
+
+[[
+Starcaller
+Abyssal Axe
+League: Mercenaries of Trarthus
+Requires Level 55, 128 Str, 60 Dex
+Trigger Level 20 Starfall on Melee Critical Strike
++17 to all Attributes
+168% increased Physical Damage
+22% increased Critical Strike Chance
+20% increased Area of Effect
+Gain 46% of Weapon Physical Damage as Extra Damage of a Random Element
+]],[[
+Wine of the Prophet
+Gold Flask
+League: Mercenaries of Trarthus
+Requires Level 27
++60 to Maximum Charges
+89% increased Charges per Use
+Grants a random Divination buff for 20 seconds when used
+]],[[
+Scornflux
+Satin Slippers
+League: Mercenaries of Trarthus
+Requires Level 54, 69 Int
++10 to Intelligence
++66 to Maximum Mana
++12% to all Elemental Resistances
+Gain Arcane Surge when you use a Movement Skill
+Increase to Cast Speed from Arcane Surge also applies to Movement Speed
+]],[[
+Prospero's Protection
+Iron Ring
+League: Mercenaries of Trarthus
+Requires Level 32
+Implicits: 1
+Adds 1 to 4 Physical Damage to Attacks
+5% chance to Block Attack Damage
++18 to Strength
++53 to Maximum Life
+Armour from equipped shield is doubled
+Gain no armour from equipped body armour
+]],[[
+Howlcrack
+Ezomyte Burgonet
+League: Mercenaries of Trarthus
+Requires Level 60, 138 Str
++33 to Strength
+121% increased Armour
+Non-instant Warcries you use yourself have no Cooldown
+Warcries have an additional Life Cost equal to 15% of your Maximum Life
+Warcry Skills have 16% increased Area of Effect
+]],[[
+Enmity's Embrace
+Vermillion Ring
+League: Mercenaries of Trarthus
+Requires Level 80
+Implicits: 1
+6% increased Maximum Life
++49 to Strength
+14% increased Fire Damage
+55% reduced Fire Resistance
+Take 449 Fire Damage when you use a Skill
+Damage penetrates Fire Resistance equal to your overcapped Fire Resistance
+]]
 }

--- a/src/Modules/CalcPerform.lua
+++ b/src/Modules/CalcPerform.lua
@@ -657,7 +657,11 @@ local function doActorMisc(env, actor)
 			modDB.conditions["AffectedByArcaneSurge"] = true
 			local effect = 1 + modDB:Sum("INC", nil, "ArcaneSurgeEffect", "BuffEffectOnSelf") / 100
 			modDB:NewMod("ManaRegen", "INC", (modDB:Max(nil, "ArcaneSurgeManaRegen") or 30) * effect, "Arcane Surge")
-			modDB:NewMod("Speed", "INC", (modDB:Max(nil, "ArcaneSurgeCastSpeed") or 10) * effect, "Arcane Surge", ModFlag.Cast)
+			local arcaneSurgeCastSpeed = (modDB:Max(nil, "ArcaneSurgeCastSpeed") or 10) * effect
+			modDB:NewMod("Speed", "INC", arcaneSurgeCastSpeed, "Arcane Surge", ModFlag.Cast)
+			if modDB:Flag(nil, "ArcaneSurgeCastSpeedToMovementSpeed") then
+				modDB:NewMod("MovementSpeed", "INC", arcaneSurgeCastSpeed, "Arcane Surge")
+			end
 			local arcaneSurgeDamage = modDB:Max(nil, "ArcaneSurgeDamage") or 0
 			if arcaneSurgeDamage ~= 0 then modDB:NewMod("Damage", "MORE", arcaneSurgeDamage * effect, "Arcane Surge", ModFlag.Spell) end
 		end

--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -1712,6 +1712,7 @@ local modTagList = {
 	["if you haven't summoned a totem in the past 2 seconds"] = { tag = { type = "Condition", var = "NoSummonedTotemsInPastTwoSeconds" }  },
 	["if you[' ]h?a?ve used a minion skill recently"] = { tag = { type = "Condition", var = "UsedMinionSkillRecently" } },
 	["if you[' ]h?a?ve used a movement skill recently"] = { tag = { type = "Condition", var = "UsedMovementSkillRecently" } },
+	["when you use a movement skill"] = { tag = { type = "Condition", var = "UsedMovementSkillRecently" } },
 	["if you haven't cast dash recently"] = { tag = { type = "Condition", var = "CastDashRecently", neg = true } },
 	["if you[' ]h?a?ve cast dash recently"] = { tag = { type = "Condition", var = "CastDashRecently" } },
 	["if you[' ]h?a?ve used a vaal skill recently"] = { tag = { type = "Condition", var = "UsedVaalSkillRecently" } },
@@ -2192,6 +2193,7 @@ local specialModList = {
 		mod("ManaConvertToArmour", "BASE", num),
 	} end,
 	["life recovery from flasks also applies to energy shield"] = { flag("LifeFlaskAppliesToEnergyShield") },
+	["increase to cast speed from arcane surge also applies to movement speed"] = { flag("ArcaneSurgeCastSpeedToMovementSpeed") },
 	["non%-instant mana recovery from flasks is also recovered as life"] = { flag("ManaFlaskAppliesToLife") },
 	["life leech effects recover energy shield instead while on full life"] = { flag("ImmortalAmbition", { type = "Condition", var = "FullLife" }, { type = "Condition", var = "LeechingLife" }) },
 	["shepherd of souls"] = {


### PR DESCRIPTION
### Description of the problem being solved:

Not sure if this is worth a PR but i added the showcased uniques to New.lua and started working on parsing for the new mods:

- [ ] `Trigger Level 20 Starfall on Melee Critical Strike`
This will require gem data to implement correctly.
- [ ] `Grants a random Divination buff for 20 seconds when used`
List of available mods is currently unknown
- [x] `Gain Arcane Surge when you use a Movement Skill`
- [x] `Increase to Cast Speed from Arcane Surge also applies to Movement Speed`
- [ ] `Armour from equipped shield is doubled`
The code for handling this could use some generalization. Currently not implemented.
- [ ] `Gain no armour from equipped body armour`
- [ ] `Non-instant Warcries you use yourself have no Cooldown`
- [ ] `Warcries have an additional Life Cost equal to 15% of your Maximum Life`
- [ ] `Damage penetrates Fire Resistance equal to your overcapped Fire Resistance`
- [ ] `Take 449 Fire Damage when you use a Skill`

I'll try to find time to implement more of these. Note that the mod ranges on the uniques are not working as they are not known right now.