### PR TITLE
Add comparisons to config tab tooltips

### DIFF
--- a/src/Classes/ConfigTab.lua
+++ b/src/Classes/ConfigTab.lua
@@ -28,14 +28,20 @@ local ConfigTabClass = newClass("ConfigTab", "UndoHandler", "ControlHost", "Cont
 	self.configSetOrderList = { 1 }
 	self:NewConfigSet(1)
 	self:SetActiveConfigSet(1, true)
-	
+
 	self.enemyLevel = 1
 
 	self.sectionList = { }
 	self.varControls = { }
-	
+
 	self.toggleConfigs = false
 
+	-- A misc calculator function which is updated by the build when it is rebuilt
+	---@type fun(): table
+	self.calcFunc = nil
+	-- A calculator base output matching the calcFunc which is updated by the build when it is rebuilt
+	---@type table
+	self.calcBase = nil
 	self.controls.sectionAnchor = new("LabelControl", { "TOPLEFT", self, "TOPLEFT" }, { 0, 20, 0, 0 }, "")
 
 	-- Set selector
@@ -582,12 +588,14 @@ local ConfigTabClass = newClass("ConfigTab", "UndoHandler", "ControlHost", "Cont
 					end
 					return innerLabel
 				end
+				local outputCache = {}
+				local outputCacheRevision = nil
 				local innerTooltipFunc = control.tooltipFunc
-				control.tooltipFunc = function (tooltip, ...)
+				control.tooltipFunc = function(tooltip, mode, index, value)
 					tooltip:Clear()
 
 					if innerTooltipFunc then
-						innerTooltipFunc(tooltip, ...)
+						innerTooltipFunc(tooltip, mode, index, value)
 					else
 						local tooltipText = control:GetProperty("tooltipText")
 						if tooltipText and tooltipText ~= '' then
@@ -596,10 +604,51 @@ local ConfigTabClass = newClass("ConfigTab", "UndoHandler", "ControlHost", "Cont
 					end
 
 					local shown = type(innerShown) == "boolean" and innerShown or innerShown()
-					local cur = self.configSets[self.activeConfigSetId].input[varData.var]
+					local inputs = self.configSets[self.activeConfigSetId].input
+					local cur = inputs[varData.var]
 					local def = self:GetDefaultState(varData.var, type(cur))
 					if not shown and cur ~= nil and cur ~= def then
 						tooltip:AddLine(14, colorCodes.NEGATIVE.."This config option is conditional with missing source and is invalid.")
+					else
+						-- avoid adding comparisons for number inputs as the
+						-- input gets applied as soon as the user types, which
+						-- means comparisons dont make sense here
+						if not self.calcFunc then
+							self.calcFunc, self.calcBase = self.build.calcsTab:GetMiscCalculator(self.build)
+						end
+						if (varData.type == "check") or (varData.type == "list") then
+							local valueMapped = (varData.type == "check") and (not cur) or
+								(type(value) == "table") and (value.val) or value
+							if (valueMapped ~= cur) then
+								local buildFlag = self.build.buildFlag
+								tooltip:AddSeparator(10)
+								-- clear cache if build has been edited
+								if outputCacheRevision ~= self.build.outputRevision then
+									outputCache = {}
+									outputCacheRevision = self.build.outputRevision
+								end
+								inputs[varData.var] = valueMapped
+								self:BuildModList()
+
+								local key = string.format("%s:%s", tostring(valueMapped), tostring(cur))
+								outputCache[key] = outputCache[key] or self.calcFunc()
+
+								inputs[varData.var] = cur
+								self:BuildModList()
+
+								-- building the mod lists flags the build for a
+								-- rebuild, but we don't actually want that as
+								-- we restore the previous state if the user
+								-- hasn't actually clicked
+								self.build.buildFlag = buildFlag
+								local prefix = (varData.type == "check") and "^7Toggling this" or "^7Selecting this"
+								self.build:AddStatComparesToTooltip(tooltip, self.calcBase, outputCache[key], prefix .. " option will give you:")
+								-- clear tooltip if it only has our separator
+								if #tooltip.lines == 1 then
+									tooltip:Clear()
+								end
+							end
+						end
 					end
 				end
 			end

--- a/src/Classes/ConfigTab.lua
+++ b/src/Classes/ConfigTab.lua
@@ -617,8 +617,12 @@ local ConfigTabClass = newClass("ConfigTab", "UndoHandler", "ControlHost", "Cont
 							self.calcFunc, self.calcBase = self.build.calcsTab:GetMiscCalculator(self.build)
 						end
 						if (varData.type == "check") or (varData.type == "list") then
-							local valueMapped = (varData.type == "check") and (not cur) or
-								(type(value) == "table") and (value.val) or value
+							local valueMapped
+							if varData.type == "check" then
+								valueMapped = not cur
+							else
+								valueMapped = type(value) == "table" and value.val or value
+							end
 							if (valueMapped ~= cur) then
 								local buildFlag = self.build.buildFlag
 								tooltip:AddSeparator(10)
@@ -627,15 +631,16 @@ local ConfigTabClass = newClass("ConfigTab", "UndoHandler", "ControlHost", "Cont
 									outputCache = {}
 									outputCacheRevision = self.build.outputRevision
 								end
-								inputs[varData.var] = valueMapped
-								self:BuildModList()
-
 								local key = string.format("%s:%s", tostring(valueMapped), tostring(cur))
-								outputCache[key] = outputCache[key] or self.calcFunc()
+								if not outputCache[key] then
+									inputs[varData.var] = valueMapped
+									self:BuildModList()
 
-								inputs[varData.var] = cur
-								self:BuildModList()
+									outputCache[key] = self.calcFunc()
 
+									inputs[varData.var] = cur
+									self:BuildModList()
+								end
 								-- building the mod lists flags the build for a
 								-- rebuild, but we don't actually want that as
 								-- we restore the previous state if the user

--- a/src/Classes/ConfigTab.lua
+++ b/src/Classes/ConfigTab.lua
@@ -612,7 +612,7 @@ local ConfigTabClass = newClass("ConfigTab", "UndoHandler", "ControlHost", "Cont
 					else
 						-- avoid adding comparisons for number inputs as the
 						-- input gets applied as soon as the user types, which
-						-- means comparisons dont make sense here
+						-- means comparisons don't make sense here
 						if not self.calcFunc then
 							self.calcFunc, self.calcBase = self.build.calcsTab:GetMiscCalculator(self.build)
 						end

--- a/src/Modules/Build.lua
+++ b/src/Modules/Build.lua
@@ -1242,6 +1242,7 @@ function buildMode:OnFrame(inputEvents)
 		self.buildFlag = false
 		self.calcsTab:BuildOutput()
 		self:RefreshStatList()
+		self.configTab.calcFunc, self.configTab.calcBase = self.calcsTab:GetMiscCalculator(self)
 	end
 	if main.showThousandsSeparators ~= self.lastShowThousandsSeparators then
 		self:RefreshStatList()


### PR DESCRIPTION
### Description of the problem being solved:

This PR adds stat comparisons to checkbox and dropdown tooltips on the config tab. These are cached per config variable, keyed with string representations of the original and new value. This seems to result in perfectly fine performance as even with a debugger attached the initial lag of generating the outputs didn't seem to be too rough.

Inspired by #10020

### Steps taken to verify a working solution:
- All configuration options currently present seem to work
- Only checkboxes and dropdowns affected

### Link to a build that showcases this PR:
https://pobb.in/yl_DWhclFAJ4
### Before screenshot:

N/A

### After screenshot:
<img width="676" height="242" alt="Path{space}of{space}Building_2026-07-28_22-35-34" src="https://github.com/user-attachments/assets/5e4fc0cd-d7cf-410f-a8b1-ba12f63b6302" />
<img width="833" height="552" alt="image" src="https://github.com/user-attachments/assets/68b8e4e3-adec-4ef8-8aec-31501a6c4a0c" />
<img width="1195" height="487" alt="image" src="https://github.com/user-attachments/assets/1bd57626-215f-4b1e-a8a0-199d2cfb3863" />
<img width="864" height="496" alt="image" src="https://github.com/user-attachments/assets/8de27eb5-ba71-4ce5-a8b4-e955708a4cc6" />
