### PR TITLE
Fix outdated unique modifier data

### DIFF
--- a/src/Data/Uniques/amulet.lua
+++ b/src/Data/Uniques/amulet.lua
@@ -33,7 +33,7 @@ Amber Amulet
 LevelReq: 49
 Implicits: 1
 {tags:attribute}+(20-30) to Strength
-{tags:critical}(40-50)% increased Global Critical Strike Chance
+{tags:critical}(30-50)% increased Global Critical Strike Chance
 {tags:resource}+(50-70) to maximum Life
 {tags:resistance}+(17-29)% to Chaos Resistance
 Every 10 seconds:
@@ -693,7 +693,7 @@ Implicits: 1
 {tags:resource}Regenerate (2-4) Life per second
 {tags:resource}Regenerate (3-5) Mana per second
 {tags:resource}(30-40)% increased Life Recovery from Flasks
-{tags:resource}(15-30)% increased Mana Recovery from Flasks
+{tags:resource}(20-30)% increased Mana Recovery from Flasks
 {tags:resource}Life Flasks used while on Low Life apply Recovery Instantly
 {tags:resource}Mana Flasks used while on Low Mana apply Recovery Instantly
 ]],[[
@@ -1059,7 +1059,7 @@ Implicits: 1
 {variant:4}Minions convert 50% of Physical Damage to Cold Damage
 {variant:1,2}Minions deal (10-15)% increased Damage
 {variant:3}{tags:elemental_damage}Minions deal (5-9) to (11-15) additional Cold Damage
-{variant:4}{tags:elemental_damage}Minions deal (25-35) to (60-65) additional Cold Damage
+{variant:4}{tags:elemental_damage}Minions deal (25-35) to (50-65) additional Cold Damage
 {variant:4}Minions deal no Non-Cold Damage
 {variant:2,3}{tags:resource}(10-15)% reduced Mana Cost of Minion Skills
 ]],[[

--- a/src/Data/Uniques/belt.lua
+++ b/src/Data/Uniques/belt.lua
@@ -724,7 +724,7 @@ LevelReq: 44
 Implicits: 1
 {tags:physical_damage}(12-24)% increased Global Physical Damage
 {tags:resource}+(60-80) to maximum Life
-{tags:resistance}+(25-40)% to Cold Resistance
+{tags:resistance}+(30-40)% to Cold Resistance
 {tags:resource,attack}0.4% of Physical Attack Damage Leeched as Life
 60% increased Flask Effect Duration
 30% reduced Flask Charges gained during any Flask Effect

--- a/src/Data/Uniques/body.lua
+++ b/src/Data/Uniques/body.lua
@@ -995,7 +995,7 @@ Implicits: 0
 (50-75)% increased Armour and Energy Shield
 {variant:1,2}+(70-80) to maximum Energy Shield
 {variant:3}+(30-40) to maximum Energy Shield
-+(50-70) to maximum Life
++(60-70) to maximum Life
 +(14-18)% to all Elemental Resistances
 {variant:1}+1 maximum Energy Shield per 5 Strength
 {variant:2,3}+2 maximum Energy Shield per 5 Strength

--- a/src/Data/Uniques/dagger.lua
+++ b/src/Data/Uniques/dagger.lua
@@ -5,9 +5,12 @@ return {
 [[
 Arakaali's Fang
 Fiend Dagger
+Variant: Pre 3.29.0
+Variant: Current
 Requires Level 53, 58 Dex, 123 Int
-Implicits: 1
-40% increased Global Critical Strike Chance
+Implicits: 2
+{variant:1}40% increased Global Critical Strike Chance
+{variant:2}(50-55)% increased Global Critical Strike Chance
 100% chance to Trigger Level 1 Raise Spiders on Kill
 (170-200)% increased Physical Damage
 Adds (8-13) to (20-30) Physical Damage
@@ -21,8 +24,9 @@ Variant: Pre 3.20.0
 Variant: Pre 3.28.0
 Variant: Current
 Requires Level 65, 81 Dex, 117 Int
-Implicits: 1
-30% increased Global Critical Strike Chance
+Implicits: 2
+{variant:1,2,3}30% increased Global Critical Strike Chance
+{variant:4}(40-45)% increased Global Critical Strike Chance
 {variant:1,2}30% increased Damage over Time
 {variant:1,2}Adds (50-60) to (120-140) Physical Damage
 {variant:3,4}Adds (140-155) to (210-235) Physical Damage
@@ -30,7 +34,7 @@ Implicits: 1
 {variant:1}+(10-15)% to Global Critical Strike Multiplier
 {variant:2,3,4}+(15-25)% to Global Critical Strike Multiplier
 {variant:3}+(8-12)% to Chaos Resistance
-{variant:4}+(17-27)% to Chaos Resistance
+{variant:4}+(17-29)% to Chaos Resistance
 {variant:1,2,3,4}On Killing a Poisoned Enemy, Enemies within 3 metres are Poisoned 
 {variant:3,4}and nearby Allies Regenerate 400 Life per second
 ]],[[
@@ -39,8 +43,9 @@ Stiletto
 Variant: Pre 2.6.0
 Variant: Current
 Requires Level 15, 30 Dex, 30 Int
-Implicits: 1
-30% increased Global Critical Strike Chance
+Implicits: 2
+{variant:1}30% increased Global Critical Strike Chance
+{variant:2}(40-45)% increased Global Critical Strike Chance
 +20 to Dexterity
 (20-40)% increased Physical Damage
 Adds (3-6) to (9-13) Physical Damage
@@ -53,9 +58,12 @@ Replica Bloodplay
 Stiletto
 League: Heist
 Source: Steal from a unique{Curio Display} during a Grand Heist
+Variant: Pre 3.29.0
+Variant: Current
 Requires Level 15, 30 Dex, 30 Int
-Implicits: 1
-30% increased Global Critical Strike Chance
+Implicits: 2
+{variant:1}30% increased Global Critical Strike Chance
+{variant:2}(40-45)% increased Global Critical Strike Chance
 +20 to Strength
 (20-40)% increased Physical Damage
 Adds (3-6) to (9-13) Physical Damage
@@ -65,9 +73,12 @@ Extra gore
 ]],[[
 Cold Iron Point
 Ezomyte Dagger
+Variant: Pre 3.29.0
+Variant: Current
 Requires Level 62, 95 Dex, 131 Int
-Implicits: 1
-30% increased Global Critical Strike Chance
+Implicits: 2
+{variant:1}30% increased Global Critical Strike Chance
+{variant:2}(40-45)% increased Global Critical Strike Chance
 +3 to Level of all Physical Spell Skill Gems
 Deal no Elemental Damage
 ]],[[
@@ -75,9 +86,12 @@ Replica Cold Iron Point
 Ezomyte Dagger
 League: Heist
 Source: Steal from a unique{Curio Display} during a Grand Heist
+Variant: Pre 3.29.0
+Variant: Current
 Requires Level 62, 95 Dex, 131 Int
-Implicits: 1
-30% increased Global Critical Strike Chance
+Implicits: 2
+{variant:1}30% increased Global Critical Strike Chance
+{variant:2}(40-45)% increased Global Critical Strike Chance
 +3 to Level of all Cold Spell Skill Gems
 Deal no Cold Damage
 ]],[[
@@ -87,8 +101,9 @@ Variant: Pre 2.2.0
 Variant: Pre 3.0.0
 Variant: Current
 Requires Level 53, 58 Dex, 123 Int
-Implicits: 1
-40% increased Global Critical Strike Chance
+Implicits: 2
+{variant:1,2}40% increased Global Critical Strike Chance
+{variant:3}(50-55)% increased Global Critical Strike Chance
 +(20-40) to Intelligence
 (40-60)% increased Fire Damage
 +1 to Level of all Fire Spell Skill Gems
@@ -104,8 +119,9 @@ Variant: Pre 3.7.0
 Variant: Pre 3.20.0
 Variant: Current
 Requires Level 66, 95 Dex, 131 Int
-Implicits: 1
-30% increased Global Critical Strike Chance
+Implicits: 2
+{variant:1,2}30% increased Global Critical Strike Chance
+{variant:3}(40-45)% increased Global Critical Strike Chance
 {variant:1,2}(50-70)% increased Spell Damage
 {variant:3}(150-200)% increased Spell Damage
 {variant:1}Gain 10 Life per Enemy Killed
@@ -123,9 +139,12 @@ Implicits: 1
 ]],[[
 Goredrill
 Skinning Knife
+Variant: Pre 3.29.0
+Variant: Current
 Requires Level 5, 16 Dex
-Implicits: 1
-30% increased Global Critical Strike Chance
+Implicits: 2
+{variant:1}30% increased Global Critical Strike Chance
+{variant:2}(40-45)% increased Global Critical Strike Chance
 +(10-15) to Dexterity
 (50-70)% increased Physical Damage
 Adds (1-2) to (3-5) Physical Damage
@@ -150,9 +169,12 @@ You have Crimson Dance if you have dealt a Critical Strike Recently
 Goblinedge
 Ambusher
 League: Ritual
+Variant: Pre 3.29.0
+Variant: Current
 Requires Level 60, 113 Dex, 113 Int
-Implicits: 1
-30% increased Global Critical Strike Chance
+Implicits: 2
+{variant:1}30% increased Global Critical Strike Chance
+{variant:2}(40-45)% increased Global Critical Strike Chance
 (200-250)% increased Physical Damage
 (20-25)% increased Attack Speed if you haven't gained a Frenzy Charge Recently
 (60-80)% increased Critical Strike Chance if you haven't gained a Power Charge Recently
@@ -166,8 +188,9 @@ Variant: Pre 2.6.0
 Variant: Pre 3.19.0
 Variant: Current
 Requires Level 50, 71 Dex, 102 Int
-Implicits: 1
-30% increased Global Critical Strike Chance
+Implicits: 2
+{variant:1,2}30% increased Global Critical Strike Chance
+{variant:3}(40-45)% increased Global Critical Strike Chance
 {variant:1}(40-50)% increased Spell Damage
 {variant:2,3}(60-70)% increased Spell Damage
 {variant:1,2}+50 to maximum Energy Shield
@@ -184,8 +207,9 @@ Variant: Current
 League: Heist
 Source: Steal from a unique{Curio Display} during a Grand Heist
 Requires Level 50, 71 Dex, 102 Int
-Implicits: 1
-30% increased Global Critical Strike Chance
+Implicits: 2
+{variant:1}30% increased Global Critical Strike Chance
+{variant:2}(40-45)% increased Global Critical Strike Chance
 (60-70)% increased Spell Damage
 {variant:1}+50 to maximum Energy Shield
 {variant:1}10% faster start of Energy Shield Recharge
@@ -199,9 +223,12 @@ The Hidden Blade
 Ambusher
 League: Heist
 Source: Steal from a unique{Curio Display} during a Grand Heist
+Variant: Pre 3.29.0
+Variant: Current
 Requires Level 60, 113 Dex, 113 Int
-Implicits: 1
-30% increased Global Critical Strike Chance
+Implicits: 2
+{variant:1}30% increased Global Critical Strike Chance
+{variant:2}(40-45)% increased Global Critical Strike Chance
 Trigger Level 20 Unseen Strike every 0.5 seconds while Phasing
 +(20-40) to Dexterity
 (230-260)% increased Physical Damage
@@ -214,8 +241,9 @@ Variant: Pre 2.6.0
 Variant: Pre 3.26.0
 Variant: Current
 Requires Level 64, 76 Dex, 149 Int
-Implicits: 1
-50% increased Global Critical Strike Chance
+Implicits: 2
+{variant:1,2,3}50% increased Global Critical Strike Chance
+{variant:4}(60-65)% increased Global Critical Strike Chance
 +5% Chance to Block Attack Damage while Dual Wielding
 {variant:1}(180-210)% increased Physical Damage
 {variant:2}(210-240)% increased Physical Damage
@@ -232,9 +260,12 @@ Implicits: 1
 ]],[[
 Mightflay
 Flaying Knife
+Variant: Pre 3.29.0
+Variant: Current
 Requires Level 35, 73 Dex, 51 Int
-Implicits: 1
-30% increased Global Critical Strike Chance
+Implicits: 2
+{variant:1}30% increased Global Critical Strike Chance
+{variant:2}(40-45)% increased Global Critical Strike Chance
 +25 to Strength
 (80-100)% increased Physical Damage
 Adds 12 to 24 Physical Damage
@@ -242,9 +273,12 @@ Grants 10 Life per Enemy Hit
 ]],[[
 Taproot
 Ambusher
+Variant: Pre 3.29.0
+Variant: Current
 Requires Level 60, 113 Dex, 113 Int
-Implicits: 1
-30% increased Global Critical Strike Chance
+Implicits: 2
+{variant:1}30% increased Global Critical Strike Chance
+{variant:2}(40-45)% increased Global Critical Strike Chance
 (180-200)% increased Physical Damage
 (10-15)% increased Attack Speed
 (15-20)% increased Poison Duration
@@ -327,8 +361,9 @@ Boot Blade
 Variant: Pre 3.0.0
 Variant: Current
 Requires Level 44, 63 Dex, 90 Int
-Implicits: 1
-30% increased Global Critical Strike Chance
+Implicits: 2
+{variant:1}30% increased Global Critical Strike Chance
+{variant:2}(40-45)% increased Global Critical Strike Chance
 {variant:1}Adds (15-25) to (35-45) Physical Damage
 {variant:2}Adds (35-40) to (55-60) Physical Damage
 (22-30)% increased Critical Strike Chance
@@ -340,9 +375,12 @@ Implicits: 1
 Festering Resentment
 Demon Dagger
 Source: Drops from unique{Uber Incarnation of Neglect} in normal{Moment of Loneliness}
+Variant: Pre 3.29.0
+Variant: Current
 Requires Level 68, 76 Dex, 149 Int
-Implicits: 1
-40% increased Global Critical Strike Chance
+Implicits: 2
+{variant:1}40% increased Global Critical Strike Chance
+{variant:2}(50-55)% increased Global Critical Strike Chance
 Trigger a Socketed Spell when you Block, with a 0.25 second Cooldown
 +(30-45)% Chance to Block Spell Damage while in Off Hand
 (100-150)% increased Spell Damage

--- a/src/Data/Uniques/gloves.lua
+++ b/src/Data/Uniques/gloves.lua
@@ -34,7 +34,7 @@ League: Heist
 Source: Steal from a unique{Curio Display} during a Grand Heist
 Requires Level 63, 100 Str
 +(60-80) to Intelligence
-(25-35)% increased Global Critical Strike Chance
+(40-60)% increased Global Critical Strike Chance
 (200-220)% increased Armour
 +(60-75) to maximum Life
 You have Perfect Agony if you've dealt a Critical Strike recently
@@ -55,7 +55,7 @@ The Celestial Brace
 Goliath Gauntlets
 Source: Drops from unique{The Searing Exarch} (Uber)
 Requires Level: 53, 77 Str
-(80-120)% increased Armour
+(100-150)% increased Armour
 1% increased Attack Speed per Fortification
 +(1-10) to maximum Fortification
 Melee Hits from Strike Skills Fortify
@@ -492,7 +492,7 @@ Adds 1 to 13 Lightning Damage to Attacks
 {variant:1}(18-24)% increased Quantity of Items found
 {variant:2}(12-16)% increased Quantity of Items found
 {variant:3}(5-10)% increased Quantity of Items found
-{variant:4}(10-15)% increased Rarity of Items found
+{variant:4}(5-15)% increased Rarity of Items found
 ]],[[
 Voidbringer
 Conjurer Gloves

--- a/src/Data/Uniques/quiver.lua
+++ b/src/Data/Uniques/quiver.lua
@@ -277,7 +277,7 @@ Regenerate (150-200) Life per Second while in Blood Stance
 (40-60)% increased Projectile Damage while in Blood Stance
 +(700-1000) to Evasion Rating while in Sand Stance
 (20-30)% increased Area of Effect while in Sand Stance
-(20-30)% increased Attack Speed if you've changed Stance Recently
+(25-30)% increased Attack Speed if you've changed Stance Recently
 ]],[[
 Skirmish
 Two-Point Arrow Quiver

--- a/src/Data/Uniques/ring.lua
+++ b/src/Data/Uniques/ring.lua
@@ -547,7 +547,7 @@ Implicits: 1
 {tags:resource}+(20-30) to maximum Mana
 {tags:attribute}+(20-40) to Intelligence
 {tags:caster,speed}Curse Skills have (8-12)% increased Cast Speed
-Non-Aura Hexes expire upon reaching 200% of base Effect
+Non-Aura Hexes expire upon reaching (180-220)% of base Effect
 Non-Aura Hexes gain 20% increased Effect per second
 ]],[[
 Gifts from Above

--- a/src/Data/Uniques/staff.lua
+++ b/src/Data/Uniques/staff.lua
@@ -147,7 +147,7 @@ Implicits: 2
 {variant:1}+18% Chance to Block Attack Damage
 {variant:2}+20% Chance to Block Spell Damage
 +12% Chance to Block Attack Damage while wielding a Staff
-(100-200)% increased Fire Damage
+100% increased Fire Damage
 (5-10)% increased Attack Speed
 Curse Enemies with Flammability on Block
 Reflects (22-44) Fire Damage to Attackers on Block
@@ -248,7 +248,7 @@ Gain (10-20)% of Elemental Damage as Extra Chaos Damage
 +1% to Critical Strike Multiplier per 1% Chance to Block Attack Damage
 +60% to Critical Strike Multiplier if you've dealt a Non-Critical Strike Recently
 {variant:1,2}120% increased Spell Damage if you've dealt a Critical Strike Recently
-{variant:3,4}(120-150)% increased Spell Damage if you've dealt a Critical Strike Recently
+{variant:3,4,5}(120-150)% increased Spell Damage if you've dealt a Critical Strike Recently
 ]],[[
 Replica Duskdawn
 Maelström Staff

--- a/src/Data/Uniques/wand.lua
+++ b/src/Data/Uniques/wand.lua
@@ -62,7 +62,7 @@ Implicits: 3
 {variant:1}Adds (10-14) to (18-22) Fire Damage
 {variant:3,4,5}Adds (20-24) to (38-46) Fire Damage
 {variant:1,2}Adds (4-6) to (7-9) Fire Damage to Spells
-{variant:3,4,5}Adds (20-24) to (36-46) Fire Damage to Spells
+{variant:3,4,5}Adds (20-24) to (38-46) Fire Damage to Spells
 {variant:1}(40-50)% increased Burning Damage
 {variant:2}(20-30)% increased Burning Damage
 {variant:1,2}(16-22)% chance to Ignite
@@ -338,8 +338,9 @@ Variant: Pre 3.4.0
 Variant: Pre 3.21.0
 Variant: Pre 3.29.0
 Variant: Current
-Implicits: 2
-{variant:1,2,4}(35-39)% increased Spell Damage
+Implicits: 3
+{variant:1,2}(35-39)% increased Spell Damage
+{variant:4}(35-39)% increased Spell Damage
 {variant:3}Adds (3-5) to (70-82) Lightning Damage to Spells and Attacks
 {variant:1,2,3}(30-40)% increased Spell Damage
 {variant:1,2,3}Adds (26-35) to (95-105) Lightning Damage to Spells

--- a/src/Export/Uniques/amulet.lua
+++ b/src/Export/Uniques/amulet.lua
@@ -33,7 +33,7 @@ Amber Amulet
 LevelReq: 49
 Implicits: 1
 StrengthImplicitAmulet1
-TalismanIncreasedCriticalChance
+CriticalStrikeChanceUnique__6
 IncreasedLifeUnique__119
 ChaosResistUniqueAmulet23
 RecoverLifeAlteratingUnique__1
@@ -690,7 +690,7 @@ Implicits: 1
 LifeRegenerationImplicitAmulet1
 AddedManaRegenerationUnique__3
 BeltFlaskLifeRecoveryUnique__1
-FlaskManaRecoveryUnique__1
+BeltFlaskManaRecoveryUnique__1
 LowLifeInstantLifeRecoveryUnique__1
 LowManaInstantManaRecoveryUnique__1
 ]],[[
@@ -1052,7 +1052,7 @@ MinionLifeUniqueAmulet3
 {variant:1,2,3}MinionRunSpeedUniqueAmulet3
 {variant:4}MinionPhysicalConvertToColdUnique__1
 {variant:3}MinionAddedColdDamageUnique__1[5,9][11,15]
-{variant:4}MinionAddedColdDamageUnique__1[25,35][60,65]
+{variant:4}MinionAddedColdDamageUnique__1
 {variant:1,2}MinionDamageUniqueAmulet3
 {variant:2,3}MinionSkillManaCostUnique__1_
 {variant:4}MinionOnlyDealColdDamageUnique__1

--- a/src/Export/Uniques/belt.lua
+++ b/src/Export/Uniques/belt.lua
@@ -718,7 +718,7 @@ LevelReq: 44
 Implicits: 1
 IncreasedPhysicalDamagePercentImplicitBelt1
 IncreasedLifeUnique__105
-ColdResistUniqueRing24
+ColdResistUniqueRing24[30,40]
 LifeLeechPermyriadUnique__3
 BeltIncreasedFlaskDurationUnique__1
 FlaskChargeRecoveryDuringFlaskEffectUnique__2

--- a/src/Export/Uniques/body.lua
+++ b/src/Export/Uniques/body.lua
@@ -987,7 +987,7 @@ Implicits: 0
 LocalIncreasedArmourAndEnergyShieldUnique__2
 {variant:1,2}IncreasedEnergyShieldUnique__5[70,80]
 {variant:3}IncreasedEnergyShieldUnique__5
-IncreasedLifeUniqueBodyDexInt1
+IncreasedLifeUniqueBodyDexInt1[60,70]
 AllResistancesUnique__3
 {variant:1}EnergyShieldPer5StrengthUnique__1[1,1][5,5]
 {variant:2,3}EnergyShieldPer5StrengthUnique__1
@@ -1324,7 +1324,7 @@ Variant: Two Abyssal Sockets (Current)
 Variant: One Abyssal Socket (Current)
 Implicits: 1
 IncreasedManaImplicitArmour1
-{variant:5}AbyssJewelSocketUnique__1[3,3]
+{variant:5}AbyssJewelSocketUnique__16
 {variant:1,3,6}AbyssJewelSocketUnique__1
 {variant:2,4,7}AbyssJewelSocketImplicit
 {variant:1,2}DisplaySupportedByElementalPenetrationUnique__1[20,20]

--- a/src/Export/Uniques/dagger.lua
+++ b/src/Export/Uniques/dagger.lua
@@ -5,9 +5,12 @@ return {
 [[
 Arakaali's Fang
 Fiend Dagger
+Variant: Pre 3.29.0
+Variant: Current
 Requires Level 53, 58 Dex, 123 Int
-Implicits: 1
-CriticalStrikeChanceImplicitDagger2
+Implicits: 2
+{variant:1}CriticalStrikeChanceImplicitDagger2
+{variant:2}CriticalStrikeChanceImplicitDaggerNew2
 SummonSpidersOnKillUnique__1
 LocalIncreasedPhysicalDamagePercentUnique__25
 LocalAddedPhysicalDamageUnique__25
@@ -21,8 +24,9 @@ Variant: Pre 3.20.0
 Variant: Pre 3.28.0
 Variant: Current
 Requires Level 65, 81 Dex, 117 Int
-Implicits: 1
-CriticalStrikeChanceImplicitDagger1
+Implicits: 2
+{variant:1,2,3}CriticalStrikeChanceImplicitDagger1
+{variant:4}CriticalStrikeChanceImplicitDaggerNew1
 {variant:1,2}DegenerationDamageUniqueDagger8
 {variant:1,2}LocalAddedPhysicalDamageUniqueDagger8[50,60][120,140]
 {variant:3,4}LocalAddedPhysicalDamageUniqueDagger8
@@ -30,7 +34,7 @@ LocalCriticalStrikeChanceUniqueDagger8
 {variant:1}CriticalMultiplierUniqueDagger8[10,15]
 {variant:2,3,4}CriticalMultiplierUniqueDagger8
 {variant:3}ChaosResistUniqueDagger8[8,12]
-{variant:4}ChaosResistUniqueDagger8[17,27]
+{variant:4}ChaosResistUniqueDagger8
 {variant:1,2,3,4}On Killing a Poisoned Enemy, Enemies within 3 metres are Poisoned 
 {variant:3,4}and nearby Allies Regenerate 400 Life per second
 ]],[[
@@ -39,8 +43,9 @@ Stiletto
 Variant: Pre 2.6.0
 Variant: Current
 Requires Level 15, 30 Dex, 30 Int
-Implicits: 1
-CriticalStrikeChanceImplicitDagger1
+Implicits: 2
+{variant:1}CriticalStrikeChanceImplicitDagger1
+{variant:2}CriticalStrikeChanceImplicitDaggerNew1
 DexterityUniqueDagger12
 LocalIncreasedPhysicalDamagePercentUniqueDagger12
 LocalAddedPhysicalDamageUniqueDagger12
@@ -53,9 +58,12 @@ Replica Bloodplay
 Stiletto
 League: Heist
 Source: Steal from a unique{Curio Display} during a Grand Heist
+Variant: Pre 3.29.0
+Variant: Current
 Requires Level 15, 30 Dex, 30 Int
-Implicits: 1
-CriticalStrikeChanceImplicitDagger1
+Implicits: 2
+{variant:1}CriticalStrikeChanceImplicitDagger1
+{variant:2}CriticalStrikeChanceImplicitDaggerNew1
 StrengthUnique__15
 LocalIncreasedPhysicalDamagePercentUniqueDagger12
 LocalAddedPhysicalDamageUniqueDagger12
@@ -65,9 +73,12 @@ ExtraGore
 ]],[[
 Cold Iron Point
 Ezomyte Dagger
+Variant: Pre 3.29.0
+Variant: Current
 Requires Level 62, 95 Dex, 131 Int
-Implicits: 1
-CriticalStrikeChanceImplicitDagger1
+Implicits: 2
+{variant:1}CriticalStrikeChanceImplicitDagger1
+{variant:2}CriticalStrikeChanceImplicitDaggerNew1
 GlobalPhysicalSpellGemsLevelUnique__1
 DealNoElementalDamageUnique__1
 ]],[[
@@ -75,9 +86,12 @@ Replica Cold Iron Point
 Ezomyte Dagger
 League: Heist
 Source: Steal from a unique{Curio Display} during a Grand Heist
+Variant: Pre 3.29.0
+Variant: Current
 Requires Level 62, 95 Dex, 131 Int
-Implicits: 1
-CriticalStrikeChanceImplicitDagger1
+Implicits: 2
+{variant:1}CriticalStrikeChanceImplicitDagger1
+{variant:2}CriticalStrikeChanceImplicitDaggerNew1
 GlobalColdSpellGemsLevelUnique__1
 DealNoColdDamageUnique__1
 ]],[[
@@ -87,8 +101,9 @@ Variant: Pre 2.2.0
 Variant: Pre 3.0.0
 Variant: Current
 Requires Level 53, 58 Dex, 123 Int
-Implicits: 1
-CriticalStrikeChanceImplicitDagger2
+Implicits: 2
+{variant:1,2}CriticalStrikeChanceImplicitDagger2
+{variant:3}CriticalStrikeChanceImplicitDaggerNew2
 IntelligenceUniqueDagger10_
 SpellDamageUniqueDagger10
 LocalIncreaseSocketedFireGemLevelUniqueDagger10
@@ -104,8 +119,9 @@ Variant: Pre 3.7.0
 Variant: Pre 3.20.0
 Variant: Current
 Requires Level 66, 95 Dex, 131 Int
-Implicits: 1
-CriticalStrikeChanceImplicitDagger1
+Implicits: 2
+{variant:1,2}CriticalStrikeChanceImplicitDagger1
+{variant:3}CriticalStrikeChanceImplicitDaggerNew1
 {variant:1,2}SpellDamageOnWeaponUniqueDagger1[50,70]
 {variant:3}SpellDamageOnWeaponUniqueDagger1
 {variant:1}LifeGainedFromEnemyDeathUniqueDagger11[10,10]
@@ -123,9 +139,12 @@ CriticalStrikeChanceImplicitDagger1
 ]],[[
 Goredrill
 Skinning Knife
+Variant: Pre 3.29.0
+Variant: Current
 Requires Level 5, 16 Dex
-Implicits: 1
-CriticalStrikeChanceImplicitDagger1
+Implicits: 2
+{variant:1}CriticalStrikeChanceImplicitDagger1
+{variant:2}CriticalStrikeChanceImplicitDaggerNew1
 DexterityUniqueDagger11
 LocalIncreasedPhysicalDamagePercentUniqueDagger11
 LocalAddedPhysicalDamageUniqueDagger11
@@ -150,9 +169,12 @@ CrimsonDanceIfCritRecentlyUnique__1
 Goblinedge
 Ambusher
 League: Ritual
+Variant: Pre 3.29.0
+Variant: Current
 Requires Level 60, 113 Dex, 113 Int
-Implicits: 1
-CriticalStrikeChanceImplicitDagger1
+Implicits: 2
+{variant:1}CriticalStrikeChanceImplicitDagger1
+{variant:2}CriticalStrikeChanceImplicitDaggerNew1
 LocalIncreasedPhysicalDamagePercentUnique__43
 AttackSpeedFrenzyChargeNotGainedUnique__1
 CriticalStrikeChancePowerChargeNotGainedUnique__1
@@ -166,8 +188,9 @@ Variant: Pre 2.6.0
 Variant: Pre 3.19.0
 Variant: Current
 Requires Level 50, 71 Dex, 102 Int
-Implicits: 1
-CriticalStrikeChanceImplicitDagger1
+Implicits: 2
+{variant:1,2}CriticalStrikeChanceImplicitDagger1
+{variant:3}CriticalStrikeChanceImplicitDaggerNew1
 {variant:1}SpellDamageOnWeaponUniqueDagger4[40,50]
 {variant:2,3}SpellDamageOnWeaponUniqueDagger4
 {variant:1,2}IncreasedEnergyShieldUniqueDagger4
@@ -184,8 +207,9 @@ Variant: Current
 League: Heist
 Source: Steal from a unique{Curio Display} during a Grand Heist
 Requires Level 50, 71 Dex, 102 Int
-Implicits: 1
-CriticalStrikeChanceImplicitDagger1
+Implicits: 2
+{variant:1}CriticalStrikeChanceImplicitDagger1
+{variant:2}CriticalStrikeChanceImplicitDaggerNew1
 SpellDamageOnWeaponUniqueDagger4
 {variant:1}IncreasedEnergyShieldUniqueDagger4
 {variant:1}ReducedEnergyShieldDelayUniqueBodyInt1
@@ -199,9 +223,12 @@ The Hidden Blade
 Ambusher
 League: Heist
 Source: Steal from a unique{Curio Display} during a Grand Heist
+Variant: Pre 3.29.0
+Variant: Current
 Requires Level 60, 113 Dex, 113 Int
-Implicits: 1
-CriticalStrikeChanceImplicitDagger1
+Implicits: 2
+{variant:1}CriticalStrikeChanceImplicitDagger1
+{variant:2}CriticalStrikeChanceImplicitDaggerNew1
 UniqueSecretBladeGrantHiddenBlade
 DexterityUnique__18
 LocalIncreasedPhysicalDamagePercentUnique__42
@@ -214,8 +241,9 @@ Variant: Pre 2.6.0
 Variant: Pre 3.26.0
 Variant: Current
 Requires Level 64, 76 Dex, 149 Int
-Implicits: 1
-CriticalStrikeChanceImplicitDagger3
+Implicits: 2
+{variant:1,2,3}CriticalStrikeChanceImplicitDagger3
+{variant:4}CriticalStrikeChanceImplicitDaggerNew3
 BlockWhileDualWieldingUniqueDagger9
 {variant:1}LocalIncreasedPhysicalDamagePercentUniqueDagger9[180,210]
 {variant:2}LocalIncreasedPhysicalDamagePercentUniqueDagger9[210,240]
@@ -232,9 +260,12 @@ BlockWhileDualWieldingUniqueDagger9
 ]],[[
 Mightflay
 Flaying Knife
+Variant: Pre 3.29.0
+Variant: Current
 Requires Level 35, 73 Dex, 51 Int
-Implicits: 1
-CriticalStrikeChanceImplicitDagger1
+Implicits: 2
+{variant:1}CriticalStrikeChanceImplicitDagger1
+{variant:2}CriticalStrikeChanceImplicitDaggerNew1
 StrengthUniqueDagger2
 LocalIncreasedPhysicalDamagePercentUniqueDagger3
 LocalAddedPhysicalDamageUniqueDagger2
@@ -242,9 +273,12 @@ LifeGainPerTargetUniqueDagger2
 ]],[[
 Taproot
 Ambusher
+Variant: Pre 3.29.0
+Variant: Current
 Requires Level 60, 113 Dex, 113 Int
-Implicits: 1
-CriticalStrikeChanceImplicitDagger1
+Implicits: 2
+{variant:1}CriticalStrikeChanceImplicitDagger1
+{variant:2}CriticalStrikeChanceImplicitDaggerNew1
 LocalIncreasedPhysicalDamagePercentUnique__20
 LocalIncreasedAttackSpeedUnique__17
 PoisonDurationUnique__1_
@@ -327,8 +361,9 @@ Boot Blade
 Variant: Pre 3.0.0
 Variant: Current
 Requires Level 44, 63 Dex, 90 Int
-Implicits: 1
-CriticalStrikeChanceImplicitDagger1
+Implicits: 2
+{variant:1}CriticalStrikeChanceImplicitDagger1
+{variant:2}CriticalStrikeChanceImplicitDaggerNew1
 {variant:1}LocalAddedPhysicalDamageUnique__8[15,25][35,45]
 {variant:2}LocalAddedPhysicalDamageUnique__8
 LocalCriticalStrikeChanceUnique__2
@@ -340,9 +375,12 @@ CriticalStrikeAttackLifeLeechUnique__1
 Festering Resentment
 Demon Dagger
 Source: Drops from unique{Uber Incarnation of Neglect} in normal{Moment of Loneliness}
+Variant: Pre 3.29.0
+Variant: Current
 Requires Level 68, 76 Dex, 149 Int
-Implicits: 1
-CriticalStrikeChanceImplicitDagger2
+Implicits: 2
+{variant:1}CriticalStrikeChanceImplicitDagger2
+{variant:2}CriticalStrikeChanceImplicitDaggerNew2
 SupportVirulenceSpellsCastOnBlockUnique_1
 SpellBlockWhileInOffHandUnique_1
 SpellDamageUnique__17

--- a/src/Export/Uniques/gloves.lua
+++ b/src/Export/Uniques/gloves.lua
@@ -34,7 +34,7 @@ League: Heist
 Source: Steal from a unique{Curio Display} during a Grand Heist
 Requires Level 63, 100 Str
 IntelligenceUniqueGlovesStr3
-CriticalStrikeChanceUniqueGlovesStr3[25,35]
+CriticalStrikeChanceUniqueGlovesStr3
 LocalIncreasedPhysicalDamageReductionRatingPercentUniqueGlovesStr3
 IncreasedLifeUniqueGlovesStr3
 PerfectAgonyIfCritRecentlyUnique__1
@@ -55,7 +55,7 @@ The Celestial Brace
 Goliath Gauntlets
 Source: Drops from unique{The Searing Exarch} (Uber)
 Requires Level: 53, 77 Str
-LocalIncreasedPhysicalDamageReductionRatingPercentUnique__19
+LocalIncreasedPhysicalDamageReductionRatingPercentUnique__19[100,150]
 AttackSpeedPerFortificationUnique__1
 MaximumFortificationUnique__1
 StrikeSkillsFortifyOnHitUnique__1
@@ -485,7 +485,7 @@ LocalIncreasedEnergyShieldUniqueGlovesInt1
 {variant:1}ItemFoundQuantityIncreaseUniqueGlovesInt1[18,24]
 {variant:2}ItemFoundQuantityIncreaseUniqueGlovesInt1[12,16]
 {variant:3}ItemFoundQuantityIncreaseUniqueGlovesInt1
-{variant:4}ItemFoundRarityIncreaseUnique__7[10,15]
+{variant:4}ItemFoundRarityIncreaseUnique__7
 ]],[[
 Voidbringer
 Conjurer Gloves

--- a/src/Export/Uniques/quiver.lua
+++ b/src/Export/Uniques/quiver.lua
@@ -276,7 +276,7 @@ LifeRegenerationBloodStanceUnique__1
 ProjectileDamageBloodStanceUnique__1
 EvasionRatingSandStanceUnique__1
 AreaOfEffectSandStanceUnique__1
-(20-30)% increased Attack Speed if you've changed Stance Recently
+AttackSpeedChangedStanceUnique__1
 ]],[[
 Skirmish
 Two-Point Arrow Quiver

--- a/src/Export/Uniques/staff.lua
+++ b/src/Export/Uniques/staff.lua
@@ -147,7 +147,7 @@ Implicits: 2
 {variant:1}StaffBlockPercentImplicitStaff1[18,18]
 {variant:2}StaffSpellBlockPercentImplicitStaff__1
 StaffBlockPercentUniqueStaff9
-IncreasedFireDamgeIfHitRecentlyUnique__1
+FireDamagePercentUnique__12___
 LocalIncreasedAttackSpeedUniqueStaff9
 FlammabilityOnBlockChanceUnique__1
 ReflectFireDamageOnBlockUnique__1___
@@ -248,7 +248,7 @@ ElementalDamagePercentAddedAsChaosUnique__2
 CriticalMultiplierPerBlockChanceUnique__1
 CritMultiIfDealtNonCritRecentlyUnique__2
 {variant:1,2}SpellDamageIfYouHaveCritRecentlyUnique__2[120,120]
-{variant:3,4}SpellDamageIfYouHaveCritRecentlyUnique__2
+{variant:3,4,5}SpellDamageIfYouHaveCritRecentlyUnique__2
 ]],[[
 Replica Duskdawn
 Maelström Staff

--- a/src/Export/Uniques/wand.lua
+++ b/src/Export/Uniques/wand.lua
@@ -62,7 +62,7 @@ Implicits: 3
 {variant:1}LocalAddedFireDamageUnique__2[10,14][18,22]
 {variant:3,4,5}LocalAddedFireDamageUnique__2
 {variant:1,2}SpellAddedFireDamageUniqueWand10[4,6][7,9]
-{variant:3,4,5}SpellAddedFireDamageUniqueWand10[20,24][36,46]
+{variant:3,4,5}SpellAddedFireDamageUnique__3
 {variant:1}BurnDamageUnique__1[40,50]
 {variant:2}BurnDamageUnique__1
 {variant:1,2}ChanceToIgniteUnique__1
@@ -333,8 +333,9 @@ Variant: Pre 3.4.0
 Variant: Pre 3.21.0
 Variant: Pre 3.29.0
 Variant: Current
-Implicits: 2
-{variant:1,2,4}SpellDamageUniqueWand1[35,39]
+Implicits: 3
+{variant:1,2}SpellDamageUniqueWand1[35,39]
+{variant:4}SpellDamageOnWeaponImplicitWand16
 {variant:3}AddedLightningDamageSpellsAndAttacksImplicit3
 {variant:1,2,3}SpellDamageUniqueWand1
 {variant:1,2,3}SpellAddedLightningDamageUnique__5


### PR DESCRIPTION
Fixes # .

### Description of the problem being solved:
Updates outdated modifier IDs, ranges, and variant handling for 33 unique items. I obviously used an LLM here to help with this work, but I manually verified every modifier line in both standard and trade league. 

The changes were determined by comparing:

- Path of Building's exported unique definitions
- `ModTextMap.lua` and `ModItemExclusive.lua`
- Current-league items
- Standard items where legacy behavior needed confirmation

Legacy variants were added only where Standard items confirmed that the previous modifier still exists.

## Changes

| Item | Change | Reason |
|---|---|---|
| Arakaali's Fang | Split the dagger implicit into legacy `40%` and current `50–55%` variants. | Current Fiend Daggers use `CriticalStrikeChanceImplicitDaggerNew2`; Standard confirms the old implicit still exists. |
| Ashcaller | Changed spell fire damage from `20–24 to 36–46` to `20–24 to 38–46`. Replaced the override with `SpellAddedFireDamageUnique__3`. | The existing line used an outdated override instead of the current modifier ID. |
| Bino's Kitchen Knife | Split the dagger implicit into legacy `30%` and current `40–45%` variants. Changed current Chaos Resistance from `17–27%` to `17–29%`. | The current base uses the new dagger implicit, and the Chaos Resistance override incorrectly truncated the current modifier. |
| Bloodplay | Split the dagger implicit into legacy `30%` and current `40–45%` variants. | Current Stilettos use the new dagger implicit; Standard confirms the legacy implicit. |
| Bloodsoaked Medallion | Changed Global Critical Strike Chance from `40–50%` to `30–50%` and replaced `TalismanIncreasedCriticalChance` with `CriticalStrikeChanceUnique__6`. | The unique was assigned the wrong modifier ID. |
| Cold Iron Point | Split the dagger implicit into legacy `30%` and current `40–45%` variants. | Current Ezomyte Daggers use the new implicit; Standard confirms the legacy implicit. |
| Divinarius | Split the dagger implicit into legacy `30%` and current `40–45%` variants. | Current Imperial Skeans use the new implicit while older variants retain the previous value. |
| Duskdawn | Applied the `120–150% increased Spell Damage` modifier to the Current variant. | The Current variant was omitted from the modifier's variant tags. |
| Fated End | Changed the generated Hex expiration value from fixed `200%` to `180–220%`. | The export definition already contains the correct range, but the generated unique data was stale. |
| Festering Resentment | Split the dagger implicit into legacy `40%` and current `50–55%` variants. | Current Demon Daggers use the new implicit; Standard confirms the legacy implicit. |
| Geofri's Sanctuary | Changed maximum Life from `50–70` to `60–70`. | Current items were manually verified with the narrower range; no separate owned modifier ID was found, so the existing ID receives a numeric override. |
| Goblinedge | Split the dagger implicit into legacy `30%` and current `40–45%` variants. | Current Ambushers use the new implicit; Standard confirms the legacy implicit. |
| Goredrill | Split the dagger implicit into legacy `30%` and current `40–45%` variants. | Current Skinning Knives use the new implicit; Standard confirms the legacy implicit. |
| Heartbreaker | Split the dagger implicit into legacy `30%` and current `40–45%` variants. | Current Royal Skeans use the new implicit while older variants retain the previous value. |
| Ikiaho's Promise | Changed Mana Recovery from Flasks from `15–30%` to `20–30%` and replaced `FlaskManaRecoveryUnique__1` with `BeltFlaskManaRecoveryUnique__1`. | The unique was assigned the wrong modifier ID. |
| Mark of the Doubting Knight | Split the dagger implicit into legacy `50%` and current `60–65%` variants. | Current Platinum Kris bases use the new implicit; Standard confirms the legacy implicit. |
| Mightflay | Split the dagger implicit into legacy `30%` and current `40–45%` variants. | Current Flaying Knives use the new implicit; Standard confirms the legacy implicit. |
| Replica Atziri's Acuity | Changed Global Critical Strike Chance from `25–35%` to `40–60%` by removing the stale override. | `CriticalStrikeChanceUniqueGlovesStr3` already contains the correct current range. |
| Replica Blood Thorn | Changed increased Fire Damage from `100–200%` to fixed `100%` and replaced the previous modifier with `FireDamagePercentUnique__12___`. | The exact current modifier is fixed at `100%`; no evidence was found that a separate `100–200%` legacy explicit existed. |
| Replica Bloodplay | Split the dagger implicit into legacy `30%` and current `40–45%` variants. | Current Stilettos use the new implicit; Standard confirms the legacy implicit. |
| Replica Cold Iron Point | Split the dagger implicit into legacy `30%` and current `40–45%` variants. | Current Ezomyte Daggers use the new implicit; Standard confirms the legacy implicit. |
| Replica Heartbreaker | Split the dagger implicit into legacy `30%` and current `40–45%` variants. | Current Royal Skeans use the new implicit; Standard confirms the legacy implicit. |
| Sadima's Touch | Changed Rarity of Items Found from `10–15%` to `5–15%` by removing the override. | `ItemFoundRarityIncreaseUnique__7` currently maps to `5–15%`.  |
| Scorpion's Call | Changed Attack Speed after changing Stance from `20–30%` to `25–30%` and replaced literal text with `AttackSpeedChangedStanceUnique__1`. | The exact modifier ID contains the current range. |
| Shimmeron | Assigned the Current variant's `35–39% increased Spell Damage` implicit to `SpellDamageOnWeaponImplicitWand16` and separated it from the legacy modifier. | The displayed text is unchanged, but the Current variant was using the wrong modifier ID. |
| Shroud of the Lightless | Replaced `AbyssJewelSocketUnique__1[3,3]` with `AbyssJewelSocketUnique__16` for the three-socket Current variant. | The current item has a dedicated three-Abyssal-socket modifier ID and should not emulate it through an override. |
| Sidhebreath | Changed minion added Cold Damage from `25–35 to 60–65` to `25–35 to 50–65`. | The previous override incorrectly raised the lower value of the second damage range. |
| Taproot | Split the dagger implicit into legacy `30%` and current `40–45%` variants. | Current Ambushers use the new implicit; Standard confirms the legacy implicit. |
| The Celestial Brace | Changed increased Armour from `80–120%` to `100–150%`. | Current items were manually verified with the new range; no separate owned modifier ID was found, so the existing ID receives an override. |
| The Consuming Dark | Split the dagger implicit into legacy `40%` and current `50–55%` variants. | Current Fiend Daggers use the new implicit while older variants retain the previous value. |
| The Hidden Blade | Split the dagger implicit into legacy `30%` and current `40–45%` variants. | Current Ambushers use the new implicit; Standard confirms the legacy implicit. |
| The Retch | Changed Cold Resistance from `25–40%` to `30–40%`. | Current items were manually verified with the new range; no separate owned modifier ID was found, so the existing ID receives an override. |
| Widowmaker | Split the dagger implicit into legacy `30%` and current `40–45%` variants. | Current Boot Blades use the new implicit while the pre-3.0 variant retains the old implicit. |

### Steps taken to verify a working solution:
- Manual modification verification across standard and Allflame league, to look for the presence of legacy modifiers/variants
- Checked ~10 of the items in current PoB against PR'd version

### Link to a build that showcases this PR:
- Build with items before PR / dev branch https://pob.codes/b/72hptGS7W8B
- Build code for items created with PR applied https://pob.codes/b/H5AzEuOGOMW


### Before screenshot:

### After screenshot:
