### PR TITLE
Fix gems being added to skill groups when sorting dropdown

### DIFF
--- a/src/Classes/GemSelectControl.lua
+++ b/src/Classes/GemSelectControl.lua
@@ -60,6 +60,7 @@ end)
 
 function GemSelectClass:CalcOutputWithThisGem(calcFunc, gemData, qualityId, useFullDPS)
 	local gemList = self.skillsTab.displayGroup.gemList
+	local displayGemList = self.skillsTab.displayGroup.displayGemList
 	local oldGem
 	if gemList[self.index] then
 		oldGem = copyTable(gemList[self.index], true)
@@ -98,7 +99,9 @@ function GemSelectClass:CalcOutputWithThisGem(calcFunc, gemData, qualityId, useF
 	else
 		gemList[self.index] = nil
 	end
-
+	
+	self.skillsTab.displayGroup.displayGemList = displayGemList
+	
 	return output, gemInstance
 end
 


### PR DESCRIPTION
Fixes issue mentioned on discord

### Description of the problem being solved:
When generating skill gem selection dropdown cache the displayGemList was not correctly reset to the previous state causing temporarily added gems to remain visible in tooltip. This issue is rather complex as essentially each calculation instance modifes the global state of the displayGemList. While the solution proposed in this PR fixes the issue currently it is rather fragile and could break in the future.
