### PR TITLE
Fix crash when both Blight + Blight of Contagion use "Maximum Sustainable Stacks"

### DIFF
--- a/src/Modules/Calcs.lua
+++ b/src/Modules/Calcs.lua
@@ -394,7 +394,7 @@ function calcs.buildActiveSkill(env, mode, skill, targetUUID, limitedProcessingF
 	-- env.limitedSkills contains a map of uuids that should be limited in calculation
 	-- this is in order to prevent infinite recursion loops
 	fullEnv.limitedSkills = fullEnv.limitedSkills or {}
-	for _, uuid in ipairs(env.limitedSkills or {}) do
+	for uuid, _ in pairs(env.limitedSkills or {}) do
 		fullEnv.limitedSkills[uuid] = true
 	end
 	for _, uuid in ipairs(limitedProcessingFlags or {}) do


### PR DESCRIPTION
### Description of the problem being solved:

Fixes an issue where characters using Blight + Blight of Contagion would stack overflow when using Maximum Sustainable Stacks.

Discovered in poe.ninja but reproduced on the build below in the desktop version by switching Blight to Maximum Sustainable Stacks.

The issue is that `ipairs` will not iterate the uuids.

### Steps taken to verify a working solution:

Re-tested in patched desktop version + patched poe.ninja version.

### Link to a build that showcases this PR:

https://poe.ninja/poe1/profile/Miyune92-0566/mirage/character/Noigatnoc_fo_Thgilb

### Before screenshot:

<img width="1385" height="1222" alt="image" src="https://github.com/user-attachments/assets/6103950d-e60b-4131-b887-0248cbdd309c" />

### After screenshot:

