### PR TITLE
Fix Conjoined Spire AoE calc

### DIFF
--- a/spec/System/TestOffence_spec.lua
+++ b/spec/System/TestOffence_spec.lua
@@ -352,4 +352,17 @@ describe("TestOffence", function()
 			assert.are.equals(1, build.calcsTab.mainOutput[outputName])
 		end)
 	end
+	it("uses the final totem limit when scaling area of effect", function()
+		build.skillsTab:PasteSocketGroup("Searing Bond of Detonation 20/0  1")
+		build.configTab.input.customMods = [[
+		+3 to Maximum Power Charges
+		Skills used by Totems have 10% more Area of Effect per maximum number of Summoned Totems
+		]]
+		build.configTab:BuildModList()
+		runCallback("OnFrame")
+
+		-- 1 base totem + 6 maximum power charges, so 70% more area of effect.
+		assert.are.equals(7, build.calcsTab.mainOutput.ActiveTotemLimit)
+		assert.are.equals(1.7, build.calcsTab.mainOutput.AreaOfEffectMod)
+	end)
 end)

--- a/src/Modules/CalcOffence.lua
+++ b/src/Modules/CalcOffence.lua
@@ -1182,6 +1182,10 @@ function calcs.offence(env, actor, activeSkill)
 		end
 	end
 	if skillFlags.area or skillData.radius or (skillFlags.mine and activeSkill.skillTypes[SkillType.Aura]) then
+		-- add totem limit output early for conjoined spire
+		if skillFlags.totem then
+			output.ActiveTotemLimit = skillModList:Sum("BASE", skillCfg, "ActiveTotemLimit", "ActiveBallistaLimit")
+		end
 		calcAreaOfEffect(skillModList, skillCfg, skillData, skillFlags, output, breakdown)
 	end
 	if activeSkill.skillTypes[SkillType.Aura] then


### PR DESCRIPTION
Fixes #10299.

### Description of the problem being solved:

Fixes the aoe size not taking into account the active totem limit. It seems the interaction was working, but they were just calculated in the wrong order.

### Steps taken to verify a working solution:
- Linked build shows correct value

### Link to a build that showcases this PR:

### Before screenshot:

### After screenshot:
<img width="1299" height="532" alt="image" src="https://github.com/user-attachments/assets/761714a0-9a16-44ba-a370-67ebdd97adc0" />
<img width="1288" height="507" alt="image" src="https://github.com/user-attachments/assets/a1a19ee1-5aaa-46d3-aebc-facec1e3d9d8" />
