### PR TITLE
[3.26] Unique changes

### DIFF
--- a/src/Data/Uniques/axe.lua
+++ b/src/Data/Uniques/axe.lua
@@ -8,10 +8,13 @@ Butcher Axe
 League: Heist
 Source: Steal from a unique{Curio Display} during a Grand Heist
 Implicits: 0
+Variant: Pre 3.26.0
+Variant: Current
 Has no Sockets
 (200-250)% increased Physical Damage
 You have no Intelligence
-Critical Strike Chance is (20-30)% for Hits with this Weapon
+{variant:1}Critical Strike Chance is (20-30)% for Hits with this Weapon
+{variant:2}Critical Strike Chance is (30-40)% for Hits with this Weapon
 ]],[[
 Dreadarc
 Cleaver

--- a/src/Data/Uniques/body.lua
+++ b/src/Data/Uniques/body.lua
@@ -818,21 +818,23 @@ Variant: Pre 2.6.0
 Variant: Pre 3.5.0
 Variant: Pre 3.16.0
 Variant: Pre 3.19.0
+Variant: Pre 3.26.0
 Variant: Current
 Implicits: 0
 {variant:1,2,3}(160-200)% increased Armour and Evasion
-{variant:4,5}(180-220)% increased Armour and Evasion
+{variant:4,5,6}(180-220)% increased Armour and Evasion
 {variant:1,2}+(40-60) to maximum Life
-{variant:3,4,5}+(60-90) to maximum Life
+{variant:3,4,5,6}+(60-90) to maximum Life
 {variant:1,2,3,4}(0.4-0.6)% of Physical Attack Damage Leeched as Life
 {variant:5}2% of Physical Attack Damage Leeched as Life
+{variant:6}2% of Attack Damage Leeched as Life
 You lose all Endurance Charges when Hit
 You gain an Endurance Charge on Kill
 {variant:1}You gain Onslaught for 1 seconds per Endurance Charge when Hit
 {variant:2}You gain Onslaught for 2 seconds per Endurance Charge when Hit
-{variant:3,4,5}You gain Onslaught for 5 seconds per Endurance Charge when Hit
+{variant:3,4,5,6}You gain Onslaught for 5 seconds per Endurance Charge when Hit
 {variant:3,4}(60-100)% increased Onslaught Effect
-{variant:5}100% increased Onslaught Effect
+{variant:5,6}100% increased Onslaught Effect
 ]],[[
 Farrul's Fur
 Triumphant Lamellar
@@ -1368,9 +1370,12 @@ The Admiral
 Varnished Coat
 League: Heist
 Source: Drops from unique{Admiral Darnaw} in normal{Contract: Death to Darnaw}
+Variant: Pre 3.26.0
+Variant: Current
 Implicits: 0
 +(30-40) to Intelligence
-(100-140)% increased Evasion and Energy Shield
+{variant:1}(100-140)% increased Evasion and Energy Shield
+{variant:2}(120-200)% increased Evasion and Energy Shield
 +(10-20)% to all Elemental Resistances
 (5-10)% chance to Freeze, Shock and Ignite
 Elemental Damage you Deal with Hits is Resisted by lowest Elemental Resistance instead

--- a/src/Data/Uniques/gloves.lua
+++ b/src/Data/Uniques/gloves.lua
@@ -300,8 +300,10 @@ Allelopathy
 {variant:1}Sorcerer Gloves
 {variant:2}Satin Gloves
 Variant: Pre 3.19.0
+Variant: Pre 3.26.0
 Variant: Current
-Grants Level 22 Blight Skill
+{variant:1,2}Grants Level 22 Blight Skill
+{variant:3}Grants Level 25 Blight Skill
 {variant:1}(20-30)% increased Damage over Time
 (100-120)% increased Energy Shield
 10% increased Area of Effect of Area Skills
@@ -312,10 +314,12 @@ Replica Allelopathy
 {variant:1}Sorcerer Gloves
 {variant:2}Satin Gloves
 Variant: Pre 3.19.0
+Variant: Pre 3.26.0
 Variant: Current
 League: Heist
 Source: Steal from a unique{Curio Display} during a Grand Heist
-Grants Level 22 Wintertide Brand
+{variant:1,2}Grants Level 22 Wintertide Brand
+{variant:3}Grants Level 25 Wintertide Brand
 {variant:1}(20-30)% increased Damage over Time
 (100-120)% increased Energy Shield
 10% increased Area of Effect

--- a/src/Data/Uniques/mace.lua
+++ b/src/Data/Uniques/mace.lua
@@ -214,12 +214,12 @@ Variant: Current
 Requires Level 68, 212 Str
 Implicits: 1
 10% reduced Enemy Stun Threshold
-Adds (45-60) to (100-120) Physical Damage 
-Gain (30-40)% of Physical Attack Damage as Extra Fire Damage 
-+4% to Chaos Resistance per Endurance Charge 
-1% reduced Elemental Damage taken from Hits per Endurance Charge 
-Adds 5 to 8 Physical Damage per Endurance Charge 
-+500 to Armour per Endurance Charge 
+Adds (45-60) to (100-120) Physical Damage
+Gain (30-40)% of Physical Attack Damage as Extra Fire Damage
++4% to Chaos Resistance per Endurance Charge
+1% reduced Elemental Damage taken from Hits per Endurance Charge
+Adds 5 to 8 Physical Damage per Endurance Charge
++500 to Armour per Endurance Charge
 {variant:1}400 Fire Damage taken per second per Endurance Charge if you've been Hit Recently
 {variant:2}200 Fire Damage taken per second per Endurance Charge if you've been Hit Recently
 ]],
