### PR TITLE
Fix Mana-Infused Staff zero-mana reservation state

### DIFF
--- a/spec/System/TestSkills_spec.lua
+++ b/spec/System/TestSkills_spec.lua
@@ -132,8 +132,12 @@ describe("TestSkills", function()
 		activeSkill = build.calcsTab.mainEnv.player.mainSkill
 		assert.is_true(activeSkill.skillFlags.disable)
 		assert.are.equals("This skill requires reserving Mana", activeSkill.disableReason)
-		assert.are.equals(0, activeSkill.skillData.ManaReservedBase)
+		assert.is_nil(activeSkill.skillData.ManaReservedBase)
+		assert.is_nil(activeSkill.skillData.ManaReservedPercent)
 		assert.is_nil(activeSkill.skillData.LifeReservedBase)
+		assert.are.equals(0, build.calcsTab.mainEnv.player.reserved_ManaPercent)
+		assert.is_nil(build.calcsTab.mainEnv.player.output.ManaReservedPercent)
+		assert.are.equals(0, #build.calcsTab.mainEnv.player.breakdown.ManaReserved.reservations)
 	end)
 	
 	it("Test Scorching ray applying exposure at max stages", function()

--- a/src/Modules/CalcPerform.lua
+++ b/src/Modules/CalcPerform.lua
@@ -1976,6 +1976,11 @@ function calcs.perform(env, skipEHP)
 		breakdown.ManaReserved = { reservations = { } }
 	end
 	for _, activeSkill in ipairs(env.player.activeSkillList) do
+		local forcedManaReservation = activeSkill.skillData.ManaReservationPercentForced
+		if forcedManaReservation and m_ceil((output.Mana or 0) * forcedManaReservation / 100) == 0 then
+			activeSkill.skillFlags.disable = true
+			activeSkill.disableReason = "This skill requires reserving Mana"
+		end
 		if (activeSkill.skillTypes[SkillType.HasReservation] or activeSkill.skillData.triggeredByAutoexertion ) and not activeSkill.skillTypes[SkillType.ReservationBecomesCost] and not activeSkill.skillFlags.disable then
 			local skillModList = activeSkill.skillModList
 			local skillCfg = activeSkill.skillCfg
@@ -2080,10 +2085,6 @@ function calcs.perform(env, skipEHP)
 				if skillModList:Flag(skillCfg, "HasUncancellableReservation") then
 					env.player["uncancellable_"..name.."Reservation"] = env.player["uncancellable_"..name.."Reservation"] + values.reservedPercent
 				end
-			end
-			if activeSkill.skillData.ManaReservationPercentForced and activeSkill.skillData.ManaReservedBase == 0 then
-				activeSkill.skillFlags.disable = true
-				activeSkill.disableReason = "This skill requires reserving Mana"
 			end
 		end
 	end


### PR DESCRIPTION
### Description of the problem being solved:

Mana-Infused Staff is correctly disabled when Blood Magic leaves the character with no mana, but the disable decision introduced by #10283 happened after its forced mana percentage had already been added to the reservation aggregate and breakdown. This left a disabled skill represented as a 30% mana reservation during the zero-mana calculation pass.

This change moves the forced-mana availability check before reservation processing and strengthens the focused system test for the per-skill fields, player aggregate, final output, and Mana Reserved breakdown.

### Steps taken to verify a working solution:

- With a valid staff and Arrogance, Mana-Infused Staff remains enabled, reserves 30% of mana, and reserves no life.
- When Blood Magic leaves the character with no mana, the skill is disabled without contributing to the reservation aggregate, final output, or Mana Reserved breakdown.
- After switching from staff to non-staff and back, the reservation state and breakdown are cleared and rebuilt correctly.
- The updated system regression test confirms that the disabled skill leaves no mana reservation aggregate, output, or breakdown entry.
- The zero-mana result was also verified in the Windows UI.

The full suite was not run locally for this narrow follow-up. No UI layout or text is changed.

AI-assisted contribution disclosure: This change was developed and reviewed with OpenAI Codex and confirmed with focused automated tests and manual UI verification.
