### PR TITLE
Fix tincture quality effect multiplier rounding issue

### DIFF
--- a/src/Modules/CalcPerform.lua
+++ b/src/Modules/CalcPerform.lua
@@ -1558,7 +1558,9 @@ function calcs.perform(env, skipEHP)
 			if item.rarity == "MAGIC" then
 				tinctureEffectInc = tinctureEffectInc + effectIncMagic
 			end
-			local effectMod = (1 + (tinctureEffectInc) / 100) * (1 + (item.quality or 0) / 100)
+			-- Compute tincture effect multiplier.
+			-- Tincture effect multiplier is rounded to 2 decimal places before applying it.
+			local effectMod = math.floor((1 + (tinctureEffectInc) / 100) * (1 + (item.quality or 0) / 100) * 100) / 100 
 
 			-- same deal as flasks, go look at the comment there
 			if buffModList[1] then


### PR DESCRIPTION
Fix tincture quality rounding issue:
https://www.reddit.com/r/pathofexile/comments/1foqn64/increased_tincture_effect_doesnt_round_the_way/
Also, this is what I got in-game vs pob (rip -3 divs of alt)
<img width="565" height="466" alt="image" src="https://github.com/user-attachments/assets/66ad8c14-7822-4e3a-9b1c-67d44c5886ce" />
<img width="523" height="64" alt="image" src="https://github.com/user-attachments/assets/747e38c1-6a9b-4687-bb97-6b4f4d3f59f4" />
<img width="507" height="255" alt="image" src="https://github.com/user-attachments/assets/1197f868-b6ba-4c7d-b07c-0c869bb9eccf" />

### Description of the problem being solved:

As the post on Reddit says, "The game calculates the increased effect and rounds it first". Thus, a 35% increase effect and a +21% quality should result in 1.35 * 1.25 = 1.6875 ≈ 1.68. Therefore, a 19% ele pen should result in 19% * 1.68 = 31.92% ≈ 31%, instead of 19% * 1.6875 = 32.0625% ≈ 32%

### Steps taken to verify a working solution:
- 
-
-

### Link to a build that showcases this PR:
https://pobb.in/XWWVPpewJTrs
### Before screenshot:
<img width="547" height="253" alt="image" src="https://github.com/user-attachments/assets/e6333738-0297-4f12-bc73-5a23f4a952c4" />

### After screenshot:
<img width="543" height="252" alt="image" src="https://github.com/user-attachments/assets/16b60801-8014-43f6-8fb8-70d34728116a" />
