### PR TITLE
Handle multi-byte characters correctly in text fields

### DIFF
--- a/src/Classes/EditControl.lua
+++ b/src/Classes/EditControl.lua
@@ -530,7 +530,6 @@ function EditClass:OnKeyDown(key, doubleClick)
 			if self.pasteFilter then
 				text = self.pasteFilter(text)
 			end
-			text = text:gsub("[\128-\255]","?")
 			if self.sel and self.sel ~= self.caret then
 				self:ReplaceSel(text)
 			else
@@ -607,8 +606,10 @@ function EditClass:OnKeyDown(key, doubleClick)
 		if self.sel and self.sel ~= self.caret then
 			self:ReplaceSel("")
 		elseif self.caret > 1 then
-			local len = 1
+			-- Remove one whole character, which may be several bytes wide.
+			local len = self.caret - (utf8.next(self.buf, self.caret, -1) or 1)
 			if IsKeyDown("CTRL") then
+				len = 1
 				while self.caret - len > 1 and self.buf:sub(self.caret - len, self.caret - len):match("%s") and not self.buf:sub(self.caret - len - 1, self.caret - len - 1):match("\n") do
 					len = len + 1
 				end
@@ -632,8 +633,10 @@ function EditClass:OnKeyDown(key, doubleClick)
 		if self.sel and self.sel ~= self.caret then
 			self:ReplaceSel("")
 		elseif self.caret <= #self.buf then
-			local len = 1
+			-- Remove one whole character, which may be several bytes wide.
+			local len = (utf8.next(self.buf, self.caret, 1) or (#self.buf + 1)) - self.caret
 			if IsKeyDown("CTRL") then
+				len = 1
 				while self.caret + len <= #self.buf and self.buf:sub(self.caret + len - 1, self.caret + len - 1):match("%s") and not self.buf:sub(self.caret + len, self.caret + len):match("\n") do
 					len = len + 1
 				end


### PR DESCRIPTION
## Description of the problem being solved

Two independent defects in `EditControl` make non-ASCII text unusable, regardless of platform or language.

**Pasting discards the text entirely.** Every byte `>= 0x80` is replaced with `"?"` before insertion:

```lua
text = text:gsub("[\128-\255]","?")
```

In a field carrying a filename filter (`\\/:%*%?\"<>|%c`), those `"?"` are then stripped again by `Insert()` as illegal characters. The result is not mangled text but *no* text — pasting a build name, folder name or item appears to do nothing at all.

**Backspace and delete corrupt the text.** Both remove a fixed single byte:

```lua
local len = 1
```

A multi-byte character is therefore cut in half, leaving an invalid sequence that renders as `?`. Caret movement already steps by whole characters via `utf8.next`, so the two behaviours disagree: the caret moves over a character but deleting only removes a third of it.

Related: #5632 (open since 2023, "POB currently cannot input languages other than english"), and #6669, which relaxed the default input filter under PoeCharm but did not address paste or deletion.

## Description of the changes

- Remove the byte substitution on paste. `Insert()` still applies each control's own filter, so filename-illegal characters are still rejected — only the blanket replacement of non-ASCII is gone.
- Derive the deletion length from `utf8.next`, the same helper caret movement already uses, so a keystroke removes exactly the character the caret moved over. The ctrl-modified word-wise paths are unchanged.

Both changes are platform-independent and affect any language that uses characters outside ASCII.

## Steps taken to verify a working solution

Tested on macOS with Traditional Chinese text in the "Save As" build name field:

- Pasting `測試中文` previously left the field empty; it now inserts the text, and saving produces a file named correctly on disk.
- Backspace previously needed three presses per character and left `?` behind after the first; it now removes one whole character per press (`卡在這` → `卡在` → `卡`).
- ASCII input, the ctrl-modified word deletion, and filename filtering are unaffected.

The fields still need engine-side font support to *display* these characters; that is separate and not part of this change.