### PR TITLE
Update 779 unique item mod IDs

### DIFF
--- a/src/Export/Uniques/amulet.lua
+++ b/src/Export/Uniques/amulet.lua
@@ -35,7 +35,7 @@ Implicits: 1
 StrengthImplicitAmulet1
 TalismanIncreasedCriticalChance
 IncreasedLifeUnique__119
-ChaosResistUniqueAmulet23
+ChaosResistUnique__29
 RecoverLifeAlteratingUnique__1
 ]],[[
 Araku Tiki
@@ -46,8 +46,8 @@ Implicits: 1
 LifeRegenerationImplicitAmulet1
 {variant:1}EvasionOnLowLifeUniqueAmulet4[100,100]
 {variant:2}EvasionOnLowLifeUniqueAmulet4
-IncreasedLifeUniqueAmulet18
-FireResistImplicitAmulet1
+IncreasedLifeUniqueAmulet4
+FireResistUniqueAmulet4
 {variant:1}LifeRegenerationOnLowLifeUniqueAmulet4
 {variant:2}ElusiveOnLowLifeUnique__1
 {variant:2}PhasingOnLowLifeUnique__1
@@ -152,7 +152,7 @@ AllAttributesImplicitAmulet1
 {variant:6,7,8,9}GlobalEvasionRatingPercentUnique__1
 {variant:10,11,12,13,14,15,16}GlobalEnergyShieldPercentUnique__1
 {variant:17}AllAttributesUnique__10_
-IncreasedLifeUnique__114
+IncreasedLifeUnique__89
 {variant:1,2,3,4,5}NearbyEnemiesReducedStunRecoveryUnique__1
 {variant:6,7,8,9}NearbyEnemiesGrantIncreasedFlaskChargesUnique__1
 {variant:1,2,3,4,5}NearbyEnemiesReducedStunRecoveryUnique__1
@@ -183,9 +183,9 @@ Variant: Current
 Requires Level 32
 Implicits: 1
 HybridStrInt
-IncreasedLifeUniqueAmulet4
-IncreasedManaUnique__22__
-ChargeBonusMaximumPowerCharges
+IncreasedLifeUnique__4
+IncreasedManaUnique__3
+IncreasedMaximumPowerChargesUnique__2
 IncreasedManaRegenerationPerPowerChargeUnique__1
 {variant:2}IncreasedPowerChargeDurationUnique__1
 DamageTakeFromManaBeforeLifePerPowerChargeUnique__1
@@ -200,7 +200,7 @@ Source: Drops from unique{Lycia, Herald of the Scourge} in normal{The Beyond}
 LevelReq: 52
 Implicits: 1
 HybridStrInt
-IncreasedManaUniqueAmulet1
+IncreasedManaUnique__23
 ChaosResistUnique__27
 IncreasedMaximumResistsUnique__2
 ElementalDamageReductionChaosResistUnique__1
@@ -345,7 +345,7 @@ Variant: Current
 LevelReq: 49
 Implicits: 1
 ManaRegenerationImplicitAmulet1
-IncreasedLifeUnique__105
+IncreasedLifeUnique__121
 FireResistUnique__34
 ColdResistUnique__39
 LightningResistUnique__29
@@ -358,7 +358,7 @@ League: Heist
 Requires Level 68
 Implicits: 1
 IntelligenceImplicitAmulet1
-ManaRegenerationUnique__13
+ManaRegenerationUnique__12
 AllResistancesUnique__19
 CriticalStrikeMultiplierIfGainedPowerChargeUnique__1_
 GlobalAddedLightningDamagePerPowerChargeUnique__1
@@ -383,7 +383,7 @@ Lapis Amulet
 LevelReq: 24
 Implicits: 1
 IntelligenceImplicitAmulet1
-AllResistancesUnique__26
+AllResistancesUnique__27
 ChanceToFreezeShockIgniteUnique__2
 CursedEnemiesCannotInflictElementalAilmentsUnique__1
 ]],[[
@@ -394,7 +394,7 @@ Variant: Current
 Requires Level 16
 Implicits: 1
 HybridStrInt
-StrengthUnique__26
+StrengthUnique___2
 GrantEnemiesUnholyMightOnKillUnique__1
 GrantEnemiesOnslaughtOnKillUnique__1
 {variant:1}UnholyMightOnKillPercentChanceUnique__1[5,5][10,10]
@@ -411,7 +411,7 @@ Implicits: 1
 AllAttributesImplicitAmulet1
 MaximumLifeUniqueAmulet6
 ItemFoundRarityIncreaseUniqueAmulet6
-CannotBeStunnedUnique__1_
+CannotBeStunned
 ]],[[
 Presence of Chayula
 Onyx Amulet
@@ -420,7 +420,7 @@ Source: Upgraded from unique{Eye of Chayula} using currency{Blessing of Chayula}
 Requires Level 60
 Implicits: 1
 AllAttributesImplicitAmulet1
-ItemFoundRarityIncreaseUniqueAmulet6
+ItemFoundRarityIncreaseUnique__2
 ChaosResistUnique__5
 CannotBeStunned
 MaximumLifeConvertedToEnergyShieldUnique__1
@@ -519,7 +519,7 @@ Variant: Current
 Requires Level 61
 Implicits: 1
 HybridStrDex
-IntelligenceUnique__19
+IntelligenceUnique__22_
 IncreasedCastSpeedUnique__20
 AreaOfEffectUnique__6
 {variant:1,2}Curse25PercentHinderEnemyUnique__1
@@ -533,9 +533,9 @@ Requires Level 40
 Implicits: 1
 HybridDexInt
 IncreasedEvasionRatingPercentUnique__2
-AllResistancesUniqueAmulet14
+AllResistancesUnique__17
 AdditionalProjectilesUnique__1__
-ProjectileSpeedUnique__10
+ProjectileSpeedUnique__6
 ProjectileModifiersApplyToSplitsUnique__1
 ]],[[
 Gloomfang
@@ -566,7 +566,7 @@ DexterityImplicitAmulet1
 {variant:1}ColdDamagePercentUnique___10
 ColdResistUnique__11
 FreezeDurationUnique__1
-ChanceToFreezeUnique__3
+ChanceToFreezeUnique__4
 {variant:2}FreezeProliferationUnique__1
 IncreasedDamageIfFrozenRecentlyUnique__1
 ]],[[
@@ -577,7 +577,7 @@ Source: Upgraded from unique{The Halcyon} using currency{Blessing of Tul}
 Requires Level 64
 Implicits: 1
 DexterityImplicitAmulet1
-ColdDamagePercentUnique__7
+ColdDamagePercentUnique___11
 ColdResistUnique__11
 ChillEnemiesWhenHitUnique__1
 OnHitBlindChilledEnemiesUnique__1_
@@ -630,7 +630,7 @@ DexterityImplicitAmulet1
 {variant:3}CriticalMultiplierUnique__3__
 {variant:3}BowAttacksCullingStrikeUnique__1
 {variant:1,2}LifeLeechPermyriadUniqueAmulet9[80,100]
-{variant:1,2,3}PrecisionAuraBonusUnique__1
+{variant:1,2,3}PrecisionReservationEfficiencyUnique__1
 ]],[[
 Replica Hyrri's Truth
 Jade Amulet
@@ -666,8 +666,8 @@ ItemFoundRarityIncreaseImplicitAmulet1
 IncreasedAccuracyUniqueAmulet7
 IncreasedEvasionRatingUniqueAmulet7
 FireResistUniqueAmulet7
-{variant:2}LightRadiusUnique__3
-{variant:2}DisplayBlindAuraUnique__1
+{variant:2}LightRadiusUnique__8
+{variant:2}NearbyEnemiesAreBlindedUnique__1
 ]],[[
 The Effigon
 Gold Amulet
@@ -711,7 +711,7 @@ AllAttributesImplicitAmulet1
 {variant:3}GlobalAddedColdDamageUnique__1
 {variant:4}GlobalAddedLightningDamageUnique__1_
 {variant:5}GlobalAddedChaosDamageUnique__1
-IncreasedLifeUnique__113
+IncreasedLifeUnique__65
 {variant:1}IncreasedPhysicalDamageReductionRatingUniqueAmulet16
 {variant:2}LifeRegenerationRatePercentUnique__4_
 {variant:3}ManaRegenerationUnique__7
@@ -736,7 +736,7 @@ Variant: Current
 Requires Level 5
 Implicits: 1
 DexterityImplicitAmulet1
-StrengthImplicitAmulet1
+StrengthUniqueAmulet5
 IncreasedAccuracyUniqueAmulet5
 {variant:2}IncreasedProjectileDamageUnique__6
 ProjectileSpeedUniqueAmulet5
@@ -749,7 +749,7 @@ Source: Steal from a unique{Curio Display} during a Grand Heist
 Requires Level 5
 Implicits: 1
 DexterityImplicitAmulet1
-IntelligenceImplicitAmulet1
+IntelligenceUnique__23
 IncreasedAccuracyUniqueAmulet5
 MovementVelocityUniqueAmulet5
 AreaOfEffectUnique__7_
@@ -816,7 +816,7 @@ Turquoise Amulet
 Requires Level 20
 Implicits: 1
 HybridDexInt
-MaximumLifeUnique__4_
+MaximumLifeUnique__6
 GainFrenzyChargeOnKillVsEnemiesWith5PoisonsUnique__1
 GainPowerChargeOnKillVsEnemiesWithLessThan5PoisonsUnique__1
 PoisonDamagePerFrenzyChargeUnique__1
@@ -830,7 +830,7 @@ Variant: Current
 Requires Level 48
 Implicits: 1
 HybridStrDex
-IntelligenceUnique__15_
+IntelligenceUnique__16
 ChaosResistUnique__15
 {variant:1}CurseEffectivenessUnique__3_[10,15]
 {variant:2}CurseEffectivenessUnique__3_
@@ -886,7 +886,7 @@ Talisman Tier: 1
 Requires Level 12
 Implicits: 1
 AmuletHasOneSocket
-LocalIncreaseSocketedGemLevelUnique__8
+LocalIncreaseSocketedGemLevelUnique__1
 SocketedGemsHaveAddedChaosDamageUnique__1
 ItemActsAsSupportBlindUnique__1
 SupportedByCastOnStunUnique___1
@@ -918,7 +918,7 @@ GolemSizeUnique__1
 {variant:1}LessGolemLifeUnique__1[-35,-45]
 {variant:2}LessGolemLifeUnique__1
 GolemMovementSpeedUnique__1
-PrimordialJewelCountUnique__1
+PrimordialJewelCountUnique__4
 ]],[[
 Rashkaldor's Patience
 Jade Amulet
@@ -1068,7 +1068,7 @@ Implicits: 1
 AllAttributesImplicitAmulet1
 {variant:1}AllDamageUnique__4[20,25]
 {variant:2}AllDamageUnique__4
-IncreasedLifeUnique__110
+IncreasedLifeUnique__92_
 {variant:1}AddedManaRegenerationUnique__2[120,180]
 {variant:2}AddedManaRegenerationUnique__2
 TemporalChainsReservationCostUnique__1
@@ -1124,7 +1124,7 @@ Variant: Current
 Requires Level 54
 Implicits: 1
 LifeRegenerationImplicitAmulet1
-IntelligenceUnique__10
+IntelligenceUnique__15_
 MinionChaosResistanceUnique__3
 RagingSpiritDurationUnique__1
 {variant:1}RagingSpiritDamageUnique__2[60,80]
@@ -1137,8 +1137,8 @@ Tainted Pact
 Coral Amulet
 Implicits: 1
 LifeRegenerationImplicitAmulet1
-StrengthImplicitAmulet1
-LifeLeechPermyriadUnique__9
+StrengthUnique__23
+LifeLeechPermyriadUnique__8
 ManaLeechPermyriadUnique__3
 ChaosDamageOverTimeHealsLeechLifeUnique__1
 ]],[[
@@ -1288,7 +1288,7 @@ DexterityImplicitAmulet1
 PercentageStrengthUnique__4_
 PercentageDexterityUnique__5
 FireResistUnique__22_
-ColdResistUniqueAmulet13
+ColdResistUnique__30
 AlternateFortifyUnique__1_
 AttackAndCastSpeedFortifyUnique__1
 ]],[[
@@ -1299,8 +1299,8 @@ Variant: Current
 Requires Level 42
 Implicits: 1
 ItemFoundRarityIncreaseImplicitAmulet1
-DexterityImplicitAmulet1
-IncreasedLifeUnique__102
+DexterityUnique__1
+IncreasedLifeUnique___7
 ColdResistUnique__5
 CannotBeChilledUnique__1
 {variant:1}LifeRegenerationWhileFrozenUnique__1[1200,1200]
@@ -1313,7 +1313,7 @@ Source: Steal from a unique{Curio Display} during a Grand Heist
 Requires Level 42
 Implicits: 1
 ItemFoundRarityIncreaseImplicitAmulet1
-DexterityImplicitAmulet1
+DexterityUnique__1
 IncreasedEnergyShieldUnique__9
 LightningResistUnique__23_
 EnergyShieldRegenerationWhileShockedUnique__1
@@ -1332,7 +1332,7 @@ StrengthImplicitAmulet1
 StrengthImplicitAmulet1
 FireDamagePercentUnique___7
 IncreasedLifeUnique__25
-FireResistUnique__29
+FireResistUnique__9
 {variant:1}CoverInAshWhenHitUnique__1
 {variant:2}NearbyEnemiesCoveredInAshUnique__1
 ]],[[
@@ -1344,7 +1344,7 @@ Requires Level 64
 Implicits: 1
 StrengthImplicitAmulet1
 MaximumLifeUnique__3
-FireResistUnique__25
+FireResistUnique__9
 PercentageStrengthUnique__3
 FirePenetrationUnique__1
 CoverInAshWhenHitUnique__1
@@ -1359,7 +1359,7 @@ Implicits: 1
 AllAttributesImplicitAmulet1
 FireResistUnique__15
 ColdResistUnique__21
-LightningResistUnique__3
+LightningResistUnique__12
 IncreasedAilmentDurationUnique__2
 ChanceToShockUnique__3
 {variant:1}EnemiesTakeIncreasedDamagePerAilmentTypeUnique__1[5,5]
@@ -1413,7 +1413,7 @@ Source: Drops from unique{Incarnation of Dread} in normal{Moment of Reverence}
 Requires Level 74
 Implicits: 1
 LifeRegenerationImplicitAmulet2
-AllAttributesUniqueAmulet22
+AllAttributesUnique__30
 GlobalIncreaseMinionSpellSkillGemLevelUnique__5
 AllResistancesReducedPerActiveNonVaalSkillMinionUnique_1
 GlobalDefensesIncreasedPerActiveNonVaalSkillMinionUnique_1
@@ -1425,11 +1425,11 @@ Source: Drops from unique{Uber Incarnation of Neglect} in normal{Moment of Lonel
 Requires Level 64
 Implicits: 1
 HybridDexInt
-ChanceToDodgeSpellsUnique__1
+ChanceToSuppressSpellsUnique__4
 SuppressedDamageBypassEnergyShieldUnique_1
 SuppressedDamageRecoupedAsEnergyShield_1
-DexterityAndIntelligenceUnique_2
-IncreasedEnergyShieldUnique__13
-IncreasedLifeUnique__71
+DexterityAndIntelligenceUnique_3
+LocalIncreasedEnergyShieldUnique__35
+MaximumLifeUnique__25
 ]],
 }

