### PR TITLE
Update Arcane Surge cast speed from 10% to 20%

### DIFF
--- a/src/Modules/CalcPerform.lua
+++ b/src/Modules/CalcPerform.lua
@@ -657,7 +657,7 @@ local function doActorMisc(env, actor)
 			modDB.conditions["AffectedByArcaneSurge"] = true
 			local effect = 1 + modDB:Sum("INC", nil, "ArcaneSurgeEffect", "BuffEffectOnSelf") / 100
 			modDB:NewMod("ManaRegen", "INC", (modDB:Max(nil, "ArcaneSurgeManaRegen") or 30) * effect, "Arcane Surge")
-			modDB:NewMod("Speed", "INC", (modDB:Max(nil, "ArcaneSurgeCastSpeed") or 10) * effect, "Arcane Surge", ModFlag.Cast)
+			modDB:NewMod("Speed", "INC", (modDB:Max(nil, "ArcaneSurgeCastSpeed") or 20) * effect, "Arcane Surge", ModFlag.Cast)
 			local arcaneSurgeDamage = modDB:Max(nil, "ArcaneSurgeDamage") or 0
 			if arcaneSurgeDamage ~= 0 then modDB:NewMod("Damage", "MORE", arcaneSurgeDamage * effect, "Arcane Surge", ModFlag.Spell) end
 		end


### PR DESCRIPTION
### Description of the problem being solved:

One liner to update arcane surge cast speed modifier calculation ahead of 3.26 based on patch notes. Feel free to close if there's a convention of waiting until closer to the release to start making these changes! Just getting my feet wet confirming my dev environment was set up correctly 😄 

Evidence for change:
https://www.pathofexile.com/forum/view-thread/3787013
![image](https://github.com/user-attachments/assets/892186c3-49da-46c0-92fc-703e82d0a993)


### Steps taken to verify a working solution:
Validated minimal case by attaching arcane surge to a sample build and confirming cast rate is impacted appropriately.

Tests pass (although as far as I can tell no direct coverage for this mod? I can look into adding some if preferred)
![image](https://github.com/user-attachments/assets/d9e66b97-1502-49e4-8db0-d1ec01fc0468)


### Before screenshot:
![image](https://github.com/user-attachments/assets/f7f49fea-8429-4e8e-89c8-5a35472c1454)![image](https://github.com/user-attachments/assets/cca2e31b-4443-46dd-baad-d2a2b8e39643)

### After screenshot:
![image](https://github.com/user-attachments/assets/f7f49fea-8429-4e8e-89c8-5a35472c1454)
![image](https://github.com/user-attachments/assets/b477107c-8251-4f04-9bd1-c35a264617ad)
