### PR TITLE
Fix influence handling in TradeQueryGenerator

### DIFF
--- a/src/Classes/TradeQueryGenerator.lua
+++ b/src/Classes/TradeQueryGenerator.lua
@@ -85,7 +85,7 @@ local tradeStatCategoryIndices = {
 local influenceSuffixes = { "_shaper", "_elder", "_adjudicator", "_basilisk", "_crusader", "_eyrie"}
 local influenceDropdownNames = { "None" }
 local hasInfluenceModIds = { }
-for i, curInfluenceInfo in ipairs(itemLib.influenceInfo) do
+for i, curInfluenceInfo in ipairs(itemLib.influenceInfo.default) do
 	influenceDropdownNames[i + 1] = curInfluenceInfo.display
 	hasInfluenceModIds[i] = "pseudo.pseudo_has_" .. string.lower(curInfluenceInfo.display) .. "_influence"
 end
@@ -810,10 +810,10 @@ function TradeQueryGeneratorClass:StartQuery(slot, options)
 
 	-- Apply any requests influences
 	if options.influence1 > 1 then
-		testItem[itemLib.influenceInfo[options.influence1 - 1].key] = true
+		testItem[itemLib.influenceInfo.default[options.influence1 - 1].key] = true
 	end
 	if options.influence2 > 1 then
-		testItem[itemLib.influenceInfo[options.influence2 - 1].key] = true
+		testItem[itemLib.influenceInfo.default[options.influence2 - 1].key] = true
 	end
 
 	-- Calculate base output with a blank item


### PR DESCRIPTION
Fixes influence selectors not being populated in trade query options window.

### Description of the problem being solved:

The influence selector dropdowns in the trade query options window were not being populated with available influence options (Shaper, Elder, Warlord, Hunter, Crusader, Redeemer). Users could only see "None" in both Influence 1 and Influence 2 dropdowns, making it impossible to filter trade queries by item influences.

**Root Cause:**
The code was attempting to iterate over `itemLib.influenceInfo` directly using `ipairs()`, but `itemLib.influenceInfo` is an object containing `.default` and `.all` properties, not an array. This caused the iteration to return no results, leaving the influence dropdowns empty except for the default "None" option.