### PR TITLE
Preserve sources of resistances granted to minions

### DIFF
--- a/spec/System/TestDefence_spec.lua
+++ b/spec/System/TestDefence_spec.lua
@@ -17,6 +17,71 @@ describe("TestDefence", function()
 		return build.calcsTab.calcs.reducePoolsByDamage(nil, takenDamages, build.calcsTab.calcsEnv.player)
 	end
 
+	it("attributes resistances inherited by minions to Bonemeld after loading a build", function()
+		build.skillsTab:PasteSocketGroup("Raise Zombie 20/0  1")
+		build.itemsTab:CreateDisplayItemFromRaw("Rarity: UNIQUE\nBonemeld\nMarble Amulet\nImplicits: 0\nMinions gain added Resistances equal to 50% of your Resistances")
+		build.itemsTab:AddDisplayItem()
+		build.configTab.input.customMods = "+135% to Fire Resistance\n+111% to Cold Resistance\n+59% to Lightning Resistance\n+39% to Chaos Resistance"
+		build.configTab:BuildModList()
+		runCallback("OnFrame")
+		loadBuildFromXML(build:SaveDB("code"))
+
+		local env = build.calcsTab.calcsEnv
+		local source = env.player.modDB:Tabulate("BASE", nil, "ResistanceAddedToMinions")[1].mod.source
+		local breakdown = build.calcsTab.controls.breakdown
+		build.calcsTab.input.showMinion = true
+		for _, case in ipairs({
+			{ "Fire", 75, 37, 77 },
+			{ "Cold", 51, 25, 65 },
+			{ "Lightning", -1, -1, 39 },
+			{ "Chaos", -21, -11, 9 },
+		}) do
+			local elem, playerResist, addedResist, minionResist = unpack(case)
+			local mods = env.minion.modDB:Tabulate("BASE", { source = "Item" }, elem.."Resist")
+			assert.are.equal(1, #mods)
+			assert.are.equal(source, mods[1].mod.source)
+			assert.are.equal(addedResist, mods[1].value)
+			assert.are.equal(playerResist, env.player.output[elem.."Resist"])
+			assert.are.equal(minionResist, env.minion.output[elem.."ResistTotal"])
+			breakdown.sectionList = { }
+			breakdown:AddModSection({ modName = elem.."Resist", modSource = "Item" })
+			local row = breakdown.sectionList[1].rowList[1]
+			assert.are.equal("Item", row.source)
+			assert.is_truthy(row.sourceName:find("Bonemeld", 1, true))
+			assert.are.equal("function", type(row.sourceNameTooltip))
+		end
+	end)
+
+	it("lists each source of inherited minion resistances and rounds each contribution", function()
+		build.skillsTab:PasteSocketGroup("Raise Zombie 20/0  1")
+		build.itemsTab:CreateDisplayItemFromRaw("Rarity: UNIQUE\nBonemeld\nMarble Amulet\nImplicits: 0\nMinions gain added Resistances equal to 50% of your Resistances")
+		build.itemsTab:AddDisplayItem()
+		build.configTab.input.customMods = "+135% to Fire Resistance\n+59% to Lightning Resistance\nMinions gain added Resistances equal to 50% of your Resistances"
+		build.configTab:BuildModList()
+		runCallback("OnFrame")
+		loadBuildFromXML(build:SaveDB("code"))
+
+		local env = build.calcsTab.calcsEnv
+		local sources = env.player.modDB:Tabulate("BASE", nil, "ResistanceAddedToMinions")
+		assert.are.equal(2, #sources)
+		for _, case in ipairs({ { "Fire", 37, 114 }, { "Lightning", -1, 38 } }) do
+			local elem, contribution, total = unpack(case)
+			local mods = env.minion.modDB:Tabulate("BASE", nil, elem.."Resist")
+			for _, source in ipairs(sources) do
+				local matches = 0
+				for _, entry in ipairs(mods) do
+					if entry.mod.source == source.mod.source then
+						matches = matches + 1
+						assert.are.equal(contribution, entry.value)
+					end
+				end
+				assert.are.equal(1, matches)
+			end
+			assert.are.equal(total, env.minion.output[elem.."ResistTotal"])
+			assert.are.equal(0, #env.minion.modDB:Tabulate("BASE", { source = "Player" }, elem.."Resist"))
+		end
+	end)
+
 	it("applies Consecrated Ground curse reduction to the player and minion", function()
 		build.skillsTab:PasteSocketGroup("Raise Zombie 20/0  1")
 		build.configTab.input.conditionOnConsecratedGround = true

--- a/src/Modules/CalcDefence.lua
+++ b/src/Modules/CalcDefence.lua
@@ -664,9 +664,11 @@ function calcs.defence(env, actor)
 
 	calcs.resistances(actor)
 	if env.minion and modDB:Sum("BASE", nil, "ResistanceAddedToMinions") > 0 then
-		for _, elem in ipairs(resistTypeList) do
-			local final = output[elem.."Resist"]
-			env.minion.modDB:NewMod(elem.."Resist", "BASE", m_floor(final * modDB:Sum("BASE", nil, "ResistanceAddedToMinions") / 100), "Player")
+		for _, value in ipairs(modDB:Tabulate("BASE", nil, "ResistanceAddedToMinions")) do
+			for _, elem in ipairs(resistTypeList) do
+				local final = output[elem.."Resist"]
+				env.minion.modDB:NewMod(elem.."Resist", "BASE", m_floor(final * value.value / 100), value.mod.source)
+			end
 		end
 	end
 	-- Formless Inferno


### PR DESCRIPTION
Fixes #10241 

### Description of the problem being solved:

Bonemeld's added minion resistances show as coming from `Player` in Calcs, with a blank Source Name.

This is because the calculation discards the original modifier source when creating the minion resistance bonuses. This preserves each contributing source so Calcs can show its name and the existing item tooltip.

Each contribution is now rounded down separately. A single source like Bonemeld will be accurate, but multiple sharing modifiers can produce slightly different totals: two 50% contributions from 75% player resistance give 37 + 37 = 74 instead of 75. The alternative solution would be to combine sources back to a generic `Player` to prevent small rounding errors. 

### Steps taken to verify a working solution:

- Added save/reload regressions for Bonemeld attribution and multiple resistance-sharing sources, including positive and negative rounding.
- Verified expected behavior using Bonemeld and a separate custom modifier.
- Passed all tests

### Link to a build that showcases this PR:
https://pob.codes/b/mpx-NPDYaIq

### Before screenshot:
<img width="1763" height="280" alt="image" src="https://github.com/user-attachments/assets/c23e6030-0588-4c41-8fe1-760c3468e6c9" />

### After screenshot:
<img width="1930" height="325" alt="image" src="https://github.com/user-attachments/assets/3dcb7cea-8b25-4071-a9f1-53e4ef34715a" />
