### PR TITLE
Fix tincture effect calculation for imported tinctures

### DIFF
--- a/src/Classes/ItemsTab.lua
+++ b/src/Classes/ItemsTab.lua
@@ -3715,7 +3715,7 @@ function ItemsTabClass:AddItemTooltip(tooltip, item, slot, dbMode)
 		if item.rarity == "MAGIC" then
 			effectInc = effectInc + modDB:Sum("INC", { actor = "player" }, "MagicTinctureEffect")
 		end
-		local effectMod = (1 + (tinctureData.effectInc + effectInc) / 100) * (1 + (item.quality or 0) / 100)
+		local effectMod = item.crafted and (1 + (tinctureData.effectInc + effectInc) / 100) * (1 + (item.quality or 0) / 100) or (1 + effectInc / 100)
 		if effectMod ~= 1 then
 			t_insert(stats, s_format("^8Tincture effect modifier: ^7%+d%%", effectMod * 100 - 100))
 		end

--- a/src/Modules/CalcPerform.lua
+++ b/src/Modules/CalcPerform.lua
@@ -1562,13 +1562,13 @@ function calcs.perform(env, skipEHP)
 		local tinctureBuffsPerBase = {}
 
 		local function calcTinctureMods(item, baseName, buffModList, modList)
-			local tinctureEffectInc = effectInc + item.tinctureData.effectInc
+			local tinctureEffectInc = effectInc + (item.crafted and item.tinctureData.effectInc or 0)
 			if item.rarity == "MAGIC" then
 				tinctureEffectInc = tinctureEffectInc + effectIncMagic
 			end
 			-- Compute tincture effect multiplier.
 			-- Tincture effect multiplier is rounded to 2 decimal places before applying it.
-			local effectMod = math.floor((1 + (tinctureEffectInc) / 100) * (1 + (item.quality or 0) / 100) * 100) / 100 
+			local effectMod = math.floor((1 + (tinctureEffectInc) / 100) * (1 + (item.crafted and item.quality or 0) / 100) * 100) / 100 
 
 			-- same deal as flasks, go look at the comment there
 			if buffModList[1] then


### PR DESCRIPTION
Recalculate tincture effect from tincture quality and local increased effect mod only when a tincture is marked as crafted.

This is a hacky workaround, but nothing better comes to my mind.

Fixes #8039
Fixes #8090

### Description of the problem being solved:

POB applies local increased effect to imported tinctures where local increased effect is already applied.

### Steps taken to verify a working solution:
- Import a Prismatic Tincture with quality and or local increased effect
- Check MH Total Increased, it should be the same as on tincture

### Link to a build that showcases this PR:

