### PR TITLE
Fix Dual Strike of Ambidexterity causing crash

### DIFF
--- a/src/Modules/CalcMirages.lua
+++ b/src/Modules/CalcMirages.lua
@@ -361,7 +361,7 @@ function calcs.mirages(env)
 			end
 		}
 	elseif env.player.mainSkill.skillData.triggeredByGeneralsCry then
-		env.player.mainSkill[SkillType.Triggered] = true
+		env.player.mainSkill.skillTypes[SkillType.Triggered] = true
 		local maxMirageWarriors = 0
 		local cooldown = 1
 		local generalsCryActiveSkill

--- a/src/Modules/CalcOffence.lua
+++ b/src/Modules/CalcOffence.lua
@@ -2310,7 +2310,7 @@ function calcs.offence(env, actor, activeSkill)
 		if output.Time > 1 then
 			modDB:NewMod("Condition:OneSecondAttackTime", "FLAG", true)
 		end
-		if skillModList:Flag(nil, "UseOffhandAttackSpeed") then
+		if skillModList:Flag(nil, "UseOffhandAttackSpeed") and not skillFlags.forceMainHand then
 			output.Speed = output.OffHand.Speed
 			output.Time = output.OffHand.Time
 			if breakdown then


### PR DESCRIPTION
Closes #8693

### Description of the problem being solved:
https://github.com/PathOfBuildingCommunity/PathOfBuilding/pull/7369 caused issues with handling for `Uses Off Hand Weapon Attack Time` (UseOffhandAttackSpeed) due to missing offHand weapon calculation.

### Steps taken to verify a working solution:
- Test build from issue

### Link to a build that showcases this PR:

See issue.
