### PR TITLE
Add text after red mods to show that PoB does not currently handle them

### DIFF
--- a/src/Classes/GemSelectControl.lua
+++ b/src/Classes/GemSelectControl.lua
@@ -719,7 +719,7 @@ function GemSelectClass:AddCommonGemInfo(gemInstance, grantedEffect, addReq, mer
 				if launch.devModeAlt then
 					line = line .. " ^1" .. lineMap[line]
 				end
-				self.tooltip:AddLine(16, colorCodes.UNSUPPORTED .. line)
+				self.tooltip:AddLine(16, colorCodes.UNSUPPORTED .. line..main.notSupportedTooltipText)
 			end
 		end
 	end

--- a/src/Classes/GemSelectControl.lua
+++ b/src/Classes/GemSelectControl.lua
@@ -719,7 +719,9 @@ function GemSelectClass:AddCommonGemInfo(gemInstance, grantedEffect, addReq, mer
 				if launch.devModeAlt then
 					line = line .. " ^1" .. lineMap[line]
 				end
-				self.tooltip:AddLine(16, colorCodes.UNSUPPORTED .. line..main.notSupportedTooltipText)
+				local line = colorCodes.UNSUPPORTED .. line
+				line = main.notSupportedModTooltips and (line .. main.notSupportedTooltipText) or line
+				self.tooltip:AddLine(line)
 			end
 		end
 	end

--- a/src/Classes/ItemsTab.lua
+++ b/src/Classes/ItemsTab.lua
@@ -762,7 +762,11 @@ holding Shift will put it in the second.]])
 					if node.sd[1] then
 						tooltip:AddLine(16, "")
 						for i, line in ipairs(node.sd) do
-							tooltip:AddLine(16, ((node.mods[i].extra or not node.mods[i].list) and colorCodes.UNSUPPORTED or colorCodes.MAGIC)..line)
+							if (node.mods[i].extra or not node.mods[i].list) and not node.mods[i].list == "" then
+								tooltip:AddLine(16, colorCodes.UNSUPPORTED..line..main.notSupportedTooltipText)
+							else
+								tooltip:AddLine(16, colorCodes.MAGIC..line)
+							end
 						end
 					end
 
@@ -3338,7 +3342,11 @@ function ItemsTabClass:AddItemTooltip(tooltip, item, slot, dbMode)
 			main:StatColor(flaskData.chargesMax, base.flask.chargesMax), flaskData.chargesMax
 		))
 		for _, modLine in pairs(item.buffModLines) do
-			tooltip:AddLine(16, (modLine.extra and colorCodes.UNSUPPORTED or colorCodes.MAGIC) .. modLine.line)
+			if modLine.extra then
+				tooltip:AddLine(16, colorCodes.UNSUPPORTED..modLine.line..main.notSupportedTooltipText)
+			else
+				tooltip:AddLine(16, colorCodes.MAGIC..modLine.line)
+			end
 		end
 	elseif base.tincture then
 		-- Tincture-specific info
@@ -3351,7 +3359,11 @@ function ItemsTabClass:AddItemTooltip(tooltip, item, slot, dbMode)
 		tooltip:AddLine(16, s_format("^x7F7F7FInflicts Mana Burn every %s%.2f ^x7F7F7FSeconds", main:StatColor(tinctureData.manaBurn, base.tincture.manaBurn), tinctureData.manaBurn))
 		tooltip:AddLine(16, s_format("^x7F7F7F%s%.2f ^x7F7F7FSecond Cooldown When Deactivated", main:StatColor(tinctureData.cooldown, base.tincture.cooldown), tinctureData.cooldown))
 		for _, modLine in pairs(item.buffModLines) do
-			tooltip:AddLine(16, (modLine.extra and colorCodes.UNSUPPORTED or colorCodes.MAGIC) .. modLine.line)
+			if modLine.extra then
+				tooltip:AddLine(16, colorCodes.UNSUPPORTED..modLine.line..main.notSupportedTooltipText)
+			else
+				tooltip:AddLine(16, colorCodes.MAGIC..modLine.line)
+			end
 		end
 	elseif item.type == "Jewel" then
 		-- Jewel-specific info

--- a/src/Classes/ItemsTab.lua
+++ b/src/Classes/ItemsTab.lua
@@ -763,7 +763,9 @@ holding Shift will put it in the second.]])
 						tooltip:AddLine(16, "")
 						for i, line in ipairs(node.sd) do
 							if line ~= " " and (node.mods[i].extra or not node.mods[i].list) then
