### PR TITLE
More generous OAuth timeout

### DIFF
--- a/src/LaunchServer.lua
+++ b/src/LaunchServer.lua
@@ -192,7 +192,7 @@ end
 -- attempt to establish a connection at the same time. In the future, this could be refactored to perform non-blocking
 -- IO, so that it can operate concurrently, but hopefully that isn't necessary.
 local attempt = 1
-local stopAt = os.time() + 30
+local stopAt = os.time() + 60
 local errMsg
 local shouldRetry, code, state = true, nil, nil
 while (os.time() < stopAt) and shouldRetry do


### PR DESCRIPTION
### Description of the problem being solved:

PoB OAuth is too impatient. By the time you are through, the return server is no longer listening.

One convoluted example how you might miss the deadline:
- Auth button opens in the default browser, but you use another one for logging into PoE
- You have slow internet, so nothing loads fast
- You are stopped by a Cloudflare check, who takes a while before allowing you to continue
- You stop to read the scary OAuth warning
- You finally return to localhost but PoB is no longer there

I have read the code comment block above this code section, explaining why it currently is `30s`.
But how much more likely are those issues, compared to people like me, not being fast enough?
The OAuth rework is great; but with the current timeout, it might bring a flood of issues about this same thing.

### Steps taken to verify a working solution:
- I was one of the victims; bumped mine to `90`, just to be safe