### PR TITLE
Fix values changing depending on order of skill groups

### DIFF
--- a/src/Modules/CalcSetup.lua
+++ b/src/Modules/CalcSetup.lua
@@ -1705,6 +1705,8 @@ function calcs.initEnv(build, mode, override, specEnv)
 			activeSkill.skillData.storedUses = skillData.storedUses
 			activeSkill.skillData.CritChance = skillData.CritChance
 			activeSkill.skillData.attackTime = skillData.attackTime
+			activeSkill.skillData.attackSpeedMultiplier = skillData.attackSpeedMultiplier
+			activeSkill.skillData.soulPreventionDuration = activeSkill.soulPreventionDuration
 			activeSkill.skillData.totemLevel = skillData.totemLevel
 			activeSkill.skillData.damageEffectiveness = skillData.damageEffectiveness
 			activeSkill.skillData.manaReservationPercent = skillData.manaReservationPercent


### PR DESCRIPTION
Fixes #8797

### Description of the problem being solved:
When rebuilding an env from cache for reuse in future calculations skillData is reset and only select properties are preserved. `attackSpeedMultiplier` was not one of them causing the dps to double in the case of #8797 due to increased attack speed.

This pr preserves `attackSpeedMultiplier` to fix the issue and `soulPreventionDuration` to prevent a potential future issue.