### PR TITLE
Fix: Timeless Abyss Jewels active in cluster sockets

### DIFF
--- a/src/Classes/PassiveSpec.lua
+++ b/src/Classes/PassiveSpec.lua
@@ -1113,7 +1113,7 @@ function PassiveSpecClass:BuildAllDependsAndPaths()
 		local item = self.build.itemsTab.items[itemId]
 		local conqueredBy = item and item.jewelData and item.jewelData.conqueredBy
 		local jewelType = conqueredBy and timelessJewelTypeByConqueror[conqueredBy.conqueror.type]
-		if jewelType and jewelType >= 7 and self.allocNodes[socketId] and not item.jewelData.limitDisabled then
+		if jewelType and jewelType >= 7 and self.allocNodes[socketId] and not (self.nodes[socketId].expansionJewel and self.nodes[socketId].expansionJewel.parent) and not item.jewelData.limitDisabled then
 			local path = jewelType == 11 and self:GetShortestPathToClassStart(socketId)
 			for nodeId, modification in pairs(data.readAbyssJewelLUT(conqueredBy.id, socketId, jewelType, path)) do
 				abyssConquests[nodeId] = {


### PR DESCRIPTION
Fixes #10345

### Description of the problem being solved:
The new Timeless abyss sockets are not able to be socketed into cluster jewel sockets. If you do that ingame they don't have any effect (don't convert any path nodes). In PoB this was not the case and the path was still converted giving the illusion that this would also work ingame.

### Steps taken to verify a working solution:
- Add a cluster to the PoB.
- Allocate Cluster + one of its sockets.
- Socket e.g. Reclaimed Malevolence into the cluster socket
- The path to the class start should not change.

### Link to a build that showcases this PR:
https://pob.codes/b/v4au0nHKMcP

### Before screenshot:
<img width="805" height="1197" alt="image" src="https://github.com/user-attachments/assets/391a06e5-8437-424e-9bb1-09307b89f16b" />

### After screenshot:
<img width="768" height="1184" alt="image" src="https://github.com/user-attachments/assets/6090940d-43f1-4ee1-88a9-99a4fb53d28d" />
