### PR TITLE
Improve flexibility in Vile Bastion keystone parsing for 3.26

### DIFF
--- a/spec/System/TestDefence_spec.lua
+++ b/spec/System/TestDefence_spec.lua
@@ -458,37 +458,75 @@ describe("TestDefence", function()
 		assert.are.equals(1250, build.calcsTab.calcsOutput.ChaosMaximumHitTaken)
 	end)
 
-	it("energy shield increased by spell block chance if corresponding flag is present", function()
-		build.configTab.input.enemyIsBoss = "None"
-		build.configTab.input.customMods = "\z
-		You have no intelligence\n\z
-		100 Energy shield \n\z
-		energy shield is increased by chance to block spell damage\n\z
-		50% chance to block spell damage\n\z
-		"
-		build.configTab:BuildModList()
-		runCallback("OnFrame")
+	describe("Energy shield increased by spell block chance", function()
+	
 
-		assert.are.equals(0, build.calcsTab.calcsOutput.SpellBlockChanceOverCap )
-		assert.are.equals(50, build.calcsTab.calcsOutput.SpellBlockChance)
-		assert.are.equals(150, build.calcsTab.calcsOutput.EnergyShield)
-	end)
+		it("energy shield increased by spell block chance if corresponding flag is present", function()
+			build.configTab.input.enemyIsBoss = "None"
+			build.configTab.input.customMods = "\z
+			You have no intelligence\n\z
+			100 Energy shield \n\z
+			energy shield is increased by chance to block spell damage\n\z
+			50% chance to block spell damage\n\z
+			"
+			build.configTab:BuildModList()
+			runCallback("OnFrame")
 
-	it("energy shield increased by spell block chance if corresponding flag is present should be capped to max block", function()
-		build.configTab.input.enemyIsBoss = "None"
+			assert.are.equals(0, build.calcsTab.calcsOutput.SpellBlockChanceOverCap )
+			assert.are.equals(50, build.calcsTab.calcsOutput.SpellBlockChance)
+			assert.are.equals(150, build.calcsTab.calcsOutput.EnergyShield)
+		end)
 
-		build.configTab.input.customMods = "\z
-		You have no intelligence\n\z
-		100 Energy shield \n\z
-		energy shield is increased by chance to block spell damage\n\z
-		100% chance to block spell damage\n\z
-		"
-		build.configTab:BuildModList()
-		runCallback("OnFrame")
+		it("energy shield increased by spell block chance if corresponding flag is present should be capped to max block", function()
+			build.configTab.input.enemyIsBoss = "None"
 
-		assert.are.equals(25, build.calcsTab.calcsOutput.SpellBlockChanceOverCap )
-		assert.are.equals(75, build.calcsTab.calcsOutput.SpellBlockChance)
-		assert.are.equals(175, build.calcsTab.calcsOutput.EnergyShield)
+			build.configTab.input.customMods = "\z
+			You have no intelligence\n\z
+			100 Energy shield \n\z
+			energy shield is increased by chance to block spell damage\n\z
+			100% chance to block spell damage\n\z
+			"
+			build.configTab:BuildModList()
+			runCallback("OnFrame")
+
+			assert.are.equals(25, build.calcsTab.calcsOutput.SpellBlockChanceOverCap )
+			assert.are.equals(75, build.calcsTab.calcsOutput.SpellBlockChance)
+			assert.are.equals(175, build.calcsTab.calcsOutput.EnergyShield)
+		end)
+
+		it("energy shield increased by spell block chance if corresponding 'maximum es' flag is present", function()
+			build.configTab.input.enemyIsBoss = "None"
+			build.configTab.input.customMods = "\z
+			You have no intelligence\n\z
+			100 Energy shield \n\z
+			maximum energy shield is increased by chance to block spell damage\n\z
+			50% chance to block spell damage\n\z
+			"
+			build.configTab:BuildModList()
+			runCallback("OnFrame")
+
+			assert.are.equals(0, build.calcsTab.calcsOutput.SpellBlockChanceOverCap )
+			assert.are.equals(50, build.calcsTab.calcsOutput.SpellBlockChance)
+			assert.are.equals(150, build.calcsTab.calcsOutput.EnergyShield)
+		end)
+
+		it("energy shield increased by spell block chance if corresponding 'maximum es' flag is present should be capped to max block", function()
+			build.configTab.input.enemyIsBoss = "None"
+
+			build.configTab.input.customMods = "\z
+			You have no intelligence\n\z
+			100 Energy shield \n\z
+			maximum energy shield is increased by chance to block spell damage\n\z
+			100% chance to block spell damage\n\z
+			"
+			build.configTab:BuildModList()
+			runCallback("OnFrame")
+
+			assert.are.equals(25, build.calcsTab.calcsOutput.SpellBlockChanceOverCap )
+			assert.are.equals(75, build.calcsTab.calcsOutput.SpellBlockChance)
+			assert.are.equals(175, build.calcsTab.calcsOutput.EnergyShield)
+		end)
+
 	end)
 
 	local function withinTenPercent(value, otherValue)

--- a/spec/System/TestDefence_spec.lua
+++ b/spec/System/TestDefence_spec.lua
@@ -459,40 +459,6 @@ describe("TestDefence", function()
 	end)
 
 	describe("Energy shield increased by spell block chance", function()
-	
-
-		it("energy shield increased by spell block chance if corresponding flag is present", function()
-			build.configTab.input.enemyIsBoss = "None"
-			build.configTab.input.customMods = "\z
-			You have no intelligence\n\z
-			100 Energy shield \n\z
-			energy shield is increased by chance to block spell damage\n\z
-			50% chance to block spell damage\n\z
-			"
-			build.configTab:BuildModList()
-			runCallback("OnFrame")
-
-			assert.are.equals(0, build.calcsTab.calcsOutput.SpellBlockChanceOverCap )
-			assert.are.equals(50, build.calcsTab.calcsOutput.SpellBlockChance)
-			assert.are.equals(150, build.calcsTab.calcsOutput.EnergyShield)
-		end)
-
-		it("energy shield increased by spell block chance if corresponding flag is present should be capped to max block", function()
-			build.configTab.input.enemyIsBoss = "None"
-
-			build.configTab.input.customMods = "\z
-			You have no intelligence\n\z
-			100 Energy shield \n\z
-			energy shield is increased by chance to block spell damage\n\z
-			100% chance to block spell damage\n\z
-			"
-			build.configTab:BuildModList()
-			runCallback("OnFrame")
-
-			assert.are.equals(25, build.calcsTab.calcsOutput.SpellBlockChanceOverCap )
-			assert.are.equals(75, build.calcsTab.calcsOutput.SpellBlockChance)
-			assert.are.equals(175, build.calcsTab.calcsOutput.EnergyShield)
-		end)
 
 		it("energy shield increased by spell block chance if corresponding 'maximum es' flag is present", function()
 			build.configTab.input.enemyIsBoss = "None"

--- a/src/Data/ModCache.lua
+++ b/src/Data/ModCache.lua
@@ -9050,7 +9050,7 @@ c["Maximum Damage Reduction for any Damage Type is 50%"]={{[1]={flags=0,keywordF
 c["Maximum Effect of Shock is 2% increased Damage taken"]={{[1]={flags=0,keywordFlags=0,name="ShockMax",type="OVERRIDE",value=2}},nil}
 c["Maximum Endurance, Frenzy and Power Charges is 0"]={{[1]={flags=0,keywordFlags=0,name="EnduranceChargesMax",type="OVERRIDE",value=0},[2]={flags=0,keywordFlags=0,name="PowerChargesMax",type="OVERRIDE",value=0},[3]={flags=0,keywordFlags=0,name="FrenzyChargesMax",type="OVERRIDE",value=0}},nil}
 c["Maximum Energy Shield is 0"]={{[1]={flags=0,keywordFlags=0,name="EnergyShield",type="OVERRIDE",value=0}},nil}
-c["Maximum Energy Shield is increased by Chance to Block Spell Damage"]={nil,"Maximum Energy Shield is increased by Chance to Block Spell Damage "}
+c["Maximum Energy Shield is increased by Chance to Block Spell Damage"]={{[1]={flags=0,keywordFlags=0,name="EnergyShieldIncreasedByChanceToBlockSpellDamage",type="FLAG",value=true}},nil}
 c["Maximum Life becomes 1, Immune to Chaos Damage"]={{[1]={flags=0,keywordFlags=0,name="ChaosInoculation",type="FLAG",value=true},[2]={flags=0,keywordFlags=0,name="ChaosDamageTaken",type="MORE",value=-100}},nil}
 c["Maximum Quality is 200%"]={{},"Maximum Quality "}
 c["Maximum Quality is 200% Corrupted"]={{},"Maximum Quality Corrupted "}

--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -4281,7 +4281,7 @@ local specialModList = {
 		mod("EnemyModifier", "LIST", { mod = mod("ColdResist", "INC", num) }),
 	} end,
 	["nearby enemies are blinded while physical aegis is not depleted"] = { mod("EnemyModifier", "LIST", { mod = flag("Condition:Blinded") }, { type = "Condition", var = "PhysicalAegisDepleted", neg = true }) },
-	["[Mm]?a?x?i?m?u?m? ?energy shield is increased by chance to block spell damage"] = { flag("EnergyShieldIncreasedByChanceToBlockSpellDamage") },
+	["maximum energy shield is increased by chance to block spell damage"] = { flag("EnergyShieldIncreasedByChanceToBlockSpellDamage") },
 	["armour is increased by uncapped fire resistance"] = { flag( "ArmourIncreasedByUncappedFireRes") },
 	["armour is increased by overcapped fire resistance"] = { flag( "ArmourIncreasedByOvercappedFireRes") },
 	["minion life is increased by t?h?e?i?r? ?overcapped fire resistance"] = { mod("MinionModifier", "LIST", { mod = mod("Life", "INC", 1, { type = "PerStat", stat = "FireResistOverCap", div = 1 }) }) },

--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -4281,7 +4281,7 @@ local specialModList = {
 		mod("EnemyModifier", "LIST", { mod = mod("ColdResist", "INC", num) }),
 	} end,
 	["nearby enemies are blinded while physical aegis is not depleted"] = { mod("EnemyModifier", "LIST", { mod = flag("Condition:Blinded") }, { type = "Condition", var = "PhysicalAegisDepleted", neg = true }) },
-	["energy shield is increased by chance to block spell damage"] = { flag("EnergyShieldIncreasedByChanceToBlockSpellDamage") },
+	["[Mm]?a?x?i?m?u?m? ?energy shield is increased by chance to block spell damage"] = { flag("EnergyShieldIncreasedByChanceToBlockSpellDamage") },
 	["armour is increased by uncapped fire resistance"] = { flag( "ArmourIncreasedByUncappedFireRes") },
 	["armour is increased by overcapped fire resistance"] = { flag( "ArmourIncreasedByOvercappedFireRes") },
 	["minion life is increased by t?h?e?i?r? ?overcapped fire resistance"] = { mod("MinionModifier", "LIST", { mod = mod("Life", "INC", 1, { type = "PerStat", stat = "FireResistOverCap", div = 1 }) }) },


### PR DESCRIPTION
Increase flexibility in parsing for energy shield being increased by spell block on 3.26 Vile Bastion

### Description of the problem being solved:

The wording on the Ascendency Node is slightly different to what I expected (because I can't read patch notes, sorry for the quick double PR for this 😶‍🌫️)

### Steps taken to verify a working solution:
- Validated with the same build as https://github.com/PathOfBuildingCommunity/PathOfBuilding/pull/8643#issue-3133398628 , and then a new build using the Occultist node as well
- Additional validation done by actually selecting the Vile Bastion node on the new tree, and confirming calcs work as expected.
- Added tests for both variants to ensure parsing is working as expected.

### Before screenshot:

![image](https://github.com/user-attachments/assets/4be27834-60cf-46c6-bfbc-fc41a8585b09)
![image](https://github.com/user-attachments/assets/4f8af011-be1a-49b3-9db1-5534110130b6)

### After screenshot:

Confirmed the new ascendency node is also getting parsed correctly and calculations are impacted appropriately in preview/calcs breakdown
![image](https://github.com/user-attachments/assets/c5cbc415-0ceb-4ebc-8ab8-f36426b7157a)
![image](https://github.com/user-attachments/assets/78e0c6a8-d091-4218-83bf-045e706acbed)

