### PR TITLE
Tooltip text "tattoo" or "runegraft" based on node type

### DIFF
--- a/src/Classes/PassiveTreeView.lua
+++ b/src/Classes/PassiveTreeView.lua
@@ -1104,7 +1104,8 @@ function PassiveTreeViewClass:AddNodeTooltip(tooltip, node, build)
 			or (node.type == "Keystone") or (node.type == "Mastery") )
 	then
 		tooltip:AddSeparator(14)
-		tooltip:AddLine(14, colorCodes.TIP.."Tip: Right click to edit the tattoo for this node")
+		local nodeEditType = (node.type == "Mastery") and "runegraft" or "tattoo"
+		tooltip:AddLine(14, colorCodes.TIP.."Tip: Right click to edit the " .. nodeEditType .. " for this node")
 	end
 
 	-- Mod differences


### PR DESCRIPTION
### Description of the problem being solved:
Tattoos are different than runegraft in game, and although unlikely, showing "tattoo" for editing the mastery may cause confusion.
EDIT: The dps is different because my build config wasn't set up the same as I have it in the release build.
### Before screenshot:
<img width="351" height="387" alt="image" src="https://github.com/user-attachments/assets/eed5bbbb-b64e-4bfb-b74b-7689a3d85129" />

### After screenshot:
<img width="365" height="364" alt="image" src="https://github.com/user-attachments/assets/be2f5585-1c95-4a1d-b84c-9f8243ee65f7" />