### PR TITLE
Fix Iron Mass giving Skeletons Triple Damage in Offhand

### DIFF
--- a/src/Classes/ModStore.lua
+++ b/src/Classes/ModStore.lua
@@ -617,7 +617,11 @@ function ModStoreClass:EvalMod(mod, cfg, globalLimits)
 					t_insert(matches, item.elder == tag.elderCond)
 				end
 			end
-
+			if tag.nameCond then
+				for _, item in pairs(items) do
+					t_insert(matches, item.name and item.name:lower() == tag.nameCond:lower())
+				end
+			end
 			local hasItems = false
 			for _, item in pairs(items) do
 				hasItems = true

--- a/src/Data/ModCache.lua
+++ b/src/Data/ModCache.lua
@@ -864,16 +864,294 @@ c["+3 to Level of Socketed Golem Gems"]={{[1]={[1]={slotName="{SlotName}",type="
 c["+3 to Level of Socketed Lightning Gems"]={{[1]={[1]={slotName="{SlotName}",type="SocketedIn"},flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyOfScaledMod="value",keyword="lightning",value=3}}},nil}
 c["+3 to Level of Socketed Minion Gems"]={{[1]={[1]={slotName="{SlotName}",type="SocketedIn"},flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyOfScaledMod="value",keyword="minion",value=3}}},nil}
 c["+3 to Level of Socketed Warcry Gems"]={{[1]={[1]={slotName="{SlotName}",type="SocketedIn"},flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyOfScaledMod="value",keyword="warcry",value=3}}},nil}
+c["+3 to Level of all Absolution Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="absolution",value=3}}},nil}
+c["+3 to Level of all Alchemist's Mark Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="alchemist's mark",value=3}}},nil}
+c["+3 to Level of all Ambush Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="ambush",value=3}}},nil}
+c["+3 to Level of all Ancestral Cry Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="ancestral cry",value=3}}},nil}
+c["+3 to Level of all Anger Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="anger",value=3}}},nil}
+c["+3 to Level of all Animate Guardian Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="animate guardian",value=3}}},nil}
+c["+3 to Level of all Animate Weapon Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="animate weapon",value=3}}},nil}
+c["+3 to Level of all Arc Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="arc",value=3}}},nil}
+c["+3 to Level of all Arcane Cloak Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="arcane cloak",value=3}}},nil}
+c["+3 to Level of all Arcanist Brand Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="arcanist brand",value=3}}},nil}
+c["+3 to Level of all Arctic Armour Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="arctic armour",value=3}}},nil}
+c["+3 to Level of all Armageddon Brand Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="armageddon brand",value=3}}},nil}
+c["+3 to Level of all Artillery Ballista Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="artillery ballista",value=3}}},nil}
+c["+3 to Level of all Assassin's Mark Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="assassin's mark",value=3}}},nil}
+c["+3 to Level of all Autoexertion Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="autoexertion",value=3}}},nil}
+c["+3 to Level of all Automation Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="automation",value=3}}},nil}
+c["+3 to Level of all Ball Lightning Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="ball lightning",value=3}}},nil}
+c["+3 to Level of all Bane Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="bane",value=3}}},nil}
+c["+3 to Level of all Barrage Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="barrage",value=3}}},nil}
+c["+3 to Level of all Battlemage's Cry Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="battlemage's cry",value=3}}},nil}
+c["+3 to Level of all Bear Trap Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="bear trap",value=3}}},nil}
+c["+3 to Level of all Berserk Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="berserk",value=3}}},nil}
+c["+3 to Level of all Blade Blast Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="blade blast",value=3}}},nil}
+c["+3 to Level of all Blade Flurry Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="blade flurry",value=3}}},nil}
+c["+3 to Level of all Blade Trap Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="blade trap",value=3}}},nil}
+c["+3 to Level of all Blade Vortex Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="blade vortex",value=3}}},nil}
+c["+3 to Level of all Bladefall Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="bladefall",value=3}}},nil}
+c["+3 to Level of all Bladefall of Trarthus Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="bladefall of trarthus",value=3}}},nil}
+c["+3 to Level of all Bladestorm Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="bladestorm",value=3}}},nil}
+c["+3 to Level of all Blast Rain Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="blast rain",value=3}}},nil}
+c["+3 to Level of all Blazing Salvo Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="blazing salvo",value=3}}},nil}
+c["+3 to Level of all Blight Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="blight",value=3}}},nil}
+c["+3 to Level of all Blink Arrow Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="blink arrow",value=3}}},nil}
+c["+3 to Level of all Blood Rage Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="blood rage",value=3}}},nil}
+c["+3 to Level of all Blood and Sand Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="blood and sand",value=3}}},nil}
+c["+3 to Level of all Bodyswap Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="bodyswap",value=3}}},nil}
+c["+3 to Level of all Bone Offering Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="bone offering",value=3}}},nil}
+c["+3 to Level of all Boneshatter Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="boneshatter",value=3}}},nil}
+c["+3 to Level of all Brand Recall Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="brand recall",value=3}}},nil}
+c["+3 to Level of all Burning Arrow Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="burning arrow",value=3}}},nil}
+c["+3 to Level of all Caustic Arrow Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="caustic arrow",value=3}}},nil}
+c["+3 to Level of all Chain Hook Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="chain hook",value=3}}},nil}
 c["+3 to Level of all Chaos Spell Skill Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keywordList={[1]="chaos",[2]="spell",[3]="skill"},value=3}}},nil}
+c["+3 to Level of all Charged Dash Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="charged dash",value=3}}},nil}
+c["+3 to Level of all Clarity Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="clarity",value=3}}},nil}
+c["+3 to Level of all Cleave Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="cleave",value=3}}},nil}
+c["+3 to Level of all Cobra Lash Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="cobra lash",value=3}}},nil}
+c["+3 to Level of all Cold Snap Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="cold snap",value=3}}},nil}
 c["+3 to Level of all Cold Spell Skill Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keywordList={[1]="cold",[2]="spell",[3]="skill"},value=3}}},nil}
+c["+3 to Level of all Conductivity Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="conductivity",value=3}}},nil}
+c["+3 to Level of all Consecrated Path Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="consecrated path",value=3}}},nil}
+c["+3 to Level of all Contagion Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="contagion",value=3}}},nil}
+c["+3 to Level of all Conversion Trap Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="conversion trap",value=3}}},nil}
+c["+3 to Level of all Convocation Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="convocation",value=3}}},nil}
+c["+3 to Level of all Corrupting Fever Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="corrupting fever",value=3}}},nil}
+c["+3 to Level of all Crackling Lance Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="crackling lance",value=3}}},nil}
+c["+3 to Level of all Creeping Frost Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="creeping frost",value=3}}},nil}
+c["+3 to Level of all Cremation Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="cremation",value=3}}},nil}
 c["+3 to Level of all Critical Support Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keywordList={[1]="critical",[2]="support"},value=3}}},nil}
+c["+3 to Level of all Crushing Fist Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="crushing fist",value=3}}},nil}
+c["+3 to Level of all Cyclone Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="cyclone",value=3}}},nil}
+c["+3 to Level of all Dark Pact Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="dark pact",value=3}}},nil}
+c["+3 to Level of all Dash Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="dash",value=3}}},nil}
+c["+3 to Level of all Decoy Totem Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="decoy totem",value=3}}},nil}
+c["+3 to Level of all Defiance Banner Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="defiance banner",value=3}}},nil}
+c["+3 to Level of all Desecrate Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="desecrate",value=3}}},nil}
+c["+3 to Level of all Despair Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="despair",value=3}}},nil}
+c["+3 to Level of all Destructive Link Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="destructive link",value=3}}},nil}
+c["+3 to Level of all Determination Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="determination",value=3}}},nil}
+c["+3 to Level of all Detonate Dead Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="detonate dead",value=3}}},nil}
+c["+3 to Level of all Detonate Mines Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="detonate mines",value=3}}},nil}
+c["+3 to Level of all Devouring Totem Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="devouring totem",value=3}}},nil}
+c["+3 to Level of all Discharge Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="discharge",value=3}}},nil}
+c["+3 to Level of all Discipline Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="discipline",value=3}}},nil}
+c["+3 to Level of all Divine Ire Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="divine ire",value=3}}},nil}
+c["+3 to Level of all Divine Retribution Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="divine retribution",value=3}}},nil}
+c["+3 to Level of all Dominating Blow Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="dominating blow",value=3}}},nil}
+c["+3 to Level of all Double Strike Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="double strike",value=3}}},nil}
+c["+3 to Level of all Dread Banner Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="dread banner",value=3}}},nil}
+c["+3 to Level of all Dual Strike Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="dual strike",value=3}}},nil}
+c["+3 to Level of all Earthquake Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="earthquake",value=3}}},nil}
+c["+3 to Level of all Earthshatter Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="earthshatter",value=3}}},nil}
+c["+3 to Level of all Elemental Hit Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="elemental hit",value=3}}},nil}
 c["+3 to Level of all Elemental Skill Gems if the stars are aligned"]={{[1]={[1]={type="Condition",var="StarsAreAligned"},flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyOfScaledMod="value",keywordList={[1]="elemental",[2]="grants_active_skill"},value=3}}},nil}
 c["+3 to Level of all Elemental Support Gems if the stars are aligned"]={{[1]={[1]={type="Condition",var="StarsAreAligned"},flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyOfScaledMod="value",keywordList={[1]="elemental",[2]="support"},value=3}}},nil}
+c["+3 to Level of all Elemental Weakness Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="elemental weakness",value=3}}},nil}
+c["+3 to Level of all Enduring Cry Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="enduring cry",value=3}}},nil}
+c["+3 to Level of all Energy Blade Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="energy blade",value=3}}},nil}
+c["+3 to Level of all Enfeeble Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="enfeeble",value=3}}},nil}
+c["+3 to Level of all Ensnaring Arrow Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="ensnaring arrow",value=3}}},nil}
+c["+3 to Level of all Essence Drain Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="essence drain",value=3}}},nil}
+c["+3 to Level of all Ethereal Knives Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="ethereal knives",value=3}}},nil}
+c["+3 to Level of all Eviscerate Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="eviscerate",value=3}}},nil}
+c["+3 to Level of all Explosive Arrow Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="explosive arrow",value=3}}},nil}
+c["+3 to Level of all Explosive Concoction Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="explosive concoction",value=3}}},nil}
+c["+3 to Level of all Explosive Trap Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="explosive trap",value=3}}},nil}
+c["+3 to Level of all Exsanguinate Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="exsanguinate",value=3}}},nil}
+c["+3 to Level of all Eye of Winter Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="eye of winter",value=3}}},nil}
 c["+3 to Level of all Fire Spell Skill Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keywordList={[1]="fire",[2]="spell",[3]="skill"},value=3}}},nil}
+c["+3 to Level of all Fire Trap Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="fire trap",value=3}}},nil}
+c["+3 to Level of all Fireball Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="fireball",value=3}}},nil}
+c["+3 to Level of all Firestorm Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="firestorm",value=3}}},nil}
+c["+3 to Level of all Flame Dash Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="flame dash",value=3}}},nil}
+c["+3 to Level of all Flame Link Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="flame link",value=3}}},nil}
+c["+3 to Level of all Flame Surge Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="flame surge",value=3}}},nil}
+c["+3 to Level of all Flame Wall Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="flame wall",value=3}}},nil}
+c["+3 to Level of all Flameblast Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="flameblast",value=3}}},nil}
+c["+3 to Level of all Flamethrower Trap Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="flamethrower trap",value=3}}},nil}
+c["+3 to Level of all Flammability Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="flammability",value=3}}},nil}
+c["+3 to Level of all Flesh Offering Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="flesh offering",value=3}}},nil}
+c["+3 to Level of all Flesh and Stone Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="flesh and stone",value=3}}},nil}
+c["+3 to Level of all Flicker Strike Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="flicker strike",value=3}}},nil}
+c["+3 to Level of all Forbidden Rite Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="forbidden rite",value=3}}},nil}
+c["+3 to Level of all Freezing Pulse Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="freezing pulse",value=3}}},nil}
+c["+3 to Level of all Frenzy Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="frenzy",value=3}}},nil}
+c["+3 to Level of all Frost Blades Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="frost blades",value=3}}},nil}
+c["+3 to Level of all Frost Bomb Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="frost bomb",value=3}}},nil}
+c["+3 to Level of all Frost Shield Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="frost shield",value=3}}},nil}
+c["+3 to Level of all Frost Wall Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="frost wall",value=3}}},nil}
+c["+3 to Level of all Frostbite Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="frostbite",value=3}}},nil}
+c["+3 to Level of all Frostblink Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="frostblink",value=3}}},nil}
+c["+3 to Level of all Frostbolt Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="frostbolt",value=3}}},nil}
+c["+3 to Level of all Frozen Legion Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="frozen legion",value=3}}},nil}
+c["+3 to Level of all Galvanic Arrow Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="galvanic arrow",value=3}}},nil}
+c["+3 to Level of all Galvanic Field Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="galvanic field",value=3}}},nil}
+c["+3 to Level of all General's Cry Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="general's cry",value=3}}},nil}
+c["+3 to Level of all Glacial Cascade Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="glacial cascade",value=3}}},nil}
+c["+3 to Level of all Glacial Hammer Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="glacial hammer",value=3}}},nil}
+c["+3 to Level of all Glacial Shield Swipe Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="glacial shield swipe",value=3}}},nil}
+c["+3 to Level of all Grace Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="grace",value=3}}},nil}
+c["+3 to Level of all Ground Slam Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="ground slam",value=3}}},nil}
+c["+3 to Level of all Haste Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="haste",value=3}}},nil}
+c["+3 to Level of all Hatred Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="hatred",value=3}}},nil}
+c["+3 to Level of all Heavy Strike Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="heavy strike",value=3}}},nil}
+c["+3 to Level of all Herald of Agony Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="herald of agony",value=3}}},nil}
+c["+3 to Level of all Herald of Ash Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="herald of ash",value=3}}},nil}
+c["+3 to Level of all Herald of Ice Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="herald of ice",value=3}}},nil}
+c["+3 to Level of all Herald of Purity Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="herald of purity",value=3}}},nil}
+c["+3 to Level of all Herald of Thunder Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="herald of thunder",value=3}}},nil}
+c["+3 to Level of all Hexblast Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="hexblast",value=3}}},nil}
+c["+3 to Level of all Holy Flame Totem Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="holy flame totem",value=3}}},nil}
+c["+3 to Level of all Hydrosphere Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="hydrosphere",value=3}}},nil}
+c["+3 to Level of all Ice Crash Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="ice crash",value=3}}},nil}
+c["+3 to Level of all Ice Nova Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="ice nova",value=3}}},nil}
+c["+3 to Level of all Ice Shot Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="ice shot",value=3}}},nil}
+c["+3 to Level of all Ice Spear Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="ice spear",value=3}}},nil}
+c["+3 to Level of all Ice Trap Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="ice trap",value=3}}},nil}
+c["+3 to Level of all Icicle Mine Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="icicle mine",value=3}}},nil}
+c["+3 to Level of all Immortal Call Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="immortal call",value=3}}},nil}
+c["+3 to Level of all Incinerate Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="incinerate",value=3}}},nil}
+c["+3 to Level of all Infernal Blow Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="infernal blow",value=3}}},nil}
+c["+3 to Level of all Infernal Cry Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="infernal cry",value=3}}},nil}
+c["+3 to Level of all Intimidating Cry Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="intimidating cry",value=3}}},nil}
+c["+3 to Level of all Intuitive Link Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="intuitive link",value=3}}},nil}
+c["+3 to Level of all Kinetic Blast Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="kinetic blast",value=3}}},nil}
+c["+3 to Level of all Kinetic Bolt Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="kinetic bolt",value=3}}},nil}
+c["+3 to Level of all Lacerate Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="lacerate",value=3}}},nil}
+c["+3 to Level of all Lancing Steel Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="lancing steel",value=3}}},nil}
+c["+3 to Level of all Leap Slam Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="leap slam",value=3}}},nil}
+c["+3 to Level of all Lightning Arrow Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="lightning arrow",value=3}}},nil}
+c["+3 to Level of all Lightning Conduit Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="lightning conduit",value=3}}},nil}
 c["+3 to Level of all Lightning Spell Skill Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keywordList={[1]="lightning",[2]="spell",[3]="skill"},value=3}}},nil}
+c["+3 to Level of all Lightning Spire Trap Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="lightning spire trap",value=3}}},nil}
+c["+3 to Level of all Lightning Strike Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="lightning strike",value=3}}},nil}
+c["+3 to Level of all Lightning Tendrils Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="lightning tendrils",value=3}}},nil}
+c["+3 to Level of all Lightning Trap Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="lightning trap",value=3}}},nil}
+c["+3 to Level of all Lightning Warp Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="lightning warp",value=3}}},nil}
+c["+3 to Level of all Malevolence Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="malevolence",value=3}}},nil}
+c["+3 to Level of all Manabond Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="manabond",value=3}}},nil}
 c["+3 to Level of all Melee Skill Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keywordList={[1]="melee",[2]="skill"},value=3}}},nil}
+c["+3 to Level of all Mirror Arrow Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="mirror arrow",value=3}}},nil}
+c["+3 to Level of all Molten Shell Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="molten shell",value=3}}},nil}
+c["+3 to Level of all Molten Strike Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="molten strike",value=3}}},nil}
+c["+3 to Level of all Orb of Storms Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="orb of storms",value=3}}},nil}
+c["+3 to Level of all Penance Brand Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="penance brand",value=3}}},nil}
+c["+3 to Level of all Perforate Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="perforate",value=3}}},nil}
+c["+3 to Level of all Pestilent Strike Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="pestilent strike",value=3}}},nil}
+c["+3 to Level of all Petrified Blood Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="petrified blood",value=3}}},nil}
+c["+3 to Level of all Phase Run Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="phase run",value=3}}},nil}
 c["+3 to Level of all Physical Spell Skill Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keywordList={[1]="physical",[2]="spell",[3]="skill"},value=3}}},nil}
+c["+3 to Level of all Plague Bearer Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="plague bearer",value=3}}},nil}
+c["+3 to Level of all Poacher's Mark Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="poacher's mark",value=3}}},nil}
+c["+3 to Level of all Poisonous Concoction Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="poisonous concoction",value=3}}},nil}
+c["+3 to Level of all Portal Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="portal",value=3}}},nil}
+c["+3 to Level of all Power Siphon Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="power siphon",value=3}}},nil}
+c["+3 to Level of all Precision Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="precision",value=3}}},nil}
+c["+3 to Level of all Pride Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="pride",value=3}}},nil}
+c["+3 to Level of all Protective Link Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="protective link",value=3}}},nil}
+c["+3 to Level of all Puncture Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="puncture",value=3}}},nil}
+c["+3 to Level of all Punishment Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="punishment",value=3}}},nil}
+c["+3 to Level of all Purifying Flame Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="purifying flame",value=3}}},nil}
+c["+3 to Level of all Purity of Elements Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="purity of elements",value=3}}},nil}
+c["+3 to Level of all Purity of Fire Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="purity of fire",value=3}}},nil}
+c["+3 to Level of all Purity of Ice Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="purity of ice",value=3}}},nil}
+c["+3 to Level of all Purity of Lightning Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="purity of lightning",value=3}}},nil}
+c["+3 to Level of all Pyroclast Mine Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="pyroclast mine",value=3}}},nil}
+c["+3 to Level of all Quickstep Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="quickstep",value=3}}},nil}
+c["+3 to Level of all Rage Vortex Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="rage vortex",value=3}}},nil}
+c["+3 to Level of all Rain of Arrows Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="rain of arrows",value=3}}},nil}
+c["+3 to Level of all Raise Spectre Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="raise spectre",value=3}}},nil}
+c["+3 to Level of all Raise Zombie Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="raise zombie",value=3}}},nil}
+c["+3 to Level of all Rallying Cry Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="rallying cry",value=3}}},nil}
+c["+3 to Level of all Reap Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="reap",value=3}}},nil}
+c["+3 to Level of all Reave Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="reave",value=3}}},nil}
+c["+3 to Level of all Rejuvenation Totem Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="rejuvenation totem",value=3}}},nil}
+c["+3 to Level of all Righteous Fire Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="righteous fire",value=3}}},nil}
+c["+3 to Level of all Rolling Magma Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="rolling magma",value=3}}},nil}
+c["+3 to Level of all Scorching Ray Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="scorching ray",value=3}}},nil}
+c["+3 to Level of all Scourge Arrow Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="scourge arrow",value=3}}},nil}
+c["+3 to Level of all Searing Bond Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="searing bond",value=3}}},nil}
+c["+3 to Level of all Seismic Cry Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="seismic cry",value=3}}},nil}
+c["+3 to Level of all Seismic Trap Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="seismic trap",value=3}}},nil}
+c["+3 to Level of all Shattering Steel Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="shattering steel",value=3}}},nil}
+c["+3 to Level of all Shield Charge Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="shield charge",value=3}}},nil}
+c["+3 to Level of all Shield Crush Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="shield crush",value=3}}},nil}
+c["+3 to Level of all Shock Nova Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="shock nova",value=3}}},nil}
+c["+3 to Level of all Shockwave Totem Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="shockwave totem",value=3}}},nil}
+c["+3 to Level of all Shrapnel Ballista Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="shrapnel ballista",value=3}}},nil}
+c["+3 to Level of all Siege Ballista Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="siege ballista",value=3}}},nil}
+c["+3 to Level of all Sigil of Power Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="sigil of power",value=3}}},nil}
+c["+3 to Level of all Siphoning Trap Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="siphoning trap",value=3}}},nil}
+c["+3 to Level of all Smite Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="smite",value=3}}},nil}
+c["+3 to Level of all Smoke Mine Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="smoke mine",value=3}}},nil}
+c["+3 to Level of all Snipe Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="snipe",value=3}}},nil}
+c["+3 to Level of all Sniper's Mark Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="sniper's mark",value=3}}},nil}
+c["+3 to Level of all Soul Link Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="soul link",value=3}}},nil}
+c["+3 to Level of all Soulrend Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="soulrend",value=3}}},nil}
 c["+3 to Level of all Spark Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="spark",value=3}}},nil}
+c["+3 to Level of all Spectral Helix Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="spectral helix",value=3}}},nil}
+c["+3 to Level of all Spectral Shield Throw Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="spectral shield throw",value=3}}},nil}
+c["+3 to Level of all Spectral Throw Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="spectral throw",value=3}}},nil}
+c["+3 to Level of all Spellslinger Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="spellslinger",value=3}}},nil}
+c["+3 to Level of all Spirit Offering Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="spirit offering",value=3}}},nil}
+c["+3 to Level of all Split Arrow Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="split arrow",value=3}}},nil}
+c["+3 to Level of all Splitting Steel Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="splitting steel",value=3}}},nil}
+c["+3 to Level of all Static Strike Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="static strike",value=3}}},nil}
+c["+3 to Level of all Steelskin Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="steelskin",value=3}}},nil}
+c["+3 to Level of all Storm Brand Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="storm brand",value=3}}},nil}
+c["+3 to Level of all Storm Burst Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="storm burst",value=3}}},nil}
+c["+3 to Level of all Storm Call Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="storm call",value=3}}},nil}
+c["+3 to Level of all Storm Rain Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="storm rain",value=3}}},nil}
+c["+3 to Level of all Stormbind Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="stormbind",value=3}}},nil}
+c["+3 to Level of all Stormblast Mine Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="stormblast mine",value=3}}},nil}
+c["+3 to Level of all Summon Carrion Golem Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="summon carrion golem",value=3}}},nil}
+c["+3 to Level of all Summon Chaos Golem Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="summon chaos golem",value=3}}},nil}
+c["+3 to Level of all Summon Flame Golem Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="summon flame golem",value=3}}},nil}
+c["+3 to Level of all Summon Holy Relic Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="summon holy relic",value=3}}},nil}
+c["+3 to Level of all Summon Ice Golem Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="summon ice golem",value=3}}},nil}
+c["+3 to Level of all Summon Lightning Golem Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="summon lightning golem",value=3}}},nil}
+c["+3 to Level of all Summon Raging Spirit Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="summon raging spirit",value=3}}},nil}
+c["+3 to Level of all Summon Reaper Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="summon reaper",value=3}}},nil}
+c["+3 to Level of all Summon Skeletons Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="summon skeletons",value=3}}},nil}
+c["+3 to Level of all Summon Skitterbots Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="summon skitterbots",value=3}}},nil}
+c["+3 to Level of all Summon Stone Golem Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="summon stone golem",value=3}}},nil}
+c["+3 to Level of all Sunder Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="sunder",value=3}}},nil}
+c["+3 to Level of all Sweep Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="sweep",value=3}}},nil}
+c["+3 to Level of all Swordstorm Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="swordstorm",value=3}}},nil}
+c["+3 to Level of all Tectonic Slam Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="tectonic slam",value=3}}},nil}
+c["+3 to Level of all Tempest Shield Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="tempest shield",value=3}}},nil}
+c["+3 to Level of all Temporal Chains Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="temporal chains",value=3}}},nil}
+c["+3 to Level of all Temporal Rift Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="temporal rift",value=3}}},nil}
+c["+3 to Level of all Tornado Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="tornado",value=3}}},nil}
+c["+3 to Level of all Tornado Shot Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="tornado shot",value=3}}},nil}
+c["+3 to Level of all Toxic Rain Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="toxic rain",value=3}}},nil}
+c["+3 to Level of all Unearth Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="unearth",value=3}}},nil}
+c["+3 to Level of all Vampiric Link Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="vampiric link",value=3}}},nil}
+c["+3 to Level of all Vengeful Cry Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="vengeful cry",value=3}}},nil}
+c["+3 to Level of all Venom Gyre Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="venom gyre",value=3}}},nil}
+c["+3 to Level of all Vigilant Strike Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="vigilant strike",value=3}}},nil}
+c["+3 to Level of all Viper Strike Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="viper strike",value=3}}},nil}
+c["+3 to Level of all Vitality Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="vitality",value=3}}},nil}
+c["+3 to Level of all Void Sphere Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="void sphere",value=3}}},nil}
+c["+3 to Level of all Volatile Dead Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="volatile dead",value=3}}},nil}
+c["+3 to Level of all Volcanic Fissure Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="volcanic fissure",value=3}}},nil}
+c["+3 to Level of all Voltaxic Burst Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="voltaxic burst",value=3}}},nil}
+c["+3 to Level of all Vortex Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="vortex",value=3}}},nil}
+c["+3 to Level of all Vulnerability Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="vulnerability",value=3}}},nil}
+c["+3 to Level of all War Banner Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="war banner",value=3}}},nil}
+c["+3 to Level of all Warlord's Mark Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="warlord's mark",value=3}}},nil}
+c["+3 to Level of all Wave of Conviction Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="wave of conviction",value=3}}},nil}
+c["+3 to Level of all Whirling Blades Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="whirling blades",value=3}}},nil}
+c["+3 to Level of all Wild Strike Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="wild strike",value=3}}},nil}
+c["+3 to Level of all Winter Orb Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="winter orb",value=3}}},nil}
+c["+3 to Level of all Wintertide Brand Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="wintertide brand",value=3}}},nil}
+c["+3 to Level of all Wither Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="wither",value=3}}},nil}
+c["+3 to Level of all Withering Step Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="withering step",value=3}}},nil}
+c["+3 to Level of all Wrath Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="wrath",value=3}}},nil}
+c["+3 to Level of all Zealotry Gems"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyword="zealotry",value=3}}},nil}
 c["+3 to Maximum Rage"]={{[1]={flags=0,keywordFlags=0,name="MaximumRage",type="BASE",value=3}},nil}
 c["+3 to maximum Fortification"]={{[1]={flags=0,keywordFlags=0,name="MaximumFortification",type="BASE",value=3}},nil}
 c["+3 to maximum number of Golems"]={{[1]={flags=0,keywordFlags=0,name="ActiveGolemLimit",type="BASE",value=3}},nil}
@@ -11356,7 +11634,7 @@ c["Summoned Raging Spirits' Melee Strikes deal Fire-only Splash"]={nil,"Summoned
 c["Summoned Raging Spirits' Melee Strikes deal Fire-only Splash Damage to Surrounding Targets"]={nil,"Summoned Raging Spirits' Melee Strikes deal Fire-only Splash Damage to Surrounding Targets "}
 c["Summoned Sentinels have 25% increased Cooldown Recovery Rate"]={{[1]={[1]={includeTransfigured=true,skillNameList={[1]="Herald of Purity",[2]="Dominating Blow",[3]="Absolution"},type="SkillName"},flags=0,keywordFlags=0,name="MinionModifier",type="LIST",value={mod={flags=0,keywordFlags=0,name="CooldownRecovery",type="INC",value=25}}}},nil}
 c["Summoned Skeleton Warriors and Soldiers deal Triple Damage with this"]={nil,"Summoned Skeleton Warriors and Soldiers deal Triple Damage with this "}
-c["Summoned Skeleton Warriors and Soldiers deal Triple Damage with this Weapon if you've Hit with this Weapon Recently"]={{[1]={[1]={type="Condition",var="HitRecentlyWithWeapon"},flags=0,keywordFlags=0,name="Dummy",type="DUMMY",value=1},[2]={[1]={skillName="Summon Skeletons",type="SkillName"},flags=0,keywordFlags=0,name="MinionModifier",type="LIST",value={mod={[1]={actor="parent",type="ActorCondition",var="HitRecentlyWithWeapon"},flags=0,keywordFlags=0,name="TripleDamageChance",type="BASE",value=100}}}},nil}
+c["Summoned Skeleton Warriors and Soldiers deal Triple Damage with this Weapon if you've Hit with this Weapon Recently"]={{[1]={[1]={skillName="Summon Skeletons",type="SkillName"},[2]={itemSlot="Weapon 1",nameCond="The Iron Mass, Gladius",type="ItemCondition"},flags=0,keywordFlags=0,name="MinionModifier",type="LIST",value={mod={[1]={actor="parent",type="ActorCondition",var="HitRecentlyWithWeapon"},flags=0,keywordFlags=0,name="TripleDamageChance",type="BASE",value=100}}}},nil}
 c["Summoned Skeleton Warriors and Soldiers wield this Weapon while in your Main Hand"]={{},nil}
 c["Summoned Skeleton Warriors are Permanent and Follow you"]={{[1]={[1]={skillName="Summon Skeletons",type="SkillName"},flags=0,keywordFlags=0,name="RaisedSkeletonPermanentDuration",type="FLAG",value=true}},nil}
 c["Summoned Skeletons Cover Enemies in Ash on Hit"]={nil,"Summoned Skeletons Cover Enemies in Ash on Hit "}

--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -4071,8 +4071,7 @@ local specialModList = {
 		mod("MinionModifier", "LIST", { mod = flag("Condition:CanWither") }),
 	},
 	["summoned skeleton warriors a?n?d? ?s?o?l?d?i?e?r?s? ?deal triple damage with this weapon if you've hit with this weapon recently"] = {
-		mod("Dummy", "DUMMY", 1, { type = "Condition", var = "HitRecentlyWithWeapon" }), -- Make the Configuration option appear
-		mod("MinionModifier", "LIST", { mod = mod("TripleDamageChance", "BASE", 100, { type = "ActorCondition", actor = "parent", var = "HitRecentlyWithWeapon" }) }, { type = "SkillName", skillName = "Summon Skeletons" }),
+		mod("MinionModifier", "LIST", { mod = mod("TripleDamageChance", "BASE", 100, { type = "ActorCondition", actor = "parent", var = "HitRecentlyWithWeapon" }) }, { type = "SkillName", skillName = "Summon Skeletons" }, { type = "ItemCondition", itemSlot = "Weapon 1", nameCond = "The Iron Mass, Gladius" } ),
 	},
 	["summoned skeleton warriors a?n?d? ?s?o?l?d?i?e?r?s? ?wield a? ?c?o?p?y? ?o?f? ?this weapon while in your main hand"] = { }, -- just make the mod blue, handled in CalcSetup
 	["each summoned phantasm grants you phantasmal might"] = { flag("Condition:PhantasmalMight") },


### PR DESCRIPTION
Fixes #3951.

### Description of the problem being solved:
As far as I know there was no way to search for Item names in Modparser, so I added a condition to "ItemCondition" in ModStore.
### Steps taken to verify a working solution:
- Having Iron Mass in main hand gives the skeletons the weapon as before, as well as off hand not giving the weapon.
- Removed the DUMMY mod so config option only shows up when Iron Mass is in main hand now.
- If you have another mod that uses the same config, it won't apply the triple damage to skeletons when toggled because we require "The Iron Mass, Gladius" to be in the main hand slot.
- "20% more damage if you have hit with your main hand weapon recently" will have the config appear with Iron Mass in offhand, and properly not give the triple damage.

### Link to a build that showcases this PR:
https://pobb.in/SzAJuJj2lVhI
