### PR TITLE
Fix Nebulis and similar mods being treated as uncapped

### DIFF
--- a/spec/System/TestItemMods_spec.lua
+++ b/spec/System/TestItemMods_spec.lua
@@ -538,6 +538,7 @@ describe("TetsItemMods", function()
 		build.configTab.input.customMods = [[
 			Gain 25% increased Armour per 5 Power for 8 seconds when you Warcry, up to a maximum of 100%
 			Warcries have infinite Power
+			warcries grant arcane surge to you and allies, with 10% increased effect per 5 power, up to 100%
 		]]
 		build.configTab:BuildModList()
 		build.itemsTab:CreateDisplayItemFromRaw([[
@@ -546,6 +547,9 @@ describe("TetsItemMods", function()
 			Armour: 32
 		]])
 		build.itemsTab:AddDisplayItem()
+		build.skillsTab:PasteSocketGroup("Arc 20/0 Default  1")
+
+		assert.are_not.equals(40, build.calcsTab.mainEnv.modDB:Sum("INC", { flags = ModFlag.Cast }, "Speed"))
 		assert.are_not.equals(64, build.calcsTab.mainOutput.Armour)
 		runCallback("OnFrame")
 	end)

--- a/spec/System/TestItemMods_spec.lua
+++ b/spec/System/TestItemMods_spec.lua
@@ -509,4 +509,44 @@ describe("TetsItemMods", function()
 
 		assert.are_not.equals(baseLife, build.calcsTab.mainOutput.Life)
 	end)
+
+	it("globalLimit mods", function()
+		build.configTab.input.customMods = [[
+			-1000% to cold resistance
+		]]
+		build.configTab:BuildModList()
+		build.itemsTab:CreateDisplayItemFromRaw([[Replica Nebulis
+			Void Sceptre
+			League: Heist
+			Quality: 20
+			Sockets: B-B-B
+			LevelReq: 68
+			Implicits: 1
+			40% increased Elemental Damage
+			{fractured}{range:1}(15-20)% increased Cast Speed
+			{range:1}(15-20)% increased Cold Damage per 1% Missing Cold Resistance, up to a maximum of 300%
+			{range:1}(15-20)% increased Fire Damage per 1% Missing Fire Resistance, up to a maximum of 300%]])
+		build.itemsTab:AddDisplayItem()
+		build.skillsTab:PasteSocketGroup("Slot: Weapon 1\nFireball 20/0 Default  1\n")
+		runCallback("OnFrame")
+
+		assert.are_not.equals(340, build.calcsTab.mainEnv.modDB:Sum("INC", "FireDamage"))
+		assert.are_not.equals(340, build.calcsTab.mainEnv.modDB:Sum("INC", "ColdDamage"))
+
+		newBuild()
+
+		build.configTab.input.customMods = [[
+			Gain 25% increased Armour per 5 Power for 8 seconds when you Warcry, up to a maximum of 100%
+			Warcries have infinite Power
+		]]
+		build.configTab:BuildModList()
+		build.itemsTab:CreateDisplayItemFromRaw([[
+			New Item
+			Plate Vest
+			Armour: 32
+		]])
+		build.itemsTab:AddDisplayItem()
+		assert.are_not.equals(64, build.calcsTab.mainOutput.Armour)
+		runCallback("OnFrame")
+	end)
 end)

--- a/src/Classes/ModStore.lua
+++ b/src/Classes/ModStore.lua
@@ -267,15 +267,6 @@ function ModStoreClass:EvalMod(mod, cfg, globalLimits)
 			local target = self
 			local limitTarget = self
 
-			if globalLimits and tag.globalLimit and tag.globalLimitKey then
-				value = value or 0
-				globalLimits[tag.globalLimitKey] = globalLimits[tag.globalLimitKey] or 0
-				if globalLimits[tag.globalLimitKey] + value > tag.globalLimit then
-					value = tag.globalLimit - globalLimits[tag.globalLimitKey]
-				end
-				globalLimits[tag.globalLimitKey] = globalLimits[tag.globalLimitKey] + value
-			end
-
 			-- Allow limiting a self multiplier on a parent multiplier (eg. Agony Crawler on player virulence)
 			-- This explicit target is necessary because even though the GetMultiplier method does call self.parent.GetMultiplier, it does so with noMod = true,
 			-- disabling the summation (3rd part): (not noMod and self:Sum("BASE", cfg, multiplierName[var]) or 0)
@@ -824,6 +815,18 @@ function ModStoreClass:EvalMod(mod, cfg, globalLimits)
 				return
 			end
 		end
-	end	
+	end
+
+	-- Apply global limits
+	for _, tag in ipairs(mod) do
+		if globalLimits and tag.globalLimit and tag.globalLimitKey then
+			value = value or 0
+			globalLimits[tag.globalLimitKey] = globalLimits[tag.globalLimitKey] or 0
+			if globalLimits[tag.globalLimitKey] + value > tag.globalLimit then
+				value = tag.globalLimit - globalLimits[tag.globalLimitKey]
+			end
+			globalLimits[tag.globalLimitKey] = globalLimits[tag.globalLimitKey] + value
+		end
+	end
 	return value
 end


### PR DESCRIPTION
Closes https://github.com/PathOfBuildingCommunity/PathOfBuilding/issues/8664 and https://github.com/PathOfBuildingCommunity/PathOfBuilding/issues/2735#issuecomment-2969197233

### Description of the problem being solved:

https://github.com/PathOfBuildingCommunity/PathOfBuilding/pull/8652 attempted to fix a problem with globalLimits where ordering of tags in the mod table caused the limit to not apply by moving the limit check into ModStore. This caused the limit to apply only to "Multiplier" type mods that do not actually multiply the mod value. This pr fixes the issue by moving the limit check into a separate loop after applying mod tags.

Ideally, looping over the tags again wouldn't be needed if there was a good way to either move the global limit variables into the main mod body or ensure ordering of mod tags inside the mod table.

### Steps taken to verify a working solution:
- Verify case from https://github.com/PathOfBuildingCommunity/PathOfBuilding/issues/8664
- Verify case from https://github.com/PathOfBuildingCommunity/PathOfBuilding/issues/2735#issuecomment-2969197233
