### PR TITLE
Adding Shortcut to Copy Node Text from Passive Tree to Clipboard

### DIFF
--- a/src/Classes/PassiveTreeView.lua
+++ b/src/Classes/PassiveTreeView.lua
@@ -114,6 +114,12 @@ function PassiveTreeViewClass:Draw(build, viewPort, inputEvents)
 				self.showHeatMap = not self.showHeatMap
 			elseif event.key == "d" and IsKeyDown("CTRL") then
 				self.showStatDifferences = not self.showStatDifferences
+			elseif event.key == "c" and IsKeyDown("CTRL") and self.hoverNode and self.hoverNode.type ~= "Socket" then
+				local result = "# ".. self.hoverNode.dn .. "\n"
+				for _, line in ipairs(self.hoverNode.sd) do
+					result = result .. line .. "\n"
+				end
+				Copy(result)
 			elseif event.key == "PAGEUP" then
 				self:Zoom(IsKeyDown("SHIFT") and 3 or 1, viewPort)
 			elseif event.key == "PAGEDOWN" then
@@ -1166,5 +1172,6 @@ function PassiveTreeViewClass:AddNodeTooltip(tooltip, node, build)
 		tooltip:AddLine(14, colorCodes.TIP.."Tip: Hold Shift or Ctrl to hide this tooltip.")
 	else
 		tooltip:AddLine(14, colorCodes.TIP.."Tip: Hold Ctrl to hide this tooltip.")
+		tooltip:AddLine(14, colorCodes.TIP.."Tip: Press Ctrl+C to copy this node's text.")
 	end
 end


### PR DESCRIPTION
Not based on an issue.

### Description of the problem being solved:
When using the custom modifiers in the configuration tab, having the exact wording for the mod can be tedious. Mainly for that, but maybe also for other use cases, a Copy Shortcut (CTRL+C) was added to nodes in the tree. An appropriate tip for this shortcut was also added.

The shortcut copies the node's text and the node's name to the clipboard, to paste it for example into the custom modifiers field.
This works for all nodes except for jewel sockets.

The format for the copy is:
```
# <Node Name>
<Mods>
```

For example this node:
![image](https://github.com/user-attachments/assets/3ac51b83-befa-423e-a1ff-87dc85cd929a)

Gets copied as:
![image](https://github.com/user-attachments/assets/b540c3e6-8182-4b0c-bc7d-489505abaa62)

### Steps taken to verify a working solution:
- Pressed CTRL+C on a node in the tree
- Pasted that into the custom modifiers field
- checked that the mods apply correctly, while the node name works like a comment

### Link to a build that showcases this PR:
https://pobb.in/Bkwaz5SbqcH_

### Before screenshot:
![image](https://github.com/user-attachments/assets/e0bc1181-c1ba-44ea-98d4-0752d2413bbf)

### After screenshot:
![image](https://github.com/user-attachments/assets/e2c3c111-a896-4d73-a02d-1147f341367d)