### PR TITLE
Fix trigger based reservation pooling

### DIFF
--- a/src/Modules/CalcActiveSkill.lua
+++ b/src/Modules/CalcActiveSkill.lua
@@ -486,9 +486,6 @@ function calcs.buildActiveSkillModList(env, activeSkill)
 			if level.manaMultiplier then
 				skillModList:NewMod("SupportManaMultiplier", "MORE", level.manaMultiplier, skillEffect.grantedEffect.modSource)
 			end
-			if level.manaReservationPercent then
-				activeSkill.skillData.manaReservationPercent = level.manaReservationPercent
-			end	
 			-- Handle multiple triggers situation and if triggered by a trigger skill save a reference to the trigger.
 			local match = skillEffect.grantedEffect.addSkillTypes and (not skillFlags.disable)
 			if match and skillEffect.grantedEffect.isTrigger then
@@ -498,12 +495,23 @@ function calcs.buildActiveSkillModList(env, activeSkill)
 				else
 					activeSkill.triggeredBy = skillEffect
 				end
+			elseif level.manaReservationPercent then
+				activeSkill.skillData.manaReservationPercent = level.manaReservationPercent
 			end
 			if level.PvPDamageMultiplier then
 				skillModList:NewMod("PvpDamageMultiplier", "MORE", level.PvPDamageMultiplier, skillEffect.grantedEffect.modSource)
 			end
 			if level.storedUses then
 				activeSkill.skillData.storedUses = level.storedUses
+			end
+		end
+	end
+
+	if activeSkill.activeEffect.srcInstance then
+		local supportEffect = activeSkill.activeEffect.srcInstance.supportEffect
+		if supportEffect and supportEffect.grantedEffect.isTrigger then
+			for effect, _ in pairs(supportEffect.isSupporting) do
+				activeSkill.skillData.manaReservationPercent = (activeSkill.skillData.manaReservationPercent or 0) + (supportEffect.grantedEffect.levels[supportEffect.level].manaReservationPercent or 0)
 			end
 		end
 	end

--- a/src/Modules/CalcPerform.lua
+++ b/src/Modules/CalcPerform.lua
@@ -1651,7 +1651,7 @@ function calcs.perform(env, skipEHP)
 		breakdown.ManaReserved = { reservations = { } }
 	end
 	for _, activeSkill in ipairs(env.player.activeSkillList) do
-		if (activeSkill.skillTypes[SkillType.HasReservation] or activeSkill.skillData.SupportedByAutoexertion) and not activeSkill.skillTypes[SkillType.ReservationBecomesCost] then
+		if activeSkill.skillTypes[SkillType.HasReservation] and not activeSkill.skillTypes[SkillType.ReservationBecomesCost] then
 			local skillModList = activeSkill.skillModList
 			local skillCfg = activeSkill.skillCfg
 			local mult = floor(skillModList:More(skillCfg, "SupportManaMultiplier"), 4)


### PR DESCRIPTION
Fixes #8042

### Description of the problem being solved:
Currently the reservation caused by skills such as Spellslinger and Autoexertion is applied to the triggered skills. This causes issues such as the mentioned where some modifiers are not applied to that reservation. This pr causes the reservation to come from the active part of the trigger skill gem allowing for correct application of reservation modifiers.

This pr makes the assumption that summing up all the raw reservation values and then applying the modifiers is the same as applying the modifiers and then summing as the text on the mentioned gems implies: `This Skill's Mana Reservation is the total of the Mana Reservations of Supported Skills, and cannot be further modified`

I also couldn't think of a good predicate for when to apply this logic so i've made the assumption that all active skills that also have a secondary effect which is a trigger support and have reservation apply the reservation pooling logic. I have not found any cases where this assumption fails currently.

The downside of this approach is that the breakdown not shows only the total reservation of the active part of the trigger and not individual one for each triggered skill. This could potentially be fixes by adding some extra logic to CalcPeform.

### Steps taken to verify a working solution:
- Test Divine Blessing
- Test Autoexertion and Spellslinger with Arrogance

