### PR TITLE
Fix issue where Rage Support was affecting Herald of Purity

### DIFF
--- a/src/Modules/CalcTools.lua
+++ b/src/Modules/CalcTools.lua
@@ -96,7 +96,7 @@ function calcLib.canGrantedEffectSupportActiveSkill(grantedEffect, activeSkill)
 	end
 
 	local effectiveSkillTypes = activeSkill.summonSkill and activeSkill.summonSkill.skillTypes or activeSkill.skillTypes
-	local effectiveMinionTypes = not grantedEffect.ignoreMinionTypes and activeSkill.summonSkill and activeSkill.summonSkill.minionSkillTypes or activeSkill.minionSkillTypes
+	local effectiveMinionTypes = not grantedEffect.ignoreMinionTypes and (activeSkill.summonSkill and activeSkill.summonSkill.minionSkillTypes or activeSkill.minionSkillTypes)
 
 	-- if the activeSkill is a Minion's skill like "Default Attack", use minion's skillTypes instead for exclusions
 	-- otherwise compare support to activeSkill directly


### PR DESCRIPTION
Fixes #8906 

### Description of the problem being solved:
In https://github.com/PathOfBuildingCommunity/PathOfBuilding/pull/8719 minion skill supports were handled better, but it appears a parentheses was missed, resulting in incorrect behavior for just a couple cases.
### Steps taken to verify a working solution:
- Verified Rage Support properly doesn't support Herald of Purity again
- Tested the issues listed in the previous PR to ensure there are no regressions
- Tested a few other gems that exhibit this same property

