### PR TITLE
Add Light Radius to weighted trade stats

### DIFF
--- a/spec/System/TestTradeQueryGenerator_spec.lua
+++ b/spec/System/TestTradeQueryGenerator_spec.lua
@@ -99,6 +99,26 @@ describe("TradeQueryGenerator", function()
 
 			assert.are.equal(result, 1.2)
 		end)
+
+		it("supports light radius as a player stat weight", function()
+			local lightRadiusStat
+			local minionLightRadiusStat
+			for _, stat in ipairs(data.powerStatList) do
+				if stat.stat == "LightRadiusMod" then
+					lightRadiusStat = stat
+				elseif stat.stat == "MinionLightRadiusMod" then
+					minionLightRadiusStat = stat
+				end
+			end
+
+			assert.is_not_nil(lightRadiusStat)
+			assert.is_nil(minionLightRadiusStat)
+			local result = mock_queryGen.WeightedRatioOutputs(
+				{ LightRadiusMod = 1 },
+				{ LightRadiusMod = 1.25 },
+				{ { stat = lightRadiusStat.stat, weightMult = 1 } })
+			assert.are.equal(result, 1.25)
+		end)
 	end)
 
 	describe("Filter prioritization", function()

--- a/src/Modules/Data.lua
+++ b/src/Modules/Data.lua
@@ -166,6 +166,7 @@ data.powerStatList = {
 	{ stat="IgniteChance", label="Ignite Chance" },
 	{ stat="ShockChance", label="Shock Chance" },
 	{ stat="EffectiveMovementSpeedMod", label="Move speed" },
+	{ stat="LightRadiusMod", label="Light Radius" },
 	{ stat="BlockChance", label="Block Chance" },
 	{ stat="SpellBlockChance", label="Spell Block Chance" },
 	{ stat="SpellSuppressionChance", label="Spell Suppression Chance" },
@@ -212,6 +213,7 @@ local minionNonApplicableStats = {
 	Int = true,
 	Spirit = true,
 	EffectiveLootRarityMod = true,
+	LightRadiusMod = true,
 }
 for i = 1, #data.powerStatList do
 	local statEntry = data.powerStatList[i]


### PR DESCRIPTION
### Description of the problem being solved:
Light Radius was not available as a stat weight for weighted trade searches. It now is.

### Steps taken to verify a working solution:
- Tested that generating a trade link which includes weights for light radius worked as expected
- Tested that other weights still work as expected such as life and life regen.

### Link to a build that showcases this PR:
Any build, but I used captainlance's build: https://pobb.in/7lt4HaxhitFu

### Before screenshot:
<img width="430" height="513" alt="image" src="https://github.com/user-attachments/assets/29a142b7-b3a7-4119-b0c6-e37af363ee47" />

### After screenshot:
<img width="428" height="514" alt="image" src="https://github.com/user-attachments/assets/953f06c3-df0e-4a18-84af-170ed2c38f55" />

