### PR TITLE
Change draw layer of calc popouts

### DIFF
--- a/src/Classes/CalcSectionControl.lua
+++ b/src/Classes/CalcSectionControl.lua
@@ -384,7 +384,7 @@ function CalcSectionClass:DrawOverlay(viewPort, inputEvents)
 	local totalHeight = self:GetOverlayHeight()
 
 	-- Ensure it's above most other controls
-	SetDrawLayer(12)
+	SetDrawLayer(10)
 
 	-- Draw background
 	SetDrawColor(0.08, 0.08, 0.08, 0.95)


### PR DESCRIPTION
### Description of the problem being solved:
The calc popouts were overlapping the common popup windows, like craft item, create custom, spectre library, and the exit program popup. The calc popouts still seem to work everywhere else.

### Before screenshot:

### After screenshot:
<img width="758" height="565" alt="image" src="https://github.com/user-attachments/assets/895f6a54-a846-4cbc-b34e-541d90b5e628" />
<img width="793" height="551" alt="image" src="https://github.com/user-attachments/assets/95c93ed4-d8ee-4309-aa84-fef91779283c" />