--- a/src/Export/Uniques/amulet.lua
+++ b/src/Export/Uniques/amulet.lua
@@ -1329,7 +1329,7 @@ Upgrade: Upgrades to unique{Xoph's Blood} using currency{Blessing of Xoph}
 Requires Level 35
 Implicits: 1
 StrengthImplicitAmulet1
-StrengthImplicitAmulet1
+StrengthUnique__6
 FireDamagePercentUnique___7
 IncreasedLifeUnique__25
 FireResistUnique__9

--- a/src/Export/Uniques/axe.lua
+++ b/src/Export/Uniques/axe.lua
@@ -24,7 +24,7 @@ LocalAddedFireDamageUniqueOneHandAxe7
 LocalIncreasedAttackSpeedUniqueOneHandAxe7
 FireResistUniqueOneHandAxe7_
 MovementVelocityUniqueOneHandAxe7
-FlammabilityOnHitUniqueOneHandAxe7
+FlammabilityOnHitUnique__1
 ]],[[
 Dreadsurge
 Cleaver
@@ -94,7 +94,7 @@ LocalAddedPhysicalDamageUniqueOneHandAxe5
 {variant:1}LocalIncreasedAttackSpeedUniqueOneHandAxe2
 {variant:1}LifeLeechPermyriadUniqueOneHandAxe6
 {variant:1}50% reduced total Recovery per second from Life Leech
-CausesBleedingUniqueOneHandAxe5
+CausesBleedingUniqueOneHandAxe5Updated_
 {variant:2}LocalBleedDamageOverTimeMultiplierUnique__1
 ]],[[
 Moonbender's Wing
@@ -121,7 +121,7 @@ LocalIncreasedPhysicalDamagePercentUniqueOneHandAxe6
 LocalAddedPhysicalDamageUniqueOneHandAxe6
 {variant:1}LifeLeechPermyriadUniqueOneHandAxe6[60,60]
 {variant:2}LifeLeechPermyriadUniqueOneHandAxe6
-CullingStrikeUnique__1
+CullingStrike
 GainOnslaughtWhenCullingEnemyUniqueOneHandAxe6
 CannotBeChilledWhenOnslaughtUniqueOneHandAxe6
 ]],[[
@@ -135,7 +135,7 @@ Variant: Current
 Implicits: 0
 LocalAddedPhysicalDamageUnique__7
 DualWieldingPhysicalDamageUnique__1
-LocalIncreasedAttackSpeedUniqueOneHandAxe2
+LocalIncreasedAttackSpeedUnique__7
 {variant:1}SwordPhysicalAttackSpeedUnique__1
 {variant:1}CausesBleedingUniqueOneHandAxe5
 {variant:2}MaxRagePerEquippedSwordUnique__1____[25,25]
@@ -158,7 +158,7 @@ Implicits: 0
 {variant:4,5}LocalIncreasedAttackSpeedUniqueOneHandAxe1
 ColdResistUniqueOneHandAxe1_
 MeleeAttacksUsableWithoutManaUniqueOneHandAxe1
-PhysicalDamageCanChillUniqueDescentOneHandAxe1
+PhysicalDamageCanChillUniqueOneHandAxe1
 {variant:5}GainSoulEaterStackOnRareOrUniqueKillWithWeaponUnique__1
 ]],[[
 Replica Soul Taker
@@ -178,7 +178,7 @@ Abyssal Axe
 Source: Drops from unique{Incarnation of Fear} in normal{Moment of Trauma}
 Requires Level 55, 128 Str, 60 Dex
 StarfellOnMeleeCriticalHitUnique__1
-AllAttributesUnique__17_
+AllAttributesUnique__29
 LocalIncreasedPhysicalDamagePercentUniqueTwoHandAxe10
 LocalCriticalStrikeChanceUniqueTwoHandAxe_1
 AreaOfEffectUnique_9
@@ -215,7 +215,7 @@ Implicits: 1
 {variant:2}LocalAddedPhysicalDamageUniqueTwoHandAxe7[205,220][250,270]
 {variant:3}LocalAddedPhysicalDamageUniqueTwoHandAxe7
 LocalIncreasedAttackSpeedUniqueTwoHandAxe7
-CausesBleedingUniqueOneHandAxe5Updated_
+CausesBleedingUniqueTwoHandAxe7Updated
 {variant:1,2}LocalIncreasedMeleeWeaponRangeUniqueTwoHandAxe7_[2,2]
 {variant:3}LocalIncreasedMeleeWeaponRangeUniqueTwoHandAxe7_
 ]],[[
@@ -232,7 +232,7 @@ IncreasedLifeUniqueTwoHandAxe4
 {variant:3}LifeRegenerationUniqueTwoHandAxe4
 LifeLeechPermyriadUniqueTwoHandAxe4
 ManaCostIncreaseUniqueTwoHandAxe4
-CausesBleedingUniqueTwoHandAxe4
+CausesBleedingUniqueTwoHandAxe4Updated
 ]],[[
 Debeon's Dirge
 Despot Axe
@@ -268,9 +268,9 @@ Variant: Current
 Implicits: 1
 {variant:2}LocalMaimOnHit2HImplicit_1
 {variant:1}LocalIncreasedPhysicalDamagePercentUniqueTwoHandAxe2[150,170]
-{variant:2}LocalIncreasedPhysicalDamagePercentUniqueTwoHandAxe2
+{variant:2}LocalIncreasedPhysicalDamagePercentUnique__2
 LocalAddedPhysicalDamage__1
-LifeLeechPermyriadUniqueTwoHandAxe4
+LifeLeechPermyriad__1
 {variant:2}AttackSpeedAfterSavageHitTakenUnique__1
 AttacksHaveBloodMagic__1
 ]],[[
@@ -289,8 +289,8 @@ Implicits: 0
 {variant:1,2}LocalAddedFireDamageUniqueTwoHandAxe1
 LifeGainedFromEnemyDeathUniqueTwoHandAxe1
 IncreasedAccuracyUniqueTwoHandAxe1
-CullingStrikeUnique__1
-{variant:5}RageOnMeleeHitE3
+CullingStrike
+{variant:5}RageOnMeleeHitUnique__1
 {variant:3,4}RageOnAttackCritUnique__1
 {variant:3,4,5}PhysicalAddedAsFirePerRageUnique__1
 ]],[[
@@ -310,11 +310,11 @@ Implicits: 0
 {variant:5}LocalIncreasedPhysicalDamagePercentUniqueTwoHandAxe9[190,240]
 {variant:6}LocalIncreasedPhysicalDamagePercentUniqueTwoHandAxe9
 LocalIncreasedAttackSpeedUniqueTwoHandAxe9
-{variant:2,3,4,5,6}CriticalStrikeChanceUniqueBow9
+{variant:2,3,4,5,6}LocalCriticalStrikeChanceUnique__9
 {variant:1}IncreasedManaUniqueTwoHandAxe9
 DisplayNearbyAlliesHaveIncreasedItemRarityUniqueTwoHandAxe9
 DisplayNearbyAlliesHaveCullingStrikeUniqueTwoHandAxe9
-{variant:2,3,4,5,6}MeleeAttacksUsableWithoutManaUniqueOneHandAxe1
+{variant:2,3,4,5,6}MeleeAttacksUsableWithoutManaUnique__1
 {variant:3,4,5,6}DisplayNearbyAlliesHaveCriticalStrikeMultiplierTwoHandAxe9
 {variant:3,4}DisplayNearbyAlliesHaveFortifyTwoHandAxe9[1,1]
 {variant:5,6}DisplayNearbyAlliesHaveFortifyTwoHandAxe9
@@ -329,7 +329,7 @@ SupportedByMeleeSplashUnique__1_
 {variant:1}LocalIncreasedPhysicalDamagePercentUnique__23[250,300]
 {variant:2}LocalIncreasedPhysicalDamagePercentUnique__23[265,330]
 {variant:3}LocalIncreasedPhysicalDamagePercentUnique__23
-LifeLeechPermyriadUniqueTwoHandAxe4
+LifeLeechPermyriadUnique__5
 ManaLeechPermyriadUnique__2
 RecoverPercentMaxLifeOnKillUnique__1
 EnemiesDestroyedOnKillUnique__1
@@ -344,7 +344,7 @@ LocalIncreaseSocketedStrengthGemLevelUniqueTwoHandAxe3
 StrengthUniqueTwoHandAxe3
 LocalIncreasedPhysicalDamagePercentUniqueTwoHandAxe3
 LocalAddedPhysicalDamageUniqueTwoHandAxe3
-CullingStrikeUnique__1
+CullingStrike
 ]],[[
 The Cauteriser
 Woodsplitter
@@ -368,8 +368,8 @@ Variant: Current
 Implicits: 0
 MoltenBurstOnMeleeHitUnique__1
 {variant:1}LocalIncreasedPhysicalDamagePercentUnique__17_[190,230]
-{variant:2}LocalIncreasedPhysicalDamagePercentUnique__17_
-LocalIncreasedAttackSpeedUnique__2
+{variant:2}LocalIncreasedPhysicalDamagePercentUnique__9
+LocalIncreasedAttackSpeedUnique__9
 {variant:1}DamageConversionFireUnique__1[50,50]
 {variant:2}DamageConversionFireUnique__1
 PenetrateEnemyFireResistUnique__1
@@ -381,7 +381,7 @@ LocalIncreasedPhysicalDamagePercentUniqueTwoHandAxe2
 ItemFoundRarityIncreaseUniqueTwoHandAxe2
 LifeGainedFromEnemyDeathUniqueTwoHandAxe2
 MovementVelocityOnFullLifeUniqueTwoHandAxe2
-CullingStrikeUnique__1
+CullingStrike
 AlwaysHits
 ]],[[
 Sinvicta's Mettle
@@ -391,10 +391,10 @@ Variant: Current
 Implicits: 0
 {variant:1}LocalIncreasedPhysicalDamagePercentUnique__33[200,212]
 {variant:2}LocalIncreasedPhysicalDamagePercentUnique__33
-IncreasedAttackSpeedUnique__5
+LocalIncreasedAttackSpeedUnique__28
 AreaOfEffectPer25RampageStacksUnique__1_
 FrenzyChargePer50RampageStacksUnique__1
-SimulatedRampageDexInt6
+SimulatedRampageUnique__3_
 ]],[[
 Spinesnatch
 Fleshripper
@@ -440,7 +440,7 @@ GrantsLevel20BoneNovaTriggerUnique__1
 LocalIncreasedPhysicalDamagePercentUnique__24
 LocalReducedAttackSpeedUnique__3
 {variant:1,2}AttacksCauseBleedingOnCursedEnemyHitUnique__1
-{variant:3}CausesBleedingUniqueTwoHandAxe7Updated
+{variant:3}LocalChanceToBleedUnique__1
 ]],[[
 Wideswing
 Poleaxe

--- a/src/Export/Uniques/belt.lua
+++ b/src/Export/Uniques/belt.lua
@@ -216,7 +216,7 @@ Variant: Pre 3.21.0
 Variant: Current
 Implicits: 1
 AbyssJewelSocketImplicit
-AbyssJewelSocketUnique__3
+AbyssJewelSocketUnique__6_
 {variant:1}AbyssJewelEffectUnique__1[50,50]
 {variant:2}AbyssJewelEffectUnique__1[75,75]
 {variant:3}AbyssJewelEffectUnique__1

--- a/src/Export/Uniques/belt.lua
+++ b/src/Export/Uniques/belt.lua
@@ -15,7 +15,7 @@ StunRecoveryImplicitBelt1
 IncreasedPhysicalDamageReductionRatingUnique__7
 MaximumLifeUnique__22
 FireResistUnique__26
-{variant:2}ChargeBonusMaximumEnduranceCharges
+{variant:2}MaximumEnduranceChargeUnique__2
 MinimumBrutalChargeModifiersEqualsEnduranceUnique__1
 MaximumBrutalChargesEqualsEnduranceUnique__1__
 GainBrutalChargesInsteadOfEnduranceUnique__1
@@ -31,7 +31,7 @@ IncreasedEnergyShieldImplicitBelt1
 IncreasedEvasionRatingUnique__2
 {variant:1}IncreasedEnergyShieldUnique__4[35,45]
 {variant:2,3}IncreasedEnergyShieldUnique__4
-AllResistancesUniqueBelt13
+AllResistancesUnique__4
 PhasingOnBeginESRechargeUnique___1
 {variant:1,2}ChanceToDodgeAttacksWhilePhasingUnique___1[6,6]
 {variant:3}ChanceToDodgeAttacksWhilePhasingUnique___1
@@ -106,10 +106,10 @@ LevelReq: 68
 Implicits: 1
 IncreasedLifeImplicitBelt1
 AddedPhysicalDamageUnique__9_
-StunDurationImplicitBelt1
+StunDurationUnique__1
 EnemiesCrushedWithRageUnique__1_
 {variant:1}MaximumRageImplicitE1[20,20]
-{variant:2}MaximumRageImplicitE1
+{variant:2}MaximumRageUnique__1
 ]],[[
 Belt of the Deceiver
 Heavy Belt
@@ -134,19 +134,19 @@ LevelReq: 30
 Implicits: 1
 StrengthImplicitBelt1
 {variant:1}ItemFoundQuantityIncreasedUnique__1
-{variant:2}AllAttributesUnique__2
-ColdResistUniqueBelt14
+{variant:2}AllAttributesUnique__28
+ColdResistUnique__15
 IncreasedRarityPerRampageStacksUnique__1
-SimulatedRampageDexInt6
+SimulatedRampageUnique__2
 ]],[[
 Bound Fate
 Cloth Belt
 LevelReq: 16
 Implicits: 1
 StunRecoveryImplicitBelt1
-DexterityUnique__1
-IntelligenceUniqueBelt1
-IncreasedLifeUnique__3
+DexterityUnique__29
+IntelligenceUnique__32
+IncreasedLifeUnique__120
 HinekoraButterflyEffectUnique__1
 ]],[[
 Chains of Emancipation
@@ -156,8 +156,8 @@ Source: Drops from unique{Friedrich Tarollo, Slave Merchant} in normal{Contract:
 LevelReq: 61
 Implicits: 1
 IncreasedEnergyShieldImplicitBelt1
-IncreasedLifeUnique__124
-ChaosResistUnique__10
+IncreasedLifeUnique__103
+ChaosResistUnique__17
 EnemyTemporalChainsOnHitUnique__1
 GainRageOnLosingTemporalChainsUnique__1__
 ImmuneToCursesWithRageUnique__1
@@ -174,11 +174,11 @@ Implicits: 1
 IncreasedEnergyShieldImplicitBelt1
 {variant:1}AllDamageUnique__2
 {variant:1}AllAttributesUnique__20[10,15]
-{variant:2}AllAttributesUnique__20
-MovementVelocityUnique__44
+{variant:2}AllAttributesUnique__9
+MovementVelocityUnique__33_
 EnemiesExtraDamageRollsWhileAffectedByVulnerabilityUnique__1_
 {variant:2}CountOnFullLifeWhileAffectedByVulnerabilityUnique__1
-UniqueSelfCurseVulnerabilityLevel20
+UniqueSelfCurseVulnerabilityLevel10
 ]],[[
 Coward's Legacy
 Chain Belt
@@ -187,11 +187,11 @@ Source: Upgraded from unique{Coward's Chains} via currency{Vial of Consequence}
 LevelReq: 52
 Implicits: 1
 IncreasedEnergyShieldImplicitBelt1
-AllAttributesUnique__12
+AllAttributesUnique__10_
 MovementVelocityUnique__33_
 IncreasedCurseEffectUnique__1
 CountAsLowLifeWhileAffectedByVulnerabilityUnique__1
-UniqueSelfCurseVulnerabilityLevel10
+UniqueSelfCurseVulnerabilityLevel20
 ]],[[
 Cyclopean Coil
 Leather Belt
@@ -200,7 +200,7 @@ Source: Drops from unique{The Elder}
 LevelReq: 68
 Implicits: 1
 IncreasedLifeImplicitBelt1
-IncreasedLifeUnique__121
+IncreasedLifeUnique__63_
 AllAttributesPercentUnique__2
 CannotBeFrozenWithDexHigherThanIntUnique__1
 CannotBeIgnitedWithStrHigherThanDexUnique__1
@@ -265,7 +265,7 @@ League: Heist
 LevelReq: 48
 Implicits: 1
 StunRecoveryImplicitBelt1
-AllAttributesUniqueBelt3
+AllAttributesUnique__22_
 BeltIncreasedFlaskChargesGainedUnique__1_
 BeltIncreasedFlaskChargedUsedUnique__1
 BeltIncreasedFlaskDurationUnique__3___
@@ -294,10 +294,10 @@ League: Talisman Standard, Talisman Hardcore
 LevelReq: 18
 Implicits: 1
 IncreasedPhysicalDamagePercentImplicitBelt1
-ColdResistUniqueBelt1
+ColdResistUnique__3
 IncreasedProjectileDamageUnique__5
 BeltReducedFlaskChargesGainedUnique__1
-BeltIncreasedFlaskDurationUnique__2
+BeltIncreasedFlaskDurationUnique__1
 DisplayChaosDegenerationAuraUnique__1
 ]],[[
 Feastbind
@@ -350,7 +350,7 @@ LevelReq: 48
 Implicits: 1
 IncreasedLifeImplicitBelt1
 {variant:1}PoachersMarkCurseOnHitHexproofUnique__1
-IncreasedLifeUnique__120
+IncreasedLifeUnique__79
 {variant:1}CullingStrikePoachersMarkUnique__1
 {variant:2}CullingStrikeCursedEnemyUnique__1_
 {variant:2}LifeGainOnHitCursedEnemyUnique__1
@@ -367,10 +367,10 @@ Source: Drops from unique{The Maven}
 LevelReq: 68
 Implicits: 1
 StunRecoveryImplicitBelt1
-IncreasedEnergyShieldUniqueBelt5
+IncreasedEnergyShieldUnique__10
 MaximumManaUnique__8
 LightningResistUnique__24
-{variant:2}ChargeBonusMaximumPowerCharges
+{variant:2}IncreasedMaximumPowerChargesUnique__4
 MinimumAbsorptionChargeModifiersEqualsPowerUnique__1
 MaximumAbsorptionChargesEqualsPowerUnique__1_
 GainAbsorptionChargesInsteadOfPowerUnique__1
@@ -426,7 +426,7 @@ Variant: Lucky Crit Chance while Focused (Current)
 LevelReq: 60
 Implicits: 1
 IncreasedLifeImplicitBelt1
-ColdResistUnique__16
+ColdResistUnique__26
 ChillNearbyEnemiesOnFocusUnique__1_
 {variant:1,2,3,4,5,6,7,8,9,10}FocusCooldownRecoveryUnique__1_[15,25]
 {variant:11,12,13,14,15,16,17,18,19}FocusCooldownRecoveryUnique__1_
@@ -476,7 +476,7 @@ Heavy Belt
 LevelReq: 56
 Implicits: 1
 StrengthImplicitBelt1
-StrengthUnique__11
+StrengthUnique__25
 IncreasedPhysicalDamageReductionRatingUnique__8
 TakeNoBurningDamageIfStopBurningUnique__1
 NearbyEnemyPhysicalDamageConvertedToFire__1
@@ -486,8 +486,8 @@ Leather Belt
 LevelReq: 49
 Implicits: 1
 IncreasedLifeImplicitBelt1
-AllAttributesUnique__10_
-IncreasedLifeUnique__110
+AllAttributesUnique__20
+IncreasedLifeUnique__98
 MultipleOfferingsAllowedUnique__1_
 OfferingDurationUnique__1
 ]],[[
@@ -540,7 +540,7 @@ Implicits: 1
 StrengthImplicitBelt1
 DexterityUnique__22
 FireResistUnique__27_
-ColdResistUnique__19
+ColdResistUnique__34
 MagicUtilityFlasksCannotUseUnique__1____
 MagicUtilityFlasksAlwaysApplyUnique__1
 MagicUtilityFlasksCannotRemoveUnique__1
@@ -566,7 +566,7 @@ StrengthUniqueBelt4
 {variant:1}AddedPhysicalDamageUniqueBelt4[5,5][15,15]
 {variant:2}AddedPhysicalDamageUniqueBelt4
 MaximumLifeUniqueBelt4
-ColdResistUniqueBelt13
+ColdResistUniqueBelt4
 BeltFlaskLifeRecoveryRateUniqueBelt4
 ]],[[
 Mother's Embrace
@@ -574,8 +574,8 @@ Heavy Belt
 LevelReq: 40
 Implicits: 1
 StrengthImplicitBelt1
-IncreasedLifeUnique__102
-ColdResistUniqueBelt1
+IncreasedLifeUnique__99
+ColdResistUnique__29
 MinionsUseFlaskOnSummonUnique__1__
 MinionFlaskChargesUsedUnique__1
 MinionFlaskDurationUnique__1
@@ -586,7 +586,7 @@ League: Necropolis
 Requires Level 16
 Implicits: 1
 StunRecoveryImplicitBelt1
-DexterityUnique__1
+DexterityUnique__31
 BeltIncreasedFlaskDurationUnique__4
 BeltIncreasedFlaskEffectUnique__2
 FlaskDurationPerLevelUnique__1
@@ -604,7 +604,7 @@ StunRecoveryImplicitBelt1
 IncreasedEvasionRatingUnique__5_
 ColdResistUnique__33
 MovementVelocityUnique__46
-{variant:2}ChargeBonusMaximumFrenzyCharges
+{variant:2}MaximumFrenzyChargesUnique__1
 MinimumAfflictionChargeModifiersEqualsFrenzyUnique__1
 MaximumAfflictionChargesEqualsFrenzyUnique__1
 GainAfflictionChargesInsteadOfFrenzyUnique__1
@@ -619,7 +619,7 @@ StunRecoveryImplicitBelt1
 AllAttributesUniqueBelt3
 {variant:1}ItemFoundQuantityIncreaseUniqueBelt3[8,12]
 {variant:2}ItemFoundQuantityIncreaseUniqueBelt3
-{variant:3}ItemFoundRarityIncreaseUnique__4_
+{variant:3}ItemFoundRarityIncreaseUnique__8
 FireResistUniqueBelt3
 BeltIncreasedFlaskDurationUniqueBelt3
 PhysicalAttackDamageReducedUniqueBelt3
@@ -629,8 +629,8 @@ Cloth Belt
 LevelReq: 40
 Implicits: 1
 StunRecoveryImplicitBelt1
-DexterityUnique__18
-IncreasedManaUnique__14
+DexterityUnique__27
+IncreasedManaUnique__25
 BeltIncreasedFlaskChargedUsedUnique__2
 LinkSkillFlaskEffectsUnique__1
 ]],[[
@@ -650,7 +650,7 @@ Variant: Current
 Implicits: 1
 ArmourAndEvasionImplicitBelt1
 MaximumLifeUnique__4_
-ColdResistUniqueBelt14
+ColdResistUnique__13
 AttackDamagePerLowestArmourOrEvasionUnique__1
 {variant:1}FortifyOnMeleeStunUnique__1[14,20]
 {variant:2}FortifyOnMeleeStunUnique__1
@@ -704,7 +704,7 @@ League: Heist
 LevelReq: 43
 Implicits: 1
 IncreasedLifeImplicitBelt1
-DexterityImplicitQuiver1
+DexterityUnique__19
 IncreasedEvasionRatingUnique__4
 ElementalStatusAilmentDurationUnique__1_
 EnemyIgnitedConvertedToFireUnique__1
@@ -717,10 +717,10 @@ Source: Vendor Recipe
 LevelReq: 44
 Implicits: 1
 IncreasedPhysicalDamagePercentImplicitBelt1
-IncreasedLifeUnique__105
+IncreasedLifeUnique__6
 ColdResistUniqueRing24
 LifeLeechPermyriadUnique__3
-BeltIncreasedFlaskDurationUnique__1
+BeltIncreasedFlaskDurationUnique__2
 FlaskChargeRecoveryDuringFlaskEffectUnique__2
 EnemiesLoseLifePlayerLeechesUnique__1
 MovementSpeedDuringFlaskEffectUnique__1
@@ -732,13 +732,13 @@ Variant: Current
 LevelReq: 20
 Implicits: 1
 StunDurationImplicitBelt1
-StrengthUnique__19_
+StrengthUnique__10
 {variant:1}RyuslathaMinimumDamageModifierUnique__1[-20,-20]
 {variant:2}RyuslathaMinimumDamageModifierUnique__1
 {variant:1}RyuslathaMaximumDamageModifierUnique__1_[20,20]
 {variant:2}RyuslathaMaximumDamageModifierUnique__1_
 AddedPhysicalDamageUnique__4
-{variant:2}IncreasedLifeUnique__108
+{variant:2}IncreasedLifeUnique__90
 LifeGainedOnStunUnique__1_
 ]],[[
 Saresh's Darkness
@@ -811,8 +811,8 @@ LevelReq: 44
 Implicits: 1
 StrengthImplicitBelt1
 IncreasedEnergyShieldPercentUnique__5
-MaximumLifeUnique__16
-ChaosResistImplicitRing1
+MaximumLifeUnique__17
+ChaosResistUnique__14
 MinionAttacksTauntOnHitChanceUnique__1
 MinionCausticCloudOnDeathUnique__1_
 ]],[[
@@ -823,8 +823,8 @@ Source: Steal from a unique{Curio Display} during a Grand Heist
 LevelReq: 44
 Implicits: 1
 StrengthImplicitBelt1
-IncreasedEnergyShieldPercentUnique__3
-MaximumLifeUnique__11
+IncreasedEnergyShieldPercentUnique__5
+MaximumLifeUnique__17
 FireResistUnique__24
 MinionBurningCloudOnDeathUnique__1
 MinionChanceToMaimOnHitUnique__1_
@@ -834,7 +834,7 @@ Cloth Belt
 LevelReq: 48
 Implicits: 1
 StunRecoveryImplicitBelt1
-IntelligenceUnique__25
+IntelligenceUnique__6
 MaximumEnergyShieldAsPercentageOfLifeUnique__1
 KeystoneSoulTetherUnique__1
 ]],[[
@@ -845,7 +845,7 @@ Source: Steal from a unique{Curio Display} during a Grand Heist
 LevelReq: 48
 Implicits: 1
 StunRecoveryImplicitBelt1
-StrengthUnique__10
+StrengthUnique__19_
 MaximumEnergyShieldAsPercentageOfLifeUnique__1
 KeystoneCorruptedSoulUnique_1
 ]],[[
@@ -854,7 +854,7 @@ Cloth Belt
 LevelReq: 45
 Implicits: 1
 StunRecoveryImplicitBelt1
-IncreasedLifeUnique__103
+IncreasedLifeUnique__3
 AllResistancesUnique__1
 BeltFlaskManaRecoveryUnique__1
 IncreasedFlaskDurationUnique__1
@@ -967,7 +967,7 @@ LevelReq: 30
 Implicits: 1
 IncreasedLifeImplicitBelt1
 MaximumLifeUnique__1
-LifeRegenerationRatePercentageUniqueJewel24
+LifeRegenerationRatePercentUnique__1
 CannotBeAffectedByFlasksUnique__1
 FlasksApplyToMinionsUnique__1
 ]],[[
@@ -1006,9 +1006,9 @@ League: Settlers of Kalguur
 Requires Level 52
 Implicits: 1
 StunDurationImplicitBelt1
-LifeRegenerationUnique__3
-FireResistUniqueBelt6
-ColdResistUniqueBelt1
+LifeRegenerationUnique__5
+FireResistUnique__35
+ColdResistUnique__41
 ConvertBodyArmourEvasionToWardUnique__1
 ]],[[
 Binds of Bloody Vengeance
@@ -1019,7 +1019,7 @@ Requires Level 78
 Implicits: 1
 ArmourAndEvasionImplicitBelt1
 IncreasedPhysicalDamageReductionRatingUnique__11
-IncreasedLifeUnique__100
+IncreasedLifeUnique__126
 AttackDamageIfHitRecentlyUnique
 AttackCritAfterBeingCritUnique
 ]],[[

--- a/src/Export/Uniques/body.lua
+++ b/src/Export/Uniques/body.lua
@@ -50,7 +50,7 @@ Implicits: 0
 {variant:1}SelfShockDurationUnique__2
 TakeNoExtraDamageFromCriticalStrikesUnique__1
 {variant:2}MaximumElementalResistanceUnique__1__
-{variant:2}NoMaximumLifePerStrengthUnique__1
+{variant:2}NoMaximumLifePerStrengthUnique__2
 ]],[[
 Craiceann's Carapace
 Golden Plate
@@ -61,10 +61,10 @@ Source: Drops from unique{Craiceann, First of the Deep}
 Implicits: 0
 GrantsCrabAspect1_
 {variant:1}LocalIncreasedPhysicalDamageReductionRatingPercentUniqueBodyStr6[300,350]
-{variant:2}LocalIncreasedPhysicalDamageReductionRatingPercentUniqueBodyStr6
+{variant:2}LocalIncreasedPhysicalDamageReductionRatingPercentUnique__16
 IncreasedLifeUnique__72_
 FireAndColdResistUnique__3
-BleedingImmunityUnique__1
+BleedingImmunityUnique__2
 MaximumCrabBarriersUnique__1
 ]],[[
 Death's Oath
@@ -78,7 +78,7 @@ AllResistancesImplicitArmour1
 AllAttributesUniqueBodyStr3
 IncreasedAttackSpeedUniqueBodyStr3
 LocalIncreasedPhysicalDamageReductionRatingUniqueBodyStr3
-{variant:3}IncreasedLifeUniqueBodyDex6
+{variant:3}IncreasedLifeUnique__55
 LifeLeechPermyriadUniqueBodyStr3
 {variant:1,2}DisplayChaosDegenerationAuraUniqueBodyStr3
 {variant:1}ChaosDegenerationOnKillUniqueBodyStr3[27000,27000][600,600]
@@ -162,8 +162,8 @@ Implicits: 0
 BlockChancePer50StrengthUnique__1
 ExtraRollsSpellBlockUnique__1
 StrengthUnique__13_
-LocalIncreasedPhysicalDamageReductionRatingPercentUnique__12
-ReducedMovementVelocityUnique__1
+LocalIncreasedPhysicalDamageReductionRatingPercentUnique__15
+ReducedMovementVelocityUnique__2
 StrengthDamageBonus3Per10Unique__1
 ]],[[
 Perfidy
@@ -173,7 +173,7 @@ Variant: Pre 3.25.0
 Variant: Current
 Implicits: 0
 MeleeDamageUnique__2
-IncreasedLifeUniqueBodyStrDex3_
+IncreasedLifeUnique__100
 Allow2ActiveBannersUnique__1
 {variant:2}BannerResourceGainedUnique__1
 ]],[[
@@ -183,7 +183,7 @@ League: Affliction
 Source: unique{The King in the Mists} in the normal{Crux of Nothingness}
 Requires Level 49, 134 Str
 LocalIncreaseSocketedActiveSkillGemLevelUnique__1
-LocalIncreasedPhysicalDamageReductionRatingPercentUnique__19
+LocalIncreasedPhysicalDamageReductionRatingPercentUnique__29
 IncreasedManaUnique__28
 LocalIncreaseSocketedGemLevelPerFilledSocketUnique__1
 ]],[[
@@ -204,8 +204,8 @@ Utula's Hunger
 Majestic Plate
 Requires Level 53, 145 Str
 LocalIncreasedPhysicalDamageReductionRatingPercentUnique__27
-MaximumLifeOnKillPercentUnique__2
-StunRecoveryUnique__2
+MaximumLifeOnKillPercentUnique__6
+StunRecoveryUnique__7
 IncreasedLifeNoLifeModifiersUnique__1
 ]],
 -- Body: Evasion
@@ -304,7 +304,7 @@ DexterityUniqueBodyDex4
 LocalIncreasedEvasionRatingPercentUniqueBodyDex4
 {variant:1,2}MovementVelocityUniqueBodyDex4
 {variant:3}MovementVelocityOnFullLifeUnique__1
-{variant:3}EnemyExtraDamageRollsOnFullLifeUnique__1
+{variant:3}EnemyExtraDamageRollsOnFullLifeUnique__2
 ]],[[
 Fox's Fortune
 Wild Leather
@@ -344,7 +344,7 @@ Zodiac Leather
 League: Heist
 Source: Steal from a unique{Curio Display} during a Grand Heist
 ChanceToSuppressSpellsUniqueBodyDex1
-IntelligenceUnique__11
+IntelligenceUnique__34
 LocalIncreasedEvasionRatingPercentUniqueBodyDex1
 ShockDurationUnique__3
 AddedLightningDamageUnique__4
@@ -412,7 +412,7 @@ Implicits: 0
 {variant:1,2}DexterityUnique__10_
 {variant:3}PercentageDexterityUnique__4
 {variant:1}LocalIncreasedEvasionRatingPercentUniqueBodyDex3[30,50]
-{variant:2,3}LocalIncreasedEvasionRatingPercentUniqueBodyDex3
+{variant:2,3}LocalIncreasedEvasionRatingPercentUnique__5
 IncreasedLifeUnique__26
 {variant:1,2}ArcticArmourBuffEffectUnique__1_[25,25]
 {variant:3}ArcticArmourBuffEffectUnique__1_
@@ -438,7 +438,7 @@ Implicits: 0
 ColdResistUnique__14
 {variant:1,2}ArcticArmourReservationCostUnique__1
 EvasionIncreasedByUncappedColdResistanceUnique__1
-Acrobatics
+KeystonePhaseAcrobaticsUnique__1
 ]],[[
 Replica Perfect Form
 Zodiac Leather
@@ -453,7 +453,7 @@ Implicits: 0
 {variant:2,3}PercentageDexterityUnique__4
 {variant:1}LocalIncreasedEvasionRatingPercentUnique__2[30,50]
 {variant:2}LocalIncreasedEvasionRatingPercentUnique__2[80,100]
-{variant:3,4}LocalIncreasedEvasionRatingPercentUnique__2
+{variant:3,4}LocalIncreasedEvasionRatingPercentUnique__4
 {variant:1}IncreasedLifeUniqueBodyStrDex4[50,80]
 {variant:2,3}IncreasedLifeUniqueBodyStrDex4
 ColdResistUnique__14
@@ -475,9 +475,9 @@ Implicits: 0
 {variant:1,4}GrantsSummonBeastRhoaUnique__1
 {variant:2,5}GrantsSummonBeastSnakeUnique__1
 {variant:3,6}GrantsSummonBeastUrsaUnique__1
-IncreasedAccuracyUnique__1
+IncreasedAccuracyUnique__5
 LocalIncreasedEvasionRatingPercentUnique__9
-IncreasedLifeUniqueBodyStrDexInt1
+IncreasedLifeUnique__51
 ProjectileAttackCriticalStrikeChanceUnique__1
 {variant:1}Projectiles from Attacks have 20% chance to Maim on Hit while you have a Bestial Minion
 {variant:4}Projectiles from Attacks have 100% chance to Maim on Hit while you have a Bestial Minion
@@ -498,7 +498,7 @@ The Apostate
 Cabalist Regalia
 Requires Level 35
 Source: Drops from unique{Synthete Nightmare} in normal{The Cortex} (Uber)
-StrengthUnique__18
+StrengthUnique__27
 AllResistancesUnique__31
 LifeFromEnergyShieldArmourUnique__1
 ]],[[
@@ -512,7 +512,7 @@ SpellDamageUnique__3
 {variant:1}IncreasedEnergyShieldImplicitRing1[55,65]
 {variant:2}IncreasedEnergyShieldImplicitRing1
 {variant:1,2}LocalIncreasedEnergyShieldUniqueBodyInt4[110,130]
-{variant:3}LocalIncreasedEnergyShieldUniqueBodyInt4
+{variant:3}LocalIncreasedEnergyShieldPercent___3
 {variant:1,2}EnergyShieldRecoveryRateUnique__1[30,40]
 {variant:3}EnergyShieldRecoveryRateUnique__1
 AreaOfEffectUnique__1
@@ -542,7 +542,7 @@ Variant: Current
 Implicits: 0
 DisplaySocketedMinionGemsSupportedByLifeLeechUnique__1
 {variant:1}LocalIncreasedEnergyShieldPercentUniqueBody_1[250,300]
-{variant:2}LocalIncreasedEnergyShieldPercentUniqueBody_1
+{variant:2}LocalIncreasedEnergyShieldPercentUnique__5
 MinionBlindImmunityUnique__1
 MinionChanceToBlindOnHitUnique__1
 MagicItemsDropIdentifiedUnique__1
@@ -607,10 +607,10 @@ Variant: Pre 3.5.0
 Variant: Pre 3.16.0
 Variant: Current
 Implicits: 0
-SocketedGemsSupportedByBlasphemyUnique__2__
+SupportedByBlasphemyUnique
 GrantCursePillarSkillUnique
 {variant:3}DoedresSkinLessCurseEffectUnique__1
-IntelligenceUniqueBodyStrInt3
+IntelligenceUnique__8
 LocalIncreasedEnergyShieldPercentUnique__14
 {variant:1}CurseEffectivenessUnique__2_[-33,-25]
 ]],[[
@@ -619,7 +619,7 @@ Widowsilk Robe
 League: Bestiary
 Source: Drops from unique{Fenumus, First of the Night}
 Implicits: 0
-IntelligenceUniqueBodyStrInt3
+IntelligenceUnique__10
 LocalIncreasedEnergyShieldPercentUnique__17
 FlatEnergyShieldRegenerationUnique__1
 DamageDealtByWebbedEnemiesUnique__1
@@ -630,7 +630,7 @@ Fleshcrafter
 Necromancer Silks
 League: Harvest
 Implicits: 0
-LocalIncreasedEnergyShieldUniqueBodyInt1
+LocalIncreasedEnergyShieldPercentUnique__28__
 Minions Convert 2% of their Maximum Life to Maximum Energy Shield per 1% Chaos Resistance they have
 MinionChaosDamageDoesNotBypassESUnique__1
 MinionEnergyShieldRechargeDelayUnique__1
@@ -691,7 +691,7 @@ Source: Drops in Chayula Breach or from unique{Chayula, Who Dreamt}
 Upgrade: Upgrades to unique{Skin of the Lords} using currency{Blessing of Chayula}
 Implicits: 0
 Roll6LinkedRandomColourSocketsUnique__1
-LocalIncreaseSocketedGemLevelUnique__2
+LocalIncreaseSocketedGemLevelUnique__5
 AllDefencesUnique__2
 ]],[[
 Soul Mantle
@@ -838,8 +838,8 @@ Triumphant Lamellar
 League: Bestiary
 Source: Drops from unique{Farrul, First of the Plains}
 Implicits: 0
-LocalIncreasedArmourAndEvasionUnique__14
-IncreasedLifeUniqueBodyStrInt7
+LocalIncreasedArmourAndEvasionUnique__7
+IncreasedLifeUnique__74
 CatAspectReservesNoManaUnique__1___
 CatsStealthDurationUnique__1_
 GainMaxFrenzyAndPowerOnCatsStealthUnique__1
@@ -850,8 +850,8 @@ Triumphant Lamellar
 League: Heist
 Source: Steal from a unique{Curio Display} during a Grand Heist
 Implicits: 0
-LocalIncreasedArmourAndEvasionUnique__12
-IncreasedLifeUniqueBodyStrInt7
+LocalIncreasedArmourAndEvasionUnique__7
+IncreasedLifeUnique__74
 CatsStealthDurationUnique__1_
 CatAspectReservesNoManaUnique__1___
 GainMaxFrenzyAndEnduranceOnCatsAgilityUnique__1
@@ -885,7 +885,7 @@ Variant: Current
 Implicits: 0
 AddedLightningDamageUniqueBodyStrDex2
 LocalIncreasedArmourAndEvasionUniqueBodyStrDex2
-IncreasedLifeUniqueBodyDexInt3
+IncreasedLifeUniqueBodyStrDex2
 LightningResistUniqueBodyStrDex2
 {variant:1}PhysicalDamageTakenAsLightningPercentUniqueBodyStrDex2[40,40]
 {variant:2}PhysicalDamageTakenAsLightningPercentUniqueBodyStrDex2[30,30]
@@ -905,7 +905,7 @@ CannotBePoisonedUnique__1
 Rigwald's Hunt
 General's Brigandine
 Requires Level 66, 103 Str, 103 Dex
-LocalIncreasedArmourAndEvasionUniqueBodyStrDex4
+LocalIncreasedArmourAndEvasionUnique__28
 MinionMovementSpeedUnique_1
 MinionDoubleDamageChancePerFortificationUnique__1
 FortifyDurationUnique_1
@@ -925,7 +925,7 @@ Implicits: 0
 {variant:1}LocalIncreasedArmourAndEnergyShieldUniqueBodyStrInt2[80,100]
 {variant:2}LocalIncreasedArmourAndEnergyShieldUniqueBodyStrInt2[140,180]
 {variant:3,4,5}LocalIncreasedArmourAndEnergyShieldUniqueBodyStrInt2
-{variant:4,5}IncreasedLifeUniqueBodyDexInt3
+{variant:4,5}IncreasedLifeUnique__42_
 {variant:1,2}AllResistancesUniqueBodyStrInt2[10,10]
 {variant:3,4,5}AllResistancesUniqueBodyStrInt2
 {variant:1,2,3,4}GainEnduranceChargeWhenCriticallyHit
@@ -941,7 +941,7 @@ League: Heist
 Source: Steal from a unique{Curio Display} during a Grand Heist
 Implicits: 0
 LocalIncreasedArmourAndEnergyShieldUniqueBodyStrInt2
-IncreasedLifeUniqueBodyDexInt3
+IncreasedLifeUnique__42_
 AllResistancesUniqueBodyStrInt2
 ShareEnduranceChargesWithParty
 GainEnduranceChargesWhenHitUnique__1_
@@ -953,7 +953,7 @@ Implicits: 0
 AnimateGuardianWeaponOnGuardianKillUnique__1_
 AnimateGuardianWeaponOnAnimatedWeaponKillUnique__1
 LocalIncreasedArmourAndEnergyShieldUnique__11
-IncreasedLifeUniqueBodyStrDex3_
+IncreasedLifeUnique__81
 AnimatedGuardianDamagePerAnimatedWeaponUnique__1__
 AnimatedMinionsHaveMeleeSplashUnique__1
 IncreasedAnimatedMinionSplashDamageUnique__1
@@ -963,8 +963,8 @@ Doryani's Prototype
 Saint's Hauberk
 League: Harvest
 Implicits: 0
-LocalIncreasedArmourAndEnergyShieldUnique__13_
-IncreasedLifeUniqueBodyStrDex3_
+LocalIncreasedArmourAndEnergyShieldUnique__21
+IncreasedLifeUnique__101
 DealNoNonLightningDamageUnique__1_
 ArmourAppliesToLightningDamageUnique__1_
 LightningResistNoReductionUnique__1_
@@ -973,7 +973,7 @@ NearbyEnemyLightningResistanceEqualUnique__1
 The Fourth Vow
 Devout Chainmail
 LocalIncreasedArmourAndEnergyShieldUnique__26
-ChaosResistUnique__25
+ChaosResistUnique__28
 LifeRegenerationRatePercentUnique__5
 ArmourAppliesToChaosDamageUnique__1
 PhysicalDamageBypassesEnergyShieldUnique__1
@@ -986,12 +986,12 @@ Variant: Current
 Implicits: 0
 LocalIncreasedArmourAndEnergyShieldUnique__2
 {variant:1,2}IncreasedEnergyShieldUnique__5[70,80]
-{variant:3}IncreasedEnergyShieldUnique__5
+{variant:3}LocalIncreasedEnergySheildUnique__2_
 IncreasedLifeUniqueBodyDexInt1
 AllResistancesUnique__3
 {variant:1}EnergyShieldPer5StrengthUnique__1[1,1][5,5]
 {variant:2,3}EnergyShieldPer5StrengthUnique__1
-KeystoneZealotsOathUnique__1_
+ZealotsOathUnique__1
 ]],[[
 Icetomb
 Latticed Ringmail
@@ -1033,7 +1033,7 @@ Implicits: 0
 {variant:2}LocalIncreasedArmourAndEnergyShieldUniqueBodyStrInt5
 IncreasedLifeUniqueBodyStrInt5
 {variant:1,2}LifeLeechPermyriadUniqueBodyStrInt5
-{variant:2}ElementalDamagePercentAddedAsChaosUnique__1
+{variant:2}ElementalDamagePercentAddedAsChaosUnique__3
 ElementalDamageTakenAsChaosUniqueBodyStrInt5
 LightRadiusUniqueBodyStrInt5
 ArcaneVisionUniqueBodyStrInt5
@@ -1168,7 +1168,7 @@ Implicits: 0
 DisplayGrantsBloodOfferingUnique__1_
 LocalIncreasedEvasionAndEnergyShieldUnique__6_
 MaximumLifeUnique__5
-MinionLifeUnique__1
+MinionLifeUnique__3_
 LifeRegenerationRatePercentUnique__3
 {variant:1}MinionDodgeChanceUnique__1[6,10]
 {variant:2}MinionDodgeChanceUnique__1
@@ -1179,7 +1179,7 @@ Variant: Pre 3.0.0
 Variant: Pre 3.5.0
 Variant: Current
 Implicits: 0
-LocalIncreasedEvasionAndEnergyShieldUniqueBodyDexInt4
+LocalIncreasedEvasionAndEnergyShieldUniqueBodyDexInt1
 IncreasedLifeUniqueBodyDexInt1
 AllResistancesUniqueBodyDexInt1
 {variant:1,2}AreaOfEffectImplicitMarakethTwoHandMace2
@@ -1203,7 +1203,7 @@ Implicits: 0
 {variant:1,2}ManaRegenerationUniqueBodyDexInt2
 {variant:3,4,5}BaseManaRegenerationUniqueBodyDexInt2
 {variant:1,3,4}DamageRemovedFromManaBeforeLifeTestMod[10,10]
-KeystoneMindOverMatterUnique__1
+ManaShield
 ]],[[
 Dendrobate
 Sentinel Jacket
@@ -1211,7 +1211,7 @@ Implicits: 0
 SupportedByLesserPoisonUnique__1
 LocalIncreasedEvasionAndEnergyShieldUnique__7
 LocalIncreasedEnergyShieldUnique__13_
-AllResistancesDemigodsImplicit
+AllResistancesUnique__11__
 PoisonDamageWithOver300DexterityUnique__1
 PoisonDurationWithOver150IntelligenceUnique__1
 ]],[[
@@ -1222,9 +1222,9 @@ Elder Item
 Source: Drops from unique{The Elder} (Uber)
 Implicits: 0
 GlimpseOfEternityWhenHitUnique__1
-LocalIncreasedEvasionAndEnergyShieldUnique__24
-IncreasedLifeUniqueBodyStrDex4
-ChaosResistUnique__11
+LocalIncreasedEvasionAndEnergyShieldUnique__18
+IncreasedLifeUnique__91
+ChaosResistUnique__12
 ElementalDamagePercentAddedAsChaosPerShaperItemUnique__1
 HitsIgnoreChaosResistanceAllShaperItemsUnique__1
 ]],[[
@@ -1236,9 +1236,9 @@ League: Heist
 Source: Steal from a unique{Curio Display} during a Grand Heist
 Implicits: 0
 TriggerShadeFormWhenHitUnique__1
-LocalIncreasedEvasionAndEnergyShieldUnique__21_
-IncreasedLifeUniqueBodyStrDex4
-ChaosResistUnique__10
+LocalIncreasedEvasionAndEnergyShieldUnique__18
+IncreasedLifeUnique__91
+ChaosResistUnique__12
 PhysicalDamagePercentAddedAsChaosPerElderItemUnique__1
 HitsIgnoreChaosResistanceAllElderItemsUnique__1
 ]],[[
@@ -1247,7 +1247,7 @@ Sentinel Jacket
 League: Heist
 Source: Steal from a unique{Curio Display} during a Grand Heist
 Implicits: 0
-LocalIncreasedEvasionAndEnergyShieldUnique__18
+LocalIncreasedEvasionAndEnergyShieldUnique__27
 MaximumLifeUnique__21
 AllDamageCanFreezeUnique__1
 FreezeChilledEnemiesMoreDamageUnique__1_
@@ -1259,7 +1259,7 @@ Variant: Pre 3.5.0
 Variant: Pre 3.7.0
 Variant: Current
 Implicits: 0
-IncreasedLifeUniqueBodyDexInt3
+IncreasedLifeUnique__56
 IncreasedDamageIfShockedRecentlyUnique__1
 {variant:1,2}ShockEffectUnique__1[25,40]
 {variant:3}ShockEffectUnique__1
@@ -1277,7 +1277,7 @@ IncreasedManaImplicitArmour1
 {variant:1}LocalIncreasedEvasionAndEnergyShieldUniqueBodyDexInt3[120,150]
 {variant:2,3}LocalIncreasedEvasionAndEnergyShieldUniqueBodyDexInt3
 {variant:1}IncreasedLifeUniqueBodyStrDex2[40,60]
-{variant:2,3}IncreasedLifeUniqueBodyStrDex2
+{variant:2,3}IncreasedLifeUniqueBodyDexInt3
 {variant:1,2}MovementVelocityPerFrenzyChargeUniqueBodyDexInt3[1,1]
 {variant:3}MovementVelocityPerFrenzyChargeUniqueBodyDexInt3
 {variant:1}LifeRegenPerMinutePerEnduranceChargeUnique__1[900,1200]
@@ -1305,7 +1305,7 @@ League: Bestiary
 Source: Drops from unique{Saqawal, First of the Sky}
 Implicits: 0
 AllAttributesUnique__5
-LightningResistUniqueBodyInt1
+LightningResistUnique__16
 ManaReservationEfficiencyUnique__2
 AvianAspectBuffEffectUnique__1
 GrantAviansAspectToAlliesUnique__1
@@ -1324,8 +1324,8 @@ Variant: Two Abyssal Sockets (Current)
 Variant: One Abyssal Socket (Current)
 Implicits: 1
 IncreasedManaImplicitArmour1
-{variant:5}AbyssJewelSocketUnique__1[3,3]
-{variant:1,3,6}AbyssJewelSocketUnique__1
+{variant:5}AbyssJewelSocketUnique__15[3,3]
+{variant:1,3,6}AbyssJewelSocketUnique__15
 {variant:2,4,7}AbyssJewelSocketImplicit
 {variant:1,2}DisplaySupportedByElementalPenetrationUnique__1[20,20]
 {variant:3,4}DisplaySupportedByElementalPenetrationUnique__1
@@ -1344,7 +1344,7 @@ Carnal Armour
 League: Heist
 Source: Steal from a unique{Curio Display} during a Grand Heist
 Implicits: 1
-IncreasedManaUnique__29
+IncreasedManaImplicitArmour1
 AbyssJewelSocketUnique__14
 ]],[[
 Stasis Prison
@@ -1365,7 +1365,7 @@ Tinkerskin
 Sadist Garb
 Implicits: 0
 LocalIncreasedEvasionAndEnergyShieldUnique__4
-IncreasedLifeUniqueBodyStrDex3_
+IncreasedLifeUnique__21
 TrapCooldownRecoveryUnique__1
 GainFrenzyChargeOnTrapTriggeredUnique__1
 PhasingOnTrapTriggeredUnique__1
@@ -1381,7 +1381,7 @@ LocalIncreaseSocketedAuraGemLevelUniqueBodyDexInt4
 {variant:1}SupportedByGenerosityUniqueBodyDexInt4_[1,1]
 {variant:2}SupportedByGenerosityUniqueBodyDexInt4_
 SocketedItemsHaveReducedReservationUniqueBodyDexInt4
-LocalIncreasedEvasionAndEnergyShieldUniqueBodyDexInt1
+LocalIncreasedEvasionAndEnergyShieldUniqueBodyDexInt4
 {variant:1}IncreasedAuraRadiusUniqueBodyDexInt4[10,20]
 {variant:2}IncreasedAuraRadiusUniqueBodyDexInt4
 IncreasedAuraEffectUniqueBodyDexInt4
@@ -1417,7 +1417,7 @@ Source: Drops from unique{Admiral Darnaw} in normal{Contract: Death to Darnaw}
 Variant: Pre 3.26.0
 Variant: Current
 Implicits: 0
-IntelligenceUniqueBodyStrInt3
+IntelligenceUnique__26_
 {variant:1}LocalIncreasedEvasionAndEnergyShieldUnique__31[100,140]
 {variant:2}LocalIncreasedEvasionAndEnergyShieldUnique__31
 AllResistancesUnique__20
@@ -1453,7 +1453,7 @@ GlobalVaalGemsLevelImplicit1_
 {variant:3,12}LocalIncreasedEvasionRatingPercentUniqueBodyStrDexInt1c
 {variant:4,5,13,14}LocalIncreasedEvasionAndEnergyShieldUniqueBodyStrDexInt1d
 {variant:6,15}LocalIncreasedEnergyShieldUniqueBodyStrDexInt1g
-{variant:7,8,16,17}LocalIncreasedArmourAndEnergyShieldUniqueBodyStrDexInt1e
+{variant:7,8,16,17}LocalIncreasedArmourAndEnergyShieldUniqueBodyStrDexInt1h
 {variant:9,18}LocalArmourAndEvasionAndEnergyShieldUniqueBodyStrDexInt1i
 {variant:1,2,3,4,7,10,11,12,13,16}IncreasedLifeUniqueBodyStrDexInt1
 {variant:5,6,8}IncreasedEnergyShieldUniqueBodyStrDexInt1[90,100]

--- a/src/Export/Uniques/boots.lua
+++ b/src/Export/Uniques/boots.lua
@@ -9,9 +9,9 @@ League: Bestiary
 Source: Drops from unique{Craiceann, First of the Deep}
 Requires Level 54, 95 Str
 LocalIncreasedPhysicalDamageReductionRatingPercentUnique__18
-IncreasedLifeUniqueBootsStr3_
-ColdResistUnique__23
-MovementVelocityUniqueBootsStr3
+IncreasedLifeUnique__73
+ColdResistUnique__24
+MovementVelocityUnique__29
 CannotBeStunned10CrabBarriersUnique__1
 CrabBarriersLostWhenHitUnique__1_
 ]],[[
@@ -82,14 +82,14 @@ Requires Level 68, 120 Str
 {variant:1}LocalIncreasedPhysicalDamageReductionRatingPercentUnique__7[60,80]
 {variant:2}LocalIncreasedPhysicalDamageReductionRatingPercentUnique__7
 {variant:1}IncreasedLifeUnique__33[50,70]
-{variant:2}IncreasedLifeUnique__33
+{variant:2}IncreasedLifeUnique__32
 {variant:1}MovementVelocityUniqueBootsA1[25,25]
-{variant:2}MovementVelocityUniqueBootsA1
+{variant:2}MovementVelocityUnique__14
 PhysicalDamageReductionWhileNotMovingUnique__1
 FrenzyChargeOnHitWhileBleedingUnique__1
 {variant:1}MovementVelocityWhileBleedingUnique__1[15,15]
 ReceiveBleedingWhenHitUnique__1_
-ItemBloodFootstepsUniqueBootsDex4
+ItemBloodFootstepsUnique__1
 ]],[[
 Replica Red Trail
 Titan Greaves
@@ -99,11 +99,11 @@ League: Heist
 Source: Steal from a unique{Curio Display} during a Grand Heist
 Requires Level 68, 120 Str
 {variant:1}LocalIncreasedPhysicalDamageReductionRatingPercentUnique__27[60,80]
-{variant:2}LocalIncreasedPhysicalDamageReductionRatingPercentUnique__27
+{variant:2}LocalIncreasedPhysicalDamageReductionRatingPercentUnique__7
 {variant:1}IncreasedLifeUnique__32[50,70]
 {variant:2}IncreasedLifeUnique__32
 {variant:1}MovementVelocityUniqueBootsA1[25,25]
-{variant:2}MovementVelocityUniqueBootsA1
+{variant:2}MovementVelocityUnique__14
 PowerChargeOnHitWhilePoisonedUnique__1
 ChaosResistanceWhileStationaryUnique__1
 {variant:1}15% increased Movement Speed while Poisoned
@@ -140,10 +140,10 @@ Requires Level 46, 82 Str
 AddedPhysicalDamageUniqueBootsStr3
 StunThresholdReductionUniqueBootsStr3
 LocalIncreasedPhysicalDamageReductionRatingPercentUniqueBootsStr3
-{variant:2}IncreasedLifeUniqueBootsDex9__
+{variant:2}IncreasedLifeUniqueBootsStr3_
 FireResistUniqueBootsStr3_
 {variant:1}MovementVelocityUniqueBootsDexInt4[20,20]
-{variant:2}MovementVelocityUniqueBootsDexInt4
+{variant:2}MovementVelocityUniqueBootsStr3
 ImmuneToBurningGroundUniqueBootsStr3
 ]],[[
 Stormcharger
@@ -158,14 +158,14 @@ LightningResistUnique__13
 {variant:2}ShockDurationUnique__2
 {variant:1}ShockEffectUnique__2[15,25]
 {variant:2}ShockEffectUnique__2
-{variant:2}ImmuneToShockedGroundUniqueBootsDexInt4
+{variant:2}ImmuneToShockedGroundUnique__1
 ]],[[
 The Tempest Rising
 Goliath Greaves
 Source: Drops from unique{Sirus, Awakener of Worlds} (Uber)
 Requires Level 54, 95 Str
-LocalIncreasedPhysicalDamageReductionRatingPercentUnique__26
-MovementVelocityUniqueBootsA1
+LocalIncreasedPhysicalDamageReductionRatingPercentUnique__31
+MovementVelocityUnique__54
 IncreasedAilmentDurationUnique__4
 FasterAilmentDamageUnique__1
 EnemiesCountAsMovingElementalAilmentsUnique__1
@@ -175,10 +175,10 @@ Antique Greaves
 Variant: Pre 3.16.0
 Variant: Current
 Requires Level 37, 67 Str
-LocalIncreasedPhysicalDamageReductionRatingPercentUnique__22
+LocalIncreasedPhysicalDamageReductionRatingPercentUnique__19
 {variant:1}TotemLifeUnique__1[30,50]
 {variant:2}TotemLifeUnique__2_
-MovementVelocityUniqueBootsDexInt4
+MovementVelocityUnique__40
 SummonTotemCastSpeedUnique__2
 {variant:1}TotemReflectFireDamageUnique__1_[25,25]
 {variant:2}TotemReflectFireDamageUnique__1_
@@ -192,7 +192,7 @@ LocalIncreasedPhysicalDamageReductionRatingUniqueBootsStr1
 AllResistancesUniqueBootsStr1
 {variant:1}MovementVelocityUniqueBootsDex8[10,10]
 {variant:2}MovementVelocityUniqueBootsDex8[15,15]
-{variant:3}MovementVelocityUniqueBootsDex8
+{variant:3}MovementVelocityUniqueBootsStr1
 {variant:1}ElementalDamageUniqueBootsStr1[10,10]
 {variant:2}ElementalDamageUniqueBootsStr1
 AdditionalCurseOnEnemiesUnique__1
@@ -215,8 +215,8 @@ Variant: Pre 3.25.0
 Variant: Current
 Source: Drops from unique{The Searing Exarch}
 {variant:2}OneAncestorTotemBuffUnique__1
-IncreasedLifeUnique__112
-MovementVelocityUniqueBootsA1
+IncreasedLifeUnique__116
+MovementVelocityUnique__49
 AncestorTotemBuffLingersUnique__1
 {variant:2}DamageTakenFromTotemLifeBeforePlayerUnique__1
 ]],
