### PR TITLE
Fix Temporal Chains double counting towards Brand Ticks

### DIFF
--- a/src/Modules/CalcOffence.lua
+++ b/src/Modules/CalcOffence.lua
@@ -2303,7 +2303,7 @@ function calcs.offence(env, actor, activeSkill)
 			output.HitSpeed = 1 / output.HitTime
 			--Brands always have hitTimeOverride
 			if activeSkill.skillTypes[SkillType.Brand] and not skillModList:Flag(nil, "UnlimitedBrandDuration") then
-				output.BrandTicks = m_floor(output.Duration * output.HitSpeed * debuffDurationMult)
+				output.BrandTicks = m_floor(output.Duration * output.HitSpeed)
 			end
 		elseif skillData.hitTimeMultiplier and output.Time and not skillData.triggeredOnDeath then
 			output.HitTime = output.Time * skillData.hitTimeMultiplier


### PR DESCRIPTION
output.Duration is already modified by debuffDurationMult in the duration block above so it doesn't need to be applied here again
Fixes #8901