### PR TITLE
Fix Light of Meaning double counting starting nodes on Ascendant

### DIFF
--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -5586,7 +5586,7 @@ local jewelOtherFuncs = {
 		end
 	end,
 	["50% increased Effect of non-Keystone Passive Skills in Radius"] = function(node, out, data)
-		if node and node.type ~= "Keystone" then
+		if node and node.type ~= "Keystone" and node.type ~= "ClassStart" then
 			out:NewMod("PassiveSkillEffect", "INC", 50, data.modSource)
 		end
 	end,
@@ -5607,7 +5607,7 @@ local jewelOtherFuncs = {
 	end,
 	["Passive Skills in Radius also grant: Traps and Mines deal (%d+) to (%d+) added Physical Damage"] = function(min, max)
 		return function(node, out, data)
-			if node and node.type ~= "Keystone" then
+			if node and node.type ~= "Keystone" and node.type ~= "ClassStart" then
 				out:NewMod("PhysicalMin", "BASE", min, data.modSource, 0, bor(KeywordFlag.Trap, KeywordFlag.Mine))
 				out:NewMod("PhysicalMax", "BASE", max, data.modSource, 0, bor(KeywordFlag.Trap, KeywordFlag.Mine))
 			end
@@ -5615,56 +5615,56 @@ local jewelOtherFuncs = {
 	end,
 	["Passive Skills in Radius also grant: (%d+)%% increased Unarmed Attack Speed with Melee Skills"] = function(num)
 		return function(node, out, data)
-			if node and node.type ~= "Keystone" then
+			if node and node.type ~= "Keystone" and node.type ~= "ClassStart" then
 				out:NewMod("Speed", "INC", num, data.modSource, bor(ModFlag.Unarmed, ModFlag.Attack, ModFlag.Melee))
 			end
 		end
 	end,
 	["Passive Skills in Radius also grant (%d+)%% increased Global Critical Strike Chance"] = function(num)
 		return function(node, out, data)
-			if node and node.type ~= "Keystone" and node.type ~= "Socket" then
+			if node and node.type ~= "Keystone" and node.type ~= "Socket" and node.type ~= "ClassStart" then
 				out:NewMod("CritChance", "INC", tonumber(num), data.modSource)
 			end
 		end
 	end,
 	["Passive Skills in Radius also grant %+(%d+) to Maximum Life"] = function(num)
 		return function(node, out, data)
-			if node and node.type ~= "Keystone" and node.type ~= "Socket" then
+			if node and node.type ~= "Keystone" and node.type ~= "Socket" and node.type ~= "ClassStart" then
 				out:NewMod("Life", "BASE", num, data.modSource)
 			end
 		end
 	end,
 	["Passive Skills in Radius also grant %+(%d+) to Maximum Mana"] = function(num)
 		return function(node, out, data)
-			if node and node.type ~= "Keystone" and node.type ~= "Socket" then
+			if node and node.type ~= "Keystone" and node.type ~= "Socket" and node.type ~= "ClassStart" then
 				out:NewMod("Mana", "BASE", num, data.modSource)
 			end
 		end
 	end,
 	["Passive Skills in Radius also grant (%d+)%% increased Energy Shield"] = function(num)
 		return function(node, out, data)
-			if node and node.type ~= "Keystone" and node.type ~= "Socket" then
+			if node and node.type ~= "Keystone" and node.type ~= "Socket" and node.type ~= "ClassStart" then
 				out:NewMod("EnergyShield", "INC", num, data.modSource)
 			end
 		end
 	end,
 	["Passive Skills in Radius also grant (%d+)%% increased Armour"] = function(num)
 		return function(node, out, data)
-			if node and node.type ~= "Keystone" and node.type ~= "Socket" then
+			if node and node.type ~= "Keystone" and node.type ~= "Socket" and node.type ~= "ClassStart" then
 				out:NewMod("Armour", "INC", num, data.modSource)
 			end
 		end
 	end,
 	["Passive Skills in Radius also grant (%d+)%% increased Evasion Rating"] = function(num)
 		return function(node, out, data)
-			if node and node.type ~= "Keystone" and node.type ~= "Socket" then
+			if node and node.type ~= "Keystone" and node.type ~= "Socket" and node.type ~= "ClassStart" then
 				out:NewMod("Evasion", "INC", num, data.modSource)
 			end
 		end
 	end,
 	["Passive Skills in Radius also grant %+(%d+) to all Attributes"] = function(num)
 		return function(node, out, data)
-			if node and node.type ~= "Keystone" and node.type ~= "Socket" then
+			if node and node.type ~= "Keystone" and node.type ~= "Socket" and node.type ~= "ClassStart" then
 				out:NewMod("Str", "BASE", num, data.modSource)
 				out:NewMod("Dex", "BASE", num, data.modSource)
 				out:NewMod("Int", "BASE", num, data.modSource)
@@ -5674,14 +5674,14 @@ local jewelOtherFuncs = {
 	end,
 	["Passive Skills in Radius also grant %+(%d+)%% to Chaos Resistance"] = function(num)
 		return function(node, out, data)
-			if node and node.type ~= "Keystone" and node.type ~= "Socket" then
+			if node and node.type ~= "Keystone" and node.type ~= "Socket" and node.type ~= "ClassStart" then
 				out:NewMod("ChaosResist", "BASE", num, data.modSource)
 			end
 		end
 	end,
 	["Passive Skills in Radius also grant (%d+)%% increased (%w+) Damage"] = function(num, type)
 		return function(node, out, data)
-			if node and node.type ~= "Keystone" and node.type ~= "Socket" then
+			if node and node.type ~= "Keystone" and node.type ~= "Socket" and node.type ~= "ClassStart" then
 				out:NewMod(firstToUpper(type).."Damage", "INC", num, data.modSource)
 			end
 		end


### PR DESCRIPTION
The Starting nodes from ascendant are within the radius of the jewels and were not checking for the ClassStart attribute to be false
Fixes #8856