### PR TITLE
Show augmented Armour/Evasion/Ward/Energy Shield in blue on item tooltip

### DIFF
--- a/src/Classes/Item.lua
+++ b/src/Classes/Item.lua
@@ -2341,9 +2341,13 @@ function ItemClass:BuildModListForSlotNum(baseList, slotNum)
 			armourData.WardBasePercentile = round(m_max(m_min(armourData.WardBasePercentile, 1), 0),4)
 		end
 
+		armourData.ArmourBase = round((self.base.armour.ArmourBaseMin or 0) + armourVariance * (armourData.ArmourBasePercentile or 1))
 		armourData.Armour = round((armourBase + armourEvasionBase + armourEnergyShieldBase + armourVariance * (armourData.ArmourBasePercentile or 1)) * (1 + (armourInc + armourEvasionInc + armourEnergyShieldInc + defencesInc) / 100) * (1 + (qualityScalar / 100)))
+		armourData.EvasionBase = round((self.base.armour.EvasionBaseMin or 0) + evasionVariance * (armourData.EvasionBasePercentile or 1))
 		armourData.Evasion = round((evasionBase + armourEvasionBase + evasionEnergyShieldBase + evasionVariance * (armourData.EvasionBasePercentile or 1)) * (1 + (evasionInc + armourEvasionInc + evasionEnergyShieldInc + defencesInc) / 100) * (1 + (qualityScalar / 100)))
+		armourData.EnergyShieldBase = round((self.base.armour.EnergyShieldBaseMin or 0) + energyShieldVariance * (armourData.EnergyShieldBasePercentile or 1))
 		armourData.EnergyShield = round((energyShieldBase + evasionEnergyShieldBase + armourEnergyShieldBase + energyShieldVariance * (armourData.EnergyShieldBasePercentile or 1)) * (1 + (energyShieldInc + armourEnergyShieldInc + evasionEnergyShieldInc + defencesInc) / 100) * (1 + (qualityScalar / 100)))
+		armourData.WardBase = round((self.base.armour.WardBaseMin or 0) + wardVariance * (armourData.WardBasePercentile or 1))
 		armourData.Ward = round((wardBase + wardVariance * (armourData.WardBasePercentile or 1)) * (1 + (wardInc + defencesInc) / 100) * (1 + (qualityScalar / 100)))
 
 		if not armourData.ArmourBasePercentile and armourData.Armour > 0 then

--- a/src/Classes/ItemsTab.lua
+++ b/src/Classes/ItemsTab.lua
@@ -4494,16 +4494,16 @@ function ItemsTabClass:AddItemTooltip(tooltip, item, slot, dbMode, maxWidth)
 			tooltip:AddLine(fontSizeBig, s_format("^x7F7F7FChance to Block: %s%d%%", main:StatColor(armourData.BlockChance, base.armour.BlockChance), armourData.BlockChance), "FONTIN SC")
 		end
 		if armourData.Armour > 0 then
-			tooltip:AddLine(fontSizeBig, s_format("^x7F7F7FArmour: %s%d", main:StatColor(armourData.Armour, base.armour.ArmourBase), armourData.Armour), "FONTIN SC")
+			tooltip:AddLine(fontSizeBig, s_format("^x7F7F7FArmour: %s%d", main:StatColor(armourData.Armour, armourData.ArmourBase), armourData.Armour), "FONTIN SC")
 		end
 		if armourData.Evasion > 0 then
-			tooltip:AddLine(fontSizeBig, s_format("^x7F7F7FEvasion Rating: %s%d", main:StatColor(armourData.Evasion, base.armour.EvasionBase), armourData.Evasion), "FONTIN SC")
+			tooltip:AddLine(fontSizeBig, s_format("^x7F7F7FEvasion Rating: %s%d", main:StatColor(armourData.Evasion, armourData.EvasionBase), armourData.Evasion), "FONTIN SC")
 		end
 		if armourData.EnergyShield > 0 then
-			tooltip:AddLine(fontSizeBig, s_format("^x7F7F7FEnergy Shield: %s%d", main:StatColor(armourData.EnergyShield, base.armour.EnergyShieldBase), armourData.EnergyShield), "FONTIN SC")
+			tooltip:AddLine(fontSizeBig, s_format("^x7F7F7FEnergy Shield: %s%d", main:StatColor(armourData.EnergyShield, armourData.EnergyShieldBase), armourData.EnergyShield), "FONTIN SC")
 		end
 		if armourData.Ward > 0 then
-			tooltip:AddLine(fontSizeBig, s_format("^x7F7F7FWard: %s%d", main:StatColor(armourData.Ward, base.armour.WardBase), armourData.Ward), "FONTIN SC")
+			tooltip:AddLine(fontSizeBig, s_format("^x7F7F7FWard: %s%d", main:StatColor(armourData.Ward, armourData.WardBase), armourData.Ward), "FONTIN SC")
 		end
 	elseif base.flask then
 		-- Flask-specific info


### PR DESCRIPTION
### Description of the problem being solved:
I believe this wasn't working for quite a while. Item bases no longer have an `Armour` or `EnergyShield` value. Instead they have Min and Max values for the percentile rolls. The defensive values should print in blue when they are "augmented", which would be from quality, or local item mods. But will print in white if not scaled in any way other than percentile.

### After screenshot:
<img width="511" height="688" alt="image" src="https://github.com/user-attachments/assets/4e5cc382-ca52-4d8b-a9d0-3ef655f5f174" />
<img width="534" height="461" alt="image" src="https://github.com/user-attachments/assets/934a0065-74b5-426f-889b-fa433f8498a4" />
<img width="531" height="522" alt="image" src="https://github.com/user-attachments/assets/0b6995aa-51e5-4197-a1c5-c1957adfcb32" />
<img width="528" height="413" alt="image" src="https://github.com/user-attachments/assets/626a436d-da18-4fc8-898d-35b05c1dc6a8" />