@@ -226,8 +226,8 @@ Abberath's Hooves
 Goathide Boots
 Requires Level 12, 26 Dex
 RepeatingShockwave
-StrengthUniqueBootsDexInt2
-MovementVelocityUniqueBootsDexInt2
+StrengthUnique__7_
+MovementVelocityUnique__7
 ChanceToIgniteUnique__4
 IgniteNearbyEnemyOnIgnitedKillUnique__1
 FireDamagePerStrengthUnique__1
@@ -241,7 +241,7 @@ Variant: Current
 Requires Level 69, 120 Dex
 LocalIncreasedEvasionRatingPercentUniqueBootsDex7
 IncreasedLifeUniqueBootsDex7
-MovementVelocityUniqueBootsDex1
+MovementVelocityUniqueBootsDex7
 {variant:1}SpellDodgeUniqueBootsDex7_
 {variant:2}SpellDodgeUniqueBootsDex7New
 ]],[[
@@ -253,7 +253,7 @@ Variant: Pre 3.11.0
 Variant: Current
 Requires Level 44, 79 Dex
 DexterityUniqueBootsDex4_
-MovementVelocityUniqueBootsDex8
+MovementVeolcityUniqueBootsDex4
 MovementVelocityPerFrenzyChargeUniqueBootsDex4
 {variant:1,2,3}AttackAndCastSpeedPerFrenzyChargeUniqueBootsDex4[-3,-3]
 {variant:4}AttackAndCastSpeedPerFrenzyChargeUniqueBootsDex4
@@ -276,15 +276,15 @@ Requires Level 22, 42 Dex
 {variant:3}DisplaySupportedByTrapUniqueBootsDex6
 LocalIncreasedEvasionRatingPercentUniqueBootsDex6
 {variant:1,2}IncreasedLifeUniqueBootsDex6
-{variant:2,3}MovementVelocityUniqueBootsDexInt2
+{variant:2,3}MovementVelocityUnique__18
 TrapThrowSpeedUniqueBootsDex6
 {variant:1}MovementSpeedOnTrapThrowUnique__1[9000,9000][30,30]
 {variant:2,3}MovementSpeedOnTrapThrowUnique__1
 ]],[[
 Orbala's Stand
 Eelskin Boots
-LocalIncreasedEvasionRatingPercentUniqueBootsDex3
-MovementVelocityUnique__53
+LocalIncreasedEvasionRatingPercentUnique__20
+MovementVelocityUnique__51
 CannotBeStunnedSuppressedDamageUnique__1
 DebilitateEnemiesSuppressedDamageUnique__1
 ]],[[
@@ -333,8 +333,8 @@ Source: Drops from unique{Farrul, First of the Plains}
 Requires Level 69, 120 Dex
 CatsStealthTriggeredIntimidatingCry
 LocalIncreasedEvasionRatingPercentUnique__13
-IncreasedLifeUniqueBootsDex9__
-MovementVelocityUniqueBootsDex8
+IncreasedLifeUnique__76
+MovementVelocityUnique__30
 MovementSpeedWithCatsStealthUnique__1
 ChanceToAvoidBleedingUnique__1
 ]],[[
@@ -357,11 +357,11 @@ Variant: Pre 3.5.0
 Variant: Pre 3.16.0
 Variant: Current
 Requires Level 62, 117 Dex
-DexterityUniqueBootsDex4_
+DexterityUnique__5
 {variant:1}LocalIncreasedEvasionRatingPercentUnique__6[80,120]
 {variant:2}LocalIncreasedEvasionRatingPercentUnique__6[320,380]
 {variant:3}LocalIncreasedEvasionRatingPercentUnique__6
-MovementVelocityUniqueBootsA1
+MovementVelocityUnique__15
 ImmuneToBurningShockedChilledGroundUnique__1
 LifeRegenerationWhileMovingUnique__1
 {variant:1}MaximumLifePer10DexterityUnique__1[1,1][10,10]
@@ -379,14 +379,14 @@ Variant: Pre 2.6.0
 Variant: Pre 3.5.0
 Variant: Current
 Requires Level 62, 117 Dex
-DexterityUniqueBootsDex8
+DexterityUniqueBootsDex1
 IntelligenceUniqueBootsDex1
 LocalIncreasedEvasionRatingPercentUniqueBootsDex1
 {variant:1}LocalIncreasedEnergyShieldUniqueBootsDex1[50,70]
 {variant:2}LocalIncreasedEnergyShieldUniqueBootsDex1[70,100]
 {variant:3}LocalIncreasedEnergyShieldUniqueBootsDex1[100,160]
 {variant:4}LocalIncreasedEnergyShieldUniqueBootsDex1
-MovementVelocityUniqueBootsA1
+MovementVelocityUniqueBootsDex1
 EnemiesCantLifeLeech
 ]],[[
 Temptation Step
@@ -395,7 +395,7 @@ League: Ultimatum
 Source: Drops from unique{The Trialmaster}
 Requires Level 55, 97 Dex
 LocalIncreasedEvasionRatingPercentUnique__18
-ChaosResistUnique__23
+ChaosResistUnique__21
 DamagePerPoisonOnSelfUnique__1_
 MovementSpeedPerPoisonOnSelfUnique__1_
 TravelSkillsReflectPoisonUnique__1
@@ -413,7 +413,7 @@ LocalIncreasedEvationRatingPercentUniqueBootsDex9
 {variant:1}IncreasedLifeUniqueBootsDex9__[30,60]
 {variant:2,3}IncreasedLifeUniqueBootsDex9__
 {variant:1}MovementVelocityUniqueBootsDexInt4[20,20]
-{variant:2,3}MovementVelocityUniqueBootsDexInt4
+{variant:2,3}MovementVelocityUnique__10
 {variant:1,2}ChanceToDodgeSpellsWhilePhasing_Unique_1[10,10]
 {variant:3}ChanceToDodgeSpellsWhilePhasing_Unique_1
 ]],[[
@@ -425,7 +425,7 @@ Requires Level 55, 97 Dex
 DexterityUniqueBootsDex9
 LocalIncreasedEvationRatingPercentUniqueBootsDex9
 IncreasedLifeUniqueBootsDex9__
-MovementVelocityUniqueBootsDexInt4
+MovementVelocityUnique__10
 ElusiveEffectUnique__1
 MovementSpeedIfHitRecentlyUnique__1_
 ]],[[
@@ -436,7 +436,7 @@ Variant: Pre 3.19.0
 Variant: Current
 DexterityUniqueBootsDex3
 IntelligenceUniqueBootsDex3
-LocalIncreasedEvasionRatingPercentUniqueBootsStrDex5
+LocalIncreasedEvasionRatingPercentUniqueBootsDex3
 {variant:2}MovementVelocityUniqueBootsDexInt2
 {variant:3}MovementVelocityUniqueBootsInt4[10,20]
 {variant:1}MovementVelocityOnLowLifeUniqueBootsDex3
@@ -519,8 +519,8 @@ Inya's Epiphany
 Arcanist Slippers
 Requires Level 61, 119 Int
 PercentageIntelligenceUnique__4
-IncreasedLifeUniqueBootsStr3_
-MovementVelocityUniqueBootsDexInt4
+IncreasedLifeUnique__49_
+MovementVelocityUnique__20_
 IncreasedDamagePerPowerChargeUnique__1
 ChanceToGainMaximumPowerChargesUnique__1_
 ]],[[
@@ -530,8 +530,8 @@ League: Heist
 Source: Steal from a unique{Curio Display} during a Grand Heist
 Requires Level 61, 119 Int
 PercentageIntelligenceUnique__4
-IncreasedLifeUniqueBootsDex9__
-ChargeBonusDamagePerPowerCharge
+IncreasedLifeUnique__49_
+IncreasedDamagePerPowerChargeUnique__1
 LifeRegenerationPerPowerChargeUnique__1__
 MovementVelocityPerPowerChargeUnique__1__
 ]],[[
@@ -553,7 +553,7 @@ Requires Level 53, 94 Int
 {variant:3,4,5,6}IncreasedManaUniqueBootsInt5
 {variant:1,3,4,5,6}AllResistancesUniqueBootsInt5
 {variant:2}AllResistancesUniqueBootsInt5[8,8]
-{variant:1,2,3,6}MovementVelocityUniqueBootsInt2
+{variant:1,2,3,6}MovementVelocityUniqueBootsInt5
 {variant:4,5}MovementVelocityUniqueBootsInt2[25,25]
 ]],[[
 Shavronne's Pace
@@ -569,7 +569,7 @@ Requires Level 32, 54 Int
 {variant:1}LocalIncreasedEnergyShieldPercentAndStunRecoveryUniqueBootsInt3[50,70][10,15]
 {variant:2,3}LocalIncreasedEnergyShieldPercentAndStunRecoveryUniqueBootsInt3[100,140][10,15]
 {variant:4}LocalIncreasedEnergyShieldPercentAndStunRecoveryUniqueBootsInt3
-{variant:3,4}MovementVelocityUniqueBootsStrDex4
+{variant:3,4}MovementVelocityUnique__17__
 {variant:1,2}MovementVelocityOnFullLifeUniqueBootsInt3[35,35]
 {variant:3,4}MovementVelocityOnFullLifeUniqueBootsInt3
 ]],[[
@@ -595,9 +595,9 @@ Sorcerer Boots
 Energy Shield: 64
 Requires Level 67, 123 Int
 IncreasedManaUnique__1
-MovementVelocityUniqueBootsA1
+MovementVelocityUnique__1
 PowerChargeOnCriticalStrikeChanceUnique__1
-ReducedManaReservationCostUnique__1
+ReservationEfficiencyUnique__3__
 NoLifeRegenerationUnique___1
 StunThresholdBasedOnManaUnique__1
 ]],[[
@@ -611,7 +611,7 @@ Requires Level 67, 123 Int
 LocalIncreasedEnergyShiledUniqueBootsInt6
 {variant:1}LocalIncreasedEnergyShieldPercentUniqueBootsInt6[110,140]
 {variant:2}LocalIncreasedEnergyShieldPercentUniqueBootsInt6
-MovementVelocityUniqueBootsA1
+MovementVelocityUniqueBootsInt6
 MovementVelocityOnShockedGroundUniqueBootsInt6_
 IncreasedDamageOnBurningGroundUniqueBootsInt6
 LifeRegenerationPercentOnChilledGroundUniqueBootsInt6
@@ -623,7 +623,7 @@ DexterityUniqueBootsInt2
 LocalIncreasedEnergyShieldUniqueBootsInt2
 ManaRegenerationUniqueBootsInt2
 MovementVelocityUniqueBootsInt2
-CannotBeFrozenUnique__1
+CannotBeFrozen
 ]],[[
 Wondertrap
 Velvet Slippers
@@ -659,10 +659,10 @@ Satin Slippers
 Source: Drops from unique{Mercenary} after winning a duel
 League: Mercenaries of Trarthus
 Requires Level 54, 69 Int
-IntelligenceUnique__31
+IntelligenceUnique__36
 AllResistancesUnique__34
 ArcaneSurgeOnMovementSkillUnique
-IncreasedManaUnique__21
+IncreasedManaUnique__30
 ArcaneSurgeMovementSpeedUnique
 ]],
 -- Boots: Armour/Evasion
@@ -725,7 +725,7 @@ Variant: Current
 LightRadiusUniqueBootsStrDex3
 ChaosResistanceWhileUsingFlaskUniqueBootsStrDex3
 {variant:3}AddedChaosDamageWhileUsingAFlaskUnique__2[15,20][25,30]
-{variant:4}AddedChaosDamageWhileUsingAFlaskUnique__2
+{variant:4}AddedChaosDamageWhileUsingAFlaskUnique__1_
 ]],[[
 Duskblight
 Ironscale Boots
@@ -752,7 +752,7 @@ League: Ritual
 Requires Level 69, 48 Str, 48 Dex
 LocalIncreasedArmourAndEvasionUnique__18
 {variant:1}AllResistancesUnique_1[-15,10]
-MovementVelocityUniqueBootsA1
+MovementVelocityUnique__45
 {variant:2}NearbyEnemiesAreScorchedUnique__1
 {variant:1}ScorchedGroundWhileMovingUnique__1
 ScorchEffectUnique__1
@@ -764,8 +764,8 @@ Variant: Pre 3.23.0
 Variant: Current
 Source: Drops from unique{The Searing Exarch} (Uber)
 GrantsTouchOfFireUnique__1
-LocalIncreasedArmourAndEvasionUniqueBootsStrDex3
-MovementVelocityUniqueBootsA1
+LocalIncreasedArmourAndEvasionUnique__21
+MovementVelocityUnique__50
 CannotBeChilledUnique__1
 CannotBeFrozen
 {variant:1}FireDamageTakenFireTouchedUnique__1[10000,10000]
@@ -832,8 +832,8 @@ League: Bestiary
 Source: Drops from unique{Saqawal, First of the Sky}
 Requires Level 59, 56 Str, 56 Dex
 GrantsBirdAspect1_
-LocalIncreasedArmourAndEvasionUnique__22
-MovementVelocityUnique__51
+LocalIncreasedArmourAndEvasionUnique__6
+MovementVelocityUnique__28
 AviansFlightDurationUnique__1
 AviansFlightLifeRegenerationUnique__1
 AviansFlightManaRegenerationUnique__1_
@@ -850,7 +850,7 @@ LocalIncreasedPhysicalDamageReductionRatingUniqueBootsStrInt2
 {variant:1}ChaosResistUniqueBootsStrInt2[9,12]
 {variant:2}ChaosResistUniqueBootsStrInt2
 {variant:1}MovementVelocityUniqueBootsDexInt4[20,20]
-{variant:2}MovementVelocityUniqueBootsDexInt4
+{variant:2}MovementVelocityUniqueBootsStrInt2_
 {variant:1}MaximumMinionCountUniqueBootsStrInt2
 {variant:2}SkeletonWarriorsPermanentMinionUnique__1
 ]],[[
@@ -865,7 +865,7 @@ LocalIncreasedPhysicalDamageReductionRatingUniqueBootsStrInt2
 {variant:1}ChaosResistUniqueBootsStrInt2[9,12]
 {variant:2}ChaosResistUniqueBootsStrInt2
 {variant:1}MovementVelocityUniqueBootsDexInt4[20,20]
-{variant:2}MovementVelocityUniqueBootsDexInt4
+{variant:2}MovementVelocityUniqueBootsStrInt2_
 CannotDealNonChaosDamageUnique__1_
 AddedChaosDamageToAttacksPer50StrengthUnique__1
 ]],[[
@@ -873,11 +873,11 @@ Death's Door
 Crusader Boots
 Source: Drops in The Eternal Labyrinth
 Requires Level 64, 62 Str, 62 Int
-StrengthUnique__10
+StrengthUnique__5
 LocalIncreasedArmourAndEnergyShieldUnique__4
-AllResistancesUniqueBootsStr1
-MovementVelocityUniqueBootsStrInt2_
-ChargeBonusMaximumEnduranceCharges
+AllResistancesUnique__5
+MovementVelocityUnique__11
+MaximumEnduranceChargeUnique__1_
 BleedingImmunityUnique__1
 SelfStatusAilmentDurationUnique__1
 ]],[[
@@ -967,8 +967,8 @@ Variant: Two Abyssal Sockets (Pre 3.21.0)
 Variant: One Abyssal Socket (Current)
 Variant: Two Abyssal Sockets (Current)
 Requires Level 69, 82 Dex, 42 Int
-{variant:1,3}AbyssJewelSocketUnique__12
-{variant:2,4}AbyssJewelSocketUnique__13
+{variant:1,3}AbyssJewelSocketUnique__3
+{variant:2,4}AbyssJewelSocketUnique__4
 DeathWalk
 {variant:1,2}MaximumLifeUnique__9
 {variant:1,2}MovementVelocityUniqueBootsA1
@@ -985,8 +985,8 @@ League: Heist
 Requires Level 55, 52 Dex, 52 Int
 Implicits: 0
 CorpseWalk
-LocalIncreasedEvasionAndEnergyShieldUnique__37
-MovementVelocityUniqueBootsDexInt4
+LocalIncreasedEvasionAndEnergyShieldUnique__28
+MovementVelocityUnique__43
 {variant:1}DamageIfConsumedCorpseUnique__1__
 {variant:2}FlatLifeRegenerationPerNearbyCorpseUnique__1[480,480]
 {variant:1}LifeRegenerationPerNearbyCorpseUnique__1
@@ -1004,11 +1004,11 @@ Upgrade: Upgrades to unique{Omeyocan} via currency{Vial of the Ritual}
 {variant:2}Requires Level 55, 52 Dex, 52 Int
 IncreasedManaUnique__13
 {variant:1}LightningResistUnique__18[15,20]
-{variant:2}LightningResistUnique__18
-MovementVelocityUniqueBootsStr3
+{variant:2}LightningResistUnique__17_
+MovementVelocityUnique__34
 OnslaughtWhileNotOnLowManaUnique__1_
 {variant:1}LoseManaPerSecondUnique__1
-{variant:2}KeystoneTheAgnosticUnique__1_
+{variant:2}KeystoneTheAgnosticUnique__2
 ]],[[
 Omeyocan
 Carnal Boots
@@ -1019,8 +1019,8 @@ League: Incursion
 Source: Upgraded from unique{Dance of the Offered} via currency{Vial of the Ritual}
 Requires Level 55, 52 Dex, 52 Int
 MaximumManaUnique__7
-LightningResistUnique__17_
-MovementVelocityUniqueBootsInt6
+LightningResistUnique__18
+MovementVelocityUnique__35
 {variant:1}DodgeAndSpellDodgePerMaximumManaUnique__1[2,2]
 {variant:2}DodgeAndSpellDodgePerMaximumManaUnique__1[10,10]
 {variant:3}DodgeAndSpellDodgePerMaximumManaUnique__1
@@ -1033,9 +1033,9 @@ League: Bestiary
 Source: Drops from unique{Fenumus, First of the Night}
 Requires Level 63, 62 Dex, 62 Int
 LocalIncreasedEvasionAndEnergyShieldUnique__14
-LightningResistUniqueBootsDexInt4
+LightningResistUnique__15
 ChaosResistUnique__10
-MovementVelocityUniqueBootsDexInt4
+MovementVelocityUnique__31
 IncreasedSpiderWebCountUnique__1
 ESOnHitWebbedEnemiesUnique__1
 AspectOfSpiderDurationUnique__1
@@ -1046,8 +1046,8 @@ Source: Drops from unique{The Eater of Worlds}
 Requires Level 70, 56 Dex, 76 Int
 Implicits: 1
 ChaosResistImplicitBoots1
-IncreasedLifeUnique__108
-MovementVelocityUniqueBootsDex7
+IncreasedLifeUnique__112
+MovementVelocityUnique__48
 GainVinesOnCriticalStrikeUnique__1
 NearbyStationaryEnemiesGainVinesUnique__1
 AllDamagePoisonsGraspingVinesUnique__1
@@ -1059,11 +1059,11 @@ Variant: Pre 2.0.0
 Variant: Pre 2.6.0
 Variant: Current
 Requires Level 16, 18 Dex, 18 Int
-DexterityUniqueBootsDex1
+DexterityUniqueBootsDex8
 LocalIncreasedEvasionRatingUniqueBootsDex8
 LocalIncreasedEnergyShieldUniqueBootsDex8
 ColdResistUniqueBootsDex8
-MovementVelocityUniqueBootsInt5
+MovementVelocityUniqueBootsDex8
 {variant:1}IncreasedPhysicalDamageTakenUniqueBootsDex8[30,30]
 {variant:2}IncreasedPhysicalDamageTakenUniqueBootsDex8
 {variant:3}DamageTakenOnFullESUnique__1
@@ -1074,7 +1074,7 @@ Assassin's Boots
 Requires Level 63, 62 Dex, 62 Int
 League: Blight
 Source: Drops in Blighted Maps
-LocalIncreasedEvasionAndEnergyShieldUnique__27
+LocalIncreasedEvasionAndEnergyShieldUnique__24
 StunRecoveryUnique__3
 ManaRegenerationRateWhileMovingUnique__1
 MovementVelocityOverrideUnique__1
@@ -1087,8 +1087,8 @@ League: Heist
 Source: Steal from a unique{Curio Display} during a Grand Heist
 Requires Level 63, 62 Dex, 62 Int
 TravelSkillMoreDamageUnique__1
-LocalIncreasedEvasionAndEnergyShieldUnique__26
-StunRecoveryUnique__2
+LocalIncreasedEvasionAndEnergyShieldUnique__24
+StunRecoveryUnique__3
 ManaRegenerationRateWhileMovingUnique__1
 MovementVelocityOverrideUnique__1
 This item can be anointed by Cassia
@@ -1103,7 +1103,7 @@ LocalIncreasedEvasionRatingPercentUniqueBootsDexInt1
 ItemFoundRarityIncreaseUniqueBootsDexInt1
 FireResistUniqueBootsDexInt1
 {variant:1}MovementVelocityUniqueBootsInt2[10,10]
-{variant:2}MovementVelocityUniqueBootsInt2
+{variant:2}MovementVelocityUniqueBootsDexInt1
 ]],[[
 Sunspite
 Clasped Boots
@@ -1123,9 +1123,9 @@ Shackled Boots
 League: Necropolis
 Requires Level 34, 34 Dex, 34 Int
 GrantsRavenousSkillUnique__1
-LocalIncreasedEvasionAndEnergyShieldUnique__28
+LocalIncreasedEvasionAndEnergyShieldUnique__37
 ChaosResistUnique__30
-MovementVelocityUnique__28
+MovementVelocityUnique__53
 ]],[[
 Voidwalker
 Murder Boots
@@ -1134,9 +1134,9 @@ Source: Drops from unique{The Shaper}
 Variant: Pre 3.0.0
 Variant: Current
 Requires Level 69, 82 Dex, 42 Int
-DexterityUnique__25
+DexterityUnique__3
 LocalIncreasedEvasionAndEnergyShieldUnique__5
-MovementVelocityUniqueBootsDex1
+MovementVelocityUnique__12
 ChanceToAvoidProjectilesWhilePhasingUnique__1
 GainPhasingIfKilledRecentlyUnique__1
 {variant:1}PrrojectilesPierceWhilePhasingUnique__1_
@@ -1149,9 +1149,9 @@ Shaper Item
 League: Heist
 Source: Steal from a unique{Curio Display} during a Grand Heist
 Requires Level 69, 82 Dex, 42 Int
-DexterityUnique__22
-LocalIncreasedEvasionAndEnergyShieldUnique__22
-MovementVelocityUniqueBootsA1
+DexterityUnique__3
+LocalIncreasedEvasionAndEnergyShieldUnique__5
+MovementVelocityUnique__12
 DamageTakenWhilePhasingUnique__1
 GainPhasingIfKilledRecentlyUnique__1
 ProjectilesChainWhilePhasingUnique__1_
@@ -1166,7 +1166,7 @@ Source: Drops from Expedition monsters
 Requires Level 48, 37 Str, 37 Dex, 37 Int
 LocalIncreasedWardPercentUnique__4_
 WardDelayRecoveryUnique__2
-MovementVelocityUniqueBootsDex8
+MovementVelocityUnique__47_
 AdrenalineOnWardBreakUnique__1
 ]],
 }

--- a/src/Export/Uniques/bow.lua
+++ b/src/Export/Uniques/bow.lua
@@ -57,14 +57,14 @@ Requires Level 62, 212 Dex
 Implicits: 2
 {variant:6,7}CriticalMultiplierImplicitBow1
 {variant:2,3}WeaponElementalDamageImplicitBow3[6,12]
-DexterityUniqueBow4
+DexterityUniqueBow6
 {variant:1,2}LocalIncreasedPhysicalDamagePercentUniqueBow6[75,100]
 {variant:3,4}LocalIncreasedPhysicalDamagePercentUniqueBow6[150,180]
 {variant:5,6}LocalIncreasedPhysicalDamagePercentUniqueBow6[200,260]
 {variant:7}LocalIncreasedPhysicalDamagePercentUniqueBow6
 LocalAddedFireDamageUniqueBow6
 {variant:1,2}IncreasedAttackSpeedUniqueGlovesDex2
-{variant:3,4,5,6,7}LocalIncreasedAttackSpeedUniqueBow11
+{variant:3,4,5,6,7}LocalIncreasedAttackSpeedUniqueBow6
 {variant:1,2,3,4}PhysicalBowDamageCloseRangeUniqueBow6[100,100]
 {variant:5,6,7}PhysicalBowDamageCloseRangeUniqueBow6
 KnockbackCloseRangeUniqueBow6
@@ -130,7 +130,7 @@ Implicits: 1
 {variant:2,3,4,5,6,7}LocalCriticalStrikeChanceImplicitBow1
 {variant:1,2,3,4,5}LocalIncreasedPhysicalDamagePercentUniqueBow3[100,125]
 {variant:6,7}LocalIncreasedPhysicalDamagePercentUniqueBow3
-LocalIncreasedAttackSpeedUniqueBow2
+LocalIncreasedAttackSpeedUniqueBow3
 {variant:1,2,4}LocalCriticalMultiplierUniqueBow3[100,100]
 {variant:3}LocalCriticalMultiplierUniqueBow3[150,150]
 {variant:5,6,7}LocalCriticalMultiplierUniqueBow3
@@ -171,12 +171,12 @@ Implicits: 2
 {variant:3,4,5}WeaponElementalDamageImplicitBow1
 {variant:2,3}LocalAddedPhysicalDamageUniqueBow11[8,12][16,20]
 {variant:4,5}LocalAddedPhysicalDamageUniqueBow11
-LocalIncreasedAttackSpeedUniqueBow6
+LocalIncreasedAttackSpeedUniqueBow11
 {variant:1,2,3}CriticalStrikeChanceUniqueBow9
 ManaRegenerationUniqueBow11
 {variant:1,2,3}WeaponPhysicalDamageAddedAsRandomElementUniqueBow11[110,110]
 {variant:4}WeaponPhysicalDamageAddedAsRandomElementUniqueBow11
-{variant:5}LocalPhysicalDamageAddedAsEachElementTransformed2
+{variant:5}LocalPhysicalDamageAddedAsEachElementUnique__1
 ]],[[
 Doomfletch's Prism
 Royal Bow
@@ -214,7 +214,7 @@ The Gluttonous Tide
 Citadel Bow
 Source: Drops from unique{The Eater of Worlds}
 Requires Level 58, 185 Dex
-LocalIncreasedPhysicalDamagePercentUnique13
+LocalIncreasedPhysicalDamagePercentUnique__44
 LocalIncreasedAttackSpeedUnique__37___
 BowAttacksFrenzyChargesArrowsUnique__1
 CriticalStrikeMultiplierFrenzyChargesUnique__1
@@ -272,9 +272,9 @@ DexterityUniqueBow7
 {variant:1}LocalIncreasedPhysicalDamagePercentUniqueBow7[110,125]
 {variant:2}LocalIncreasedPhysicalDamagePercentUniqueBow7
 LocalAddedPhysicalDamageUniqueBow7
-MovementVelocityMarakethBowImplicit2
+MovementVelocityUniqueBow7
 IncreasedAccuracyUniqueBow7
-CannotLeechMana
+CannotLeechManaUnique__1_
 AttackProjectilesForkUnique__1
 AttackProjectilesForkExtraTimesUnique__1
 ]],[[
@@ -325,7 +325,7 @@ Implicits: 3
 {variant:6,7}LocalAddedPhysicalDamageUniqueBow1
 {variant:1,2,3,4,5,6}LocalIncreasedAttackSpeedUniqueBow1
 IncreasedManaUniqueBow1
-AlwaysHitsUnique__1
+AlwaysHits
 {variant:7}AttacksYouUseYourselfRepeatCountUnique__1
 {variant:7}AttacksYouUseYourselfAttackSpeedFinalUnique__1
 {variant:4,5,6,7}PlayerFarShotUnique__1
@@ -353,10 +353,10 @@ Variant: Current
 Requires Level 68, 212 Dex
 Implicits: 1
 LocalCriticalStrikeChanceImplicitBow1
-LocalReducedPhysicalDamagePercentUniqueBow8
+LocalReducedPhysicalDamagePercentUnique__1
 {variant:1,2}LocalAddedColdDamageUnique__4[120,140][180,210]
 {variant:3}LocalAddedColdDamageUnique__4
-LocalIncreasedAttackSpeedUniqueBow10
+LocalIncreasedAttackSpeedUnique__13
 LightRadiusUnique__2
 SpreadChilledGroundOnFreezeUnique__1
 SpreadConsecratedGroundOnShatterUnique__1
@@ -370,8 +370,8 @@ Variant: Pre 2.6.0
 Variant: Pre 3.9.0
 Variant: Current
 Requires Level 5, 26 Dex
-DexterityUniqueBow6
-{variant:2,3}LocalIncreasedPhysicalDamagePercentUniqueDescentBow1
+DexterityUniqueBow4
+{variant:2,3}LocalIncreasedPhysicalDamagePercentUnique__26
 LocalIncreasedAttackSpeedUniqueBow4
 {variant:2,3}ManaGainPerTargetUnique__2
 ProjectileSpeedUniqueBow4_
@@ -387,7 +387,7 @@ Source: Steal from a unique{Curio Display} during a Grand Heist
 Requires Level 5, 26 Dex
 SupportedByArrowNovaUnique__1
 DexterityUniqueBow4
-LocalIncreasedPhysicalDamagePercentUniqueDescentBow1
+LocalIncreasedPhysicalDamagePercentUnique__26
 LocalIncreasedAttackSpeedUnique__35
 ManaGainPerTargetUnique__2
 ProjectileSpeedUniqueBow4_
@@ -408,8 +408,8 @@ Variant: Current
 {variant:1}LocalAddedPhysicalDamageUnique__16_[25,40][100,115]
 {variant:2,3,4,5}LocalAddedPhysicalDamageUnique__16_[15,30][70,95]
 {variant:6}LocalAddedPhysicalDamageUnique__16_
-LocalIncreasedAttackSpeedUnique__9
-ProjectileSpeedUnique__3
+LocalIncreasedAttackSpeedUnique__16
+ProjectileSpeedUnique__4
 {variant:5,6}VolleyFirstPointPierceUnique__1_
 {variant:5,6}VolleySecondPointForkUnique__1
 {variant:5,6}VolleyThirdPointReturnUnique__1__
@@ -425,7 +425,7 @@ Variant: Current
 Requires Level 18, 71 Dex
 Implicits: 1
 {variant:2,3}CriticalMultiplierImplicitBow1
-LocalIncreasedPhysicalDamagePercentUniqueBow5
+LocalIncreasedPhyiscalDamagePercentUnique__3
 {variant:1,2}LocalIncreasedAttackSpeedUnique__1
 {variant:1,2}AdditionalChainUnique__1[1,1]
 {variant:3}AdditionalChainUnique__1
@@ -508,7 +508,7 @@ Variant: Current
 {variant:3,4}LocalAddedLightningDamageUniqueBow10
 LocalIncreasedAttackSpeedUniqueBow10
 {variant:1,2}ConvertLightningDamageToChaosUniqueBow10[60,60]
-{variant:3,4}ConvertLightningDamageToChaosUniqueBow10
+{variant:3,4}ConvertLightningDamageToChaosUniqueBow10Updated
 {variant:1,2}ChanceToShockUniqueBow10
 ChaosDamageCanShockUniqueBow10
 {variant:2,3}AttacksShockAsIfDealingMoreDamageUniqueBow10
@@ -552,9 +552,9 @@ Implicits: 1
 WeaponElementalDamageImplicitBow1
 AddedColdDamageUniqueBow9
 AddedLightningDamageUniqueBow9
-LocalIncreasedAttackSpeedUniqueBow10
-LocalCriticalStrikeChanceUniqueBow11
-FrozenMonstersTakeIncreasedDamage
+LocalIncreasedAttackSpeedUniqueBow9
+CriticalStrikeChanceUniqueBow9
+FrozenMonstersTakeIncreasedDamageUnique__1
 GainEnergyShieldOnKillShockedEnemyUnique__1_
 ]],[[
 Xoph's Inception
@@ -588,7 +588,7 @@ Requires Level 64, 185 Dex
 {variant:1,2,3}LocalIncreasedPhysicalDamagePercentUnique__38[250,300]
 {variant:4}LocalIncreasedPhysicalDamagePercentUnique__38
 ConvertPhysicalToFireUnique__1
-ChanceToIgniteUnique__2
+ChanceToIgniteUnique__3
 {variant:1}GlobalIgniteProlifUnique__1[12,12]
 {variant:2}GlobalIgniteProlifUnique__1
 GainLifeOnIgnitingEnemyUnique__1
@@ -603,8 +603,8 @@ WeaponElementalDamageImplicitBow1
 MainHandTriggerSocketedSpellOnFreezingHitUnique_1
 LocalAddedColdDamageUnique__11
 LocalAddedChaosDamageUnique__4
-LocalIncreasedAttackSpeedUnique__30
+LocalIncreasedAttackSpeedUnique__44
 ChaosDamageCanFreezeUnique_1
-BattlemageKeystoneUnique__1
+BattlemageKeystoneUnique__6
 ]],
 }

--- a/src/Export/Uniques/claw.lua
+++ b/src/Export/Uniques/claw.lua
@@ -13,11 +13,11 @@ Implicits: 2
 {variant:2}LifeGainPerTargetImplicit2Claw8
 SocketedGemsSupportedByFortifyUnique____1
 AdditionalBlockUnique__2
