### PR TITLE
Add support for Replica Dragonfang's Flight variants

### DIFF
--- a/src/Data/Uniques/Special/Generated.lua
+++ b/src/Data/Uniques/Special/Generated.lua
@@ -881,3 +881,58 @@ for _, modId in ipairs(sortedCharmsMods) do
 end
 
 table.insert(data.uniques.generated, table.concat(thatWhichWasTaken, "\n"))
+
+
+local replicaDragonfangsFlightMods = {}
+
+LoadModule("Modules/CalcTools")
+for _, gem in pairs(data.gems) do
+	if not string.match(gem.grantedEffectId, "Alt[XY]$") and calcLib.gemIsType(gem, "active skill", false) and calcLib.gemIsType(gem, "non-vaal", false) then
+		replicaDragonfangsFlightMods[gem.name] = "+3 to Level of all "..gem.name.." Gems"
+	end
+end
+
+local replicaDragonfangsFlight = {
+    [[Replica Dragonfang's Flight
+    Onyx Amulet
+    Selected Variant: 2
+    Has Alt Variant: true
+    Selected Alt Variant: 3
+    LevelReq: 56
+	]]
+}
+
+table.insert(replicaDragonfangsFlight,
+[[Variant: Pre 3.23.0
+Variant: Current
+]]
+)
+
+for name, _ in pairs(replicaDragonfangsFlightMods) do
+	table.insert(replicaDragonfangsFlight, "Variant: "..name)
+end
+
+table.insert(replicaDragonfangsFlight,
+[[Implicits: 1
+{tags:jewellery_attribute}{range:1}+(10-16) to all Attributes
+{tags:jewellery_resistance}{variant:1}{range:1}+(10-15)% to all Elemental Resistances
+{tags:jewellery_resistance}{variant:2}{range:1}+(5-10)% to all Elemental Resistances
+]]
+)
+
+local index = 3
+for _, line in pairs(replicaDragonfangsFlightMods) do
+	table.insert(replicaDragonfangsFlight, "{variant:"..index.."}"..line)
+	index = index + 1
+end
+
+table.insert(replicaDragonfangsFlight,
+[[
+{variant:1}{range:1}(10-15)% increased Reservation Efficiency of Skills
+{variant:2}{range:1}(5-10)% increased Reservation Efficiency of Skills
+{variant:1}{range:1}Items and Gems have (10-15)% reduced Attribute Requirements
+{variant:2}{range:1}Items and Gems have (5-10)% reduced Attribute Requirements
+]]
+)
+
+table.insert(data.uniques.generated, table.concat(replicaDragonfangsFlight, "\n"))

--- a/src/Data/Uniques/Special/Generated.lua
+++ b/src/Data/Uniques/Special/Generated.lua
@@ -914,9 +914,9 @@ end
 
 table.insert(replicaDragonfangsFlight,
 [[Implicits: 1
-{tags:jewellery_attribute}{range:1}+(10-16) to all Attributes
-{tags:jewellery_resistance}{variant:1}{range:1}+(10-15)% to all Elemental Resistances
-{tags:jewellery_resistance}{variant:2}{range:1}+(5-10)% to all Elemental Resistances
+{tags:jewellery_attribute}+(10-16) to all Attributes
+{tags:jewellery_resistance}{variant:1}+(10-15)% to all Elemental Resistances
+{tags:jewellery_resistance}{variant:2}+(5-10)% to all Elemental Resistances
 ]]
 )
 
@@ -928,10 +928,10 @@ end
 
 table.insert(replicaDragonfangsFlight,
 [[
-{variant:1}{range:1}(10-15)% increased Reservation Efficiency of Skills
-{variant:2}{range:1}(5-10)% increased Reservation Efficiency of Skills
-{variant:1}{range:1}Items and Gems have (10-15)% reduced Attribute Requirements
-{variant:2}{range:1}Items and Gems have (5-10)% reduced Attribute Requirements
+{variant:1}(10-15)% increased Reservation Efficiency of Skills
+{variant:2}(5-10)% increased Reservation Efficiency of Skills
+{variant:1}Items and Gems have (10-15)% reduced Attribute Requirements
+{variant:2}Items and Gems have (5-10)% reduced Attribute Requirements
 ]]
 )
 

--- a/src/Data/Uniques/amulet.lua
+++ b/src/Data/Uniques/amulet.lua
@@ -904,21 +904,6 @@ Implicits: 1
 {variant:2}Always Freeze, Shock and Ignite
 {variant:1}Cannot gain Power Charges
 ]],[[
-Replica Dragonfang's Flight
-Onyx Amulet
-Variant: Pre 3.23.0
-Variant: Current
-LevelReq: 56
-Implicits: 1
-{tags: jewellery_attribute}+(10-16) to all Attributes
-{variant:1}{tags:jewellery_resistance}+(10-15)% to all Elemental Resistances
-{variant:2}{tags:jewellery_resistance}+(5-10)% to all Elemental Resistances
-+3 to Level of all Spark Gems
-{variant:1}(10-15)% increased Reservation Efficiency of Skills
-{variant:2}(5-10)% increased Reservation Efficiency of Skills
-{variant:1}Items and Gems have (10-15)% reduced Attribute Requirements
-{variant:2}Items and Gems have (5-10)% reduced Attribute Requirements
-]],[[
 Retaliation Charm
 Citrine Amulet
 Variant: Pre 3.19.0


### PR DESCRIPTION
Generate variants for all **_active_**, **_non-vaal_**, **_non-transfigured_** skill gems for Replica Dragonfang's Flight

Fixes Replica Dragonfang's Flight only having Spark variant.

### Description of the problem being solved:

### Steps taken to verify a working solution:
- Copied all variant names and variant modifiers from generated item in to google sheets
- Check if variant name (gem name) is contained in variant modifier text (ex. "Tempest Shield" is in "{variant:3}+3 to Level of all Tempest Shield Gems"
- Check if variant number matches corresponding row number

https://docs.google.com/spreadsheets/d/1AnPz_zLoBIeEYl65xxF5qD0ppUlQJVTfkTBXGZDtGJ8/edit?usp=sharing

### Before screenshot:
![image](https://github.com/user-attachments/assets/3cccb913-6586-4bb9-a863-edd38fb9631f)

### After screenshot:
![image](https://github.com/user-attachments/assets/aa57a97e-90b0-4adb-9522-7e386a7a5578)
![image](https://github.com/user-attachments/assets/73d8905f-fabf-4e2b-b1f1-850edeee1275)


