### PR TITLE
Fix Elemental Overload applying to skills with 0 Crit Chance

### DIFF
--- a/src/Modules/CalcOffence.lua
+++ b/src/Modules/CalcOffence.lua
@@ -2921,6 +2921,9 @@ function calcs.offence(env, actor, activeSkill)
 				}
 			end
 		end
+		if output.CritChance ~= 0 then
+			skillModList.conditions["CritInPast8Sec"] = true
+		end
 
 		output.ScaledDamageEffect = 1
 

--- a/src/Modules/CalcPerform.lua
+++ b/src/Modules/CalcPerform.lua
@@ -236,9 +236,6 @@ local function doActorAttribsConditions(env, actor)
 		end
 	end
 	if env.mode_combat then
-		if not modDB:Flag(env.player.mainSkill.skillCfg, "NeverCrit") then
-			condList["CritInPast8Sec"] = true
-		end
 		if not actor.mainSkill.skillData.triggered and not actor.mainSkill.skillFlags.trap and not actor.mainSkill.skillFlags.mine and not actor.mainSkill.skillFlags.totem then
 			if actor.mainSkill.skillFlags.attack then
 				condList["AttackedRecently"] = true


### PR DESCRIPTION
Fixes #8770
The elemental flag for "CritInPast8s" was only false when the "NeverCrit" flag was true instead of checking to see if the skill has any crit chance
