### PR TITLE
Fix Iron Grip double-dipping spell damage conversion for proj attacks

### DIFF
--- a/src/Modules/CalcOffence.lua
+++ b/src/Modules/CalcOffence.lua
@@ -625,6 +625,7 @@ function calcs.offence(env, actor, activeSkill)
 				skillModList:NewMod("Damage", "INC", mod.value * multiplier, mod.source, bor(band(mod.flags, bnot(ModFlag.Spell)), ModFlag.Attack), mod.keywordFlags, unpack(modifiers))
 				if mod.source == "Strength" then -- Prevent double-dipping from converted strength's damage bonus
 					skillModList:ReplaceMod("PhysicalDamage", "INC", 0, "Strength", ModFlag.Melee)
+					skillModList:ReplaceMod("PhysicalDamage", "INC", 0, "Strength", bor(ModFlag.Attack, ModFlag.Projectile))
 				end
 			end
 		end


### PR DESCRIPTION
Fixes #3915 .

### Description of the problem being solved:
Iron Grip didn't have a guard for projectile attacks as opposed to melee, which meant it was benefitting from double dipping.

### Steps taken to verify a working solution:
- Checked damage calc with kinetic blast

### Link to a build that showcases this PR:

### Before screenshot:

### After screenshot:
