### PR TITLE
fix(skills): Forbidden right of soul sacrifice extra +1 in dps multiplier

### DIFF
--- a/src/Data/Skills/act_int.lua
+++ b/src/Data/Skills/act_int.lua
@@ -7698,7 +7698,7 @@ skills["ForbiddenRiteAltX"] = {
 		activeSkill.skillData.ChaosMin = activeSkill.skillData.ChaosMin + add
 		activeSkill.skillData.ChaosMax = activeSkill.skillData.ChaosMax + add
 		if activeSkill.skillPart == 2 then
-			activeSkill.skillData.dpsMultiplier = (activeSkill.skillData.dpsMultiplier or 1) * (output.ProjectileCount + 1)
+			activeSkill.skillData.dpsMultiplier = (activeSkill.skillData.dpsMultiplier or 1) * output.ProjectileCount
 		end
 		output.FRDamageTaken = SelfDamageTakenES + chaosFlat
 		if breakdown then

--- a/src/Export/Skills/act_int.txt
+++ b/src/Export/Skills/act_int.txt
@@ -1532,7 +1532,7 @@ local skills, mod, flag, skill = ...
 		activeSkill.skillData.ChaosMin = activeSkill.skillData.ChaosMin + add
 		activeSkill.skillData.ChaosMax = activeSkill.skillData.ChaosMax + add
 		if activeSkill.skillPart == 2 then
-			activeSkill.skillData.dpsMultiplier = (activeSkill.skillData.dpsMultiplier or 1) * (output.ProjectileCount + 1)
+			activeSkill.skillData.dpsMultiplier = (activeSkill.skillData.dpsMultiplier or 1) * output.ProjectileCount
 		end
 		output.FRDamageTaken = SelfDamageTakenES + chaosFlat
 		if breakdown then


### PR DESCRIPTION
Fixes # .

### Description of the problem being solved:

Forbidden rite of soul sacrifice has extra +1 in dps multiplier for "All projectiles hit" mode.
Shows 2 for no extra proj, 6 with GMP, 7 with Woke GMP (should be 1, 5, 6 accordingly)

### Steps taken to verify a working solution:
- checked the values after fix

### Link to a build that showcases this PR:
https://pobb.in/_CS_5UA3ED09
### Before screenshot:
<img width="717" height="471" alt="image" src="https://github.com/user-attachments/assets/f080ac10-75ed-46d9-bebb-bd9bc6a97326" />

### After screenshot:
<img width="717" height="475" alt="image" src="https://github.com/user-attachments/assets/20062f41-df72-4be9-a644-a05f076ab14d" />