@@ -232,12 +232,12 @@ Variant: Pre 3.5.0
 Variant: Current
 Requires Level 68, 104 Str, 122 Int
 Implicits: 1
-40% increased Elemental Damage 
-(180-200)% increased Physical Damage 
-(10-15)% increased Attack Speed 
-(80-100)% increased Critical Strike Chance 
-50% of Physical Damage Converted to Lightning Damage 
-Every 16 seconds you gain Elemental Overload for 8 seconds 
+40% increased Elemental Damage
+(180-200)% increased Physical Damage
+(10-15)% increased Attack Speed
+(80-100)% increased Critical Strike Chance
+50% of Physical Damage Converted to Lightning Damage
+Every 16 seconds you gain Elemental Overload for 8 seconds
 You have Resolute Technique while you do not have Elemental Overload
 {variant:2}100% increased Physical Damage while you have Resolute Technique
 ]],[[
@@ -261,7 +261,7 @@ Requires Level 60, 95 Str, 131 Int
 Implicits: 1
 40% increased Elemental Damage
 Grants Level 25 Scorching Ray Skill
-(12-20)% increased Cast Speed 
+(12-20)% increased Cast Speed
 Recover (1-3)% of Life on Kill
 Recover (1-3)% of Mana on Kill
 10% increased Scorching Ray beam length
@@ -593,25 +593,27 @@ Shepherd of Souls
 ]],
 -- Weapon: Two Handed Mace
 [[
-Brain Rattler 
+Brain Rattler
 Meatgrinder
 Variant: Pre 2.6.0
 Variant: Pre 3.11.0
+Variant: Pre 3.26.0
 Variant: Current
 Implicits: 3
 {variant:1}20% increased Stun Duration on Enemies
 {variant:2}30% increased Stun Duration on Enemies
-{variant:3}5% chance to deal Double Damage
+{variant:3,4}5% chance to deal Double Damage
 {variant:1,2}Adds (80-100) to (320-370) Physical Damage
 {variant:3}Adds (60-80) to (270-320) Physical Damage
+{variant:4}Adds (100-130) to (360-430) Physical Damage
 50% of Physical Damage Converted to Lightning Damage
 {variant:1,2}15% chance to Shock
-{variant:3}50% chance to Shock
+{variant:3,4}50% chance to Shock
 {variant:1,2}10% chance to Cause Monsters to Flee
 Damage Penetrates 20% Lightning Resistance
 Enemies you Shock have 30% reduced Cast Speed
 Enemies you Shock have 20% reduced Movement Speed
-{variant:3}Hits with this Weapon Shock Enemies as though dealing 300% more Damage
+{variant:3,4}Hits with this Weapon Shock Enemies as though dealing 300% more Damage
 ]],[[
 Chober Chaber
 Great Mallet
@@ -818,7 +820,7 @@ League: Settlers of Kalguur
 Requires Level 53, 170 Str
 Implicits: 1
 10% reduced Enemy Stun Threshold
-+(30-40) to Strength 
++(30-40) to Strength
 +(30-40) to Dexterity
 (150-250)% increased Physical Damage
 +(400-500) to Accuracy Rating


### PR DESCRIPTION
Fixes #8641  .

### Description of the problem being solved:
Patch 3.26 buffs a bunch of old uniques (see https://www.pathofexile.com/forum/view-thread/3787013#updates). This adds the numerical changes, except for because I have no clue how to change the cooldown of the skill for just that unique

```
The Icicle Burst skill triggered by the Cameria's Avarice Unique One Handed Mace now has a cooldown of 0.3 seconds (from 0.5 seconds) and deals 200% of base and added damage (previously 150%).
```
6/35 changes done

### Steps taken to verify a working solution:
- Add each unique to the build one by one and compare with the changes in the patch notes
-
-

### Link to a build that showcases this PR:
 none
### Before screenshot:
too many to list
### After screenshot:
too many to list