### PR TITLE
Fix precision of Critical Strike Chance value

### DIFF
--- a/spec/System/TestBifurcatedCrit_spec.lua
+++ b/spec/System/TestBifurcatedCrit_spec.lua
@@ -1,5 +1,5 @@
 describe("Bifurcated critical strikes", function()
-	local function setupBifurcate(socketGroup, bifurcate, lucky, extremeLuck, useDefaultCritMultiplier)
+	local function setupBifurcate(socketGroup, bifurcate, lucky, extremeLuck, useDefaultCritMultiplier, extraMods)
 		newBuild()
 		build.itemsTab:CreateDisplayItemFromRaw([[
 				New Item
@@ -15,6 +15,7 @@ describe("Bifurcated critical strikes", function()
 		runCallback("OnFrame")
 
 		build.configTab.input.customMods = "+44% to critical hit chance\n"
+			.. (extraMods or "")
 			.. (bifurcate and "spell critical strike chance bifurcates\n" or "")
 			.. (lucky and "your critical strike chance is lucky\n" or "")
 			.. (extremeLuck and "your lucky or unlucky effects use the best or worst from three rolls instead of two\n" or "")
@@ -24,6 +25,13 @@ describe("Bifurcated critical strikes", function()
 
 		return build.calcsTab.mainOutput
 	end
+
+	it("uses quantised raw chance for each roll", function()
+		local luckyOutput = setupBifurcate("Spark 1/0  1", false, true, false, false,
+			"+0.01% to critical hit chance\n1% increased critical strike chance\n")
+		assert.are.equals(50.51, luckyOutput.PreEffectiveCritChance)
+		assert.are.near((1 - (1 - 0.5051) ^ 2) * 100, luckyOutput.CritChance, 10 ^ -9)
+	end)
 
 	it("calculates bifurcated critical hit damage", function()
 		local normalOutput = setupBifurcate("Spark 1/0  1")

--- a/src/Modules/CalcOffence.lua
+++ b/src/Modules/CalcOffence.lua
@@ -3017,7 +3017,8 @@ function calcs.offence(env, actor, activeSkill)
 					inc = skillModList:Sum("INC", cfg, "CritChance") + (env.mode_effective and enemyDB:Sum("INC", nil, "SelfCritChance") or 0)
 					more = skillModList:More(cfg, "CritChance")
 				end
-				output.CritChance = (baseCrit + base) * (1 + inc / 100) * more
+				-- The game uses an integer permyriad chance for each critical strike roll.
+				output.CritChance = round((baseCrit + base) * (1 + inc / 100) * more * 100) / 100
 				local preCapCritChance = output.CritChance
 				output.CritChance = m_min(output.CritChance, skillModList:Override(nil, "CritChanceCap") or skillModList:Sum("BASE", cfg, "CritChanceCap"))
 				if (baseCrit + base) > 0 then


### PR DESCRIPTION

### Description of the problem being solved:
The game stores crit chance values down to 0.01% but PoB was saving them to 0.001% which technically would be incorrect when using lucky or other extra crit roll chance mods

This was also the reason why you'd sometimes see effective crit chance in the sidebar even when you were accuracy capped and had no lucky crit


### Link to a build that showcases this PR:
https://maxroll.gg/poe/pob/d63eam0h

### Before screenshot:
<img width="307" height="198" alt="image" src="https://github.com/user-attachments/assets/a59f649c-01f6-45f6-a9de-c414370256e1" />

### After screenshot:
<img width="308" height="179" alt="image" src="https://github.com/user-attachments/assets/1a9b2cd9-7160-43fa-a140-8b47e564d255" />
