### PR TITLE
Fix "Tukohama, War's Herald" breaking fist of war support gem

### DIFF
--- a/spec/System/TestItemMods_spec.lua
+++ b/spec/System/TestItemMods_spec.lua
@@ -1103,4 +1103,22 @@ describe("TetsItemMods", function()
 		assert.is_not_nil(sentinel)
 		assert.are.equals(1, countSupport(sentinel, "SupportMinionDamage"))
 	end)
+	-- #10310
+	it("an item's own ExtraSupport for a support gem does not disable that support elsewhere", function()
+		addItem("Supporting Gloves\nSpiked Gloves\nGrants Level 20 Sunder")
+		build.skillsTab:PasteSocketGroup("Slot: Gloves\nFist of War 20/0  1\n")
+		runCallback("OnFrame")
+
+		local sunder = findActiveSkill("Sunder")
+		assert.is_not_nil(sunder)
+		assert.is_true(hasSupport(sunder, "SupportFistofWar"))
+
+		addItem("Breaking Body Armour\nSimple Robe\nSkills from Equipped Body Armour are Supported by Level 20 Fist of War")
+		build.skillsTab:PasteSocketGroup("Slot: Body Armour\nHeavy Strike 20/0  1\n")
+		runCallback("OnFrame")
+
+		sunder = findActiveSkill("Sunder")
+		assert.is_not_nil(sunder)
+		assert.is_true(hasSupport(sunder, "SupportFistofWar"))
+	end)
 end)

--- a/src/Modules/CalcSetup.lua
+++ b/src/Modules/CalcSetup.lua
@@ -1600,6 +1600,12 @@ function calcs.initEnv(build, mode, override, specEnv)
 		local supportLists = { }
 		local groupCfgList = { }
 		local processedSockets = {}
+		-- granted effects normally refer to the global tables in data.skills,
+		--which means that modifying them will do so permanently until the
+		--client is restarted. this avoids that by mapping from the original
+		--table to a modified table.
+		---@type table<table, table>
+		local fromItemReplacements = {}
 		-- Process support gems adding them to applicable support lists
 		for index, group in ipairs(build.skillsTab.socketGroupList) do
 			local slot = group.slot and build.itemsTab.slots[group.slot]
@@ -1634,7 +1640,12 @@ function calcs.initEnv(build, mode, override, specEnv)
 						grantedEffect = env.data.skills["Support"..value.skillId]
 					end
 					if value and grantedEffect then -- Only item ExtraSupport gems should be flagged as fromItem. Imbued gems do not pass this check
-						grantedEffect.fromItem = true
+						if not fromItemReplacements[grantedEffect] then
+							local taggedGrantedEffect = copyTable(grantedEffect, true)
+							taggedGrantedEffect.fromItem = true
+							fromItemReplacements[grantedEffect] = taggedGrantedEffect
+						end
+						grantedEffect = fromItemReplacements[grantedEffect]
 					end
 					if grantedEffect then
 						for _, targetList in ipairs(targetListList) do

--- a/src/Modules/CalcSetup.lua
+++ b/src/Modules/CalcSetup.lua
@@ -1601,9 +1601,9 @@ function calcs.initEnv(build, mode, override, specEnv)
 		local groupCfgList = { }
 		local processedSockets = {}
 		-- granted effects normally refer to the global tables in data.skills,
-		--which means that modifying them will do so permanently until the
-		--client is restarted. this avoids that by mapping from the original
-		--table to a modified table.
+		-- which means that modifying them will do so permanently until the
+		-- client is restarted. this avoids that by mapping from the original
+		-- table to a modified table.
 		---@type table<table, table>
 		local fromItemReplacements = {}
 		-- Process support gems adding them to applicable support lists

--- a/src/Modules/Common.lua
+++ b/src/Modules/Common.lua
@@ -543,7 +543,7 @@ function specCopy(env)
 end
 
 -- Wipe all keys from the table and return it, or return a new table if no table
--- provided. This is useful to avoid alllocations in hot paths if a table can be reused. Using LuaJIT's `table.clear()` is another alternative to this, but this performs similarly on small tables, or tables which are often already empty.
+-- provided. This is useful to avoid allocations in hot paths if a table can be reused. Using LuaJIT's `table.clear()` is another alternative to this, but this performs similarly on small tables, or tables which are often already empty.
 ---@param tbl table?
 ---@return table tbl
 function wipeTable(tbl)


### PR DESCRIPTION
Fixes #10310.

### Description of the problem being solved:

It seems the `grantedEffect.fromItem = true` line was actually modifying the global table which means evaluating the tree node broke the actual support gem until the client was restarted. This works around that by copying the table in initEnv(). This seems to have fixed the problem without breaking other tests, but I'm not really convinced it can't be a problem elsewhere

### Steps taken to verify a working solution:
- Test added
- Tests pass

### Link to a build that showcases this PR:
See issue
### Before screenshot:

### After screenshot:
