### PR TITLE
Fix Wretched Defiler missing skill types

### DIFF
--- a/src/Export/Skills/spectre.txt
+++ b/src/Export/Skills/spectre.txt
@@ -2168,6 +2168,7 @@ skills["DarkMarionetteExplodePerfect"] = {
 #flags spell area hit
 #mods
 
+#addSkillTypes Damage Multicastable
 #skill RevenantBossSpellProjectile Lightning Projectile
 #flags spell projectile triggerable
 #mods


### PR DESCRIPTION
Wretched Defilers do not work with many skill gems due to missing skill types

Fixes # .

### Description of the problem being solved:
Wretched Defiler's skill doesn't work with gems like Controlled Destruction and Spell Echo for some reason, even though Spell Echo clearly works in game.  I looked at the `spectre.lua` file and compared the skill to another spectre's skill that do work with those support gems, and found it's missing `[SkillType.Damage] = true, [SkillType.Multicastable] = true, `. Added those to `skillTypes` and it worked (see screenshots below)

I'm not familiar with how the export works, I assume `#addSkillTypes Damage Multicastable` is all I need to fix this during the next export script run? I didn't run it either. Please advise.

### Steps taken to verify a working solution:
- Add `[SkillType.Damage] = true, [SkillType.Multicastable] = true, ` to `skillTypes` in `Data/skills/spectre.lua`
- Verify in PoB that hovering the support skill checkbox shows DPS increase
- Don't know how export files work, please advise if it's correct

### Link to a build that showcases this PR:

### Before screenshot:
<img src="https://github.com/user-attachments/assets/f217c8a2-98a4-4f91-a903-fbdab75bdc2e" width=48%>
<img src="https://github.com/user-attachments/assets/7ca97ec1-b6c4-4644-ad13-470dfa3ef0a2" width=48%>

### After screenshot:
<img src="https://github.com/user-attachments/assets/0d8fee90-473a-4bb1-a68f-2109e43a8537" width=48%>
<img src="https://github.com/user-attachments/assets/69282cfa-a199-403e-9a5c-b1ec6375f5f9" width=48%>

