### PR TITLE
Fix Attribute Requirement sorting

### DIFF
--- a/src/Modules/CalcPerform.lua
+++ b/src/Modules/CalcPerform.lua
@@ -1760,6 +1760,7 @@ function calcs.perform(env, skipEHP)
 			local breakdownAttr = omniRequirements and "Omni" or attr
 			if breakdown then
 				breakdown["Req"..attr] = {
+					source = "",
 					rowList = { },
 					colList = {
 						{ label = attr, key = "req" },
@@ -1812,17 +1813,6 @@ function calcs.perform(env, skipEHP)
 					output["Req"..breakdownAttr.."String"] = out.val > (output[breakdownAttr] or 0) and colorCodes.NEGATIVE..(out.val) or out.val
 				end
 			end
-		end
-		if breakdown and breakdown["ReqOmni"] then
-			table.sort(breakdown["ReqOmni"].rowList, function(a, b)
-				if a.reqNum ~= b.reqNum then
-					return a.reqNum > b.reqNum
-				elseif a.source ~= b.source then
-					return a.source < b.source
-				else
-					return a.sourceName < b.sourceName
-				end
-			end)
 		end
 	end
 


### PR DESCRIPTION
Fixes #8813

### Description of the problem being solved:
Required attributes was not being sorted in the breakdown, but Omni was on it's own. Setting the .source flag fixes this and let's us remove redundant sorting later as it is taken care of within CalcBreakdownControl now #7211.

At least that's the theory. Seems to work, makes sense to me, hope this is right. _cross fingers_

### After screenshot:
Without Omni
![image](https://github.com/user-attachments/assets/acb0d5d5-c052-42cb-9dfc-0e890d0c6848)
With Omni
![image](https://github.com/user-attachments/assets/2756e93d-8873-4e0f-92df-99a51f59b022)
