### PR TITLE
Properly disable only hexes and not marks with Coiling Whisper

### DIFF
--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -3674,7 +3674,7 @@ local specialModList = {
 	} end,
 	["temporal chains has (%d+)%% reduced effect on you"] = function(num) return { mod("CurseEffectOnSelf", "INC", -num, { type = "SkillName", skillName = "Temporal Chains" }) } end,
 	["unaffected by temporal chains"] = { mod("CurseEffectOnSelf", "MORE", -100, { type = "SkillName", skillName = "Temporal Chains" }, { type = "GlobalEffect", effectType = "Global", unscalable = true }) },
-	["targets are unaffected by your hexes"] = { mod("CurseEffect", "MORE", -100) },
+	["targets are unaffected by your hexes"] = { mod("CurseEffect", "MORE", -100, { type = "SkillType", skillType = SkillType.Hex } ) },
 	["([%+%-][%d%.]+) seconds to cat's stealth duration"] = function(num) return { mod("PrimaryDuration", "BASE", num, { type = "SkillName", skillName = "Aspect of the Cat" }) } end,
 	["([%+%-][%d%.]+) seconds to cat's agility duration"] = function(num) return { mod("SecondaryDuration", "BASE", num, { type = "SkillName", skillName = "Aspect of the Cat" }) } end,
 	["([%+%-][%d%.]+) seconds to avian's might duration"] = function(num) return { mod("PrimaryDuration", "BASE", num, { type = "SkillName", skillName = "Aspect of the Avian" }) } end,


### PR DESCRIPTION
It does not disable marks only hexes

### Description of the problem being solved:

Currently coiling whisper disables both marks and hexes which is incorrect

### Link to a build that showcases this PR:

https://pobb.in/AT-Lg1r-3zm-

### Before screenshot:

![image](https://github.com/user-attachments/assets/4c4d8ed3-88b2-473e-8eb8-fce6c721d41d)

### After screenshot:

![image](https://github.com/user-attachments/assets/a4807181-7fb2-466f-af23-5d25facfd58c)
