### PR TITLE
fix: number of projectiles in spiral

### DIFF
--- a/src/Data/SkillStatMap.lua
+++ b/src/Data/SkillStatMap.lua
@@ -1350,6 +1350,10 @@ return {
 ["number_of_additional_projectiles"] = {
 	mod("ProjectileCount", "BASE", nil),
 },
+["base_number_of_projectiles_in_spiral_nova"] = {
+	mod("ProjectileCount", "BASE", nil),
+	base = -1
+},
 ["projectile_damage_+%_per_remaining_chain"] = {
 	mod("Damage", "INC", nil, ModFlag.Projectile, 0, { type = "PerStat", stat = "ChainRemaining" }),
 	mod("Damage", "INC", nil, ModFlag.Ailment, 0, { type = "PerStat", stat = "ChainRemaining" }),
@@ -2082,7 +2086,7 @@ return {
 	mod("AdditionalCooldownUses", "BASE", nil)
 },
 ["kill_enemy_on_hit_if_under_10%_life"] = {
-	mod("CullPercent", "MAX", nil), 
+	mod("CullPercent", "MAX", nil),
 	value = 10
 },
 ["spell_cast_time_added_to_cooldown_if_triggered"] = {


### PR DESCRIPTION
Fixes #8896

### Description of the problem being solved:
- The problem was related to all skills that use the "base_number_of_projectiles_in_spiral_nova" tag.
- Added calculation for the number of projectiles fired in a spiral to the SkillStatMap

### Changes Made
- Updated SkillStatMap to include calculation for "base_number_of_projectiles_in_spiral_nova"

### After screenshot:
**Examples of related skills:**

<img width="652" height="74" alt="Screenshot 2025-09-30 124951" src="https://github.com/user-attachments/assets/aa9360e8-f302-4ef8-9936-0293d54a193f" />

**Soulrend of the Spiral**

<img width="635" height="55" alt="Screenshot 2025-09-30 132529" src="https://github.com/user-attachments/assets/bc1474e7-10b3-4e0f-a36a-5a8dcf8774b7" />

**Vaal Spectral Throw**

<img width="624" height="60" alt="Screenshot 2025-09-30 132545" src="https://github.com/user-attachments/assets/ad6015e4-9f29-49d7-9b91-23f644815404" />

**Vaal Fireball**