### PR TITLE
Correct skill slot comparison for General's Cry detection

### DIFF
--- a/src/Modules/CalcMirages.lua
+++ b/src/Modules/CalcMirages.lua
@@ -374,7 +374,7 @@ function calcs.mirages(env)
 
 		-- Find the active General's Cry gem to get active properties
 		for _, skill in ipairs(env.player.activeSkillList) do
-			if skill.activeEffect.grantedEffect.name == "General's Cry" and env.player.mainSkill.socketGroup.slot == env.player.mainSkill.socketGroup.slot then
+			if skill.activeEffect.grantedEffect.name == "General's Cry" and skill.socketGroup.slot == env.player.mainSkill.socketGroup.slot then
 				cooldown = calcSkillCooldown(skill.skillModList, skill.skillCfg, skill.skillData)
 				generalsCryActiveSkill = skill
 				break
@@ -397,7 +397,7 @@ function calcs.mirages(env)
 			env.player.mainSkill.skillData.timeOverride = 1
 		end
 
-		-- This is so that it's consistant with the info message but removing this could make it more accurate numbers wise
+		-- This is so that it's consistent with the info message but removing this could make it more accurate numbers wise
 		mirageSpawnTime = round(mirageSpawnTime, 2)
 		cooldown = m_max(cooldown, mirageSpawnTime)
 


### PR DESCRIPTION
### Description of the problem being solved:
The `CalcMirages.lua` logic for detecting the active "General's Cry" skill incorrectly compared `env.player.mainSkill.socketGroup.slot` to itself, causing the slot-matching condition to always be true. This could result in the wrong skill being used for cooldown and active property calculations. This small PR fixes it.

### Steps taken to verify a working solution:
- Updated the condition to compare the iterated skill's socket group slot (`skill.socketGroup.slot`) against the main skill's socket group slot.
- Ran the full busted test suite with `--lua=luajit` to confirm no issues.