-								tooltip:AddLine(16, colorCodes.UNSUPPORTED..line..main.notSupportedTooltipText)
+								local line = colorCodes.UNSUPPORTED .. line
+								line = main.notSupportedModTooltips and (line .. main.notSupportedTooltipText) or line
+								tooltip:AddLine(16, line)
 							else
 								tooltip:AddLine(16, colorCodes.MAGIC..line)
 							end
@@ -3343,7 +3345,9 @@ function ItemsTabClass:AddItemTooltip(tooltip, item, slot, dbMode)
 		))
 		for _, modLine in pairs(item.buffModLines) do
 			if modLine.extra then
-				tooltip:AddLine(16, colorCodes.UNSUPPORTED..modLine.line..main.notSupportedTooltipText)
+				local line = colorCodes.UNSUPPORTED..modLine.line
+				line = main.notSupportedModTooltips and (line .. main.notSupportedTooltipText) or line
+				tooltip:AddLine(16, line)
 			else
 				tooltip:AddLine(16, colorCodes.MAGIC..modLine.line)
 			end
@@ -3360,7 +3364,9 @@ function ItemsTabClass:AddItemTooltip(tooltip, item, slot, dbMode)
 		tooltip:AddLine(16, s_format("^x7F7F7F%s%.2f ^x7F7F7FSecond Cooldown When Deactivated", main:StatColor(tinctureData.cooldown, base.tincture.cooldown), tinctureData.cooldown))
 		for _, modLine in pairs(item.buffModLines) do
 			if modLine.extra then
-				tooltip:AddLine(16, colorCodes.UNSUPPORTED..modLine.line..main.notSupportedTooltipText)
+				local line = colorCodes.UNSUPPORTED..modLine.line
+				line = main.notSupportedModTooltips and (line .. main.notSupportedTooltipText) or line
+				tooltip:AddLine(16, line)
 			else
 				tooltip:AddLine(16, colorCodes.MAGIC..modLine.line)
 			end

--- a/src/Classes/ItemsTab.lua
+++ b/src/Classes/ItemsTab.lua
@@ -762,7 +762,7 @@ holding Shift will put it in the second.]])
 					if node.sd[1] then
 						tooltip:AddLine(16, "")
 						for i, line in ipairs(node.sd) do
-							if (node.mods[i].extra or not node.mods[i].list) and not node.mods[i].list == "" then
+							if line ~= " " and (node.mods[i].extra or not node.mods[i].list) then
 								tooltip:AddLine(16, colorCodes.UNSUPPORTED..line..main.notSupportedTooltipText)
 							else
 								tooltip:AddLine(16, colorCodes.MAGIC..line)

--- a/src/Classes/NotableDBControl.lua
+++ b/src/Classes/NotableDBControl.lua
@@ -255,7 +255,9 @@ function NotableDBClass:AddValueTooltip(tooltip, index, node)
 			tooltip:AddLine(16, "")
 			for i, line in ipairs(node.sd) do
 				if line ~= " " and (node.mods[i].extra or not node.mods[i].list) then
-					tooltip:AddLine(16, colorCodes.UNSUPPORTED..line..main.notSupportedTooltipText)
+					local line = colorCodes.UNSUPPORTED..modLine.line
+					line = main.notSupportedModTooltips and (line .. main.notSupportedTooltipText) or line
+					tooltip:AddLine(16, line)
 				else
 					tooltip:AddLine(16, colorCodes.MAGIC..line)
 				end

--- a/src/Classes/NotableDBControl.lua
+++ b/src/Classes/NotableDBControl.lua
@@ -254,7 +254,7 @@ function NotableDBClass:AddValueTooltip(tooltip, index, node)
 		if node.sd[1] then
 			tooltip:AddLine(16, "")
 			for i, line in ipairs(node.sd) do
-				if (node.mods[i].extra or not node.mods[i].list) and not node.mods[i].list == "" then
+				if line ~= " " and (node.mods[i].extra or not node.mods[i].list) then
 					tooltip:AddLine(16, colorCodes.UNSUPPORTED..line..main.notSupportedTooltipText)
 				else
 					tooltip:AddLine(16, colorCodes.MAGIC..line)

--- a/src/Classes/NotableDBControl.lua
+++ b/src/Classes/NotableDBControl.lua
@@ -254,7 +254,11 @@ function NotableDBClass:AddValueTooltip(tooltip, index, node)
 		if node.sd[1] then
 			tooltip:AddLine(16, "")
 			for i, line in ipairs(node.sd) do
