### PR TITLE
Fix crash when clicking "Add modifier" button on Tinctures

### DIFF
--- a/src/Classes/ItemsTab.lua
+++ b/src/Classes/ItemsTab.lua
@@ -2693,22 +2693,24 @@ function ItemsTabClass:AddCustomModifierToDisplayItem()
 			end)
 		end
 	end
-	if self.displayItem.type ~= "Jewel" then
-		t_insert(sourceList, { label = "Crafting Bench", sourceId = "MASTER" })
-	end
-	if self.displayItem.type ~= "Jewel" and self.displayItem.type ~= "Flask" then
-		t_insert(sourceList, { label = "Essence", sourceId = "ESSENCE" })
-		t_insert(sourceList, { label = "Veiled", sourceId = "VEILED"})
-	end
-	if self.displayItem.type == "Helmet" or self.displayItem.type == "Body Armour" or self.displayItem.type == "Gloves" or self.displayItem.type == "Boots" then
-		t_insert(sourceList, { label = "Necropolis", sourceId = "NECROPOLIS"})
-	end
-	if not self.displayItem.clusterJewel and self.displayItem.type ~= "Flask" then
-		t_insert(sourceList, { label = "Delve", sourceId = "DELVE"})
-	end
-	if not self.displayItem.crafted then
-		t_insert(sourceList, { label = "Prefix", sourceId = "PREFIX" })
-		t_insert(sourceList, { label = "Suffix", sourceId = "SUFFIX" })
+	if self.displayItem.type ~= "Tincture"  then
+		if self.displayItem.type ~= "Jewel" then
+			t_insert(sourceList, { label = "Crafting Bench", sourceId = "MASTER" })
+		end
+		if self.displayItem.type ~= "Jewel" and self.displayItem.type ~= "Flask" then
+			t_insert(sourceList, { label = "Essence", sourceId = "ESSENCE" })
+			t_insert(sourceList, { label = "Veiled", sourceId = "VEILED"})
+		end
+		if self.displayItem.type == "Helmet" or self.displayItem.type == "Body Armour" or self.displayItem.type == "Gloves" or self.displayItem.type == "Boots" then
+			t_insert(sourceList, { label = "Necropolis", sourceId = "NECROPOLIS"})
+		end
+		if not self.displayItem.clusterJewel and self.displayItem.type ~= "Flask" then
+			t_insert(sourceList, { label = "Delve", sourceId = "DELVE"})
+		end
+		if not self.displayItem.crafted then
+			t_insert(sourceList, { label = "Prefix", sourceId = "PREFIX" })
+			t_insert(sourceList, { label = "Suffix", sourceId = "SUFFIX" })
+		end
 	end
 	t_insert(sourceList, { label = "Custom", sourceId = "CUSTOM" })
 	buildMods(sourceList[1].sourceId)


### PR DESCRIPTION
Fixes #8903 
Implemented a very hacky solution. Will look for a better solution.
Currently, there is a mix of both exclusionary and inclusionary filtering for the `BaseTypes`. 

Ideally it would be refactored to solely be based on inclusionary filtering, preventing this bug from recurring when a new BaseType is added to POE. The best long term solution would be directly associating `sourceId` flags with the item `BaseType`, allowing us to bypass this logic entirely.

Not fully confident on doing this yet, as I am still new to the codebase. If anyone has any good ideas on the best way to approach this, I'd really appreciate it :)

### Description of the problem being solved:
Add modifier to Tincture Causes Crash

No Longer crashes, and invalid `sourceId`'s are no long visible

### Before screenshot:
<img width="800" height="564" alt="image" src="https://github.com/user-attachments/assets/5271f0a2-57cd-49c5-92a7-d5266f80e6b3" />

### After screenshot:
<img width="958" height="539" alt="image" src="https://github.com/user-attachments/assets/826499e4-1943-4adb-a0a1-1f758f696556" />