-LocalIncreasedPhysicalDamagePercentUniqueClaw6
+LocalIncreasedPhysicalDamagePercentUnique__10
 IncreasedEvasionRatingUnique___1
 IncreasedEnergyShieldUnique__2
-IncreasedLifeUnique__11
-AttackerTakesDamageShieldImplicit7
+IncreasedLifeUnique__8
+AttackerTakesDamageUnique__1
 ]],[[
 Replica Advancing Fortress
 Gut Ripper
@@ -28,8 +28,8 @@ Implicits: 1
 LifeGainPerTargetImplicit2Claw8
 SupportedByCastOnDamageTakenUnique__1
 AdditionalBlockUnique__2
-LocalIncreasedPhysicalDamagePercentUniqueClaw6
-IncreasedLifeUnique__107
+LocalIncreasedPhysicalDamagePercentUnique__10
+IncreasedLifeUnique__8
 ShieldArmourIncreaseUnique__1
 AddedFireDamageIfBlockedRecentlyUnique__1
 ]],[[
@@ -43,7 +43,7 @@ LifeLeechPermyriadImplicitClaw2
 {variant:1}LocalIncreasedPhysicalDamagePercentUnique__1[80,100]
 {variant:2}LocalIncreasedPhysicalDamagePercentUnique__1
 LocalAddedPhysicalDamageUnique__1
-LocalIncreasedAttackSpeedUnique__16
+LocalIncreasedAttackSpeedUnique__2
 MovementSpeedWhilePhasedUnique__1
 {variant:1}GainPhasingOnVaalSkillUseUnique__1[3000,3000]
 {variant:2}GainPhasingOnVaalSkillUseUnique__1
@@ -57,7 +57,7 @@ Implicits: 1
 LifeLeechPermyriadImplicitClaw2
 LocalIncreasedPhysicalDamagePercentUnique__1
 LocalAddedPhysicalDamageUnique__1
-LocalIncreasedAttackSpeedUnique__16
+LocalIncreasedAttackSpeedUnique__2
 LifeGainedOnTauntingEnemyUnique__1
 OnslaughtOnKillingTauntedEnemyUnique__1
 TauntedEnemiesTakeIncreasedDamage_
@@ -84,7 +84,7 @@ LifeLeechPermyriadUniqueClaw6
 {variant:1,2,3,4}StunThresholdReductionUniqueClaw6
 {variant:6}WarcryTauntChaosExplosionUnique__1_
 {variant:5}WarcryEffectUnique__1[50,50]
-{variant:6}WarcryEffectUnique__1
+{variant:6}WarcryEffectUnique__2
 {variant:5,6}WarcryCooldownIs2SecondsUnique__1
 ]],[[
 Bloodseeker
@@ -200,7 +200,7 @@ Variant: Current
 Requires Level 68, 131 Dex, 95 Int
 Implicits: 2
 {variant:1}LifeGainPerTargetImplicit2Claw10[25,25]
-{variant:2,3,4,5}LifeGainPerTargetImplicit2Claw10
+{variant:2,3,4,5}LifeGainPerTargetImplicit2Claw13
 PercentageDexterityUnique__3
 PercentageIntelligenceUnique__3
 {variant:4,5}LifeLeechFromAttacksPermyriadUnique__1
@@ -230,9 +230,9 @@ PhysicalDamageWhileFrozenUnique___1
 Last Resort
 Nailed Fist
 Implicits: 1
-LifeGainPerTargetImplicitClaw1
+LifeGainPerTargetImplicit2Claw1
 IncreasedAttackSpeedWhenOnLowLifeUniqueClaw4
-LocalIncreasedPhysicalDamagePercentUniqueClaw5
+LocalIncreasedPhysicalDamagePercentUniqueClaw4
 LocalAddedPhysicalDamagePercentUniqueClaw4
 IncreasedClawDamageOnLowLifeUniqueClaw4
 IncreasedAccuracyWhenOnLowLifeUniqueClaw4
@@ -246,7 +246,7 @@ Source: Steal from a unique{Curio Display} during a Grand Heist
 Implicits: 1
 LifeGainPerTargetImplicit2Claw1
 {variant:1}IncreasedAttackSpeedWhenOnLowLifeUniqueClaw4[50,50]
-{variant:2}IncreasedAttackSpeedWhenOnLowLifeUniqueClaw4
+{variant:2}IncreasedAttackSpeedWhenOnLowLifeUnique__1
 LocalIncreasedPhysicalDamagePercentUniqueClaw4
 IncreasedAccuracyWhenOnLowLifeUniqueClaw4
 IncreasedClawDamageOnLowLifeUnique__1__
@@ -263,7 +263,7 @@ Implicits: 1
 LifeLeechPermyriadImplicitClaw1
 {variant:1}20% chance to Trigger Level 20 Summon Spectral Wolf on Critical Strike with this Weapon
 {variant:2}SummonWolfOnCritUnique__1
-LocalIncreasedAttackSpeedUnique__25
+LocalIncreasedAttackSpeedUnique__33
 LocalCriticalStrikeChanceUnique__17_
 CriticalMultiplierUnique__4____
 ]],[[
@@ -311,9 +311,9 @@ Terror Claw
 Requires Level 70, 113 Dex, 113 Int
 Implicits: 1
 LifeLeechPermyriadImplicitClaw2
-LocalIncreasedPhyiscalDamagePercentUnique__3
+LocalIncreasedPhysicalDamagePercentUnique__11_
 LocalAddedPhysicalDamageUnique__13
-CausesBleedingUnique__1
+CausesBleedingUnique__2Updated
 IncreasePhysicalDegenDamagePerDexterityUnique__1
 IncreaseBleedDurationPerIntelligenceUnique__1
 BleedingEnemiesFleeOnHitUnique__1
@@ -327,7 +327,7 @@ Implicits: 1
 LifeLeechPermyriadImplicitClaw2
 {variant:1}SummonWolfOnKillUnique__1
 LocalAddedPhysicalDamageUnique__23_
-LocalIncreasedAttackSpeedUniqueClaw9
+LocalIncreasedAttackSpeedUnique__17
 IncreasedMinionAttackSpeedUnique__1_
 MinionDamageAlsoAffectsYouUnique__1
 IncreasedMinionDamageIfYouHitEnemyUnique__1
@@ -339,10 +339,10 @@ Variant: Current
 Requires Level 68, 131 Dex, 95 Int
 Implicits: 2
 {variant:1}LifeGainPerTargetImplicit2Claw10[25,25]
-{variant:2}LifeGainPerTargetImplicit2Claw10
+{variant:2}LifeGainPerTargetImplicit2Claw13
 LocalAddedPhysicalDamageUnique__14
 ColdDamagePercentUnique__8
-LocalCriticalStrikeChanceUnique__10
+LocalCriticalStrikeChanceUnique__3
 ChanceToGainFrenzyChargeOnKillingFrozenEnemyUnique__1
 AdditionalChainWhileAtMaxFrenzyChargesUnique___1
 ChanceToFreezeUnique__3
@@ -374,7 +374,7 @@ Implicits: 2
 StrengthUniqueClaw9
 DexterityUniqueClaw9
 LocalAddedPhysicalDamageUniqueClaw9
-LocalIncreasedAttackSpeedUniqueClaw8
+LocalIncreasedAttackSpeedUniqueClaw9
 DamageWithMovementSkillsUniqueClaw9
 AttackSpeedWithMovementSkillsUniqueClaw9
 AccuracyPercentUniqueClaw9

--- a/src/Export/Uniques/dagger.lua
+++ b/src/Export/Uniques/dagger.lua
@@ -56,7 +56,7 @@ Source: Steal from a unique{Curio Display} during a Grand Heist
 Requires Level 15, 30 Dex, 30 Int
 Implicits: 1
 CriticalStrikeChanceImplicitDagger1
-StrengthUnique__15
+StrengthUnique__20_
 LocalIncreasedPhysicalDamagePercentUniqueDagger12
 LocalAddedPhysicalDamageUniqueDagger12
 LocalChanceToBleedUniqueDagger12
@@ -69,7 +69,7 @@ Requires Level 62, 95 Dex, 131 Int
 Implicits: 1
 CriticalStrikeChanceImplicitDagger1
 GlobalPhysicalSpellGemsLevelUnique__1
-DealNoElementalDamageUnique__1
+DealNoElementalDamageUnique__2
 ]],[[
 Replica Cold Iron Point
 Ezomyte Dagger
@@ -191,7 +191,7 @@ SpellDamageOnWeaponUniqueDagger4
 {variant:1}ReducedEnergyShieldDelayUniqueBodyInt1
 {variant:2}ReducedEnergyShieldDelayUniqueDagger4
 {variant:1}IncreasedLifeUnique__123[40,50]
-{variant:2}IncreasedLifeUnique__123
+{variant:2}IncreasedLifeUnique__107
 ImpaleEffectUnique__1
 ChanceToImpaleWithSpellsUnique__1
 ]],[[
@@ -203,7 +203,7 @@ Requires Level 60, 113 Dex, 113 Int
 Implicits: 1
 CriticalStrikeChanceImplicitDagger1
 UniqueSecretBladeGrantHiddenBlade
-DexterityUnique__18
+DexterityUnique__20__
 LocalIncreasedPhysicalDamagePercentUnique__42
 ReducedAttackSpeedWhilePhasingUnique__1
 ]],[[
@@ -223,7 +223,7 @@ BlockWhileDualWieldingUniqueDagger9
 {variant:1,2,3}LocalReducedAttackSpeedUniqueDagger9[10,10]
 {variant:4}LocalReducedAttackSpeedUniqueDagger9
 {variant:4}LocalCriticalStrikeChanceUnique__23
-{variant:4}LocalCriticalMultiplierUniqueDagger4
+{variant:4}CriticalMultiplierUnique__8
 {variant:1,2,3}AllResistancesUniqueDagger9
 {variant:3,4}CauseseBleedingOnCritUniqueDagger9
 {variant:3,4}CausesPoisonOnCritUniqueDagger9
@@ -236,7 +236,7 @@ Requires Level 35, 73 Dex, 51 Int
 Implicits: 1
 CriticalStrikeChanceImplicitDagger1
 StrengthUniqueDagger2
-LocalIncreasedPhysicalDamagePercentUniqueDagger3
+LocalIncreasedPhysicalDamagePercentUniqueDagger2
 LocalAddedPhysicalDamageUniqueDagger2
 LifeGainPerTargetUniqueDagger2
 ]],[[
@@ -245,8 +245,8 @@ Ambusher
 Requires Level 60, 113 Dex, 113 Int
 Implicits: 1
 CriticalStrikeChanceImplicitDagger1
-LocalIncreasedPhysicalDamagePercentUnique__20
-LocalIncreasedAttackSpeedUnique__17
+LocalIncreasedPhysicalDamagePercentUnique__29
+LocalIncreasedAttackSpeedUnique__22
 PoisonDurationUnique__1_
 AttackDamageManaLeechAgainstPoisonedEnemiesUnique_2
 LifeLeechFromAttackDamageAgainstMaimedEnemiesUnique__1
@@ -264,7 +264,7 @@ CriticalStrikeChanceImplicitDagger1
 {variant:2}BlockWhileDualWieldingUniqueDagger3[20,20]
 {variant:1,3}BlockWhileDualWieldingUniqueDagger3
 DexterityUniqueDagger3
-LocalIncreasedPhysicalDamagePercentUniqueDagger2
+LocalIncreasedPhysicalDamagePercentUniqueDagger3
 AddedLightningDamageUniqueDagger3
 LocalIncreasedAttackSpeedUniqueDagger3
 CriticalStrikeChanceUniqueDagger3
@@ -278,8 +278,8 @@ Implicits: 1
 CriticalStrikeChanceImplicitDagger1
 BlockWhileDualWieldingUnique__2_
 DexterityUniqueDagger3
-LocalIncreasedAttackSpeedUniqueDagger12
-CriticalStrikeChanceImplicitDagger3
+LocalIncreasedAttackSpeedUniqueDagger3
+CriticalStrikeChanceUniqueDagger3
 ChanceToChillAttackersOnBlockUnique__2__
 ChanceToShockAttackersOnBlockUnique__2
 ]],[[
@@ -314,7 +314,7 @@ Requires Level 66, 95 Dex, 131 Int
 Implicits: 1
 CriticalStrikeChanceImplicitDaggerNew1
 LocalAddedColdDamageUnique__7
-LocalIncreasedAttackSpeedUnique__13
+LocalIncreasedAttackSpeedUnique__23
 {variant:1}IncreasedEvasionRatingUnique__3[300,400]
 {variant:2,3}IncreasedEvasionRatingUnique__3
 {variant:1}IncreasedColdDamageWhileOffhandIsEmpty_[100,100]
@@ -332,7 +332,7 @@ CriticalStrikeChanceImplicitDagger1
 {variant:1}LocalAddedPhysicalDamageUnique__8[15,25][35,45]
 {variant:2}LocalAddedPhysicalDamageUnique__8
 LocalCriticalStrikeChanceUnique__2
-LocalCriticalMultiplierUniqueDagger4
+CriticalMultiplierUnique__2
 CriticalChanceAgainstEnemiesOnFullLifeUnique__1
 CriticalStrikeAttackLifeLeechUnique__1
 ]],

--- a/src/Export/Uniques/flask.lua
+++ b/src/Export/Uniques/flask.lua
@@ -99,7 +99,7 @@ FlaskLightRadiusUniqueFlask1
 ]],[[
 The Writhing Jar
 Hallowed Hybrid Flask
-FlaskChargesUsedUnique__11
+LocalFlaskChargesUsedUnique__2
 FlaskFullInstantRecoveryUnique__1
 SummonsWormsOnUse
 ]],
@@ -228,7 +228,7 @@ Variant: Pre 3.16.0
 Variant: Current
 LevelReq: 68
 {variant:2}FlaskChargesUsedUnique__4
-{variant:3,4}FlaskChargesUsedUnique___2
+{variant:3,4}FlaskChargesUsedUnique__5
 {variant:3}FlaskEffectDurationUnique__2[-60,-40]
 {variant:4}FlaskLessDurationUnique1
 {variant:1}FlaskIncreasedAreaOfEffectDuringEffectUnique__1_[30,30]
@@ -453,7 +453,7 @@ Variant: Current (Spells)
 Variant: Current (Attacks)
 LevelReq: 68
 {variant:5,6,7,8,9,10,11,12,13}FlaskChargesUsedUnique__6_
-{variant:14,15,16,17,18}FlaskChargesUsedUnique__5
+{variant:14,15,16,17,18}FlaskChargesUsedUnique___2
 ShockNearbyEnemiesDuringFlaskEffect___1
 ShockSelfDuringFlaskEffect__1
 {variant:1,5,11}LightningPenetrationDuringFlaskEffect__1[10,10]
@@ -510,7 +510,7 @@ Stibnite Flask
 League: Heist
 Source: Steal from a unique{Curio Display} during a Grand Heist
 UtilityFlaskSmokeCloud
-FlaskChargesUsedUnique__10
+FlaskChargesUsedUnique__4
 VulnerabilityAuraDuringFlaskEffectUnique__1Alt
 ]],[[
 Wine of the Prophet

--- a/src/Export/Uniques/gloves.lua
+++ b/src/Export/Uniques/gloves.lua
@@ -9,7 +9,7 @@ League: Settlers of Kalguur
 Source: Drops from unique{Admiral Valerius} in normal{Shipping encounters}
 Requires Level 39, 58 Str
 IncreasedAttackSpeedUnique__7
-LocalIncreasedPhysicalDamageReductionRatingPercentUnique__1
+LocalIncreasedPhysicalDamageReductionRatingPercentUnique__32
 ChanceToGainMaximumRageUnique__1
 GlobalIncreaseMeleeSkillGemLevelUnique__1
 ]],[[
@@ -65,7 +65,7 @@ Titan Gauntlets
 League: Bestiary
 Source: Drops from unique{Craiceann, First of the Deep}
 Requires Level 69, 98 Str
-LocalIncreasedPhysicalDamageReductionRatingUniqueGlovesStr2
+LocalIncreasedPhysicalDamageReductionRatingPercentUnique__17
 LifeRegenerationUnique__1
 FireResistUnique__16
 DamagePerCrabBarrierUnique__1
@@ -77,7 +77,7 @@ Variant: Pre 3.23.0
 Variant: Pre 3.26.0
 Variant: Current
 IncreasedLifeUnique__114
-FireResistUnique__1
+FireResistUnique__30
 LifeLeechPermyriadUnique__7
 LifeRegenerationNotAppliedUnique__1
 {variant:1}RageRegenerationPerLifeRegenerationUnique__1[100,100]
@@ -175,7 +175,7 @@ Titan Gauntlets
 Requires Level 69, 98 Str
 IncreasedAttackSpeedUnique_1
 LocalIncreasedPhysicalDamageReductionRatingPercentUnique7
-ChanceToDodgeUniqueRing37
+MovementVelocityUnique__9_
 IncreasedStunDurationOnSelfUnique_1
 IncreasedDamagePerEnduranceChargeUnique_1
 CannotBeShockedWhileMaximumEnduranceChargesUnique_1
@@ -187,7 +187,7 @@ Implicits: 0
 TriggerSocketedCurseSkillsOnCurseUnique__1_
 LocalIncreasedEnergyShieldUnique__27_
 EnergyShieldLeechPerCurseUnique__1_
-AdditionalCurseOnEnemiesUnique__1
+AdditionalCurseOnEnemiesUnique__2
 CurseCastSpeedUnique__1
 ]],[[
 Winds of Change
@@ -196,12 +196,12 @@ Source: Drops in The Lord's Labyrinth
 Variant: Pre 2.6.0
 Variant: Current
 Requires Level 47, 68 Str
-IncreasedLifeUnique__16
-ProjectileSpeedUnique__2
+IncreasedLifeUnique__1
+ProjectileSpeedUnique___1
 {variant:1}MovementVelocityUnique__2[-10,-10]
 {variant:2}MovementVelocityUnique__2
 KnockbackChanceUnique__1
-IncreasedProjectileDamageUnique___12
+IncreasedProjectileDamageUnique__1
 ]],[[
 The Caged Mammoth
 Antique Gauntlets
@@ -220,7 +220,7 @@ Great Old One's Tentacles
 Eelskin Gloves
 Requires Level 38, 56 Dex
 AddedPhysicalDamageUnique__8
-IncreasedLifeUniqueGlovesStrDex4
+IncreasedLifeUnique__102
 AttackImpaleChanceUnique__1
 EnemiesKilledApplyImpaleDamageUnique__1
 ]],[[
@@ -294,9 +294,9 @@ Nubuck Gloves
 Variant: Pre 3.16.0
 Variant: Current
 Requires Level 52, 50 Dex
-CurseOnHitCriticalWeaknessUnique__1
+CurseOnHitCriticalWeaknessUniqueNewUnique__1
 IncreasedAccuracyPercentUnique__1
-IncreasedLifeUnique__41
+IncreasedLifeUnique__61
 ChaosResistUnique__8
 {variant:1}ChanceToDodgeSpellsUnique__3_[7,8]
 {variant:2}ChanceToDodgeSpellsUnique__3_
@@ -367,7 +367,7 @@ IntelligenceUniqueGlovesInt3
 {variant:3}IncreasedLifeUniqueGlovesInt3
 {variant:1,2}IncreasedManaUniqueGlovesInt3[20,30]
 {variant:3}IncreasedManaUniqueGlovesInt3
-{variant:1,2,3}TemporalChainsOnHitUniqueGlovesInt3
+{variant:1,2,3}CurseOnHitTemporalChainsUnique__1
 {variant:3}CursesRemainOnDeathUnique__1_
 {variant:3}EnemiesNearCursesBlindAndExplodeUnique__1
 ]],[[
@@ -394,7 +394,7 @@ IncreasedCastSpeedUnique__11__
 {variant:1}LocalIncreasedEnergyShieldUnique__25[50,70]
 {variant:2}LocalIncreasedEnergyShieldUnique__25
 {variant:1}IncreasedLifeUnique__72_[50,70]
-{variant:2}IncreasedLifeUnique__72_
+{variant:2}IncreasedLifeUnique__86_
 {variant:1}SacrificeLifeToGainESUnique__1[5,5]
 {variant:2}SacrificeLifeToGainESUnique__1
 ]],[[
@@ -434,8 +434,8 @@ Grip of the Council
 Arcanist Gloves
 Requires Level 60, 95 Int
 StrengthUnique__4
-IncreasedLifeUnique__11
-ColdResistUnique__12
+IncreasedLifeUnique__20
+ColdResistUnique__8
 MinionRunSpeedUnique__1
 MinionColdResistUnique__1
 MinionPhysicalDamageAddedAsColdUnique__1_
@@ -445,9 +445,9 @@ Arcanist Gloves
 League: Heist
 Source: Steal from a unique{Curio Display} during a Grand Heist
 Requires Level 60, 95 Int
-StrengthUnique__1
-IncreasedLifeUnique__107
-FireResistUnique__23_
+StrengthUnique__4
+IncreasedLifeUnique__20
+FireResistUnique__25
 MinionLifeUnique__4__
 MinionFireResistUnique__1
 MinionPhysicalDamageAddedAsFireUnique__1
@@ -456,9 +456,9 @@ Kalisa's Grace
 Samite Gloves
 Requires Level 55, 68 Int
 SupportedByFasterCastUnique__1
-IntelligenceUniqueGlovesInt5
+IntelligenceUnique__7
 LocalIncreasedEnergyShieldUnique__14
-IncreasedLifeUniqueGlovesStrDex4
+IncreasedLifeUnique__62
 GainCriticalStrikeChanceOnManaSpentUnique__1
 ]],[[
 Replica Kalisa's Grace
@@ -467,9 +467,9 @@ League: Heist
 Source: Steal from a unique{Curio Display} during a Grand Heist
 Requires Level 55, 68 Int
 DisplaySupportedByUnleashUnique__1
-IntelligenceUniqueGlovesInt3
+IntelligenceUnique__7
 LocalIncreasedEnergyShieldUnique__14
-IncreasedLifeUniqueGlovesStrDex4
+IncreasedLifeUnique__62
 GainAreaOfEffectPluspercentOnManaSpentUnique__1
 ]],[[
 Sadima's Touch
@@ -518,10 +518,10 @@ Hydrascale Gauntlets
 Requires Level 59, 45 Str, 45 Dex
 League: Blight
 Source: Drops in Blighted Maps
-LocalIncreasedArmourAndEvasionUnique__19_
+LocalIncreasedArmourAndEvasionUnique__12
 IncreasedManaUnique__16
 AllResistancesUnique__16
-AttackAndCastSpeedUnique__2
+AttackAndCastSpeedUnique__5
 ReviveEnemiesOnKillUnique__1
 This item can be anointed by Cassia
 ]],[[
@@ -531,7 +531,7 @@ League: Bestiary
 Source: Drops from unique{Farrul, First of the Plains}
 Requires Level 59, 45 Str, 45 Dex
 LocalIncreasedArmourAndEvasionUnique__8_
-IncreasedLifeUniqueGlovesStrDex4
+IncreasedLifeUnique__75
 AccuracyAgainstBleedingEnemiesUnique__1
 AttacksBleedOnHitWithCatsStealthUnique__1_
 DamageAgainstBleedingEnemiesUnique__1
@@ -546,21 +546,21 @@ LocalIncreasedArmourAndEvasionUniqueGlovesStrDex5
 LifeRegenerationUniqueGlovesStrDex5
 HealOnRampageUniqueGlovesStrDex5
 VaalSoulsOnRampageUniqueGlovesStrDex5
-SimulatedRampageStrInt2
+SimulatedRampageStrDex5
 ]],[[
 Gravebind
 Hydrascale Gauntlets
 Requires Level 59, 45 Str, 45 Dex
 Implicits: 0
-LocalIncreasedArmourAndEvasionUnique__14
-ChaosResistUnique__21
+LocalIncreasedArmourAndEvasionUnique__19_
+ChaosResistUnique__23
 LifeGainedFromEnemyDeathUnique__3
 EnemiesKilledCountAsYoursUnique__1
 ]],[[
 Haemophilia
 Serpentscale Gauntlets
 Requires Level 43, 34 Str, 34 Dex
-StrengthUniqueGlovesStrInt2
+StrengthUnique__8
 DegenerationDamageUnique__1
 ChanceToBleedUnique__1_
 AttackDamageAgainstBleedingUnique__1__
@@ -616,7 +616,7 @@ Variant: Searching: Onslaught
 {variant:4}AbyssJewelSocketUnique__10
 {variant:5}AbyssJewelSocketUnique__11_
 {variant:1,2}IncreasedAttackSpeedUniqueGlovesStrDex1[6,10]
-{variant:3}IncreasedAttackSpeedUniqueGlovesStrDex1
+{variant:3}IncreasedAttackSpeedUnique__2
 {variant:1,2}MaximumLifeUnique__7
 {variant:6}IntimidateOnHitWithMeleeAbyssJewelUnique__1
 {variant:7}FortifyOnHitWithMeleeAbyssJewelUnique__1
@@ -660,7 +660,7 @@ Variant: Current
 Requires Level 49, 38 Str, 38 Dex
 ItemActsAsConcentratedAOESupportUnique__1
 LocalIncreasedArmourAndEvasionUnique__1
-IncreasedLifeUniqueGlovesStrDex4
+IncreasedLifeUnique__2
 {variant:1}ReduceManaCostPerEnduranceChargeUnique__1
 {variant:2}ManaCostEfficiencyPerEnduranceChargeUnique__1
 RampageWhileAtMaxEnduranceChargesUnique__1
@@ -668,9 +668,9 @@ LoseEnduranceChargesOnRampageEndUnique___1
 ]],[[
 Tanu Ahi
 Wyrmscale Gauntlets
-IncreasedAttackSpeedUniqueGlovesDexInt_1
-LocalIncreasedArmourAndEvasionUnique__12
-LifeLeechPermyriadUnique__8
+IncreasedAttackSpeedUnique__5
+LocalIncreasedArmourAndEvasionUnique__22
+LifeLeechPermyriadUnique__9
 AdrenalineOnFillingLifeLeechUnique__1
 OnslaughtOnFillingLifeLeechUnique__1
 ]],
@@ -687,7 +687,7 @@ Variant: Two Abyssal Sockets
 Requires Level 37, 29 Str, 29 Int
 {variant:1,3}AbyssJewelSocketImplicit
 {variant:2,4}AbyssJewelSocketUnique__1
-IncreasedCastSpeedUniqueGlovesDemigods1
+IncreasedCastSpeedUnique__12
 MaximumLifeUnique__13
 {variant:1,2}MinionAccuracyWithMinionAbyssJewelUnique__1
 {variant:3,4}With a Ghastly Eye Jewel Socketed, Minions have 25% chance to gain Unholy Might on Hit with Spells
@@ -698,7 +698,7 @@ Mesh Gloves
 League: Necropolis
 Requires Level 32, 26 Str, 26 Int
 LocalIncreasedArmourAndEnergyShieldUnique__28
