### PR TITLE
Show Forbidden Jewels' Allocated Node in their names

### DIFF
--- a/src/Classes/Item.lua
+++ b/src/Classes/Item.lua
@@ -11,6 +11,7 @@ local m_max = math.max
 local m_floor = math.floor
 
 local dmgTypeList = {"Physical", "Lightning", "Cold", "Fire", "Chaos"}
+local forbiddenNotableLen = 18
 local catalystList = {"Abrasive", "Accelerating", "Dextral", "Fertile", "Imbued", "Intrinsic", "Noxious", "Prismatic", "Sinistral", "Tempering", "Turbulent", "Unstable"}
 local catalystDescriptorList = {"Attack", "Speed", "Suffix", "Life and Mana", "Caster", "Attribute", "Physical and Chaos", "Resistance", "Prefix", "Defence", "Elemental", "Critical"}
 local catalystTags = {
@@ -1587,7 +1588,19 @@ function ItemClass:ParseRaw(raw, rarity, highQuality)
 		self.title = self.title:gsub("[Ff]oulborn ", "")
 	end
 	if self.baseName and self.title then
-		self.name = self.title .. ", " .. self.baseName:gsub(" %(.+%)", "")
+		local title = self.title
+		if (self.title == "Forbidden Flame" or self.title == "Forbidden Flesh") and not (main.uniqueDB and main.uniqueDB.loading) then
+			-- Name the half by the notable it grants, so a pair is identifiable in the item list
+			for _, modLine in ipairs(self.explicitModLines) do
+				local notable = modLine.line:match("^Allocates (.+) if you have the matching modifiers? on Forbidden ")
+				if notable and self:CheckModLineVariant(modLine) then
+					title = self.title .. " (" .. (#notable > forbiddenNotableLen
+						and notable:sub(1, forbiddenNotableLen - 3) .. "..." or notable) .. ")"
+					break
+				end
+			end
+		end
+		self.name = title .. ", " .. self.baseName:gsub(" %(.+%)", "")
 	end
 	if not self.quality then
 		self:NormaliseQuality()


### PR DESCRIPTION
### Description of the problem being solved:
QoL for #10235.

I noticed when ff counterpart jewels are auto-generated, if a user adds a few different sets, it's hard to keep track of which jewels correspond to which set (unless hovered over).

This PR adds the allocated node's name within each jewel's entry in the item tab, while truncating longer ascendancy names such as Champion's `First to Strike, Last to Fall`. With regards to the original qol issue mentioned earlier, it also makes sure the node names stay in sync on edit.


### Before:
<img width="452" height="408" alt="image" src="https://github.com/user-attachments/assets/0de20ce5-8768-472d-8b8f-6a04e1be8979" />

### After:
<img width="453" height="412" alt="image" src="https://github.com/user-attachments/assets/7811ad1e-8ea0-4407-bc5b-6f6842fb9f1d" />


https://github.com/user-attachments/assets/952e1d2f-3225-4a34-8ecf-a45f567a386e