```
eNrtHGtz2zbyc_QrMJrpTTNnyyL1sOSzeyPLduKpHbuSk9x9ysAkJLGBCJUEbaud_vfbBfiSI1CkpE6nN01mEpLYNxaL3SWo03-_zDl5YkHoCf-sbjWadcJ8R7iePz2rf3y4OuzV__1D7fSeytnd5DzyOI78UHtzqq4JZ0-MA16dSBpMmfyUUGp9AUoL6ssZE_4t_VkE74R7Vv8gfFYnj9R3PZncOZyG4Qc6Z2f1sQPIdUJDh_nuMHseA85oQB3JghvkOoikuBUujMoggtE59fyxcL4y-S4Q0UIJ9eSxZw1zfXt_N3rIieT5eZFAozen95wuWTCWVJIQ_jmrD8AwdMou6Bz-BWqUR0DK7lmNjt23W3a73e916keFyOdREMrtKIwXjLkpUrPR69tG2PuAXU4mzJHeExsGnhzOqO9kHI14a2CtRrsQ_Dbi0ltwjwU5FCPG-2_o230T7IOQlF_cjzPQjtWwu-1eq9_vWu0NeEJmtjJBfvbk7JyDWbfggrjXU9-TbEvke-GFwt9BvzyqUcVhxDms0RU2x42-1WtZnU7Hso-PTZgjFrLgiUpvVUgzJzF_9PxXtjzuN0qwGgSM3k20x46o60XhLZMBCzM6DcuEe0t9OhRhNtuWXQR6zwKIJnIFo7kBYcwcAQFohUmzcWyV4LMe28jwxpuw8pCVdIkRqkqznR6X47JwlQlvJ9AIAm45yLGIeElImYU828yZ_ZIHtDpGt7lgL-Xo5QHbLRPgtS_LkcsDdntm6Z6EVPvxJruo-HT5_j6FbPUatt2HANA8Pi7Ys2bL0HMov6Uv3jyaw07xQL-yjF-3wE-nM-lDlDOhtoyR58oLWHWsoeDuFlgzKkIjWs8cTTz_PaRIA8eJIOFZ5nbOwpVbwnCQUjgnCHvtO-XCwUc_UNtCLhPpFiKMYJFi6vPIWUmMjEW81HNBdwOrKfNjfsty6tww5szegYFHVLJy-0GWRBWbFWFLmRUB15i1UxKhgpEQ0WCkRr8IqaKZLn0WTJfjmce4Ww06EWxIFyXiL5o5j13K3KvsKnlMHrWiST7TwC23S5WDqir5Ew3zsdvqFhtVg5dzXwYJNCC47FVi3zQXJ-JnLE14NbRBMBdRUNItNHApBZJ9R1dlI-ZGTrl9Lq2wzjkUmmXVSLFATs4roQ6kpM7XC-FOSxtNMamEsSrfOFosINKgN5QlgFsq1A5eLoU67JaAvgNXLrXucfctzyCDLs0gzSfKc3mFUl4XzAkqKJOBl2aRTugtBIs5bBWqkXArsnhkzEivoHgsVfspwJIV6b14Bsln2CAKq0FD7pTlS0ZRAub_uixNfwW8FINL34U8DJZCaR6vMdaxefDmEEjD8IJKStw41_5EA4_60lbdq5DRwJndwNRfUc4fIRKc1fNP1Z3qeF15XLLgAp4hUxTsNUUrmfTTI9W5w6vr-UIEkrAX_O-eBnJ5Vp9QHjINqJ4AnVB6vmoKQDzivE7GM_E8cJ-Q04MQPEyQCF0smO-u0HgIGCM0iS4OCqGUxxsypyFIvdTuGqI2ucbftavU8AUIALlRr9dqoe5YANJgOVgF9D2QSwKvXP_R7satRU0J2b45_Ti6URdvZlIuwpOjo-fn58aCypmYsBfYnxqOmB8tAAkEPgy_epwfItmjAfw5nw7UH0XoKKF0qnuO4ZG-w0UaeCCznuQjVFRZHS2BFx-EZCGO4cPk5nSMrEKYzUC-Y_PwfAkL6wqzjlddltiUCD1mUntJHidphrpsQiOOz3-KKPdwZpv5pze6b-uLYJ7WX0AKZhbjv6b4sFyg6Qc3N3pkwGVMDNkl06ynMxaIeG4yxfFD1ZYdZFIPKXdCJbfnOzxyoRCJY07qRpw-omzYiMYiws03eHOUUkZvTkGeGPgdF4-U2wmKmkH044xt3LGG-phM2Rx945ZJ6sIiPLqWoNcRKnekOMDVeO7pZE8tIoSOnyjKuftfcmZOuSqG8QjCXmj711eEtRJhX6nriMjXFHw6j1ePZha7mhYydrN4ApSraWfCS6W2grj2F5FUlM7qcy90vjxGkwm2xkFcGahu_-XV1eXw4frTZRyg8ihKpS9-NH_Erq_-P9tGxkwlUCSMHkN9eVb_5LFnJcgFmNfjISrEOV2ELI0QyltiyTngFVBTUFBCJ4309bQyADOlyxcWQECbQn7uBB4zypWObxBKM8SsHAO6iRo2p82EdJo3hHCoawuDpdTrADMV7M0b1cHBAlzYCig3co5HN1hCYrwAN_UmnoN7YfGUY3TRUAV2SRsgxvmOc1QzDdXtNxHQg2Zk3bE3YcejBVZVbwuMVtWjZvQL5lCj7nrQjJyWq8IHM5mopFAFlD4IXzk5LJqBxzGfNM7sJWcpiJngnZyxIN71TZRuIUYlIIULJ_AeI2lexjmIAlup5pnBQjhmRtUNIoMOOFYQiVaaJgaD5mHMpHSzwRjIilB1bWG0X1ypFExBXKQbzK9HC4yQ9CkM-sfDBYtExd_Bk_BcXa0alssrsKKAAQnd7mRUCb47mdc1-e4UryAn_mqc73jUjP5RepjOrKGi05ZSRHBR7UYB19ZuFB4gAZVRwLYmMHqdiWS4o-IcJK0j1yIno0WRIy4vt6agi-Ct0VWNvjW2iv-QCzPQoHADSGEK1oeM_AswhixYGyVJKbHWB5JMu0q09Fa4VtPKFPUCj18hFcUADbKBEOzl7wuyxXKU0j7Te0Y5Hm8QfDeC37wq24UY9sqjBfXdhNzduhw9m4eS1hMyBJqqh3KBLfldbeiz-XINIbNcp0dJVae6K1hnxT2hsYSaTMZhjbAJJjW_CjH_71n90Go2e41Ot9ltN9t291gPxF0Ay4pLf0jHLzxAC5QzJkIg5H-ARMvqdBvtZrPVaXf024RTVTHHTQm8TnsSZmpRyPRr_M-MLoSvMHKdBKSSlNt4bEmZwNaF_ggey-UJ-fjh-qePl7UfqZj_A2iE_wrJfeDNoVCAZ0HkkeFMLBYsqN0wOo3YCblhUzB2LW6FnQA0I1aj2WiuPmo1jr99ZFnfPrM7-WfDKAAVZU0Xscwl6UinFjdMTojdrMWNohMyOkz_1tQUjNgvANyrQZ3FPcdDmGbtt9gKJ9bvv0GwnzK4-N6ym4dWp_n2O2yfBIyCr5DkdQbRnpIh2getPGq3eWjbJVE7B-08ahO4tkuiWgd2hjpw3ZAA60PbekukIN-37MNW7y3BlwAJJpYfYB-CSQGBaSNqTZAfoUhkbi0l9c_vQfFDG5RHQklpSKBihmBWi089EVgD3tecNC1QRDGwCG7KBJYflsJKcggM5NmTM0JV_R0eEF-QuQDJJFSVAOrAKsLXbaTZ6MS9xzBnI024kxJWL8aQ6gr7g87vl4qIAgNPF2QKOsmQWN8RMXltSEJDcvkiA7piI-z33Ap3hLYgyiK6h-amTRjjuL1hvLVhvG0ax1fICqKzgUJ3I4XjjRC9jRD9jRBW0q9Xnb4s3OSalkmIuR28ux7WhugCPswFrmoIMeEcnM0hSeaIs4ebygKzIXRCRU2t6BPSW1382Trvrqxzq2Z17fy6ghIak4bMH5SHatfSITOsXfsTwAcPwiyYnEeBn_pp2yLj2FF78RUZwsbsimefPM-YTy6YiteoU63VybNmaj-vdfv5hxkLNEMtL0gi4T3zmTJSSFrN73Ia6OIRs6lww8xsnLvWRogd_DSF6JodpPVHOsjf_vGX94_2Ov-49APPme0YPOxC52jv0znaVZxjhG_AiQPEvuKOnAw0yJ3Pl7AfskxX2CaXIgrII-OAAXvrY_JWEPZeQomEtLyRE8ihkCaGiIOUuQhZvFkqKnNdJmh4TBhC3L71lRK6QYaah5uJC1g-mJQvD4gIwC6cExpJoSYFH-dgtarIHMzqzEhTcWrsyUXXOU_nj3Ke5t--8__uO911vvOty9SGAZ2ALicE6zAAYBPv5YTg1y-1cTTJbvJZy4q__CbpNDxhiZt8cZWbHMT_pc8PdDadKx-Om1h-vq3qbJtz3nXmOP6jzPGXtEavpDXMk_7nyN3_i8ptNStGcoMfpuIncLrXdqVOzDyIF9Rz2TIv3FzUP_5z_XZtCtm2ClLIbWrdNFDaW4ZSPLxibk2tnmvhQhIPcO4fP45u8KCKPiPxjosn7PLikD5zdFSMEGfJVoZib0I5FwJ238HjMgzB6rqjRDoVeJ7jLvoK366Ar96KkFaG0S-rJRk_08Vr1u0tzLWL-jENew801ivU3YNC3T0otBWNdQpZVZxrnXe29mARe1_aVPG394zPmdzJHmsWW3dnCezKFHZm2dqX_Tt7cAZrD8vD2oMc7YqesK8QY--6Itt7MGD1PSM39cc76d_aVX97xyVcTQB3SfQpmF18UOcWu1BYv7A7O1Po7sutrX3FmOqumWNtbWeF9s5z2dmPU1VRfjCPOJN7iIStPQSU1o6Lsr0jvrUf-2-9U1Z22pzC3XIYOd_olZVtR6t2do3Ve5qW9r6Cy97y6ta2cbMC3gjfiNs7hyZ7P3Owt51iHwVfezudqhp_9z1-T8lGZ2dBdt_iulWDwa7B41uGuuujP5TB81PUZWN1duozwzcSoT5gpY41qe9nhD_xpvHrBn0TH3FS-OkTIj3JWe4Dn3y_KP8djROFUsxvhRtm390cHqbdwBC_oeMec_HVBb5EmNEnRqxmc6XrpntoiUXuOXXYTHCXBTEThudn4h-PSj7VOW42NyCsfJiaoLU2YaWfwSZf5iSYtt22NnHM_fZUgtbZgJP_1jjF2agaPNlCPuS1BZrqvWYYvbYZfp7-lBb-PhQLmDtWXwLhp19jxie5T606JXSsbJh09u7xtGU66WWxqk8E-thrk_b63RITUUlC9KzXbFplvKQsl7Ej1IFLPDb2zfdwRg7xDw4IzlVrOr86N2Amu0-C0LX6vb4ZJ_SmHr-bqGPaIKQ6a15WyNVfR6jk-enHHCmvptUusuIM4rTBiKdHaXTVh17V3Q-106PXv0X4P5f8tB4=
```

### Before screenshot:

<img width="437" height="450" alt="image" src="https://github.com/user-attachments/assets/3922b934-7652-4c5c-82af-00a96b10eb7c" />

<img width="376" height="29" alt="image" src="https://github.com/user-attachments/assets/1d7a940e-bf9d-4fd0-9825-e4691011a550" />


### After screenshot:

<img width="434" height="432" alt="image" src="https://github.com/user-attachments/assets/b98efa64-2baa-41b9-88e2-78f46d80e132" />

<img width="368" height="23" alt="image" src="https://github.com/user-attachments/assets/196eb383-52a6-429d-b60b-bfb5abd87a08" />

