### PR TITLE
Thread of Hope all-rings planning toggle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,6 @@ src/Data/TimelessJewelData/*.bin
 # Simplegraphic Debugging
 runtime/imgui.ini
 runtime/SimpleGraphic/SimpleGraphic.log
+
+# Local-only documentation notes (never commit upstream)
+.notes/

--- a/src/Classes/ItemsTab.lua
+++ b/src/Classes/ItemsTab.lua
@@ -3564,6 +3564,11 @@ function ItemsTabClass:AddItemTooltip(tooltip, item, slot, dbMode)
 		end
 		if item.jewelRadiusLabel then
 			tooltip:AddLine(fontSizeBig, "^x7F7F7FRadius: ^7"..item.jewelRadiusLabel, "FONTIN SC")
+			if item.jewelRadiusLabel == "Variable" then
+				-- Display-only hint, not added to rawLines, so item import/export is unaffected.
+				tooltip:AddSeparator(4)
+				tooltip:AddLine(fontSizeBig, colorCodes.MAGIC.."Tip: Press ^x7F7F7FT"..colorCodes.MAGIC.." in the tree view to toggle all five ring sizes.", "FONTIN")
+			end
 		end
 		if item.jewelRadiusData and slot and item.jewelRadiusData[slot.nodeId] then
 			local radiusData = item.jewelRadiusData[slot.nodeId]

--- a/src/Classes/PassiveSpec.lua
+++ b/src/Classes/PassiveSpec.lua
@@ -1031,16 +1031,32 @@ function PassiveSpecClass:AddMasteryEffectOptionsToNode(node)
 	node.allMasteryOptions = true
 end
 
+-- Returns jewelRadius indices to consider for this item. When the tree-view planning
+-- toggle is on for a Variable-radius jewel, all 5 Variable rings are treated as candidate
+-- radii so dependency/path calculations cover every possible socketed roll.
+function PassiveSpecClass:GetEffectiveRadiusIndices(item)
+	local toHMode = self.build.treeTab and self.build.treeTab.viewer
+		and self.build.treeTab.viewer.toHRingMode
+	if toHMode and item.jewelRadiusLabel == "Variable" then
+		return { 6, 7, 8, 9, 10 }
+	end
+	return { item.jewelRadiusIndex }
+end
+
 function PassiveSpecClass:NodesInIntuitiveLeapLikeRadius(node)
 	local result = { }
 	if self.jewels[node.id] and self.jewels[node.id] > 0 then
 		local item = self.build.itemsTab.items[self.jewels[node.id]]
 		local radiusIndex = item.jewelRadiusIndex
 		if item and item.jewelData and item.jewelData.intuitiveLeapLike then
-			local inRadius = self.nodes[node.id].nodesInRadius and self.nodes[node.id].nodesInRadius[radiusIndex]
-			for affectedNodeId, affectedNode in pairs(inRadius or {}) do
-				if self.nodes[affectedNodeId].alloc then
-					t_insert(result, self.nodes[affectedNodeId])
+			local seen = { }
+			for _, idx in ipairs(self:GetEffectiveRadiusIndices(item)) do
+				local inRadius = self.nodes[node.id].nodesInRadius and self.nodes[node.id].nodesInRadius[idx]
+				for affectedNodeId, affectedNode in pairs(inRadius or {}) do
+					if self.nodes[affectedNodeId].alloc and not seen[affectedNodeId] then
+						seen[affectedNodeId] = true
+						t_insert(result, self.nodes[affectedNodeId])
+					end
 				end
 			end
 		end
@@ -1082,18 +1098,21 @@ function PassiveSpecClass:BuildAllDependsAndPaths()
 				local item = self.build.itemsTab.items[itemId]
 				if item and item.jewelRadiusIndex and self.allocNodes[nodeId] and item.jewelData and not item.jewelData.limitDisabled then
 					local radiusIndex = item.jewelRadiusIndex
-					if self.nodes[nodeId].nodesInRadius and self.nodes[nodeId].nodesInRadius[radiusIndex][node.id] then
-						if itemId ~= 0 then
-							if item.jewelData.intuitiveLeapLike and not (item.jewelData.intuitiveLeapKeystoneOnly and node.type ~= "Keystone") then
-								-- This node depends on Intuitive Leap-like behaviour
-								-- This flag:
-								-- 1. Prevents generation of paths from this node unless it's also connected to the start
-								-- 2. Prevents allocation of path nodes when this node is being allocated
-								t_insert(node.intuitiveLeapLikesAffecting, self.nodes[nodeId])
+					for _, idx in ipairs(self:GetEffectiveRadiusIndices(item)) do
+						if self.nodes[nodeId].nodesInRadius and self.nodes[nodeId].nodesInRadius[idx][node.id] then
+							if itemId ~= 0 then
+								if item.jewelData.intuitiveLeapLike and not (item.jewelData.intuitiveLeapKeystoneOnly and node.type ~= "Keystone") then
+									-- This node depends on Intuitive Leap-like behaviour
+									-- This flag:
+									-- 1. Prevents generation of paths from this node unless it's also connected to the start
+									-- 2. Prevents allocation of path nodes when this node is being allocated
+									t_insert(node.intuitiveLeapLikesAffecting, self.nodes[nodeId])
+								end
+								if item.jewelData.conqueredBy then
+									node.conqueredBy = item.jewelData.conqueredBy
+								end
 							end
-							if item.jewelData.conqueredBy then
-								node.conqueredBy = item.jewelData.conqueredBy
-							end
+							break
 						end
 					end
 
@@ -1447,19 +1466,22 @@ function PassiveSpecClass:BuildAllDependsAndPaths()
 				local prune = true
 				for nodeId, itemId in pairs(self.jewels) do
 					if self.allocNodes[nodeId] then
-						if itemId ~= 0 and (
-							 self.build.itemsTab.items[itemId] and (
-								self.build.itemsTab.items[itemId].jewelData
-									and self.build.itemsTab.items[itemId].jewelData.intuitiveLeapLike
-									and self.build.itemsTab.items[itemId].jewelRadiusIndex
-									and self.nodes[nodeId].nodesInRadius
-									and self.nodes[nodeId].nodesInRadius[self.build.itemsTab.items[itemId].jewelRadiusIndex][depNode.id]
-							) or (
-								self.build.itemsTab.items[itemId].jewelData
-									and self.build.itemsTab.items[itemId].jewelData.impossibleEscapeKeystones
-									and self:NodeInKeystoneRadius(self.build.itemsTab.items[itemId].jewelData.impossibleEscapeKeystones, depNode.id, self.build.itemsTab.items[itemId].jewelRadiusIndex)
-							)
-						) then
+						local item = self.build.itemsTab.items[itemId]
+						local socketNode = self.nodes[nodeId]
+						local leapHit = false
+						if itemId ~= 0 and item and item.jewelData and item.jewelData.intuitiveLeapLike
+							and item.jewelRadiusIndex and socketNode.nodesInRadius then
+							for _, idx in ipairs(self:GetEffectiveRadiusIndices(item)) do
+								if socketNode.nodesInRadius[idx] and socketNode.nodesInRadius[idx][depNode.id] then
+									leapHit = true
+									break
+								end
+							end
+						end
+						local keyHit = itemId ~= 0 and item and item.jewelData
+							and item.jewelData.impossibleEscapeKeystones
+							and self:NodeInKeystoneRadius(item.jewelData.impossibleEscapeKeystones, depNode.id, item.jewelRadiusIndex)
+						if leapHit or keyHit then
 							-- Hold off on the pruning; this node could be supported by Intuitive Leap-like jewel
 							prune = false
 							if not intuitiveLeaps[nodeId] then

--- a/src/Classes/PassiveTreeView.lua
+++ b/src/Classes/PassiveTreeView.lua
@@ -65,6 +65,7 @@ local PassiveTreeViewClass = newClass("PassiveTreeView", function(self)
 	self.searchStrCached = ""
 	self.searchStrResults = {}
 	self.showStatDifferences = true
+	self.toHRingMode = nil  -- nil | true (planning toggle: show all Variable rings)
 	self.hoverNode = nil
 end)
 
@@ -116,6 +117,15 @@ function PassiveTreeViewClass:Draw(build, viewPort, inputEvents)
 				end
 			elseif event.key == "p" then
 				self.showHeatMap = not self.showHeatMap
+			elseif event.key == "t" then
+				-- Toggle Thread of Hope all-rings planning view
+				self.toHRingMode = not self.toHRingMode or nil
+				if not main.toHHintDismissed then
+					main.toHHintDismissed = true
+					main:SaveSettings()
+				end
+				build.spec:BuildAllDependsAndPaths()
+				build.buildFlag = true
 			elseif event.key == "d" and IsKeyDown("CTRL") then
 				self.showStatDifferences = not self.showStatDifferences
 			elseif event.key == "c" and IsKeyDown("CTRL") and self.hoverNode and self.hoverNode.type ~= "Socket" then
@@ -635,6 +645,35 @@ function PassiveTreeViewClass:Draw(build, viewPort, inputEvents)
 		end
 	end
 
+	-- One pass over allocated jewel sockets: detects whether any Variable-radius jewel is
+	-- socketed (used to gate the first-time hint), and when the planning toggle is on, builds
+	-- a nodeId -> ring colour tint map. First-seen wins when sockets overlap; rings within one
+	-- socket are non-overlapping so per-socket order is deterministic.
+	local toHTintMap = self.toHRingMode and { } or nil
+	local hasVariableJewel = false
+	for socketNodeId, itemId in pairs(spec.jewels) do
+		if itemId ~= 0 and spec.allocNodes[socketNodeId] then
+			local item = build.itemsTab.items[itemId]
+			local socketNode = spec.nodes[socketNodeId]
+			if item and item.jewelRadiusLabel == "Variable" then
+				hasVariableJewel = true
+				if toHTintMap and socketNode and socketNode.nodesInRadius then
+					for ringIdx = 6, 10 do
+						local nodesInRing = socketNode.nodesInRadius[ringIdx]
+						local radData = build.data.jewelRadius[ringIdx]
+						if nodesInRing and radData then
+							for nId in pairs(nodesInRing) do
+								if not toHTintMap[nId] then
+									toHTintMap[nId] = radData.col
+								end
+							end
+						end
+					end
+				end
+			end
+		end
+	end
+
 	-- Draw the nodes
 	for nodeId, node in pairs(spec.nodes) do
 		-- Determine the base and overlay images for this node based on type and state
@@ -850,11 +889,13 @@ function PassiveTreeViewClass:Draw(build, viewPort, inputEvents)
 		if overlay then
 			-- Draw overlay
 			if node.type ~= "ClassStart" and node.type ~= "AscendClassStart" then
+				local hoverTinted = false
 				if hoverNode and hoverNode ~= node then
 					-- Mouse is hovering over a different node
 					if hoverDep and hoverDep[node] then
 						-- This node depends on the hover node, turn it red
 						SetDrawColor(1, 0, 0)
+						hoverTinted = true
 					elseif hoverNode.type == "Socket" and hoverNode.nodesInRadius then
 						-- Hover node is a socket, check if this node falls within its radius and color it accordingly
 						local socket, jewel = build.itemsTab:GetSocketAndJewelForNodeID(hoverNode.id)
@@ -866,6 +907,7 @@ function PassiveTreeViewClass:Draw(build, viewPort, inputEvents)
 									-- Draw Thread of Hope's annuli
 									if data.inner ~= 0 then
 										SetDrawColor(data.col)
+										hoverTinted = true
 										break
 									end
 								end
@@ -877,12 +919,17 @@ function PassiveTreeViewClass:Draw(build, viewPort, inputEvents)
 									-- Draw normal jewel radii
 									if data.inner == 0 then
 										SetDrawColor(data.col)
+										hoverTinted = true
 										break
 									end
 								end
 							end
 						end
 					end
+				end
+				if not hoverTinted and toHTintMap and toHTintMap[nodeId] then
+					-- Planning toggle is on: tint nodes by the Thread of Hope ring they sit in
+					SetDrawColor(toHTintMap[nodeId])
 				end
 			end
 			self:DrawAsset(tree.assets[overlay], scrX, scrY, scale)
@@ -959,7 +1006,18 @@ function PassiveTreeViewClass:Draw(build, viewPort, inputEvents)
 					end
 				end
 			elseif node.alloc then
-				if jewel and jewel.jewelRadiusIndex then
+				if self.toHRingMode and jewel and jewel.jewelRadiusLabel == "Variable" then
+					-- Planning toggle: draw all five Variable-radius annuli around the socket
+					for _, radData in ipairs(build.data.jewelRadius) do
+						local outerSize = radData.outer * scale
+						local innerSize = radData.inner * scale
+						if innerSize ~= 0 then
+							SetDrawColor(radData.col)
+							DrawImage(self.ring, scrX - outerSize, scrY - outerSize, outerSize * 2, outerSize * 2)
+							DrawImage(self.ring, scrX - innerSize, scrY - innerSize, innerSize * 2, innerSize * 2)
+						end
+					end
+				elseif jewel and jewel.jewelRadiusIndex then
 					-- Draw only the selected jewel radius
 					local radData = build.data.jewelRadius[jewel.jewelRadiusIndex]
 					local outerSize = radData.outer * scale
@@ -1005,6 +1063,14 @@ function PassiveTreeViewClass:Draw(build, viewPort, inputEvents)
 				end
 			end
 		end
+	end
+
+	-- First-time hint: shown only while the toggle is off, the user has never pressed T,
+	-- and the build has at least one allocated Variable-radius jewel.
+	if hasVariableJewel and not self.toHRingMode and not main.toHHintDismissed then
+		SetDrawLayer(nil, 100)
+		DrawString(viewPort.x + 12, viewPort.y + 12, "LEFT", 18, "FONTIN",
+			"^xFFCC00Tip: ^7Press ^xFFCC00T^7 to view all Thread of Hope ring sizes.")
 	end
 end
 function PassiveTreeViewClass:DrawImageRotated(handle, x, y, width, height, angle, ...)

--- a/src/Modules/Data.lua
+++ b/src/Modules/Data.lua
@@ -540,13 +540,13 @@ data.jewelRadii = {
 		{ inner = 0, outer = 1440, col = "^x66FFCC", label = "Medium" },
 		{ inner = 0, outer = 1800, col = "^x2222CC", label = "Large" },
 		{ inner = 0, outer = 2400, col = "^xC100FF", label = "Very Large" },	
-		{ inner = 0, outer = 2880, col = "^x0B9300", label = "Massive" },
+		{ inner = 0, outer = 2880, col = "^xFFD700", label = "Massive" },
 
 		{ inner = 960, outer = 1320, col = "^xD35400", label = "Variable" },
 		{ inner = 1320, outer = 1680, col = "^x66FFCC", label = "Variable" },
 		{ inner = 1680, outer = 2040, col = "^x2222CC", label = "Variable" },
 		{ inner = 2040, outer = 2400, col = "^xC100FF", label = "Variable" },
-		{ inner = 2400, outer = 2880, col = "^x0B9300", label = "Variable" },
+		{ inner = 2400, outer = 2880, col = "^xFFD700", label = "Variable" },
 	}
 }
 

--- a/src/Modules/Main.lua
+++ b/src/Modules/Main.lua
@@ -580,6 +580,9 @@ function main:LoadSettings(ignoreBuild)
 				if node.attrib.edgeSearchHighlight then
 					self.edgeSearchHighlight = node.attrib.edgeSearchHighlight == "true"
 				end
+				if node.attrib.toHHintDismissed then
+					self.toHHintDismissed = node.attrib.toHHintDismissed == "true"
+				end
 				if node.attrib.defaultGemQuality then
 					self.defaultGemQuality = m_min(tonumber(node.attrib.defaultGemQuality) or 0, 23)
 				end
@@ -745,6 +748,7 @@ function main:SaveSettings()
 		showTitlebarName = tostring(self.showTitlebarName),
 		betaTest = tostring(self.betaTest),
 		edgeSearchHighlight = tostring(self.edgeSearchHighlight),
+		toHHintDismissed = tostring(self.toHHintDismissed or false),
 		defaultGemQuality = tostring(self.defaultGemQuality or 0),
 		defaultCharLevel = tostring(self.defaultCharLevel or 1),
 		defaultItemAffixQuality = tostring(self.defaultItemAffixQuality or 0.5),


### PR DESCRIPTION
## What this does

Adds a single tree-view hotkey for Thread of Hope planning:

- **`T`** toggles "show all 5 rings" mode for any allocated Thread of Hope socket.

While the mode is on, ToH is treated as if every Variable ring were equipped, so nodes inside any of the five rings become allocatable via the existing intuitive-leap mechanic, regardless of the variant the player actually picked. Nodes are also tinted by the colour of the ring they sit in, matching how the in-game jewel highlights its affected passives.

State is session-only (not saved to build XML), so loading a saved build never lands you in a mystery "all rings" state.

## Discoverability

The hotkey is surfaced in two places:

- A small first-time hint appears top-left whenever a Thread of Hope is socketed and the user has never pressed `T`. The first press dismisses the hint forever (persisted on `main.toHHintDismissed` alongside the other `Misc` settings in `Settings.xml`).
- The Thread of Hope item tooltip gains a display-only `Tip: Press T...` line directly under `Radius: Variable`. This line is added via `tooltip:AddLine` and is never written to `item.rawLines`, so import/export and build-share codes are unaffected.

## How it works

A new `PassiveSpec:GetEffectiveRadiusIndices(item)` helper reads the override from `build.treeTab.viewer.toHRingMode` and returns either:

- `{ item.jewelRadiusIndex }` by default (unchanged behaviour)
- `{ 6, 7, 8, 9, 10 }` (the five Variable ring indices) when the toggle is on for a Variable-radius jewel

All four call sites that previously used `item.jewelRadiusIndex` directly now route through this helper:

- `BuildAllDependsAndPaths`, populating `intuitiveLeapLikesAffecting`
- `BuildAllDependsAndPaths`, orphan-pruning check (the load-bearing fix; without it, freshly-allocated leap nodes were getting deallocated by the same pass that allocated them when the override didn't match the variant)
- `NodesInIntuitiveLeapLikeRadius`
- `PassiveTreeView` ring rendering

The override only kicks in when `item.jewelRadiusLabel == "Variable"`, so other radius-using uniques (Impossible Escape, etc.) are unaffected.

## Visual changes

- The Massive jewel-radius colour was changed from dark green (`^x0B9300`) to gold (`^xFFD700`). With all five Variable rings drawn at once, the Medium ring's teal (`^x66FFCC`) and the old Massive's dark green were both reading as shades of green and were hard to tell apart. Gold keeps all five rings clearly distinguishable. The same colour is shared by the regular Massive Cluster Jewel radius since both come from `data.jewelRadii`. Happy to revert to the original palette if preferred.
- A pre-pass over `spec.jewels` builds a `nodeId -> ring colour` map when the toggle is on, and the existing overlay-tinting block applies it as a fallback when no hover-based tint is active.

## Changes

- `src/Classes/PassiveSpec.lua`: `GetEffectiveRadiusIndices` helper; the 3 call sites now route through it
- `src/Classes/PassiveTreeView.lua`: `T` keybind, ring drawing + node tinting when the toggle is on, first-time hint
- `src/Classes/ItemsTab.lua`: Variable-radius tooltip hint line (display-only)
- `src/Modules/Main.lua`: `main.toHHintDismissed` load/save in the `Misc` element
- `src/Modules/Data.lua`: Massive radius colour swap

## Steps taken to verify

- [x] `T` toggles all 5 rings on a build with a Variable Thread of Hope; clicking unconnected nodes inside any ring allocates them as a leap-jump (1 point) regardless of the actual variant
- [x] Pressing `T` again hides the rings and reverts dependency calcs to the variant-only radius
- [x] Nodes inside each ring render in that ring's colour while the toggle is on
- [x] First-time hint appears top-left when a ToH is socketed; vanishes for good after the first `T` press; stays dismissed across PoB restarts
- [x] Tooltip hint line shows under `Radius: Variable`, and the export build code does not contain it
- [x] Default behaviour (toggle off) is unchanged; no new state lands in saved build XML
- [x] Other radius-based uniques (Impossible Escape, etc.) unaffected
- [x] Hot-reload (F5) works without errors