-				tooltip:AddLine(16, ((node.mods[i].extra or not node.mods[i].list) and colorCodes.UNSUPPORTED or colorCodes.MAGIC)..line)
+				if (node.mods[i].extra or not node.mods[i].list) and not node.mods[i].list == "" then
+					tooltip:AddLine(16, colorCodes.UNSUPPORTED..line..main.notSupportedTooltipText)
+				else
+					tooltip:AddLine(16, colorCodes.MAGIC..line)
+				end
 			end
 		end
 

--- a/src/Classes/PassiveTreeView.lua
+++ b/src/Classes/PassiveTreeView.lua
@@ -1028,7 +1028,7 @@ function PassiveTreeViewClass:AddNodeTooltip(tooltip, node, build)
 					line = line .. "  " .. modStr
 				end
 			end
-			if (node.mods[i].extra or not node.mods[i].list) and not node.mods[i].list == "" then
+			if line ~= " " and (node.mods[i].extra or not node.mods[i].list) then 
 				tooltip:AddLine(16, colorCodes.UNSUPPORTED..line..main.notSupportedTooltipText)
 			else
 				tooltip:AddLine(16, colorCodes.MAGIC..line)

--- a/src/Classes/PassiveTreeView.lua
+++ b/src/Classes/PassiveTreeView.lua
@@ -1028,7 +1028,11 @@ function PassiveTreeViewClass:AddNodeTooltip(tooltip, node, build)
 					line = line .. "  " .. modStr
 				end
 			end
-			tooltip:AddLine(16, ((node.mods[i].extra or not node.mods[i].list) and colorCodes.UNSUPPORTED or colorCodes.MAGIC)..line)
+			if (node.mods[i].extra or not node.mods[i].list) and not node.mods[i].list == "" then
+				tooltip:AddLine(16, colorCodes.UNSUPPORTED..line..main.notSupportedTooltipText)
+			else
+				tooltip:AddLine(16, colorCodes.MAGIC..line)
+			end
 		end
 	end
 

--- a/src/Classes/PassiveTreeView.lua
+++ b/src/Classes/PassiveTreeView.lua
@@ -1029,7 +1029,9 @@ function PassiveTreeViewClass:AddNodeTooltip(tooltip, node, build)
 				end
 			end
 			if line ~= " " and (node.mods[i].extra or not node.mods[i].list) then 
-				tooltip:AddLine(16, colorCodes.UNSUPPORTED..line..main.notSupportedTooltipText)
+				local line = colorCodes.UNSUPPORTED..line
+				line = main.notSupportedModTooltips and (line .. main.notSupportedTooltipText) or line
+				tooltip:AddLine(16, line)
 			else
 				tooltip:AddLine(16, colorCodes.MAGIC..line)
 			end

--- a/src/Classes/SkillsTab.lua
+++ b/src/Classes/SkillsTab.lua
@@ -769,7 +769,7 @@ function SkillsTabClass:CreateGemSlot(index)
 						if grantedEffect.statMap[qual[1]] or self.build.data.skillStatMap[qual[1]] then
 							tooltip:AddLine(16, colorCodes.MAGIC..line)
 						else
-							tooltip:AddLine(16, colorCodes.UNSUPPORTED..line)
+							tooltip:AddLine(16, colorCodes.UNSUPPORTED..line..main.notSupportedTooltipText)
 						end
 					end
 				end

--- a/src/Classes/SkillsTab.lua
+++ b/src/Classes/SkillsTab.lua
@@ -769,7 +769,9 @@ function SkillsTabClass:CreateGemSlot(index)
 						if grantedEffect.statMap[qual[1]] or self.build.data.skillStatMap[qual[1]] then
 							tooltip:AddLine(16, colorCodes.MAGIC..line)
 						else
-							tooltip:AddLine(16, colorCodes.UNSUPPORTED..line..main.notSupportedTooltipText)
+							local line = colorCodes.UNSUPPORTED..line
+							line = main.notSupportedModTooltips and (line .. main.notSupportedTooltipText) or line
+							tooltip:AddLine(16, line)
 						end
 					end
 				end

--- a/src/Classes/Tooltip.lua
+++ b/src/Classes/Tooltip.lua
@@ -49,9 +49,6 @@ end)
 function TooltipClass:Clear()
 	wipeTable(self.lines)
 	wipeTable(self.blocks)
