### PR TITLE
Fix CWC not supporting triggerbots

### DIFF
--- a/spec/System/TestTriggers_spec.lua
+++ b/spec/System/TestTriggers_spec.lua
@@ -1359,4 +1359,54 @@ describe("TestTriggers", function()
 
 		assert.True(build.calcsTab.mainOutput.SkillTriggerRate ~= nil)
 	end)
+
+	it("Triggerbots CWCHandler", function()
+		build.skillsTab:PasteSocketGroup("Cyclone 1/0 Default  1\nCast while Channelling 20/20 Default  1\nFireball 1/0 Default  1\n")
+		runCallback("OnFrame")
+		local baseRate = build.calcsTab.mainOutput.SkillTriggerRate
+		assert.True(build.calcsTab.mainOutput.SkillTriggerRate ~= nil)
+
+		build.configTab.input.customMods = [[
+			Triggers Level 20 Summon Triggerbots when Allocated
+		]]
+		build.configTab:BuildModList()
+		runCallback("OnFrame")
+		assert.are.equals(math.floor(build.calcsTab.mainOutput.SkillTriggerRate * 100), math.floor(baseRate * 100))
+	end)
+
+	it("Triggerbots defaultHandler", function()
+		build.itemsTab:CreateDisplayItemFromRaw([[Elemental 1H Sword
+		Eternal Sword
+		Crafted: true
+		Prefix: {range:0.5}WeaponElementalDamageOnWeapons4
+		Prefix: None
+		Prefix: None
+		Suffix: {range:0.5}LocalIncreasedAttackSpeed3
+		Suffix: {range:0.5}LocalCriticalStrikeChance3
+		Suffix: {range:0.5}LocalCriticalMultiplier4
+		Quality: 20
+		Sockets: G-G-G
+		LevelReq: 66
+		Implicits: 1
+		{tags:attack}+475 to Accuracy Rating
+		12% increased Attack Speed
+		22% increased Critical Strike Chance
+		+27% to Global Critical Strike Multiplier
+		40% increased Elemental Damage with Attack Skills]])
+		build.itemsTab:AddDisplayItem()
+		runCallback("OnFrame")
+
+		build.skillsTab:PasteSocketGroup("Cast On Critical Strike 20/0 Default  1\nArc 20/0 Default  1\nCyclone 20/0 Default  1\n")
+		runCallback("OnFrame")
+
+		local baseRate = build.calcsTab.mainOutput.SkillTriggerRate
+		assert.True(build.calcsTab.mainOutput.SkillTriggerRate ~= nil)
+
+		build.configTab.input.customMods = [[
+			Triggers Level 20 Summon Triggerbots when Allocated
+		]]
+		build.configTab:BuildModList()
+		runCallback("OnFrame")
+		assert.are.equals(math.floor(build.calcsTab.mainOutput.SkillTriggerRate * 100), math.floor(baseRate * 100))
+	end)
 end)

--- a/spec/System/TestTriggers_spec.lua
+++ b/spec/System/TestTriggers_spec.lua
@@ -1361,7 +1361,7 @@ describe("TestTriggers", function()
 	end)
 
 	it("Triggerbots CWCHandler", function()
-		build.skillsTab:PasteSocketGroup("Cyclone 1/0 Default  1\nCast while Channelling 20/20 Default  1\nFireball 1/0 Default  1\n")
+		build.skillsTab:PasteSocketGroup("Arc 20/0 Default  1\nCast while Channelling 20/0 Default  1\nBlight 20/0 Default  1\n")
 		runCallback("OnFrame")
 		local baseRate = build.calcsTab.mainOutput.SkillTriggerRate
 		assert.True(build.calcsTab.mainOutput.SkillTriggerRate ~= nil)
@@ -1371,7 +1371,7 @@ describe("TestTriggers", function()
 		]]
 		build.configTab:BuildModList()
 		runCallback("OnFrame")
-		assert.are.equals(math.floor(build.calcsTab.mainOutput.SkillTriggerRate * 100), math.floor(baseRate * 100))
+		assert.are.not_equals(math.floor(build.calcsTab.mainOutput.SkillTriggerRate * 100), math.floor(baseRate * 100))
 	end)
 
 	it("Triggerbots defaultHandler", function()
@@ -1407,6 +1407,6 @@ describe("TestTriggers", function()
 		]]
 		build.configTab:BuildModList()
 		runCallback("OnFrame")
-		assert.are.equals(math.floor(build.calcsTab.mainOutput.SkillTriggerRate * 100), math.floor(baseRate * 100))
+		assert.are.not_equals(math.floor(build.calcsTab.mainOutput.SkillTriggerRate * 100), math.floor(baseRate * 100))
 	end)
 end)

