### PR TITLE
Fix granted skill regression test construction

### DIFF
--- a/spec/System/TestItemParse_spec.lua
+++ b/spec/System/TestItemParse_spec.lua
@@ -1359,7 +1359,7 @@ describe("TestAdvancedItemParse #item", function()
 			assert.equal(8, spellDamage())
 		end)
 		it("does not scale modifiers that grant skills", function()
-			local item = new("Item", [[
+			local item = new("Item"):Item([[
 				Item Class: Rings
 				Rarity: Rare
 				Plague Knuckle


### PR DESCRIPTION
### Description of the problem being solved:

PR #10174 added an item parsing regression test using the legacy `new("Item", raw)` constructor form. The current class API rejects constructor arguments passed to `new()`, so the test errors before reaching its granted-skill magnitude assertions.

This changes the call to `new("Item"):Item(raw)`, matching the established constructor form. The production parser, fixture, and assertions remain unchanged.
