### PR TITLE
Fix Plague Bearer default config not applying

### DIFF
--- a/src/Modules/ConfigOptions.lua
+++ b/src/Modules/ConfigOptions.lua
@@ -476,7 +476,7 @@ return {
 		modList:NewMod("Multiplier:MomentumStacksRemoved", "BASE", val, "Config")
 	end },
 	{ label = "Plague Bearer:", ifSkill = "Plague Bearer"},
-	{ var = "plagueBearerState", type = "list", label = "State:", ifSkill = "Plague Bearer", list = {{val="INC",label="Incubating"},{val="INF",label="Infecting"}}, apply = function(val, modList, enemyModList)
+	{ var = "plagueBearerState", type = "list", label = "State:", defaultIndex = 1, ifSkill = "Plague Bearer", list = {{val="INC",label="Incubating"},{val="INF",label="Infecting"}}, apply = function(val, modList, enemyModList)
 		if val == "INC" then
 			modList:NewMod("Condition:PlagueBearerIncubating", "FLAG", true, "Config")
 		elseif val == "INF" then


### PR DESCRIPTION
### Description of the problem being solved:
Plague Bearer "Incubating" was the default drop down selection, but it was not applying. By switching to "Infecting", the DPS would stay the same. Then switching back to "Incubating" would lower poison damage by 20% as expected. But after saving and reloading the build, the DPS would be higher again, I guess because it counts as having nothing selected.

### Link to a build that showcases this PR:
https://pobb.in/7ciL29S6yGvx

Screenshots not really helpful here.
Also, plz help my build