### PR TITLE
Fix item modifier classification on character import

### DIFF
--- a/spec/System/TestImport_spec.lua
+++ b/spec/System/TestImport_spec.lua
@@ -70,6 +70,38 @@ describe("TestImport", function()
 		isEquipped(4, "Fulgent Bliss, Small Cluster Jewel")
 	end)
 
+	it("imports modifier flags from the 3.29 item API", function()
+		build.importTab:ImportItem({
+			id = "test-item-mod-flags",
+			frameType = 2,
+			name = "Test Grip",
+			typeLine = "Rawhide Gloves",
+			inventoryId = "Gloves",
+			ilvl = 10,
+			properties = { },
+			implicitMods = {
+				{ description = "+20 to maximum Life" },
+			},
+			explicitMods = {
+				{ description = "+10 to maximum Life", flags = { crafted = true } },
+				{ description = "+11 to maximum Mana", flags = { fractured = true } },
+				{ description = "+12 to Strength", flags = { mutated = true } },
+			},
+		})
+
+		local itemId = build.itemsTab.slots.Gloves.selItemId
+		local item = build.itemsTab.items[itemId]
+		local explicitMods = { }
+		for _, modLine in ipairs(item.explicitModLines) do
+			explicitMods[modLine.line] = modLine
+		end
+
+		assert.are.equal("+20 to maximum Life", item.implicitModLines[1].line)
+		assert.is_true(explicitMods["+10 to maximum Life"].crafted)
+		assert.is_true(explicitMods["+11 to maximum Mana"].fractured)
+		assert.is_true(explicitMods["+12 to Strength"].mutated)
+	end)
+
 	function importAndReimportWithOldJewel(shouldDelete)
 		local oldJewel = new("Item", [[Rarity: RARE
 TEST JEWEL

--- a/src/Classes/ImportTab.lua
+++ b/src/Classes/ImportTab.lua
@@ -1652,12 +1652,13 @@ function ImportTabClass:ImportItem(itemData, slotName, ignoreWeaponSwap)
 	if itemData.explicitMods then
 		for _, itemMod in ipairs(itemData.explicitMods) do
 			local modLine = itemMod.description or itemMod
+			local flags = itemMod.flags or itemMod
 			for line in modLine:gmatch("[^\n]+") do
 				local modList, extra = modLib.parseMod(line)
 				t_insert(item.explicitModLines, { line = line, extra = extra, mods = modList or { },
-					fractured = itemMod.fractured,
-					crafted = itemMod.crafted,
-					mutated = itemMod.mutated })
+					fractured = flags.fractured,
+					crafted = flags.crafted,
+					mutated = flags.mutated })
 			end
 		end
 	end


### PR DESCRIPTION
### Description of the problem being solved:

Path of Exile 3.29 moved the `crafted`, `fractured`, and `mutated` classification fields under `ItemMod.flags`. The 3.29 import update reads those fields directly from `ItemMod`, so imported modifiers retain their text but lose their classification.

Read the nested `flags` object while retaining the existing fallback for older string/top-level modifier shapes.

### Steps taken to verify a working solution:

- Added regression coverage using the 3.29 `ItemMod` response shape.
- Verified the test checks crafted, fractured, and mutated classifications after the imported item's raw rebuild/parse cycle.
- Ran `git diff --check`.
- Busted was not run locally because Docker Desktop's WSL integration and a local LuaJIT/Busted installation were unavailable.

### Link to a build that showcases this PR:

N/A — character import data handling only.

### Before screenshot:

N/A

### After screenshot:

N/A
