### PR TITLE
Fix Nightblade support not working with Windburst

### DIFF
--- a/spec/System/TestSkills_spec.lua
+++ b/spec/System/TestSkills_spec.lua
@@ -89,6 +89,29 @@ describe("TestSkills", function()
 
 		assert.True(build.calcsTab.mainOutput.MirageDPS ~= nil)
 	end)
+
+	it("checks equipped weapon types for support-granted attacks", function()
+		build.itemsTab:CreateDisplayItemFromRaw("Test Claw\nImperial Claw")
+		build.itemsTab:AddDisplayItem()
+		build.skillsTab:PasteSocketGroup("Cobra Lash 20/0  1\nWindburst 20/0  1\nNightblade 20/0  1\nSacred Wisps 20/0  1\n")
+		runCallback("OnFrame")
+
+		local windburst
+		for _, activeSkill in ipairs(build.calcsTab.mainEnv.player.activeSkillList) do
+			if activeSkill.activeEffect.grantedEffect.id == "TriggeredSupportWindburst" then
+				windburst = activeSkill
+				break
+			end
+		end
+		assert.is_not_nil(windburst)
+
+		local supports = { }
+		for _, effect in ipairs(windburst.effectList) do
+			supports[effect.grantedEffect.id] = true
+		end
+		assert.is_true(supports.SupportNightblade)
+		assert.is_nil(supports.SupportSacredWisps)
+	end)
 	
 	it("Test Scorching ray applying exposure at max stages", function()
 		build.skillsTab:PasteSocketGroup("Scorching Ray 20/0  1\n")

--- a/src/Modules/CalcTools.lua
+++ b/src/Modules/CalcTools.lua
@@ -117,7 +117,8 @@ function calcLib.canGrantedEffectSupportActiveSkill(grantedEffect, activeSkill, 
 	-- Special case for Sacred Wisps, i.e. Wisps Support has a weaponType of Wand so it should only match with Active Skills that at least have Wand as a weaponType.
 	-- Super special case for Varunastra, e.g. allow Nightblade to support Smite.
 	local actorHasAllOneHand = (activeSkill.actor.weaponData1 and activeSkill.actor.weaponData1.countsAsAll1H) or (activeSkill.actor.weaponData2 and activeSkill.actor.weaponData2.countsAsAll1H)
-	if grantedEffect.weaponTypes then
+	-- Skills granted by a support gem (e.g. Windburst) have no weapon types of their own; the weapon restriction applies to the skill that triggers them.
+	if grantedEffect.weaponTypes and not effectiveSkillTypes[SkillType.SkillGrantedBySupport] then
 		-- Build a lookup of the active skill's weapon types
 		local activeTypeLookup = { }
 		if activeSkill.activeEffect.grantedEffect.weaponTypes then

--- a/src/Modules/CalcTools.lua
+++ b/src/Modules/CalcTools.lua
@@ -117,13 +117,20 @@ function calcLib.canGrantedEffectSupportActiveSkill(grantedEffect, activeSkill, 
 	-- Special case for Sacred Wisps, i.e. Wisps Support has a weaponType of Wand so it should only match with Active Skills that at least have Wand as a weaponType.
 	-- Super special case for Varunastra, e.g. allow Nightblade to support Smite.
 	local actorHasAllOneHand = (activeSkill.actor.weaponData1 and activeSkill.actor.weaponData1.countsAsAll1H) or (activeSkill.actor.weaponData2 and activeSkill.actor.weaponData2.countsAsAll1H)
-	-- Skills granted by a support gem (e.g. Windburst) have no weapon types of their own; the weapon restriction applies to the skill that triggers them.
-	if grantedEffect.weaponTypes and not effectiveSkillTypes[SkillType.SkillGrantedBySupport] then
+	if grantedEffect.weaponTypes then
 		-- Build a lookup of the active skill's weapon types
 		local activeTypeLookup = { }
 		if activeSkill.activeEffect.grantedEffect.weaponTypes then
 			for activeType in pairs(activeSkill.activeEffect.grantedEffect.weaponTypes) do
 				activeTypeLookup[activeType] = true
+			end
+		elseif effectiveSkillTypes[SkillType.SkillGrantedBySupport] then
+			-- Skills granted by supports do not have their own weaponTypes, so check the equipped weapons instead.
+			if activeSkill.actor.weaponData1.type then
+				activeTypeLookup[activeSkill.actor.weaponData1.type] = true
+			end
+			if activeSkill.actor.weaponData2.type then
+				activeTypeLookup[activeSkill.actor.weaponData2.type] = true
 			end
 		end
 		-- If the support expects a weapon type but the active skill doesn't have any (e.g. shield skills), it's not a match.


### PR DESCRIPTION
Fixes #10240 .

### Description of the problem being solved:
Nightblade was incompatible with support-granted attacks due being gated claw/dagger weapon types. This PR fixes by skipping the gate if the attacks was granted by a support.

### Steps taken to verify a working solution:
- Equip windburst and nightblade

### Link to a build that showcases this PR:

### Before screenshot:

### After screenshot:
