### PR TITLE
Remember the selected build-sharing website

### DIFF
--- a/spec/System/TestImport_spec.lua
+++ b/spec/System/TestImport_spec.lua
@@ -200,4 +200,30 @@ Implicits: 0]])
 		end
 		assert.truthy(found)
 	end)
+
+	it("remembers the persisted sharing website across build initialization", function()
+		local previousWebsite = main.lastExportedWebsite
+		local previousSessionWebsite = main.lastExportWebsite
+		main.lastExportedWebsite = "POBBin"
+		main.lastExportWebsite = nil
+		newBuild()
+		local selected = build.importTab.controls.exportFrom:GetSelValue().id
+		local control = build.importTab.controls.exportFrom
+		for index, site in ipairs(control.list) do
+			if site.id == "PoBCodes" then
+				control:SetSel(index)
+				break
+			end
+		end
+		local savedWebsite = main.lastExportedWebsite
+		main.lastExportWebsite = nil
+		newBuild()
+		local restored = build.importTab.controls.exportFrom:GetSelValue().id
+		main.lastExportedWebsite = previousWebsite
+		main.lastExportWebsite = previousSessionWebsite
+		assert.are.equal("POBBin", selected)
+		assert.are.equal("PoBCodes", savedWebsite)
+		assert.are.equal("PoBCodes", restored)
+	end)
+
 end)

--- a/src/Classes/ImportTab.lua
+++ b/src/Classes/ImportTab.lua
@@ -533,10 +533,10 @@ function ImportTabClass:ImportTab(build)
 	local exportWebsitesList = getExportSitesFromImportList()
 
 	self.controls.exportFrom = new("DropDownControl"):DropDownControl({ "LEFT", self.controls.generateCodeCopy, "RIGHT" }, { 8, 0, 120, 20 }, exportWebsitesList, function(_, selectedWebsite)
-		main.lastExportWebsite = selectedWebsite.id
+		main.lastExportedWebsite = selectedWebsite.id
 		self.exportWebsiteSelected = selectedWebsite.id
 	end)
-	self.controls.exportFrom:SelByValue(self.exportWebsiteSelected or main.lastExportWebsite or "Pastebin", "id")
+	self.controls.exportFrom:SelByValue(self.exportWebsiteSelected or main.lastExportedWebsite or exportWebsitesList[1].id, "id")
 	self.controls.generateCodeByLink = new("ButtonControl"):ButtonControl({ "LEFT", self.controls.exportFrom, "RIGHT" }, { 8, 0, 100, 20 }, "Share", function()
 		local exportWebsite = exportWebsitesList[self.controls.exportFrom.selIndex]
 		local subScriptId = buildSites.UploadBuild(self.controls.generateCodeOut.buf, exportWebsite)


### PR DESCRIPTION
Fixes #10173 

### Description of the problem being solved:
When #9812 was ported over, it changed `lastExportedWebsite` to `lastExportWebsite` in ImportTab.lua, breaking this functionality in PoB1. [Link](https://github.com/PathOfBuildingCommunity/PathOfBuilding/pull/9812/changes#diff-9c92f7ea8e0528b99067d974565d47e61b86fb3c1eb98961299b511f9be7fe5b)

<img width="1015" height="577" alt="image" src="https://github.com/user-attachments/assets/8bfd336a-bbb1-4c51-9e92-6c04cc8ae165" />


### Steps taken to verify a working solution:
- Apply PR
- Select a non-Maxroll website for generating a share link
- Close and reopen PoB
- New site selection is persisted

### Link to a build that showcases this PR:

### Before screenshot:

### After screenshot:
