### PR TITLE
Fix flashing cmd window during update check

### DIFF
--- a/src/UpdateCheck.lua
+++ b/src/UpdateCheck.lua
@@ -79,8 +79,8 @@ end
 ConPrintf("Checking for update...")
 
 -- Use built-in helpers to obtain absolute paths without spawning a shell.
-scriptPath = (GetScriptPath and GetScriptPath()) or "."
-runtimePath = (GetRuntimePath and GetRuntimePath()) or scriptPath
+local scriptPath = (GetScriptPath and GetScriptPath()) or "."
+local runtimePath = (GetRuntimePath and GetRuntimePath()) or scriptPath
 
 -- Load and process local manifest
 local localVer

--- a/src/UpdateCheck.lua
+++ b/src/UpdateCheck.lua
@@ -78,13 +78,9 @@ end
 
 ConPrintf("Checking for update...")
 
-local scriptPath
-local runtimePath
-do
-	local currentDir = io.popen("cd"):read() or io.popen("pwd"):read() or "."
-	scriptPath = currentDir
-	runtimePath = currentDir
-end
+-- Use built-in helpers to obtain absolute paths without spawning a shell.
+scriptPath = (GetScriptPath and GetScriptPath()) or "."
+runtimePath = (GetRuntimePath and GetRuntimePath()) or scriptPath
 
 -- Load and process local manifest
 local localVer


### PR DESCRIPTION
Fixes #8667 

### Description of the problem being solved:
585a5ee1e105e7a1916fc033da609837206b28a1 implemented the ability to resume failed downloads.  In the process, it changed how scriptPath and runtimePath were assigned, going from "." to the following:
```lua
local currentDir = io.popen("cd"):read() or io.popen("pwd"):read() or "."
```

Unfortunately, io.popen briefly flashes a cmd prompt on Windows.  This is particularly bothersome when automatic update checks  randomly cause these windows to flash.  It took me a while to determine the source of these flashes, and I was concerned for some time that it might be malware.

This pull request changes UpdateCheck.lua to assign those path vars using GetScriptPath and GetRuntimePath, which are used elsewhere throughout the codebase.  In my testing, this was a suitable substitution.  It still falls back to "." if those methods are unavailable or fail.

### Steps taken to verify a working solution:
-Observe command prompt flashing during automatic checks or manual checks
-Verify that flashing doesn't occur with new implementation
-Verify that update method still succeeds and that the methods return the appropriate path

### Link to a build that showcases this PR:
N/A

### Before screenshot:
N/A

### After screenshot:
N/A
