### PR TITLE
Update current unique item data

### DIFF
--- a/src/Data/ModCache.lua
+++ b/src/Data/ModCache.lua
@@ -1086,7 +1086,6 @@ c["+22 to maximum Mana"]={{[1]={flags=0,keywordFlags=0,name="Mana",type="BASE",v
 c["+22% Chance to Block Attack Damage"]={{[1]={flags=0,keywordFlags=0,name="BlockChance",type="BASE",value=22}},nil}
 c["+22% Chance to Block Spell Damage"]={{[1]={flags=0,keywordFlags=0,name="SpellBlockChance",type="BASE",value=22}},nil}
 c["+22% to Chaos Damage over Time Multiplier"]={{[1]={flags=0,keywordFlags=0,name="ChaosDotMultiplier",type="BASE",value=22}},nil}
-c["+22% to Chaos Resistance"]={{[1]={flags=0,keywordFlags=0,name="ChaosResist",type="BASE",value=22}},nil}
 c["+22% to Cold Damage over Time Multiplier"]={{[1]={flags=0,keywordFlags=0,name="ColdDotMultiplier",type="BASE",value=22}},nil}
 c["+22% to Cold Resistance"]={{[1]={flags=0,keywordFlags=0,name="ColdResist",type="BASE",value=22}},nil}
 c["+22% to Critical Strike Multiplier with Bows"]={{[1]={flags=131076,keywordFlags=0,name="CritMultiplier",type="BASE",value=22}},nil}
@@ -5001,8 +5000,8 @@ c["14% increased Elemental Damage"]={{[1]={flags=0,keywordFlags=0,name="Elementa
 c["14% increased Elemental Weakness Curse Effect"]={{[1]={[1]={includeTransfigured=true,skillName="Elemental Weakness",type="SkillName"},flags=0,keywordFlags=0,name="CurseEffect",type="INC",value=14}},nil}
 c["14% increased Endurance Charge Duration"]={{[1]={flags=0,keywordFlags=0,name="EnduranceChargesDuration",type="INC",value=14}},nil}
 c["14% increased Energy Shield Recharge Rate"]={{[1]={flags=0,keywordFlags=0,name="EnergyShieldRecharge",type="INC",value=14}},nil}
-end)();(function()
 c["14% increased Energy Shield Recovery rate"]={{[1]={flags=0,keywordFlags=0,name="EnergyShieldRecoveryRate",type="INC",value=14}},nil}
+end)();(function()
 c["14% increased Enfeeble Curse Effect"]={{[1]={[1]={includeTransfigured=true,skillName="Enfeeble",type="SkillName"},flags=0,keywordFlags=0,name="CurseEffect",type="INC",value=14}},nil}
 c["14% increased Evasion Rating"]={{[1]={flags=0,keywordFlags=0,name="Evasion",type="INC",value=14}},nil}
 c["14% increased Evasion Rating and Armour"]={{[1]={flags=0,keywordFlags=0,name="ArmourAndEvasion",type="INC",value=14}},nil}
@@ -7362,7 +7361,6 @@ c["25% increased Attack Speed"]={{[1]={flags=1,keywordFlags=0,name="Speed",type=
 c["25% increased Attack Speed if you haven't Cast Dash recently"]={{[1]={[1]={neg=true,type="Condition",var="CastDashRecently"},flags=1,keywordFlags=0,name="Speed",type="INC",value=25}},nil}
 c["25% increased Attack Speed if you haven't gained a Frenzy Charge Recently"]={{[1]={[1]={neg=true,type="Condition",var="GainedFrenzyChargeRecently"},flags=1,keywordFlags=0,name="Speed",type="INC",value=25}},nil}
 c["25% increased Attack Speed if you've Killed Recently"]={{[1]={[1]={type="Condition",var="KilledRecently"},flags=1,keywordFlags=0,name="Speed",type="INC",value=25}},nil}
-c["25% increased Attack Speed if you've changed Stance Recently"]={{[1]={[1]={type="Condition",var="ChangedStanceRecently"},flags=1,keywordFlags=0,name="Speed",type="INC",value=25}},nil}
 c["25% increased Attack Speed when on Low Life"]={{[1]={[1]={type="Condition",var="LowLife"},flags=1,keywordFlags=0,name="Speed",type="INC",value=25}},nil}
 c["25% increased Attack and Cast Speed while at maximum Fortification"]={{[1]={[1]={type="Condition",var="HaveMaximumFortification"},flags=0,keywordFlags=0,name="Speed",type="INC",value=25}},nil}
 c["25% increased Battlemage's Cry Buff Effect"]={{[1]={[1]={includeTransfigured=true,skillName="Battlemage's Cry",type="SkillName"},flags=0,keywordFlags=0,name="BuffEffect",type="INC",value=25}},nil}
@@ -10003,9 +10001,9 @@ c["5% increased Poison Duration"]={{[1]={flags=0,keywordFlags=0,name="EnemyPoiso
 c["5% increased Poison Duration for each Poison you have inflicted Recently, up"]={{[1]={[1]={type="Multiplier",var="PoisonAppliedRecently"},flags=0,keywordFlags=0,name="EnemyPoisonDuration",type="INC",value=5}},"  , up "}
 c["5% increased Poison Duration for each Poison you have inflicted Recently, up to a maximum of 100%"]={{[1]={[1]={globalLimit=100,globalLimitKey="DurationPerPoisonRecently",type="Multiplier",var="PoisonAppliedRecently"},flags=0,keywordFlags=0,name="EnemyPoisonDuration",type="INC",value=5}},nil}
 c["5% increased Projectile Damage per Power Charge"]={{[1]={[1]={type="Multiplier",var="PowerCharge"},flags=1024,keywordFlags=0,name="Damage",type="INC",value=5}},nil}
-end)();(function()
 c["5% increased Projectile Speed"]={{[1]={flags=0,keywordFlags=0,name="ProjectileSpeed",type="INC",value=5}},nil}
 c["5% increased Projectile Speed per Frenzy Charge"]={{[1]={[1]={type="Multiplier",var="FrenzyCharge"},flags=0,keywordFlags=0,name="ProjectileSpeed",type="INC",value=5}},nil}
+end)();(function()
 c["5% increased Quantity of Gold Dropped by Slain Enemies"]={{}," Quantity of Gold Dropped by Slain Enemies "}
 c["5% increased Quantity of Items found"]={{[1]={flags=0,keywordFlags=0,name="LootQuantity",type="INC",value=5}},nil}
 c["5% increased Rarity of Items found"]={{[1]={flags=0,keywordFlags=0,name="LootRarity",type="INC",value=5}},nil}
@@ -15005,9 +15003,9 @@ c["Damage of Enemies Hitting you is Unlucky"]={nil,"Damage of Enemies Hitting yo
 c["Damage of Enemies Hitting you is Unlucky Damage with Hits is Unlucky"]={nil,"Damage of Enemies Hitting you is Unlucky Damage with Hits is Unlucky "}
 c["Damage of Enemies Hitting you is Unlucky while you are Cursed with Vulnerability"]={nil,"Damage of Enemies Hitting you is Unlucky while you are Cursed with Vulnerability "}
 c["Damage of Enemies Hitting you is Unlucky while you are Cursed with Vulnerability You count as on Full Life while you are Cursed with Vulnerability"]={nil,"Damage of Enemies Hitting you is Unlucky while you are Cursed with Vulnerability You count as on Full Life while you are Cursed with Vulnerability "}
-end)();(function()
 c["Damage of Enemies Hitting you is Unlucky while you are on Full Life"]={nil,"Damage of Enemies Hitting you is Unlucky while you are on Full Life "}
 c["Damage of Enemies Hitting you is Unlucky while you are on Low Life"]={nil,"Damage of Enemies Hitting you is Unlucky while you are on Low Life "}
+end)();(function()
 c["Damage of Enemies Hitting you is Unlucky while you have a Magic Ring Equipped"]={nil,"Damage of Enemies Hitting you is Unlucky while you have a Magic Ring Equipped "}
 c["Damage of Enemies Hitting you is Unlucky while you have a Magic Ring Equipped You are Hexproof if you have a Magic Ring in right slot"]={nil,"Damage of Enemies Hitting you is Unlucky while you have a Magic Ring Equipped You are Hexproof if you have a Magic Ring in right slot "}
 c["Damage of Hits against you is Lucky"]={nil,"Damage of Hits  is Lucky "}
@@ -17881,7 +17879,6 @@ c["Minions deal 3 to 7 additional Physical Damage"]={{[1]={flags=0,keywordFlags=
 c["Minions deal 3% increased Damage"]={{[1]={flags=0,keywordFlags=0,name="MinionModifier",type="LIST",value={mod={flags=0,keywordFlags=0,name="Damage",type="INC",value=3}}}},nil}
 c["Minions deal 30 to 58 additional Chaos Damage"]={{[1]={flags=0,keywordFlags=0,name="MinionModifier",type="LIST",value={mod={flags=0,keywordFlags=0,name="ChaosMin",type="BASE",value=30}}},[2]={flags=0,keywordFlags=0,name="MinionModifier",type="LIST",value={mod={flags=0,keywordFlags=0,name="ChaosMax",type="BASE",value=58}}}},nil}
 c["Minions deal 30 to 58 additional Cold Damage"]={{[1]={flags=0,keywordFlags=0,name="MinionModifier",type="LIST",value={mod={flags=0,keywordFlags=0,name="ColdMin",type="BASE",value=30}}},[2]={flags=0,keywordFlags=0,name="MinionModifier",type="LIST",value={mod={flags=0,keywordFlags=0,name="ColdMax",type="BASE",value=58}}}},nil}
-c["Minions deal 30 to 63 additional Cold Damage"]={{[1]={flags=0,keywordFlags=0,name="MinionModifier",type="LIST",value={mod={flags=0,keywordFlags=0,name="ColdMin",type="BASE",value=30}}},[2]={flags=0,keywordFlags=0,name="MinionModifier",type="LIST",value={mod={flags=0,keywordFlags=0,name="ColdMax",type="BASE",value=63}}}},nil}
 c["Minions deal 30% increased Damage"]={{[1]={flags=0,keywordFlags=0,name="MinionModifier",type="LIST",value={mod={flags=0,keywordFlags=0,name="Damage",type="INC",value=30}}}},nil}
 c["Minions deal 30% increased Damage if you've used a Minion Skill Recently"]={{[1]={[1]={type="Condition",var="UsedMinionSkillRecently"},flags=0,keywordFlags=0,name="MinionModifier",type="LIST",value={mod={flags=0,keywordFlags=0,name="Damage",type="INC",value=30}}}},nil}
 c["Minions deal 31% increased Damage"]={{[1]={flags=0,keywordFlags=0,name="MinionModifier",type="LIST",value={mod={flags=0,keywordFlags=0,name="Damage",type="INC",value=31}}}},nil}
@@ -18423,6 +18420,8 @@ c["Non-Aura Curses you inflict are not removed from Dying Enemies"]={nil,"Non-Au
 c["Non-Aura Curses you inflict are not removed from Dying Enemies Enemies near corpses affected by your Curses are Blinded"]={nil,"Non-Aura Curses you inflict are not removed from Dying Enemies Enemies near corpses affected by your Curses are Blinded "}
 c["Non-Aura Hexes expire upon reaching 200% of base Effect"]={nil,"Non-Aura Hexes expire upon reaching 200% of base Effect "}
 c["Non-Aura Hexes expire upon reaching 200% of base Effect Non-Aura Hexes gain 20% increased Effect per second"]={{[1]={[1]={actor="enemy",limit=200,limitTotal=true,type="Multiplier",var="CurseDurationExpired"},[2]={neg=true,skillType=39,type="SkillType"},[3]={skillType=97,type="SkillType"},flags=0,keywordFlags=0,name="CurseEffect",type="INC",value=20}},nil}
+c["Non-Aura Hexes expire upon reaching 220% of base Effect"]={nil,"Non-Aura Hexes expire upon reaching 220% of base Effect "}
+c["Non-Aura Hexes expire upon reaching 220% of base Effect Non-Aura Hexes gain 20% increased Effect per second"]={{[1]={[1]={actor="enemy",limit=220,limitTotal=true,type="Multiplier",var="CurseDurationExpired"},[2]={neg=true,skillType=39,type="SkillType"},[3]={skillType=97,type="SkillType"},flags=0,keywordFlags=0,name="CurseEffect",type="INC",value=20}},nil}
 c["Non-Aura Hexes gain 20% increased Effect per second"]={nil,"Non-Aura Hexes gain 20% increased Effect per second "}
 c["Non-Aura Vaal Skills require 20% reduced Souls Per Use"]={{[1]={[1]={neg=true,skillType=39,type="SkillType"},flags=0,keywordFlags=512,name="SoulCost",type="INC",value=-20}},nil}
 c["Non-Aura Vaal Skills require 25% reduced Souls Per Use during Effect"]={{[1]={[1]={neg=true,skillType=39,type="SkillType"},[2]={type="Condition",var="UsingFlask"},flags=0,keywordFlags=512,name="SoulCost",type="INC",value=-25}},nil}
@@ -20007,8 +20006,8 @@ c["Skills Socketed in your Boots are Supported by level 20 High-Impact Mine"]={{
 c["Skills Socketed in your Boots are Supported by level 20 Hypothermia"]={{[1]={[1]={slotName="Boots",type="SocketedIn"},flags=0,keywordFlags=0,name="ExtraSupport",type="LIST",value={appliesToGrantedSkills=true,level=20,skillId="SupportHypothermia"}}},nil}
 c["Skills Socketed in your Boots are Supported by level 20 Ice Bite"]={{[1]={[1]={slotName="Boots",type="SocketedIn"},flags=0,keywordFlags=0,name="ExtraSupport",type="LIST",value={appliesToGrantedSkills=true,level=20,skillId="SupportIceBite"}}},nil}
 c["Skills Socketed in your Boots are Supported by level 20 Ignite Proliferation"]={{[1]={[1]={slotName="Boots",type="SocketedIn"},flags=0,keywordFlags=0,name="ExtraSupport",type="LIST",value={appliesToGrantedSkills=true,level=20,skillId="SupportIgniteProliferation"}}},nil}
-end)();(function()
 c["Skills Socketed in your Boots are Supported by level 20 Immolate"]={{[1]={[1]={slotName="Boots",type="SocketedIn"},flags=0,keywordFlags=0,name="ExtraSupport",type="LIST",value={appliesToGrantedSkills=true,level=20,skillId="SupportImmolate"}}},nil}
+end)();(function()
 c["Skills Socketed in your Boots are Supported by level 20 Impale"]={{[1]={[1]={slotName="Boots",type="SocketedIn"},flags=0,keywordFlags=0,name="ExtraSupport",type="LIST",value={appliesToGrantedSkills=true,level=20,skillId="SupportImpale"}}},nil}
 c["Skills Socketed in your Boots are Supported by level 20 Increased Area of Effect"]={{[1]={[1]={slotName="Boots",type="SocketedIn"},flags=0,keywordFlags=0,name="ExtraSupport",type="LIST",value={appliesToGrantedSkills=true,level=20,skillId="SupportIncreasedAreaOfEffect"}}},nil}
 c["Skills Socketed in your Boots are Supported by level 20 Increased Critical Damage"]={{[1]={[1]={slotName="Boots",type="SocketedIn"},flags=0,keywordFlags=0,name="ExtraSupport",type="LIST",value={appliesToGrantedSkills=true,level=20,skillId="SupportIncreasedCriticalDamage"}}},nil}

--- a/src/Data/Uniques/amulet.lua
+++ b/src/Data/Uniques/amulet.lua
@@ -33,7 +33,7 @@ Amber Amulet
 LevelReq: 49
 Implicits: 1
 {tags:attribute}+(20-30) to Strength
-{tags:critical}(40-50)% increased Global Critical Strike Chance
+{tags:critical}(30-50)% increased Global Critical Strike Chance
 {tags:resource}+(50-70) to maximum Life
 {tags:resistance}+(17-29)% to Chaos Resistance
 Every 10 seconds:
@@ -693,7 +693,7 @@ Implicits: 1
 {tags:resource}Regenerate (2-4) Life per second
 {tags:resource}Regenerate (3-5) Mana per second
 {tags:resource}(30-40)% increased Life Recovery from Flasks
-{tags:resource}(15-30)% increased Mana Recovery from Flasks
+{tags:resource}(20-30)% increased Mana Recovery from Flasks
 {tags:resource}Life Flasks used while on Low Life apply Recovery Instantly
 {tags:resource}Mana Flasks used while on Low Mana apply Recovery Instantly
 ]],[[
@@ -1059,7 +1059,7 @@ Implicits: 1
 {variant:4}Minions convert 50% of Physical Damage to Cold Damage
 {variant:1,2}Minions deal (10-15)% increased Damage
 {variant:3}{tags:elemental_damage}Minions deal (5-9) to (11-15) additional Cold Damage
-{variant:4}{tags:elemental_damage}Minions deal (25-35) to (60-65) additional Cold Damage
+{variant:4}{tags:elemental_damage}Minions deal (25-35) to (50-65) additional Cold Damage
 {variant:4}Minions deal no Non-Cold Damage
 {variant:2,3}{tags:resource}(10-15)% reduced Mana Cost of Minion Skills
 ]],[[

--- a/src/Data/Uniques/belt.lua
+++ b/src/Data/Uniques/belt.lua
@@ -724,7 +724,7 @@ LevelReq: 44
 Implicits: 1
 {tags:physical_damage}(12-24)% increased Global Physical Damage
 {tags:resource}+(60-80) to maximum Life
-{tags:resistance}+(25-40)% to Cold Resistance
+{tags:resistance}+(30-40)% to Cold Resistance
 {tags:resource,attack}0.4% of Physical Attack Damage Leeched as Life
 60% increased Flask Effect Duration
 30% reduced Flask Charges gained during any Flask Effect

--- a/src/Data/Uniques/body.lua
+++ b/src/Data/Uniques/body.lua
@@ -995,7 +995,8 @@ Implicits: 0
 (50-75)% increased Armour and Energy Shield
 {variant:1,2}+(70-80) to maximum Energy Shield
 {variant:3}+(30-40) to maximum Energy Shield
-+(50-70) to maximum Life
+{variant:1,2}+(50-70) to maximum Life
+{variant:3}+(60-70) to maximum Life
 +(14-18)% to all Elemental Resistances
 {variant:1}+1 maximum Energy Shield per 5 Strength
 {variant:2,3}+2 maximum Energy Shield per 5 Strength

--- a/src/Data/Uniques/dagger.lua
+++ b/src/Data/Uniques/dagger.lua
@@ -7,7 +7,7 @@ Arakaali's Fang
 Fiend Dagger
 Requires Level 53, 58 Dex, 123 Int
 Implicits: 1
-40% increased Global Critical Strike Chance
+(50-55)% increased Global Critical Strike Chance
 100% chance to Trigger Level 1 Raise Spiders on Kill
 (170-200)% increased Physical Damage
 Adds (8-13) to (20-30) Physical Damage
@@ -22,7 +22,8 @@ Variant: Pre 3.28.0
 Variant: Current
 Requires Level 65, 81 Dex, 117 Int
 Implicits: 1
-30% increased Global Critical Strike Chance
+{variant:1,2,3}30% increased Global Critical Strike Chance
+{variant:4}(40-45)% increased Global Critical Strike Chance
 {variant:1,2}30% increased Damage over Time
 {variant:1,2}Adds (50-60) to (120-140) Physical Damage
 {variant:3,4}Adds (140-155) to (210-235) Physical Damage
@@ -30,7 +31,7 @@ Implicits: 1
 {variant:1}+(10-15)% to Global Critical Strike Multiplier
 {variant:2,3,4}+(15-25)% to Global Critical Strike Multiplier
 {variant:3}+(8-12)% to Chaos Resistance
-{variant:4}+(17-27)% to Chaos Resistance
+{variant:4}+(17-29)% to Chaos Resistance
 {variant:1,2,3,4}On Killing a Poisoned Enemy, Enemies within 3 metres are Poisoned 
 {variant:3,4}and nearby Allies Regenerate 400 Life per second
 ]],[[
@@ -40,7 +41,8 @@ Variant: Pre 2.6.0
 Variant: Current
 Requires Level 15, 30 Dex, 30 Int
 Implicits: 1
-30% increased Global Critical Strike Chance
+{variant:1}30% increased Global Critical Strike Chance
+{variant:2}(40-45)% increased Global Critical Strike Chance
 +20 to Dexterity
 (20-40)% increased Physical Damage
 Adds (3-6) to (9-13) Physical Damage
@@ -55,7 +57,7 @@ League: Heist
 Source: Steal from a unique{Curio Display} during a Grand Heist
 Requires Level 15, 30 Dex, 30 Int
 Implicits: 1
-30% increased Global Critical Strike Chance
+(40-45)% increased Global Critical Strike Chance
 +20 to Strength
 (20-40)% increased Physical Damage
 Adds (3-6) to (9-13) Physical Damage
@@ -67,7 +69,7 @@ Cold Iron Point
 Ezomyte Dagger
 Requires Level 62, 95 Dex, 131 Int
 Implicits: 1
-30% increased Global Critical Strike Chance
+(40-45)% increased Global Critical Strike Chance
 +3 to Level of all Physical Spell Skill Gems
 Deal no Elemental Damage
 ]],[[
@@ -77,7 +79,7 @@ League: Heist
 Source: Steal from a unique{Curio Display} during a Grand Heist
 Requires Level 62, 95 Dex, 131 Int
 Implicits: 1
-30% increased Global Critical Strike Chance
+(40-45)% increased Global Critical Strike Chance
 +3 to Level of all Cold Spell Skill Gems
 Deal no Cold Damage
 ]],[[
@@ -88,7 +90,8 @@ Variant: Pre 3.0.0
 Variant: Current
 Requires Level 53, 58 Dex, 123 Int
 Implicits: 1
-40% increased Global Critical Strike Chance
+{variant:1,2}40% increased Global Critical Strike Chance
+{variant:3}(50-55)% increased Global Critical Strike Chance
 +(20-40) to Intelligence
 (40-60)% increased Fire Damage
 +1 to Level of all Fire Spell Skill Gems
@@ -105,7 +108,8 @@ Variant: Pre 3.20.0
 Variant: Current
 Requires Level 66, 95 Dex, 131 Int
 Implicits: 1
-30% increased Global Critical Strike Chance
+{variant:1,2}30% increased Global Critical Strike Chance
+{variant:3}(40-45)% increased Global Critical Strike Chance
 {variant:1,2}(50-70)% increased Spell Damage
 {variant:3}(150-200)% increased Spell Damage
 {variant:1}Gain 10 Life per Enemy Killed
@@ -125,7 +129,7 @@ Goredrill
 Skinning Knife
 Requires Level 5, 16 Dex
 Implicits: 1
-30% increased Global Critical Strike Chance
+(40-45)% increased Global Critical Strike Chance
 +(10-15) to Dexterity
 (50-70)% increased Physical Damage
 Adds (1-2) to (3-5) Physical Damage
@@ -152,7 +156,7 @@ Ambusher
 League: Ritual
 Requires Level 60, 113 Dex, 113 Int
 Implicits: 1
-30% increased Global Critical Strike Chance
+(40-45)% increased Global Critical Strike Chance
 (200-250)% increased Physical Damage
 (20-25)% increased Attack Speed if you haven't gained a Frenzy Charge Recently
 (60-80)% increased Critical Strike Chance if you haven't gained a Power Charge Recently
@@ -167,7 +171,8 @@ Variant: Pre 3.19.0
 Variant: Current
 Requires Level 50, 71 Dex, 102 Int
 Implicits: 1
-30% increased Global Critical Strike Chance
+{variant:1,2}30% increased Global Critical Strike Chance
+{variant:3}(40-45)% increased Global Critical Strike Chance
 {variant:1}(40-50)% increased Spell Damage
 {variant:2,3}(60-70)% increased Spell Damage
 {variant:1,2}+50 to maximum Energy Shield
@@ -185,7 +190,8 @@ League: Heist
 Source: Steal from a unique{Curio Display} during a Grand Heist
 Requires Level 50, 71 Dex, 102 Int
 Implicits: 1
-30% increased Global Critical Strike Chance
+{variant:1}30% increased Global Critical Strike Chance
+{variant:2}(40-45)% increased Global Critical Strike Chance
 (60-70)% increased Spell Damage
 {variant:1}+50 to maximum Energy Shield
 {variant:1}10% faster start of Energy Shield Recharge
@@ -201,7 +207,7 @@ League: Heist
 Source: Steal from a unique{Curio Display} during a Grand Heist
 Requires Level 60, 113 Dex, 113 Int
 Implicits: 1
-30% increased Global Critical Strike Chance
+(40-45)% increased Global Critical Strike Chance
 Trigger Level 20 Unseen Strike every 0.5 seconds while Phasing
 +(20-40) to Dexterity
 (230-260)% increased Physical Damage
@@ -215,7 +221,8 @@ Variant: Pre 3.26.0
 Variant: Current
 Requires Level 64, 76 Dex, 149 Int
 Implicits: 1
-50% increased Global Critical Strike Chance
+{variant:1,2,3}50% increased Global Critical Strike Chance
+{variant:4}(60-65)% increased Global Critical Strike Chance
 +5% Chance to Block Attack Damage while Dual Wielding
 {variant:1}(180-210)% increased Physical Damage
 {variant:2}(210-240)% increased Physical Damage
@@ -234,7 +241,7 @@ Mightflay
 Flaying Knife
 Requires Level 35, 73 Dex, 51 Int
 Implicits: 1
-30% increased Global Critical Strike Chance
+(40-45)% increased Global Critical Strike Chance
 +25 to Strength
 (80-100)% increased Physical Damage
 Adds 12 to 24 Physical Damage
@@ -244,7 +251,7 @@ Taproot
 Ambusher
 Requires Level 60, 113 Dex, 113 Int
 Implicits: 1
-30% increased Global Critical Strike Chance
+(40-45)% increased Global Critical Strike Chance
 (180-200)% increased Physical Damage
 (10-15)% increased Attack Speed
 (15-20)% increased Poison Duration
@@ -328,7 +335,8 @@ Variant: Pre 3.0.0
 Variant: Current
 Requires Level 44, 63 Dex, 90 Int
 Implicits: 1
-30% increased Global Critical Strike Chance
+{variant:1}30% increased Global Critical Strike Chance
+{variant:2}(40-45)% increased Global Critical Strike Chance
 {variant:1}Adds (15-25) to (35-45) Physical Damage
 {variant:2}Adds (35-40) to (55-60) Physical Damage
 (22-30)% increased Critical Strike Chance
@@ -342,7 +350,7 @@ Demon Dagger
 Source: Drops from unique{Uber Incarnation of Neglect} in normal{Moment of Loneliness}
 Requires Level 68, 76 Dex, 149 Int
 Implicits: 1
-40% increased Global Critical Strike Chance
+(50-55)% increased Global Critical Strike Chance
 Trigger a Socketed Spell when you Block, with a 0.25 second Cooldown
 +(30-45)% Chance to Block Spell Damage while in Off Hand
 (100-150)% increased Spell Damage

--- a/src/Data/Uniques/gloves.lua
+++ b/src/Data/Uniques/gloves.lua
@@ -34,7 +34,7 @@ League: Heist
 Source: Steal from a unique{Curio Display} during a Grand Heist
 Requires Level 63, 100 Str
 +(60-80) to Intelligence
-(25-35)% increased Global Critical Strike Chance
+(40-60)% increased Global Critical Strike Chance
 (200-220)% increased Armour
 +(60-75) to maximum Life
 You have Perfect Agony if you've dealt a Critical Strike recently
@@ -55,7 +55,7 @@ The Celestial Brace
 Goliath Gauntlets
 Source: Drops from unique{The Searing Exarch} (Uber)
 Requires Level: 53, 77 Str
-(80-120)% increased Armour
+(100-150)% increased Armour
 1% increased Attack Speed per Fortification
 +(1-10) to maximum Fortification
 Melee Hits from Strike Skills Fortify
@@ -492,7 +492,7 @@ Adds 1 to 13 Lightning Damage to Attacks
 {variant:1}(18-24)% increased Quantity of Items found
 {variant:2}(12-16)% increased Quantity of Items found
 {variant:3}(5-10)% increased Quantity of Items found
-{variant:4}(10-15)% increased Rarity of Items found
+{variant:4}(5-15)% increased Rarity of Items found
 ]],[[
 Voidbringer
 Conjurer Gloves

--- a/src/Data/Uniques/quiver.lua
+++ b/src/Data/Uniques/quiver.lua
@@ -277,7 +277,8 @@ Regenerate (150-200) Life per Second while in Blood Stance
 (40-60)% increased Projectile Damage while in Blood Stance
 +(700-1000) to Evasion Rating while in Sand Stance
 (20-30)% increased Area of Effect while in Sand Stance
-(20-30)% increased Attack Speed if you've changed Stance Recently
+{variant:1}(20-30)% increased Attack Speed if you've changed Stance Recently
+{variant:2}(25-30)% increased Attack Speed if you've changed Stance Recently
 ]],[[
 Skirmish
 Two-Point Arrow Quiver

--- a/src/Data/Uniques/ring.lua
+++ b/src/Data/Uniques/ring.lua
@@ -547,7 +547,7 @@ Implicits: 1
 {tags:resource}+(20-30) to maximum Mana
 {tags:attribute}+(20-40) to Intelligence
 {tags:caster,speed}Curse Skills have (8-12)% increased Cast Speed
-Non-Aura Hexes expire upon reaching 200% of base Effect
+Non-Aura Hexes expire upon reaching (180-220)% of base Effect
 Non-Aura Hexes gain 20% increased Effect per second
 ]],[[
 Gifts from Above

--- a/src/Data/Uniques/staff.lua
+++ b/src/Data/Uniques/staff.lua
@@ -147,7 +147,8 @@ Implicits: 2
 {variant:1}+18% Chance to Block Attack Damage
 {variant:2}+20% Chance to Block Spell Damage
 +12% Chance to Block Attack Damage while wielding a Staff
-(100-200)% increased Fire Damage
+{variant:1}(100-200)% increased Fire Damage
+{variant:2}100% increased Fire Damage
 (5-10)% increased Attack Speed
 Curse Enemies with Flammability on Block
 Reflects (22-44) Fire Damage to Attackers on Block
@@ -248,7 +249,7 @@ Gain (10-20)% of Elemental Damage as Extra Chaos Damage
 +1% to Critical Strike Multiplier per 1% Chance to Block Attack Damage
 +60% to Critical Strike Multiplier if you've dealt a Non-Critical Strike Recently
 {variant:1,2}120% increased Spell Damage if you've dealt a Critical Strike Recently
-{variant:3,4}(120-150)% increased Spell Damage if you've dealt a Critical Strike Recently
+{variant:3,4,5}(120-150)% increased Spell Damage if you've dealt a Critical Strike Recently
 ]],[[
 Replica Duskdawn
 Maelström Staff

--- a/src/Data/Uniques/wand.lua
+++ b/src/Data/Uniques/wand.lua
@@ -62,7 +62,7 @@ Implicits: 3
 {variant:1}Adds (10-14) to (18-22) Fire Damage
 {variant:3,4,5}Adds (20-24) to (38-46) Fire Damage
 {variant:1,2}Adds (4-6) to (7-9) Fire Damage to Spells
-{variant:3,4,5}Adds (20-24) to (36-46) Fire Damage to Spells
+{variant:3,4,5}Adds (20-24) to (38-46) Fire Damage to Spells
 {variant:1}(40-50)% increased Burning Damage
 {variant:2}(20-30)% increased Burning Damage
 {variant:1,2}(16-22)% chance to Ignite


### PR DESCRIPTION
### Description of the problem being solved:

Following up on #10321 , there are more uniques that need fixing to match current in game values.

### Steps taken to verify a working solution:
- Used PyPoe + `dat-schema` to generate list of uniques where their modifiers in the game data did not patch PoB
- Manually verified every item against in game modifier ranges/values
- Excluded the following items from the PR because their data mined values are not accurate:
- Volkuur’s Guidance - 50-70 --> 60-70 life in datamine
- Death Rush  - Loses Life on kill and +2s adrenaline in datamine
- Blightwell - Loses flask duration in datamine
- Lioneye’s Remorse - 20% --> 40% Stun and Block Recovery in datamine

### Link to a build that showcases this PR:
N/A

### Before screenshot:
N/A

### After screenshot:
N/A