### PR TITLE
Fix corruption source crash with fifth implicit

### DIFF
--- a/spec/System/TestItemCorruption_spec.lua
+++ b/spec/System/TestItemCorruption_spec.lua
@@ -1,0 +1,56 @@
+describe("Item corruption source transitions", function()
+	local initialPopupCount
+
+	local function assertImplicitSelectionsCleared(controls)
+		for i = 1, 5 do
+			assert.are.equal(1, controls["implicit" .. i].selIndex)
+		end
+	end
+
+	before_each(function()
+		newBuild()
+		main:SelectControl()
+		initialPopupCount = #main.popups
+		build.itemsTab.displayItem = new("Item"):Item(main.uniqueDB.byTitle["glimpse of chaos"].raw)
+		build.itemsTab:CorruptDisplayItem()
+	end)
+
+	after_each(function()
+		main:SelectControl()
+		while #main.popups > initialPopupCount do
+			main:ClosePopup()
+		end
+	end)
+
+	it("switches from Glimpse of Chaos to Scourge with the fifth implicit selected", function()
+		local controls = main.popups[1].controls
+		controls.implicit5:SetSel(2)
+		assert.are.equal(2, controls.implicit5.selIndex)
+
+		assert.has_no.errors(function()
+			controls.source:SetSel(3)
+		end)
+		assert.are.equal("Scourge", controls.source:GetSelValue())
+		assertImplicitSelectionsCleared(controls)
+		assert.is_false(controls.implicit5:IsShown())
+	end)
+
+	it("clears implicit selections across adjacent source transitions", function()
+		local controls = main.popups[1].controls
+		local transitions = {
+			{ fromSourceIndex = 1, implicitIndex = 5, toSourceIndex = 2 },
+			{ fromSourceIndex = 2, implicitIndex = 5, toSourceIndex = 1 },
+			{ fromSourceIndex = 2, implicitIndex = 4, toSourceIndex = 3 },
+			{ fromSourceIndex = 3, implicitIndex = 4, toSourceIndex = 2 },
+		}
+
+		for _, transition in ipairs(transitions) do
+			controls.source:SetSel(transition.fromSourceIndex)
+			controls["implicit" .. transition.implicitIndex]:SetSel(2)
+			assert.are.equal(2, controls["implicit" .. transition.implicitIndex].selIndex)
+			controls.source:SetSel(transition.toSourceIndex)
+			assert.are.equal(transition.toSourceIndex, controls.source.selIndex)
+			assertImplicitSelectionsCleared(controls)
+		end
+	end)
+end)

--- a/src/Classes/ItemsTab.lua
+++ b/src/Classes/ItemsTab.lua
@@ -3425,6 +3425,10 @@ function ItemsTabClass:CorruptDisplayItem()
 		"^7Source:")
 	controls.source = new("DropDownControl"):DropDownControl({ "TOPLEFT", nil, "TOPLEFT" }, { 100, 30, 150, 18 },
 		sourceList, function(index, value)
+			-- Clear selections without callbacks before the source changes; Implicit #5 has no Scourge pair.
+			for i = 1, maxImplicitNum do
+				controls[string.format("implicit%d", i)]:SetSel(1, true)
+			end
 			if value == "Scourge" then
 				currentModType = "ScourgeUpside"
 				buildImplicitList("ScourgeUpside")
@@ -3444,9 +3448,6 @@ function ItemsTabClass:CorruptDisplayItem()
 				applySort(controls.sort.list[controls.sort.selIndex].stat)
 			else
 				buildCorruptLists(currentModType)
-			end
-			for i = 1, maxImplicitNum do
-				controls[string.format("implicit%d", i)]:SetSel(1)
 			end
 		end)
 	controls.source.enabled = #sourceList > 1


### PR DESCRIPTION
### Description of the problem being solved:

PR #10206 added five-slot Glimpse of Chaos corruption support, but changing Source reset implicit selections only after switching modes and rebuilding source-specific lists. With Implicit #5 selected, switching to Scourge invoked its callback under Scourge pairing rules and attempted to access a nonexistent Implicit #6 control.

This change clears all implicit selections without callbacks before changing Source and rebuilding the lists, preserving the existing reset behavior without the crash.

### Steps taken to verify a working solution:

- Added system coverage for the reachable Glimpse of Chaos Implicit #5 to Scourge path.
- Covered adjacent Glimpse of Chaos, Corrupted, and Scourge transitions in both directions.
- Ran the full automated test suite and manually verified the corruption popup workflow.
