### PR TITLE
Remove Channelling time config box for Focused Channelling - Existing users should update their config

### DIFF
--- a/src/Data/Skills/sup_int.lua
+++ b/src/Data/Skills/sup_int.lua
@@ -2326,10 +2326,10 @@ skills["SupportFocusedChannelling"] = {
 	statDescriptionScope = "gem_stat_descriptions",
 	statMap = {
 		["support_focus_channel_cost_+%_final_per_second_channelling_up_to_100%"] = {
-			mod("Cost", "MORE", nil, 0, 0, { type = "Multiplier", var = "ChannellingSeconds", limit = 100, limitTotal = true }),
+			mod("Cost", "MORE", nil, 0, 0, { type = "Multiplier", var = "ChannellingTime", limit = 100, limitTotal = true }),
 		},
 		["support_focus_channel_damage_+%_final_per_second_channelling_up_to_60%"] = {
-			mod("Damage", "MORE", nil, 0, 0, { type = "Multiplier", var = "ChannellingSeconds", limit = 60, limitTotal = true }),
+			mod("Damage", "MORE", nil, 0, 0, { type = "Multiplier", var = "ChannellingTime", limit = 60, limitTotal = true }),
 		},
 	},
 	qualityStats = {

--- a/src/Export/Skills/sup_int.txt
+++ b/src/Export/Skills/sup_int.txt
@@ -300,10 +300,10 @@ local skills, mod, flag, skill = ...
 #skill SupportFocusedChannelling
 	statMap = {
 		["support_focus_channel_cost_+%_final_per_second_channelling_up_to_100%"] = {
-			mod("Cost", "MORE", nil, 0, 0, { type = "Multiplier", var = "ChannellingSeconds", limit = 100, limitTotal = true }),
+			mod("Cost", "MORE", nil, 0, 0, { type = "Multiplier", var = "ChannellingTime", limit = 100, limitTotal = true }),
 		},
 		["support_focus_channel_damage_+%_final_per_second_channelling_up_to_60%"] = {
-			mod("Damage", "MORE", nil, 0, 0, { type = "Multiplier", var = "ChannellingSeconds", limit = 60, limitTotal = true }),
+			mod("Damage", "MORE", nil, 0, 0, { type = "Multiplier", var = "ChannellingTime", limit = 60, limitTotal = true }),
 		},
 	},
 #mods

--- a/src/Modules/ConfigOptions.lua
+++ b/src/Modules/ConfigOptions.lua
@@ -402,10 +402,6 @@ return {
 	{ var = "FlickerStrikeBypassCD", type = "check", label = "Bypass CD?", ifSkill = "Flicker Strike", includeTransfigured = true, defaultState = true, apply = function(val, modList, enemyModList)
 		modList:NewMod("CooldownRecovery", "OVERRIDE", 0, "Config", { type = "SkillName", skillName = "Flicker Strike", includeTransfigured = true })
 	end },
-	{ label = "Focused Channelling Support:", ifSkill = "Focused Channelling" },
-	{ var = "channellingSeconds", type = "count", label = "Seconds spent Channelling:", ifSkill = "Focused Channelling", tooltip = "Sets the amount of time you've spent channelling in seconds.", apply = function(val, modList, enemyModList)
-		modList:NewMod("Multiplier:ChannellingSeconds", "BASE", val, "Config")
-	end },
 	{ label = "Fresh Meat:", ifSkill = "Fresh Meat" },
 	{ var = "freshMeatBuffs", type = "check", label = "Is Fresh Meat active?", ifSkill = "Fresh Meat", apply = function(val, modList, enemyModList)
 		modList:NewMod("Condition:FreshMeatActive", "FLAG", true, "Config")


### PR DESCRIPTION
Fixes #8822 .

### Description of the problem being solved:
There were two sections in the Config Tab that let you specify time spent channelling, leading to confusion in the above issue.  This PR removes the skill-specific one and has Focused Channelling rely on the existing ChannellingTime multiplier instead.

**This will break people's builds if they didn't have this box set up for something else.**
