### PR TITLE
Fix Summon Phantasm minion level incorrectly using the active gem level

### DIFF
--- a/src/Data/Skills/sup_int.lua
+++ b/src/Data/Skills/sup_int.lua
@@ -5194,9 +5194,6 @@ skills["SupportSummonPhantasm"] = {
 	addSkillTypes = { SkillType.CreatesMinion, SkillType.MinionsCanExplode, },
 	excludeSkillTypes = { SkillType.MinionsPersistWhenSkillRemoved, },
 	statDescriptionScope = "gem_stat_descriptions",
-	addFlags = {
-		minion = true,
-	},
 	addMinionList = {
 		"SummonedPhantasm"
 	},

--- a/src/Export/Skills/sup_int.txt
+++ b/src/Export/Skills/sup_int.txt
@@ -688,9 +688,6 @@ local skills, mod, flag, skill = ...
 #mods
 
 #skill SupportSummonPhantasm
-	addFlags = {
-		minion = true,
-	},
 	addMinionList = {
 		"SummonedPhantasm"
 	},

--- a/src/Modules/CalcActiveSkill.lua
+++ b/src/Modules/CalcActiveSkill.lua
@@ -615,6 +615,7 @@ function calcs.buildActiveSkillModList(env, activeSkill)
 
 	-- Create minion
 	local minionList, isSpectre
+	local minionSupportLevel = { }
 	if activeGrantedEffect.minionList then
 		if activeGrantedEffect.minionList[1] then
 			minionList = copyTable(activeGrantedEffect.minionList)
@@ -629,6 +630,7 @@ function calcs.buildActiveSkillModList(env, activeSkill)
 		if skillEffect.grantedEffect.support and skillEffect.grantedEffect.addMinionList then
 			for _, minionType in ipairs(skillEffect.grantedEffect.addMinionList) do
 				t_insert(minionList, minionType)
+				minionSupportLevel[minionType] = skillEffect.grantedEffect.levels[skillEffect.level].levelRequirement
 			end
 		end
 	end
@@ -654,7 +656,7 @@ function calcs.buildActiveSkillModList(env, activeSkill)
 			minion.minionData = env.data.minions[minionType]
 			minion.level = activeSkill.skillData.minionLevelIsEnemyLevel and env.enemyLevel or 
 								activeSkill.skillData.minionLevelIsPlayerLevel and (m_min(env.build and env.build.characterLevel or activeSkill.skillData.minionLevel or activeEffect.grantedEffectLevel.levelRequirement, activeSkill.skillData.minionLevelIsPlayerLevel)) or 
-								activeSkill.skillData.minionLevel or activeEffect.grantedEffectLevel.levelRequirement
+								minionSupportLevel[minion.type] or activeSkill.skillData.minionLevel or activeEffect.grantedEffectLevel.levelRequirement
 			-- fix minion level between 1 and 100
 			minion.level = m_min(m_max(minion.level,1),100) 
 			minion.itemList = { }

--- a/src/Modules/CalcOffence.lua
+++ b/src/Modules/CalcOffence.lua
@@ -967,7 +967,7 @@ function calcs.offence(env, actor, activeSkill)
 	runSkillFunc("preSkillTypeFunc")
 
 	-- Calculate skill type stats
-	if skillFlags.minion then
+	if activeSkill.minion then
 		if activeSkill.minion and activeSkill.minion.minionData.limit then
 			output.ActiveMinionLimit = m_floor(env.modDB:Override(nil, activeSkill.minion.minionData.limit) or calcLib.val(skillModList, activeSkill.minion.minionData.limit, skillCfg))
 		end
@@ -3649,7 +3649,7 @@ function calcs.offence(env, actor, activeSkill)
 		end
 	end
 	
-	if skillFlags.minion then
+	if activeSkill.minion then
 		skillData.summonSpeed = output.SummonedMinionsPerCast * (output.HitSpeed or output.Speed) * skillData.dpsMultiplier
 	end
 


### PR DESCRIPTION
Fixes #7449, Fixes #4038
The Summon Phantasm support is meant to use the level of the Summon Phantasm gem to determine the level of the minion, not the level of the active skill which it is linked to
This also removes the minon flag from the support as it does not grant the minion tag to supported skills in game
