### PR TITLE
Fix mirrored items missing "Mirrored" text when using API character import

### DIFF
--- a/spec/System/TestImport_spec.lua
+++ b/spec/System/TestImport_spec.lua
@@ -115,6 +115,7 @@ describe("TestImport", function()
 			typeLine = "Rawhide Gloves",
 			inventoryId = "Gloves",
 			ilvl = 10,
+			duplicated = true,
 			vestigial = true,
 			properties = { },
 			implicitMods = {
@@ -139,6 +140,7 @@ describe("TestImport", function()
 		assert.is_true(explicitMods["+10 to maximum Life"].crafted)
 		assert.is_true(explicitMods["+11 to maximum Mana"].fractured)
 		assert.is_true(explicitMods["+12 to Strength"].mutated)
+		assert.is_true(item.mirrored)
 		assert.is_true(item.vestigial)
 		assert.is_true(explicitMods["+13 to Dexterity"].vestigial)
 		assert.is_truthy(item:BuildRaw():find("{vestigial}", 1, true))

--- a/src/Classes/ImportTab.lua
+++ b/src/Classes/ImportTab.lua
@@ -1637,7 +1637,7 @@ function ImportTabClass:ImportItem(itemData, slotName, ignoreWeaponSwap, itemSet
 		end
 	end
 	item.split = itemData.split
-	item.mirrored = itemData.mirrored
+	item.mirrored = itemData.duplicated or itemData.mirrored
 	item.corrupted = itemData.corrupted
 	item.fractured = itemData.fractured
 	item.synthesised = itemData.synthesised


### PR DESCRIPTION
Fixes # N/A

### Description of the problem being solved:

Mirrored items were not displaying the "Mirrored" tag when imported via the character import workflow. This is because GGG's item API uses the `duplicated` field on mirrored items, but the character import workflow was only checking `itemData.mirrored`.

This maps `itemData.duplicated` to PoB's existing `mirrored` state while retaining `itemData.mirrored` as a compatibility fallback.

The existing 3.29 item API import test now supplies `duplicated = true` and verifies that the resulting item is mirrored.

### Steps taken to verify a working solution:
- Import a character with a mirrored item. 
- In this case I was looking at `Halnao#2882` , character `HaL_Allflame` . They have a rare ring named `Death Nail` that has the mirrored tag. Viewable on PoE.Ninja here https://poe.ninja/poe1/builds/allflame/character/Halnao-2882/HaL_Allflame

### Link to a build that showcases this PR:

See above

### Before screenshot:

<img width="530" height="324" alt="image" src="https://github.com/user-attachments/assets/5c099c84-704f-4424-a771-6a20e8a01c19" />

### After screenshot:

<img width="538" height="372" alt="image" src="https://github.com/user-attachments/assets/c06e225b-4645-4450-8d19-52a53fb059b2" />
