### PR TITLE
Add network mode option for Kinetic Fusillade effective attack rate

### DIFF
--- a/src/Data/Skills/act_int.lua
+++ b/src/Data/Skills/act_int.lua
@@ -11063,8 +11063,17 @@ skills["KineticFusillade"] = {
 		local maxEffectiveAPS = 1 / effectiveDelayRounded
 		local maxEffectivePredictiveAPS = 1 / effectiveDelay
 		local currentAPS = output.Speed
+		-- Network mode is selected in the Configuration tab (defaults to Lockstep)
+		local isPredictive = activeSkill.skillModList:Flag(activeSkill.skillCfg, "Condition:KineticFusilladePredictive")
+		local selectedEffectiveAPS = isPredictive and maxEffectivePredictiveAPS or maxEffectiveAPS
 
-		output.KineticFusilladeMaxEffectiveAPS = maxEffectiveAPS
+		output.KineticFusilladeMaxEffectiveAPS = selectedEffectiveAPS
+
+		-- Cap the attack rate so the sidebar Attack Rate and DPS reflect the effective rate
+		if currentAPS > selectedEffectiveAPS then
+			output.Speed = selectedEffectiveAPS
+			output.Time = 1 / selectedEffectiveAPS
+		end
 
 		if breakdown then
 			local breakdownAPS = {}
@@ -11107,14 +11116,9 @@ skills["KineticFusillade"] = {
 			breakdown.KineticFusilladeMaxEffectiveAPS = breakdownAPS
 		end
 
-		-- Adjust dpsMultiplier if attacking too fast (only for "All Projectiles" mode)
-		if activeSkill.skillPart == 1 then
-			if currentAPS and currentAPS > maxEffectiveAPS then
-				local efficiencyRatio = maxEffectiveAPS / currentAPS
-				local originalMultiplier = skillData.dpsMultiplier or output.ProjectileCount
-				skillData.dpsMultiplier = originalMultiplier * efficiencyRatio
-			end
-		end
+		-- The stock dpsMultiplier efficiency scaling is disabled: the rate reduction is
+		-- handled by capping output.Speed above (network-mode aware), so scaling
+		-- dpsMultiplier here as well would double-count the penalty.
 	end,
 	statMap = {
 		["kinetic_fusillade_damage_+%_final_per_projectile_fired"] = {
@@ -11281,8 +11285,17 @@ skills["KineticFusilladeAltX"] = {
 		local maxEffectiveAPS = 1 / effectiveDelayRounded
 		local maxEffectivePredictiveAPS = 1 / effectiveDelay
 		local currentAPS = output.Speed
+		-- Network mode is selected in the Configuration tab (defaults to Lockstep)
+		local isPredictive = activeSkill.skillModList:Flag(activeSkill.skillCfg, "Condition:KineticFusilladePredictive")
+		local selectedEffectiveAPS = isPredictive and maxEffectivePredictiveAPS or maxEffectiveAPS
 
-		output.KineticFusilladeMaxEffectiveAPS = maxEffectiveAPS
+		output.KineticFusilladeMaxEffectiveAPS = selectedEffectiveAPS
+
+		-- Cap the attack rate so the sidebar Attack Rate and DPS reflect the effective rate
+		if currentAPS > selectedEffectiveAPS then
+			output.Speed = selectedEffectiveAPS
+			output.Time = 1 / selectedEffectiveAPS
+		end
 
 		if breakdown then
 			local breakdownAPS = {}
@@ -11325,14 +11338,9 @@ skills["KineticFusilladeAltX"] = {
 			breakdown.KineticFusilladeMaxEffectiveAPS = breakdownAPS
 		end
 
-		-- Adjust dpsMultiplier if attacking too fast (only for "All Projectiles" mode)
-		if activeSkill.skillPart == 1 then
-			if currentAPS and currentAPS > maxEffectiveAPS then
-				local efficiencyRatio = maxEffectiveAPS / currentAPS
-				local originalMultiplier = skillData.dpsMultiplier or output.ProjectileCount
-				skillData.dpsMultiplier = originalMultiplier * efficiencyRatio
-			end
-		end
+		-- The stock dpsMultiplier efficiency scaling is disabled: the rate reduction is
+		-- handled by capping output.Speed above (network-mode aware), so scaling
+		-- dpsMultiplier here as well would double-count the penalty.
 	end,
 	statMap = {
 		["kinetic_fusillade_damage_+%_final_per_projectile_fired"] = {

--- a/src/Export/Skills/act_int.txt
+++ b/src/Export/Skills/act_int.txt
@@ -2345,11 +2345,21 @@ local skills, mod, flag, skill = ...
 		local maxEffectiveAPS = 1 / effectiveDelayRounded
 		local maxEffectivePredictiveAPS = 1 / effectiveDelay
 		local currentAPS = output.Speed
+		-- Network mode is selected in the Configuration tab (defaults to Lockstep)
+		local isPredictive = activeSkill.skillModList:Flag(activeSkill.skillCfg, "Condition:KineticFusilladePredictive")
+		local selectedEffectiveAPS = isPredictive and maxEffectivePredictiveAPS or maxEffectiveAPS
 
-		output.KineticFusilladeMaxEffectiveAPS = maxEffectiveAPS
+		output.KineticFusilladeMaxEffectiveAPS = selectedEffectiveAPS
+
+		-- Cap the attack rate so the sidebar Attack Rate and DPS reflect the effective rate
+		if currentAPS > selectedEffectiveAPS then
+			output.Speed = selectedEffectiveAPS
+			output.Time = 1 / selectedEffectiveAPS
+		end
 
 		if breakdown then
 			local breakdownAPS = {}
+			t_insert(breakdownAPS, s_format("^8Selected network mode (Configuration tab):^7 %s", isPredictive and "Predictive" or "Lockstep"))
 			t_insert(breakdownAPS, s_format("^8Base hover delay:^7 %.1fs", hoverDelay))
 			t_insert(breakdownAPS, s_format("^8Base delay between projectiles:^7 %.2fs", baseDelayBetweenProjectiles))
 			t_insert(breakdownAPS, s_format("^8Base time for^7 %d added ^8projectiles:^7 %.2fs x %d = %.1fs", (projectileCount - 1), baseDelayBetweenProjectiles, (projectileCount - 1), baseTimeForAllProjectiles))
@@ -2389,14 +2399,9 @@ local skills, mod, flag, skill = ...
 			breakdown.KineticFusilladeMaxEffectiveAPS = breakdownAPS
 		end
 
-		-- Adjust dpsMultiplier if attacking too fast (only for "All Projectiles" mode)
-		if activeSkill.skillPart == 1 then
-			if currentAPS and currentAPS > maxEffectiveAPS then
-				local efficiencyRatio = maxEffectiveAPS / currentAPS
-				local originalMultiplier = skillData.dpsMultiplier or output.ProjectileCount
-				skillData.dpsMultiplier = originalMultiplier * efficiencyRatio
-			end
-		end
+		-- The stock dpsMultiplier efficiency scaling is disabled: the rate reduction is
+		-- handled by capping output.Speed above (network-mode aware), so scaling
+		-- dpsMultiplier here as well would double-count the penalty.
 	end,
 	statMap = {
 		["kinetic_fusillade_damage_+%_final_per_projectile_fired"] = {
@@ -2487,11 +2492,21 @@ local skills, mod, flag, skill = ...
 		local maxEffectiveAPS = 1 / effectiveDelayRounded
 		local maxEffectivePredictiveAPS = 1 / effectiveDelay
 		local currentAPS = output.Speed
+		-- Network mode is selected in the Configuration tab (defaults to Lockstep)
+		local isPredictive = activeSkill.skillModList:Flag(activeSkill.skillCfg, "Condition:KineticFusilladePredictive")
+		local selectedEffectiveAPS = isPredictive and maxEffectivePredictiveAPS or maxEffectiveAPS
 
-		output.KineticFusilladeMaxEffectiveAPS = maxEffectiveAPS
+		output.KineticFusilladeMaxEffectiveAPS = selectedEffectiveAPS
+
+		-- Cap the attack rate so the sidebar Attack Rate and DPS reflect the effective rate
+		if currentAPS > selectedEffectiveAPS then
+			output.Speed = selectedEffectiveAPS
+			output.Time = 1 / selectedEffectiveAPS
+		end
 
 		if breakdown then
 			local breakdownAPS = {}
+			t_insert(breakdownAPS, s_format("^8Selected network mode (Configuration tab):^7 %s", isPredictive and "Predictive" or "Lockstep"))
 			t_insert(breakdownAPS, s_format("^8Base hover delay:^7 %.1fs", hoverDelay))
 			t_insert(breakdownAPS, s_format("^8Base delay between projectiles:^7 %.2fs", baseDelayBetweenProjectiles))
 			t_insert(breakdownAPS, s_format("^8Base time for^7 %d added ^8projectiles:^7 %.2fs x %d = %.1fs", (projectileCount - 1), baseDelayBetweenProjectiles, (projectileCount - 1), baseTimeForAllProjectiles))
@@ -2531,14 +2546,9 @@ local skills, mod, flag, skill = ...
 			breakdown.KineticFusilladeMaxEffectiveAPS = breakdownAPS
 		end
 
-		-- Adjust dpsMultiplier if attacking too fast (only for "All Projectiles" mode)
-		if activeSkill.skillPart == 1 then
-			if currentAPS and currentAPS > maxEffectiveAPS then
-				local efficiencyRatio = maxEffectiveAPS / currentAPS
-				local originalMultiplier = skillData.dpsMultiplier or output.ProjectileCount
-				skillData.dpsMultiplier = originalMultiplier * efficiencyRatio
-			end
-		end
+		-- The stock dpsMultiplier efficiency scaling is disabled: the rate reduction is
+		-- handled by capping output.Speed above (network-mode aware), so scaling
+		-- dpsMultiplier here as well would double-count the penalty.
 	end,
 	statMap = {
 		["kinetic_fusillade_damage_+%_final_per_projectile_fired"] = {

--- a/src/Modules/ConfigOptions.lua
+++ b/src/Modules/ConfigOptions.lua
@@ -501,6 +501,12 @@ return {
 	{ var = "OverloadedIntensity", type = "count", label = "# of Overloaded Intensity:", ifSkill = "Overloaded Intensity", apply = function(val, modList, enemyModList)
 		modList:NewMod("Multiplier:OverloadedIntensity", "BASE", m_min(val, 3), "Config")
 	end },
+	{ label = "Kinetic Fusillade:", ifSkill = { "Kinetic Fusillade", "Kinetic Fusillade of Detonation" } },
+	{ var = "kineticFusilladeNetworkMode", type = "list", label = "Network mode:", ifSkill = { "Kinetic Fusillade", "Kinetic Fusillade of Detonation" }, tooltip = "Selects the network mode used to calculate the maximum effective attack rate:\n\tLockstep: projectile fire delay is rounded up to server ticks\n\tPredictive: no server tick rounding\nThe summary Attack Rate and DPS are capped at the effective rate.", list = {{val="LOCKSTEP",label="Lockstep"},{val="PREDICTIVE",label="Predictive"}}, apply = function(val, modList, enemyModList)
+		if val == "PREDICTIVE" then
+			modList:NewMod("Condition:KineticFusilladePredictive", "FLAG", true, "Config")
+		end
+	end },
 	{ label = "Link Skills:", ifSkill = { "Destructive Link", "Flame Link", "Intuitive Link", "Protective Link", "Soul Link", "Vampiric Link" } },
 	{ var = "multiplierLinkedTargets", type = "count", label = "# of linked Targets:", ifSkill = { "Destructive Link", "Flame Link", "Intuitive Link", "Protective Link", "Soul Link", "Vampiric Link" }, apply = function(val, modList, enemyModList)
 		modList:NewMod("Multiplier:LinkedTargets", "BASE", val, "Config")


### PR DESCRIPTION
### Description of the problem being solved:

Kinetic Fusillade's max effective attack rate depends on the network mode: in-game testing showed that Lockstep rounds the projectile fire delay up to server ticks while Predictive does not (see #9362 and #9452, where this difference was discovered and is already noted in a code comment and shown in the Calcs breakdown). However:

- Only the Lockstep value is actually used for DPS (via `dpsMultiplier` scaling), so players on Predictive see a pessimistic DPS and wrong breakpoints.
- The sidebar Attack Rate always shows the raw attack speed, even when a large part of it is wasted, which is misleading when comparing gear or tree changes.
- The cap is not applied to the "1 Projectile" skill part at all.

This PR adds a **"Network mode" (Lockstep / Predictive) option to the Configuration tab**, shown only when Kinetic Fusillade or Kinetic Fusillade of Detonation is socketed, defaulting to Lockstep (current behaviour).

Implementation notes:
- The cap is now applied by clamping `output.Speed` to the selected mode's max effective rate. For the "All Projectiles" part this is mathematically equivalent to the previous `dpsMultiplier` scaling (`avg × APS × count × cap/APS ≡ avg × min(APS, cap) × count`), but it additionally makes the sidebar Attack Rate, ailment calcs and the "1 Projectile" part consistent with the effective rate.
- The previous `dpsMultiplier` efficiency scaling is removed, since keeping both would double-count the penalty.
- The Calcs breakdown still shows both Lockstep and Predictive numbers, and now also displays which mode is selected.
- `src/Data/Skills/act_int.lua` and `src/Export/Skills/act_int.txt` are kept in sync.

### Steps taken to verify a working solution:
- Verified that Total DPS in Lockstep mode is bit-identical before/after this change on a 12-projectile ballista build (confirms the equivalence of the two capping approaches).
- Verified that switching to Predictive removes the server-tick rounding on the same build (effective APS cap 7.58 → 8.34, above the build's 8.29 raw APS, Total DPS +9.4%).
- Verified that attack speed changes (e.g. toggling Haste) now propagate to DPS proportionally while below the cap, and are correctly treated as wasted above it.
- Verified the Configuration option only appears when a Kinetic Fusillade gem is socketed.

### Link to a build that showcases this PR:
https://pobb.in/4mxi3Ncmborf

### Before screenshot:
Sidebar shows the raw attack rate (8.29) even though most of it is wasted:

<img src="https://raw.githubusercontent.com/hackoh/PathOfBuilding/kf-netmode-assets/before_leftpanel.png" width="350" />

Breakdown shows both modes but there is no way to choose which one applies:

<img src="https://raw.githubusercontent.com/hackoh/PathOfBuilding/kf-netmode-assets/before_breakdown.png" width="600" />

### After screenshot:
Lockstep (default) — Total DPS is identical to before; the sidebar Attack Rate now shows the effective rate:

<img src="https://raw.githubusercontent.com/hackoh/PathOfBuilding/kf-netmode-assets/after_lockstep.png" width="900" />

Predictive — server-tick rounding removed (+9.4% DPS on this build):

<img src="https://raw.githubusercontent.com/hackoh/PathOfBuilding/kf-netmode-assets/after_predictive.png" width="900" />

Breakdown now shows the selected mode:

<img src="https://raw.githubusercontent.com/hackoh/PathOfBuilding/kf-netmode-assets/after_breakdown.png" width="600" />