--- a/src/Modules/CalcTriggers.lua
+++ b/src/Modules/CalcTriggers.lua
@@ -816,6 +816,12 @@ local function defaultTriggerHandler(env, config)
 							s_format("/ %.2f ^8(Estimated impact of skill rotation, cooldown alignment and trigger chance)", m_max(output.EffectiveSourceRate / output.SkillTriggerRate, 1)),
 							s_format("= %.2f ^8per second", output.SkillTriggerRate),
 						}
+						if triggerBotsEffective then
+							t_insert(breakdown.SkillTriggerRate, 3, "x 2 ^8(Trigger bots effectively cause the skill to trigger twice)")
+						end
+						if hits_per_cast > 1 then
+							t_insert(breakdown.SkillTriggerRate, 3, s_format("x %.2f ^8(hits per triggered skill cast)", hits_per_cast))
+						end
 						if triggerChance ~= 100 then
 							t_insert(breakdown.SkillTriggerRate, 1, "")
 							t_insert(breakdown.SkillTriggerRate, 1, s_format("= %.2f%% ^8(Effective chance to trigger)", triggerChance))
@@ -823,12 +829,6 @@ local function defaultTriggerHandler(env, config)
 								t_insert(breakdown.SkillTriggerRate, 1, line)
 							end
 							t_insert(breakdown.SkillTriggerRate, 1, "100% ^8(Base chance)")
-						end
-						if triggerBotsEffective then
-							t_insert(breakdown.SkillTriggerRate, 3, "x 2 ^8(Trigger bots effectively cause the skill to trigger twice)")
-						end
-						if hits_per_cast > 1 then
-							t_insert(breakdown.SkillTriggerRate, 3, s_format("x %.2f ^8(hits per triggered skill cast)", hits_per_cast))
 						end
 						if simBreakdown.extraSimInfo then
 							t_insert(breakdown.SkillTriggerRate, "")

--- a/src/Modules/CalcTriggers.lua
+++ b/src/Modules/CalcTriggers.lua
@@ -261,6 +261,10 @@ local function CWCHandler(env)
 			local simBreakdown = nil
 			output.TriggerRateCap = m_min(1 / effCDTriggeredSkill, triggerRateOfTrigger)
 			output.SkillTriggerRate, simBreakdown = calcMultiSpellRotationImpact(env, triggeredSkills, triggerRateOfTrigger, 0)
+			local triggerBotsEffective = env.player.modDB:Flag(nil, "HaveTriggerBots") and env.player.mainSkill.skillTypes[SkillType.Spell]
+			if triggerBotsEffective then
+				output.SkillTriggerRate = 2 * output.SkillTriggerRate
+			end
 
 			if breakdown then
 				if triggeredCD or cooldownOverride then
@@ -331,13 +335,16 @@ local function CWCHandler(env)
 				t_insert(breakdown.TriggerRateCap, s_format("1 / %.3f ^8(trigger rate adjusted for triggering interval)", 1 / output.TriggerRateCap))
 				t_insert(breakdown.TriggerRateCap, s_format("= %.2f ^8 %s casts per second", output.TriggerRateCap, triggeredName))
 
+				-- Hide Skill Trigger Rate breakdown if there's only one skill to av
 				if #triggeredSkills > 1 then
 					breakdown.SkillTriggerRate = {
 						s_format("%.2f ^8(%s triggers per second)", triggerRateOfTrigger, triggerName),
 						s_format("/ %.2f ^8(Estimated impact of linked spells)", (triggerRateOfTrigger / output.SkillTriggerRate) or 1),
 						s_format("= %.2f ^8%s casts per second", output.SkillTriggerRate, triggeredName),
 					}
-
+					if triggerBotsEffective then
+						t_insert(breakdown.SkillTriggerRate, 3, "x 2 ^8(Trigger bots effectively cause the skill to trigger twice)")
+					end
 					if simBreakdown.extraSimInfo then
 						t_insert(breakdown.SkillTriggerRate, "")
 						t_insert(breakdown.SkillTriggerRate, simBreakdown.extraSimInfo)


### PR DESCRIPTION
Closes https://github.com/PathOfBuildingCommunity/PathOfBuilding/issues/8659

### Description of the problem being solved:

CWCHandler did not have handling for trigger bots. This PR adds that and fixes a minor breakdown issue in the defaultHandler (lines ended up in the wrong section of the breakdown).

### Steps taken to verify a working solution:
- Check breakdown generation
- Check numbers using the build from issue

### Link to a build that showcases this PR:
See issue

### Before screenshot:
![obraz](https://github.com/user-attachments/assets/44b1f874-5b85-4c74-96fc-bf0c600471bb)

### After screenshot:
![obraz](https://github.com/user-attachments/assets/e41e76d6-4f43-4b27-88fb-2e592c5efc9a)
