### PR TITLE
Fix Crash when hovering over the PvP toggle while having Shaper Beam

### DIFF
--- a/src/Modules/CalcDefence.lua
+++ b/src/Modules/CalcDefence.lua
@@ -3075,7 +3075,7 @@ function calcs.buildDefenceEstimations(env, actor)
 	
 	-- pvp
 	if env.configInput.PvpScaling then
-		local PvpTvalue = output.enemySkillTime
+		local PvpTvalue = output.enemySkillTime or 1
 		local PvpMultiplier = (env.configInput.enemyMultiplierPvpDamage or 100) / 100
 		
 		local PvpNonElemental1 = data.misc.PvpNonElemental1


### PR DESCRIPTION
### Description of the problem being solved:
Fixes the crash when you hover over the PvP toggle while having the Shaper Beam skill selected
The skill uses the `DamageOverTime` config so `output.enemySkillTime` is never set so when the PvP calcs expect to find it they instead get a nil crash

### Before screenshot:
<img width="888" height="396" alt="image" src="https://github.com/user-attachments/assets/9adc27b2-5e83-42b7-8458-70151ff76d64" />

### After screenshot:
<img width="350" height="41" alt="image" src="https://github.com/user-attachments/assets/0636dfbd-9a39-4986-8af4-a6b512ff71e8" />
