### PR TITLE
Require confirmation before deleting unused items

### DIFF
--- a/spec/System/TestItemListControl_spec.lua
+++ b/spec/System/TestItemListControl_spec.lua
@@ -176,6 +176,33 @@ describe("ItemListControl", function()
 		assert.are.same({ }, itemsTab.items)
 	end)
 
+	it("requires confirmation before deleting unused items", function()
+		local control, itemsTab = newItemListControl()
+		local onConfirm
+		local deleted = false
+		itemsTab.GetEquippedSlotForItem = function()
+			return nil
+		end
+		itemsTab.DeleteItem = function()
+			deleted = true
+		end
+		itemsTab.build.treeTab.specList = { }
+		main.OpenConfirmPopup = function(_, title, message, confirmLabel, callback)
+			assert.are.equal("Delete Unused", title)
+			assert.are.equal("Are you sure you want to delete all unused items in this build?", message)
+			assert.are.equal("Delete", confirmLabel)
+			onConfirm = callback
+		end
+
+		control.controls.deleteUnused.onClick()
+
+		assert.is_false(deleted)
+
+		onConfirm()
+
+		assert.is_true(deleted)
+	end)
+
 	it("releases focus after opening an item with a double click", function()
 		local control, itemsTab = newItemListControl()
 		local item = new("Item"):Item([[

--- a/src/Classes/ItemListControl.lua
+++ b/src/Classes/ItemListControl.lua
@@ -23,7 +23,7 @@ function ItemListClass:ItemListControl(anchor, rect, itemsTab, forceTooltip)
 		itemsTab:SortItemList()
 		self:UpdateList()
 	end)
-	self.controls.deleteUnused = new("ButtonControl"):ButtonControl({"LEFT",self.controls.sort,"RIGHT"}, {4, 0, 84, 18}, "Del Unused", function()
+	local function deleteUnused()
 		local delList = {}
 		for _, itemId in pairs(itemsTab.itemOrderList) do
 			if not itemsTab:GetEquippedSlotForItem(itemsTab.items[itemId]) and not self:FindEquippedAbyssJewel(itemId, false) and not self:FindSocketedJewel(itemId, false) then
@@ -42,6 +42,9 @@ function ItemListClass:ItemListControl(anchor, rect, itemsTab, forceTooltip)
 		itemsTab:AddUndoState()
 		itemsTab.build.buildFlag = true
 		self:UpdateList()
+	end
+	self.controls.deleteUnused = new("ButtonControl"):ButtonControl({"LEFT",self.controls.sort,"RIGHT"}, {4, 0, 84, 18}, "Del Unused", function()
+		main:OpenConfirmPopup("Delete Unused", "Are you sure you want to delete all unused items in this build?", "Delete", deleteUnused)
 	end)
 	self.controls.deleteUnused.enabled = function()
 		return #self.list > 0


### PR DESCRIPTION
### Description of the problem being solved:

It's too easy to accidentally delete unused items. In https://github.com/PathOfBuildingCommunity/PathOfBuilding/pull/10292 I made this risk slightly greater by making the delete buttons larger so that they match the style of other "action" buttons in PoB. This change uses the existing confirmation check that "delete all" uses and makes this page safer/easier to use.

### Steps taken to verify a working solution:
- Load a build
- Add items
- Click "Delete Unused" and ensure the confirmation window appears
- Window appears and the confirmation button works

### Link to a build that showcases this PR:
N/A

### Before screenshot:
N/A

### After screenshot:
N/A