### PR TITLE
Fix Runegraft of the Bound scaling Facebreaker's incorrectly

### DIFF
--- a/src/Classes/ModDB.lua
+++ b/src/Classes/ModDB.lua
@@ -45,8 +45,9 @@ function ModDBClass:ReplaceModInternal(mod)
 	local modIndex = -1
 	for i = 1, #modList do
 		local curMod = modList[i]
-		if mod.name == curMod.name and mod.type == curMod.type and mod.flags == curMod.flags and mod.keywordFlags == curMod.keywordFlags and mod.source == curMod.source then
+		if mod.name == curMod.name and mod.type == curMod.type and mod.flags == curMod.flags and mod.keywordFlags == curMod.keywordFlags and mod.source == curMod.source and not curMod.replaced then
 			modIndex = i
+			mod.replaced = true
 			break;
 		end
 	end

--- a/src/Classes/ModStore.lua
+++ b/src/Classes/ModStore.lua
@@ -34,7 +34,7 @@ local ModStoreClass = newClass("ModStore", function(self, parent)
 	self.conditions = { }
 end)
 
-function ModStoreClass:ScaleAddMod(mod, scale)
+function ModStoreClass:ScaleAddMod(mod, scale, replace)
 	local unscalable = false
 	for _, effects in ipairs(mod) do
 		if effects.unscalable then
@@ -63,7 +63,11 @@ function ModStoreClass:ScaleAddMod(mod, scale)
 				subMod.value = m_modf(round(subMod.value * scale, 2))
 			end
 		end
-		self:AddMod(scaledMod)
+		if replace then
+			self:ReplaceModInternal(scaledMod)
+		else
+			self:AddMod(scaledMod)
+		end
 	end
 end
 

--- a/src/Modules/CalcSetup.lua
+++ b/src/Modules/CalcSetup.lua
@@ -1188,27 +1188,23 @@ function calcs.initEnv(build, mode, override, specEnv)
 	end
 	
 	if env.player.itemList["Gloves"] then
-		local gloveEffectMod = env.modDB:Sum("INC", nil, "EffectOfBonusesFromGloves") / 100
-		if gloveEffectMod ~= 0 then
+		local gloveEffectMod = calcLib.mod(env.modDB, nil, "EffectOfBonusesFromGloves")
+		if gloveEffectMod ~= 1 then
 			local modList = env.player.itemList["Gloves"].modList
 			for _, mod in ipairs(modList) do
 				if not (mod.name == "ExtraSupport" or mod.name == "ExtraSkill" or mod.name == "ExtraSupport" or mod.name == "ExtraSkillMod" or (mod[1] and mod[1].type == "SocketedIn")) then
-					local modCopy = copyTable(mod)
-					modCopy.source = tostring(gloveEffectMod * 100) .. "% Gloves Bonus Effect"
-					modDB:ScaleAddMod(modCopy, gloveEffectMod)
+					modDB:ScaleAddMod(mod, gloveEffectMod, true)
 				end
 			end
 		end
 	end
 	if env.player.itemList["Boots"] then
-		local bootEffectMod = env.modDB:Sum("INC", nil, "EffectOfBonusesFromBoots") / 100
-		if bootEffectMod ~= 0 then
+		local bootEffectMod = calcLib.mod(env.modDB, nil, "EffectOfBonusesFromBoots")
+		if bootEffectMod ~= 1 then
 			local modList = env.player.itemList["Boots"].modList
 			for _, mod in ipairs(modList) do
 				if not (mod.name == "ExtraSupport" or mod.name == "ExtraSkill" or mod.name == "ExtraSupport" or mod.name == "ExtraSkillMod" or (mod[1] and mod[1].type == "SocketedIn")) then
-					local modCopy = copyTable(mod)
-					modCopy.source = tostring(bootEffectMod * 100) .. "% Boots Bonus Effect"
-					modDB:ScaleAddMod(modCopy, bootEffectMod)
+					modDB:ScaleAddMod(mod, bootEffectMod, true)
 				end
 			end
 		end


### PR DESCRIPTION
The mod was scaling the more multiplier on the gloves incorrectly by adding another More multiplier mod instead of modifying the existing mod
This change also made me realise that we sometime incorrectly handle mods when the are 2 instances of them on an item
e.g. T1 Life + crafted hybrid life shows up as 2 mods on the item so we process them in 2 loops which results in the rounding being incorrect
Would have to somehow merge all similar mods on an item first then loop though them to fix it I think
Before:
<img width="506" height="82" alt="image" src="https://github.com/user-attachments/assets/f589cca0-3ce2-4278-85d3-5cef43175ea4" />


After:
<img width="429" height="66" alt="image" src="https://github.com/user-attachments/assets/e3e2fd2f-8192-4dd6-b7f7-dd4ec6db4df8" />
