### PR TITLE
Fix Eldritch implicit cleanup after influence reset

### DIFF
--- a/spec/System/TestItemParse_spec.lua
+++ b/spec/System/TestItemParse_spec.lua
@@ -368,6 +368,37 @@ describe("TestItemParse", function()
 		assert.truthy(item.explicitModLines[1].exarch)
 	end)
 
+	it("removes Eldritch implicits when influence removed", function()
+		local eldritchRaw = table.concat({
+			"Searing Exarch Item",
+			"Eater of Worlds Item",
+			"Implicits: 2",
+			"{exarch}+8 to Strength",
+			"{eater}+9 to Dexterity",
+		}, "\n")
+		local item = new("Item", raw(eldritchRaw))
+		assert.are.equals(2, #item.implicitModLines)
+		assert.truthy(item.cleansing)
+		assert.truthy(item.tangle)
+
+		item:ResetInfluence()
+		item.tangle = true
+		item:BuildAndParseRaw()
+
+		assert.falsy(item.cleansing)
+		assert.truthy(item.tangle)
+		assert.are.equals(1, #item.implicitModLines)
+		assert.truthy(item.implicitModLines[1].eater)
+		assert.are.equals("+9 to Dexterity", item.implicitModLines[1].line)
+
+		item:ResetInfluence()
+		item:BuildAndParseRaw()
+
+		assert.falsy(item.cleansing)
+		assert.falsy(item.tangle)
+		assert.are.equals(0, #item.implicitModLines)
+	end)
+
 	it("fractured", function()
 		local item = new("Item", raw("{fractured}+8 to Strength"))
 		assert.truthy(item.explicitModLines[1].fractured)

--- a/src/Classes/Item.lua
+++ b/src/Classes/Item.lua
@@ -1043,7 +1043,19 @@ function ItemClass:BuildRaw()
 	if self.itemLevel then
 		t_insert(rawLines, "Item Level: " .. self.itemLevel)
 	end
+	local function shouldWriteModLine(modLine)
+		if modLine.exarch and not self.cleansing then
+			return false
+		end
+		if modLine.eater and not self.tangle then
+			return false
+		end
+		return true
+	end
 	local function writeModLine(modLine)
+		if not shouldWriteModLine(modLine) then
+			return
+		end
 		local line = modLine.line
 		if modLine.range and line:match("%(%-?[%d%.]+%-%-?[%d%.]+%)") then
 			line = "{range:" .. round(modLine.range, 3) .. "}" .. line
@@ -1142,7 +1154,18 @@ function ItemClass:BuildRaw()
 	if self.classRestriction then
 		t_insert(rawLines, "Requires Class " .. self.classRestriction)
 	end
-	t_insert(rawLines, "Implicits: " .. (#self.enchantModLines + #self.implicitModLines + #self.scourgeModLines))
+	local implicitLineCount = 0
+	local function countModLines(list)
+		for _, modLine in ipairs(list) do
+			if shouldWriteModLine(modLine) then
+				implicitLineCount = implicitLineCount + 1
+			end
+		end
+	end
+	countModLines(self.enchantModLines)
+	countModLines(self.scourgeModLines)
+	countModLines(self.implicitModLines)
+	t_insert(rawLines, "Implicits: " .. implicitLineCount)
 	for _, modLine in ipairs(self.enchantModLines) do
 		writeModLine(modLine)
 	end


### PR DESCRIPTION
Fixes # .

### Description of the problem being solved: 
When Searing Exarch or Eater of Worlds influences were toggled off, their Eldritch implicit modifiers stayed behind in the serialized item text. This left orphaned implicits and an incorrect implicit count.

### Steps taken to verify a working solution:
- Added a regression in spec/System/TestItemParse_spec.lua that builds an item with both Eldritch implicits, then removes each influence in turn and asserts the implicits disappear accordingly.
- Manually verified the item serialization logic in src/Classes/Item.lua now omits {exarch}/{eater} lines and recalculates the implicit count whenever the matching influence is absent.

