### PR TITLE
Fix Brand attachment duration not being scaled by Temporal Chains

### DIFF
--- a/src/Data/Skills/act_int.lua
+++ b/src/Data/Skills/act_int.lua
@@ -570,6 +570,9 @@ skills["BrandSupport"] = {
 		duration = true,
 		brand = true,
 	},
+	baseMods = {
+		skill("debuff", true),
+	},
 	qualityStats = {
 		Default = {
 			{ "sigil_repeat_frequency_+%", 0.5 },
@@ -832,6 +835,7 @@ skills["ArmageddonBrand"] = {
 	},
 	baseMods = {
 		skill("radiusSecondary", 8),
+		skill("debuff", true),
 	},
 	qualityStats = {
 		Default = {
@@ -1012,6 +1016,9 @@ skills["ArmageddonBrandAltY"] = {
 		area = true,
 		duration = true,
 		brand = true,
+	},
+	baseMods = {
+		skill("debuff", true),
 	},
 	qualityStats = {
 		Default = {
@@ -13258,6 +13265,7 @@ skills["PenanceBrandAltX"] = {
 	baseMods = {
 		skill("radius", 28),
 		mod("Multiplier:PenanceBrandofDissipationMaxStages", "BASE", 20, 0, 0, { type = "SkillPart", skillPart = 1 }),
+		skill("debuff", true),
 	},
 	qualityStats = {
 		Default = {
@@ -13352,6 +13360,7 @@ skills["PenanceBrandAltY"] = {
 	baseMods = {
 		skill("radius", 28),
 		skill("showAverage", true),
+		skill("debuff", true),
 	},
 	qualityStats = {
 		Default = {
@@ -16550,6 +16559,7 @@ skills["StormBrand"] = {
 	},
 	baseMods = {
 		skill("radius", 9),
+		skill("debuff", true),
 	},
 	qualityStats = {
 		Default = {
@@ -16648,6 +16658,7 @@ skills["StormBrandAltX"] = {
 	},
 	baseMods = {
 		skill("radius", 9),
+		skill("debuff", true),
 	},
 	qualityStats = {
 		Default = {
@@ -20162,13 +20173,14 @@ skills["WintertideBrand"] = {
 		activeSkill.skillData.hitTimeOverride = activeSkill.skillData.repeatFrequency / (1 + activeSkill.skillModList:Sum("INC", activeSkill.skillCfg, "Speed", "BrandActivationFrequency") / 100) / activeSkill.skillModList:More(activeSkill.skillCfg, "BrandActivationFrequency")
 		if activeSkill.skillPart == 2 then
 			local skillMaxStages = activeSkill.skillModList:Sum("BASE", activeSkill.skillCfg, "Multiplier:WintertideBrandMaxStages")
-			local duration = calcSkillDuration(activeSkill.skillModList, activeSkill.skillCfg, activeSkill.skillData, {})
+			local debuffDurationMult = 1 / math.max(data.misc.BuffExpirationSlowCap, calcLib.mod(activeSkill.actor.enemy.modDB, activeSkill.skillCfg, "BuffExpireFaster"))
+			local duration = calcSkillDuration(activeSkill.skillModList, activeSkill.skillCfg, activeSkill.skillData, {}) * debuffDurationMult
 			local maxStages = math.min(duration / activeSkill.skillData.hitTimeOverride + 1, skillMaxStages)
 			local timeToReachMaxStages = (maxStages - 1) * activeSkill.skillData.hitTimeOverride
 			local timeAtMaxStages = duration - timeToReachMaxStages
 			local damagePerStage = activeSkill.skillModList:Sum("BASE", activeSkill.skillCfg, "Multiplier:WintertideBrandDamagePerStage")
 			-- Get the average damage before reaching max stages and then damage at max stages
-			local dpsMultiplier = ((2 + damagePerStage + maxStages * damagePerStage)/2*timeToReachMaxStages+timeAtMaxStages*(1+maxStages*damagePerStage))/duration
+			local dpsMultiplier = ((2 + damagePerStage + maxStages * damagePerStage) / 2 * timeToReachMaxStages + timeAtMaxStages * (1 + maxStages * damagePerStage)) / duration
 			activeSkill.skillModList:NewMod("Damage", "MORE", dpsMultiplier, "Wintertide Brand Average Multiplier")
 		end
 	end,
@@ -20204,6 +20216,7 @@ skills["WintertideBrand"] = {
 	},
 	baseMods = {
 		skill("radius", 20),
+		skill("debuff", true),
 		skill("debuffTertiary", true),
 	},
 	qualityStats = {

--- a/src/Export/Skills/act_int.txt
+++ b/src/Export/Skills/act_int.txt
@@ -73,6 +73,7 @@ local skills, mod, flag, skill = ...
 	preDamageFunc = function(activeSkill, output)
 		activeSkill.skillData.hitTimeOverride = activeSkill.skillData.repeatFrequency / (1 + activeSkill.skillModList:Sum("INC", activeSkill.skillCfg, "Speed", "BrandActivationFrequency") / 100) / activeSkill.skillModList:More(activeSkill.skillCfg, "BrandActivationFrequency")
 	end,
+#baseMod skill("debuff", true)
 #mods
 
 #skill SupportBrandSupport
@@ -110,6 +111,7 @@ local skills, mod, flag, skill = ...
 		},
 	},
 #baseMod skill("radiusSecondary", 8)
+#baseMod skill("debuff", true)
 #mods
 
 #skill ArmageddonBrandAltX
@@ -129,6 +131,7 @@ local skills, mod, flag, skill = ...
 		["base_skill_show_average_damage_instead_of_dps"] = {
 		},
 	},
+#baseMod skill("debuff", true)
 #mods
 
 #skill AssassinsMark
@@ -2939,6 +2942,7 @@ local skills, mod, flag, skill = ...
 	},
 #baseMod skill("radius", 28)
 #baseMod mod("Multiplier:PenanceBrandofDissipationMaxStages", "BASE", 20, 0, 0, { type = "SkillPart", skillPart = 1 })
+#baseMod skill("debuff", true)
 #mods
 
 #skill PenanceBrandAltY
@@ -2948,6 +2952,7 @@ local skills, mod, flag, skill = ...
 	end,
 #baseMod skill("radius", 28)
 #baseMod skill("showAverage", true)
+#baseMod skill("debuff", true)
 #mods
 
 #skill PowerSiphon
@@ -3553,6 +3558,7 @@ local skills, mod, flag, skill = ...
 		},
 	},
 #baseMod skill("radius", 9)
+#baseMod skill("debuff", true)
 #mods
 
 #skill StormBrandAltX
@@ -3565,6 +3571,7 @@ local skills, mod, flag, skill = ...
 		},
 	},
 #baseMod skill("radius", 9)
+#baseMod skill("debuff", true)
 #mods
 
 #skill StormblastMine
@@ -4168,13 +4175,14 @@ local skills, mod, flag, skill = ...
 		activeSkill.skillData.hitTimeOverride = activeSkill.skillData.repeatFrequency / (1 + activeSkill.skillModList:Sum("INC", activeSkill.skillCfg, "Speed", "BrandActivationFrequency") / 100) / activeSkill.skillModList:More(activeSkill.skillCfg, "BrandActivationFrequency")
 		if activeSkill.skillPart == 2 then
 			local skillMaxStages = activeSkill.skillModList:Sum("BASE", activeSkill.skillCfg, "Multiplier:WintertideBrandMaxStages")
-			local duration = calcSkillDuration(activeSkill.skillModList, activeSkill.skillCfg, activeSkill.skillData, {})
+			local debuffDurationMult = 1 / math.max(data.misc.BuffExpirationSlowCap, calcLib.mod(activeSkill.actor.enemy.modDB, activeSkill.skillCfg, "BuffExpireFaster"))
+			local duration = calcSkillDuration(activeSkill.skillModList, activeSkill.skillCfg, activeSkill.skillData, {}) * debuffDurationMult
 			local maxStages = math.min(duration / activeSkill.skillData.hitTimeOverride + 1, skillMaxStages)
 			local timeToReachMaxStages = (maxStages - 1) * activeSkill.skillData.hitTimeOverride
 			local timeAtMaxStages = duration - timeToReachMaxStages
 			local damagePerStage = activeSkill.skillModList:Sum("BASE", activeSkill.skillCfg, "Multiplier:WintertideBrandDamagePerStage")
 			-- Get the average damage before reaching max stages and then damage at max stages
-			local dpsMultiplier = ((2 + damagePerStage + maxStages * damagePerStage)/2*timeToReachMaxStages+timeAtMaxStages*(1+maxStages*damagePerStage))/duration
+			local dpsMultiplier = ((2 + damagePerStage + maxStages * damagePerStage) / 2 * timeToReachMaxStages + timeAtMaxStages * (1 + maxStages * damagePerStage)) / duration
 			activeSkill.skillModList:NewMod("Damage", "MORE", dpsMultiplier, "Wintertide Brand Average Multiplier")
 		end
 	end,
@@ -4203,6 +4211,7 @@ local skills, mod, flag, skill = ...
 		},
 	},
 #baseMod skill("radius", 20)
+#baseMod skill("debuff", true)
 #baseMod skill("debuffTertiary", true)
 #mods
 

--- a/src/Modules/CalcOffence.lua
+++ b/src/Modules/CalcOffence.lua
@@ -2297,7 +2297,7 @@ function calcs.offence(env, actor, activeSkill)
 			output.HitSpeed = 1 / output.HitTime
 			--Brands always have hitTimeOverride
 			if activeSkill.skillTypes[SkillType.Brand] and not skillModList:Flag(nil, "UnlimitedBrandDuration") then
-				output.BrandTicks = m_floor(output.Duration * output.HitSpeed)
+				output.BrandTicks = m_floor(output.Duration * output.HitSpeed * debuffDurationMult)
 			end
 		elseif skillData.hitTimeMultiplier and output.Time and not skillData.triggeredOnDeath then
 			output.HitTime = output.Time * skillData.hitTimeMultiplier


### PR DESCRIPTION
The Brand attachment time is affected by temportal chains so this affects the maximum number of ticks a brand can do. More relevant for Wintertide Brand as we uses the attachment duration for DPS calcs
