### PR TITLE
Show sources of disabled damage types on Calcs page

### DIFF
--- a/spec/System/TestOffence_spec.lua
+++ b/spec/System/TestOffence_spec.lua
@@ -257,6 +257,11 @@ describe("TestOffence", function()
 
 		-- Arc is pure lightning, so the player can no longer deal damage with it
 		assert.are.equals(0, build.calcsTab.calcsOutput.LightningMax)
+		local lightningBreakdown = build.calcsTab.calcsEnv.player.breakdown.Lightning
+		assert.are.equals("You can't deal Lightning damage", lightningBreakdown[1])
+		assert.are.equals(1, #lightningBreakdown.modList)
+		assert.are.equals("DealNoLightning", lightningBreakdown.modList[1].mod.name)
+		assert.matches("^Item:%d+:New Item", lightningBreakdown.modList[1].mod.source)
 	end)
 
 	it("keeps deal no non-elemental damage as its own literal", function()

--- a/src/Classes/CalcBreakdownControl.lua
+++ b/src/Classes/CalcBreakdownControl.lua
@@ -410,7 +410,7 @@ function CalcBreakdownClass:AddModSection(sectionData, modList)
 			-- Multiple stat names specified, add this modifier's stat to the table
 			row.name = self:FormatModName(row.mod.name)
 		end
-		local sourceType = row.mod.source:match("[^:]+") or ""
+		local sourceType = row.mod.source and row.mod.source:match("[^:]+") or ""
 		row.source = sourceType
 		if not modList and not sectionData.modSource then
 			-- No modifier source specified, add the source type to the table

--- a/src/Modules/CalcOffence.lua
+++ b/src/Modules/CalcOffence.lua
@@ -1930,8 +1930,13 @@ function calcs.offence(env, actor, activeSkill)
 
 	-- Cache global damage disabling flags
 	local canDeal = { }
+	local damageDisableMods = breakdown and { }
 	for _, damageType in ipairs(dmgTypeList) do
-		canDeal[damageType] = not skillModList:Flag(skillCfg, "DealNo"..damageType, "DealNoDamage")
+		local damageDisabled = skillModList:Flag(skillCfg, "DealNo"..damageType, "DealNoDamage")
+		canDeal[damageType] = not damageDisabled
+		if damageDisableMods and damageDisabled then
+			damageDisableMods[damageType] = skillModList:Tabulate("FLAG", skillCfg, "DealNo"..damageType, "DealNoDamage")
+		end
 	end
 
 	-- Calculate damage conversion percentages
@@ -3640,7 +3645,8 @@ function calcs.offence(env, actor, activeSkill)
 				else
 					if breakdown then
 						breakdown[damageType] = {
-							"You can't deal "..damageType.." damage"
+							"You can't deal "..damageType.." damage",
+							modList = damageDisableMods[damageType],
 						}
 					end
 				end


### PR DESCRIPTION
### Description of the problem being solved:
It's really confusing to see that a build does no damage of various types on the Calcs tab, unless you're already familiar with many of the sources of restriction like Replica Alberon's, Avatar of Fire, Brutality, Void Manipulation, etc. This small change leverages boolean values that PoB already calculates, and simply shows them on hover in the calcs page for the given damage types.

### Steps taken to verify a working solution:
- Load several builds with several different sources of damage restriction
- Compare to baseline dev branch
- Confirm numbers and modList data looks accurate
- Full test suite passed

### Link to a build that showcases this PR:
- https://pob.codes/b/dbnjZNAjjPq
- Path to Avatar of Fire to see another source beyond the 2 already included.

### Before screenshot:
<img width="896" height="191" alt="image" src="https://github.com/user-attachments/assets/acff0aee-9691-4ba4-8860-687a0c2f8413" />


### After screenshot:
<img width="931" height="244" alt="image" src="https://github.com/user-attachments/assets/7b3c0cca-0c41-4443-a5ea-cac4a221dcd0" />
