### PR TITLE
Fix: Show cluster jewel small passive effect scaling correctly on UI

### DIFF
--- a/spec/System/TestClusterJewelGraphs_spec.lua
+++ b/spec/System/TestClusterJewelGraphs_spec.lua
@@ -112,4 +112,42 @@ Added Small Passive Skills grant: 12% increased Chaos Damage]])
 		spec:DeallocNode(nestedSocket)
 		assert.are.equal(1, countSubgraphs(spec))
 	end)
+
+	it("shows increased effect on added small passive skill stats", function()
+		local spec = build.spec
+		local outerSocket = getOuterSocket(spec)
+		spec:AllocNode(outerSocket)
+
+		local largeCluster = addItem([[Rarity: RARE
+New Item
+Large Cluster Jewel
+Implicits: 3
+Adds 8 Passive Skills
+2 Added Passive Skills are Jewel Sockets
+Added Small Passive Skills grant: 12% increased Fire Damage
+Added Small Passive Skills also grant: +5% to Chaos Resistance
+Added Small Passive Skills also grant: +7% to Fire Resistance
+Added Small Passive Skills also grant: +10 to Maximum Life
+Added Small Passive Skills have 35% increased Effect]])
+		spec.jewels[outerSocket.id] = largeCluster.id
+		spec:BuildClusterJewelGraphs()
+
+		local smallNode
+		for _, subgraph in pairs(spec.subGraphs) do
+			for _, node in ipairs(subgraph.nodes) do
+				if node.type == "Normal" and node.expansionSkill then
+					smallNode = node
+					break
+				end
+			end
+		end
+
+		assert.is_truthy(smallNode)
+		assert.are.same({
+			"16% increased Fire Damage",
+			"+6% to Chaos Resistance",
+			"+9% to Fire Resistance",
+			"+13 to Maximum Life",
+		}, smallNode.sd)
+	end)
 end)

--- a/src/Classes/PassiveSpec.lua
+++ b/src/Classes/PassiveSpec.lua
@@ -2316,6 +2316,12 @@ function PassiveSpecClass:BuildSubgraph(jewel, parentSocket, id, upSize, importe
 		self.tree:ProcessNode(node)
 		if node.modList and jewelData.clusterJewelIncEffect and node.type == "Normal" then
 			node.modList:NewMod("PassiveSkillEffect", "INC", jewelData.clusterJewelIncEffect)
+			-- ProcessNode must parse the base values before the tooltip text is scaled,
+			-- otherwise PassiveSkillEffect would apply to the scaled values a second time.
+			local effectScalar = 1 + jewelData.clusterJewelIncEffect / 100
+			for index, line in ipairs(node.sd) do
+				node.sd[index] = itemLib.applyRange(line, 1, effectScalar)
+			end
 		end
 	end
 


### PR DESCRIPTION
Fixes #3198 #4034 #8762 .

### Description of the problem being solved:
Fixes the very long standing issue where the 25/35% increased effect on cluster jewels wasn't correctly reflected in the UI.
No calculations were changed as part of this fix.

### Steps taken to verify a working solution:
- Add a cluster jewel with the 25/35% inc effect of small passive skills mod
- Hover over the small nodes - they should be correctly scaled now with the 25/35% inc effect using the same scaling as everywhere else.

### Link to a build that showcases this PR:
https://pob.codes/b/gSyxRyaDvW5

Example Cluster jewel:

<img width="522" height="363" alt="image" src="https://github.com/user-attachments/assets/9cfd54ae-cde2-4f29-ae77-350e9124e08a" />

### Before screenshot:
<img width="449" height="148" alt="image" src="https://github.com/user-attachments/assets/908dea78-e14e-4277-93d1-08d069ccfc7d" />

### After screenshot:
<img width="423" height="148" alt="image" src="https://github.com/user-attachments/assets/23daa703-f2dd-4197-9cf5-1d3e7c912ae9" />