### Link to a build that showcases this PR:
```bash
eNrdXFt34rYWfp7-Ci-eM4CvQBdpFwm59YQJhczM6VOXsEVwI1vUlpPQX390sY25yMjY04czDzNg7W_ftLW1tWVm-OtHgLQ3GMU-Di9bervb0mDoYs8PXy5bX59vP_dbv_7y03AKyOppeZX4iI388tOnIf-sIfgGEcWZLY2A6AWSbxkr80_Kag1CsoI4nIC_cHSHvcvWFxzClrYAoeeT7JuLQBx_AQG8bM1dCm5pIHZh6F1vn6eEKxABl8DokYkdJQRPsEdHSZTQ0QD44Ry7r5DcRThZUxVa2psP3wXNw2T6NHsuqOSHRZWoSZ-GUwQ2MJoTQLSY_nXZGrnEf4OUlGr16Ac-oRwBSii7bqsjgVBnghd4X6C1u05bt4wTiKskiskYBPSjKnK-htDLifW2pZvbPzLQNII3yyXkll1HPrlegdDdinRkuKq0kwQRf418GBU0tGWI-wPmelfq42dMABpP5zltT7fbptUznXIEVpi_7z5ZXSHq10r8GerhJfQJrAybYj_G4VnWFEFSg64ThOiaVaKdwRhGb4D4uwrJeeNg4YcVfTWKIHhaihicAc9P4gkkEYxzDmZbl2EnIATXON7OozzOGekURjSRkB1E9wRgDl1Mc08RYjltx1KQcxwtFfjoL6E6ZSVbUkBVbc6z42auSleZ8XkKzWgOVaOc4wQpUpJtHjNKFtDfRUJdl0byGH5sg1jK7yHcqjawS6QWCXXblkt9w4Rvsafs5Tnm5n665Wqa7b5h2YP-oGs78u1ltYl9F6AJ-PCDJKB5_Rm8wrDgO0segS8rEtJcJcPqhtSwWz-CZ8CuMfLOga0AjuW4ftkaU_EE3djdnxnxQ-iqrdyvYcRzd6EeKPX0Es7ogmKVxwJBVchWSLouVTZrIesFhqnAjZpBjxC6qzta0s0AgWrJu7AABqWeZcRKnmWERzyr6wM1xL6bela7bxk9p2cMbHvQK2Ny3GVGu18Gqui0mxBGL5v5yofIq0adKXYN1gqpk_m8iFby_a64SvFThFZ0yXcQeWobTFWd3kBcTLy6U-4uQa4WpZDWqxTgwb0Suis_A-C_2AkAVYONogAnkeKEC2IlA7I9Q5x-ZtBLXLVNKj_IXCF68FM1I0dRPRGqBB0RAtzXMfZelJ3GhVRC7Oo3T9Zrmk9YNKgyYJshLeX9Ql3z2VGgfqKhrLSi2bapLmBLrSwgLwXUpexB1G1he3kFY7bkyiLyCZ3QZBHQDYEf3Ce4eHbvyksbeoBTOo1xQsVT4RS_U-VXrGcTV6OmZc-2cJWqEsHwn40y_x1yJQE3oZdEbDUoy9hHKIk53QASY4ftnL1OjtnrtmnZYNoy2H4vxzQPeznNgA66J9bAbFsDw3L4n145Diu44GgPRVHK8U5KBfBhP6WifcfWzwFxSVflgPZEV-WQ95GuiqINOwcMe6AbZYTlFcxRSHk1dQA5WmDqet9QAVRUT73oe_YDWjHF8RgQoHnpifgbiHwQEoPq19JiCCJ39Uhz_C1AaEG3_MtW8Sn_xlvNtz4iMBrTZyy1MBn7HHXGkQkednjPnH16CNY4Ihr8YP9MQUQ2l60lQDEUhPwJ5RMTP-RhQ7MKQi1tvsLvI--NSXrGGMUZSAPrNQy9HR7PEYQayMoIlynBjWdftADEVOuN2JdiZk2h4_7gcTNCTBVgDTbbsi_0ftc0L6xe1zEuLKc7MC5sfWCYF7aj2-ZFf2D1L-x-n5LQw409uNB1p9-_sPq9Xp9CHce8MPt6z7mwKC_nwqQHIO5k1tEB0Wa0Kzv0qamEql-4SzCc9JpAKMcs-TT8OnvkHz6tCFnHP3c67-_v7TUgK7yEH7S2bbs46KwpiPrgc_zqI_SZse2M6J-rl9FojCe_zcI7U49-n2zIdPF9_thdjGLy96Pzn_kT_PbwePf768al1JeXXGAnkzgU9wxxR3xjhUDkU3eJ-OowH_MJZ5PAPnzBBMZsjD3MvgznTKWYBlJE7mAQX23ogr9l4buXAtJZZNRzSESAFjHZBYgHlyBB7PnvCUA-C6pu8emjuKwJcRTk_RnKigYVqzEFx-fNms366PFRjIwQSZkxcVmEiUhKFdJ8L4uu9CG_ihlttb4GyI253n7oosSDD2Fa1OQRjMCC6cZun1hHwite6hQ45YI-Dak-KfEdwguAjAzCZzpND7vSCyPpw9GHH99Q6-Cc1qg-jO7p3o28pyUvJlvZ9ZZB3fgCAxZ7E0iAR_NG54FQf3SYUzpcCv2UgadJRP3F0g5PAAy2P8Q1kQ4UlOd6_12YzvQzw47FzLZ23KBnbthzpIuTUMROCII0JQjhGl5qR8Sfck7n1DwoOi8PvVlaL-VOS4fE89xjO0-LnuEULHUWfdaIn7isdK2L2T4d7DyLHYY7f_yvBHu12J0nQcAPmDi-wwgGexOxO0iTwh87MyId3olk-8dFslBB4zpoXAkW1WQFtQmAKCYRDvaCWyCgVzC58Yi-xiGVjKjuY7qXR9uuxn6ISwj3Y15C9u8sgq1wrSi9cafxe2MXiNP4vqN4R-TGXeFD5xSGfliUMREal_H_nQ1Gixij5CBai49z9x883Fnzxo-bDYng4sAzDNYIRL8lXp7A60dq5qPIBSGt-68iEHo7buJP0qgsOGr3cT2vpFXTUbekemlCscbXJ18ECwQ8KF2g6ejRFZqO_dAlKmQcLNH0Iy1ZeXEuym_2kS8TTvEQrhPC2V22Aj92_1wkyyV7gYhaQyL-UtTN7e3N9fPDt5v0NFmEcIv_DJNgwd56Ef9mxz-aICBPmVqcLGLx8bL1zYfvXJExdbqPYmYVQmAdF2aZ1dep5ojiSrhxqns_f43oOK8tgZzTzQeM6Onz5Ts98kY-lOqVj59QSghkR3l2-pZxY90lOSPRfL-mW4M41ks8xXtici7s3SSpOWywBEvP7QBJJaejJzxB2AmLxqq_9F3WviifcnYeE1QlfnHdJALupmS-05sDOQ_erpMxEINysGi5ydDpaIlXebtP6lUxKoePoQuktotBOTjvFOGQv7J3nEtOVcLpCw55kNNFM_IR6_JLZ_YGwZxEzvCJlq9R2qKRcZrQHJWRlC6cyF8kRL6MCxQlvuLNRYmH2JgcKq7nJTawsZJMtNNDlDi0SCNnJS53pYmsDCpufKT-S--PSqYgvTqVuF-Mljghuz2W2J8OlywSnn9Hb9j3xB2iZLnskZUlDOy-1mfDL0brs9m_Ka3P8RaB-FU63-moHP6V-KymOcJF1C5KTNiiqseBra16HJ7pqYUkETybwWy_EtliZ-U1SH61dxScjZZljvTG72wO4l7ybDi_Nj0bzfM_LYghtaB0A8hpStYHScIxdQYpWRuKrLhaxxPJ1rpKvMRWeNTSyhzFAk9fyCvLAYLkBCO6l9-XVItqnPLb_3sIELufxKgew4MXD-swYxdsyZqeFDN2T8dq9O08KHoPk5jy5BdeY3aPV9eHIQw2RxjJ9Rp2slMdvwpj56z0Am9OItZt-Qfj4I_LVt-w25YhvqYXJE56KULL7rFPJy_iQZcJY4T_vWx91gd6u2uKm8whPymnFzXsc35PI-eTxFC80_wdgjUOOaJwu5JyKSHbvXdBmGi0Tg6mi6-zR2afOJHSE_QbW1NsSNyddcoBQoymV4BcYTrb2mixiWOANHE1ptlVGEBE9vFGBTzfgzTzDCu1-TtY74u2zmFUw_yUh9EAj-MGOQ0Y5DRg0Fk8jhlUOzrNBjxiNGVNlXi7h3SzJLX8cWSxObU1MCpzqC3SbMr_dgPBoDewPPQG9LAqRkJTKcaouyKtBhxYfc9oLMWade03ai7hagp4G030HOrEoKgt6nA4vrDt2hycpqZVbyrHVA_N-n60as-l3UxQVTF-FCQIkgYyodlAQjFrLkqrJl5vxv9n75SVg9aqjDiniqrpVbturm5oWqymkktjdfXZR6gKuJkfvlSawuOpyWhmDhrbKZo48Fnn2VTV-fX3-IaKDbu2IvW3OKdqMqibPA4FDjtps0e8nR4BD855p-o7ZG9axqKdxVtM_G0FHC79l7TZJL6k7SaOz59oxCcIFt6pKPaLpgi4cIWRB6NUWchabOkPSrI3F3rd3EYJYOfXUxnMPIXKf6uVvaiQIQ3D0k9JLPw_JBnMPoEp_iAux5w0jT45Qz8m6wwY7z1uEX1LTh_k_7MK-70LjKA35y9GsNdh5hAtC2-e2Ao2VnZMPntT1nzOJ10VVX0iWIztu7Q_cBQmopKGLLL2xZgqUaIqZe5i3n-mkxUfvB4klZD-KhYjNANhUbfeKd2y7SEDOPqgP5BjYv_FR09LfmtFleRXb6pK7v6Et1Lk53fbuayubpV5cUUTqcSJw06e_sQdAP_2y0_Dzv7_YPU_pDMbLQ==
```
### Before screenshot:
See issue
### After screenshot:
<img width="845" height="205" alt="image" src="https://github.com/user-attachments/assets/662b931b-2244-4ff7-9940-1869776b4e9d" />
