### PR TITLE
Fix Shield block chance calcs

### DIFF
--- a/src/Classes/Item.lua
+++ b/src/Classes/Item.lua
@@ -2112,7 +2112,7 @@ function ItemClass:BuildModListForSlotNum(baseList, slotNum)
 		end
 
 		if self.base.armour.BlockChance then
-			armourData.BlockChance = m_floor((self.base.armour.BlockChance * (1 + calcLocal(modList, "BlockChance", "INC", 0) / 100) + calcLocal(modList, "BlockChance", "BASE", 0)))
+			armourData.BlockChance = m_floor((self.base.armour.BlockChance + calcLocal(modList, "BlockChance", "BASE", 0)) * (1 + calcLocal(modList, "BlockChance", "INC", 0) / 100))
 		end
 		if self.base.armour.MovementPenalty then
 			modList:NewMod("MovementSpeed", "INC", -self.base.armour.MovementPenalty, self.modSource, { type = "Condition", var = "IgnoreMovementPenalties", neg = true })


### PR DESCRIPTION
Fixes #10097 partially

### Description of the problem being solved:
Block chance on shields were scaling by increased on the item first, followed by base block chance. Instead it should add the base block chance to the shields armour block chance, and then scale by increased local mods.

Aegis Aurora should be
26 base +6 local base mod = 32
32 x 1.2 = 38.4

26 x 1.2 = 31.2
31.2 + 6 = 37.1


### After screenshot:
<img width="498" height="368" alt="image" src="https://github.com/user-attachments/assets/ea7ee6d0-64b9-4a18-a576-703f9ce47601" />
