### PR TITLE
Fix allocated nodes appearing in unallocated power report list

### DIFF
--- a/spec/System/TestPowerReport_spec.lua
+++ b/spec/System/TestPowerReport_spec.lua
@@ -1,0 +1,38 @@
+describe("PowerReportListControl", function()
+	local PowerReportListControl
+
+	before_each(function()
+		LoadModule("Classes/PowerReportListControl")
+		PowerReportListControl = common.classes.PowerReportListControl
+	end)
+
+	local function relist(originalList, showClusters, allocated)
+		local control = {
+			originalList = originalList,
+			showClusters = showClusters or false,
+			allocated = allocated or false,
+		}
+		PowerReportListControl.ReList(control)
+		return control.list
+	end
+
+	it("Show Unallocated excludes allocated nodes", function()
+		local list = relist({
+			{ name = "allocated", power = 10, pathDist = 1, allocated = true },
+			{ name = "unallocated", power = 5, pathDist = 1, allocated = false },
+		}, false, false)
+
+		assert.are.equal(1, #list)
+		assert.are.equal("unallocated", list[1].name)
+	end)
+
+	it("Show Allocated includes allocated nodes", function()
+		local list = relist({
+			{ name = "allocated", power = -10, pathDist = 1, allocated = true },
+			{ name = "unallocated", power = 5, pathDist = 1, allocated = false },
+		}, false, true)
+
+		assert.are.equal(1, #list)
+		assert.are.equal("allocated", list[1].name)
+	end)
+end)

--- a/src/Classes/PowerReportListControl.lua
+++ b/src/Classes/PowerReportListControl.lua
@@ -112,6 +112,8 @@ function PowerReportListClass:ReList()
 		end
 		if self.allocated then
 			insert = item.allocated
+		elseif item.allocated then
+			insert = false
 		end
 		if not self.showMasteries and item.type == "Mastery" then
 			insert = false


### PR DESCRIPTION
Related to #3810 (partial overlap; this does not close the issue).

### Description of the problem being solved:

Allocated passive nodes could appear in **Show Unallocated** when their computed power was positive, so the report did not match the selected mode.

Explicitly exclude allocated entries from unallocated modes while preserving **Show Allocated** behavior, including allocated nodes whose removal power is negative.

### Steps taken to verify a working solution:

- Added focused tests covering both regression cases: **Show Unallocated** excludes a positive-power allocated node, while **Show Allocated** retains a negative-power allocated node.

### Before screenshot:

<img width="715" height="541" alt="before-show-unallocated-allocated-resolute-technique" src="https://github.com/user-attachments/assets/86b5d5ba-e229-49a9-b1ed-1b6b1299ec12" />

### After screenshot:

<img width="714" height="607" alt="after-show-unallocated-allocated-resolute-technique" src="https://github.com/user-attachments/assets/53757522-ddd8-4615-a5b2-e81d498d7812" />
