### PR TITLE
Fix Multistrike + Awakened Spell Echo not working properly with minions

### DIFF
--- a/src/Data/SkillStatMap.lua
+++ b/src/Data/SkillStatMap.lua
@@ -266,7 +266,8 @@ return {
 	mod("RepeatCount", "BASE", nil, 0, 0, {type = "SkillType", skillType = SkillType.Multicastable }),
 },
 ["base_melee_attack_repeat_count"] = {
-	mod("RepeatCount", "BASE", nil, 0, 0, { type = "SkillType", skillType = SkillType.Multistrikeable }),
+	mod("RepeatCount", "BASE", nil, 0, 0, { type = "ModFlagOr", modFlags = bit.bor(ModFlag.WeaponMelee, ModFlag.Unarmed) }),
+	mod("RepeatCount", "BASE", nil, 0, 0, { type = "SkillType", skillType = SkillType.RequiresShield }),
 },
 ["skill_repeat_count"] = {
 	mod("RepeatCount", "BASE", nil, 0, 0, { type = "SkillType", skillType = SkillType.Multicastable }),

--- a/src/Modules/ConfigOptions.lua
+++ b/src/Modules/ConfigOptions.lua
@@ -844,8 +844,10 @@ Huge sets the radius to 11.
 	}, defaultIndex = 2, apply = function(val, modList, enemyModList)
 		if val == "AVERAGE" then
 			modList:NewMod("Condition:averageRepeat", "FLAG", true, "Config")
+			modList:NewMod("MinionModifier", "LIST", { mod = modLib.createMod("Condition:averageRepeat", "FLAG", true, "Config") })
 		elseif val == "FINAL" or val == "FINAL_DPS" then
 			modList:NewMod("Condition:alwaysFinalRepeat", "FLAG", true, "Config")
+			modList:NewMod("MinionModifier", "LIST", { mod = modLib.createMod("Condition:alwaysFinalRepeat", "FLAG", true, "Config") })
 		end
 	end },
 	{ var = "ruthlessSupportMode", type = "list", label = "Ruthless Support Mode:", ifSkill = "Ruthless", tooltip = "Controls how the hit/ailment effect of Ruthless Support is calculated:\n\tAverage: damage is based on the average application\n\tMax Effect: damage is based on maximum effect", list = {{val="AVERAGE",label="Average"},{val="MAX",label="Max Effect"}} },


### PR DESCRIPTION
Multistrike would only add repeats to skills with the tag on it, which broke support for minions' skills
It now uses the same criteria that the damage mods do
This also made me realise that the repeat damage config was not working when used with minion skills, as we were only setting the condition on the player
So the average repeat damage and final repeat values were completely wrong, and the double damage with spells line on Awakened Spell Echo was not working at all with minions

Build: https://pobb.in/ymtQ4g2S_2As

Before:
![image](https://github.com/user-attachments/assets/0d5a6b19-aea7-45fc-89a9-77e7373268f7)
![image](https://github.com/user-attachments/assets/38c0d0fd-01a9-4f72-b16a-fb8b5935d43c)
![image](https://github.com/user-attachments/assets/348acda5-243a-4833-858a-3653a7e119f0)


After:
![image](https://github.com/user-attachments/assets/f86ee2a8-7d21-4b4d-8162-a0ce9d52d399)
![image](https://github.com/user-attachments/assets/1bb229be-38e1-4d98-9502-37212834bcbe)
![image](https://github.com/user-attachments/assets/cd2af47e-8a3e-4564-b7e0-264e5d2b9423)

