### PR TITLE
Fix tooltip showing pathing differences for nodes affected by II/IL

### DIFF
--- a/src/Classes/PassiveTreeView.lua
+++ b/src/Classes/PassiveTreeView.lua
@@ -1145,7 +1145,7 @@ function PassiveTreeViewClass:AddNodeTooltip(tooltip, node, build)
 			end
 		end
 		local count = build:AddStatComparesToTooltip(tooltip, calcBase, nodeOutput, realloc and "^7Reallocating this node will give you:" or node.alloc and "^7Unallocating this node will give you:" or isGranted and "^7This node is granted by an item. Removing it will give you:" or "^7Allocating this node will give you:")
-		if pathLength > 1 and not isGranted then
+		if pathLength > 1 and not isGranted and (#node.intuitiveLeapLikesAffecting == 0 or node.alloc) then
 			count = count + build:AddStatComparesToTooltip(tooltip, calcBase, pathOutput, node.alloc and "^7Unallocating this node and all nodes depending on it will give you:" or "^7Allocating this node and all nodes leading to it will give you:", pathLength)
 		end
 		if count == 0 then


### PR DESCRIPTION
### Description of the problem being solved:

Hovering over an unallocated node in radius of Impossible Escape or Intuitive Leap currently shows difference for taking a path from the class start which it doesn't require and won't take on click.

This is confusing and not helpful because highlight for the pathing is being suppressed already.

### Steps taken to verify a working solution:
- Hovering over an unallocated node in radius of Impossible Escape or Intuitive Leap no longer shows `Allocating this node and all nodes leading to it will give you:`.
- Hovering over an allocated node in radius of Impossible Escape or Intuitive Leap that some other nodes not in radius of jewles depends on continues to show `Unallocating this node and all nodes depending on it will give you:`.

### Link to a build that showcases this PR:
```
eNrdG1132rjyufkVPjynCbbBITmkewgkKXuShoWkvfe-9AhbgLbC4thyEvbX70iyjaHIkTFPtw8pWPOtmdHMWHT_eF9S6xVHMWHhdcM-azYsHPosIOH8uvHyfPe50_jjy0l3hPjiaXaTECpWvpx86srPFsWvmAJeE_A4iuaYf89ouT_h2QqFfIFZ-Ij-ZtE9C64b31iIG9YUhQHh2Tefojj-hpb4ujHxAblhodjHYdDfPE8BFyhCPsfRg-DbSzh7ZAGszhCNYXmJSDhh_i_M7yOWrECuhvVK8JsCGj6OnsbPBZlIWJQJlPrUHVG0xtGEI27F8Oe60QPboDkeoCX8BWqIJkCqeWY3zksRbpIo5uZYkxXGQQ5onzk6wFGEb2cz7HPyivsR4f0FCv0CCx1eVdjHhHKyogRHBanaOoyvvxF3tLDPjCM6GE2KZnHKgRn_WOgfhC9uKFjRlLRAGM5DwnEVjBEjMQurir8FrzV7QikElxHsGMc4ekWc7Miipc2WUxKaG-cRhajPYgO7C8gRjiBceSWECfYZRHhVHhUxH8gMm0NW0iNFqCrNYXrcTkzhKhM-TKAxJDYzyAlLqCEk3yQbRws1wO8GUMNww9AtofXKuDxwPpJNRvLt11EO2XG8s86lfeFdep7tdrT5erGOiY_oI3ony2QJifIZ_cIbhrbT6ujdZb7gIaQEHfKF5-lw70iED0DrMxocgrZALNbidUoCm4RfoRTo-X4CB_t6s7FupyyIjMwHZ6p_JaCHoW8Wmy9hJPNq8Sgu3Z8ZHkPMiBN_SrExzoZNGnsbzGaznNkchynHdYGd_mAWWA8Y-4t7sPQYcWyWbDd713ZLzSuAi-a1vTKye-xbwmAbo4KpBOJ-Uzm2vgQTWBVNdRviaL6eLAimQTXoTLI-WhnkRWHpIraRQ2-z22cNI9SKJvmBosDs9Kgq0yuKi5la72nKXArcyFKPGOpGQAiwaYU8itjfogan1dB60ZIlkeGGK2AjBbJDRvUbYxwkvtmplrcSNxTaJlM1ciyQk9JKqD3Okf9rwIK5sdEkk0oY2_JNktUKkojwBlMC4vCECpsUipbPngH0E7iyUUSLY9acwQbamEFeOphz2UEx10Wc_RWU2YAbs8g39BGSxRJOAdkuQ1e_yQbazYGmyqhDkoCGndqIvYHkCzHviKtBQ420KUu1okQ4_GdtTH8L3IjBbRhAuQWhYMxjF2Mfm2eyhEQaxwPEkRWklfV3FBEUckfOYmKMIn_xAFt_hyidQia4bhSfym9yfnNHKMfRAJ4JpkKwXYp2tundczmKEp-GyxWLuIXfxX8jFPF1NhqSgPIJ0Ik5CWXrDPmI0oY1WbC3XvAqOD0zRuN8noRWKxwGWzSeI4wtlGUXXwghlRdfrCWKQeq1ctdYaFOYYw0DqUbIQIDrhue4zVPHbtunLrQQzdNW58LrnLY7Hdc9tW2v04EnLcc9bXt22z1tXTQ959RzLy88YS_RpqFo3dsmHhLQhYN8hRGc46XTNcVdiPqp-zJ-kB8-LThfxVfn529vb2crxBdsht_hTDvz2fJ8BUig5Of4F6H0syB73oN_N_Nerz9e_Ojf4-enyOs9IHL55yX_H7-ctj1YlwzOMw5dNY2LFbv0mzSBkEfq3LAIx0vxNY3h3-GErTZgqbsBlyLxrkgmEQHbKmc8FxsivUPsmPjwjXEsYcXD7Et3ItSLwesifo-X8c0aEsCdqHt2ZibplgvoCebKm4s41w0eJVh46QwlVDz_K0GUCA9sFp8-qIFpyKJl3hQCKfBAcU4pis_rlXCR3sODWulRnhIT7DJ3VG6XCmSRYBMPSifxsY-oL3XuDsNVAhaVs9Qlif2f02Q2E3NRYMEjOe29vbu77T8Pv9-m8VxEkV7wM0yWUzEQVP9vsu4Ey3rDipNprD5eN74T_CYFGWCOCIUc4zNK0SrGeUBJoVMNKOCVUJNQ0FlmE9X9tDYAekq37ziC-J9DoepHBGvlytc_EEoxFEWsyH86amKEqSekqqI-ZA9VZGssJWfEeipibKtVRyyW4ELmRFTLOV39wBJcuC1EHZkRXxwd5VsunFxBldglHwto9zst6fQ05ExYR0At6pHVtFeHna6WWFWOl7VWVat69AH2kVZ3tahHzvs2FoKZdFRyqBJK31gonRyCpkeoKL-0O3tLcQ6iJ_jEFzhKD0kdpUfIURlIaeBEZJpwfRgXIEpsJUdKGguJNT2qmpZodBBrJZloa3qgMWgRRk9Kdd3aRFaGqkpxrf3Swr5kC9KeVmN-tVpihKyt1-ifLpcEicy_vVdGAtXcacJlB6wsYUBZUZ-M7Fjrk9ltYetTvINy8Jd2v9NVPfoLJ6IS2UNFFUBGRERQ1aMgYqsehWcS-jyJ8MEExruVyAZ3XF6D5G3XXuRstSxzpN3YwRRUz3gwumxpD8aW-X-AZxg0KD0AcpiS-OBJOABj8JLYMCQlxdqfSDbaVaKljsK9mlamqAI8fbNSlgMUyAeE4Cz_WlItmlHKxzJfMaLi1Tij9Qj-9gapDjExWk5WKAwyck_7avTNPhhaj_EYaMqRw0BMsOvaMMTL9R5Cerm651lXJ4cRos9KRygTHomZwz-MLf8Lzdll56zpNZ1Wy71s2upx2n3aTtpyQv09ILCLkfS-jKuA_I8Y4rXsswv3wvNct2VfKuZD6MLjtBsWn_NmWE8uibF6s_wDoxULJUahhRVU0vZVdvJjBK3K-sp6-Tb86-X2RMx04OSbUmzdxj5a4ZPvBPp8gkLrT_yG6YnEl4pdWZ2LkzEKSBJfWRPor-nJA1lCjR1YnF1ZtqBFiQ9-f2U1T0ZqwBFbJLQUksVm1nA5RVTEf2DdJ1A5WT4wmmKrR6EsgOYsOHkjfMGgMZ5iCCLYsjCEvZQsrDXUOnICc9JnUZSsBLiYTUCfPUbhHFuR-CtuXnhuo9Cyw54KLbbN4ew3R8gTIowPKqPVri22lf9I3V3VLCPVDlbI_T9SSIxc9H5ddOfuhDIuh1ej6cv4QQSoGqncU_YqDoVsrtXM5lo6BMXGsiug3DBIV1Zvuo5jRK10rNauQgBTvovvVMCXRZTlHqClNXlDq13WrUMI1VA_peEY0ZBLwwAI7EwuFS3p0NZmlpmxqmMP7wj28I5gj4No7FOotnO7R7CIcyxtqrjrVwzFIq9ljz2x6tWWwKlMoTZL91j2bx_BGewjhId9BDlaFT3hWCnXqRuRrSMYsPqR0z6W_m5d_Z2aIVxNgGBtqZlbHR9UpUkdCvsDu12bgnesbbWPlWOqu2Z9O7Zq72X7OE5VRfneMqGYHyETukdIKG7NoGzVxLePY_-DT8rKTtuqjHFIFVXTqu26udo2rOvTmwvFwr5wmcGwsi_Z19axstPRCvODW7gKeGPRpDu1c5tznNg62lFzjIazdZhOVY1fv0g4UrXSri1I_TPSq5pN6maf3xmqqdMEc3XBLkIBnshR7w8sbmvGah4sZ7Lyug8LZ2SeTmfVl3Q-K_HzJxYnnGJxh0BeS9qeV40o8vGC0QBHqbBYzKjTXyhmV38umrmOGoSte6EZmvsRVn4LNbvpk2E6Tsv-iGPhN44ZWvsDnOJV3xznQ9XgyQHyCV4HoMnZ9gaj09LDL_NfbYrfKuIIBxN5s4glIZ9gOitc3Wob6FjZMPnujcTbm3zTTbGqb4TwsV2Tdi69D9DySwe5NZp2yzXwrl1WromnmNpi4jP5Egc2LP7tjp2WQ3rnn1EqB9jFCP0AMzsiMgTPvuxc6nFiMif0aSZf_YKQ8v21qZDbP1CoHDTGFlxAItUYsHuepz_1Ek1--3LSPd_9bfu_TI8YAw==
```

### Before screenshot:
<img width="378" height="443" alt="image" src="https://github.com/user-attachments/assets/52e06377-14c5-4846-b6ea-69d442671558" />

### After screenshot:
<img width="359" height="218" alt="image" src="https://github.com/user-attachments/assets/38b37af8-202d-43c6-8f48-f2d924caf706" />
