### PR TITLE
Fix Skill Set allowing editing a nil value after saving new Skill Set

### DIFF
--- a/src/Classes/SkillSetListControl.lua
+++ b/src/Classes/SkillSetListControl.lua
@@ -62,7 +62,7 @@ function SkillSetListClass:RenameSet(skillSet, addOnName)
 		if addOnName then
 			t_insert(self.list, skillSet.id)
 			self.selIndex = #self.list
-			self.selValue = skillSet
+			self.selValue = skillSet.id
 		end
 		self.skillsTab:AddUndoState()
 		self.skillsTab.build:SyncLoadouts()


### PR DESCRIPTION
Fixes #8726.

### Description of the problem being solved:
On saving a new Skill Set, the Rename/Copy/Delete buttons are still enabled, but no Skill Set selected. This selects the recently saved Skill Set from the list.

### After screenshot:
![image](https://github.com/user-attachments/assets/0df0b0d3-5b4c-429b-a1b2-55685e37e4ea)