### PR TITLE
Fix Unleash incorrect mana cost

### DIFF
--- a/src/Modules/CalcOffence.lua
+++ b/src/Modules/CalcOffence.lua
@@ -909,7 +909,9 @@ function calcs.offence(env, actor, activeSkill)
 					skillModList:NewMod("Damage", "MORE", mod.value*output.SealMax, mod.source, mod.flags, mod.keywordFlags, unpack(mod))
 				end
 				env.player.mainSkill.skillData.dpsMultiplier = (1 + output.SealMax * calcLib.mod(skillModList, skillCfg, "SealRepeatPenalty"))
-				env.player.mainSkill.skillData.hitTimeOverride = m_max(output.TimeMaxSeals, (1 / activeSkill.activeEffect.grantedEffect.castTime * 1.1 * calcLib.mod(skillModList, skillCfg, "Speed") * output.ActionSpeedMod))
+				-- Penalty on Cast Time per Seal
+				skillModList:NewMod("Speed", "INC", -10 * output.SealMax, "Unleash penalty", ModFlag.Spell)
+				env.player.mainSkill.skillData.hitTimeOverride = output.TimeMaxSeals
 			else
 				env.player.mainSkill.skillData.dpsMultiplier = 1 + 1 / output.SealCooldown / (1 / activeSkill.activeEffect.grantedEffect.castTime * 1.1 * calcLib.mod(skillModList, skillCfg, "Speed") * output.ActionSpeedMod) * calcLib.mod(skillModList, skillCfg, "SealRepeatPenalty")
 			end
@@ -5632,7 +5634,7 @@ function calcs.offence(env, actor, activeSkill)
 				timeType = "totem placement"
 			-- nil check until ailment pass for skills like Vortex
 			elseif skillModList:Flag(nil, "HasSeals") and skillModList:Flag(nil, "UseMaxUnleash") and env.player.mainSkill.skillData.hitTimeOverride then
-				useSpeed = env.player.mainSkill.skillData.hitTimeOverride / repeats
+				useSpeed = 1 / env.player.mainSkill.skillData.hitTimeOverride / repeats
 				timeType = "full unleash"
 			else
 				useSpeed = (output.Cooldown and output.Cooldown > 0 and (output.Speed > 0 and output.Speed or 1 / output.Cooldown) or output.Speed) / repeats


### PR DESCRIPTION
Fixes #9602 

When `Do you wait for Max Unleash Seals?` is ticked the hit rate should always be determined by the time it takes to get max seals. Cast Speed has no influence on the `Soul Gain Frequency`, but in the release version getting `increased cast speed` also influences the hit rate, which it shouldnt.

Also Wiki states:

> (Spell cast time is 10% longer for each time the Spell reoccurs)

which i think translates to `10% reduced cast speed per seal`.

 ### With 100% increased cast speed in release version vs now: 
<img width="303" height="889" alt="image" src="https://github.com/user-attachments/assets/68a4ac57-cc11-4984-a290-cbc7b6553501" />
<img width="310" height="884" alt="image" src="https://github.com/user-attachments/assets/86d678de-9bac-4111-841b-bf5c80ee2760" />







