### PR TITLE
Deterministic xml: emit element attributes in sorted key order

### DIFF
--- a/runtime/lua/xml.lua
+++ b/runtime/lua/xml.lua
@@ -117,19 +117,26 @@ local function composeNode(frag, node, lvl)
 	t_insert(frag, '<')
 	t_insert(frag, node.elem)
 	if node.attrib then
+		local attribKeys = { }
 		for key, val in pairs(node.attrib) do
 			if val then
 				if type(key) ~= "string" then
 					return "invalid xml tree (attribute name in <"..node.elem.."> is not a string)"
-				elseif type(val) ~= "string" then
-					return "invalid xml tree (value for attribute '"..key.."' in <"..node.elem.."> is not a string)"
 				end
-				t_insert(frag, ' ')
-				t_insert(frag, key)
-				t_insert(frag, '="')
-				t_insert(frag, encodeContent(val))
-				t_insert(frag, '"')
+				t_insert(attribKeys, key)
 			end
+		end
+		table.sort(attribKeys)
+		for _, key in ipairs(attribKeys) do
+			local val = node.attrib[key]
+			if type(val) ~= "string" then
+				return "invalid xml tree (value for attribute '"..key.."' in <"..node.elem.."> is not a string)"
+			end
+			t_insert(frag, ' ')
+			t_insert(frag, key)
+			t_insert(frag, '="')
+			t_insert(frag, encodeContent(val))
+			t_insert(frag, '"')
 		end
 	end
 	if not node[1] then


### PR DESCRIPTION
### Description of the problem being solved:

composeNode() walked node.attrib with pairs(), so attributes came out in string-hash order and the same tree could serialise differently between processes. Collect the keys, sort them, then emit.

### Steps taken to verify a working solution:

Has been running headless in poe.ninja for about a month.