### PR TITLE
Fix invalid new() syntax in TestItemParse spec

### DIFF
--- a/spec/System/TestItemParse_spec.lua
+++ b/spec/System/TestItemParse_spec.lua
@@ -1359,7 +1359,7 @@ describe("TestAdvancedItemParse #item", function()
 			assert.equal(8, spellDamage())
 		end)
 		it("does not scale modifiers that grant skills", function()
-			local item = new("Item", [[
+			local item = new("Item"):Item([[
 				Item Class: Rings
 				Rarity: Rare
 				Plague Knuckle


### PR DESCRIPTION
## Description of the problem being solved

The "does not scale modifiers that grant skills" test added in #10174 constructs its item with `new("Item", [[...]])`, but `new()` forbids constructor arguments — `Modules/Common.lua` raises *"Extra argument passed to new() during creation of class Item"* — so the test errors instead of running:

```
Error -> ../spec/System/TestItemParse_spec.lua @ 1361
TestAdvancedItemParse #item mod magnitude scaling does not scale modifiers that grant skills
Modules/Common.lua:163: Extra argument passed to new() during creation of class Item. Extra arguments are not allowed.
```

This changes it to the `new("Item"):Item([[...]])` form used by every other test in the file. The test's assertions all pass once it actually runs.

## Steps taken to verify a working solution

Ran `busted --lua=luajit -p TestItemParse_spec.lua`: previously 87 successes / 1 error, now 88 successes / 0 errors. Full suite: 572 successes / 0 failures / 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)