### PR TITLE
Update Augyre, Eber's Unification, and Martyr of Innocence unique modifiers

### DIFF
--- a/src/Data/Uniques/helmet.lua
+++ b/src/Data/Uniques/helmet.lua
@@ -599,7 +599,7 @@ Hubris Circlet
 Requires Level 69, 154 Int
 Implicits: 0
 Trigger Level 10 Void Gaze when you use a Skill
-(120-150)% increased Energy Shield
+(150-180)% increased Energy Shield
 +(50-80) to maximum Mana
 50% increased Stun and Block Recovery
 Gain (5-8)% of Elemental Damage as Extra Chaos Damage

--- a/src/Data/Uniques/mace.lua
+++ b/src/Data/Uniques/mace.lua
@@ -289,7 +289,8 @@ Variant: Current
 Requires Level 68, 104 Str, 122 Int
 Implicits: 1
 40% increased Elemental Damage
-(180-200)% increased Physical Damage
+{variant:1}(180-200)% increased Physical Damage
+{variant:2}(180-220)% increased Physical Damage
 (10-15)% increased Attack Speed
 (80-100)% increased Critical Strike Chance
 50% of Physical Damage Converted to Lightning Damage

--- a/src/Data/Uniques/staff.lua
+++ b/src/Data/Uniques/staff.lua
@@ -521,11 +521,12 @@ Implicits: 2
 {variant:1,2,3,4}+(12-16)% Chance to Block Attack Damage while wielding a Staff
 {variant:5}+(20-25)% Chance to Block Attack Damage while wielding a Staff
 {variant:1,2,3,4}100% increased Fire Damage
-{variant:5}100% increased Fire Damage
+{variant:5}(100-200)% increased Fire Damage
 {variant:1,2}Adds (350-400) to (500-600) Fire Damage
 {variant:3,4,5}Adds (315-360) to (450-540) Fire Damage
 Damage Penetrates 15% of Fire Resistance if you have Blocked Recently
 Immune to Freeze and Chill while Ignited
+{variant:5}Grants Level 15 Battlemage's Cry Skill
 Battlemage
 ]],[[
 Pillar of the Caged God


### PR DESCRIPTION
### Description of the problem being solved:

Several unique item definitions in `src/Data/Uniques` are out of date compared to current in-game item text (Advanced Copy):

- **Augyre** (Current variant): physical damage range is `(180-200)%` but current items show `(180-220)%`.
- **Eber's Unification**: energy shield range is `(120-150)%` but current items show `(150-180)%`.
- **Martyr of Innocence** (Current variant): fire damage is fixed `100%` but current items show `(100-200)%`; the item also grants **Battlemage's Cry** in addition to the existing **Battlemage** keyword, but the grant line is missing from the Current variant.

### Steps taken to verify a working solution:

- Confirmed all three unique entries load from `src/Data/Uniques` after the edit.
- **Augyre**: Pre 3.5.0 variant retains `(180-200)%`; Current variant uses `(180-220)%`.
- **Eber's Unification**: entry updated to `(150-180)% increased Energy Shield`.
- **Martyr of Innocence**: variants 1–4 retain fixed `100% increased Fire Damage`; Current (variant 5) uses `(100-200)%`, adds `Grants Level 15 Battlemage's Cry Skill` (variant 5 only), and keeps unscoped `Battlemage`.
- No changes to auto-generated `ModCache.lua`.
- No unrelated files modified.

### Link to a build that showcases this PR:

N/A — data-only unique definition update.

### Before screenshot:

N/A

### After screenshot:

N/A

### Evidence note

Updated ranges and the Battlemage's Cry grant were verified against current in-game **Advanced Copy** output on dropped items (Augyre, Eber's Unification, Martyr of Innocence). This is live client item text, not an official GGG data export.