### PR TITLE
Preserve the save warning for Notes and Party edits after generating a share code

### DIFF
--- a/spec/System/TestImport_spec.lua
+++ b/spec/System/TestImport_spec.lua
@@ -200,4 +200,36 @@ Implicits: 0]])
 		end
 		assert.truthy(found)
 	end)
+
+	for _, target in ipairs({ { "NOTES", "notesTab", "edit" }, { "PARTY", "partyTab", "editAuras" } }) do
+		it("keeps " .. target[1] .. " changes unsaved after exporting a build", function()
+			build:ResetModFlags()
+			local tab = build[target[2]]
+			tab.controls[target[3]]:SetText("Unsaved text")
+			build.viewMode = target[1]
+			runCallback("OnFrame")
+			assert.is_true(build.unsaved)
+			local xml = build:SaveDB("code")
+			assert.is_truthy(xml:find("Unsaved text", 1, true))
+			runCallback("OnFrame")
+			assert.is_true(build.unsaved)
+			assert.is_true(tab.modFlag)
+
+			local openFile = io.open
+			local written
+			io.open = function()
+				return { write = function(_, text) written = text; return true end, close = function() return true end }
+			end
+			build.dbFileName = "test.xml"
+			local ok, err = pcall(build.SaveDBFile, build)
+			io.open = openFile
+			build.dbFileName = nil
+			assert.is_true(ok, err)
+			assert.is_truthy(written:find("Unsaved text", 1, true))
+			runCallback("OnFrame")
+			assert.is_false(build.unsaved)
+			assert.is_false(tab.modFlag)
+		end)
+	end
+
 end)

--- a/src/Classes/NotesTab.lua
+++ b/src/Classes/NotesTab.lua
@@ -84,7 +84,11 @@ end
 function NotesTabClass:Save(xml)
 	self:SetShowColorCodes(false)
 	t_insert(xml, self.controls.edit.buf)
+end
+
+function NotesTabClass:ResetModFlags()
 	self.lastContent = self.controls.edit.buf
+	self.modFlag = false
 end
 
 function NotesTabClass:Draw(viewPort, inputEvents)

--- a/src/Classes/PartyTab.lua
+++ b/src/Classes/PartyTab.lua
@@ -651,6 +651,14 @@ function PartyTabClass:Save(xml)
 		t_insert(child, exportString)
 		t_insert(xml, child)
 	end
+	xml.attrib = {
+		destination = self.controls.importCodeDestination.list[self.controls.importCodeDestination.selIndex],
+		append = tostring(self.controls.appendNotReplace.state),
+		ShowAdvanceTools = tostring(self.controls.ShowAdvanceTools.state)
+	}
+end
+
+function PartyTabClass:ResetModFlags()
 	self.lastContent.PartyMemberStats = self.controls.editPartyMemberStats.buf
 	self.lastContent.Aura = self.controls.editAuras.buf
 	self.lastContent.Curse = self.controls.editCurses.buf
@@ -659,12 +667,8 @@ function PartyTabClass:Save(xml)
 	self.lastContent.EnemyCond = self.controls.enemyCond.buf
 	self.lastContent.EnemyMods = self.controls.enemyMods.buf
 	self.lastContent.EnableExportBuffs = self.enableExportBuffs
-	xml.attrib = {
-		destination = self.controls.importCodeDestination.list[self.controls.importCodeDestination.selIndex],
-		append = tostring(self.controls.appendNotReplace.state),
-		ShowAdvanceTools = tostring(self.controls.ShowAdvanceTools.state)
-	}
 	self.lastContent.showAdvancedTools = self.controls.ShowAdvanceTools.state
+	self.modFlag = false
 end
 
 function PartyTabClass:Draw(viewPort, inputEvents)

--- a/src/Modules/Build.lua
+++ b/src/Modules/Build.lua
@@ -1099,8 +1099,8 @@ end
 
 function buildMode:ResetModFlags()
 	self.modFlag = false
-	self.notesTab.modFlag = false
-	self.partyTab.modFlag = false
+	self.notesTab:ResetModFlags()
+	self.partyTab:ResetModFlags()
 	self.configTab.modFlag = false
 	self.treeTab.modFlag = false
 	self.treeTab.searchFlag = false


### PR DESCRIPTION
### Description of the problem being solved:
Codex discovered issue. Generating a share code mistakenly makes PoB remember your current Notes and Party text as saved. When you return to either tab, and close PoB, PoB compares the text there with what it remembers. Because they match, it decides there are no unsaved changes. This allows you to close PoB with unsaved changes, and no warning.

This fix makes PoB remember that text as saved only when you actually save the build file.

### Steps taken to verify a working solution:

- Headless regressions for both Notes and Party edits failed against the original code and passed with the fix.
- Confirmed that I could no longer reproduce the issue.
- Test suite

### Link to a build that showcases this PR:

### Before screenshot:

### After screenshot: