### PR TITLE
Fix Howlcrack causing inf DPS with Generals Cry

### DIFF
--- a/src/Modules/CalcMirages.lua
+++ b/src/Modules/CalcMirages.lua
@@ -375,9 +375,6 @@ function calcs.mirages(env)
 			end
 		end
 
-		-- Scale dps with GC's cooldown
-		env.player.mainSkill.skillData.dpsMultiplier = (env.player.mainSkill.skillData.dpsMultiplier or 1) * (1 / cooldown)
-
 		-- Does not use player resources
 		env.player.mainSkill.skillModList:NewMod("HasNoCost", "FLAG", true, "Used by mirage")
 
@@ -414,7 +411,19 @@ function calcs.mirages(env)
 			env.player.mainSkill.skillModList:NewMod("QuantityMultiplier", mod.type, mod.value, mod.source, mod.flags, mod.keywordFlags)
 			maxMirageWarriors = maxMirageWarriors + mod.value
 		end
+		
+		-- Scale cooldown to have maximum number of Mirages at once. 0.3s for first mirage then 0.2s for each extra
+		local mirageSpawnTime = 0.3 + 0.2 * maxMirageWarriors
+		if env.player.mainSkill.skillTypes[SkillType.Channel] then
+			mirageSpawnTime = mirageSpawnTime + 1
+		end
+		cooldown = m_max(cooldown, mirageSpawnTime)
+		
+		-- Scale dps with GC's cooldown
+		env.player.mainSkill.skillData.dpsMultiplier = (env.player.mainSkill.skillData.dpsMultiplier or 1) * (1 / cooldown)
+		
 		env.player.mainSkill.infoMessage = tostring(maxMirageWarriors) .. " GC Mirage Warriors using " .. env.player.mainSkill.activeEffect.grantedEffect.name
+		env.player.mainSkill.infoMessage2 = tostring(mirageSpawnTime) .. "s for " .. tostring(maxMirageWarriors) .. " Mirages to finish Attacking"
 	end
 
 	return calculateMirage(env, config)


### PR DESCRIPTION
Howlcrack set the cooldown to 0 which caused inf DPS as we were assuming that all Mirages are spawned instantly and attack
They spawn after a short delay so now the cooldown is modified to be at least the amount of time to spawn all the mirages and have them channel for 1s
Not sure how to get the attack time for the main skill in the CalcMirages file so I can have it properly handle non-channeled skills too

Fixes #8842