### PR TITLE
Fix Timeless jewel search error

### DIFF
--- a/src/Modules/CalcSetup.lua
+++ b/src/Modules/CalcSetup.lua
@@ -111,7 +111,9 @@ function calcs.buildModListForNode(env, node)
 		modList:AddMod(node.keystoneMod)
 	else
 		-- Apply effect scaling
-		local scale = calcLib.mod(node.modList, nil, "PassiveSkillEffect")
+		local modListToMerge = new("ModList") -- Timeless jewel finder nodes don't have a real modList
+		modListToMerge:AddList(node.modList)
+		local scale = calcLib.mod(modListToMerge, nil, "PassiveSkillEffect")
 		if scale ~= 1 then
 			local combinedList = new("ModList")
 			for _, mod in ipairs(node.modList) do


### PR DESCRIPTION
Fixes #8835  .

### Description of the problem being solved:
Timeless jewel node mod lists are stitched together in a strange way.  I couldn't follow the logic on what needs to change in there, so this just creates a real modList to add those mods to.
### Steps taken to verify a working solution:
- Operate a timeless jewel search for each type of jewel
