### PR TITLE
Enable Sorting of folders by date and inherit the sort order in the build save dialog

### DIFF
--- a/src/Classes/FolderListControl.lua
+++ b/src/Classes/FolderListControl.lua
@@ -16,7 +16,7 @@ end
 local FolderListClass = newClass("FolderListControl", "ListControl", function(self, anchor, rect, subPath, onChange)
 	self.ListControl(anchor, rect, 16, "VERTICAL", false, { })
 	self.subPath = subPath or ""
-    self.onChangeCallback = onChange
+	self.onChangeCallback = onChange
 
 	self.controls.path = new("PathControl", {"BOTTOM",self,"TOP"}, {0, -2, self.width, 24}, main.buildPath, self.subPath, function(newSubPath)
 		self.subPath = newSubPath
@@ -31,21 +31,21 @@ local FolderListClass = newClass("FolderListControl", "ListControl", function(se
 end)
 
 function FolderListClass:SortList()
-    if not self.list then return end
-    local sortMode = main.buildSortMode or "NAME"
+	if not self.list then return end
+	local sortMode = main.buildSortMode or "NAME"
 
-    table.sort(self.list, function(a, b)
-        if sortMode == "EDITED" then
-            local modA = a.modified or 0 
-            local modB = b.modified or 0
-            if modA ~= modB then
-                return modA > modB
-            end
-            return naturalSortCompare(a.name, b.name)
-        else
-            return naturalSortCompare(a.name, b.name)
-        end
-    end)
+	table.sort(self.list, function(a, b)
+		if sortMode == "EDITED" then
+			local modA = a.modified or 0 
+			local modB = b.modified or 0
+			if modA ~= modB then
+				return modA > modB
+			end
+			return naturalSortCompare(a.name, b.name)
+		else
+			return naturalSortCompare(a.name, b.name)
+		end
+	end)
 end
 
 function FolderListClass:BuildList()
@@ -56,13 +56,13 @@ function FolderListClass:BuildList()
 		t_insert(self.list, { 
 			name = fileName,
 			fullFileName = main.buildPath..self.subPath..fileName,
-            modified = handle:GetFileModifiedTime()
+			modified = handle:GetFileModifiedTime()
 		})
 		if not handle:NextFile() then
 			break
 		end
 	end
-    if handle and handle.Close then handle:Close() end
+	if handle and handle.Close then handle:Close() end
 
 	self:SortList()
 	if self.UpdateScrollbar then self:UpdateScrollbar() end

--- a/src/Classes/FolderListControl.lua
+++ b/src/Classes/FolderListControl.lua
@@ -6,20 +6,47 @@
 local ipairs = ipairs
 local t_insert = table.insert
 
+local function naturalSortCompare(a, b)
+    if _G.naturalSortCompare then return _G.naturalSortCompare(a,b)
+    elseif common and common.naturalSortCompare then return common.naturalSortCompare(a,b)
+    else return a < b
+    end
+end
+
 local FolderListClass = newClass("FolderListControl", "ListControl", function(self, anchor, rect, subPath, onChange)
 	self.ListControl(anchor, rect, 16, "VERTICAL", false, { })
 	self.subPath = subPath or ""
-	self.controls.path = new("PathControl", {"BOTTOM",self,"TOP"}, {0, -2, self.width, 24}, main.buildPath, self.subPath, function(subPath)
-		self.subPath = subPath
+    self.onChangeCallback = onChange
+
+	self.controls.path = new("PathControl", {"BOTTOM",self,"TOP"}, {0, -2, self.width, 24}, main.buildPath, self.subPath, function(newSubPath)
+		self.subPath = newSubPath
 		self:BuildList()
 		self.selIndex = nil
 		self.selValue = nil
-		if onChange then
-			onChange(subPath)
+		if self.onChangeCallback then
+			self.onChangeCallback(newSubPath)
 		end
 	end)
 	self:BuildList()
 end)
+
+function FolderListClass:SortList()
+    if not self.list then return end
+    local sortMode = main.buildSortMode or "NAME"
+
+    table.sort(self.list, function(a, b)
+        if sortMode == "EDITED" then
+            local modA = a.modified or 0 
+            local modB = b.modified or 0
+            if modA ~= modB then
+                return modA > modB
+            end
+            return naturalSortCompare(a.name, b.name)
+        else
+            return naturalSortCompare(a.name, b.name)
+        end
+    end)
+end
 
 function FolderListClass:BuildList()
 	wipeTable(self.list)
@@ -29,11 +56,17 @@ function FolderListClass:BuildList()
 		t_insert(self.list, { 
 			name = fileName,
 			fullFileName = main.buildPath..self.subPath..fileName,
+            modified = handle:GetFileModifiedTime()
 		})
 		if not handle:NextFile() then
 			break
 		end
 	end
+    if handle and handle.Close then handle:Close() end
+
+	self:SortList()
+	if self.UpdateScrollbar then self:UpdateScrollbar() end
+	if self.Redraw then self:Redraw() end
 end
 
 function FolderListClass:OpenFolder(folderName)
@@ -61,7 +94,7 @@ function FolderListClass:OnSelDelete(index, folder)
 			main:OpenMessagePopup("Error", "Couldn't delete '"..folder.fullFileName.."': "..msg)
 			return
 		end
-		self:BuildList()
+		self:BuildList() 
 		self.selIndex = nil
 		self.selValue = nil
 	end

--- a/src/Classes/FolderListControl.lua
+++ b/src/Classes/FolderListControl.lua
@@ -6,13 +6,6 @@
 local ipairs = ipairs
 local t_insert = table.insert
 
-local function naturalSortCompare(a, b)
-    if _G.naturalSortCompare then return _G.naturalSortCompare(a,b)
-    elseif common and common.naturalSortCompare then return common.naturalSortCompare(a,b)
-    else return a < b
-    end
-end
-
 local FolderListClass = newClass("FolderListControl", "ListControl", function(self, anchor, rect, subPath, onChange)
 	self.ListControl(anchor, rect, 16, "VERTICAL", false, { })
 	self.subPath = subPath or ""

--- a/src/Modules/BuildList.lua
+++ b/src/Modules/BuildList.lua
@@ -231,13 +231,14 @@ function listMode:BuildList()
 			break
 		end
 	end
-	handle = NewFileSearch(main.buildPath..self.subPath.."*", true)
+handle = NewFileSearch(main.buildPath..self.subPath.."*", true)
 	while handle do
 		local folderName = handle:GetFileName()
 		t_insert(self.list, {
 			folderName = folderName,
 			subPath = self.subPath,
 			fullFileName = main.buildPath..self.subPath..folderName,
+			modified = handle:GetFileModifiedTime()
 		})
 		if not handle:NextFile() then
 			break
@@ -249,35 +250,58 @@ end
 function listMode:SortList()
 	local oldSelFileName = self.controls.buildList.selValue and self.controls.buildList.selValue.fileName
 	table.sort(self.list, function(a, b)
-		if a.folderName and b.folderName then
-			return naturalSortCompare(a.folderName, b.folderName)
-		elseif a.folderName and not b.folderName then
-			return true
-		elseif not a.folderName and b.folderName then
-			return false
-		end
+		local a_is_folder = a.folderName ~= nil
+		local b_is_folder = b.folderName ~= nil
+
+		if a_is_folder and not b_is_folder then return true end
+		if not a_is_folder and b_is_folder then return false end
+
+
 		if main.buildSortMode == "EDITED" then
-			return a.modified > b.modified
-		elseif main.buildSortMode == "CLASS" then
-			if a.className and not b.className then
-				return false
-			elseif not a.className and b.className then
-				return true
-			elseif a.className ~= b.className then
-				return a.className < b.className
-			elseif a.ascendClassName ~= b.ascendClassName then
-				return a.ascendClassName < b.ascendClassName
+			local modA = a.modified or 0 -- Use 0 as fallback if modified time is nil
+			local modB = b.modified or 0
+			if modA ~= modB then
+				return modA > modB -- Newest first maybe allow for inverting of order?
 			end
-		elseif main.buildSortMode == "LEVEL" then
-			if a.level and not b.level then
-				return false
-			elseif not a.level and b.level then
-				return true
+			-- If modified times are the same or both 0 fall back to name sort
+			if a_is_folder then
+				return naturalSortCompare(a.folderName, b.folderName)
 			else
-				return a.level < b.level
+				return naturalSortCompare(a.fileName, b.fileName)
 			end
 		end
-		return naturalSortCompare(a.fileName, b.fileName)
+
+		if a_is_folder then
+			return naturalSortCompare(a.folderName, b.folderName)
+		else
+			if main.buildSortMode == "CLASS" then
+				local a_has_class = a.className ~= nil
+				local b_has_class = b.className ~= nil
+				if not a_has_class and b_has_class then return true
+				elseif a_has_class and not b_has_class then return false
+				elseif a_has_class and b_has_class and a.className ~= b.className then
+					return a.className < b.className
+				end
+
+				local a_has_asc = a.ascendClassName ~= nil
+				local b_has_asc = b.ascendClassName ~= nil
+				if not a_has_asc and b_has_asc then return true
+				elseif a_has_asc and not b_has_asc then return false
+				elseif a_has_asc and b_has_asc and a.ascendClassName ~= b.ascendClassName then
+					return a.ascendClassName < b.ascendClassName
+				end
+				return naturalSortCompare(a.fileName, b.fileName)
+			elseif main.buildSortMode == "LEVEL" then
+				if a.level and not b.level then return false
+				elseif not a.level and b.level then return true
+				elseif a.level and b.level then
+					if a.level ~= b.level then return a.level < b.level end
+				end
+				return naturalSortCompare(a.fileName, b.fileName)
+			else
+				return naturalSortCompare(a.fileName, b.fileName)
+			end
+		end
 	end)
 	if oldSelFileName then
 		self.controls.buildList:SelByFileName(oldSelFileName)


### PR DESCRIPTION
This PR introduces improved folder sorting capabilities:
Build List:
Folders are now sorted by modification time (newest first) when "Sort by Last Edited" is active.
For other sort modes (Name, Class, Level), folders are sorted by name (A-Z).
Files continue to sort based on the selected mode.
Folders are always listed before files.
Save As Dialog:
The folder list within the "Save As" dialog now inherits its sorting behavior from the main build list's current Sort by setting (main.buildSortMode).
If "Sort by Last Edited" is active in the main list, folders in the "Save As" dialog are sorted by modification time (newest first).
Otherwise, folders in the "Save As" dialog are sorted by name (A-Z).