### PR TITLE
Allow toggling individual item mods just by clicking on them

### DIFF
--- a/spec/System/TestItemParse_spec.lua
+++ b/spec/System/TestItemParse_spec.lua
@@ -341,6 +341,11 @@ describe("TestItemParse", function()
 		assert.are.same({ "life", "physical_damage" }, item.explicitModLines[1].modTags)
 	end)
 
+	it("ignores disabled modifiers in item conditions", function()
+		local item = new("Item", raw("{disabled}+100 to maximum Life"))
+		assert.is_false(item:FindModifierSubstring("life", "body armour"))
+	end)
+
 	it("variant", function()
 		local item = new("Item", raw([[
 			Selected Variant: 2
@@ -731,6 +736,18 @@ describe("TestAdvancedItemParse #item", function()
 			build.itemsTab:AddDisplayItem()
 			runCallback("OnFrame")
 			assert.are.equals(221, chaosDamageInc())
+		end)
+
+		it("does not apply disabled modifier magnitude", function()
+			local item = new("Item", [[
+			Rarity: UNIQUE
+			Magnitude Test
+			Plate Vest
+			Implicits: 1
+			{range:0.5}+(10-20) to maximum Life
+			{disabled}100% increased Implicit Modifier magnitudes
+		]])
+			assert.are.equals(1, item.implicitModLines[1].valueScalar)
 		end)
 
 		it("scales properly using old Eyes of the Greatwolf line", function()

--- a/src/Classes/Item.lua
+++ b/src/Classes/Item.lua
@@ -284,7 +284,7 @@ function ItemClass:FindModifierSubstring(substring, itemSlotName)
 		else
 			currentVariant = true
 		end
-		if currentVariant then
+		if not v.disabled and currentVariant then
 			if v.line:lower():find(substring) and not v.line:lower():find(substring .. " modifier") then
 				local excluded = false
 				if data.itemTagSpecialExclusionPattern[substring] and data.itemTagSpecialExclusionPattern[substring][itemSlotName] then
@@ -950,7 +950,7 @@ function ItemClass:ParseRaw(raw, rarity, highQuality)
 						modList, extra = modLib.parseMod(rangedLine)
 					end
 				end
-				local lineLower = line:lower()
+				local lineLower = modLine.disabled and "" or line:lower()
 				-- \d+% increased/reduced explicit/implicit/ *tags* modifier magnitudes
 				local modMagnitudePattern = { "(%d+)%% ([ir][ne][cd][ru][ec][ae][sd]e?d?) ?([%a%s]*) modifier magnitudes",
 					-- \d+% increased/reduced effect of suffixes/prefixes
@@ -1019,7 +1019,7 @@ function ItemClass:ParseRaw(raw, rarity, highQuality)
 					enchantment = "enchant",
 				}
 				for _, pattern in ipairs(modMagnitudePattern) do
-					if rangedLine:lower():find(pattern) then
+					if not modLine.disabled and rangedLine:lower():find(pattern) then
 						local rangedLine = itemLib.applyRange(line, modLine.range or main.defaultItemAffixQuality or 1, catalystScalar, modLine.corruptedRange)
 						local amount, increaseOrDecrease, modTagsString = rangedLine:lower():match(pattern)
 						local multiplier

--- a/src/Classes/Item.lua
+++ b/src/Classes/Item.lua
@@ -730,6 +730,8 @@ function ItemClass:ParseRaw(raw, rarity, highQuality)
 						modLine.range = tonumber(val)
 					elseif k == "corruptedRange" then
 						modLine.corruptedRange = tonumber(val)
+					elseif k == "disabled" then
+						modLine.disabled = true
 					elseif lineFlags[k] then
 						modLine[k] = true
 					end
@@ -1530,6 +1532,9 @@ function ItemClass:BuildRaw()
 		if modLine.corruptedRange then
 			line = "{corruptedRange:" .. round(modLine.corruptedRange, 2) .. "}" .. line
 		end
+		if modLine.disabled then
+			line = "{disabled}" .. line
+		end
 		if modLine.crafted then
 			line = "{crafted}" .. line
 		end
@@ -2148,6 +2153,9 @@ function ItemClass:BuildModList()
 		end
 	end
 	local function processModLine(modLine)
+		if modLine.disabled then
+			return
+		end
 		if self:CheckModLineVariant(modLine) then
 			-- special section for variant over-ride of pre-modifier item parameters
 			if modLine.line:find("Requires Class") then

--- a/src/Classes/Item.lua
+++ b/src/Classes/Item.lua
@@ -85,6 +85,7 @@ local lineFlags = {
 	["crafted"] = true,
 	["crucible"] = true,
 	["custom"] = true,
+	["disabled"] = true,
 	["eater"] = true,
 	["enchant"] = true,
 	["exarch"] = true,
@@ -730,8 +731,6 @@ function ItemClass:ParseRaw(raw, rarity, highQuality)
 						modLine.range = tonumber(val)
 					elseif k == "corruptedRange" then
 						modLine.corruptedRange = tonumber(val)
-					elseif k == "disabled" then
-						modLine.disabled = true
 					elseif lineFlags[k] then
 						modLine[k] = true
 					end

--- a/src/Classes/ItemsTab.lua
+++ b/src/Classes/ItemsTab.lua
@@ -1455,6 +1455,27 @@ function ItemsTabClass:Draw(viewPort, inputEvents)
 	if self.displayItem then
 		local x, y = self.controls.displayItemTooltipAnchor:GetPos()
 		self.displayItemTooltip:Draw(x, y, nil, nil, viewPort)
+
+		-- Toggle mods
+		local cursorX, cursorY = GetCursorPos()
+		for _, line in ipairs(self.displayItemTooltip.lines) do
+			if line.modLine and line.bounds then
+				local b = line.bounds
+				if cursorX >= b.x and cursorX <= b.x + b.width and cursorY >= b.y and cursorY <= b.y + b.height then
+					SetDrawColor(1, 1, 1, 0.15)
+					DrawImage(nil, b.x, b.y, b.width, b.height)
+					SetDrawColor(1, 1, 1)
+
+					for id, event in ipairs(inputEvents) do
+						if event.type == "KeyDown" and event.key:match("BUTTON") then
+							inputEvents[id] = nil
+							self:ToggleDisplayItemModLine(line.modLine)
+							break
+						end
+					end
+				end
+			end
+		end
 	end
 
 	self:UpdateSockets()
@@ -1867,6 +1888,21 @@ function ItemsTabClass:UpdateDisplayItemTooltip()
 	self.displayItemTooltip:Clear()
 	self:AddItemTooltip(self.displayItemTooltip, self.displayItem)
 	self.displayItemTooltip.center = true
+end
+
+function ItemsTabClass:ToggleDisplayItemModLine(modLine)
+	if not self.displayItem or not modLine then
+		return
+	end
+	modLine.disabled = not modLine.disabled
+	self.displayItem:BuildAndParseRaw()
+	self:UpdateDisplayItemTooltip()
+	self:UpdateDisplayItemRangeLines()
+	self:UpdateCustomControls()
+	if self.displayItem.crafted then
+		self:UpdateAffixControls()
+	end
+	self.build.buildFlag = true
 end
 
 function ItemsTabClass:UpdateSocketControls()
@@ -4324,7 +4360,10 @@ function ItemsTabClass:AddItemTooltip(tooltip, item, slot, dbMode, maxWidth)
 		if modList[1] then
 			for _, modLine in ipairs(modList) do
 				if item:CheckModLineVariant(modLine) then
-					tooltip:AddLine(fontSizeBig, itemLib.formatModLine(modLine, dbMode), "FONTIN SC")
+					local formatted = itemLib.formatModLine(modLine, dbMode)
+					if formatted then
+						tooltip:AddLine(fontSizeBig, formatted, "FONTIN SC", modLine)
+					end
 				end
 			end
 			tooltip:AddSeparator(10)

--- a/src/Classes/Tooltip.lua
+++ b/src/Classes/Tooltip.lua
@@ -84,7 +84,7 @@ function TooltipClass:CheckForUpdate(...)
 	end
 end
 
-function TooltipClass:AddLine(size, text, font)
+function TooltipClass:AddLine(size, text, font, modLine)
 	if text then
 		local fontToUse
 		if main.showFlavourText then
@@ -100,10 +100,10 @@ function TooltipClass:AddLine(size, text, font)
 			end
 			if self.maxWidth then
 				for _, wrappedLine in ipairs(main:WrapString(line, size, self.maxWidth - H_PAD)) do
-					t_insert(self.lines, { size = size, text = wrappedLine, block = #self.blocks, font = fontToUse, center = self.center })
+					t_insert(self.lines, { size = size, text = wrappedLine, block = #self.blocks, font = fontToUse, center = self.center, modLine = modLine })
 				end
 			else
-				t_insert(self.lines, { size = size, text = line, block = #self.blocks, font = fontToUse, center = self.center })
+				t_insert(self.lines, { size = size, text = line, block = #self.blocks, font = fontToUse, center = self.center, modLine = modLine })
 			end
 		end
 	end
@@ -294,7 +294,12 @@ function TooltipClass:CalculateColumns(ttY, ttX, ttH, ttW, viewPort)
 			local lineX = lineCentered and (x + ttW / 2) or (x + (H_PAD / 2))
 			local lineAlign = lineCentered and "CENTER_X" or "LEFT"
 
-			t_insert(drawStack, {lineX, y, lineAlign, data.size, font, data.text})
+			local stackEntry = {lineX, y, lineAlign, data.size, font, data.text}
+			if data.modLine and data.modLine.disabled then
+				stackEntry.strikethrough = true
+			end
+			t_insert(drawStack, stackEntry)
+			data.bounds = { x = x + (H_PAD / 2), y = y, width = ttW - H_PAD, height = data.size + 2 }
 			y = y + data.size + 2
 
 			-- track max width for extra columns
@@ -595,6 +600,19 @@ function TooltipClass:Draw(x, y, w, h, viewPort)
 			end
 		else
 			DrawString(unpack(line))
+			if line.strikethrough then
+				local textX = line[1]
+				local textY = line[2]
+				local align = line[3]
+				local size = line[4]
+				local font = line[5]
+				local text = line[6]
+				local textW = DrawStringWidth(size, font, text)
+				local strikeX = align == "CENTER_X" and (textX - textW / 2) or textX
+				local strikeY = textY + size / 2
+				SetDrawColor(0.75, 0.75, 0.75, 0.35)
+				DrawImage(nil, strikeX, strikeY, textW, 1.0)
+			end
 		end
 	end
 

--- a/src/Data/Global.lua
+++ b/src/Data/Global.lua
@@ -17,6 +17,7 @@ colorCodes = {
 	CUSTOM = "^x5CF0BB",
 	SOURCE = "^x88FFFF",
 	UNSUPPORTED = "^xF05050",
+	DISABLED = "^x7F7F7F",
 	WARNING = "^xFF9922",
 	TIP = "^x80A080",
 	FIRE = "^xB97123",

--- a/src/Modules/ItemTools.lua
+++ b/src/Modules/ItemTools.lua
@@ -355,7 +355,7 @@ function itemLib.formatModLine(modLine, dbMode)
 		return
 	end
 	if modLine.disabled then
-		return "^x7F7F7F" .. line
+		return colorCodes.DISABLED .. line
 	end
 	local colorCode
 	if modLine.extra then

--- a/src/Modules/ItemTools.lua
+++ b/src/Modules/ItemTools.lua
@@ -354,6 +354,9 @@ function itemLib.formatModLine(modLine, dbMode)
 	if line:match("^%+?0%%? ") or (line:match(" %+?0%%? ") and not line:match("0 to [1-9]")) or line:match(" 0%-0 ") or line:match(" 0 to 0 ") then -- Hack to hide 0-value modifiers
 		return
 	end
+	if modLine.disabled then
+		return "^x7F7F7F" .. line
+	end
 	local colorCode
 	if modLine.extra then
 		colorCode = colorCodes.UNSUPPORTED


### PR DESCRIPTION
Fixes # .

### Description of the problem being solved:

To toggle a mod, you have to go through the hassle of selecting the item, clicking edit, locating the mod, typing a comment at the start of the line, click save, and then go again in the same process to toggle it back.

I solved this by allowing to click on individual mods to toggle them, and by introducing a `{disabled}` line flag so we can also visualize disabled mods properly

### Steps taken to verify a working solution:
-
-
-

### Link to a build that showcases this PR:

### Before screenshot:

### After screenshot:


https://github.com/user-attachments/assets/cdccf60d-dea1-475a-be74-d32b77fe2481