-	if self.updateParams then
-		wipeTable(self.updateParams)
-	end
 	self.recipe = nil
 	self.center = false
 	self.color = { 0.5, 0.3, 0 }
@@ -63,17 +60,17 @@ function TooltipClass:CheckForUpdate(...)
 	if not self.updateParams then
 		self.updateParams = { }
 	end
+
 	for i = 1, select('#', ...) do
-		if self.updateParams[i] ~= select(i, ...) then
+		local temp = select(i, ...)
+		if self.updateParams[i] ~= temp then
+			self.updateParams[i] = temp
 			doUpdate = true
-			break
 		end
 	end
-	if doUpdate then
+	if doUpdate or self.updateParams.notSupportedModTooltips ~= main.notSupportedModTooltips then
+		self.updateParams.notSupportedModTooltips = main.notSupportedModTooltips
 		self:Clear()
-		for i = 1, select('#', ...) do
-			self.updateParams[i] = select(i, ...)
-		end
 		return true
 	end
 end

--- a/src/Modules/ItemTools.lua
+++ b/src/Modules/ItemTools.lua
@@ -127,7 +127,7 @@ function itemLib.formatModLine(modLine, dbMode)
 	local colorCode
 	if modLine.extra then
 		colorCode = colorCodes.UNSUPPORTED
-		line = line..main.notSupportedTooltipText
+		line = main.notSupportedModTooltips and (line .. main.notSupportedTooltipText) or line
 		if launch.devModeAlt then
 			line = line .. "   ^1'" .. modLine.extra .. "'"
 		end

--- a/src/Modules/ItemTools.lua
+++ b/src/Modules/ItemTools.lua
@@ -127,6 +127,7 @@ function itemLib.formatModLine(modLine, dbMode)
 	local colorCode
 	if modLine.extra then
 		colorCode = colorCodes.UNSUPPORTED
+		line = line..main.notSupportedTooltipText
 		if launch.devModeAlt then
 			line = line .. "   ^1'" .. modLine.extra .. "'"
 		end

--- a/src/Modules/Main.lua
+++ b/src/Modules/Main.lua
@@ -101,6 +101,7 @@ function main:Init()
 	self.showTitlebarName = true
 	self.showWarnings = true
 	self.slotOnlyTooltips = true
+	self.notSupportedModTooltips = true
 	self.POESESSID = ""
 	self.showPublicBuilds = true
 
@@ -606,6 +607,10 @@ function main:LoadSettings(ignoreBuild)
 				if node.attrib.slotOnlyTooltips then
 					self.slotOnlyTooltips = node.attrib.slotOnlyTooltips == "true"
 				end
+				if node.attrib.notSupportedModTooltips then
+					self.notSupportedModTooltips = node.attrib.notSupportedModTooltips == "true"
+					self.notSupportedTooltipText = self.notSupportedModTooltips and " ^8(Not supported in PoB yet)" or ""
+				end
 				if node.attrib.POESESSID then
 					self.POESESSID = node.attrib.POESESSID or ""
 				end
@@ -725,6 +730,7 @@ function main:SaveSettings()
 		lastExportWebsite = self.lastExportWebsite,
 		showWarnings = tostring(self.showWarnings),
 		slotOnlyTooltips = tostring(self.slotOnlyTooltips),
+		notSupportedModTooltips = tostring(self.notSupportedModTooltips),
 		POESESSID = self.POESESSID,
 		invertSliderScrollDirection = tostring(self.invertSliderScrollDirection),
 		disableDevAutoSave = tostring(self.disableDevAutoSave),
@@ -970,6 +976,13 @@ function main:OpenOptionsPopup()
 	controls.slotOnlyTooltips.state = self.slotOnlyTooltips
 	
 	nextRow()
+	controls.notSupportedModTooltips = new("CheckBoxControl", { "TOPLEFT", nil, "TOPLEFT" }, { defaultLabelPlacementX, currentY, 20 }, "^7Show tooltip for unsuppoprted mods :", function(state)
+		self.notSupportedModTooltips = state
+	end)
+	controls.notSupportedModTooltips.tooltipText = "Show ^8(Not supported in PoB yet) ^7next to unsupported mods\nRequires PoB to restart for it to take effect"
+	controls.notSupportedModTooltips.state = self.notSupportedModTooltips
+	
+	nextRow()
 	controls.invertSliderScrollDirection = new("CheckBoxControl", { "TOPLEFT", nil, "TOPLEFT" }, { defaultLabelPlacementX, currentY, 20 }, "^7Invert slider scroll direction:", function(state)
 		self.invertSliderScrollDirection = state
 	end)
