### PR TITLE
Respect spell cooldowns for traps/mines while calculating DPS

### DIFF
--- a/spec/System/TestOffence_spec.lua
+++ b/spec/System/TestOffence_spec.lua
@@ -13,6 +13,64 @@ describe("TestOffence", function()
 			string.format("%s: expected ~%.2f (within %.1f%%), got %.2f", msg, expected, tolerance * 100, actual))
 	end
 
+	for _, support in ipairs({
+		{ name = "Trap", cooldown = "TrapCooldown", speed = "TrapThrowingSpeed", rate = 119 / 60 },
+		{ name = "Blastchain Mine", cooldown = "Cooldown", speed = "MineLayingSpeed", rate = 10 / 3 },
+		{ name = "High-Impact Mine", cooldown = "Cooldown", speed = "MineLayingSpeed", rate = 10 / 3 },
+	}) do
+		it("limits " .. support.name .. " hit DPS and Full DPS by cooldown without exceeding throwing speed", function()
+			build.skillsTab:PasteSocketGroup("Frost Bomb 20/0  1\n" .. support.name .. " 20/0  1")
+			build.skillsTab.socketGroupList[1].includeInFullDPS = true
+			for _, case in ipairs({
+				{ recovery = 0, cooldown = 2.508 },
+				{ recovery = 100, cooldown = 1.254 },
+				{ recovery = 1000, cooldown = 0.231 },
+			}) do
+				build.configTab.input.customMods = case.recovery .. "% increased Cooldown Recovery Rate"
+				build.configTab:BuildModList()
+				runCallback("OnFrame")
+
+				local output = build.calcsTab.mainOutput
+				local expectedRate = case.recovery == 1000 and support.rate or 1 / case.cooldown
+				assert.near(case.cooldown, output[support.cooldown], 0.000001)
+				assert.near(support.rate, output[support.speed], 0.000001)
+				assert.near(expectedRate, output.Speed, 0.000001)
+				assert.near(output.AverageDamage * expectedRate, output.TotalDPS, 0.000001)
+				assert.near(output.TotalDPS, output.FullDPS, 0.000001)
+			end
+		end)
+
+		it("keeps cooldown-free " .. support.name .. " skills limited by throwing speed", function()
+			build.skillsTab:PasteSocketGroup("Fireball 20/0  1\n" .. support.name .. " 20/0  1")
+			runCallback("OnFrame")
+
+			local output = build.calcsTab.mainOutput
+			assert.is_nil(output[support.cooldown])
+			assert.near(support.rate, output.Speed, 0.000001)
+			assert.near(output.AverageDamage * support.rate, output.TotalDPS, 0.000001)
+		end)
+	end
+
+	it("preserves Lightning Spire Trap's independent hit rate", function()
+		build.skillsTab:PasteSocketGroup("Lightning Spire Trap 20/0  1")
+		runCallback("OnFrame")
+
+		local output = build.calcsTab.mainOutput
+		assert.near(8.019, output.TrapCooldown, 0.000001)
+		assert.near(1 / 0.36, output.HitSpeed, 0.000001)
+		assert.near(output.AverageDamage / 0.36, output.TotalDPS, 0.000001)
+	end)
+
+	it("preserves the cooldown cap for spells used by totems", function()
+		build.skillsTab:PasteSocketGroup("Frost Bomb 20/0  1\nSpell Totem 20/0  1")
+		runCallback("OnFrame")
+
+		local output = build.calcsTab.mainOutput
+		assert.near(2.508, output.Cooldown, 0.000001)
+		assert.near(1 / 2.508, output.Speed, 0.000001)
+		assert.near(output.AverageDamage / 2.508, output.TotalDPS, 0.000001)
+	end)
+
 	it("counts only permanent minions for Communion", function()
 		build.skillsTab:PasteSocketGroup("Fireball 20/0  1\nCommunion 3/0  1")
 		build.skillsTab:PasteSocketGroup("Summon Reaper 20/0  1")

--- a/src/Modules/CalcOffence.lua
+++ b/src/Modules/CalcOffence.lua
@@ -2275,6 +2275,10 @@ function calcs.offence(env, actor, activeSkill)
 			output.Speed = 0
 		elseif skillData.timeOverride then
 			output.Time = skillData.timeOverride
+			local cooldown = globalOutput.TrapCooldown or globalOutput.Cooldown
+			if cooldown then
+				output.Time = m_max(output.Time, cooldown)
+			end
 			output.Speed = 1 / output.Time
 		elseif skillData.fixedCastTime then
 			output.Time = activeSkill.activeEffect.grantedEffect.castTime


### PR DESCRIPTION
Fixes #10334 

### Description of the problem being solved:
Skills supported by Trap, Blastchain Mine, or High-Impact Mine would calculate hit DPS using their throwing rate without checking the spell's cooldown. 

This adds a check modeled after other similar checks in CalcOffence.lua. I believe Totems and other proxies are already properly supported.

### Steps taken to verify a working solution:
- Check Full DPS before and after the patch, comparing self cast / trap / mine supported versions of Frost Bomb

### Link to a build that showcases this PR:
https://pob.codes/b/WrERGRSB92V

### Before screenshot:
<img width="376" height="112" alt="image" src="https://github.com/user-attachments/assets/f97900dd-43a8-48f7-81b8-d89f225e486e" />

### After screenshot:
<img width="332" height="101" alt="image" src="https://github.com/user-attachments/assets/ade9502b-c2d7-46e9-9c6b-b6bcad60ff42" />

