### PR TITLE
Fix catalyst quality state when catalyst is cleared

### DIFF
--- a/spec/System/TestItemMods_spec.lua
+++ b/spec/System/TestItemMods_spec.lua
@@ -7,6 +7,50 @@ describe("TetsItemMods", function()
 		-- newBuild() takes care of resetting everything in setup()
 	end)
 
+	local function createCraftedRing()
+		build.itemsTab:CreateDisplayItemFromRaw([[Rarity: Rare
+			Test Ring
+			Amethyst Ring
+			Crafted: true
+			Prefix: None
+			Prefix: None
+			Prefix: None
+			Suffix: None
+			Suffix: None
+			Suffix: None
+			Quality: 12
+			Implicits: 0]])
+		return build.itemsTab.displayItem
+	end
+
+	it("clears catalyst quality when no catalyst is selected", function()
+		local item = createCraftedRing()
+		local controls = build.itemsTab.controls
+		local catalyst = controls.displayItemCatalyst
+		local catalystQuality = controls.displayItemCatalystQualityEdit
+
+		catalyst:SetSel(2)
+		assert.are.equals(1, item.catalyst)
+		assert.are.equals(20, item.catalystQuality)
+		catalystQuality:SetText("17", true)
+		assert.are.equals(17, item.catalystQuality)
+		assert.is_truthy(item:BuildRaw():match("Catalyst: Abrasive"))
+		assert.is_truthy(item:BuildRaw():match("CatalystQuality: 17"))
+
+		catalyst:SetSel(1)
+		assert.are.equals(0, item.catalyst)
+		assert.is_nil(item.catalystQuality)
+		assert.are.equals("0", catalystQuality.buf)
+		assert.is_nil(item:BuildRaw():match("Catalyst:"))
+		assert.is_nil(item:BuildRaw():match("CatalystQuality:"))
+
+		item.catalystQuality = 20
+		build.itemsTab:SetDisplayItem(item)
+		assert.is_nil(item.catalystQuality)
+		assert.are.equals("0", catalystQuality.buf)
+		assert.is_nil(item:BuildRaw():match("CatalystQuality:"))
+	end)
+
 	it("shows versioned reusable variant groups", function()
 		build.itemsTab:CreateDisplayItemFromRaw([[
 			Rarity: Unique

--- a/src/Classes/ItemsTab.lua
+++ b/src/Classes/ItemsTab.lua
@@ -663,9 +663,14 @@ holding Shift will put it in the second.]])
 		 "Prismatic (Resistance)","Sinistral (Prefix)","Tempering (Defense)","Turbulent (Elemental)","Unstable (Critical)"},
 		function(index, value)
 			self.displayItem.catalyst = index - 1
-			if not self.displayItem.catalystQuality then
-				self.displayItem.catalystQuality = 20
-				self.controls.displayItemCatalystQualityEdit:SetText(self.displayItem.catalystQuality)
+			if index > 1 then
+				if not self.displayItem.catalystQuality then
+					self.displayItem.catalystQuality = 20
+					self.controls.displayItemCatalystQualityEdit:SetText(self.displayItem.catalystQuality)
+				end
+			else
+				self.displayItem.catalystQuality = nil
+				self.controls.displayItemCatalystQualityEdit:SetText(0)
 			end
 			if self.displayItem.crafted then
 				for i = 1, self.displayItem.affixLimit do
@@ -2033,6 +2038,9 @@ end
 -- Sets the display item to the given item
 function ItemsTabClass:SetDisplayItem(item)
 	self.displayItem = item
+	if item and not (item.catalyst and item.catalyst > 0) then
+		item.catalystQuality = nil
+	end
 	if item then
 		-- Update the display item controls
 		self:UpdateDisplayItemTooltip()


### PR DESCRIPTION
### Description of the problem being solved:

If you select a catalyst from the drop down on catalyst eligible items, and then change the drop down back to "catalyst", the item retains a quality value that gets exported with the build, effectively creating a "20% quality" item with no catalyst/bonus.

The fix removes catalyst quality whenever no catalyst is selected.

### Steps taken to verify a working solution:
- Create/edit jewellery items
- Select various catalyst types
- Change the catalyst selector back to "Catalyst"
- Click "Edit" and observe that no quality value is stored

### Link to a build that showcases this PR:

### Before screenshot:

<img width="1010" height="939" alt="image" src="https://github.com/user-attachments/assets/3f6f7a6f-8d73-4060-a87a-90281df13dec" />

### After screenshot:

<img width="1013" height="949" alt="image" src="https://github.com/user-attachments/assets/1713b382-748f-46d1-8c60-68fa77924c52" />
