### PR TITLE
'Monsters cannot be Leeched from' map mod now disables ES leech

### DIFF
--- a/src/Data/ModMap.lua
+++ b/src/Data/ModMap.lua
@@ -217,7 +217,7 @@ return {
 			apply = function(val, mapModEffect, modList, enemyModList)
 				enemyModList:NewMod("CannotLeechLifeFromSelf", "FLAG", true, "Map mod of Congealment")
 				enemyModList:NewMod("CannotLeechManaFromSelf", "FLAG", true, "Map mod of Congealment")
-				--missing cannot leech es?
+				enemyModList:NewMod("CannotLeechEnergyShieldFromSelf", "FLAG", true, "Map mod of Congealment")
 			end
 		},
 		["of Drought"] = {


### PR DESCRIPTION
Fixes problem when map mod **Monsters cannot be Leeched from** doesn't disables ES leech.

### Description of the problem being solved:
Map mod **Monsters cannot be Leeched from** must disable Life, Mana, ES leech. However, ES leech wasn't disabled.
### Steps taken to verify a working solution:
- Make your character to Leech ES.
- Turn the **Monsters cannot be Leeched from** mod in config.
- Check your ES leech.

### Link to a build that showcases this PR:
`https://pobb.in/La8FWqDeM3By`
### Before screenshot:
<img width="1060" height="599" alt="image" src="https://github.com/user-attachments/assets/b646de25-ba08-49bb-b9ac-e786dd6b271a" />

### After screenshot:
<img width="1062" height="586" alt="image" src="https://github.com/user-attachments/assets/af6bdba1-d79e-468f-b150-61bfd6d19050" />
