### PR TITLE
Fix Consecrated Ground not reducing curse effect

### DIFF
--- a/spec/System/TestDefence_spec.lua
+++ b/spec/System/TestDefence_spec.lua
@@ -17,6 +17,25 @@ describe("TestDefence", function()
 		return build.calcsTab.calcs.reducePoolsByDamage(nil, takenDamages, build.calcsTab.calcsEnv.player)
 	end
 
+	it("applies Consecrated Ground curse reduction to the player and minion", function()
+		build.skillsTab:PasteSocketGroup("Raise Zombie 20/0  1")
+		build.configTab.input.conditionOnConsecratedGround = true
+		build.configTab.input.playerCursedWithElementalWeakness = 20
+		build.configTab:BuildModList()
+		runCallback("OnFrame")
+
+		assert.are.equals(50, build.calcsTab.mainOutput.CurseEffectOnSelf)
+		assert.are.equals(50, build.calcsTab.mainEnv.minion.output.CurseEffectOnSelf)
+		local fireResistOnConsecratedGround = build.calcsTab.mainOutput.FireResist
+
+		newBuild()
+		build.configTab.input.playerCursedWithElementalWeakness = 20
+		build.configTab:BuildModList()
+		runCallback("OnFrame")
+
+		assert.is_true(fireResistOnConsecratedGround > build.calcsTab.mainOutput.FireResist)
+	end)
+
 	-- boring part
 	it("no armour max hits", function()
 		build.configTab.input.enemyIsBoss = "None"

--- a/src/Modules/CalcPerform.lua
+++ b/src/Modules/CalcPerform.lua
@@ -770,7 +770,6 @@ local function doActorMisc(env, actor)
 		if modDB:Flag(nil, "Condition:OnConsecratedGround") then
 			local effect = 1 + modDB:Sum("INC", nil, "ConsecratedGroundEffect") / 100
 			modDB:NewMod("LifeRegenPercent", "BASE", 5 * effect, "Consecrated Ground")
-			--modDB:NewMod("CurseEffectOnSelf", "INC", -50 * effect, "Consecrated Ground") -- Moved to L3087
 			modDB:NewMod("Accuracy", "INC", m_floor(modDB:Sum("INC", nil, "ConsecratedGroundAlsoAccuracy") * effect), "Consecrated Ground")
 		end
 		if modDB:Flag(nil, "Condition:PhantasmalMight") then
@@ -3084,15 +3083,12 @@ function calcs.perform(env, skipEHP)
 		end
 	end
 
-	-- Consecrated Ground grants 50% reduced Effect of Curses on you
-	-- Moved curse reduction here so it properly affects curse effect on player
-	if env.mode_combat and modDB:Flag(nil, "Condition:OnConsecratedGround") then
-		local effect = 1 + modDB:Sum("INC", nil, "ConsecratedGroundEffect") / 100
-		modDB:NewMod("CurseEffectOnSelf", "INC", -50 * effect, "Consecrated Ground")
-	end
-
 	-- Check for extra curses
 	for dest, modDB in pairs({[curses] = modDB, [minionCurses] = env.minion and env.minion.modDB}) do
+		if env.mode_combat and modDB:Flag(nil, "Condition:OnConsecratedGround") then
+			local effect = 1 + modDB:Sum("INC", nil, "ConsecratedGroundEffect") / 100
+			modDB:NewMod("CurseEffectOnSelf", "INC", -50 * effect, "Consecrated Ground")
+		end
 		for _, value in ipairs(modDB:List(nil, "ExtraCurse")) do
 			local gemModList = new("ModList")
 			local grantedEffect = env.data.skills[value.skillId]

--- a/src/Modules/CalcPerform.lua
+++ b/src/Modules/CalcPerform.lua
@@ -770,7 +770,7 @@ local function doActorMisc(env, actor)
 		if modDB:Flag(nil, "Condition:OnConsecratedGround") then
 			local effect = 1 + modDB:Sum("INC", nil, "ConsecratedGroundEffect") / 100
 			modDB:NewMod("LifeRegenPercent", "BASE", 5 * effect, "Consecrated Ground")
-			modDB:NewMod("CurseEffectOnSelf", "INC", -50 * effect, "Consecrated Ground")
+			--modDB:NewMod("CurseEffectOnSelf", "INC", -50 * effect, "Consecrated Ground") -- Moved to L3087
 			modDB:NewMod("Accuracy", "INC", m_floor(modDB:Sum("INC", nil, "ConsecratedGroundAlsoAccuracy") * effect), "Consecrated Ground")
 		end
 		if modDB:Flag(nil, "Condition:PhantasmalMight") then
@@ -3082,6 +3082,13 @@ function calcs.perform(env, skipEHP)
 			modDB:NewMod("EnemyBrittleEffect", "MORE", effectPerAffliction, "Affliction Charges", { type = "Multiplier", var = "AfflictionCharge" } )
 			modDB:NewMod("EnemySapEffect", "MORE", effectPerAffliction, "Affliction Charges", { type = "Multiplier", var = "AfflictionCharge" } )
 		end
+	end
+
+	-- Consecrated Ground grants 50% reduced Effect of Curses on you
+	-- Moved curse reduction here so it properly affects curse effect on player
+	if env.mode_combat and modDB:Flag(nil, "Condition:OnConsecratedGround") then
+		local effect = 1 + modDB:Sum("INC", nil, "ConsecratedGroundEffect") / 100
+		modDB:NewMod("CurseEffectOnSelf", "INC", -50 * effect, "Consecrated Ground")
 	end
 
 	-- Check for extra curses


### PR DESCRIPTION
Fixes #10150 .

### Description of the problem being solved:
Conc ground was not properly applying the `reduced effect of curses on player` mod.

### Steps taken to verify a working solution:
- Added multiple curses through config options

### Link to a build that showcases this PR:

### Before screenshot:
<img width="1012" height="260" alt="632377956-3d6364c2-bc8f-4fc9-bd27-eb344ab919f3" src="https://github.com/user-attachments/assets/507c9175-2469-457b-93ce-1340b4301180" />

### After screenshot:
<img width="405" height="57" alt="image" src="https://github.com/user-attachments/assets/3651ce2a-913b-4e6f-ac50-ec133bc3781c" />

<img width="272" height="82" alt="image" src="https://github.com/user-attachments/assets/9968a7dd-ded8-47a0-b939-721a843c9818" />
