### PR TITLE
Fix: Pact uptime with repeated spells

### DIFF
--- a/src/Modules/CalcOffence.lua
+++ b/src/Modules/CalcOffence.lua
@@ -2908,7 +2908,9 @@ function calcs.offence(env, actor, activeSkill)
 							local castTime = 1 / m_min(castRate, data.misc.ServerTickRate)
 							local count = value.skillModList:Sum("BASE", value.skillCfg, pactKey.."EmpoweredSpells")
 							local storedUses = value.skillData.storedUses + value.skillModList:Sum("BASE", value.skillCfg, "AdditionalCooldownUses")
-							local uptime = (globalOutput.Speed or 0) == 0 and 100 or m_min((count / globalOutput.Speed) / (cooldown + castTime), 1) * 100
+							-- Repeated spells retain the empowerment from the initial cast without consuming another use.
+							local empoweredUseRate = (globalOutput.Speed or 0) / (globalOutput.Repeats or 1)
+							local uptime = empoweredUseRate == 0 and 100 or m_min((count / empoweredUseRate) / (cooldown + castTime), 1) * 100
 							uptime = m_min(100, uptime * storedUses)
 							local effect = skillModList:Flag(nil, "Condition:PactMaxHit") and 100 or uptime
 							local effectMult = effect / 100
@@ -2921,7 +2923,7 @@ function calcs.offence(env, actor, activeSkill)
 							if globalBreakdown then
 								globalBreakdown[pactKey.."UpTimeRatio"] = {
 									s_format("(%.2f ^8(number of Empowered)", count),
-									s_format("/ %.2f) ^8(casts per second)", globalOutput.Speed or 0),
+									s_format("/ %.2f) ^8(non-repeated casts per second)", empoweredUseRate),
 									s_format("/ (%.2f ^8(pact cooldown)", cooldown),
 									s_format("+ %.2f) ^8(pact cast time)", castTime),
 									s_format("* %.2f ^8(stored uses)", storedUses),


### PR DESCRIPTION
Fixes #10309 


### Description of the problem being solved:
Pact of Beidat only uses 1 charge on non-repeats, the current implementation used 1 charge for each repeat as well.

### Steps taken to verify a working solution:
- add pact of beidat to buil
- add any spell to build (e.g. fireball)
- check pact uptime
- add greater spell echo to fireball
- check pact uptime again

### Link to a build that showcases this PR:
https://pobb.in/dgYHi6UBhxzP (taken from issue)

### Before screenshot:
(Taken from Issue)
<img width="724" height="183" alt="image" src="https://github.com/user-attachments/assets/7696ec61-05b5-4c27-9f6c-ead77897105b" />

### After screenshot:
<img width="709" height="162" alt="image" src="https://github.com/user-attachments/assets/3f79c309-6626-4cca-a921-1c290746b568" />
