### PR TITLE
Show timeless passive source names in Calcs

### DIFF
--- a/src/Classes/CalcBreakdownControl.lua
+++ b/src/Classes/CalcBreakdownControl.lua
@@ -434,14 +434,22 @@ function CalcBreakdownClass:AddModSection(sectionData, modList)
 		elseif sourceType == "Tree" then
 			-- Modifier is from a passive node, add node name, and add node ID (used to show node location)
 			local nodeId = row.mod.source:match("Tree:(%d+)")
-			local tattooNodeId = row.mod.source:match("Tree:(%w+)")
+			local textNodeId = row.mod.source:match("Tree:([%w_]+)")
 			if nodeId then
 				local nodeIdNumber = tonumber(nodeId)
 				local node = build.spec.nodes[nodeIdNumber] or build.spec.tree.nodes[nodeIdNumber] or build.latestTree.nodes[nodeIdNumber]
 				row.sourceName = node.dn
 				row.sourceNameNode = node
-			elseif tattooNodeId then
-				row.sourceName = build.spec.tree.tattoo.idMap[tattooNodeId]
+			elseif textNodeId then
+				row.sourceName = build.spec.tree.tattoo.idMap[textNodeId]
+				if not row.sourceName then
+					for _, node in pairs(build.spec.tree.legion.nodes) do
+						if node.id == textNodeId then
+							row.sourceName = node.dn
+							break
+						end
+					end
+				end
 			end
 		elseif sourceType == "Skill" then
 			-- Extract skill name


### PR DESCRIPTION
Fixes #10247

### Description of the problem being solved:

Tempered by War doesn't show its name in Calcs for its resistance penalties or damage taken conversions.

This is because the source lookup only handles numbered tree nodes and tattoos, and cuts off textual IDs at underscores. This adds support for complete textual IDs and looks up timeless passive names when no tattoo matches. Existing tattoo support is preserved.

### Steps taken to verify a working solution:

- Observed visual fix in PoB
- Test suite passed

### Link to a build that showcases this PR:

https://pobb.in/kOXu-99xHr7w (from the issue)

### Before screenshot:
<img width="1361" height="271" alt="image" src="https://github.com/user-attachments/assets/8e7d938e-40e3-4ecf-8f5d-17230c580373" />

<img width="676" height="239" alt="image" src="https://github.com/user-attachments/assets/f192bd41-1e92-4651-ac58-e07af761d139" />


### After screenshot:
<img width="1369" height="279" alt="image" src="https://github.com/user-attachments/assets/923f5e27-00eb-4a01-a4a0-8edfcc20a36c" />

<img width="673" height="238" alt="image" src="https://github.com/user-attachments/assets/09dbe344-f128-4fc5-8b58-a4b85e7b040b" />
