### PR TITLE
Search for items by modifier in craft item menu.

### DIFF
--- a/spec/System/TestSearchHost_spec.lua
+++ b/spec/System/TestSearchHost_spec.lua
@@ -1,4 +1,39 @@
 describe("SearchHost", function()
+	it("searches item bases by full name and base effects", function()
+		local cases = {
+			{ type = "Amulet: Talisman", search = "monkey power charge", name = "Monkey Paw Talisman (Power)" },
+			{ type = "Amulet: Talisman", search = "moon rite", name = "Greatwolf Talisman" },
+			{ type = "Amulet: Talisman", search = "fire-to-cold", name = "Avian Twins Talisman (Fire-To-Cold)" },
+		}
+
+		for _, testCase in ipairs(cases) do
+			local control = new("DropDownControl"):DropDownControl(nil, { 0, 0, 100, 20 }, data.itemBaseLists[testCase.type])
+			for char in testCase.search:gmatch(".") do
+				control:OnSearchChar(char)
+			end
+
+			assert.are.equal(1, control:GetMatchCount())
+			assert.are.equal(testCase.name, control.list[control:DropIndexToListIndex(1)].name)
+		end
+	end)
+
+	it("searches flask bases by buff effects", function()
+		local control = new("DropDownControl"):DropDownControl(nil, { 0, 0, 100, 20 }, data.itemBaseLists["Flask: Utility"])
+		for char in ("res"):gmatch(".") do
+			control:OnSearchChar(char)
+		end
+
+		local matches = { }
+		for index, searchInfo in ipairs(control.searchInfos) do
+			if searchInfo.matches then
+				matches[control.list[index].name] = true
+			end
+		end
+		assert.is_true(matches["Ruby Flask"])
+		assert.is_true(matches["Sapphire Flask"])
+		assert.is_true(matches["Topaz Flask"])
+	end)
+
 	it("merges all overlapping ranges when word order is ignored", function()
 		local searchHost = new("SearchHost"):SearchHost(function()
 			return { "caster" }

--- a/src/Modules/Data.lua
+++ b/src/Modules/Data.lua
@@ -1234,6 +1234,7 @@ end
 ---@class ItemBaseTincture
 ---@field manaBurn? number
 ---@field cooldown? number
+---@field buff? string[] # tincture-granted buff line(s)
 
 ---@type table<string, ItemBase>
 data.itemBases = { }
@@ -1243,6 +1244,7 @@ end
 
 ---@class ItemBaseEntry
 ---@field label string
+---@field searchFilter string
 ---@field name string
 ---@field base ItemBase
 
@@ -1256,7 +1258,25 @@ for name, base in pairs(data.itemBases) do
 			type = type .. ": " .. base.subType
 		end
 		data.itemBaseLists[type] = data.itemBaseLists[type] or { }
-		table.insert(data.itemBaseLists[type], { label = name:gsub(" %(.+%)",""), name = name, base = base })
+		local label = name:gsub(" %(.+%)","")
+		local searchTerms = { name }
+		if base.implicit then
+			t_insert(searchTerms, base.implicit)
+		end
+		if base.enchant then
+			t_insert(searchTerms, base.enchant)
+		end
+		if base.flask and base.flask.buff then
+			for _, line in ipairs(base.flask.buff) do
+				t_insert(searchTerms, line)
+			end
+		end
+		if base.tincture and base.tincture.buff then
+			for _, line in ipairs(base.tincture.buff) do
+				t_insert(searchTerms, line)
+			end
+		end
+		table.insert(data.itemBaseLists[type], { label = label, searchFilter = t_concat(searchTerms, " "), name = name, base = base })
 	end
 end
 data.itemBaseTypeList = { }


### PR DESCRIPTION
Fixes #10316 

### Description of the problem being solved:
When crafting an item through the crafting item menu, many item bases have implicits, enchants, or other modifiers that users would like to be able to search for. In this case, there are tons of Talismans and you might know you want one with "+1 Frenzy Charge" but you don't remember that it's a Cobra Talisman.

This PR is generalized to all item base items in the craft item menu. This can be useful when you're searching for a utility flask with `res` , so that the search is narrowed to Bismuth/Ruby/Topaz/Sapphire, etc.

The code here is modeled after the import character workflow which allows for searching by class or character name. We're adding support for implicits, enchants, base flasks, and base tinctures (even though they use implicits for the base item atm)

### Steps taken to verify a working solution:
- Run the tests included in the PR
- Manually verify across different item categories and base types that partial string searches are returning only expected results
- Run the full test suite
- Used Codex to create a small benchmark that showed a <1 ms increase in time to create the index of all base entries, compared to just the base item name

### Link to a build that showcases this PR:

### Before screenshot:

<img width="489" height="185" alt="image" src="https://github.com/user-attachments/assets/3e80f373-8f93-41fc-bb41-43095a9b8ce9" />

<img width="483" height="177" alt="image" src="https://github.com/user-attachments/assets/c1bb4081-9264-4b53-8e34-7442f1fe32fb" />

<img width="496" height="194" alt="image" src="https://github.com/user-attachments/assets/7a88df1a-c032-4b51-bb7f-a0119007d613" />


### After screenshot:

<img width="835" height="986" alt="image" src="https://github.com/user-attachments/assets/c9ecbb3a-42e4-4a65-92c0-61ed44d9db68" />

<img width="463" height="268" alt="image" src="https://github.com/user-attachments/assets/bc46bbd2-24da-473e-8a36-8cf25a0028c6" />

<img width="473" height="186" alt="image" src="https://github.com/user-attachments/assets/180b74d7-5134-44f6-8185-ccf8d9c67c54" />