-AllResistancesUnique__10
+AllResistancesUnique__32
 AuraEffectWhileLinkedUnique__1
 AurasOnlyApplyToLinkedTargetUnique__1
 ]],[[
@@ -710,7 +710,7 @@ League: Ritual
 Source: Purchase from Ritual Reward
 Requires Level 43, 34 Str, 34 Int
 LocalIncreasedArmourAndEnergyShieldUnique__23_
-IncreasedLifeUniqueGlovesStrDex4
+IncreasedLifeUnique__110
 SacrificialZealOnSkillUseUnique__1_
 {variant:1}ArmourPenetrationSacrificialZealUnique__1[10,15]
 {variant:2}ArmourPenetrationSacrificialZealUnique__1
@@ -719,9 +719,9 @@ Hands of the High Templar
 Crusader Gloves
 Source: Drops from unique{Sirus, Awakener of Worlds}
 CorruptUntilFiveImplicits
-LocalIncreasedArmourAndEnergyShieldUnique__15
+LocalIncreasedArmourAndEnergyShieldUnique__20
 MaximumLifeUnique__19
-FireAndLightningResistUnique__1
+FireAndLightningResistUnique__2
 ]],[[
 Null and Void
 Legion Gloves
@@ -733,15 +733,15 @@ IncreasedLifeUniqueGlovesStrInt2
 ManaRegenerationUniqueGlovesStrInt2
 DispelStatusAilmentsOnRampageUniqueGlovesStrInt2
 PhysicalDamageImmunityOnRampageUniqueGlovesStrInt2
-SimulatedRampageStrDex5
+SimulatedRampageStrInt2
 ]],[[
 Offering to the Serpent
 Legion Gloves
 League: Synthesis
 Source: Drops from unique{Synthete Nightmare} in normal{The Cortex}
 Requires Level 57, 44 Str, 44 Int
-AllAttributesUnique__14
-LocalIncreasedArmourAndEnergyShieldUnique__13_
+AllAttributesUnique__16_
+LocalIncreasedArmourAndEnergyShieldUnique__15
 MaximumLifeLeechAmountUnique__1
 AttackAndCastSpeedUnique__4
 IncreasedDamageWhileLeechingUnique__2__
@@ -765,8 +765,8 @@ Soldier Gloves
 League: Bestiary
 Source: Drops from unique{Saqawal, First of the Sky}
 Requires Level 51, 40 Str, 40 Int
-LocalIncreasedArmourAndEnergyShieldUnique__10_
-IncreasedLifeUnique__1
+LocalIncreasedArmourAndEnergyShieldUnique__9_
+IncreasedLifeUnique__69
 ColdAndLightningResistUnique__1
 AviansMightDurationUnique__1
 AviansMightColdDamageUnique__1
@@ -848,7 +848,7 @@ Requires Level 43, 34 Str, 34 Int
 {variant:1}AddedFireDamageUnique__1_
 {variant:2}AddedColdDamageUnique__2
 {variant:3}AddedLightningDamageUnique__1
-IncreasedLifeUniqueGlovesStrDex4
+IncreasedLifeUnique__50
 {variant:1}FireResistUnique__12
 {variant:2}ColdResistUnique__16
 {variant:3}LightningResistUnique__10
@@ -866,7 +866,7 @@ League: Heist
 Source: Steal from a unique{Curio Display} during a Grand Heist
 Requires Level 43, 34 Str, 34 Int
 GlobalAddedChaosDamageUnique__6_
-IncreasedLifeUniqueGlovesStrInt2
+IncreasedLifeUnique__50
 ChaosResistUnique__19
 ChaosDamageCanIgniteUnique__1
 ChanceToIgniteWithChaosSkillsUnique__1
@@ -892,7 +892,7 @@ Ambush Mitts
 League: Harvest
 Source: Drops from unique{Oshabi, Avatar of the Grove}
 Requires Level 45, 35 Dex, 35 Int
-LocalIncreasedEvasionAndEnergyShieldUnique__24
+LocalIncreasedEvasionAndEnergyShieldUnique__26
 AttackAndCastSpeedUnique__6
 WitherOnHitChanceUnique__1
 WitherGrantsElementalDamageTakenUnique__1__
@@ -900,8 +900,8 @@ CannotPenetrateResistancesUnique__1
 ]],[[
 Stormseeker
 Ambush Mitts
-IncreasedEnergyShieldUnique__12
-IncreasedManaUnique__14
+LocalIncreasedEnergyShieldUnique__34
+IncreasedManaUnique__24
 ChillEffectLeechingManaUnique__1
 ShockEffectLeechingESUnique__1
 UnaffectedByChillLeechingManaUnique__1
@@ -911,7 +911,7 @@ Algor Mortis
 Carnal Mitts
 League: Delirium
 Requires Level 50, 39 Dex, 39 Int
-IncreasedEnergyShieldUnique__9
+LocalIncreasedEnergyShieldUnique__28
 ColdAndLightningResistUnique__2
 ChanceToSapVsEnemiesInChillingAreasUnique__1
 ChillingAreasAlsoGrantLightningDamageTakenUnique__1
@@ -921,7 +921,7 @@ Aukuna's Will
 Clasped Mitts
 League: Legion
 Requires Level 31, 25 Dex 25 Int
-DexterityUnique__19
+DexterityUnique__16
 IncreasedCastSpeedUnique__18_
 LocalIncreasedEvasionAndEnergyShieldUnique__21_
 ZombieIncreasedLifeUnique__1
@@ -938,9 +938,9 @@ Source: Opening normal{Fortified Casket} in normal{Defense Research Lab}
 Upgrade: Upgrades to unique{Slavedriver's Hand} via currency{Vial of Dominance}
 {variant:1}Requires Level 16
 {variant:2}Requires Level 45, 35 Dex, 35 Int
-DexterityUnique__16
+DexterityUnique__10_
 {variant:1}LocalIncreasedEvasionAndEnergyShieldUnique__23[100,125]
-{variant:2}LocalIncreasedEvasionAndEnergyShieldUnique__23
+{variant:2}LocalIncreasedEvasionAndEnergyShieldUnique__16
 TrapThrowSpeedUnique__1_
 {variant:1}TrapAreaOfEffectUnique__1
 {variant:2}ChanceToThrowFourAdditionalTrapsUnique__1
@@ -964,8 +964,8 @@ Assassin's Mitts
 Elder Item
 Source: Drops from unique{The Elder}
 Requires Level 58, 45 Dex, 45 Int
-DexterityUniqueGlovesDexInt4
-LocalIncreasedEvasionAndEnergyShieldUnique__35
+DexterityUnique__7
+LocalIncreasedEvasionAndEnergyShieldUnique__10
 IncreasedLifeUnique__67_
 IncreasedLifePerElderItemUnique__1
 AilmentDamageOverTimeMultiplierPerElderItemUnique__1
@@ -977,8 +977,8 @@ Carnal Mitts
 Requires Level 50, 39 Dex, 39 Int
 SupportedByVileToxinsUnique__1
 AddedChaosDamageToAttacksAndSpellsUnique__2
-IncreasedLifeUniqueGlovesStrDex4
-ChaosResistUnique__28
+IncreasedLifeUnique__54
+ChaosResistUnique__6
 PoisonDurationUnique__2
 ]],[[
 Facebreaker
@@ -1007,7 +1007,7 @@ Source: Drops from unique{Fenumus, First of the Night}
 Requires Level 50, 39 Dex, 39 Int
 GrantsSpiderAspect1
 LocalIncreasedEvasionAndEnergyShieldUnique__13
-IncreasedLifeUnique__118
+IncreasedLifeUnique__77
 AttackAndCastSpeedUnique__3
 DamageAgainstEnemiesWith3WebsUnique__1_
 ChaosDamagePerWebOnEnemyUnique__1
@@ -1028,7 +1028,7 @@ Machina Mitts
 Murder Mitts
 Requires Level: 67
 League: Blight
-LocalIncreasedEvasionAndEnergyShieldUnique__16
+LocalIncreasedEvasionAndEnergyShieldUnique__23
 MineDamageLeechedToYouUnique__1
 LifeEnergyShieldRecoveryRateUnique__1
 LifeAndEnergyShieldRecoveryRatePerPowerChargeUnique__1
@@ -1054,7 +1054,7 @@ Murder Mitts
 Source: Drops from unique{Nightmare of the Depraved Trinity} in normal{Abomination Map}
 Requires Level 67, 51 Dex, 51 Int
 LocalIncreasedEvasionAndEnergyShieldUnique__8
-IncreasedLifeUniqueGlovesInt3
+IncreasedLifeUnique__58
 LifeGainedFromEnemyDeathUnique__1
 EnergyShieldGainedFromEnemyDeathUnique__1
 GainThaumaturgyBuffRotationUnique__1_
@@ -1096,9 +1096,9 @@ Storm's Gift
 Assassin's Mitts
 League: Synthesis
 Requires Level 58, 45 Dex, 45 Int
-DegenerationDamageUnique__2
+DegenerationDamageUnique__5
 LocalIncreasedEvasionAndEnergyShieldUnique__19___
-LightningResistImplicitRing1
+LightningResistUnique__20
 ShockOnKillUnique__1
 ShockProliferationUnique__1
 ]],[[
@@ -1115,7 +1115,7 @@ Requires Level 67, 51 Dex, 51 Int
 {variant:2}AddedLightningDamageUniqueGlovesDexInt3[1,1][40,40]
 IncreasedAttackSpeedUniqueGlovesDexInt3
 {variant:1,2,3}LocalIncreasedEnergyShieldUniqueGlovesDexInt3
-{variant:4}LocalIncreasedEvasionAndEnergyShieldUnique__10
+{variant:4}LocalIncreasedEvasionAndEnergyShieldUnique__35
 {variant:1,2,3}StunDurationUniqueGlovesDexInt3
 {variant:1,2,3}ShockDurationUniqueGlovesDexInt3
 {variant:4}LightningAilmentEffectUnique__1
@@ -1124,8 +1124,8 @@ Entropic Devastation
 Assassin's Mitts
 Source: Drops from unique{The Shaper} (Uber)
 Shaper Item
-GrantsCallOfSteelSkillUnique__1_
-LocalIncreasedEvasionAndEnergyShieldUnique__18
+GrantsCallOfSteelSkillUnique__2
+LocalIncreasedEvasionAndEnergyShieldUnique__36
 SpellImpaleEffectUnique__1
 SpellImpaleOnCritChanceUnique__1
 ]],
@@ -1151,7 +1151,7 @@ League: Expedition
 Source: Drops from Expedition monsters
 Requires Level 48, 31 Str, 31 Dex, 31 Int
 LocalIncreasedWardPercentUnique__1_
-ChaosResistUnique__10
+ChaosResistUnique__22
 {variant:1}GlobalAddedChaosDamageWardUnique__[25,25]
 {variant:2}GlobalAddedChaosDamageWardUnique__[20,20]
 {variant:3}GlobalAddedChaosDamageWardUnique__

--- a/src/Export/Uniques/helmet.lua
+++ b/src/Export/Uniques/helmet.lua
@@ -35,7 +35,7 @@ Close Helmet
 Variant: Pre 3.10.0
 Variant: Current
 Requires Level 26, 58 Str
-LocalIncreaseSocketedMinionGemLevelUnique__4
+LocalIncreaseSocketedMinionGemLevelUnique__2_
 {variant:1}StrengthUnique__10
 {variant:1}MinionLifeUniqueRing33[20,20]
 {variant:2}MinionLifeUnique__2
@@ -77,9 +77,9 @@ Variant: Pre 3.21.0
 Variant: Current
 Requires Level 48, 101 Str
 {variant:1,2}LocalIncreasedPhysicalDamageReductionRatingUnique__1
-{variant:3}LocalIncreasedPhysicalDamageReductionRatingPercentUnique__26
+{variant:3}LocalIncreasedPhysicalDamageReductionRatingPercentUnique__6
 {variant:1,2}IncreasedLifeUnique__118
-{variant:3}FireResistUniqueHelmetInt7
+{variant:3}FireResistUnique__10
 {variant:1,2}ReducedFireDamageTakenUnique__1[-20,-20]
 {variant:3}ReducedFireDamageTakenUnique__1
 {variant:1,2,3}ArmourIncreasedByUncappedFireResistanceUnique__1
@@ -95,8 +95,8 @@ Requires Level 65, 148 Str
 {variant:3}SupportedByInfernalLegionUnique__1
 {variant:1,2}LocalIncreasedPhysicalDamageReductionRatingPercentUnique__22
 {variant:1,2}IncreasedLifeUniqueHelmetDexInt2[40,50]
-{variant:3}IncreasedLifeUniqueHelmetDexInt2
-FireResistUniqueHelmetInt7
+{variant:3}IncreasedLifeUnique__33
+FireResistUnique__10
 {variant:1,2}PhysicalDamageTakenAsFirePercentUnique__1
 {variant:1,2}ArmourIncreasedByUncappedFireResistanceUnique__1
 {variant:3}MinionLifeIncreasedByOvercappedFireResistanceUnique__1
@@ -107,8 +107,8 @@ Royal Burgonet
 Source: Drops from unique{The Shaper} (Uber)
 Requires Level 65, 148 Str
 SocketedWarcryCooldownCountUnique__1
-LocalIncreasedPhysicalDamageReductionRatingPercentUnique__19
-IncreasedLifeUniqueHelmetStrDex5
+LocalIncreasedPhysicalDamageReductionRatingPercentUnique__26
+IncreasedLifeUnique__113
 TakePhysicalDamagePerWarcryExertingUnique__1
 MoreDamagePerWarcryExertingUnique__1
 ]],[[
@@ -122,7 +122,7 @@ Requires Level 55, 114 Str
 {variant:2,3}FireDamagePercentUniqueStrHelmet2
 {variant:1}LocalIncreasedPhysicalDamageReductionRatingPercentAndStunRecoveryUniqueStrHelmet2[40,60]
 {variant:2,3}LocalIncreasedPhysicalDamageReductionRatingPercentAndStunRecoveryUniqueStrHelmet2
-{variant:3}IncreasedLifeUniqueHelmetStrDex5
+{variant:3}IncreasedLifeUnique__44
 ColdResistUniqueStrHelmet2
 {variant:1,2}ChanceToAvoidChilledUnique__1
 {variant:1,2}JewelImplicitChanceToAvoidFreeze[50,50]
@@ -133,7 +133,7 @@ Siege Helmet
 League: Settlers of Kalguur
 Source: Kingsmarch Shipping to normal{Ngakanu} or normal{Te Onui}
 Requires Level 48, 101 Str
-IncreasedLifeUnique__3
+IncreasedLifeUnique__124
 WarcrySpeedUnique__2
 WarcryCorpseExplosionUnique__1
 WarcryAreaOfEffectUnique__1
@@ -165,7 +165,7 @@ Ezomyte Burgonet
 Source: Drops from unique{Mercenary} after winning a duel
 League: Mercenaries of Trarthus
 Requires Level 60, 138 Str
-StrengthUnique__28
+StrengthUnique__30
 LocalIncreasedPhysicalDamageReductionRatingPercentUnique__33
 NoCooldownWarcriesUnique
 WarcryLifeCostUnique
@@ -189,7 +189,7 @@ Source: Drops from unique{Uber Incarnation of Dread} in normal{Moment of Reveren
 Requires Level 73, 101 Str, 101 Int
 LocalIncreasedPhysicalDamageReductionRatingPercentUnique__35
 AllResistancesUnique__35
-LightRadiusUniqueSceptre2
+LightRadiusUnique__11
 LinksTargetDamageableMinionsUnique_1
 LinksGrantMinionsLessDamageTakenUnique_1
 LinkedMinionsStealRareModsUnique_1
@@ -200,11 +200,11 @@ Alpha's Howl
 Sinner Tricorne
 Requires Level 64, 138 Dex
 LocalIncreaseSocketedAuraGemLevelUniqueHelmetDex5
-LocalIncreasedEvasionRatingPercentUniqueDexHelmet2
-ColdResistDexHelmet2
+LocalIncreasedEvasionRatingPercentUniqueHelmetDex5
+ColdResistUniqueHelmetDex5
 CannotBeFrozen
 ChanceToAvoidFreezeAndChillUniqueDexHelmet5
-ReducedManaReservationsCostUniqueHelmetDex5
+ManaReservationEfficiencyUniqueHelmetDex5_
 ]],[[
 Replica Alpha's Howl
 Sinner Tricorne
@@ -212,11 +212,11 @@ League: Heist
 Source: Steal from a unique{Curio Display} during a Grand Heist
 Requires Level 64, 138 Dex
 LocalIncreaseSocketedHeraldLevelUnique__2
-LocalIncreasedEvasionRatingPercentUniqueDexHelmet2
-ChaosResistUniqueHelmetStrInt2
+LocalIncreasedEvasionRatingPercentUniqueHelmetDex5
+ChaosResistUnique__18_
 ChanceToAvoidPoisonUnique__1
-ManaReservationEfficiencyUniqueHelmetDex5_
-YouCannotBeHinderedUnique__1
+ReducedManaReservationsCostUniqueHelmetDex5
+YouCannotBeHinderedUnique__2
 ]],[[
 Assailum
 Sinner Tricorne
@@ -262,7 +262,7 @@ Variant: Current
 Requires Level 20, 46 Dex
 {variant:1}LocalIncreaseSocketedFireGemLevelUniqueDexHelmet2
 {variant:1}LocalIncreaseSocketedColdGemLevelUniqueDexHelmet2
-LocalIncreasedEvasionRatingPercentUniqueHelmetDex5
+LocalIncreasedEvasionRatingPercentUniqueDexHelmet2
 ManaRegenerationUniqueDexHelmet2
 {variant:1}FireResistUniqueDexHelmet2[-20,-10]
 {variant:2,3,4}FireResistUniqueDexHelmet2
@@ -280,8 +280,8 @@ League: Heist
 Source: Steal from a unique{Curio Display} during a Grand Heist
 LocalIncreasedEvasionRatingPercentUniqueDexHelmet2
 ManaRegenerationUniqueDexHelmet2
-ColdResistUniqueHelmetDex5
-LightningResistUniqueDexHelmet1
+ColdResistDexHelmet2
+LightningResistUnique__31
 LightningAddedAsColdShockedEnemyUnique__1
 ]],[[
 Frostferno
@@ -309,7 +309,7 @@ IncreaseProjectileAttackDamagePerAccuracyUnique__1
 Elevore
 Wolf Pelt
 ChanceToSuppressSpellsUnique__2
-IncreasedEvasionRatingPercentUnique__1_
+LocalIncreasedEvasionRatingPercentUnique__19
 AvoidElementalAilmentsUnique__2
 RecoverLifeOnSuppressUnique__1
 ]],[[
@@ -320,7 +320,7 @@ IncreasedAttackSpeedUniqueHelmetDex6
 CriticalStrikeChanceUniqueHelmetDex6
 LocalIncreasedEvasionRatingPercentUniqueHelmetDex6
 ItemFoundRarityIncreaseUniqueHelmetDex6
-MovementVelocityUniqueHelmetInt6
+MovementVelocityUniqueHelmetDex6
 ActorSizeUniqueHelmetDex6
 ]],[[
 Saqawal's Flock
@@ -329,8 +329,8 @@ League: Bestiary
 Source: Drops from unique{Saqawal, First of the Sky}
 Requires Level 60, 138 Dex
 GrantsAvianTornadoUnique__1__
-LocalIncreasedEvasionRatingPercentUnique__15_
-IncreasedLifeUnique__26
+LocalIncreasedEvasionRatingPercentUnique__12
+IncreasedLifeUnique__71
 LightningResistUnique__14
 MovementVelocityUnique__32
 ]],[[
@@ -387,7 +387,7 @@ Requires Level 59, 122 Int
 League: Blight
 Source: Drops in Blighted Maps
 MultipleEnchantmentsAllowedUnique__1
-AllAttributesUnique__8_
+AllAttributesUnique__19
 LocalIncreasedEnergyShieldPercentUnique__26
 ReducedFireResistanceUnique__1
 ReducedColdResistanceUnique__1
@@ -514,7 +514,7 @@ Variant: Damage if consumed corpse
 {variant:1,2,3,4,5,6,7,8,9,10,11,12,13}SocketedItemsHaveReducedReservationUnique__1[40,40]
 {variant:14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38}SocketedItemsHaveReducedReservationUnique__1
 TriggerFeastOfFleshSkillUnique__1_
-LocalIncreasedEnergyShieldPercentUnique__19
+LocalIncreasedEnergyShieldPercentUnique__21
 StartEnergyShieldRechargeOnSkillUnique__1
 KeystoneEldritchBatteryUnique__1
 {variant:1}StrengthUniqueHelmetStrDex3[10,25]
@@ -568,10 +568,10 @@ KeystoneEldritchBatteryUnique__1
 Wilma's Requital
 Solaris Circlet
 IncreasedAccuracyUnique__10
-LocalIncreasedEnergyShieldPercentUnique__33
+LocalIncreasedEnergyShieldPercentUnique__32
 CastSpeedAppliesToAttackSpeedUnique__1
 WeaponElementalDamageUnique__6
-KeystoneAncestralBondUnique__1
+KeystoneAncestralBondUnique__2
 ]],[[
 Doedre's Scorn
 Lunaris Circlet
@@ -581,8 +581,8 @@ Variant: Current
 Requires Level 39, 83 Int
 {variant:1}IncreaseSocketedCurseGemLevelUniqueHelmetInt9[1,1]
 {variant:2,3}IncreaseSocketedCurseGemLevelUniqueHelmetInt9
-{variant:2,3}LocalIncreasedEnergyShieldUnique__25
-IntelligenceUniqueHelmetWard1
+{variant:2,3}LocalIncreasedEnergyShieldUnique__9
+IntelligenceUniqueHelmetInt9
 {variant:1,2}ElementalDamageUniqueHelmetInt9
 {variant:1,2}IncreasedDamagePerCurseUniqueHelmetInt9
 IncreasedCurseDurationUniqueHelmetInt9
@@ -595,7 +595,7 @@ Implicits: 0
 GrantsVoidGazeUnique__1
 LocalIncreasedEnergyShieldUniqueHelmetInt7
 IncreasedManaUnique__9
-StunRecoveryUniqueHelmetInt6
+StunRecoveryUnique__1_
 ElementalDamagePercentAddedAsChaosUnique__4
 ]],[[
 Fenumus' Toxins
@@ -615,7 +615,7 @@ Necromancer Circlet
 League: Sanctum
 Source: Drops from unique{Lycia, Herald of the Scourge} in normal{The Beyond}
 IncreasedCastSpeedUnique__24
-LocalIncreasedEnergyShieldPercentUnique__32
+LocalIncreasedEnergyShieldPercentUnique__33
 AvoidInterruptionWhileCastingUnique__1
 SpellCritChanceEqualsWeaponCritChanceUnique__1
 AttacksCannotCritUnique__1
@@ -626,7 +626,7 @@ Variant: Pre 3.19.0
 Variant: Current
 Requires Level 59, 122 Int
 LocalIncreasedEnergyShieldPercentUnique__23
-FireResistUnique__12
+FireResistUnique__20_
 ElementalDamageUnique__3
 {variant:1}AlternateFireAilmentUnique__1[25,25][1,1]
 {variant:2}AlternateFireAilmentUnique__1
@@ -638,7 +638,7 @@ Variant: Pre 3.19.0
 Variant: Current
 Requires Level 59, 122 Int
 LocalIncreasedEnergyShieldPercentUnique__23
-ColdResistUnique__17
+ColdResistUnique__27
 ElementalDamageUnique__3
 {variant:1}AlternateColdAilmentUnique__1[25,25][1,1]
 {variant:2}AlternateColdAilmentUnique__1
@@ -668,7 +668,7 @@ Source: Drops from unique{The Elder} (Uber)
 Variant: Pre 3.5.0
 Variant: Current
 Requires Level 69, 154 Int
-LocalIncreasedEnergyShieldPercentUnique__10
+LocalIncreasedEnergyShieldPercentUnique__16
 MaximumManaUnique__6
 NonInstantManaRecoveryAlsoAffectsLifeUnique__1
 ManaCostPer200ManaSpentRecentlyUnique__1
@@ -698,7 +698,7 @@ League: Legion
 Requires Level 48, 101 Int
 (60-80)% increased Critical Strike Chance for Spells
 LocalIncreasedEnergyShieldPercentUnique__25_
-IncreasedLifeUniqueHelmetStrDex5
+IncreasedLifeUnique__96__
 UnaffectedByPoisonUnique__1_
 DamageTakenGainedAsLifeUnique__1_
 ]],[[
@@ -741,7 +741,7 @@ Mind Cage
 League: Torment
 Requires Level 65, 138 Int
 SpellDamageUniqueHelmetInt8
-ReducedCastSpeedUniqueHelmetStrInt6
+ReducedCastSpeedUniqueHelmetInt8
 IncreasedManaUniqueHelmetInt8
 PhysicalDamageOnSkillUseUniqueHelmetInt8
 ]],[[
@@ -750,7 +750,7 @@ Steel Circlet
 Source: Drops from unique{The Black Star}
 Requires Level 48, 101 Int
 LocalIncreasedEnergyShieldPercentUnique__30___
-IncreasedManaUniqueHelmetStrDex5_
+IncreasedManaUnique__22__
 EnergyShieldRechargeOnKillUnique__1__
 LessRechargeRateSoullessEleganceUnique__1
 ]],[[
@@ -760,7 +760,7 @@ Variant: Pre 3.19.0
 Variant: Current
 Requires Level 59, 122 Int
 LocalIncreasedEnergyShieldPercentUnique__23
-LightningResistUnique__10
+LightningResistUnique__19_
 ElementalDamageUnique__3
 {variant:1}AlternateLightningAilmentUnique__1__[25,25][1,1]
 {variant:2}AlternateLightningAilmentUnique__1__
@@ -775,7 +775,7 @@ Source: Drops from unique{Nightmare of Catarina} in normal{Ziggurat Map}
 Requires Level: 34, 73 Int
 {variant:3}AbyssJewelSocketUnique__17
 {variant:1,2}LocalIncreaseSocketedMinionGemLevelUnique__3
-LocalIncreasedEnergyShieldUniqueHelmetInt7
+LocalIncreasedEnergyShieldPercentUnique__12
 {variant:3}GlobalIncreaseMinionSpellSkillGemLevelUnique__2
 {variant:2}MaximumMinionCountUnique__1__
 {variant:1}MinionLifeRegenerationUnique__1
@@ -787,10 +787,10 @@ Wreath of Phrecia
 Iron Circlet
 League: Legion
 Requires Level 8
-LocalNoAttributeRequirementsUnique__1
+LocalNoAttributeRequirementsUnique__2
 LightRadiusToAreaOfEffectUnique__1
 LightRadiusToDamageUnique_1
-LightRadiusUnique__7_
+LightRadiusUnique__5
 DealNoChaosDamageUnique_1
 ]],[[
 Ylfeban's Trickery
@@ -899,7 +899,7 @@ HasOneSocketUnique__2
 LocalIncreaseSocketedGemLevelUnique__9
 SocketedGemQualityUnique__1
 SocketedSkillsDoubleDamageUnique__1_
-LocalIncreasedArmourAndEvasionUnique__12
+LocalIncreasedArmourAndEvasionUnique__14
 ]],[[
 Deidbell
 Gilded Sallet
@@ -944,7 +944,7 @@ The Devourer of Minds
 Pig-Faced Bascinet
 Source: Drops from unique{The Elder} (Uber Uber)
 Requires Level 63, 85 Str, 62 Dex
-IntelligenceUnique__19
+IntelligenceUnique__35
 LocalIncreasedArmourAndEvasionUnique__27
 GlobalIncreaseMinionSpellSkillGemLevelUnique__3
 LightRadiusUnique__9
@@ -955,7 +955,7 @@ Lacquered Helmet
 League: Heist
 Source: Drops from unique{Nashta, The Usurper} in normal{Contract: Heart of Glory}
 Requires Level 51, 57 Str, 57 Dex
-LocalIncreasedArmourAndEvasionUniqueHelmetStrDex2
+LocalIncreasedArmourAndEvasionUnique__17_
 ProjectileSpeedUnique__8
 IncreasedProjectileDamageUnique___10_
 NearbyEnemiesAvoidProjectilesUnique__1
@@ -1010,7 +1010,7 @@ Visored Sallet
 League: Affliction
 Source: Drops from Viridian Wildwood and Ritual monsters
 Requires Level 23, 28 Str, 28 Dex
-LocalIncreasedArmourAndEvasionUnique__21
+LocalIncreasedArmourAndEvasionUnique__25
 AttackerTakesColdDamageUnique__1
 AttackerTakesFireDamageUnique__1
 AttackerTakesLightningDamageUnique__1
@@ -1021,9 +1021,9 @@ EnemyElementalResistanceZeroWhenHitUnique__1
 Ahn's Contempt
 Praetor Crown
 Requires Level 68, 62 Str, 91 Int
-AllAttributesUnique__10_
+AllAttributesUnique__4
 LocalIncreasedArmourAndEnergyShieldUnique__7
-IncreasedLifeUnique__55
+IncreasedLifeUnique__57
 ReducedMaximumPowerChargesUnique__1
 PhysAddedAsChaosWithMaxPowerChargesUnique__1
 ReducedExtraDamageFromCritsWithNoPowerChargesUnique__1
@@ -1034,7 +1034,7 @@ League: Ritual
 Requires Level 73, 76 Str, 76 Int
 Implicits: 1
 MinionDamageImplicitHelmet1
-LocalIncreasedArmourAndEnergyShieldUniqueHelmetStrInt_1
+LocalIncreasedArmourAndEnergyShieldUnique__25
 MinionLifeUnique__5_
 MinionRunSpeedUnique__6
 MinionCriticalStrikeChanceMaximumPowerChargeUnique__1
@@ -1049,10 +1049,10 @@ Requires Level 63, 85 Str, 62 Int
 {variant:1}LocalIncreasedArmourAndEnergyShieldUnique__6[100,120]
 {variant:2,3}LocalIncreasedArmourAndEnergyShieldUnique__6
 {variant:1}IncreasedLifeUniqueHelmetDex4[50,70]
-{variant:2,3}IncreasedLifeUniqueHelmetDex4
+{variant:2,3}IncreasedLifeUnique__35
 {variant:3}MaximumColdResistUnique__2
 {variant:1,2}ColdResistUnique__10
-CannotBeFrozenUnique__1
+CannotBeFrozen
 {variant:2}ColdDamageTakenUnique__1
 {variant:1}AddedArmourWhileStationaryUnique__1[800,800]
 {variant:2,3}AddedArmourWhileStationaryUnique__1
@@ -1155,7 +1155,7 @@ Variant: Pre 3.29.0
 Variant: Current
 Requires Level 12, 16 Str, 16 Int
 {variant:2}LocalIncreaseSocketedGemLevelUnique__10
-{variant:3,4}LocalIncreaseSocketedGemLevelUnique__11_
+{variant:3,4}LocalIncreaseSocketedGemLevelUnique__8
 {variant:1,2}AddedLightningDamageUniqueHelmetStrInt1[1,1][13,13]
 {variant:3,4}AddedLightningDamageUniqueHelmetStrInt1
 {variant:1}LocalIncreasedArmourAndEnergyShieldUniqueHelmetStrInt1[40,50]
@@ -1174,9 +1174,9 @@ Variant: Current
 Requires Level 44, 50 Str, 50 Int
 {variant:1}ChanceToCastOnManaSpentUnique__1[100,100][30,30]
 {variant:2}ChanceToCastOnManaSpentUnique__1
-ReducedCastSpeedUniqueHelmetInt8
+ReducedCastSpeedUniqueHelmetStrInt6
 LocalIncreasedArmourAndEnergyShieldUniqueHelmetStrInt6
-IncreasedManaUnique__16
+IncreasedManaUnique__5
 ]],[[
 Lightpoacher
 Great Crown
@@ -1186,10 +1186,10 @@ Variant: One Abyssal Socket (Pre 3.21.0)
 Variant: Two Abyssal Sockets (Pre 3.21.0)
 Variant: One Abyssal Socket (Current)
 Variant: Two Abyssal Sockets (Current)
-{variant:1,3}AbyssJewelSocketImplicit
-{variant:2,4}AbyssJewelSocketUnique__1
+{variant:1,3}AbyssJewelSocketUnique__7
+{variant:2,4}AbyssJewelSocketUnique__2
 LocalDisplayGrantLevelXSpiritBurstUnique__1
-AllResistancesUnique__14
+AllResistancesUnique__12
 MaximumSpiritChargesPerAbyssJewelEquippedUnique__1
 {variant:1,2}GainSpiritChargeOnKillChanceUnique__1[15,20]
 {variant:3,4}GainSpiritChargeOnKillChanceUnique__1
@@ -1226,7 +1226,7 @@ Upgrade: Upgrades to unique{Mask of the Stitched Demon} via currency{Vial of Sum
 {variant:2}LocalIncreasedArmourAndEnergyShieldUnique__12
 {variant:2}LocalIncreasedEnergyShieldUnique__31
 {variant:1}IncreasedLifeUniqueHelmetDex4[30,50]
-{variant:2}IncreasedLifeUniqueHelmetDex4
+{variant:2}IncreasedLifeUnique__82
 CannotGainEnergyShieldUnique__1
 LifeRegenerationWith500EnergyShieldUnique__1
 LifeRegenerationWith1000EnergyShieldUnique__1
@@ -1238,7 +1238,7 @@ Magistrate Crown
 League: Incursion
 Source: Upgraded from unique{Mask of the Spirit Drinker} via currency{Vial of Summoning}
 Requires Level 58, 64 Str, 64 Int
-IntelligenceUniqueHelmetInt6
+IntelligenceUnique__11
 LocalIncreasedEnergyShieldUnique__24_
 NoMaximumLifePerStrengthUnique__1
 NoMaximumManaPerIntelligenceUnique__1
@@ -1256,7 +1256,7 @@ Variant: Pre 3.29.0
 Variant: Current
 Requires Level 58, 64 Str, 64 Int
 AllAttributesUnique__15
-LocalIncreasedArmourAndEnergyShieldUniqueHelmetStrInt_1
+LocalIncreasedArmourAndEnergyShieldUnique__13_
 {variant:2,3}BlockPer100StrengthAuraUnique__1___
 {variant:1}DefencesPer100StrengthAuraUnique__1
 CriticalMultiplierPer100DexterityAuraUnique__1
@@ -1283,10 +1283,10 @@ Memory Vault
 Praetor Crown
 Requires Level 68, 62 Str, 91 Int
 LocalIncreasedEnergyShieldUnique__15
-IncreasedManaUnique__26
+IncreasedManaUnique__10
 ManaRegenerationUnique__6
-FireResistUniqueDexHelmet2
-IncreasedManaReservationsCostUnique__2
+FireResistUnique__13
+ReservationEfficiencyUnique__2
 GainArmourEqualToManaReservedUnique__1
 ]],[[
 Mindspiral
@@ -1304,7 +1304,7 @@ Requires Level 37, 42 Str, 42 Int
 EnemiesCannotLeechMana
 {variant:1,2}PercentDamageGoesToManaUniqueHelmetStrInt3[5,10]
 {variant:3}PercentDamageGoesToManaUniqueHelmetStrInt3
-CannotLeechManaUnique__1_
+CannotLeechMana
 ]],[[
 Ravenous Passion
 Zealot Helmet
@@ -1312,8 +1312,8 @@ Variant: Pre 3.25.0
 Variant: Current
 Source: Drops from unique{The Eater of Worlds} (Uber)
 Requires Level: 44, 50 Str, 50 Int
-StrengthUnique__18
-LocalIncreasedArmourAndEnergyShieldUnique__16
+StrengthUnique__26
+LocalIncreasedArmourAndEnergyShieldUnique__27
 {variant:1}GainRageOnManaSpentUnique__1[10,15][200,200]
 {variant:2}GainRageOnManaSpentUnique__1
 RageCasterStatsUnique__1
@@ -1321,7 +1321,7 @@ RageCasterStatsUnique__1
 Speaker's Wreath
 Prophet Crown
 Requires Level 63, 85 Str, 62 Int
-DexterityUnique__20__
+DexterityUnique__6
 SkillEffectDurationUnique__1
 MinionAttackSpeedPerXDexUnique__1
 MinionMovementSpeedPerXDexUnique__1
@@ -1364,7 +1364,7 @@ Variant: Current
 IncreasedPhysicalDamageReductionRatingUnique__2
 FireResistUnique__7_
 ChaosResistUnique__2
-LightRadiusUnique__8
+LightRadiusUnique__3
 IncreasedLifeWhileNoCorruptedItemsUnique__1
 {variant:1}LifeRegenerationPerMinuteWhileNoCorruptedItemsUnique__1[6000,6000]
 {variant:2}LifeRegenerationPerMinuteWhileNoCorruptedItemsUnique__1
@@ -1387,7 +1387,7 @@ Variant: Pre 3.19.0
 Variant: Current
 Requires Level 52, 58 Dex, 58 Int
 LocalIncreasedEvasionAndEnergyShieldUniqueHelmetDexInt6
-{variant:2,3}IncreasedLifeUnique__124
+{variant:2,3}IncreasedLifeUnique__45
 LifeLeechPermyriadUniqueHelmetDexInt6
 AttackerTakesDamageUniqueHelmetDexInt6
 {variant:1,2}DamageYouReflectGainedAsLifeUniqueHelmetDexInt6[30,30]
@@ -1480,7 +1480,7 @@ Requires Level 52, 58 Dex, 58 Int
 Implicits: 0
 PetrificationStatueUnique__1
 LocalIncreasedEnergyShieldPercentUnique__15_
-IncreasedLifeUnique__121
+IncreasedLifeUnique__66
 AttackAndCastSpeedUnique__2
 AdditionalPhysicalDamageReductionWhileMovingUnique__1
 ReducedElementalDamageTakenWhileStationaryUnique__1_
@@ -1497,9 +1497,9 @@ Requires Level 38, 44 Dex, 44 Int
 LocalIncreasedEvasionAndEnergyShieldUniqueHelmetDexInt3
 {variant:2}LocalIncreasedEnergyShieldUnique__11[40,65]
 {variant:3,4}LocalIncreasedEnergyShieldUnique__11
-{variant:2,3,4}IncreasedLifeUnique__120
+{variant:2,3,4}IncreasedLifeUnique__46
 {variant:1}IncreasedManaUniqueHelmetDexInt3
-{variant:2,3,4}ColdResistUnique__16
+{variant:2,3,4}ColdResistUnique__17
 {variant:1}LifeGainedFromEnemyDeathUniqueHelmetDexInt3
 {variant:1}EnergyShieldGainedFromEnemyDeathUniqueHelmetDexInt3
 {variant:1,2,3}ShrineBuffEffectUniqueHelmetDexInt3[75,75]
@@ -1514,7 +1514,7 @@ Variant: Pre 3.0.0
 Variant: Pre 3.20.0
 Variant: Current
 Requires Level 67, 73 Dex, 88 Int
-{variant:1,4}IncreaseSocketedCurseGemLevelUniqueHelmetInt9[2,2]
+{variant:1,4}IncreaseSocketedCurseGemLevelUnique__1[2,2]
 {variant:2,3}IncreaseSocketedCurseGemLevelUniqueHelmetInt9[1,1]
 SocketedGemsSupportedByBlasphemyUnique__1
 ReducedReservationForSocketedCurseGemsUnique__1
@@ -1526,7 +1526,7 @@ Leer Cast
 Festival Mask
 Variant: Pre 3.19.0
 Variant: Current
-DexterityUniqueHelmetStrDex3
+DexterityUniqueHelmetDexInt2
 {variant:1}AllDamageUniqueHelmetDexInt2[-30,-30]
 {variant:2}AllDamageUniqueHelmetDexInt2
 {variant:1}IncreasedLifeUniqueHelmetDexInt2[20,30]
@@ -1562,11 +1562,11 @@ StrengthUniqueHelmetDexInt1
 {variant:1,2,3,4,5}SpellDamageUniqueHelmetDexInt1
 {variant:1,2,3,4,5}LightningDamageUniqueHelmetDexInt1
 {variant:1,2,3,4,5}LightningResistUniqueStrDexHelmet1[10,10]
-{variant:6}LightningResistUniqueDexHelmet1
+{variant:6}LightningResistUniqueHelmetDexInt1
 {variant:1}ManaCostReductionUniqueJewel44[100,100]
 {variant:2}ManaCostReductionUniqueJewel44[20,20]
 {variant:6}SpellsDoubleDamageChanceUnique__1
-KeystoneMortalConvictionUnique__1
+BloodMagic
 {variant:4}KeystoneMortalConvictionUnique__1
 ]],[[
 Malachai's Awakening
@@ -1620,8 +1620,8 @@ SupportedByIceBiteUnique__1
 SupportedByInnervateUnique__1
 HarbingerSkillOnEquipUnique2_5
 LocalIncreasedEvasionRatingUnique__1
-LocalIncreasedEnergyShieldUniqueHelmetInt5_
-IncreasedLifeUnique__103
+LocalIncreasedEnergyShieldUnique__12
+IncreasedLifeUnique__53
 AllResistancesUnique__10
 ]],[[
 The Three Dragons
@@ -1661,7 +1661,7 @@ Source: Drops from unique{The Maven} (Uber)
 Requires Level 68, 62 Str, 91 Int
 LocalIncreaseSocketedGemLevelUnique__10
 LocalIncreasedArmourAndEnergyShieldUnique__24
-AllResistancesDemigodsImplicit
+AllResistancesUnique__21
 AnyRingMagicDamageExtraRollUnique__1
 RightRingMagicHexproofUnique__1
 LeftRingMagicNoCritDamageUnique__1
@@ -1684,11 +1684,11 @@ League: Expedition
 Source: Drops from Expedition monsters
 Variant: Pre 3.19.0
 Variant: Current
-IntelligenceUniqueHelmetInt9
+IntelligenceUniqueHelmetWard1
 LocalIncreasedWardPercentUnique__2
 {variant:1}WardDelayRecoveryUnique__1[20,30]
 {variant:2}WardDelayRecoveryUnique__1
-LightRadiusUnique__5
+LightRadiusUnique__7_
 EnergyShieldAdditiveModifiersInsteadApplyToWardUnique__
 ]],[[
 Cadigan's Crown
@@ -1697,5 +1697,5 @@ League: Expedition
 Source: Drops from unique{Olroth, Origin of the Fall} in normal{Expedition Logbook}
 Requires Level 68, 66 Str, 66 Dex, 66 Int
 CannotCrit
-BattlemageKeystoneUnique__6
+BattlemageKeystoneUnique__3
 ]],}

--- a/src/Export/Uniques/jewel.lua
+++ b/src/Export/Uniques/jewel.lua
@@ -25,7 +25,7 @@ League: Heist
 Source: Drops from unique{The Unbreakable} in normal{Contract: Breaking the Unbreakable}
 Limited to: 1
 Requires Level 20
-SpellDamageUnique__12
+SpellDamageUnique__13
 CriticalStrikeChancePerIntensityUnique__1
 SpellsGainIntensityUnique__1
 ]],[[
@@ -523,7 +523,7 @@ Viridian Jewel
 GolemAttackAndCastSpeedUnique__1
 GolemBuffEffectUnique__1
 GolemArmourRatingUnique__1
-PrimordialJewelCountUnique__4
+PrimordialJewelCountUnique__3
 ]],[[
 Primordial Harmony
 Cobalt Jewel
@@ -534,7 +534,7 @@ GolemSkillsCooldownRecoveryUnique__1
 {variant:2}GolemsSkillsCooldownRecoveryUnique__1_
 IncreasedGolemDamagePerGolemUnique__1
 GolemLifeRegenerationUnique__1
-PrimordialJewelCountUnique__3
+PrimordialJewelCountUnique__1
 ]],[[
 Primordial Might
 Crimson Jewel
@@ -671,7 +671,7 @@ Variant: Current
 Radius: Medium
 AdditionalStrengthPerAllocatedStrengthJewelUnique__1_
 {variant:1,2}AdditionalPhysicalReductionPerAllocatedStrengthJewelUnique__1
-{variant:2,3}CriticalStrikeMultiplierPerUnallocatedStrengthJewelUnique__1_
+{variant:2,3}CriticalStrikeMultiplierPerUnallocatedStrengthUnique__1
 {variant:1}CriticalStrikeMultiplierPerUnallocatedStrengthJewelUnique__1_[5,5][10,10]
 {variant:3}LifeRecoveryRatePerAllocatedStrengthUnique__2
 {variant:3}LifeRecoveryRatePerUnallocatedStrengthUnique__1_
@@ -716,7 +716,7 @@ Variant: Current
 Radius: Medium
 AdditionalDexterityPerAllocatedDexterityJewelUnique__1
 {variant:1}FlatManaPerUnallocatedDexterityJewelUnique__1
-{variant:2}MovementSpeedPerAllocatedDexterityJewelUnique__1
+{variant:2}MovementSpeedPerAllocatedDexterityUnique__1
 ]],[[
 Transcendent Spirit
 Viridian Jewel
@@ -744,8 +744,8 @@ Radius: Variable
 Implicits: 0
 {variant:1}JewelRingRadiusValuesUnique__1
 {variant:5}JewelRingRadiusValuesUnique__2
-JewelUniqueAllocateDisconnectedPassives
-AllResistancesUnique__6
+AllocateDisconnectedPassivesDonutUnique__1
+AllResistancesUnique__18
 {variant:2}Only affects Passives in Medium Ring
 {variant:3}Only affects Passives in Large Ring
 {variant:4}Only affects Passives in Very Large Ring
@@ -1698,7 +1698,7 @@ Emperor's Cunning
 Viridian Jewel
 Source: Drops in The Eternal Labyrinth
 Limited to: 1
-PercentageDexterityUniqueJewel29
+PercentageDexterityUnique__2
 PercentIncreasedAccuracyJewelUnique__1
 ActorSizeUnique__1
 ]],[[
@@ -1715,7 +1715,7 @@ Emperor's Might
 Crimson Jewel
 Source: Drops in The Eternal Labyrinth
 Limited to: 1
-PercentageStrengthUniqueJewel29
+PercentageStrengthUnique__2
 AllDamageUnique__1
 ActorSizeUnique__1
 ]],[[

--- a/src/Export/Uniques/mace.lua
+++ b/src/Export/Uniques/mace.lua
@@ -27,7 +27,7 @@ Requires Level 66, 212 Str
 Implicits: 2
 {variant:2}StunThresholdReductionImplicitMace2
 {variant:1}StunDurationImplicitMace1[40,40]
-LocalIncreasedPhysicalDamagePercentUniqueTwoHandMace8
+LocalIncreasedPhysicalDamageUniqueOneHandMace5
 LocalAddedPhysicalDamageUniqueOneHandMace5
 StunThresholdReductionUniqueOneHandMace5
 CannotKnockBackUniqueOneHandMace5_
@@ -120,7 +120,7 @@ Implicits: 2
 {variant:3}LocalAddedPhysicalDamageUnique__6_
 {variant:1,2}LocalAddedColdDamageUnique__2[16,22][26,32]
 {variant:3}LocalAddedColdDamageUnique__2
-LocalIncreasedAttackSpeedUnique__12
+LocalIncreasedAttackSpeedUnique__11
 FireResistUnique__4
 IncreasedChillDurationUnique__1
 LocalDoubleDamageToChilledEnemiesUnique__1
@@ -134,7 +134,7 @@ Implicits: 1
 StunThresholdReductionImplicitMace2
 LocalAddedChaosDamageUnique__2
 LocalIncreasedAttackSpeedUnique__11
-ChaosResistUnique__15
+ChaosResistUnique__20_
 ChaosDamageCanChill
 LocalDoubleDamageToChilledEnemiesUnique__1
 ]],[[
@@ -221,7 +221,7 @@ League: Heist
 Source: Steal from a unique{Curio Display} during a Grand Heist
 Requires Level 68, 104 Str, 122 Int
 Implicits: 1
-ElementalDamagePercentImplicitSceptre3
+ElementalDamagePercentImplicitSceptreNew22
 {variant:2}ReplicaNebulisImplicitModifierMagnitudeUnique_1
 IncreasedCastSpeedUnique__16
 {variant:1}ColdDamagePerMissingColdResistanceUnique__1
@@ -251,9 +251,9 @@ Dream Mace
 Requires Level 32, 107 Str
 Implicits: 1
 StunThresholdReductionImplicitMace1
-LocalIncreasedPhysicalDamagePercentUniqueOneHandMace1
+LocalIncreasedPhysicalDamagePercentUnique__52
 LocalAddedPhyiscalDamageUnique__43
-IncreasedAttackSpeedUniqueShieldDex6
+LocalIncreasedAttackSpeedUnique__42
 BlockIsUnluckyUnique__1
 CountAsBlockingAttackFromShieldAttackFirstTargetUnique__1
 ]],[[
@@ -282,7 +282,7 @@ Requires Level 68, 104 Str, 122 Int
 Implicits: 1
 ElementalDamagePercentImplicitSceptreNew22
 LocalIncreasedPhysicalDamagePercentUnique__29
-LocalIncreasedAttackSpeedUnique__20
+LocalIncreasedAttackSpeedUnique__26_
 LocalCriticalStrikeChanceUnique__14
 ConvertPhysicaltoLightningUnique__3
 GainElementalOverloadEvery16SecondsUnique__1
@@ -296,7 +296,7 @@ Variant: Current
 Requires Level 10, 22 Str, 22 Int
 Implicits: 2
 {variant:1}ElementalDamagePercentImplicitSceptreNew2[10,10]
-{variant:2}ElementalDamagePercentImplicitSceptreNew2
+{variant:2}ElementalDamagePercentImplicitSceptreNew3
 SpellAddedFireDamageUnique__4
 SpellAddedColdDamageUnique__3
 SpellAddedLightningDamageUnique__3
@@ -318,13 +318,13 @@ Bitterdream
 Shadow Sceptre
 Requires Level 32, 52 Str, 62 Int
 Implicits: 1
-ElementalDamagePercentImplicitSceptreNew12___
+ElementalDamagePercentImplicitSceptreNew8
 DisplaySupportedByBonechillUnique__1
 DisplaySupportedByHypothermiaUnique__1
-DisplaySupportedByIceBiteUnique__2
+DisplaySupportedByIceBiteUnique__1
 DisplaySupportedByColdPenetrationUnique__1
 DisplaySupportedByAddedColdDamageUnique__1
-DisplaySupportedByReducedManaUnique__2
+DisplaySupportedByReducedManaUnique__1
 ]],[[
 Replica Bitterdream
 Shadow Sceptre
@@ -339,8 +339,8 @@ ElementalDamagePercentImplicitSceptreNew8
 {variant:2}DisplaySupportedByElementalPenetrationUnique__2
 DisplaySupportedByImmolateUnique__1
 DisplaySupportedByUnboundAilmentsUnique__1__
-DisplaySupportedByIceBiteUnique__1
-DisplaySupportedByReducedManaUnique__1
+DisplaySupportedByIceBiteUnique__2
+DisplaySupportedByReducedManaUnique__2
 SupportedByInnervateUnique__2
 ]],[[
 The Black Cane
@@ -348,7 +348,7 @@ Royal Sceptre
 Requires Level 50, 86 Str, 86 Int
 Implicits: 1
 ElementalDamagePercentImplicitSceptreNew14
-Intelligence__1
+IntelligenceUnique__18
 IncreasedCastSpeedUnique__19__
 ManaRegenerationUnique__11___
 MinionDamageUnique__8_
@@ -361,13 +361,13 @@ Variant: Pre 3.29.0
 Variant: Current
 Requires Level 66, 113 Str, 113 Int
 Implicits: 1
-ElementalDamagePercentImplicitSceptreNew20
+ElementalDamagePercentImplicitSceptreNew21__
 LocalIncreasedPhysicalDamagePercentUnique__16
 {variant:1}IncreasedChaosDamageUnique__2[60,80]
 {variant:2}IncreasedChaosDamageUnique__2[80,100]
 {variant:3}IncreasedChaosDamageUnique__2
 {variant:1,2}AreaOfEffectUnique_9[10,10]
-{variant:3}AreaOfEffectUnique_9
+{variant:3}AreaOfEffectUnique__2_
 {variant:1,2}ChaosSkillEffectDurationUnique__1[40,40]
 {variant:3}ChaosSkillEffectDurationUnique__1
 ]],[[
@@ -381,13 +381,13 @@ Variant: Current
 Requires Level 28, 51 Str, 51 Int
 Implicits: 2
 {variant:1}ElementalDamagePercentImplicitSceptreNew6[10,10]
-{variant:2,3,4}ElementalDamagePercentImplicitSceptreNew6
+{variant:2,3,4}ElementalDamagePercentImplicitSceptreNew7
 LocalIncreasedPhysicalDamageUniqueSceptre9
 {variant:1,2}LocalAddedFireDamageAgainstIgnitedEnemiesUniqueSceptre9
 LocalAddedPhysicalDamageUniqueSceptre9
 FireDamagePercentUniqueSceptre9
-LocalIncreasedAttackSpeedUnique__33
-LocalCriticalStrikeChanceUniqueTwoHandMace6
+LocalIncreasedAttackSpeedUniqueSceptre9
+LocalCriticalStrikeChanceUniqueSceptre9
 {variant:3}AddedFireDamagePerStrengthUnique__1[2,2][4,4]
 {variant:4}AddedFireDamagePerStrengthUnique__1
 ]],[[
@@ -425,7 +425,7 @@ Variant: Current (Mana/ES)
 Requires Level 32, 52 Str, 62 Int
 Implicits: 2
 {variant:1}ElementalDamagePercentImplicitSceptreNew12___[15,15]
-{variant:2,3,4,5,6,7,8,9,10,11}ElementalDamagePercentImplicitSceptreNew12___
+{variant:2,3,4,5,6,7,8,9,10,11}ElementalDamagePercentImplicitSceptreNew8
 {variant:1,2,3,4,5}AllDamageUniqueSceptre8[30,50]
 {variant:6,7,8}AllDamageUniqueSceptre8
 {variant:9,10,11}GlobalSpellGemsLevelUnique__1
@@ -480,11 +480,11 @@ Variant: Current
 Requires Level 75, 113 Str, 113 Int
 Implicits: 2
 {variant:1}ElementalDamagePercentImplicitSceptreNew21__[10,10]
-{variant:2}ElementalDamagePercentImplicitSceptreNew21__
+{variant:2}ElementalDamagePercentImplicitSceptreNew20
 SocketedGemsGetElementalProliferationUniqueSceptre7
 LocalAddedPhysicalDamageUniqueSceptre7
 LocalIncreasedAttackSpeedUniqueSceptre7
-IncreasedCastSpeedUnique__12
+IncreasedCastSpeedUniqueSceptre7
 CriticalSrikeChanceUniqueSceptre7
 ElementalDamageLeechedAsLifePermyriadUniqueSceptre7_
 ElementalDamageUniqueSceptre7
@@ -494,7 +494,7 @@ Grinning Fetish
 Requires Level 35, 62 Str, 62 Int
 Implicits: 1
 ElementalDamagePercentImplicitSceptreNew9
-AllAttributesUnique__18
+AllAttributesUnique__11
 MinionDamageUnique__5
 SkeletonsCoverEnemiesInAshUnique__1
 SkeletonsTakeFireDamagrPerSecondUnique__1
@@ -506,7 +506,7 @@ League: Heist
 Source: Steal from a unique{Curio Display} during a Grand Heist
 Requires Level 35, 62 Str, 62 Int
 Implicits: 1
-ElementalDamagePercentImplicitSceptreNew10
+ElementalDamagePercentImplicitSceptreNew9
 AllAttributesUnique__11
 MinionDamageUnique__5
 ZombiesCoverInAshOnHitUnique__1
@@ -519,7 +519,7 @@ Variant: Pre 3.25.0
 Variant: Current
 Requires Level 56, 96 Str, 96 Int
 Implicits: 1
-ElementalDamagePercentImplicitSceptreNew17
+ElementalDamagePercentImplicitSceptreNew16
 IntelligenceUnique__33
 LocalIncreasedAttackSpeedUnique__46
 MinionMovementSpeedUnique_2
@@ -531,8 +531,8 @@ Variant: Pre 3.25.0
 Variant: Current
 Requires Level 56, 96 Str, 96 Int
 Implicits: 1
-ElementalDamagePercentImplicitSceptreNew17
-IntelligenceUnique__10
+ElementalDamagePercentImplicitSceptreNew16
+IntelligenceUnique__33
 {variant:1}LocalCriticalStrikeChanceUnique__21[25,50]
 {variant:2}LocalCriticalStrikeChanceUnique__21
 GlobalIncreaseMinionSpellSkillGemLevelUnique__1
@@ -548,7 +548,7 @@ Variant: Current
 Requires Level 68, 104 Str, 122 Int
 Implicits: 2
 {variant:1,2}ElementalDamagePercentImplicitSceptre3[15,15]
-{variant:3,4,5}ElementalDamagePercentImplicitSceptre3
+{variant:3,4,5}ElementalDamagePercentImplicitSceptreNew22
 NumberOfZombiesSummonedPercentageUniqueSceptre3
 {variant:1}ZombieLifeUniqueSceptre3[500,500]
 {variant:2,3}ZombieLifeUniqueSceptre3[2000,2000]
@@ -570,19 +570,19 @@ Variant: Current
 Requires Level 41, 59 Str, 85 Int
 Implicits: 2
 {variant:1,2}ElementalDamagePercentImplicitSceptreNew15[20,20]
-{variant:3,4,5}ElementalDamagePercentImplicitSceptreNew15
+{variant:3,4,5}ElementalDamagePercentImplicitSceptreNew11
 {variant:4}LocalIncreaseSocketedFireGemLevelUnique__1_
 {variant:1,2,3}ItemActsAsFireDamageSupportUniqueSceptre2
 {variant:1,2,3}ItemActsAsColdToFireSupportUniqueSceptre2
 {variant:1,2,3,4}ItemActsAsFirePenetrationSupportUniqueSceptre2
 {variant:4}SupportFlatAddedFireDamageUnique__1
 {variant:1,2,3,4}SpellDamageUniqueSceptre2
-{variant:2,3,4,5}LocalIncreasedPhysicalDamageUniqueOneHandMace5
+{variant:2,3,4,5}LocalIncreasedPhysicalDamagePercentUniqueSceptre2
 {variant:5}LocalAddedFireDamageUnique__7
 {variant:1,2,3,4}LifeGainPerTargetUniqueSceptre2
 {variant:1,2,3,4}LightRadiusUnique__11[25,25]
-{variant:5}LightRadiusUnique__11
-{variant:5}BattlemageKeystoneUnique__3
+{variant:5}LightRadiusUniqueSceptre2
+{variant:5}BattlemageKeystoneUnique__4
 ]],[[
 The Sands of Time
 Tyrant's Sekhem
@@ -602,7 +602,7 @@ Tyrant's Sekhem
 League: Legion
 Requires Level 58, 99 Str, 99 Int
 Implicits: 1
-ElementalDamagePercentImplicitSceptreNew16
+ElementalDamagePercentImplicitSceptreNew17
 GrantsLevel30SmiteUnique__1
 StrengthIntelligenceUnique__2
 ElementalAilmentsOnYouInsteadOfAlliesUnique__1
@@ -616,7 +616,7 @@ Variant: Current
 Requires Level 62, 113 Str, 113 Int
 Implicits: 2
 {variant:1}ElementalDamagePercentImplicitSceptreNew11[10,10]
-{variant:2,3,4}ElementalDamagePercentImplicitSceptreNew11
+{variant:2,3,4}ElementalDamagePercentImplicitSceptreNew19
 {variant:1,2}SpellAddedLightningDamageUnique__2[30,40][60,70]
 {variant:3,4}SpellAddedLightningDamageUnique__2
 IncreasedCastSpeedUnique__2
@@ -653,7 +653,7 @@ Variant: Current
 Requires Level 41, 59 Str, 136 Int
 Implicits: 2
 {variant:1,2}ElementalDamagePercentImplicitSceptre2[20,20]
-{variant:3,4}ElementalDamagePercentImplicitSceptre2
+{variant:3,4}ElementalDamagePercentImplicitSceptreNew11
 {variant:4}LocalInflictHallowingFlameOnHitUnique__1
 LocalIncreaseSocketedGemLevelUniqueSceptre1
 IncreasedIntelligenceRequirementsUniqueSceptre1
@@ -683,12 +683,12 @@ Platinum Sceptre
 Source: Obtained from unique{Shipping} in normal{Kingsmarch}
 Requires Level 62, 113 Str, 113 Int
 Implicits: 1
-ElementalDamagePercentImplicitSceptre2
+ElementalDamagePercentImplicitSceptreNew19
 LocalAddedPhysicalDamageUnique__38
 AdditionalTotemsUniqueScepter_1
 Maximum2OfSameTotemUnique__1
 SummonTotemCastSpeedUnique__3
-BattlemageKeystoneUnique__2_
+BattlemageKeystoneUnique__5
 ]],
 -- Weapon: Two Handed Mace
 [[
@@ -935,9 +935,9 @@ Requires Level 61, 212 Str
 Implicits: 1
 StunThresholdReductionImplicitMace3_
 GrantsTawhoasChosenUnique__1
-StrengthUnique__11
+StrengthUnique__28
 LocalIncreasedPhysicalDamagePercentUnique__49
-StunDurationUnique__1
+StunDurationUnique__2
 StunThresholdReductionUnique__2
 ]],[[
 Tidebreaker
@@ -978,7 +978,7 @@ Requires Level 40, 131 Str
 Implicits: 1
 StunDurationImplicitMace1
 IncreasedAccuracyUnique__9____
-LocalAlwaysCrit
+LocalAttacksAlwaysCritUnique__1
 ]],[[
 Voidhome
 Dread Maul

--- a/src/Export/Uniques/quiver.lua
+++ b/src/Export/Uniques/quiver.lua
@@ -9,7 +9,7 @@ LevelReq: 56
 Implicits: 1
 LifeGainPerTargetImplicitQuiver3New
 AddedColdDamageUnique__11
-ColdResistUnique__37
+ColdResistUnique__40
 EnemiesChilledIncreasedDamageTakenUnique__1
 QuiverChillAsThoughtDealingMoreDamageUnique__1
 ]],[[
@@ -24,7 +24,7 @@ Implicits: 2
 {variant:1,2}IncreasedAccuracyPercentImplicitQuiver7
 {variant:3}ProjectileSpeedImplicitQuiver4New
 {variant:2,3}GrantsFrostbiteUnique__1
-IncreasedAttackSpeedUniqueQuiver3
+IncreasedAttackSpeedUniqueQuiver5
 ColdResistUniqueQuiver5
 IncreasedChillDurationUniqueQuiver5
 ConvertPhysicalToColdUniqueQuiver5
@@ -49,7 +49,7 @@ Implicits: 3
 IncreasedAttackSpeedUniqueQuiver1
 {variant:1}IncreasedEvasionRatingUniqueQuiver3_[20,20]
 {variant:2,3,4}IncreasedEvasionRatingUniqueQuiver1
-IncreasedManaUniqueQuiver1
+IncreasedManaUniqueQuiver1a
 {variant:1,2}ConvertPhysicalToFireUniqueQuiver1_[30,50]
 {variant:3,4}ConvertPhysicalToFireUniqueQuiver1_
 {variant:3,4}AddedFireDamageUniqueQuiver1a
@@ -112,7 +112,7 @@ IncreasedAttackSpeedUniqueQuiver3
 IncreasedEvasionRatingUniqueQuiver3_
 IncreasedLifeUniqueQuiver3
 AddedPhysicalDamageUniqueQuiver3
-ArrowPierceAppliesToProjectileDamageUniqueQuiver3
+ArrowDamageAgainstPiercedTargetsUnique__1
 ]],[[
 The Fracturing Spinner
 Blunt Arrow Quiver
@@ -176,7 +176,7 @@ QuiverHasOneSocket
 HasTwoSocketsUnique__1
 TriggerBowSkillsOnBowAttackUnique__1
 IncreasedAttackSpeedUnique__4_
-IncreasedLifeUniqueQuiver9
+IncreasedLifeUnique__95
 AttacksBlindOnHitChanceUnique__1
 ]],[[
 Replica Maloney's Mechanism
@@ -189,7 +189,7 @@ QuiverHasOneSocket
 HasTwoSocketsUnique__1
 TriggerBowSkillsOnCastUnique__1
 IncreasedCastSpeedUnique__21
-IncreasedLifeUniqueQuiver9
+IncreasedLifeUnique__95
 AttacksBlindOnHitChanceUnique__1
 ]],[[
 Maloney's Nightfall
@@ -203,7 +203,7 @@ Implicits: 2
 {variant:1,2}StunDurationImplicitQuiver9
 {variant:3}PhysicalDamageAddedAsChaosImplicitQuiver11New
 {variant:1}IncreasedAttackSpeedImplicitQuiver10New
-{variant:2,3}IncreasedAttackSpeedUniqueQuiver1
+{variant:2,3}IncreasedAttackSpeedUniqueQuiver9
 IncreasedLifeUniqueQuiver9
 ChaosResistUniqueQuiver9
 {variant:1}AddedPhysicalDamageUniqueQuiver9[5,7][8,10]
@@ -224,7 +224,7 @@ Implicits: 2
 BlockPercentUniqueQuiver4
 SpellBlockPercentageUniqueQuiver4
 IncreasedPhysicalDamageReductionRatingUniqueQuiver4
-ProjectileSpeedImplicitQuiver4New
+ProjectileSpeedUniqueQuiver4
 StunRecoveryUniqueQuiver4
 IncreasedProjectileDamageUniqueQuiver4
 ]],[[
@@ -238,10 +238,10 @@ Requires Level 56
 Implicits: 1
 IncreasedAccuracyPercentImplicitQuiver7New
 FireResistUnique__3
-LightningResistImplicitRing1
+LightningResistUnique__2
 LifeGainPerTargetUnique__1
-ProjectileSpeedUniqueQuiver2
-IncreasedProjectileDamageUnique__1
+ProjectileSpeedUnique__3
+IncreasedProjectileDamageUnique___4
 {variant:1}Projectiles Fork
 {variant:2}ProjectilesForkUnique____1
 ]],[[
@@ -254,10 +254,10 @@ Requires Level 45
 Implicits: 2
 {variant:1}CriticalStrikeChanceImplicitQuiver8New
 {variant:2}ProjectileSpeedImplicitQuiver4New
-DexterityImplicitQuiver1
+DexterityUnique__2
 IncreasedCastSpeedUnique__5
-IncreasedLifeUnique__1
-LightningResistUnique__12
+IncreasedLifeUnique__16
+LightningResistUnique__5
 StunAvoidanceUnique___1
 IncreasedLightningDamagePer10IntelligenceUnique__1
 ]],[[
@@ -282,10 +282,10 @@ Skirmish
 Two-Point Arrow Quiver
 Requires Level 36
 Implicits: 1
-IncreasedAccuracyPercentImplicitQuiver7
-IntelligenceUniqueQuiver6
-IncreasedManaUnique__16
-ManaRegenerationImplicitAmulet1
+IncreasedAccuracyPercentImplicitQuiver7New
+IntelligenceUnique__3
+IncreasedManaUnique__7
+ManaRegenerationUnique__4
 ManaLeechPermyriadUnique__1
 Attack skills can have 1 additional Totem Summoned at a time
 ]],[[
@@ -313,7 +313,7 @@ Implicits: 1
 CriticalStrikeChanceImplicitQuiver8New
 DexterityUniqueQuiver7
 AddedChaosDamageUniqueQuiver7
-IncreasedAttackSpeedUniqueQuiver5
+IncreasedAttackSpeedUniqueQuiver7
 IncreasedEnergyShieldUniqueQuiver7
 ReducedEnergyShieldRegenerationRateUniqueQuiver7
 {variant:1}ReducedEnergyShieldDelayUniqueQuiver7[150,150]
@@ -353,7 +353,7 @@ Implicits: 2
 VoidShotOnSkillUseUnique__1_
 AddedColdDamageUnique__7
 IncreasedEnergyShieldUnique__7
-ColdResistUnique__1
+ColdResistUnique__22_
 {variant:1,2,3}ManaGainedFromEnemyDeathUnique__2
 {variant:1,2,3}ProjectileSpeedUnique__2
 {variant:1,4}MaximumVoidArrowsUnique__1
@@ -363,8 +363,8 @@ The Poised Prism
 Primal Arrow Quiver
 Implicits: 1
 WeaponElementalDamageImplicitQuiver13New
-FireResistUnique__24
-ColdResistUnique__19
+FireResistUnique__32
+ColdResistUnique__38
 LightningResistUnique__27
 ColdDamageToAttacksPerDexterityUnique__1
 FireDamageToAttacksPerStrengthUnique__1

--- a/src/Export/Uniques/ring.lua
+++ b/src/Export/Uniques/ring.lua
@@ -302,7 +302,7 @@ Variant: Buff Effect (Current)
 Variant: Max Resistance
 Variant: Fire Resistance
 Implicits: 1
-FireResistUnique__21
+FireResistImplicitRing1
 {fractured}StrengthUnique__16
 GlobalAddedFireDamageUnique__3_
 FireResistUnique__21
@@ -328,7 +328,7 @@ Variant: Buff Effect (Current)
 Variant: Max Resistance
 Variant: Cold Resistance
 Implicits: 1
-ColdResistUnique__28
+ColdResistImplicitRing1
 {fractured}DexterityUnique__14
 GlobalAddedColdDamageUnique__3
 ColdResistUnique__28
@@ -380,7 +380,7 @@ Variant: Buff Effect (Current)
 Variant: Agony Damage
 Variant: Chaos Resistance
 Implicits: 1
-ChaosResistUnique__13
+ChaosResistImplicitRing1
 {fractured}AllAttributesUnique__17_
 GlobalAddedChaosDamageUnique__5_
 ChaosResistUnique__13
@@ -406,7 +406,7 @@ Variant: Buff Effect (Current)
 Variant: Max Resistance
 Variant: Lightning Resistance
 Implicits: 1
-LightningResistUnique__21
+LightningResistImplicitRing1
 {fractured}IntelligenceUnique__14
 GlobalAddedLightningDamageUnique__3
 LightningResistUnique__21
@@ -1618,7 +1618,7 @@ Source: Drops from unique{The Elder} (Uber Uber)
 Requires Level 16
 Implicits: 1
 ColdResistImplicitRing1
-ColdResistImplicitRing1
+ColdResistUnique__37
 AllDamageCanChillUnique__1
 AllDamageTakenCanChillUnique__1
 ChillHitsCauseShatteringUnique__1

--- a/src/Export/Uniques/ring.lua
+++ b/src/Export/Uniques/ring.lua
@@ -21,7 +21,7 @@ Source: Drops from unique{Ahuatotli, the Blind}
 Requires Level 49
 Implicits: 1
 FireResistImplicitRing1
-StrengthUnique__20_
+StrengthUnique__15
 IncreasedEnergyShieldPercentUnique__4
 MaximumLifeUnique__14
 ]],[[
@@ -43,15 +43,15 @@ Implicits: 1
 ItemFoundRarityIncreaseImplicitRing1
 DexterityUniqueRing3
 ItemFoundRarityIncreaseUniqueRing3
-AllResistancesUniqueRing25
+AllResistancesUniqueRing3
 ]],[[
 Astral Projector
 Topaz Ring
 Requires Level 40
 Implicits: 1
 LightningResistImplicitRing1
-IntelligenceUnique__22_
-SpellDamageUniqueRing35
+IntelligenceUnique__19
+SpellDamageUnique__12
 AvoidElementalAilmentsUnique__1_
 NovaSpellsAreaOfEffectUnique__1
 NovaSkillsTargetLocationUnique__1__
@@ -80,7 +80,7 @@ ColdAndLightningResistImplicitRing1
 {variant:2,3}AddedLightningDamageUniqueRing19
 IncreasedLifeUniqueRing19
 {variant:1}LifeLeechPermyriadOnFrozenEnemiesUniqueRing19
-{variant:2,3}LifeLeechPermyriadVsShockedEnemiesUniqueRing29
+{variant:2,3}LifeLeechPermyriadOnFrozenEnemiesUniqueRing19
 {variant:1,2}ManaLeechPermyriadOnShockedEnemiesUniqueRing19
 {variant:3}EnergyShieldLeechPermyriadOnFrozenEnemiesUniqueRing19
 ]],[[
@@ -141,7 +141,7 @@ AddedPhysicalDamageImplicitRing1
 {variant:2}AddedChaosDamageUniqueRing1
 {variant:1}IncreasedLifeImplicitRing1
 {variant:1}LifeRegenerationUniqueRing33[120,240]
-{variant:2}LifeRegenerationUniqueRing33
+{variant:2}LifeRegenerationUniqueRing1
 HitsCauseMonsterFleeUniqueRing1
 ]],[[
 Voidheart
@@ -187,7 +187,7 @@ IncreasedLifeImplicitRing1
 AddedFireDamageUniqueRing28
 AddedColdDamageUnique__6
 IncreasedLifeUniqueRing28
-ColdResistUnique__24
+ColdResistUnique__23
 MovementVelocityWhileIgnitedUnique__1
 EffectOfChillIsReversedUnique__1
 ]],[[
@@ -259,7 +259,7 @@ Selected Alt Variant: 2
 Has Alt Variant Two: true
 Selected Alt Variant Two: 3
 Implicits: 0
-AllAttributesUnique__29
+AllAttributesUnique__27
 AllResistancesUnique__33
 HeraldReservationEfficiencyUnique__1
 {variant:1}HeraldBonusThunderReservationEfficiency
@@ -302,12 +302,12 @@ Variant: Buff Effect (Current)
 Variant: Max Resistance
 Variant: Fire Resistance
 Implicits: 1
-FireResistImplicitRing1
-{fractured}StrengthUniqueRing8
+FireResistUnique__21
+{fractured}StrengthUnique__16
 GlobalAddedFireDamageUnique__3_
-FireResistImplicitRing1
+FireResistUnique__21
 {variant:1}HeraldBonusAshReservation[30,40]
-{variant:2}HeraldBonusAshReservation
+{variant:2}HeraldBonusAshReservationEfficiency__
 {variant:3}HeraldBonusAshFireDamage
 {variant:4}HeraldBonusAshEffect[70,100]
 {variant:5}HeraldBonusAshEffect
@@ -328,12 +328,12 @@ Variant: Buff Effect (Current)
 Variant: Max Resistance
 Variant: Cold Resistance
 Implicits: 1
-ColdResistImplicitRing1
-{fractured}DexterityUnique__12
+ColdResistUnique__28
+{fractured}DexterityUnique__14
 GlobalAddedColdDamageUnique__3
-ColdResistImplicitRing1
+ColdResistUnique__28
 {variant:1}HeraldBonusIceReservation_[30,40]
-{variant:2}HeraldBonusIceReservation_
+{variant:2}HeraldBonusIceReservationEfficiency__
 {variant:3}HeraldBonusIceColdDamage
 {variant:4}HeraldBonusIceEffect_[70,100]
 {variant:5}HeraldBonusIceEffect_
@@ -355,11 +355,11 @@ Variant: Sentinel Damage
 Variant: Damage Reduction
 Implicits: 1
 AddedPhysicalDamageImplicitRing1
-{fractured}AllAttributesUnique__27
+{fractured}AllAttributesUnique__17_
 GlobalAddedPhysicalDamageUnique__2
 IncreasedPhysicalDamageReductionRatingUnique__4
 {variant:1}HeraldBonusPurityReservation_[30,40]
-{variant:2}HeraldBonusPurityReservation_
+{variant:2}HeraldBonusPurityReservationEfficiency_
 {variant:3}HeraldBonusPurityPhysicalDamage
 {variant:4}HeraldBonusPurityEffect[70,100]
 {variant:5}HeraldBonusPurityEffect
@@ -380,12 +380,12 @@ Variant: Buff Effect (Current)
 Variant: Agony Damage
 Variant: Chaos Resistance
 Implicits: 1
-ChaosResistImplicitRing1
-{fractured}AllAttributesUnique__25
+ChaosResistUnique__13
+{fractured}AllAttributesUnique__17_
 GlobalAddedChaosDamageUnique__5_
-ChaosResistImplicitRing1
+ChaosResistUnique__13
 {variant:1}HeraldBonusAgonyReservation[30,40]
-{variant:2}HeraldBonusAgonyReservation
+{variant:2}HeraldBonusAgonyReservationEfficiency
 {variant:3}HeraldBonusAgonyChaosDamage_
 {variant:4}HeraldBonusAgonyEffect[70,100]
 {variant:5}HeraldBonusAgonyEffect
@@ -406,12 +406,12 @@ Variant: Buff Effect (Current)
 Variant: Max Resistance
 Variant: Lightning Resistance
 Implicits: 1
-LightningResistImplicitRing1
+LightningResistUnique__21
 {fractured}IntelligenceUnique__14
 GlobalAddedLightningDamageUnique__3
-LightningResistImplicitRing1
+LightningResistUnique__21
 {variant:1}HeraldBonusThunderReservation[30,40]
-{variant:2}HeraldBonusThunderReservation
+{variant:2}HeraldBonusThunderReservationEfficiency
 {variant:3}HeraldBonusThunderLightningDamage
 {variant:4}HeraldBonusThunderEffect[70,100]
 {variant:5}HeraldBonusThunderEffect
@@ -482,7 +482,7 @@ Implicits: 1
 ColdResistImplicitRing1
 MaximumManaUniqueRing5
 ManaRegenerationUniqueRing5
-{variant:2}ColdResistUnique__17
+{variant:2}ColdResistUnique__16
 {variant:1}CannotBeFrozen
 {variant:2}CannotBeFrozenOrChilledUnique__1
 ]],[[
@@ -534,7 +534,7 @@ Implicits: 1
 RingHasOneSocket
 LocalIncreaseSocketedAuraGemLevelUnique___1
 SocketedAurasReserveNoManaUnique__1
-IncreasedManaReservationsCostUnique__1
+ReservationEfficiencyUnique__1_
 ]],[[
 Fated End
 Paua Ring
@@ -584,10 +584,10 @@ Source: Created from 4 different unique{Grattus} family corpses in the normal{Ne
 Requires Level 64
 Implicits: 1
 CriticalStrikeChanceImplicitRing1
-IncreasedAttackSpeedUniqueRing37
-IncreasedCastSpeedUnique__15_
-IncreasedEnergyShieldUnique__13
-IncreasedLifeUnique__15
+IncreasedAttackSpeedUnique__6
+IncreasedCastSpeedUnique__26
+IncreasedEnergyShieldUnique__12
+IncreasedLifeUnique__123
 AttackCriticalStrikesUnnerveUnique__1
 SpellCriticalStrikesIntimidateUnique__1
 ]],[[
@@ -607,7 +607,7 @@ Moonstone Ring
 Requires Level 20
 Implicits: 1
 IncreasedEnergyShieldImplicitRing1
-LifeRegenerationUniqueRing1
+LifeRegenerationUniqueRing33
 ManaRegenerationUniqueRing33
 MinionLifeUniqueRing33
 MinonAreaOfEffectUniqueRing33
@@ -638,8 +638,8 @@ Moonstone Ring
 LevelReq: 49
 Implicits: 1
 IncreasedEnergyShieldImplicitRing1
-IntelligenceUnique__16
-IncreasedCastSpeedUniqueRing27
+IntelligenceUnique__30
+IncreasedCastSpeedUnique__23
 PowerChargeOnCurseUnique__1
 CurseLimitMaximumPowerChargesUnique__1
 ]],[[
@@ -654,7 +654,7 @@ ItemFoundRarityIncreaseImplicitRing1
 ItemFoundRarityIncreaseUnique__5
 {variant:2}LifeLeechAnyDamageUnique__1
 {variant:1}MovementVelocityUnique__4
-{variant:2}MovementVelocityUnique__33_
+{variant:2}MovementVelocityUnique__44
 {variant:1}StealChargesOnHitPercentUniqueGlovesStrDex6[25,25]
 {variant:1}DamageLeechWith5ChargesUnique__1
 {variant:2}StealChargesOnHitPercentUnique__1
@@ -686,7 +686,7 @@ Requires Level: 49
 League: Blight
 Implicits: 1
 AddedPhysicalDamageImplicitRing1
-DexterityUnique__1
+DexterityUnique__17
 ChanceToPoisonUnique__1_______
 PoisonDamageUnique__1
 ChilledWhilePoisonedUnique__1
@@ -745,7 +745,7 @@ Source: Drops from unique{The Eater of Worlds} (Uber)
 LevelReq: 48
 Implicits: 1
 LightningResistImplicitRing1
-DexterityUnique__3
+DexterityUnique__25
 IncreasedProjectileDamageUnique___11
 ReturningProjectilesUnique__1
 RandomProjectileDirectionUnique__1
@@ -789,7 +789,7 @@ Requires Level 5
 Implicits: 1
 RingHasOneSocket
 {variant:1}AllResistancesUniqueRing3[-25,-25]
-{variant:2}AllResistancesUniqueRing3
+{variant:2}AllResistancesUniqueRing25
 FireResistanceWhenSocketedWithRedGemUniqueRing25
 ColdResistanceWhenSocketedWithGreenGemUniqueRing25
 LightningResistanceWhenSocketedWithBlueGemUniqueRing25
@@ -825,8 +825,8 @@ Requires Level 80
 Implicits: 1
 AddedPhysicalDamageImplicitRing2
 AddedColdDamageUnique__5
-IncreasedEnergyShieldPercentUnique__5
-MaximumLifeUnique__16
+IncreasedEnergyShieldPercentUnique__3
+MaximumLifeUnique__11
 AttackDamageShaperItemUnique__1
 CannotBeStunnedByAttacksElderItemUnique__1
 TentacleSmashOnKillUnique__1_
@@ -975,8 +975,8 @@ Requires Level 80
 Implicits: 1
 ElementalDamagePercentImplicitAtlasRing_
 CriticalStrikeChanceUnique__5__
-FireResistUnique__9
-ColdResistUnique__15
+FireResistUnique__29
+ColdResistUnique__36_
 IncreasedAilmentDurationUnique__3_
 LeftRingCoveredInAshUnique__1_
 RightRingCoveredInFrostUnique__1
@@ -1001,8 +1001,8 @@ LevelReq: 52
 Implicits: 1
 RingHasOneSocket
 IncreaseSocketedCurseGemLevelUnique__2
-ColdResistImplicitRing1
-LightningResistImplicitRing1
+ColdResistUnique__32
+LightningResistUnique__22
 SupportSkitterBotAilmentAuraReplaceWithCurse____1
 ]],[[
 Putembo's Meadow
@@ -1076,7 +1076,7 @@ RingHasOneSocket
 {variant:1}LocalIncreaseSocketedGolemLevelUniqueRing36[2,2]
 {variant:2}LocalIncreaseSocketedGolemLevelUniqueRing36
 StrengthUniqueRing36
-{variant:2}IncreasedLifeUniqueRing19
+{variant:2}IncreasedLifeUnique__48
 {variant:1}AddedFireDamageUniqueRing36
 FireDamagePercentUniqueRing36
 {variant:1}DisplaySocketedGemsSupportedByLesserMultipleProjectilesUniqueRing36
@@ -1093,10 +1093,10 @@ Source: Drops from unique{Rigwald, the Wolven King} (Level 60+)
 Requires Level 49
 Implicits: 1
 FireAndColdResistImplicitRing1
-SummonWolfOnKillUnique__1
+SummonWolfOnKillUnique__1New
 {variant:1}FireDamagePercentUniqueRing36
 {variant:1}ColdDamagePercentUnique___11
-ManaRegenerationUnique__4
+ManaRegenerationUnique__2
 ]],[[
 Romira's Banquet
 Diamond Ring
@@ -1124,11 +1124,11 @@ Variant: Current
 Requires Level 56
 Implicits: 1
 RingHasOneSocket
-SupportedByBlasphemyUnique
+SocketedGemsSupportedByBlasphemyUnique__2__
 CurseAurasAffectYouUnique__1
 {variant:1}ReducedReservationForSocketedCurseGemsUnique__2[-50,-50]
 {variant:2}ReducedReservationForSocketedCurseGemsUnique__2
-IntelligenceUnique__12
+IntelligenceUnique__27
 ReducedCurseEffectUnique__1
 HitAndAilmentDamageCursedEnemiesUnique__1
 ]],[[
@@ -1199,7 +1199,7 @@ Implicits: 1
 ColdResistImplicitRing1
 {variant:1}ColdDamagePercentUnique__9
 {variant:2}SpellDamageUnique__11
-IncreasedCastSpeedUnique__15_
+IncreasedCastSpeedUnique__6
 {variant:1}AdditionalSpellProjectilesUnique__1
 {variant:2}LeftRingSpellProjectilesCannotChainUnique__1
 {variant:2}LeftRingSpellProjectilesForkUnique__1_
@@ -1212,7 +1212,7 @@ Paua Ring
 LevelReq: 44
 Implicits: 1
 IncreasedManaImplicitRing1
-AllAttributesUnique__17_
+AllAttributesUnique__24
 LinkSkillCastSpeedUnique__1
 LinkSkillEffectDurationUnique__1
 LinkTargetCannotDieUnique__1
@@ -1227,7 +1227,7 @@ Requires Level 80
 Implicits: 1
 ElementalDamagePercentImplicitAtlasRing_
 ManaRegenerationUnique__8
-FireAndLightningResistUnique__2
+FireAndLightningResistUnique__1
 {variant:1}BurningDamagePerEnemyShockedRecentlyUnique__1_[4,6][120,120]
 {variant:2,3}BurningDamagePerEnemyShockedRecentlyUnique__1_
 {variant:1,2}AddedLightningDamageAgainstIgnitedEnemiesUnique__1[1,3][62,70]
@@ -1240,7 +1240,7 @@ League: Harvest
 Requires Level 56
 Implicits: 1
 LightningResistImplicitRing1
-Intelligence__1
+IntelligenceUnique__20
 LightningDamagePercentUnique__7
 ChanceToShockUnique__4_
 ActivateHeraldOfThunderOnShockUnique__1
@@ -1297,7 +1297,7 @@ ColdResistImplicitRing1
 AddedColdDamageUnique__10
 IncreasedEvasionRatingUniqueRing30
 ColdDamageCannotFreeze
-ImmuneToChillUnique__2__
+ImmuneToChillUnique__1
 AddedColdDamageAgainstFrozenEnemiesUnique__2
 ]],[[
 Tawhanuku's Timing
@@ -1479,9 +1479,9 @@ Requires Level 38
 Implicits: 1
 IncreasedEnergyShieldImplicitRing1
 {variant:1}IncreasedEnergyShieldUniqueRing18[10,20]
-{variant:2}IncreasedEnergyShieldUniqueRing18
+{variant:2}IncreasedEnergyShieldUnique__5
 {variant:1}FireResistUnique__20_[20,30]
-{variant:2}FireResistUnique__20_
+{variant:2}FireResistUnique__8
 ColdResistUnique__9
 StunDurationBasedOnEnergyShieldUnique__1
 ]],[[
@@ -1491,7 +1491,7 @@ Requires Level: 49
 League: Blight
 Implicits: 1
 AddedPhysicalDamageImplicitRing1
-StrengthUniqueRing8
+StrengthUnique__17
 CausesBleedingUnique__1
 BleedDamageUnique__1_
 ChilledWhileBleedingUnique__1_
@@ -1544,7 +1544,7 @@ RingHasOneSocket
 LocalIncreaseSocketedAuraGemLevelUnique___2___
 {variant:1,2,3,4,5,6,7,8,9,10,11}Socketed Gems have 20% reduced Mana Reservation Efficiency
 {variant:13,14,15,16,17,18,19,20,21}SocketedItemsHaveIncreasedReservationUnique__1
-AllAttributesUnique__16_
+AllAttributesUnique__14
 LifeRegenPerUncorruptedItemUnique__1
 TotalManaCostPerCorruptedItemUnique__1
 {variant:1}FireAndChaosDamageResistanceUnique__1__[8,15]
@@ -1604,7 +1604,7 @@ Ruby Ring
 Requires Level 16
 Implicits: 1
 FireResistImplicitRing1
-StrengthUnique__32
+StrengthUnique__18
 MeleeDamageUnique__1
 AvoidStunUnique__1
 RingAttackSpeedUnique__1
@@ -1638,8 +1638,8 @@ Implicits: 1
 AddedPhysicalDamageImplicitRing2
 DexterityUnique__33
 AllResistancesUnique_1
-ChaosResistUnique__18_
-MovementVelocityUnique__3
+ChaosResistUnique__32
+MovementVelocityUnique__58
 AdditionalPoisonChanceUnique__1
 ]],[[
 Coiling Whisper
@@ -1658,7 +1658,7 @@ Source: Drops from unique{Incarnation of Fear} in normal{Moment of Trauma}
 Requires Level 80
 Implicits: 1
 MaximumLifeImplicitAtlasRing
-StrengthUnique__27
+StrengthUnique__32
 FireDamagePercentUnique__13
 ReducedFireResistanceUnique__2
 FireDamageOnSkillUseUnique__1
@@ -1671,7 +1671,7 @@ Implicits: 1
 AddedPhysicalDamageImplicitRing1
 BlockPercentUnique__3
 StrengthUnique__31
-IncreasedLifeUnique__14
+MaximumLifeUnique__24
 ArmourFromShieldDoubledUnique__1
 GainNoArmourFromBodyArmourUnique__1
 ]],[[
@@ -1693,7 +1693,7 @@ Requires Level 42
 Implicits: 1
 FormlessBreachRingImplicit
 HeraldOfTheBreachUnique_1
-AllResistancesUnique__33
+AllResistancesUnique__37
 ChaosResistUnique__36
 ]],
 [[
@@ -1706,8 +1706,8 @@ ChayulaBreachRingImplicit
 AllAttributesUnique__31
 GlobalAddedChaosDamageUnique__7
 ChaosResistUnique__35
-AuraIncreasedIncreasedAreaOfEffectUnique_3
-ReservationEfficiencyUnique__6
+AuraIncreasedIncreasedAreaOfEffectUnique_6
+ReservationEfficiencyUnique__10
 ChaosDamageModsApplyToChaosAuraEffectAtPercentUnique_1
 ]],
 [[
@@ -1735,11 +1735,11 @@ Source: Drops from unique{It That Was Esh} and unique{It That Was Tul} in normal
 Requires Level 42
 Implicits: 1
 EshBreachRingImplicit
-IntelligenceUniqueRing34
+IntelligenceUnique__37
 GlobalAddedLightningDamageUnique__5
-LightningResistImplicitRing1
-AuraIncreasedIncreasedAreaOfEffectUnique_2
-ReservationEfficiencyUnique__10
+LightningResistUnique__33
+AuraIncreasedIncreasedAreaOfEffectUnique_4
+ReservationEfficiencyUnique__8
 LightningDamageModsApplyToLightningAuraEffectAtPercentUnique_1
 ]],
 [[
@@ -1751,9 +1751,9 @@ Implicits: 1
 TulBreachRingImplicit
 DexterityUnique__34
 GlobalAddedColdDamageUnique__5
-ColdResistImplicitRing1
+ColdResistUnique__43
 AuraIncreasedIncreasedAreaOfEffectUnique_2
-ReservationEfficiencyUnique__10
+ReservationEfficiencyUnique__6
 ColdDamageModsApplyToColdAuraEffectAtPercentUnique_1
 ]],
 [[
@@ -1763,11 +1763,11 @@ Source: Drops from unique{It That Was Esh} and unique{It That Was Tul} in normal
 Requires Level 42
 Implicits: 1
 UulNetolBreachRingImplicit
-StrengthUniqueRing31__
+StrengthUnique__34
 GlobalAddedPhysicalDamageUnique__3
 GlobalPhysicalDamageReductionRatingPercentUnique__2
-AuraIncreasedIncreasedAreaOfEffectUnique_2
-ReservationEfficiencyUnique__10
+AuraIncreasedIncreasedAreaOfEffectUnique_5
+ReservationEfficiencyUnique__9
 PhysicalDamageModsApplyToPhysicalAuraEffectAtPercentUnique_1
 ]],
 [[
@@ -1777,11 +1777,11 @@ Source: Drops from unique{It That Was Esh} and unique{It That Was Tul} in normal
 Requires Level 42
 Implicits: 1
 XophBreachRingImplicit
-StrengthUniqueRing31__
+StrengthUnique__33
 GlobalAddedFireDamageUnique__6
-FireResistImplicitRing1
-AuraIncreasedIncreasedAreaOfEffectUnique_2
-ReservationEfficiencyUnique__10
+FireResistUnique__37
+AuraIncreasedIncreasedAreaOfEffectUnique_3
+ReservationEfficiencyUnique__7
 FireDamageModsApplyToFireAuraEffectAtPercentUnique_1
 ]],
 [[

--- a/src/Export/Uniques/shield.lua
+++ b/src/Export/Uniques/shield.lua
@@ -28,7 +28,7 @@ Variant: Pre 3.0.0
 Variant: Pre 3.21.0
 Variant: Current
 Implicits: 1
-{variant:2,3}IncreasedLifeUnique__28[30,40]
+{variant:2,3}IncreasedLifeImplicitShield3[30,40]
 {variant:1,2}LocalIncreasedPhysicalDamageReductionRatingPercentUnique__4[120,160]
 {variant:3}LocalIncreasedPhysicalDamageReductionRatingPercentUnique__4
 IncreasedLifeUnique__28

--- a/src/Export/Uniques/shield.lua
+++ b/src/Export/Uniques/shield.lua
@@ -11,10 +11,10 @@ Variant: Current
 Implicits: 1
 {variant:2,3}IncreasedLifeImplicitShield1
 LocalIncreasedPhysicalDamageReductionRatingPercentUnique__8
-IncreasedLifeUniqueShieldDex2
+IncreasedLifeUnique__38
 ReducedMaximumEnduranceChargeUnique__1
 MaximumBlockChanceUnique__1
-AdditionalBlockChanceUniqueShieldStrInt4
+AdditionalBlockChanceUnique__4
 {variant:1,2}MaximumResistanceWithNoEnduranceChargesUnique__1__[3,3]
 {variant:3}MaximumResistanceWithNoEnduranceChargesUnique__1__
 OnslaughtWithMaxEnduranceChargesUnique__1
@@ -28,11 +28,11 @@ Variant: Pre 3.0.0
 Variant: Pre 3.21.0
 Variant: Current
 Implicits: 1
-{variant:2,3}IncreasedLifeUniqueShieldDex6[30,40]
+{variant:2,3}IncreasedLifeUnique__28[30,40]
 {variant:1,2}LocalIncreasedPhysicalDamageReductionRatingPercentUnique__4[120,160]
 {variant:3}LocalIncreasedPhysicalDamageReductionRatingPercentUnique__4
-IncreasedLifeUniqueShieldDex6
-AdditionalBlockChanceUniqueShieldStrInt4
+IncreasedLifeUnique__28
+AdditionalBlockChanceUnique__2
 {variant:1,2}GainArmourIfBlockedRecentlyUnique__1[1000,1000]
 {variant:3}GainArmourIfBlockedRecentlyUnique__1
 EnemiesBlockedAreIntimidatedUnique__1
@@ -53,7 +53,7 @@ Implicits: 1
 IncreasedLifeUnique__31
 {variant:1,2}GainLifeOnBlockUnique__1[250,250]
 {variant:3,4}GainLifeOnBlockUnique__1
-AdditionalBlockChanceUniqueShieldStrInt4
+AdditionalBlockChanceUnique__2
 {variant:1,2}GainArmourIfBlockedRecentlyUnique__1[1500,1500]
 ]],[[
 Chernobog's Pillar
@@ -68,7 +68,7 @@ Implicits: 1
 {variant:2}AddedFireDamageUniqueShieldStr3[7,10][15,25]
 {variant:3,4}AddedFireDamageUniqueShieldStr3
 LocalIncreasedPhysicalDamageReductionRatingUniqueShieldStr3
-{variant:3,4}IncreasedLifeUniqueShieldDex2
+{variant:3,4}IncreasedLifeUnique__43
 FireResistUniqueShieldStr3
 ConvertPhysicalToFireUniqueShieldStr3
 {variant:1,2}EnfeebleOnHitUniqueShieldStr3[10,10]
@@ -103,7 +103,7 @@ Implicits: 1
 MovementVelocityUniqueShieldStr1
 {variant:1,2,3,4}RangedAttackDamageReducedUniqueShieldStr1[-25,-25]
 {variant:5}RangedAttackDamageReducedUniqueShieldStr1
-AdditionalBlockChanceUniqueShieldDex1
+AdditionalBlockChanceUniqueShieldStr1
 ]],[[
 Lycosidae
 Rawhide Tower Shield
@@ -112,9 +112,9 @@ Variant: Current
 Implicits: 1
 {variant:2}IncreasedLifeImplicitShield1
 LocalIncreasedPhysicalDamageReductionRatingPercentUnique__2
-IncreasedLifeImplicitShield3
+IncreasedLifeUnique__19
 AlwaysHitsUnique__2
-AdditionalBlockChanceUniqueShieldStrDex3__
+AdditionalBlockChanceUnique__1
 CounterAttacksAddedColdDamageUnique__1
 ]],[[
 Magna Eclipsis
@@ -128,7 +128,7 @@ LocalIncreaseSocketedGemLevelUnique__6
 TriggeredElementalAegisSkillUnique__1_
 {variant:1}LocalIncreasedPhysicalDamageReductionRatingPercentUnique__14_[200,250]
 {variant:2}LocalIncreasedPhysicalDamageReductionRatingPercentUnique__14_
-IncreasedLifeUniqueShieldDex2
+IncreasedLifeUnique__59
 LocalFlatIncreasedEvasionAndEnergyShieldUnique__1
 ]],[[
 Redblade Banner
@@ -141,15 +141,15 @@ Variant: Pre 3.11.0
 Variant: Current
 Implicits: 1
 {variant:3,4}IncreasedLifeImplicitShield2
-{variant:2,3,4}LocalIncreasedPhysicalDamageReductionRatingPercentUnique__12
+{variant:2,3,4}LocalIncreasedPhysicalDamageReductionRatingPercentUnique__9
 {variant:1}LocalIncreaseSocketedWarcryGemLevelUniqueShieldStr4
 {variant:1}IncreasedLifeUniqueShieldStr4[20,60]
 {variant:2,3,4}IncreasedLifeUniqueShieldStr4
 IncreasedTauntDurationUniqueShieldStr4
 {variant:1}LifeGainedOnTauntingEnemyUniqueShieldStr4
 {variant:1}EnduranceChargeDurationUniqueBodyStrInt4[20,20]
-AdditionalBlockChanceUniqueShieldDex1
-{variant:2,3,4}WarcryCooldownSpeedUnique__2
+AdditionalBlockChanceUniqueShieldStr4
+{variant:2,3,4}WarcryCooldownSpeedUnique__1
 {variant:2,3}AttackLeechAgainstTauntedEnemyUnique__1
 {variant:4}WarcryInfiniteEnemyPowerUnique__1__
 ]],[[
@@ -160,9 +160,9 @@ Source: Drops from unique{The Black Knight} in a normal{Starfall Crater}
 Requires Level 51, 123 Str
 Implicits: 1
 IncreasedLifeImplicitShield1
-SpellBlockPercentageUniqueShieldInt1
+SpellBlockPercentageUnique__4
 LocalIncreasedWardUnique__1
-MaximumBlockChanceUnique__1
+MaximumBlockChanceUnique__2
 MaximumSpellBlockChanceUnique__1
 BlockIsLuckyUnique__1
 TriggerSocketedElementalSpellOnBlockUnique__1
@@ -204,11 +204,11 @@ Variant: Current
 Implicits: 1
 {variant:2,3}IncreasedLifeImplicitShield2
 TotemDamageUnique__1_
-IncreasedLifeUnique__82
+IncreasedLifeUnique__29
 AdditionalTotemsUnique__1
 {variant:1,2}ArmourPerTotemUnique__1[300,300]
 {variant:3}ArmourPerTotemUnique__1
-KeystoneBloodMagicUnique__1_
+BloodMagic
 ]],[[
 Replica Tukohama's Fortress
 Ebony Tower Shield
@@ -218,7 +218,7 @@ Variant: Pre 3.29.0
 Variant: Current
 Implicits: 1
 IncreasedLifeImplicitShield2
-IncreasedLifeUnique__90
+IncreasedLifeUnique__29
 AdditionalBrandUnique__1
 {variant:1}CriticalStrikeChancePerBrandUnique__1___[20,20]
 {variant:2}CriticalStrikeChancePerBrandUnique__1___
@@ -309,7 +309,7 @@ LifeRegenerationUniqueShieldDex2
 LightningResistUniqueShieldDex2
 LifeLeechPermyriadUniqueShieldDex2
 {variant:1}AdditionalBlockChanceUniqueShieldStr4[10,10]
-{variant:2,3}AdditionalBlockChanceUniqueShieldStr4
+{variant:2,3}AdditionalBlockChanceUniqueShieldDex2
 ]],[[
 Great Old One's Ward
 Corrugated Buckler
@@ -331,12 +331,12 @@ Variant: Current
 Implicits: 1
 {variant:4}MovementVelocityImplicitShield2
 LocalIncreasedEvasionRatingPercentUniqueShieldDex1
-IncreasedMaximumColdResistUniqueShieldStrInt4
+MaximumColdResistUniqueShieldDex1
 ColdResistUniqueShieldDex1
 {variant:3,4}PhysicalAddedAsColdUnique__2
 {variant:1}MeleeAttackerTakesColdDamageUniqueShieldDex1[5,10]
 {variant:2,3,4}MeleeAttackerTakesColdDamageUniqueShieldDex1
-AdditionalBlockChanceUniqueShieldStr1
+AdditionalBlockChanceUniqueShieldDex1
 ]],[[
 Kaltensoul
 Painted Buckler
@@ -359,7 +359,7 @@ Ironwood Buckler
 Requires Level 57, 137 Dex
 Implicits: 1
 MovementVelocityImplicitShield1
-LocalIncreasedEvasionRatingPercentUnique__20
+LocalIncreasedEvasionRatingPercentUnique__21
 AvoidElementalAilmentsUnique__3
 AdditionalBlockChanceUnique__10
 TreatResistancesAsMaxChanceUnique__1
@@ -370,7 +370,7 @@ Lacquered Buckler
 Implicits: 1
 MovementVelocityImplicitShield2
 LocalIncreasedEvasionRatingPercentUnique__17
-MovementVelocityUnique__37
+MovementVelocityUnique__42
 FireAndColdResistUnique__4_
 AvoidElementalDamagePhasingUnique__1
 MaximumBlockChanceIfNotBlockedRecentlyUnique__1
@@ -382,8 +382,8 @@ League: Heist
 Source: Steal from a unique{Curio Display} during a Grand Heist
 Implicits: 1
 MovementVelocityImplicitShield2
-LocalIncreasedEvasionRatingPercentUnique__14
-MovementVelocityUnique__37
+LocalIncreasedEvasionRatingPercentUnique__17
+MovementVelocityUnique__42
 FireAndColdResistUnique__4_
 SpellBlockIfNotBlockedRecentlyUnique__1
 AvoidPhysicalDamageWhilePhasingUnique__1
@@ -401,13 +401,13 @@ Implicits: 1
 {variant:3,4,5}MovementVelocityImplicitShield2
 {variant:1}LocalIncreaseSocketedWarcryGemLevelUniqueShieldDex7
 {variant:1}IncreasedChaosDamageUniqueShieldDex7
-{variant:2,3,4}LocalIncreasedEvasionRatingPercentUnique__5
+{variant:2,3,4}LocalIncreasedEvasionRatingPercentUnique__8
 ColdResistUniqueShieldDex7
-AreaOfEffectUniqueShieldDexInt2
+AreaOfEffectUniqueShieldDex7
 {variant:1}OnslaughtOnKillingTauntedEnemyUniqueShieldDex7
 {variant:2,3,4}OnslaughtOnUsingWarcryUnique__1
 {variant:2,3,4}WarcryEffectUnique__1
-{variant:4}KeystoneCallToArmsUnique__1
+{variant:4}KeystoneCallToArmsUnique__2_
 ]],[[
 Thousand Teeth Temu
 Vaal Buckler
@@ -451,7 +451,7 @@ Upgrade: Upgrades to unique{Apep's Supremacy} via currency{Vial of Awakening}
 Implicits: 1
 SpellDamageImplicitShield1
 {variant:1}GlobalAddedChaosDamageUnique__3[20,22][30,37]
-{variant:2}GlobalAddedChaosDamageUnique__3
+{variant:2}GlobalAddedChaosDamageUnique__2
 LocalIncreasedEnergyShieldUnique__21
 ChanceToBePoisonedUnique__1
 MaximumResistancesWhilePoisonedUnique__1
@@ -548,7 +548,7 @@ Implicits: 2
 {variant:1}LocalIncreaseSocketedWarcryGemLevelUniqueShieldInt5[1,1]
 {variant:2,3,4}LocalIncreaseSocketedWarcryGemLevelUniqueShieldInt5
 {variant:1}IncreasedAttackSpeedUniqueShieldInt5
-{variant:2,3,4}IncreasedCastSpeedUnique__5
+{variant:2,3,4}IncreasedCastSpeedUnique__9
 LocalIncreasedEnergyShieldUniqueShieldInt5
 ManaRegenerationUniqueShieldInt5
 {variant:1}ManaGainedOnHitAgainstTauntedEnemyUniqueShieldInt5
@@ -576,7 +576,7 @@ Source: Drops in Esh Breach or from unique{Esh, Forked Thought}
 Upgrade: Upgrades to unique{Esh's Visage} using currency{Blessing of Esh}
 Implicits: 1
 {variant:2}SpellDamageImplicitShield1
-IntelligenceUniqueShieldInt4
+IntelligenceUnique__4
 {variant:1}LocalIncreasedEnergyShieldPercentUnique__7[80,100]
 {variant:2}LocalIncreasedEnergyShieldPercentUnique__7
 {variant:1}IncreasedLifeUnique__36_
@@ -598,8 +598,8 @@ Implicits: 2
 LocalIncreasedEnergyShieldPercentUnique__9
 {variant:1,2}IncreasedLifeUnique__36_[40,70]
 {variant:3}IncreasedLifeUnique__36_
-LightningResistUnique__10
-ChaosResistUnique__25
+LightningResistUnique__8
+ChaosResistUnique__4
 ChaosDamageDoesNotBypassESNotLowLifeOrManaUnique__1
 ReflectsShockToEnemiesInRadiusUnique__1
 ]],[[
@@ -608,11 +608,11 @@ Chiming Spirit Shield
 Implicits: 1
 SpellDamageImplicitShield2
 UniqueTriggerSocketedWarcriesOnEnduranceChargeExpireOrUse
-IncreasedLifeUniqueShieldDex2
-ChaosResistUnique__10
+IncreasedLifeUnique__85_
+ChaosResistUnique__11
 LoseEnduranceChargesOnMaxEnduranceChargesUnique__1_
 NeverBlockUnique__1
-WarcryCooldownSpeedUnique__1
+WarcryCooldownSpeedUnique__2
 ]],[[
 Kongming's Stratagem
 {variant:1,2,3,4}Ivory Spirit Shield
@@ -628,7 +628,7 @@ Implicits: 3
 {variant:5}SpellDamageImplicitShield1
 {variant:1,2}SocketedTrapSkillsCreateSmokeCloudWhenDetonated__1
 {variant:3,4,5}CreateSmokeCloudWhenTrapTriggeredUnique__1
-IntelligenceUniqueShieldInt4
+Intelligence__1
 {variant:1,2}LocalIncreasedEnergyShieldPercent__1[80,120]
 {variant:3,4,5}LocalIncreasedEnergyShieldPercent__1
 {variant:1,2,3}FireDamageToBlindEnemies__1[30,30]
@@ -736,7 +736,7 @@ Implicits: 0
 {variant:1}SpellBlockPercentageUnique__1[12,18]
 {variant:2,3,4,5}SpellBlockPercentageUnique__1[10,15]
 {variant:1,2}SpellDamageUniqueShieldInt1
-LocalIncreasedEnergyShieldPercent___3
+LocalIncreasedEnergyShieldPercentUniqueShieldInt1
 MaximumLifeShieldInt1
 {variant:1,2}LightningResistUniqueShieldInt1
 {variant:3}SacrificeLifeOnSpellSkillUnique__1[4,4]
@@ -769,7 +769,7 @@ Implicits: 0
 {variant:2,3}SpellBlockPercentageUniqueShieldInt4
 IntelligenceUniqueShieldInt4
 {variant:1,2}ItemFoundQuantityIncreaseUniqueShieldInt4
-AdditionalBlockChanceUniqueShieldDex4
+AdditionalBlockChanceUniqueShieldInt4
 PunishmentOnMeleeBlockUniqueShieldInt4
 TemporalChainsOnProjectileBlockUniqueShieldInt4
 ElementalWeaknessOnSpellBlockUniqueShieldInt4
@@ -783,7 +783,7 @@ Source: Drops from Viridian Wildwood and Ritual monsters
 Requires Level 39, 52 Str, 52 Dex
 Implicits: 1
 BlockRecoveryImplicitShield3
-LocalIncreasedArmourAndEvasionUniqueShieldStrDex4
+LocalIncreasedArmourAndEvasionUnique__26
 AdditionalBlockChanceUnique__11
 ElementalDamageFromBlockedHitsUnique__1
 ElementalDamageTakenAsPhysicalUnique__1
@@ -805,7 +805,7 @@ BlockRecoveryImplicitShield2
 {variant:1}ColdResistUniqueShieldInt3
 {variant:1}LightningResistUniqueShieldInt3
 {variant:2,3}AllResistancesUniqueShieldStrInt1[10,20]
-{variant:4}AllResistancesUniqueShieldStrInt1
+{variant:4}AllResistancesUnique__8
 {variant:1,2,3}AdditionalBlockChanceUniqueShieldStrDex1
 {variant:2,3}AttackBlockIfBlockedSpellRecentlyUnique__1_[20,20]
 {variant:4}AttackBlockIfBlockedSpellRecentlyUnique__1_
@@ -835,7 +835,7 @@ Implicits: 1
 BlockRecoveryImplicitShield3
 LocalIncreaseSocketedSupportGemLevelUnique__1
 TriggeredPhysicalAegisSkillUnique__1
-LocalIncreasedArmourAndEvasionRatingUnique__1
+LocalIncreasedArmourAndEvasionUnique__16__
 {variant:1}ChanceToAvoidBleedingUnique__1[30,50]
 {variant:2}BleedingImmunityUnique__1
 AttackAndCastSpeedWithoutPhysicalAegisUnique__1
@@ -848,7 +848,7 @@ Implicits: 1
 BlockRecoveryImplicitShield2
 SpellDamageSuppressedUnique__2
 ChanceToSuppressSpellsUnique__1_
-LocalIncreasedArmourAndEvasionUniqueShieldStrDex1
+LocalIncreasedArmourAndEvasionUnique__20
 AdditionalBlockChanceUnique__8_
 BaseBlockDamageTakenUnique__1___
 ]],[[
@@ -872,7 +872,7 @@ Source: Steal from a unique{Curio Display} during a Grand Heist
 Implicits: 0
 StrUniqueShieldTriggerShieldShatterOnBlock
 LocalIncreasedArmourAndEvasionUnique__15_
-IncreasedLifeUnique__112
+IncreasedLifeUnique__108
 AdditionalBlockChanceUnique__7__
 ]],[[
 The Squire
@@ -892,11 +892,11 @@ Vix Lunaris
 Cardinal Round Shield
 Source: Drops from unique{Selenia, the Endless Night} in normal{The Twilight Temple}
 Implicits: 0
-LocalIncreaseSocketedGemLevelUnique__11_
+LocalIncreaseSocketedGemLevelUnique__6
 TriggeredColdAegisSkillUnique__1
-LocalIncreasedArmourAndEvasionUniqueShieldStrDex1
-IncreasedLifeUniqueShieldDex2
-CannotBeFrozen
+LocalIncreasedArmourAndEvasionUnique__4
+IncreasedLifeUnique__59
+CannotBeFrozenUnique__1
 ]],[[
 Wheel of the Stormsail
 Rotted Round Shield
@@ -983,10 +983,10 @@ Archon Kite Shield
 Source: Drops from unique{Helial, the Day Unending}
 Implicits: 1
 AllResistancesImplicitShield3
-LocalIncreaseSocketedGemLevelUnique__1
+LocalIncreaseSocketedGemLevelUnique__6
 TriggeredFireAegisSkillUnique__1_
-LocalIncreasedArmourAndEnergyShieldUnique__18_
-IncreasedLifeUniqueShieldDex2
+LocalIncreasedArmourAndEnergyShieldUnique__8
+IncreasedLifeUnique__59
 AvoidIgniteUnique__1
 ]],[[
 Prism Guardian
@@ -1010,12 +1010,12 @@ Steel Kite Shield
 League: Ultimatum
 Source: Drops from unique{The Trialmaster}
 Implicits: 0
-KeystoneCorruptedSoulUnique_1
+KeystoneCorruptedSoulUnique__2_
 KeystoneDivineFleshUnique__1_
-KeystoneEternalYouthUnique__1
+KeystoneEternalYouthUnique__2_
 KeystoneEverlastingSacrificeUnique__1
-NoEnergyShieldRegenerationUnique__1
-KeystoneVaalPactUnique__1
+KeystoneSoulTetherUnique__2
+KeystoneVaalPactUnique__2
 ]],[[
 Rise of the Phoenix
 Mosaic Kite Shield
@@ -1027,7 +1027,7 @@ Implicits: 2
 {variant:1}AllResistancesImplicitShield2[16,16]
 {variant:2,3,4}AllResistancesImplicitShield2
 {variant:1,2,3}LocalIncreasedArmourAndEnergyShieldUnique__6[80,100]
-{variant:4}LocalIncreasedArmourAndEnergyShieldUnique__6
+{variant:4}LocalIncreasedArmourAndEnergyShieldUniqueShieldStrInt5
 {variant:3}IncreasedLifeUniqueShieldStrInt6
 {variant:1,2}LifeRegenerationUniqueTwoHandAxe4[360,360]
 {variant:3}LifeRegenerationUniqueShieldStrInt5[900,1200]
@@ -1053,7 +1053,7 @@ Implicits: 2
 {variant:4}SpellBlockPercentageUniqueShieldStrInt1
 SpellDamageUniqueShieldStrInt1
 {variant:1,2,3}AllResistancesUniqueShieldStrInt4
-{variant:4}AllResistancesUniqueShieldDex3
+{variant:4}AllResistancesUniqueShieldStrInt1
 {variant:1}IncreasedMaximumResistsUniqueShieldStrInt1[5,5]
 {variant:2,3,4}IncreasedMaximumResistsUniqueShieldStrInt1
 CannotBlockAttacks
@@ -1068,7 +1068,7 @@ Variant: Current
 Implicits: 2
 {variant:1}AllResistancesImplicitShield1[8,8]
 {variant:2,3,4,5}AllResistancesImplicitShield1
-LocalIncreasedArmourAndEnergyShieldUnique__27
+LocalIncreasedArmourAndEnergyShieldUniqueShieldStrInt3
 {variant:5}LifeRegenerationUnique__3
 {variant:1,2,3,4}ReducedFreezeDurationUniqueShieldStrInt3[50,50]
 {variant:5}ReducedFreezeDurationUniqueShieldStrInt3
@@ -1122,10 +1122,10 @@ Source: Upgraded from unique{The Unshattered Will} via currency{Specularity Scro
 Implicits: 1
 AllResistancesImplicitShield3
 HarbingerSkillOnEquipUnique2__3
-IncreasedLifeUniqueShieldDex2
-AllResistancesUnique__10
+IncreasedLifeUnique__52
+AllResistancesUnique__9
 GainManaOnBlockUnique__1
-AdditionalBlockChanceUniqueShieldDex1
+AdditionalBlockChanceUnique__5
 ChannelledSkillDamageUnique__1
 ]],[[
 Unyielding Flame
@@ -1135,8 +1135,8 @@ Implicits: 1
 AllResistancesImplicitShield3
 CommandmentOfInfernoOnCritUnique__1
 CriticalStrikeChanceUnique__3
-IncreasedLifeUniqueShieldDex2
-FireResistUnique__1
+IncreasedLifeUnique__78
+FireResistUnique__18
 AttackSpeedIfCriticalStrikeDealtRecentlyUnique__1
 CastSpeedIfCriticalStrikeDealtRecentlyUnique__1
 ]],[[
@@ -1146,8 +1146,8 @@ Variant: Pre 2.6.0
 Variant: Current
 Implicits: 1
 AllResistancesImplicitShield2
-IncreasedLifeUniqueShieldDex6
-LightningResistUnique__15
+IncreasedLifeUnique__12_
+LightningResistUnique__4
 ChaosResistUnique__1
 {variant:1}IncreasedAuraRadiusUnique__1[10,10]
 {variant:2}IncreasedAuraRadiusUnique__1
@@ -1160,8 +1160,8 @@ League: Heist
 Source: Steal from a unique{Curio Display} during a Grand Heist
 Implicits: 1
 AllResistancesImplicitShield2
-IncreasedLifeUniqueShieldStrDex7
-LightningResistImplicitRing1
+IncreasedLifeUnique__12_
+LightningResistUnique__4
 ChaosResistUnique__1
 AuraEffectUnique__2____
 GrantsAlliesEnduranceChargeOnHitUnique__1
@@ -1178,8 +1178,8 @@ Source: Steal from a unique{Curio Display} during a Grand Heist
 Implicits: 1
 ChanceToDodgeImplicitShield2
 {variant:1}LocalIncreasedEvasionAndEnergyShieldUnique__25[500,600]
-{variant:2}LocalIncreasedEvasionAndEnergyShieldUnique__25
-ManaRegenerationUnique__12
+{variant:2}LocalIncreasedEvasionAndEnergyShieldUnique__30_
+ManaRegenerationUnique__13
 ChanceToBeShockedUnique__2
 ColdHitAndDoTDamageTakenAsLightningUnique__1
 FireHitAndDoTDamageTakenAsLightningUnique__1
@@ -1207,7 +1207,7 @@ Variant: Pre 3.8.0
 Variant: Current
 Implicits: 2
 {variant:1,2}AttackerTakesDamageShieldImplicit12
-{variant:3,4}ChanceToDodgeImplicitShield2
+{variant:3,4}ChanceToDodgeSpellsImplicitShield2
 {variant:1,2,3}GrantsBearTrapUniqueShieldDexInt1[20,20]
 {variant:4}GrantsBearTrapUniqueShieldDexInt1
 TrapDamageUniqueShieldDexInt1
@@ -1225,7 +1225,7 @@ Implicits: 1
 ChanceToDodgeImplicitShield2
 {variant:1}LocalIncreasedEvasionAndEnergyShieldUnique__9[130,150]
 {variant:2}LocalIncreasedEvasionAndEnergyShieldUnique__9
-IncreasedLifeUniqueShieldDex2
+IncreasedLifeUnique__64
 IncreasedAilmentDurationUnique__1
 AdditionalBlockChanceUnique__6
 SharedSufferingUnique__1
@@ -1241,7 +1241,7 @@ Implicits: 2
 IncreasedAttackSpeedUniqueShieldDexInt2
 MaximumLifeUniqueShieldDexInt2
 AllResistancesUniqueShieldDexInt2
-AreaOfEffectUniqueShieldDex7
+AreaOfEffectUniqueShieldDexInt2
 {variant:1,2}HealAlliesOnDeathUniqueShieldDexInt2[200,200]
 {variant:3}HealAlliesOnDeathUniqueShieldDexInt2
 ]],[[
@@ -1277,7 +1277,7 @@ Implicits: 1
 ChanceToDodgeImplicitShield2
 SpellDamageUnique__7
 LocalIncreasedEnergyShieldUnique__23
-IncreasedLifeUniqueShieldDex6
+IncreasedLifeUnique__83
 AreaOfEffectPerEnemyKilledRecentlyUnique__1
 ZealotsOathIfHaventBeenHitRecentlyUnique__1
 ]],[[

--- a/src/Export/Uniques/staff.lua
+++ b/src/Export/Uniques/staff.lua
@@ -100,7 +100,7 @@ Implicits: 2
 UniqueStaffGrantQueensDemand___
 UniqueStaffTriggerAtziriStormFlameblast__1
 UniqueStaffTriggerAtziriStormCall__1____
-CannotBeStunned
+CannotBeStunnedUnique__1_
 DamageCannotBeReflectedUnique__1
 {variant:3}SpellCriticalStrikeChanceUnique__6
 ]],[[
@@ -118,9 +118,9 @@ LocalIncreasedPhysicalDamagePercentUnique__45
 {variant:1,2}CriticalMultiplierUnique__6[100,100]
 {variant:3}CriticalMultiplierUnique__6
 DamageConversionToRandomElementUnique__1
-PhysicalDamageConvertedToChaosUnique__1
+PhysicalDamageConvertToChaosUnique__1
 MaximumCritChanceIs50Unique__1
-NonCriticalStrikesDealNoDamageUnique__1
+NonCriticalStrikesDealNoDamageUnique__2
 ]],[[
 The Blood Thorn
 Gnarled Branch
@@ -132,7 +132,7 @@ Implicits: 3
 {variant:2}StaffBlockPercentImplicitStaff1[18,18]
 {variant:3}StaffSpellBlockPercentImplicitStaff__1
 StaffBlockPercentUniqueStaff9
-LocalIncreasedPhysicalDamagePercentUniqueDescentStaff1
+LocalIncreasedPhysicalDamagePercentUniqueStaff9
 LocalIncreasedAttackSpeedUniqueStaff9
 ReflectDamageToAttackersOnBlockUniqueStaff9
 VulnerabilityOnBlockUniqueStaff9
@@ -180,7 +180,7 @@ Implicits: 3
 {variant:2,3,4,5}ChaosNonAilmentDamageOverTimeMultiplierUnique__1
 {variant:1}IncreasedChaosDamageUnique__4_2[60,80]
 {variant:2,3,4}IncreasedChaosDamageUnique__4_2
-{variant:5}IncreasedMaximumPowerChargesUniqueStaff7
+{variant:5}IncreasedMaximumPowerChargesUnique__5
 {variant:1,2,3,4}IncreasedCastSpeedPerPowerChargeUnique__1[2,2]
 {variant:5}IncreasedCastSpeedPerPowerChargeUnique__1
 LocalIncreaseSocketedChaosGemLevelUnique__1
@@ -243,7 +243,7 @@ Implicits: 3
 {variant:1,2}StaffBlockPercentUnique__2_[4,4]
 {variant:3,4}StaffBlockPercentUnique__2_[10,10]
 {variant:5}StaffBlockPercentUnique__2_
-SpellCriticalStrikeChanceUnique__2
+SpellCriticalStrikeChanceUnique__3
 ElementalDamagePercentAddedAsChaosUnique__2
 CriticalMultiplierPerBlockChanceUnique__1
 CritMultiIfDealtNonCritRecentlyUnique__2
@@ -262,7 +262,7 @@ StaffBlockPercentImplicitStaff3
 {variant:1}StaffBlockPercentUnique__2_[10,10]
 {variant:2}StaffBlockPercentUnique__2_
 LocalCriticalStrikeChanceUnique__19
-ElementalDamagePercentAddedAsChaosUnique__1
+ElementalDamagePercentAddedAsChaosUnique__2
 CriticalMultiplierPerBlockChanceUnique__1
 CritMultiIfDealtNonCritRecentlyUnique__2
 ElementalDamageIfCritRecently
@@ -325,7 +325,7 @@ StaffBlockPercentUnique__4_
 {variant:3}CriticalBleedDotMultiplierUnique__1_
 {variant:1,2}LocalAddedPhysicalDamageUnique__28[160,185][200,225]
 {variant:3}LocalAddedPhysicalDamageUnique__28
-LocalCriticalStrikeChanceUnique__3
+LocalCriticalStrikeChanceUnique__10
 ]],[[
 Femurs of the Saints
 Primordial Staff
@@ -338,8 +338,8 @@ Implicits: 3
 {variant:4}StaffSpellBlockPercent3
 {variant:1}StaffBlockPercentImplicitStaff1[12,12]
 {variant:2,3}StaffBlockPercentImplicitStaff1[18,18]
-LocalIncreaseSocketedMinionGemLevelUnique__2_
-{variant:3,4}MinionDamageUnique__3_
+LocalIncreaseSocketedMinionGemLevelUnique__1
+{variant:3,4}MinionDamageUnique__7
 {variant:1,2}MinionLifeRegenerationPerRagingSpirit__1
 {variant:1,2}MinionAttackAndCastSpeedPerSkeleton__1
 {variant:1,2}MinionDurationPerZombie__1
@@ -386,7 +386,7 @@ Requires Level 58, 99 Str, 99 Int
 Implicits: 2
 {variant:2}StaffSpellBlockPercent3
 {variant:1}StaffBlockPercentImplicitStaff1[18,18]
-SocketedGemsGetBloodMagicUnique__1
+SocketedGemsSupportedByLifetapUnique__1
 IncreasedCastSpeedUnique__25
 LifeDegenerationGracePeriodUnique__1
 SpellAddedChaosDamageMaximumLifeUnique__1
@@ -437,11 +437,11 @@ Implicits: 3
 {variant:2}StaffSpellBlockPercentImplicitStaff__1
 {variant:1}StaffBlockPercentImplicitStaff3[18,18]
 {variant:3,4}StaffBlockPercentImplicitStaff3
-{variant:4}LocalDoubleImplicitMods
+{variant:4}LocalDoubleImplicitModsUnique__2
 HasNoSockets
 {variant:1,2,3}AllDamageUnique__3[250,300]
 {variant:4}AllDamageUnique__3
-LocalIncreasedAttackSpeedUnique__44
+LocalIncreasedAttackSpeedUnique__30
 {variant:1,2,3}IncreasedMaximumResistsUnique__1[1,4]
 {variant:4}IncreasedMaximumResistsUnique__1
 ]],[[
@@ -501,7 +501,7 @@ IncreasedCastSpeedUniqueStaff_1
 GlobalSpellGemsLevelUniqueStaff_1
 RemembranceGainedPerEnergyShieldUnique_1
 MaximumRemembranceUnique_1
-KeystoneEldritchBatteryUnique__2
+KeystoneEldritchBatteryUnique__3
 ]],[[
 Martyr of Innocence
 Highborn Staff
@@ -522,7 +522,7 @@ Implicits: 2
 {variant:3,4,5}LocalAddedFireDamageUnique__3
 FirePenetrationIfBlockedRecentlyUnique__1
 ImmuneToFreezeAndChillWhileIgnitedUnique__1
-BattlemageKeystoneUnique__4
+BattlemageKeystoneUnique__1
 ]],[[
 Pillar of the Caged God
 Iron Staff
@@ -620,7 +620,7 @@ Implicits: 3
 {variant:4,5,6,7}FireDamagePercentUniqueStaff1_
 {variant:1,2,3,4,5,6}IncreasedCastSpeedUniqueStaff1[10,10]
 {variant:7}IncreasedCastSpeedUniqueStaff1
-{variant:7}KeystoneFirePuristUnique__1
+{variant:7}KeystoneFirePuristUnique__2
 LocalIncreaseSocketedFireGemLevelUniqueStaff1
 {variant:1,2,3,4}BurnDamageUniqueStaff1
 ]],[[
@@ -721,7 +721,7 @@ IncreasedCastSpeedUniqueStaff2
 {variant:5}LocalIncreaseSocketedColdGemLevelUniqueStaff2
 {variant:1,2,3,4}ChanceToFreezeUniqueStaff2[8,8]
 {variant:5}ChanceToFreezeUniqueStaff2
-FrozenMonstersTakeIncreasedDamageUnique__1
+FrozenMonstersTakeIncreasedDamage
 ]],[[
 Tremor Rod
 Military Staff
@@ -798,7 +798,7 @@ Implicits: 2
 {variant:1}StaffBlockPercentUnique__1[18,18]
 {variant:2,3}StaffBlockPercentUnique__1[20,20]
 StaffBlockPercentUnique__1
-SpellDamageUnique__18
+SpellDamageUnique__2
 {variant:1,2}IncreasedEnergyShieldUnique__3[70,100]
 {variant:3}IncreasedEnergyShieldUnique__3
 LocalIncreaseSocketedGemLevelUnique___3

--- a/src/Export/Uniques/sword.lua
+++ b/src/Export/Uniques/sword.lua
@@ -11,7 +11,7 @@ StrengthRequirementsUnique__1
 LocalAddedPhysicalDamageUnique__27
 LocalCriticalStrikeChanceUnique__12
 ReducedMaximumFrenzyChargesUnique__1
-AreaOfEffectUnique__3
+AreaOfEffectUnique__5
 GlobalCriticalMultiplierWithNoFrenzyChargesUnique__1
 AccuracyRatingWithMaxFrenzyChargesUnique__1
 ]],[[
@@ -62,7 +62,7 @@ Source: Steal from a unique{Curio Display} during a Grand Heist
 Implicits: 1
 IncreasedAccuracySwordImplicit9
 LocalAddedPhyiscalDamageUnique__41_
-IncreasedAttackSpeedUnique__2
+LocalIncreasedAttackSpeedUnique__36
 IncreasedPhysicalDamageReductionRatingUnique__5
 ReducedMovementVelocityUnique__3
 IncreasedAccuracyUniqueOneHandSword9
@@ -151,10 +151,10 @@ Implicits: 1
 IncreasedAccuracySwordImplicit9
 {variant:1}LocalIncreasedPhysicalDamagePercentUnique__30[170,190]
 {variant:2}LocalIncreasedPhysicalDamagePercentUnique__30
-LocalIncreasedAttackSpeedUniqueSceptre9
+LocalIncreasedAttackSpeedUnique__25
 IncreasedArmourWhileStationaryUnique__1
 NumberOfProjectilesIfHitRecentlyUnique__1
-KeystonePointBlankUnique__1
+KeystonePointBlankUnique__2
 GainIronReflexesWhileStationaryUnique__1
 ]],[[
 Hyaon's Fury
@@ -191,7 +191,7 @@ LocalAddedPhysicalDamageUniqueOneHandSword11
 {variant:1}LocalIncreasedAttackSpeedUniqueOneHandSword11[10,15]
 {variant:2}LocalIncreasedAttackSpeedUniqueOneHandSword11
 IncreasedBuffEffectivenessUniqueOneHandSword11
-IncreasedManaReservationsCostUniqueOneHandSword11
+ManaReservationEfficiencyUniqueOneHandSword11
 CannotBeBuffedByAlliedAurasUniqueOneHandSword11
 AurasCannotBuffAlliesUniqueOneHandSword11
 ]],[[
@@ -205,7 +205,7 @@ Implicits: 2
 LocalIncreasedPhysicalDamagePercentUnique__13
 LocalIncreasedAttackSpeedUnique__14
 ChaosDamageLifeLeechPermyriadUnique__1
-PhysicalDamageConvertToChaosUnique__1
+PhysicalDamageConvertedToChaosUnique__1
 LocalMaimOnHitUnique__1
 ]],[[
 Replica Innsbury Edge
@@ -216,7 +216,7 @@ League: Heist
 Source: Steal from a unique{Curio Display} during a Grand Heist
 Implicits: 1
 IncreasedAccuracySwordImplicit5
-LocalIncreasedPhysicalDamagePercentUnique__48
+LocalIncreasedPhysicalDamagePercentUnique__13
 ChaosDamageLifeLeechPermyriadUnique__1
 PhysicalDamageConvertedToChaosUnique__2
 {variant:1}PhysicalDamageTakenAsChaosUnique__1
@@ -256,10 +256,10 @@ Ezomyte Blade
 League: Settlers of Kalguur
 Requires Level 61, 113 Str, 113 Dex
 Implicits: 1
-CriticalMultiplierImplicitSword1
-LocalIncreasedPhysicalDamagePercentUnique__4
+CriticalMultiplierImplicitSword2H1
+LocalIncreasedPhysicalDamagePercentUnique__48
 LocalIncreasedAttackSpeedUnique__40
-CannotBePoisonedUnique__1
+CannotBePoisonedUnique__2
 AdditionalTinctureUnique__1
 TinctureRemoveToxicityOnKillUnique__1
 ]],[[
@@ -367,7 +367,7 @@ Implicits: 2
 {variant:2}AccuracyPercentImplicitSword1
 IncreasedPhysicalDamagePercentOnLowLifeUniqueOneHandSword1
 LocalIncreasedPhysicalDamagePercentUniqueOneHandSword1
-LocalAddedPhysicalDamageUniqueDescentOneHandSword1
+LocalAddedPhysicalDamageUniqueOneHandSword1
 LocalIncreasedAttackSpeedUniqueOneHandSword1
 IncreasedLifeUniqueOneHandSword1
 LifeGainPerTargetUniqueOneHandSword1
@@ -446,10 +446,10 @@ AccuracyPercentImplicitSword1
 HarbingerSkillOnEquipUnique2_1
 LocalGrantsStormCascadeOnAttackUnique__1
 SpellDamageUnique__5
-LocalIncreasedPhysicalDamagePercentUnique__5
+LocalIncreasedPhysicalDamagePercentUnique__27
 LocalAddedLightningDamageUnique__5
 SpellAddedLightningDamageUnique__4
-AreaOfEffectUnique__1
+AreaOfEffectUnique__3
 ]],[[
 The Saviour
 Legion Sword
@@ -462,7 +462,7 @@ SummonDoubleOnCritUnique__1
 {variant:1}LocalIncreasedPhysicalDamagePercentUnique__37__[40,50]
 {variant:2}LocalIncreasedPhysicalDamagePercentUnique__37__
 LocalAddedPhyiscalDamageUnique__40__
-IncreasedAttackSpeedUnique__5
+LocalIncreasedAttackSpeedUnique__31
 LocalCriticalStrikeChanceUnique__16
 ]],[[
 Scaeva
@@ -542,7 +542,7 @@ Implicits: 2
 {variant:4}MinionDamageUnique__7
 MinionChaosResistanceUnique__2__
 {variant:1,2}MinionsPoisonEnemiesOnHitUnique__1[100,100]
-{variant:3,4,5}MinionsPoisonEnemiesOnHitUnique__1
+{variant:3,4,5}MinionsPoisonEnemiesOnHitUnique__2
 {variant:1,2,3,4}MinionLeechOnPoisonedEnemiesUnique__1
 {variant:5}MinionsRecoverLifeOnKillingPoisonedEnemyUnique__1_
 ]],[[
@@ -558,8 +558,8 @@ Implicits: 2
 {variant:1}IncreasedAccuracySwordImplicit7[240,240]
 {variant:2}IncreasedAccuracySwordImplicit7
 {variant:1}LocalIncreasedPhysicalDamagePercentUnique__35[110,120]
-{variant:2}LocalIncreasedPhysicalDamagePercentUnique__35
-LocalIncreasedAttackSpeedUniqueOneHandSword13_
+{variant:2}LocalIncreasedPhysicalDamagePercentUnique__34___
+LocalIncreasedAttackSpeedUnique__29
 {variant:1}LifeGainedFromEnemyDeathUnique__2
 LocalDamageConversionToRandomElementUnique__1
 LocalAlwaysInflictElementalAilmentsUnique__1
@@ -574,11 +574,11 @@ Source: Upgraded from unique{Story of the Vaal} via currency{Vial of Fate}
 Variant: Pre 3.10.0
 Variant: Current
 Implicits: 1
-IncreasedAccuracy2hSwordImplicit7
+IncreasedAccuracySwordImplicit7
 {variant:1}LocalIncreasedPhysicalDamagePercentUnique__34___[160,180]
-{variant:2}LocalIncreasedPhysicalDamagePercentUnique__34___
-LocalIncreasedAttackSpeedUniqueOneHandSword13_
-LocalDamageConversionToRandomElementImplicitE1
+{variant:2}LocalIncreasedPhysicalDamagePercentUnique__35
+LocalIncreasedAttackSpeedUnique__29
+LocalDamageConversionToRandomElementUnique__2_
 LocalAlwaysInflictElementalAilmentsUnique__1
 LocalElementalDamageAgainstIgnitedEnemiesUnique__1_
 LocalElementalDamageAgainstFrozenEnemiesUnique__1
@@ -592,8 +592,8 @@ Implicits: 2
 {variant:1}AccuracyPercentImplicitSword1[18,18]
 {variant:2}AccuracyPercentImplicitSword1
 LocalAddedPhysicalDamageUnique__10
-LocalIncreasedAttackSpeedUnique__11
-AlwaysHits
+LocalIncreasedAttackSpeedUnique__12
+AlwaysHitsUnique__1
 LocalElementalPenetrationUnique__1
 AttackPhysicalDamageAddedAsFireUnique__1
 AttackPhysicalDamageAddedAsLightningUnique__1
@@ -605,7 +605,7 @@ Source: Steal from a unique{Curio Display} during a Grand Heist
 Implicits: 1
 AccuracyPercentImplicitSword1
 LocalAddedPhysicalDamageUnique__10
-LocalIncreasedAttackSpeedUnique__11
+LocalIncreasedAttackSpeedUnique__12
 AccuracyPercentUnique__1
 OneHandedMeleeCriticalStrikeMultiplierUnique__1
 LocalElementalPenetrationUnique__1
@@ -638,7 +638,7 @@ Implicits: 3
 {variant:1}CriticalMultiplierImplicitSword1[20,20]
 {variant:2}CriticalMultiplierImplicitSword1[30,30]
 {variant:3}CriticalMultiplierImplicitSword1
-LocalIncreasedPhysicalDamagePercentUniqueTwoHandSword1
+LocalIncreasedPhysicalDamagePercentUniqueRapier2
 ItemFoundRarityIncreaseUniqueRapier2
 AllResistancesUniqueRapier2
 LifeGainPerTargetUniqueRapier2
@@ -669,7 +669,7 @@ Implicits: 2
 {variant:2}CriticalMultiplierImplicitSword1
 CastSocketedColdSkillsOnCriticalStrikeUnique__1
 AddedIntelligenceRequirementsUnique__1
-LocalReducedPhysicalDamagePercentUniqueOneHandSword7
+LocalReducedPhysicalDamagePercentUnique__2
 LocalAddedColdDamageUnique__5
 SpellAddedColdDamageUnique__4
 LocalIncreasedAttackSpeedUnique__18
@@ -713,7 +713,7 @@ Implicits: 3
 LocalReducedPhysicalDamagePercentUniqueOneHandSword7
 LocalAddedLightningDamageUniqueOneHandSword7
 LocalIncreasedAttackSpeedUniqueOneHandSword7
-LifeGainPerTargetUniqueOneHandSword1
+LifeGainPerTargetUniqueOneHandSword7
 {variant:1,2}ChanceToShockUniqueDescentTwoHandSword1[5,5]
 {variant:3}ChanceToShockUniqueOneHandSword7
 {variant:3}HeraldOfThunderBuffEffectUnique__1
@@ -724,7 +724,7 @@ League: Affliction
 Requires Level 50, 78 Str, 94 Dex
 Implicits: 1
 IncreasedAccuracySwordImplicit6
-LocalCriticalStrikeChanceUnique__20
+LocalCriticalStrikeChanceUnique__22
 LifeLeechLocalPermyriadUnique__1
 ManaLeechPermyriadLocalUnique__1
 CriticalStrikeMultiplierMonsterPowerUnique__1
@@ -741,13 +741,13 @@ Implicits: 3
 {variant:3}CriticalMultiplierImplicitSword1
 LocalIncreaseSocketedMeleeGemLevelUniqueRapier1
 DisableOffhandSlot
-LocalIncreasedPhysicalDamagePercentUniqueOneHandSword4
+LocalIncreasedPhysicalDamagePercentUniqueRapier1
 LocalAddedFireDamageUniqueRapier1
-LocalIncreasedAttackSpeedUniqueTwoHandSword1
-CriticalStrikeChanceUnique__1
+LocalIncreasedAttackSpeedUniqueRapier1
+CriticalStrikeChanceUniqueRapier1
 IncreasedEvasionRatingUniqueRapier1
 ItemFoundRarityDecreaseUniqueRapier1
-MovementVelocityOnLowLifeUniqueBootsDex3
+MovementVelocityOnLowLifeUniqueRapier1
 ]],
 -- Weapon: Two Handed Sword
 [[
@@ -762,8 +762,8 @@ Implicits: 3
 {variant:2}AccuracyPercentImplicit2HSword1[40,40]
 {variant:3,4}AccuracyPercentImplicit2HSword1
 {variant:1,2}LocalIncreasedPhysicalDamagePercentUnique__55[160,190]
-{variant:3,4}LocalIncreasedPhysicalDamagePercentUnique__55
-LocalIncreasedAttackSpeedUniqueOneHandSword7
+{variant:3,4}LocalIncreasedPhysicalDamagePercentUnique__7
+LocalIncreasedAttackSpeedUnique__5
 MovementVelocityUnique__4
 DisplayManifestWeaponUnique__1
 SimulatedRampageUnique__1
@@ -844,7 +844,7 @@ Implicits: 1
 StrengthDexterityImplicitSword_1
 IntelligenceRequirementsUnique_1
 LocalIncreasedPhysicalDamagePercentUnique__53
-IncreasedAttackSpeedUniqueGlovesDemigods1
+LocalIncreasedAttackSpeedUnique__43
 LocalCriticalStrikeChanceUnique__24
 LocalNoCriticalStrikeMultiplierUnique_1
 GainShrineOnRareOrUniqueKillUnique_1
@@ -859,7 +859,7 @@ Implicits: 3
 {variant:1}AccuracyPercentImplicit2HSword1[18,18]
 {variant:2}AccuracyPercentImplicit2HSword1[40,40]
 {variant:3}AccuracyPercentImplicit2HSword1
-SocketedGemsSupportedByLifetapUnique__1
+SocketedGemsGetBloodMagicUnique__1
 LocalAddedPhysicalDamageUnique__15
 LocalCriticalStrikeChanceUnique__4
 ReflectPhysicalDamageToSelfOnHitUnique__1
@@ -873,7 +873,7 @@ Variant: Current
 Implicits: 3
 {variant:1}AccuracyPercentImplicit2HSword1[18,18]
 {variant:2}IncreasedAccuracy2hSwordImplicit8
-{variant:3}CriticalMultiplierImplicitSword1
+{variant:3}CriticalMultiplierImplicitSword2H1
 {variant:1,2}LocalIncreasedPhysicalDamagePercentUnique__18[270,320]
 {variant:3}LocalIncreasedPhysicalDamagePercentUnique__18
 LifeLeechPermyriadUnique__4
@@ -909,9 +909,9 @@ League: Heist
 Source: Steal from a unique{Curio Display} during a Grand Heist
 Implicits: 1
 WeaponElementalDamageImplicitSword1
-LocalReducedPhysicalDamagePercentUniqueOneHandSword7
+LocalReducedPhysicalDamagePercentUniqueTwoHandSword6
 LocalAddedColdDamageUnique__9_
-LocalIncreasedAttackSpeedUniqueOneHandSword13_
+LocalIncreasedAttackSpeedUniqueTwoHandSword6
 {variant:1}LifeLeechPermyriadOnFrozenEnemiesUnique__1
 ChanceToFreezeUnique__5
 IncreasedPhysicalDamageTakenUniqueTwoHandSword6
@@ -979,8 +979,8 @@ Implicits: 2
 {variant:3,4,5}IncreasedAccuracy2hSwordImplicit5
 LocalIncreasedPhysicalDamagePercentUniqueTwoHandSword1
 {variant:1}LocalIncreasedAttackSpeedUniqueTwoHandSword3[10,10]
-{variant:2,3,4,5}LocalIncreasedAttackSpeedUniqueTwoHandSword3
-MovementVelocityUniqueTwoHandSword3
+{variant:2,3,4,5}LocalIncreasedAttackSpeedUniqueTwoHandSword1
+MovementVelocityUniqueTwoHandSword1
 {variant:1,2,3}IncreasedAccuracyUniqueTwoHandSword1[150,200]
 {variant:4,5}IncreasedAccuracyUniqueTwoHandSword1
 {variant:5}MovementSpeedIfKilledRecentlyUnique___2
@@ -1013,11 +1013,11 @@ Implicits: 2
 {variant:1}LocalIncreasedPhysicalDamagePercentUnique__19[400,500]
 {variant:2}LocalIncreasedPhysicalDamagePercentUnique__19[200,300]
 {variant:3}LocalIncreasedPhysicalDamagePercentUnique__19
-LocalIncreasedAttackSpeedUnique__27
-IncreasedLifeUnique__51
+LocalIncreasedAttackSpeedUnique__19
+IncreasedLifeUnique__24
 PhysicalDamageCanShockUnique__1
-IncreasedAttackAreaOfEffectUnique__2_
-DealNoElementalDamageUnique__2
+IncreasedAttackAreaOfEffectUnique__1_
+DealNoElementalDamageUnique__1
 ]],[[
 Terminus Est
 Tiger Sword
@@ -1030,10 +1030,10 @@ Implicits: 2
 {variant:1}LocalIncreasedPhysicalDamagePercentUniqueTwoHandSword3[120,180]
 {variant:2}LocalIncreasedPhysicalDamagePercentUniqueTwoHandSword3[220,260]
 {variant:3}LocalIncreasedPhysicalDamagePercentUniqueTwoHandSword3
-LocalIncreasedAttackSpeedUniqueTwoHandSword1
+LocalIncreasedAttackSpeedUniqueTwoHandSword3
 {variant:2,3}LocalCriticalStrikeChanceUnique__8
 ManaGainedFromEnemyDeathUniqueTwoHandSword3
-MovementVelocityUniqueTwoHandSword1
+MovementVelocityUniqueTwoHandSword3
 GainFrenzyChargeOnCriticalHit
 ]],[[
 Voidforge
@@ -1049,12 +1049,12 @@ Implicits: 2
 {variant:2,3}WeaponElementalDamageImplicitSword1
 {variant:1}LocalIncreasedPhysicalDamagePercentUnique__53[50,100]
 {variant:2}LocalIncreasedPhysicalDamagePercentUnique__53[30,60]
-LocalIncreasedAttackSpeedUnique__19
-IncreasedLifeUnique__24
+LocalIncreasedAttackSpeedUnique__27
+IncreasedLifeUnique__70
 ElementalDamageCanShockUnique__1__
 {variant:1,2}WeaponPhysicalDamageAddedAsRandomElementUnique__1__[300,300]
 {variant:3}WeaponPhysicalDamageAddedAsRandomElementUnique__1__
-IncreasedAttackAreaOfEffectUnique__1_
+IncreasedAttackAreaOfEffectUnique__2_
 DealNoNonElementalDamageUnique__1
 ]],[[
 Paradoxica

--- a/src/Export/Uniques/wand.lua
+++ b/src/Export/Uniques/wand.lua
@@ -157,7 +157,7 @@ IntelligenceUniqueWand2
 {variant:3,4}MinionRunSpeedUniqueWand2
 {variant:1,2}MinionDamageUniqueWand2[10,30]
 {variant:3,4}MinionDamageUniqueWand2
-MaximumMinionCountUniqueWand2
+MaximumMinionCountUniqueWand2Updated
 ]],[[
 Replica Midnight Bargain
 {variant:1}Engraved Wand
@@ -196,7 +196,7 @@ SpellDamageUniqueWand1
 {variant:2,3}LocalIncreasedPhysicalDamagePercentUnique__26[175,175]
 {variant:4,5}LocalIncreasedPhysicalDamagePercentUniqueWand1
 LightningDamageUniqueWand1
-IncreasedCastSpeedImplicitMarakethWand1
+IncreasedCastSpeedUniqueWand1
 BlindingHitUniqueWand1
 ]],[[
 Mystic Refractor
@@ -209,7 +209,7 @@ IncreasedCastSpeedImplicitMarakethWand1
 AdditionalProjectilesUniqueWand_1
 {variant:1}ProjectileSpeedUnique__9[10,20]
 {variant:2}ProjectileSpeedUnique__9
-IncreasedProjectileDamageUnique__1
+IncreasedProjectileDamageUnique___12
 ProjectilesExpireOnHitUniqueWand_1
 ]],[[
 Obliteration
@@ -320,7 +320,7 @@ Variant: Pre 3.5.0
 Variant: Current
 Implicits: 1
 SpellDamageOnWeaponImplicitWand6
-ElementalDamagePercentAddedAsChaosUnique__3
+ElementalDamagePercentAddedAsChaosUnique__1
 CriticalStrikesDealNoDamageUnique__1
 {variant:1}SpellDamageIfYouHaveCritRecentlyUnique__1[120,120]
 {variant:2}SpellDamageIfYouHaveCritRecentlyUnique__1
@@ -338,7 +338,7 @@ Implicits: 2
 {variant:3}AddedLightningDamageSpellsAndAttacksImplicit3
 {variant:1,2,3}SpellDamageUniqueWand1
 {variant:1,2,3}SpellAddedLightningDamageUnique__5
-{variant:4}IncreasedMaximumPowerChargesUnique__5
+{variant:4}IncreasedMaximumPowerChargesUnique__6
 CriticalMultiplierPerPowerChargeUnique__1
 AdditionalCriticalStrikeChancePerPowerChargeUnique__1
 ChanceToBlockSpellsPerPowerChargeUnique__1
@@ -361,7 +361,7 @@ Implicits: 3
 LocalIncreasedPhysicalDamagePercentUnique__8
 LocalAddedLightningDamageUnique__2
 ManaRegenerationUnique__1
-IncreasedMaximumPowerChargesUniqueWand3
+IncreasedMaximumPowerChargesUnique__1
 PowerChargeOnKillChanceUnique__1
 ]],[[
 Tulborn
@@ -400,7 +400,7 @@ Implicits: 3
 {variant:3}AddedColdDamageSpellsAndAttacksImplicit3
 {variant:4}SpellDamageOnWeaponImplicitWand14
 {variant:1,2}IncreasedCastSpeedUniqueWand3[10,15]
-{variant:3,4}IncreasedCastSpeedUniqueWand3
+{variant:3,4}IncreasedCastSpeedUnique__8
 {variant:1}GainPowerChargeOnKillingFrozenEnemyUnique__1[50,50]
 {variant:2,3,4}GainPowerChargeOnKillingFrozenEnemyUnique__1
 {variant:1,2}AddedColdDamagePerPowerChargeUnique__2[15,15][25,25]
@@ -423,7 +423,7 @@ Implicits: 3
 {variant:2}AddedColdDamageSpellsAndAttacksImplicit3
 {variant:3}SpellDamageOnWeaponImplicitWand14
 IncreasedCastSpeedUnique__22
-LosePowerChargesOnMaxPowerChargesUnique__1
+LosePowerChargesOnMaxPowerChargesUnique__2
 WhenReachingMaxPowerChargesGainAFrenzyChargeUnique__1
 {variant:1,2}IncreasedColdDamagePerFrenzyChargeUnique__2[15,20]
 {variant:3}IncreasedColdDamagePerFrenzyChargeUnique__2
@@ -461,7 +461,7 @@ Implicits: 2
 {variant:2}KineticWandImplicit
 LocalIncreasedPhysicalDamagePercentUniqueWand9x
 LocalIncreasedAttackSpeedUniqueWand9
-LocalCriticalStrikeChanceUnique__22
+LocalCriticalStrikeChanceUnique__20
 AttackAdditionalProjectilesUnique__1
 ]],[[
 Unlight Extant


### PR DESCRIPTION
### Description of the problem being solved:
This updates 779 outdated unique item modifier IDs across 19 files in src/Export/Uniques using current live game data.

Each replacement was restricted to any case where:
- the unique name and current base type matched exactly
- the existing and candidate IDs resolved to the same complete stat-text tuple in ModItemExclusive.lua
- exactly one authoritative replacement candidate was available

There is a small handful of mod IDs that remain unchanged as they:
- have no matching unique item (these look like removed legacy items)
- have no matching modID in the json
- contain multiple modID lines, not matching the existing lua files in Export

These possible changes should be reviewed manually if it is deemed that they need to be updated.

Changes were updated using a patcher I put together in Python (screenshots below). The UI for the patcher was built by Codex because I hate doing UI stuff. This can be expanded to include any type of item ID if it's something you could see as useful. Adjustments can be made to update roll ranges on items, variants, or whatever else. It can also be used across both PoE1 and PoE2 game data, so anything we have a json for live data can be applied. If you're interested, I can submit a PR for the patcher or you should be able to check it out in my personal fork.

### Steps taken to verify a working solution:
- Reanalyzed all 21 unique item export files after applying changes
- confirmed zero remaining safe replacement candidates
- confirmed that repeated analysis produces no further changes

### Before screenshot:
<img width="1671" height="807" alt="image" src="https://github.com/user-attachments/assets/6b5bac86-f51a-4b80-9b4a-a2989bff0aab" />

### After screenshot:
<img width="1671" height="807" alt="image" src="https://github.com/user-attachments/assets/f64323eb-a714-4020-b91e-c14ae36b53b2" />