@@ -1004,6 +1017,7 @@ function main:OpenOptionsPopup()
 	local initialDefaultItemAffixQuality = self.defaultItemAffixQuality or 0.5
 	local initialShowWarnings = self.showWarnings
 	local initialSlotOnlyTooltips = self.slotOnlyTooltips
+	local initialNotSupportedModTooltips = self.notSupportedModTooltips
 	local initialInvertSliderScrollDirection = self.invertSliderScrollDirection
 	local initialDisableDevAutoSave = self.disableDevAutoSave
 	local initialShowPublicBuilds = self.showPublicBuilds
@@ -1054,6 +1068,7 @@ function main:OpenOptionsPopup()
 		self.defaultItemAffixQuality = initialDefaultItemAffixQuality
 		self.showWarnings = initialShowWarnings
 		self.slotOnlyTooltips = initialSlotOnlyTooltips
+		self.notSupportedModTooltips = initialNotSupportedModTooltips
 		self.invertSliderScrollDirection = initialInvertSliderScrollDirection
 		self.disableDevAutoSave = initialDisableDevAutoSave
 		self.showPublicBuilds = initialShowPublicBuilds

--- a/src/Modules/Main.lua
+++ b/src/Modules/Main.lua
@@ -102,6 +102,7 @@ function main:Init()
 	self.showWarnings = true
 	self.slotOnlyTooltips = true
 	self.notSupportedModTooltips = true
+	self.notSupportedTooltipText = ""
 	self.POESESSID = ""
 	self.showPublicBuilds = true
 

--- a/src/Modules/Main.lua
+++ b/src/Modules/Main.lua
@@ -977,7 +977,7 @@ function main:OpenOptionsPopup()
 	controls.slotOnlyTooltips.state = self.slotOnlyTooltips
 	
 	nextRow()
-	controls.notSupportedModTooltips = new("CheckBoxControl", { "TOPLEFT", nil, "TOPLEFT" }, { defaultLabelPlacementX, currentY, 20 }, "^7Show tooltip for unsuppoprted mods :", function(state)
+	controls.notSupportedModTooltips = new("CheckBoxControl", { "TOPLEFT", nil, "TOPLEFT" }, { defaultLabelPlacementX, currentY, 20 }, "^7Show tooltip for unsupported mods :", function(state)
 		self.notSupportedModTooltips = state
 	end)
 	controls.notSupportedModTooltips.tooltipText = "Show ^8(Not supported in PoB yet) ^7next to unsupported mods\nRequires PoB to restart for it to take effect"

--- a/src/Modules/Main.lua
+++ b/src/Modules/Main.lua
@@ -102,7 +102,7 @@ function main:Init()
 	self.showWarnings = true
 	self.slotOnlyTooltips = true
 	self.notSupportedModTooltips = true
-	self.notSupportedTooltipText = ""
+	self.notSupportedTooltipText = " ^8(Not supported in PoB yet)"
 	self.POESESSID = ""
 	self.showPublicBuilds = true
 
@@ -610,7 +610,6 @@ function main:LoadSettings(ignoreBuild)
 				end
 				if node.attrib.notSupportedModTooltips then
 					self.notSupportedModTooltips = node.attrib.notSupportedModTooltips == "true"
-					self.notSupportedTooltipText = self.notSupportedModTooltips and " ^8(Not supported in PoB yet)" or ""
 				end
 				if node.attrib.POESESSID then
 					self.POESESSID = node.attrib.POESESSID or ""


### PR DESCRIPTION
PoB does not calculate mods that have red text on them but many users do not know this. Adding this reminder text after all the lines should make it more obvious

<img width="460" height="235" alt="image" src="https://github.com/user-attachments/assets/b26c191d-25f5-4f44-b6f4-74a4a0c9d2cf" />
<img width="653" height="131" alt="image" src="https://github.com/user-attachments/assets/7b4b6460-dc11-4a44-a18d-9f689cf1679b" />
<img width="441" height="368" alt="image" src="https://github.com/user-attachments/assets/772e8be2-94fc-444b-b32d-b04d057b47de" />
<img width="1049" height="271" alt="image" src="https://github.com/user-attachments/assets/7b4bc440-e4da-4f1c-b492-e146fa94a7eb" />
