### PR TITLE
Fix Righteous Fire of Arcane Devotion more Cast Speed mod not working

### DIFF
--- a/src/Data/Skills/act_int.lua
+++ b/src/Data/Skills/act_int.lua
@@ -14941,7 +14941,7 @@ skills["RighteousFireAltX"] = {
 			skill("RFManaMultiplier", nil),
 			div = 6000,
 		},
-		["righteous_fire_spell_damage_+%_final"] = {
+		["righteous_fire_cast_speed_+%_final"] = {
 			mod("Speed", "MORE", nil, ModFlag.Cast, 0, { type = "GlobalEffect", effectType = "Buff" }),
 		},
 	},

--- a/src/Export/Skills/act_int.txt
+++ b/src/Export/Skills/act_int.txt
@@ -3256,7 +3256,7 @@ local skills, mod, flag, skill = ...
 			skill("RFManaMultiplier", nil),
 			div = 6000,
 		},
-		["righteous_fire_spell_damage_+%_final"] = {
+		["righteous_fire_cast_speed_+%_final"] = {
 			mod("Speed", "MORE", nil, ModFlag.Cast, 0, { type = "GlobalEffect", effectType = "Buff" }),
 		},
 	},


### PR DESCRIPTION
### Description of the problem being solved:
Righteous Fire of Arcane Devotion did not provide more cast speed when active.

### Steps taken to verify a working solution:
- Compared a test build with Fireball and Righteous Fire of Arcane Devotion on latest release, dev branch and branch with my fix
- Only edited file in `./src/Export` and then ran GGPK export

### Link to a build that showcases this PR:
https://pobb.in/yeT4ZfjWoCqF

### Before screenshot:
<img width="478" height="328" alt="Path_of_Building_8iDfvqPcuW" src="https://github.com/user-attachments/assets/97175b22-83cb-4521-8fe2-e94fe3b3a14b" />
<img width="206" height="119" alt="Path_of_Building_X6ZPZjmGYq" src="https://github.com/user-attachments/assets/5b8aeb5b-f556-423b-936d-aa5d361b254e" />

### After screenshot:
<img width="483" height="332" alt="Path{space}of{space}Building_qgdiLmXzhf" src="https://github.com/user-attachments/assets/edd048af-1978-44fc-891a-3121967535be" />
<img width="249" height="203" alt="Path{space}of{space}Building_Sv5cT37o2k" src="https://github.com/user-attachments/assets/ea70cbce-83bf-4668-b484-a7f02744e4c5" />