### Link to a build that showcases this PR:
```
eNrNHGtz4jjy8-RXuPjMBPyAQCqZLfKaYTeZcJB57H3ZErYAbYTF2HIS9ur--7Uk2xgGGRt7qm63agNWv9Xd6m6ZvfjtbUmNFxyEhPmXDfO03TCw7zKP-PPLxpenu_e9xm8fTi5GiC8eZ1cRoWLlw8m7C_nZoPgFU8DrNAyOgjnmXxNS9l9AaoV8vsDMf0B_s-Aj8y4bn5mPG8YU-R7hyTeXojD8jJb4sjFxAblhoNDFvne9eR4DLlCAXI6De8F2EHH2wDxY5UEEq0tE_AlznzH_GLBoBVI1jBeCXxXM8GH0OH7KiET8rEig0ruLEUVrHEw44kYI_7lsDMAyaI4_EQ6kEI2ATrvRyoW9ioKQ36AlfDyMM1lh7B0Guw4If4goJytKcJDCm6cdHQZIfL1AvruRwWxryT8xjujNaHJYEAXJCljjG-GLKwraFaIroIdzn3BcGHzESMj8UlIXAr6OKAUXLwQ7xiEOXhAnBQW5Zssp8Qva5AH56JqFvBjkCAcQMrwUwgS7DKKsLI-SmPdkhotDltIjRigrzXF63E6KwpUmfJxAY0gxxSAnLKIFIXlQJGOM8Y8tyI42Ed3gtxTM0kIN_Y1sVh7XLKDZ6-m5vjAuT5JCueH202hD1TZPux2zazt9x9RLPFqsQ-Ii-oDeyDJaQr59Qs94w9Ds23oXnC-4DzlGi2t1dbh3JMBHoF0z6h2DtkAs1OOZeUG22c9uL-f4c88F8NB3i4XuFz-QOTdzauZaeobHEFHiZJ5SXBRlwyQOzBTxzDptm07f6thntmk7-Xzn2I-Zr4spd4-xu_gIVcwYcVwsJWfc1sm1sgAuZGUBuM_K7X4xjF2T9cxT27Gtnt3pWfk09lvMOrXzkEra7NbHwXw9WRBMvXLQiWDXaFWornPPs9iFTL_NrpT7ZFFLmuQbCrxih01ZmV5QmM3BZj_fXAo8aylL69MPGGpLwPDwTpmrlWYUsL-xywkthzYIliwKCu64Ai6mQXKAqFZhjL3ILXZi3c5mQo8XfEWh2SmqR4oFglJaCnXAOXKfb5g3L2w1yaQUxrZ8k2i1goQi_KEoAXEyQj1OMlXO-04B6Edw5kIxLc7Q4gw20IUZpHVBcS47KMV1EQf7LptuEfDCLNINfYB0sYQTQfa60Itv8oF2c6AFK9QiScCCfd2IvYLkCzGkCMtBQwGUImjPorsA-_-sC9PfAi_E4Nb3okCEQmEeuxj72DyRJWTSMLxBHBleXDV_RQFBPrfkBCXEKHAX97D1d4jSKWSCy0b2qfi2g2gme3vRklMi8Wm4XLGAG_hN_BmhgK8vGzNEQ6wA5ROgE3Liy34a0g6lDWOyYK8D70Vo8cQYDRMkA61W2Pe2aDwFGBsoSSKuEELqKL4YSxRyOLWUV4ZC6MyMaegJMxo-AwHANo7Tbjdtp2PaTbNvOk7Tts_MXtNun9l207JNy2o63c5Zr9m1zDY86dl2u9npwZ9mv9_vNB3b7FpNu392ZjedvgmAptPudJuWdQbgDlBzhAVFp4eC9WBbDp-A2hxUyUzSoEJXQzIlqNDq3cWX8b388G7B-So8b7VeX19PV4gv2Ay_wTF36rJlawVIYI_34TOh9L0g2xrAP1fzweB2-G9IHnd_rIePFh6Y6Evwfd1bedEP4t7_-P3H9Ls7QJ-jxZ9Bl0aAcimZthKuF2rSFrbUN5EWAgLmU27VEjaXDiA2RXz4zDgOxZp4mHy5mAixQiMEn_iIl-HVGkL5TtQwO7OSeFcF9ARz5ZdZnGQE6OEZiqh4_q8IUSKcrJ19eq_GlT4LlmnrBqTAycSJoyg-rVfCCwb392plQHlMTLBLPE55ViyQQbzE2-KHchg52Eh9jagbSrmJ79LIg44nznLxjlM0FZKJ6atoVbzsUDNDJ2Xz7gKkiYE_UjZF1EpQ4pks9NHGHC-FyzxgjjyI8NaQgwotoUdLkoNP8rwNxchLTRZlBAuk7QXpQD8__pExc_xZAN0oize2BDQTAXdUdFnkqz310TIO3S0urXo1HgTulqLye6qf_Par1BLE69Imddgb8gKBciXSONhrew8V0C7EZjP3r_8q9RUfI2UUJw-1M4ejRwZK1fgR0Id2QNrngfiQfneit5ynAR59YtAVhNsOF3GG33Cg6v2N5_38OCODZP_L_FLHGpamIaORWHjCyxVFwe8RlPV1x6SsVcAlrlVjmZpq63lqqa2nv8omCRNDcKk9aKEDY94DmhN3X8AOgoDNVd-zG6uZpV-XpRIW_68BWs65ZDE_IauFaq9TY289T-289fRXmVgyMWIuP1k5_giVhayhVJUkPko7S4ihv4q4JHjZWJLQ_WsazWbiphM04YG8vb29u7u9fhp-vY1r_SyK1PYvP1pOxSmu_m46sgmWswgjjKah-njZ-ErwqxTkBixNaCj0ohStQpxW4bIMiiWngJdDTUJ9IulF6X5aGwA9pVuZtvz5N2hIAoK1cqXrB4RSDMWIS_RGOmriDlRPSE1MrqHlUCM4jaXk5a-eirj11aojFnNwod1CVMs5Xj1gCS4KYfBWMiOuaCvzt1yUzQoqxy6uCx2pu87Z73jco6chL5V1BNSiHlldGuuw49Ucq8oraq1V1aoe_Qa7SKu7WtQjp1Nd5svXEfZTSaFyKH1mvnRyCJoBoWI0o93ZW4pTED3BR77AQdxZ6yg9QI5KQHIDJyDTiOvDOAORYyt5_6SxkFjTo6pLFY0OYi0nE23dLWgMmoXRk1IzeW0iy0NVYzqt_eKhX84WxANvjfnVao4RkqG_Rv94OSdIZP4dvDDiqSpHEy47YHkJg7nP1cnIaXZ1Mrvj7eoU7ygKn7X7Ha_q0b9wIqqaPVRU9VKIiAiqahREbFWj8ASFJ48CfDSB8W4lssEd59cg6Uh2L3Kympc54knt0RTUPPlodFmOHo0t8z-UxBg0yD0AUpic-OCRfwPG4DmxUZCUFGt_ItloV4qWOgr3alqaogrw-JWKvBygQA4QgrP8U061WIxSemXzCSMq3rBjtBrBn14dqUJMXDxHK-R7CbnHfTX6Zh8KWo_xEGjKe4obcb9d1YY-Xq73ENLLddFKujp5gyH6rPh6ZcID0TD_w9jyz8vGe9O0-qe9s16nq57Fw-xePMCG2vuGwA4G0vMSjgLw-2Wj0-2e9oCA4ih75HioLj6nM3U9nSjE6t20bxitmC8xkk5d0svOwMfQY_P1uTEejG9PoIYUUYOo8Q0MfTJcTiPsqc_XAZpx7J0bgsfJKMAz8nZu_AdS4Ryft087_71nLqIDz8OeuLBVluvlA4qL10KA6d1pAj2BDnof9NB3A4xgF1VbJ9s2SwstGjNxrw-bR57j62_7IPTm7V7nJL5tODes9kl8y3JuXL2Hf0_klo_xj3Oj0wdLAoJLxGpbDg3ENqT7Ia4ldJu2fV9BGTegcVmOpl_G98Lh1IjgI4UmGJxYLKl7p1Y-gmJimBsU8xDKFYPwMwbTdRiCfyhljU4JnleY8l18qwS-LAoM-wgtjckrWu2ydo4hVEH9mIZVA439CnVrUKhbg0JH0dinkFnGufZ5p12DRay6tCnjb58wVC-8kj32BFu3sgRWaQqVWdp12b9TgzOYNYSHWYMcTklPqCvFWFUj0qnBgOXPjNpSrF1Vf6tiCJcTwFsbaghUxQdVbVGFwv7A7lSm0K1rW826ckx516xuR6fyXnbqcaoyyg-WEcW8hkxo15BQ7IpB6VTEN-ux_9EnZWmndUpjHFNFVbRqp2qurmlbnLqSS2119dEtVAm8sXgbw6qcmqx69qC2k6KOhs85Tqeyxq9-xtdUbHQqC1L9iOuWTQZVk8fPDNXMJ3lPRI715GsizJ-ReTzgU1_iEZ9ESp9szYFGFLl4waiHg1gILGaZ8U_Uk1dEztqp7BqErd8WJGj2IaydadwG07Ic8xDHYPNr9wStcwAn-3ORFOegaulssZR8m9llKTQ57Ntg9Bw9_DIdH4qfxuMAexP5Bop482iC6Szzik-ngI6lDZPu3khM-dNNL4pVfiOEj-2atNfvHkBLL6dTa7RNxy5gkFJqxb_oYpSOxbA3Gzt6zInL5MQfdi386YWsXM_fNcPBUEtSf4LQNfu9vh4nJHNCH2fqtTiO5D1nUfm2f-RWOmiKmn2ygASpsd1FK0136rJFfvtwctHa_X-a_A_vRTUC
```
