### PR TITLE
Update Death Aura damage

### DIFF
--- a/src/Data/Skills/other.lua
+++ b/src/Data/Skills/other.lua
@@ -803,7 +803,7 @@ skills["DeathAura"] = {
 		skill("radius", 30),
 	},
 	constantStats = {
-		{ "base_chaos_damage_to_deal_per_minute", 60000 },
+		{ "base_chaos_damage_to_deal_per_minute", 75000 },
 	},
 	stats = {
 		"cast_on_gain_skill",


### PR DESCRIPTION
Fixes #8636

### Description of the problem being solved:
GGG buffed Death Aura in the 3.26 patch notes, increasing its base chaos damage over time. This PR updates the Path of Building implementation to reflect that change — raising the base damage from 1000 to 1250 chaos damage per second (i.e., from 60000 to 75000 per minute in internal values).

### Steps taken to verify a working solution:

1. Modified src/Data/Skills/other.lua, changing:

```
constantStats = {
{ "base_chaos_damage_to_deal_per_minute", 60000 },
},
```
to:
```
constantStats = {
{ "base_chaos_damage_to_deal_per_minute", 75000 },
},
```
2. Launched local build of Path of Building.
3. Created a test build with Death's Oath to see Death Aura changes.
4. Verified that the Chaos Damage per Second reflected the new base value (1250).
5. Compared DPS in item tooltip and skill breakdown panel.

### Link to a build that showcases this PR:
[Level 1 Death Aura Scion](https://pobb.in/wxDdoJ5lfpTW)

**Before screenshot:**
<img width="414" alt="{79876787-E03B-4EDC-957C-F5FE8E8DA83F}" src="https://github.com/user-attachments/assets/a1f370a0-2aff-4ea0-a2d1-c94b39374cc0" />

**After screenshot:**
<img width="605" alt="{D342AE5A-5781-47C2-9DBD-358C65DFCB7A}" src="https://github.com/user-attachments/assets/c975ed7b-a174-42ee-84a1-f13370620d2e" />