### PR TITLE
Fix Pact of Beidat not affecting ailment calc for Hit-based spells

### DIFF
--- a/src/Data/Skills/other.lua
+++ b/src/Data/Skills/other.lua
@@ -2921,7 +2921,7 @@ skills["PactOfBeidat"] = {
 			mod("BeidatAdditionalCascades", "BASE", nil),
 		},
 		["pact_skill_damage_+%_final_with_hits_and_ailments_to_grant"] = {
-			mod("BeidatPactDamage", "LIST", { mod = mod("Damage", "MORE", nil, ModFlag.Spell, bit.bor(KeywordFlag.Hit, KeywordFlag.Ailment)) }),
+			mod("BeidatPactDamage", "LIST", { mod = mod("Damage", "MORE", nil, 0, bit.bor(KeywordFlag.Hit, KeywordFlag.Ailment)) }),
 		},
 	},
 	baseFlags = {

--- a/src/Export/Skills/other.txt
+++ b/src/Export/Skills/other.txt
@@ -804,7 +804,7 @@ return function(skills, mod, flag, skill)
 			mod("BeidatAdditionalCascades", "BASE", nil),
 		},
 		["pact_skill_damage_+%_final_with_hits_and_ailments_to_grant"] = {
-			mod("BeidatPactDamage", "LIST", { mod = mod("Damage", "MORE", nil, ModFlag.Spell, bit.bor(KeywordFlag.Hit, KeywordFlag.Ailment)) }),
+			mod("BeidatPactDamage", "LIST", { mod = mod("Damage", "MORE", nil, 0, bit.bor(KeywordFlag.Hit, KeywordFlag.Ailment)) }),
 		},
 	},
 #mods


### PR DESCRIPTION
Fixes #10280.

### Description of the problem being solved:
Pact of Beidat was only not affecting the ailment portion of hit-based spells which had an innate or could gain a dot component i.e. EK, BV, fireball, blade-blast etc.


### Steps taken to verify a working solution:
- Equipped a range of spell with innate or external dot component (through shaper of flames / chance to poison) and tested with pact of beidat
