### PR TITLE
Fix crash when trying to edit Config/Item Set after saving a new Set

### DIFF
--- a/src/Classes/ConfigSetListControl.lua
+++ b/src/Classes/ConfigSetListControl.lua
@@ -52,7 +52,7 @@ function ConfigSetListClass:RenameSet(configSet, addOnName)
 		if addOnName then
 			t_insert(self.list, configSet.id)
 			self.selIndex = #self.list
-			self.selValue = configSet
+			self.selValue = configSet.id
 		end
 		self.configTab:AddUndoState()
 		self.configTab.build:SyncLoadouts()

--- a/src/Classes/ItemSetListControl.lua
+++ b/src/Classes/ItemSetListControl.lua
@@ -53,7 +53,7 @@ function ItemSetListClass:RenameSet(itemSet, addOnName)
 		if addOnName then
 			t_insert(self.list, itemSet.id)
 			self.selIndex = #self.list
-			self.selValue = itemSet
+			self.selValue = itemSet.id
 		end
 		self.itemsTab:AddUndoState()
 		self.itemsTab.build:SyncLoadouts()


### PR DESCRIPTION
Fixes #8726.
Missed in the original #8738 PR

### Description of the problem being solved:
I missed the Config and Item set menus from the original issue. Oopsie.

### After screenshot:
![image](https://github.com/user-attachments/assets/71943b62-d7f4-47a8-8417-ed841d81dd8a)
