### PR TITLE
Fix Mana cost efficiency rounding

### DIFF
--- a/spec/System/TestSkills_spec.lua
+++ b/spec/System/TestSkills_spec.lua
@@ -331,8 +331,8 @@ describe("TestSkills", function()
 		runCallback("OnFrame")
 
 		local genericEfficiencyCost = build.calcsTab.mainOutput.ManaCost
-		-- Test actual behavior: 12/1.25 = 9.6 (not rounded)
-		assert.True(math.abs(genericEfficiencyCost - 9.6) < 0.001)
+		-- The game rounds 12 / 1.25 = 9.6 after applying efficiency.
+		assert.are.equals(10, genericEfficiencyCost)
 
 		-- Test multiple efficiency sources stacking additively
 		build.configTab.input.customMods = "25% increased Cost Efficiency\n25% increased Mana Cost Efficiency"

--- a/src/Modules/CalcOffence.lua
+++ b/src/Modules/CalcOffence.lua
@@ -1783,6 +1783,10 @@ function calcs.offence(env, actor, activeSkill)
 				end
 				-- Apply cost efficiency (similar to reservation efficiency)
 				output[costName] = m_max(0, output[costName] / costEfficiency)
+				if val.upfront and not val.percent then
+					-- The game stores upfront resource costs as whole numbers after efficiency.
+					output[costName] = round(output[costName])
+				end
 				output[costName] = m_max(0, output[costName] + val.totalCost)
 				if val.type == "Mana" and hybridLifeCost > 0 then -- Life/Mana Mastery
 					output[costName] = m_max(0, m_floor((1 - hybridLifeCost) * output[costName]))
@@ -1796,6 +1800,10 @@ function calcs.offence(env, actor, activeSkill)
 				output[costName] = m_max(0, moreType * output[costName])
 				-- Apply cost efficiency for unaffected costs too
 				output[costName] = m_max(0, output[costName] / costEfficiency)
+				if val.upfront and not val.percent then
+					-- The game stores upfront resource costs as whole numbers after efficiency.
+					output[costName] = round(output[costName])
+				end
 				output[costName] = m_max(0, output[costName] + val.totalCost)
 				output[costNameRaw] = val.baseCostRaw and m_max(0, m_max(0, (1 + inc / 100) * (val.baseCostRaw + val.baseCostNoMult) * moreType / costEfficiency) + val.totalCost)
 			end


### PR DESCRIPTION
### Description of the problem being solved:
PoE rounds flat upfront resource costs to whole values after cost efficiency is applied.
PoB was not rounding so it retained a fractional result causing costs such as 12 mana with 25% efficiency to appear as 9.6 instead of 10.

### Link to a build that showcases this PR:
 https://pobb.in/GlAR21JdjdSZ

### Before screenshot:
<img width="312" height="127" alt="image" src="https://github.com/user-attachments/assets/0d3b8cb8-aacb-44f2-b686-a3f66ed08096" />

### After screenshot:
<img width="309" height="123" alt="image" src="https://github.com/user-attachments/assets/53b2d294-651e-4936-ad1e-cd8bd7998881" />
