### PR TITLE
Fix LIST type mods being duplicated

### DIFF
--- a/src/Classes/ModList.lua
+++ b/src/Classes/ModList.lua
@@ -45,7 +45,7 @@ function ModListClass:ReplaceModInternal(mod)
 	return false
 end
 
-function ModListClass:MergeMod(mod)
+function ModListClass:MergeMod(mod, skipNonAdditive)
 	if mod.type == "BASE" or mod.type == "INC" or mod.type == "MORE" then
 		for i = 1, #self do
 			if modLib.compareModParams(self[i], mod) then
@@ -55,7 +55,9 @@ function ModListClass:MergeMod(mod)
 			end
 		end
 	end
-	self:AddMod(mod)
+	if not skipNonAdditive then
+		self:AddMod(mod)
+	end
 end
 
 function ModListClass:AddList(modList)

--- a/src/Modules/CalcSetup.lua
+++ b/src/Modules/CalcSetup.lua
@@ -1067,7 +1067,7 @@ function calcs.initEnv(build, mode, override, specEnv)
 					local scaledList = new("ModList")
 					scaledList:ScaleAddList(combinedList, scale)
 					for _, mod in ipairs(scaledList) do
-						combinedList:MergeMod(mod)
+						combinedList:MergeMod(mod, true)
 					end
 					env.itemModDB:AddList(combinedList)
 				elseif item.type == "Boots" and calcLib.mod(env.initialNodeModDB, nil, "EffectOfBonusesFromBoots") ~= 1 then
@@ -1079,7 +1079,7 @@ function calcs.initEnv(build, mode, override, specEnv)
 					local scaledList = new("ModList")
 					scaledList:ScaleAddList(combinedList, scale)
 					for _, mod in ipairs(scaledList) do
-						combinedList:MergeMod(mod)
+						combinedList:MergeMod(mod, true)
 					end
 					env.itemModDB:AddList(combinedList)
 				else


### PR DESCRIPTION
Fixes #8971

### Description of the problem being solved:
https://github.com/PathOfBuildingCommunity/PathOfBuilding/pull/8862 seems to have caused an issue where LIST type mods are duplicated due to how `ModListClass:MergeMod` handles them https://github.com/PathOfBuildingCommunity/PathOfBuilding/blob/d2524f92d902fc015e225cf78bce4f48b936462a/src/Classes/ModList.lua#L48-L59

This PR adds a switch to `ModListClass:MergeMod` causing mods which cannot be merged to not be added.
